### PR TITLE
[PVR] PVRGUIInfo: Fix clock format handling for PVR.Timeshift(Start|End|Play)Time and PVR.EpgEventFinishTime.

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1475,14 +1475,14 @@ std::string CDateTime::GetAsLocalizedDateTime(bool longDate/*=false*/, bool with
   return GetAsLocalizedDate(longDate) + ' ' + GetAsLocalizedTime("", withSeconds);
 }
 
-std::string CDateTime::GetAsLocalizedTime(TIME_FORMAT format) const
+std::string CDateTime::GetAsLocalizedTime(TIME_FORMAT format, bool withSeconds /* = false */) const
 {
   const std::string timeFormat = g_langInfo.GetTimeFormat();
   bool use12hourclock = timeFormat.find('h') != std::string::npos;
   switch (format)
   {
     case TIME_FORMAT_GUESS:
-      return GetAsLocalizedTime("", false);
+      return GetAsLocalizedTime("", withSeconds);
     case TIME_FORMAT_SS:
       return GetAsLocalizedTime("ss", true);
     case TIME_FORMAT_MM:

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -212,7 +212,7 @@ public:
   std::string GetAsLocalizedDate(const std::string &strFormat) const;
   std::string GetAsLocalizedTime(const std::string &format, bool withSeconds=true) const;
   std::string GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
-  std::string GetAsLocalizedTime(TIME_FORMAT format) const;
+  std::string GetAsLocalizedTime(TIME_FORMAT format, bool withSeconds = false) const;
   std::string GetAsRFC1123DateTime() const;
   std::string GetAsW3CDate() const;
   std::string GetAsW3CDateTime(bool asUtc = false) const;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1389,33 +1389,27 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem *item, const CGUIInfo &info, b
 
 namespace
 {
-  int TimeFromDateTime(time_t datetime)
+  std::string TimeToTimeString(time_t datetime, TIME_FORMAT format, bool withSeconds)
   {
     CDateTime time;
     time.SetFromUTCDateTime(datetime);
-    return time.GetHour() * 60 * 60 + time.GetMinute() * 60 + time.GetSecond();
+    return time.GetAsLocalizedTime(format, withSeconds);
   }
 } // unnamed namespace
 
 void CPVRGUIInfo::CharInfoTimeshiftStartTime(TIME_FORMAT format, std::string &strValue) const
 {
-  if (format == TIME_FORMAT_GUESS)
-    format = TIME_FORMAT_HH_MM;
-
-  strValue = StringUtils::SecondsToTimeString(TimeFromDateTime(m_iTimeshiftStartTime), format).c_str();
+  strValue = TimeToTimeString(m_iTimeshiftStartTime, format, false);
 }
 
 void CPVRGUIInfo::CharInfoTimeshiftEndTime(TIME_FORMAT format, std::string &strValue) const
 {
-  if (format == TIME_FORMAT_GUESS)
-    format = TIME_FORMAT_HH_MM;
-
-  strValue = StringUtils::SecondsToTimeString(TimeFromDateTime(m_iTimeshiftEndTime), format).c_str();
+  strValue = TimeToTimeString(m_iTimeshiftEndTime, format, false);
 }
 
 void CPVRGUIInfo::CharInfoTimeshiftPlayTime(TIME_FORMAT format, std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString(TimeFromDateTime(m_iTimeshiftPlayTime), format).c_str();
+  strValue = TimeToTimeString(m_iTimeshiftPlayTime, format, true);
 }
 
 void CPVRGUIInfo::CharInfoTimeshiftOffset(TIME_FORMAT format, std::string &strValue) const
@@ -1466,12 +1460,9 @@ void CPVRGUIInfo::CharInfoEpgEventRemainingTime(const CFileItem *item, TIME_FORM
 
 void CPVRGUIInfo::CharInfoEpgEventFinishTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
-  if (format == TIME_FORMAT_GUESS)
-    format = TIME_FORMAT_HH_MM;
-
   CDateTime finish = CDateTime::GetCurrentDateTime();
   finish += CDateTimeSpan(0, 0, 0, GetRemainingTime(item));
-  strValue = StringUtils::SecondsToTimeString(finish.GetHour() * 60 * 60 + finish.GetMinute() * 60 + finish.GetSecond(), format).c_str();
+  strValue = finish.GetAsLocalizedTime(format);
 }
 
 void CPVRGUIInfo::CharInfoBackendNumber(std::string &strValue) const


### PR DESCRIPTION
Before:

![screenshot001](https://user-images.githubusercontent.com/3226626/40864389-e8a16d56-65f3-11e8-821f-be9f7a01ca28.png)

After:

![screenshot000](https://user-images.githubusercontent.com/3226626/40864400-f06dc9ee-65f3-11e8-931e-6f04a9564239.png)

runtime-tested on latest kodi master, macOS

@Jalle19 for review?
