### PR TITLE
Games: Compiler warning and typo fixes

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -40,7 +40,7 @@ GAME_ERROR LoadGame(const char* url);
 /*!
  * \brief Load a game that requires multiple files
  *
- * \param type The game stype
+ * \param type The game type
  * \param urls An array of urls
  * \param urlCount The number of urls in the array
  *
@@ -145,7 +145,7 @@ GAME_ERROR HwContextDestroy(void);
 bool HasFeature(const char* controller_id, const char* feature_name);
 
 /*!
- * \brief Get the input topolgy that specifies which controllers can be connected
+ * \brief Get the input topology that specifies which controllers can be connected
  *
  * \return The input topology, or null to use the default
  *

--- a/xbmc/cores/RetroPlayer/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAudio.cpp
@@ -112,14 +112,14 @@ bool CRetroPlayerAudio::OpenEncodedStream(AVCodecID codec, unsigned int samplera
   return true; //! @todo
 }
 
-void CRetroPlayerAudio::AddData(const uint8_t* data, unsigned int size)
+void CRetroPlayerAudio::AddData(const uint8_t* data, size_t size)
 {
   if (m_bAudioEnabled)
   {
     if (m_pAudioStream)
     {
-      const unsigned int frameSize = m_pAudioStream->GetChannelCount() * (CAEUtil::DataFormatToBits(m_pAudioStream->GetDataFormat()) >> 3);
-      m_pAudioStream->AddData(&data, 0, size / frameSize);
+      const size_t frameSize = m_pAudioStream->GetChannelCount() * (CAEUtil::DataFormatToBits(m_pAudioStream->GetDataFormat()) >> 3);
+      m_pAudioStream->AddData(&data, 0, static_cast<unsigned int>(size / frameSize));
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAudio.h
@@ -41,7 +41,7 @@ namespace RETRO
     unsigned int NormalizeSamplerate(unsigned int samplerate) const override;
     bool OpenPCMStream(AEDataFormat format, unsigned int samplerate, const CAEChannelInfo& channelLayout) override;
     bool OpenEncodedStream(AVCodecID codec, unsigned int samplerate, const CAEChannelInfo& channelLayout) override;
-    void AddData(const uint8_t* data, unsigned int size) override;
+    void AddData(const uint8_t* data, size_t size) override;
     void CloseStream() override;
 
     void Enable(bool bEnabled) { m_bAudioEnabled = bEnabled; }

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -65,7 +65,7 @@ bool CRetroPlayerVideo::OpenEncodedStream(AVCodecID codec)
   return false; //! @todo
 }
 
-void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
+void CRetroPlayerVideo::AddData(const uint8_t* data, size_t size)
 {
   m_renderManager.AddFrame(data, size);
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
@@ -45,7 +45,7 @@ namespace RETRO
     // implementation of IGameVideoCallback
     bool OpenPixelStream(AVPixelFormat pixfmt, unsigned int width, unsigned int height, unsigned int orientationDeg) override;
     bool OpenEncodedStream(AVCodecID codec) override;
-    void AddData(const uint8_t* data, unsigned int size) override;
+    void AddData(const uint8_t* data, size_t size) override;
     void CloseStream() override;
 
   private:

--- a/xbmc/cores/RetroPlayer/process/IRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/process/IRenderBuffer.h
@@ -46,7 +46,7 @@ namespace RETRO
     virtual IRenderBufferPool *GetPool() = 0;
 
     // Buffer functions
-    virtual bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size) = 0;
+    virtual bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) = 0;
     virtual void Update() { } //! @todo Remove me
     virtual size_t GetFrameSize() const = 0;
     virtual uint8_t *GetMemory() = 0;

--- a/xbmc/cores/RetroPlayer/process/RenderBufferGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferGuiTexture.cpp
@@ -29,7 +29,7 @@ CRenderBufferGuiTexture::CRenderBufferGuiTexture(ESCALINGMETHOD scalingMethod) :
   m_textureFormat = XB_FMT_A8R8G8B8;
 }
 
-bool CRenderBufferGuiTexture::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size)
+bool CRenderBufferGuiTexture::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
 {
   // Initialize IRenderBuffer
   m_format = TranslateFormat(m_textureFormat);

--- a/xbmc/cores/RetroPlayer/process/RenderBufferGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferGuiTexture.h
@@ -37,7 +37,7 @@ namespace RETRO
     virtual ~CRenderBufferGuiTexture() = default;
 
     // implementation of IRenderBuffer via CBaseRenderBuffer
-    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size) override;
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
     size_t GetFrameSize() const override;
     uint8_t *GetMemory() override;
     bool UploadTexture() override;

--- a/xbmc/cores/RetroPlayer/process/RenderBufferSysMem.cpp
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferSysMem.cpp
@@ -23,7 +23,7 @@
 using namespace KODI;
 using namespace RETRO;
 
-bool CRenderBufferSysMem::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size)
+bool CRenderBufferSysMem::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
 {
   // Initialize IRenderBuffer
   m_format = format;

--- a/xbmc/cores/RetroPlayer/process/RenderBufferSysMem.h
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferSysMem.h
@@ -35,7 +35,7 @@ namespace RETRO
     virtual ~CRenderBufferSysMem() = default;
 
     // implementation of IRenderBuffer
-    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size) override;
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
     size_t GetFrameSize() const override;
     uint8_t *GetMemory() override;
 

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -99,7 +99,7 @@ bool CRPRenderManager::Configure(AVPixelFormat format, unsigned int width, unsig
   return true;
 }
 
-void CRPRenderManager::AddFrame(const uint8_t* data, unsigned int size)
+void CRPRenderManager::AddFrame(const uint8_t* data, size_t size)
 {
   // Validate parameters
   if (data == nullptr || size == 0)
@@ -491,10 +491,10 @@ void CRPRenderManager::CopyFrame(IRenderBuffer *renderBuffer, const uint8_t *dat
     if (scalerContext != nullptr)
     {
       uint8_t *source = const_cast<uint8_t*>(data);
-      const int sourceStride = size / m_height;
+      const int sourceStride = static_cast<int>(size / m_height);
 
       uint8_t *target = renderBuffer->GetMemory();
-      const int targetStride = renderBuffer->GetFrameSize() / renderBuffer->GetHeight();
+      const int targetStride = static_cast<int>(renderBuffer->GetFrameSize() / renderBuffer->GetHeight());
 
       uint8_t* src[] =       { source,        nullptr,   nullptr,   nullptr };
       int      srcStride[] = { sourceStride,  0,         0,         0       };

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -87,7 +87,7 @@ namespace RETRO
 
     // Functions called from game loop
     bool Configure(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int orientation);
-    void AddFrame(const uint8_t* data, unsigned int size);
+    void AddFrame(const uint8_t* data, size_t size);
 
     // Functions called from the player
     void SetSpeed(double speed);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -157,8 +157,8 @@ bool CWinRenderBuffer::CreateScalingContext()
 
 void CWinRenderBuffer::ScalePixels(uint8_t *source, size_t sourceSize, uint8_t *target, size_t targetSize)
 {
-  const int sourceStride = sourceSize / m_height;
-  const int targetStride = targetSize / m_height;
+  const int sourceStride = static_cast<int>(sourceSize / m_height);
+  const int targetStride = static_cast<int>(targetSize / m_height);
 
   uint8_t* src[] =       { source,        nullptr,   nullptr,   nullptr };
   int      srcStride[] = { sourceStride,  0,         0,         0       };

--- a/xbmc/games/addons/GameClientCallbacks.h
+++ b/xbmc/games/addons/GameClientCallbacks.h
@@ -40,7 +40,7 @@ namespace GAME
     virtual unsigned int NormalizeSamplerate(unsigned int samplerate) const = 0;
     virtual bool OpenPCMStream(AEDataFormat format, unsigned int samplerate, const CAEChannelInfo& channelLayout) = 0;
     virtual bool OpenEncodedStream(AVCodecID codec, unsigned int samplerate, const CAEChannelInfo& channelLayout) = 0;
-    virtual void AddData(const uint8_t* data, unsigned int size) = 0;
+    virtual void AddData(const uint8_t* data, size_t size) = 0;
     virtual void CloseStream() = 0;
   };
 
@@ -51,7 +51,7 @@ namespace GAME
 
     virtual bool OpenPixelStream(AVPixelFormat pixfmt, unsigned int width, unsigned int height, unsigned int orientationDeg) = 0;
     virtual bool OpenEncodedStream(AVCodecID codec) = 0;
-    virtual void AddData(const uint8_t* data, unsigned int size) = 0;
+    virtual void AddData(const uint8_t* data, size_t size) = 0;
     virtual void CloseStream() = 0;
   };
 

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
@@ -73,7 +73,7 @@ void CGameClientReversiblePlayback::SeekTimeMs(unsigned int timeMs)
 
   if (offsetFrames > 0)
   {
-    const unsigned int frames = std::min(static_cast<unsigned int>(offsetFrames), m_futureFrameCount);
+    const uint64_t frames = std::min(static_cast<uint64_t>(offsetFrames), m_futureFrameCount);
     if (frames > 0)
     {
       m_gameLoop.SetSpeed(0.0);
@@ -83,7 +83,7 @@ void CGameClientReversiblePlayback::SeekTimeMs(unsigned int timeMs)
   }
   else if (offsetFrames < 0)
   {
-    const unsigned int frames = std::min(static_cast<unsigned int>(-offsetFrames), m_pastFrameCount);
+    const uint64_t frames = std::min(static_cast<uint64_t>(-offsetFrames), m_pastFrameCount);
     if (frames > 0)
     {
       m_gameLoop.SetSpeed(0.0);
@@ -243,7 +243,7 @@ void CGameClientReversiblePlayback::AddFrame()
   m_totalFrameCount++;
 }
 
-void CGameClientReversiblePlayback::RewindFrames(unsigned int frames)
+void CGameClientReversiblePlayback::RewindFrames(uint64_t frames)
 {
   CSingleLock lock(m_mutex);
 
@@ -257,7 +257,7 @@ void CGameClientReversiblePlayback::RewindFrames(unsigned int frames)
   m_totalFrameCount -= std::min(m_totalFrameCount, static_cast<uint64_t>(frames));
 }
 
-void CGameClientReversiblePlayback::AdvanceFrames(unsigned int frames)
+void CGameClientReversiblePlayback::AdvanceFrames(uint64_t frames)
 {
   CSingleLock lock(m_mutex);
 
@@ -276,9 +276,9 @@ void CGameClientReversiblePlayback::UpdatePlaybackStats()
   m_pastFrameCount = m_memoryStream->PastFramesAvailable();
   m_futureFrameCount = m_memoryStream->FutureFramesAvailable();
 
-  const unsigned int played = m_pastFrameCount + (m_memoryStream->CurrentFrame() ? 1 : 0);
-  const unsigned int total = m_memoryStream->MaxFrameCount();
-  const unsigned int cached = m_futureFrameCount;
+  const uint64_t played = m_pastFrameCount + (m_memoryStream->CurrentFrame() ? 1 : 0);
+  const uint64_t total = m_memoryStream->MaxFrameCount();
+  const uint64_t cached = m_futureFrameCount;
 
   m_playTimeMs = MathUtils::round_int(1000.0 * played / m_gameLoop.FPS());
   m_totalTimeMs = MathUtils::round_int(1000.0 * total / m_gameLoop.FPS());

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.h
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.h
@@ -47,9 +47,9 @@ namespace GAME
     virtual ~CGameClientReversiblePlayback();
 
     // implementation of IGameClientPlayback
-    virtual bool CanPause() const override               { return true; }
-    virtual bool CanSeek() const override                { return true; }
-    virtual unsigned int GetTimeMs() const override      { return m_playTimeMs; }
+    virtual bool CanPause() const override { return true; }
+    virtual bool CanSeek() const override { return true; }
+    virtual unsigned int GetTimeMs() const override { return m_playTimeMs; }
     virtual unsigned int GetTotalTimeMs() const override { return m_totalTimeMs; }
     virtual unsigned int GetCacheTimeMs() const override { return m_cacheTimeMs; }
     virtual void SeekTimeMs(unsigned int timeMs) override;
@@ -77,18 +77,18 @@ namespace GAME
     CGameClient* const m_gameClient;
 
     // Gameplay functionality
-    CGameLoop                      m_gameLoop;
+    CGameLoop m_gameLoop;
     std::unique_ptr<IMemoryStream> m_memoryStream;
-    CCriticalSection               m_mutex;
+    CCriticalSection m_mutex;
 
     // Savestate functionality
     std::unique_ptr<CSavestateWriter> m_savestateWriter;
     std::unique_ptr<CSavestateReader> m_savestateReader;
 
     // Playback stats
-    uint64_t     m_totalFrameCount;
-    uint64_t     m_pastFrameCount;
-    uint64_t     m_futureFrameCount;
+    uint64_t m_totalFrameCount;
+    uint64_t m_pastFrameCount;
+    uint64_t m_futureFrameCount;
     unsigned int m_playTimeMs;
     unsigned int m_totalTimeMs;
     unsigned int m_cacheTimeMs;

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.h
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.h
@@ -68,8 +68,8 @@ namespace GAME
 
   private:
     void AddFrame();
-    void RewindFrames(unsigned int frames);
-    void AdvanceFrames(unsigned int frames);
+    void RewindFrames(uint64_t frames);
+    void AdvanceFrames(uint64_t frames);
     void UpdatePlaybackStats();
     void UpdateMemoryStream();
 
@@ -87,8 +87,8 @@ namespace GAME
 
     // Playback stats
     uint64_t     m_totalFrameCount;
-    unsigned int m_pastFrameCount;
-    unsigned int m_futureFrameCount;
+    uint64_t     m_pastFrameCount;
+    uint64_t     m_futureFrameCount;
     unsigned int m_playTimeMs;
     unsigned int m_totalTimeMs;
     unsigned int m_cacheTimeMs;

--- a/xbmc/games/addons/savestates/BasicMemoryStream.cpp
+++ b/xbmc/games/addons/savestates/BasicMemoryStream.cpp
@@ -28,7 +28,7 @@ CBasicMemoryStream::CBasicMemoryStream()
   Reset();
 }
 
-void CBasicMemoryStream::Init(size_t frameSize, size_t maxFrameCount)
+void CBasicMemoryStream::Init(size_t frameSize, uint64_t maxFrameCount)
 {
   Reset();
 

--- a/xbmc/games/addons/savestates/BasicMemoryStream.h
+++ b/xbmc/games/addons/savestates/BasicMemoryStream.h
@@ -35,18 +35,18 @@ namespace GAME
     virtual ~CBasicMemoryStream() = default;
 
     // implementation of IMemoryStream
-    virtual void           Init(size_t frameSize, size_t maxFrameCount) override;
+    virtual void Init(size_t frameSize, uint64_t maxFrameCount) override;
     virtual void           Reset() override;
     virtual size_t         FrameSize() const override                      { return m_frameSize; }
-    virtual unsigned int   MaxFrameCount() const override                  { return 1; }
-    virtual void           SetMaxFrameCount(size_t maxFrameCount) override { }
+    virtual uint64_t MaxFrameCount() const override { return 1; }
+    virtual void SetMaxFrameCount(uint64_t maxFrameCount) override { }
     virtual uint8_t*       BeginFrame() override;
     virtual void           SubmitFrame() override;
     virtual const uint8_t* CurrentFrame() const override;
-    virtual unsigned int   FutureFramesAvailable() const override          { return 0; }
-    virtual unsigned int   AdvanceFrames(unsigned int frameCount) override { return 0; }
-    virtual unsigned int   PastFramesAvailable() const override            { return 0; }
-    virtual unsigned int   RewindFrames(unsigned int frameCount) override  { return 0; }
+    virtual uint64_t FutureFramesAvailable() const override { return 0; }
+    virtual uint64_t AdvanceFrames(uint64_t frameCount) override { return 0; }
+    virtual uint64_t PastFramesAvailable() const override { return 0; }
+    virtual uint64_t RewindFrames(uint64_t frameCount) override { return 0; }
     virtual uint64_t       GetFrameCounter() const override                { return 0; }
     virtual void           SetFrameCounter(uint64_t frameCount) override   { };
 

--- a/xbmc/games/addons/savestates/BasicMemoryStream.h
+++ b/xbmc/games/addons/savestates/BasicMemoryStream.h
@@ -36,24 +36,24 @@ namespace GAME
 
     // implementation of IMemoryStream
     virtual void Init(size_t frameSize, uint64_t maxFrameCount) override;
-    virtual void           Reset() override;
-    virtual size_t         FrameSize() const override                      { return m_frameSize; }
+    virtual void Reset() override;
+    virtual size_t FrameSize() const override { return m_frameSize; }
     virtual uint64_t MaxFrameCount() const override { return 1; }
     virtual void SetMaxFrameCount(uint64_t maxFrameCount) override { }
-    virtual uint8_t*       BeginFrame() override;
-    virtual void           SubmitFrame() override;
+    virtual uint8_t* BeginFrame() override;
+    virtual void SubmitFrame() override;
     virtual const uint8_t* CurrentFrame() const override;
     virtual uint64_t FutureFramesAvailable() const override { return 0; }
     virtual uint64_t AdvanceFrames(uint64_t frameCount) override { return 0; }
     virtual uint64_t PastFramesAvailable() const override { return 0; }
     virtual uint64_t RewindFrames(uint64_t frameCount) override { return 0; }
-    virtual uint64_t       GetFrameCounter() const override                { return 0; }
-    virtual void           SetFrameCounter(uint64_t frameCount) override   { };
+    virtual uint64_t GetFrameCounter() const override { return 0; }
+    virtual void SetFrameCounter(uint64_t frameCount) override { };
 
   private:
-    size_t                     m_frameSize;
+    size_t m_frameSize;
     std::unique_ptr<uint8_t[]> m_frameBuffer;
-    bool                       m_bHasFrame;
+    bool m_bHasFrame;
   };
 }
 }

--- a/xbmc/games/addons/savestates/DeltaPairMemoryStream.cpp
+++ b/xbmc/games/addons/savestates/DeltaPairMemoryStream.cpp
@@ -61,14 +61,14 @@ void CDeltaPairMemoryStream::SubmitFrameInternal()
     CullPastFrames(1);
 }
 
-unsigned int CDeltaPairMemoryStream::PastFramesAvailable() const
+uint64_t CDeltaPairMemoryStream::PastFramesAvailable() const
 {
-  return static_cast<unsigned int>(m_rewindBuffer.size());
+  return static_cast<uint64_t>(m_rewindBuffer.size());
 }
 
-unsigned int CDeltaPairMemoryStream::RewindFrames(unsigned int frameCount)
+uint64_t CDeltaPairMemoryStream::RewindFrames(uint64_t frameCount)
 {
-  unsigned int rewound;
+  uint64_t rewound;
 
   for (rewound = 0; rewound < frameCount; rewound++)
   {
@@ -94,9 +94,9 @@ unsigned int CDeltaPairMemoryStream::RewindFrames(unsigned int frameCount)
   return rewound;
 }
 
-void CDeltaPairMemoryStream::CullPastFrames(unsigned int frameCount)
+void CDeltaPairMemoryStream::CullPastFrames(uint64_t frameCount)
 {
-  for (unsigned int removedCount = 0; removedCount < frameCount; removedCount++)
+  for (uint64_t removedCount = 0; removedCount < frameCount; removedCount++)
   {
     if (m_rewindBuffer.empty())
     {

--- a/xbmc/games/addons/savestates/DeltaPairMemoryStream.h
+++ b/xbmc/games/addons/savestates/DeltaPairMemoryStream.h
@@ -39,7 +39,7 @@ namespace GAME
     virtual ~CDeltaPairMemoryStream() = default;
 
     // implementation of IMemoryStream via CLinearMemoryStream
-    virtual void         Reset() override;
+    virtual void Reset() override;
     virtual uint64_t PastFramesAvailable() const override;
     virtual uint64_t RewindFrames(uint64_t frameCount) override;
 
@@ -60,7 +60,7 @@ namespace GAME
      */
     struct DeltaPair
     {
-      size_t   pos;
+      size_t pos;
       uint32_t delta;
     };
 
@@ -69,7 +69,7 @@ namespace GAME
     struct MemoryFrame
     {
       DeltaPairVector buffer;
-      uint64_t        frameHistoryCount;
+      uint64_t frameHistoryCount;
     };
 
     std::deque<MemoryFrame> m_rewindBuffer;

--- a/xbmc/games/addons/savestates/DeltaPairMemoryStream.h
+++ b/xbmc/games/addons/savestates/DeltaPairMemoryStream.h
@@ -40,13 +40,13 @@ namespace GAME
 
     // implementation of IMemoryStream via CLinearMemoryStream
     virtual void         Reset() override;
-    virtual unsigned int PastFramesAvailable() const override;
-    virtual unsigned int RewindFrames(unsigned int frameCount) override;
+    virtual uint64_t PastFramesAvailable() const override;
+    virtual uint64_t RewindFrames(uint64_t frameCount) override;
 
   protected:
     // implementation of CLinearMemoryStream
     virtual void SubmitFrameInternal() override;
-    virtual void CullPastFrames(unsigned int frameCount) override;
+    virtual void CullPastFrames(uint64_t frameCount) override;
 
     /*!
      * Rewinding is implemented by applying XOR deltas on the specific parts of

--- a/xbmc/games/addons/savestates/IMemoryStream.h
+++ b/xbmc/games/addons/savestates/IMemoryStream.h
@@ -62,7 +62,7 @@ namespace GAME
      * \param frameSize The size of the serialized memory state
      * \param maxFrameCount The maximum number of frames this steam can hold
      */
-    virtual void Init(size_t frameSize, size_t maxFrameCount) = 0;
+    virtual void Init(size_t frameSize, uint64_t maxFrameCount) = 0;
 
     /*!
      * \brief Free any resources used by this stream
@@ -77,14 +77,14 @@ namespace GAME
     /*!
      * \brief Return the current max frame count
      */
-    virtual unsigned int MaxFrameCount() const = 0;
+    virtual uint64_t MaxFrameCount() const = 0;
 
     /*!
      * \brief Update the max frame count
      *
      * Old frames may be deleted if the max frame count is reduced.
      */
-    virtual void SetMaxFrameCount(size_t maxFrameCount) = 0;
+    virtual void SetMaxFrameCount(uint64_t maxFrameCount) = 0;
 
     /*!
      * \ brief Get a pointer to which FrameSize() bytes can be written
@@ -116,26 +116,26 @@ namespace GAME
      * If the stream supports forward seeking, frames that are passed over
      * during a "rewind" operation can be recovered again.
      */
-    virtual unsigned int FutureFramesAvailable() const = 0;
+    virtual uint64_t FutureFramesAvailable() const = 0;
 
     /*!
      * \brief Seek ahead the specified number of frames
      *
      * \return The number of frames advanced
      */
-    virtual unsigned int AdvanceFrames(unsigned int frameCount) = 0;
+    virtual uint64_t AdvanceFrames(uint64_t frameCount) = 0;
 
     /*!
      * \brief Return the number of frames behind the current frame
      */
-    virtual unsigned int PastFramesAvailable() const = 0;
+    virtual uint64_t PastFramesAvailable() const = 0;
 
     /*!
      * \brief Seek backwards the specified number of frames
      *
      * \return The number of frames rewound
      */
-    virtual unsigned int RewindFrames(unsigned int frameCount) = 0;
+    virtual uint64_t RewindFrames(uint64_t frameCount) = 0;
 
     /*!
      * \brief Get the total number of frames played until the current frame

--- a/xbmc/games/addons/savestates/LinearMemoryStream.cpp
+++ b/xbmc/games/addons/savestates/LinearMemoryStream.cpp
@@ -31,7 +31,7 @@ CLinearMemoryStream::CLinearMemoryStream()
   Reset();
 }
 
-void CLinearMemoryStream::Init(size_t frameSize, size_t maxFrameCount)
+void CLinearMemoryStream::Init(size_t frameSize, uint64_t maxFrameCount)
 {
   Reset();
 
@@ -52,7 +52,7 @@ void CLinearMemoryStream::Reset()
   m_currentFrameHistory = 0;
 }
 
-void CLinearMemoryStream::SetMaxFrameCount(size_t maxFrameCount)
+void CLinearMemoryStream::SetMaxFrameCount(uint64_t maxFrameCount)
 {
   if (maxFrameCount == 0)
   {
@@ -60,7 +60,7 @@ void CLinearMemoryStream::SetMaxFrameCount(size_t maxFrameCount)
   }
   else
   {
-    const unsigned int frameCount = BufferSize();
+    const uint64_t frameCount = BufferSize();
     if (maxFrameCount < frameCount)
       CullPastFrames(frameCount - maxFrameCount);
   }
@@ -110,7 +110,7 @@ void CLinearMemoryStream::SubmitFrame()
   }
 }
 
-unsigned int CLinearMemoryStream::BufferSize() const
+uint64_t CLinearMemoryStream::BufferSize() const
 {
   return PastFramesAvailable() + (m_bHasCurrentFrame ? 1 : 0);
 }

--- a/xbmc/games/addons/savestates/LinearMemoryStream.h
+++ b/xbmc/games/addons/savestates/LinearMemoryStream.h
@@ -22,6 +22,7 @@
 #include "IMemoryStream.h"
 
 #include <memory>
+#include <stdint.h>
 
 namespace KODI
 {
@@ -35,30 +36,30 @@ namespace GAME
     virtual ~CLinearMemoryStream() = default;
 
     // partial implementation of IMemoryStream
-    virtual void           Init(size_t frameSize, size_t maxFrameCount) override;
+    virtual void Init(size_t frameSize, uint64_t maxFrameCount) override;
     virtual void           Reset() override;
     virtual size_t         FrameSize() const override                      { return m_frameSize; }
-    virtual unsigned int   MaxFrameCount() const override                  { return m_maxFrames; }
-    virtual void           SetMaxFrameCount(size_t maxFrameCount) override;
+    virtual uint64_t MaxFrameCount() const override { return m_maxFrames; }
+    virtual void SetMaxFrameCount(uint64_t maxFrameCount) override;
     virtual uint8_t*       BeginFrame() override;
     virtual void           SubmitFrame() override;
     virtual const uint8_t* CurrentFrame() const override;
-    virtual unsigned int   FutureFramesAvailable() const override          { return 0; }
-    virtual unsigned int   AdvanceFrames(unsigned int frameCount) override { return 0; }
-    virtual unsigned int   PastFramesAvailable() const override = 0;
-    virtual unsigned int   RewindFrames(unsigned int frameCount) override = 0;
+    virtual uint64_t FutureFramesAvailable() const override { return 0; }
+    virtual uint64_t AdvanceFrames(uint64_t frameCount) override { return 0; }
+    virtual uint64_t PastFramesAvailable() const override = 0;
+    virtual uint64_t RewindFrames(uint64_t frameCount) override = 0;
     virtual uint64_t       GetFrameCounter() const override                { return m_currentFrameHistory; }
     virtual void           SetFrameCounter(uint64_t frameCount) override   { m_currentFrameHistory = frameCount; }
 
   protected:
     virtual void SubmitFrameInternal() = 0;
-    virtual void CullPastFrames(unsigned int frameCount) = 0;
+    virtual void CullPastFrames(uint64_t frameCount) = 0;
 
     // Helper function
-    unsigned int BufferSize() const;
+    uint64_t BufferSize() const;
 
     size_t m_paddedFrameSize;
-    unsigned int m_maxFrames;
+    uint64_t m_maxFrames;
 
     /**
      * Simple double-buffering. After XORing the two states, the next becomes

--- a/xbmc/games/addons/savestates/LinearMemoryStream.h
+++ b/xbmc/games/addons/savestates/LinearMemoryStream.h
@@ -37,19 +37,19 @@ namespace GAME
 
     // partial implementation of IMemoryStream
     virtual void Init(size_t frameSize, uint64_t maxFrameCount) override;
-    virtual void           Reset() override;
-    virtual size_t         FrameSize() const override                      { return m_frameSize; }
+    virtual void Reset() override;
+    virtual size_t FrameSize() const override { return m_frameSize; }
     virtual uint64_t MaxFrameCount() const override { return m_maxFrames; }
     virtual void SetMaxFrameCount(uint64_t maxFrameCount) override;
-    virtual uint8_t*       BeginFrame() override;
-    virtual void           SubmitFrame() override;
+    virtual uint8_t* BeginFrame() override;
+    virtual void SubmitFrame() override;
     virtual const uint8_t* CurrentFrame() const override;
     virtual uint64_t FutureFramesAvailable() const override { return 0; }
     virtual uint64_t AdvanceFrames(uint64_t frameCount) override { return 0; }
     virtual uint64_t PastFramesAvailable() const override = 0;
     virtual uint64_t RewindFrames(uint64_t frameCount) override = 0;
-    virtual uint64_t       GetFrameCounter() const override                { return m_currentFrameHistory; }
-    virtual void           SetFrameCounter(uint64_t frameCount) override   { m_currentFrameHistory = frameCount; }
+    virtual uint64_t GetFrameCounter() const override { return m_currentFrameHistory; }
+    virtual void SetFrameCounter(uint64_t frameCount) override { m_currentFrameHistory = frameCount; }
 
   protected:
     virtual void SubmitFrameInternal() = 0;
@@ -68,8 +68,8 @@ namespace GAME
      */
     std::unique_ptr<uint32_t[]> m_currentFrame;
     std::unique_ptr<uint32_t[]> m_nextFrame;
-    bool                        m_bHasCurrentFrame;
-    bool                        m_bHasNextFrame;
+    bool m_bHasCurrentFrame;
+    bool m_bHasNextFrame;
 
     uint64_t m_currentFrameHistory;
 

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -187,7 +187,7 @@ void CGUIWindowGames::GetContextButtons(int itemNumber, CContextButtons &buttons
   {
     if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->IsSourcesPath())
     {
-      // Context buttons for a sources path, like "Add source", "Remove Source", etc.
+      // Context buttons for a sources path, like "Add Source", "Remove Source", etc.
       CGUIDialogContextMenu::GetContextButtons("games", item, buttons);
     }
     else


### PR DESCRIPTION
This silences some compiler warnings by using a consistent size for frame counts and memory sizes. It also fixes some typos. Includes https://github.com/garbear/xbmc/pull/95.

## How Has This Been Tested?
Tested compile on windows. Warning count drops from 1,211 to 1,171. (don't let hudo see these numbers)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
