### PR TITLE
[videoplayer] DVDDemux::GetStreamType(): Add more codecs and channel …

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -22,35 +22,66 @@
 
 std::string CDemuxStreamAudio::GetStreamType()
 {
-  char sInfo[64] = {0};
-
-  if (codec == AV_CODEC_ID_AC3) strcpy(sInfo, "AC3 ");
-  else if (codec == AV_CODEC_ID_DTS)
+  std::string strInfo;
+  switch (codec)
   {
+  case AV_CODEC_ID_AC3:
+    strInfo = "AC3 ";
+    break;
+  case AV_CODEC_ID_EAC3:
+    strInfo = "DD+ ";
+    break;
+  case AV_CODEC_ID_DTS:
+  {
+    switch (profile)
+    {
 #ifdef FF_PROFILE_DTS_HD_MA
-    if (profile == FF_PROFILE_DTS_HD_MA)
-      strcpy(sInfo, "DTS-HD MA ");
-    else if (profile == FF_PROFILE_DTS_HD_HRA)
-      strcpy(sInfo, "DTS-HD HRA ");
-    else
+    case FF_PROFILE_DTS_HD_MA:
+      strInfo = "DTS-HD MA ";
+      break;
+    case FF_PROFILE_DTS_HD_HRA:
+      strInfo = "DTS-HD HRA ";
+      break;
 #endif
-      strcpy(sInfo, "DTS ");
+    default:
+      strInfo = "DTS ";
+      break;
+    }
+    break;
   }
-  else if (codec == AV_CODEC_ID_MP2) strcpy(sInfo, "MP2 ");
-  else if (codec == AV_CODEC_ID_TRUEHD) strcpy(sInfo, "Dolby TrueHD ");
-  else strcpy(sInfo, "");
+  case AV_CODEC_ID_MP2:
+    strInfo = "MP2 ";
+    break;
+  case AV_CODEC_ID_MP3:
+    strInfo = "MP3 ";
+    break;
+  case AV_CODEC_ID_TRUEHD:
+    strInfo = "TrueHD ";
+    break;
+  case AV_CODEC_ID_AAC:
+    strInfo = "AAC ";
+    break;
+  case AV_CODEC_ID_ALAC:
+    strInfo = "ALAC ";
+    break;
+  case AV_CODEC_ID_FLAC:
+    strInfo = "FLAC ";
+    break;
+  case AV_CODEC_ID_VORBIS:
+    strInfo = "Vorbis ";
+    break;
+  case AV_CODEC_ID_PCM_BLURAY:
+  case AV_CODEC_ID_PCM_DVD:
+    strInfo = "PCM ";
+    break;
+  default:
+    strInfo = "";
+    break;
+  }
 
-  if (iChannels == 1) strcat(sInfo, "Mono");
-  else if (iChannels == 2) strcat(sInfo, "Stereo");
-  else if (iChannels == 6) strcat(sInfo, "5.1");
-  else if (iChannels == 8) strcat(sInfo, "7.1");
-  else if (iChannels != 0)
-  {
-    char temp[32];
-    sprintf(temp, " %d%s", iChannels, "-chs");
-    strcat(sInfo, temp);
-  }
-  return sInfo;
+  strInfo += m_channelLayoutName;
+
+  return strInfo;
 }
 
 int CDVDDemux::GetNrOfStreams(StreamType streamType)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -35,14 +35,12 @@ std::string CDemuxStreamAudio::GetStreamType()
   {
     switch (profile)
     {
-#ifdef FF_PROFILE_DTS_HD_MA
     case FF_PROFILE_DTS_HD_MA:
       strInfo = "DTS-HD MA ";
       break;
     case FF_PROFILE_DTS_HD_HRA:
       strInfo = "DTS-HD HRA ";
       break;
-#endif
     default:
       strInfo = "DTS ";
       break;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -191,6 +191,7 @@ public:
   int iBitRate;
   int iBitsPerSample;
   uint64_t iChannelLayout;
+  std::string m_channelLayoutName;
 };
 
 class CDemuxStreamSubtitle : public CDemuxStream

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1443,6 +1443,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
         st->iBitsPerSample = pStream->codecpar->bits_per_raw_sample;
         st->iChannelLayout = pStream->codecpar->channel_layout;
+        char buf[32] = { 0 };
+        av_get_channel_layout_string(buf, 31, st->iChannels, st->iChannelLayout);
+        st->m_channelLayoutName = buf;
         if (st->iBitsPerSample == 0)
           st->iBitsPerSample = pStream->codecpar->bits_per_coded_sample;
   

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1831,7 +1831,6 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
   std::string strName;
   if (stream)
   {
-#ifdef FF_PROFILE_DTS_HD_MA
     /* use profile to determine the DTS type */
     if (stream->codec == AV_CODEC_ID_DTS)
     {
@@ -1844,7 +1843,6 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
 
       return strName;
     }
-#endif
 
     AVCodec *codec = avcodec_find_decoder(stream->codec);
     if (codec)


### PR DESCRIPTION
The motivation was that E-AC3 (DD+) was missing. The layout names are take from 
https://ffmpeg.org/doxygen/4.0/channel__layout_8c.html#a5fb8d8660239f03323dae7e7c1699f29
Additionally I've renamed Dolby TrueHD to TrueHD

If desired I could strip of the strings in bracket,