### PR TITLE
[guiinfo] Fix LISTITEM_RATING parameter handling.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6248,6 +6248,7 @@ int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop
     }
     else if (prop.name == "property" ||
              prop.name == "art" ||
+             prop.name == "rating" ||
              prop.name == "votes" ||
              prop.name == "ratingandvotes")
     {


### PR DESCRIPTION
Fixes another regression introduced with #13754 ...

Problem reported and fix confirmed in the forum https://forum.kodi.tv/showthread.php?tid=330696&pid=2739861#pid2739861

@Jalle19 mind taking a look.