### PR TITLE
GUIDialogSubtitles: close SUBTITLE_OSD_SETTINGS after a subtitle download

### DIFF
--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -171,6 +171,11 @@
  */
 #define GUI_MSG_STATE_CHANGED  51
 
+/*!
+ \brief Called when a subtitle download has finished
+ */
+#define GUI_MSG_SUBTITLE_DOWNLOADED  52
+
 
 #define GUI_MSG_USER         1000
 

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -79,6 +79,15 @@ void CGUIDialogSubtitleSettings::FrameMove()
   CGUIDialogSettingsManualBase::FrameMove();
 }
 
+bool CGUIDialogSubtitleSettings::OnMessage(CGUIMessage& message)
+{
+  if (message.GetMessage() == GUI_MSG_SUBTITLE_DOWNLOADED)
+  {
+    Close();
+  }
+  return CGUIDialogSettingsManualBase::OnMessage(message);
+}
+
 void CGUIDialogSubtitleSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 {
   if (setting == NULL)

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
@@ -34,6 +34,7 @@ class CGUIDialogSubtitleSettings : public CGUIDialogSettingsManualBase
 public:
   CGUIDialogSubtitleSettings();
   ~CGUIDialogSubtitleSettings() override;
+  bool OnMessage(CGUIMessage& message) override;
 
   // specialization of CGUIWindow
   void FrameMove() override;

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -30,7 +30,9 @@
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
 #include "settings/Settings.h"
@@ -575,6 +577,10 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
     }
   }
 
+  // Notify window manager that a subtitle was downloaded
+  CGUIMessage msg(GUI_MSG_SUBTITLE_DOWNLOADED, 0, 0);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  
   // Close the window
   Close();
 }


### PR DESCRIPTION
## Description
This pull request makes the subtitle download dialog close the subtitle OSD settings dialog (`WINDOW_DIALOG_SUBTITLE_OSD_SETTINGS`) after a subtitle download is successful.  

## Motivation and Context
In Krypton, the subtitle download dialog was started directly from the video OSD. As a result, the video was paused before downloading a subtitle and resumed after the download. When the download was successful, the subtitle download dialog was closed and we were back on the OSD window watching the video file along with the downloaded subtitles.

In Leia the subtitle download dialog is started from the subtitle settings dialog. So, when we download a subtitle, the video is resumed but we are left with the subtitles settings window in front of it. Any adjustment to the subtitle (or even the download of a new subtitle) is only possible after the user has effectively watched a bit of the media file along with the subtitle. Having the dialog on top of the video OSD (plus the dim overlay) does not seem correct (and requires an additional remote click to be closed).

This is my attempt to implement my own feature request (see: https://forum.kodi.tv/showthread.php?tid=331122). It received a few +1 from other users.

## How Has This Been Tested?
Runtime tested on OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
