### PR TITLE
[guiinfo] Fix: 'Skin.String(string1, string2)' did not work if string2 was empty.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6056,9 +6056,9 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         if (prop.name == "string")
         {
           if (prop.num_params() == 2)
-            return AddMultiInfo(CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0)), prop.param(1)));
+            return AddMultiInfo(CGUIInfo(SKIN_STRING_IS_EQUAL, CSkinSettings::GetInstance().TranslateString(prop.param(0)), prop.param(1)));
           else
-            return AddMultiInfo(CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
+            return AddMultiInfo(CGUIInfo(SKIN_STRING_NOT_EMPTY, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
         if (prop.name == "hassetting")
           return AddMultiInfo(CGUIInfo(SKIN_BOOL, CSkinSettings::GetInstance().TranslateBool(prop.param(0))));

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -360,6 +360,8 @@
 
 #define SKIN_BOOL                   600
 #define SKIN_STRING                 601
+#define SKIN_STRING_IS_EQUAL        602
+#define SKIN_STRING_NOT_EMPTY       603
 #define SKIN_THEME                  604
 #define SKIN_COLOUR_THEME           605
 #define SKIN_HAS_THEME              606

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
@@ -106,12 +106,14 @@ bool CSkinGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWi
       value = CSkinSettings::GetInstance().GetBool(info.GetData1());
       return true;
     }
-    case SKIN_STRING:
+    case SKIN_STRING_IS_EQUAL:
     {
-      if (!info.GetData3().empty())
-        value = StringUtils::EqualsNoCase(CSkinSettings::GetInstance().GetString(info.GetData1()), info.GetData3());
-      else
-        value = !CSkinSettings::GetInstance().GetString(info.GetData1()).empty();
+      value = StringUtils::EqualsNoCase(CSkinSettings::GetInstance().GetString(info.GetData1()), info.GetData3());
+      return true;
+    }
+    case SKIN_STRING_NOT_EMPTY:
+    {
+      value = !CSkinSettings::GetInstance().GetString(info.GetData1()).empty();
       return true;
     }
     case SKIN_HAS_THEME:


### PR DESCRIPTION
Fixes yet another (really edge case) regression introduced with #13754 ...

Problem was reported in the forum https://forum.kodi.tv/showthread.php?tid=330696&pid=2740140#pid2740140

@Jalle19 mind taking a look.