### PR TITLE
Tone Mapping: Workaround real life

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -210,7 +210,7 @@ void COutputShader::ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWid
   }
   if (m_toneMapping)
   {
-    float param = 0.5;
+    float param = 0.7;
     if (m_hasLightMetadata)
       param = log10(100) / log10(m_lightMetadata.MaxCLL);
     else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -216,6 +216,10 @@ void COutputShader::ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWid
     else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)
       param = log10(100) / log10(m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den);
 
+    // Sanity check
+    if (param < 0.1f || param > 5.0f)
+      param = 0.7f;
+
     param *= m_toneMappingParam;
 
     float coefs[3];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -170,7 +170,7 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
 
   if (m_toneMapping)
   {
-    float param = 0.5;
+    float param = 0.7;
     if (m_hasLightMetadata)
       param = log10(100) / log10(m_lightMetadata.MaxCLL);
     else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -176,6 +176,10 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
     else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)
       param = log10(100) / log10(m_displayMetadata.max_luminance.num/m_displayMetadata.max_luminance.den);
 
+    // Sanity check
+    if (param < 0.1f || param > 5.0f)
+      param = 0.7f;
+
     param *= m_toneMappingParam;
 
     float coefs[3];


### PR DESCRIPTION
There are some semi broken samples out there, e.g. http://www.4ktv.de/sony-camp-2016-hdr-version-download/

Implement a sanity check and also use a different default (if no metadata is set) to not hide details by default.