### PR TITLE
windowing/gbm: set fullscreen flag and other small fixes

### DIFF
--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -174,7 +174,7 @@ void CDRMAtomic::DestroyDrm()
   m_req = nullptr;
 }
 
-bool CDRMAtomic::SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo)
+bool CDRMAtomic::SetVideoMode(RESOLUTION_INFO& res, struct gbm_bo *bo)
 {
   m_need_modeset = true;
 

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -28,7 +28,7 @@ public:
   CDRMAtomic() = default;
   ~CDRMAtomic() { DestroyDrm(); };
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override;
-  virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
+  virtual bool SetVideoMode(RESOLUTION_INFO& res, struct gbm_bo *bo) override;
   virtual bool SetActive(bool active) override;
   virtual bool InitDrm() override;
   virtual void DestroyDrm() override;

--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -38,7 +38,7 @@
 
 static int flip_happening = 0;
 
-bool CDRMLegacy::SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo)
+bool CDRMLegacy::SetVideoMode(RESOLUTION_INFO& res, struct gbm_bo *bo)
 {
   struct drm_fb *drm_fb = DrmFbGetFromBo(bo);
 

--- a/xbmc/windowing/gbm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/DRMLegacy.h
@@ -28,7 +28,7 @@ public:
   CDRMLegacy() = default;
   ~CDRMLegacy() { DestroyDrm(); };
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override;
-  virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
+  virtual bool SetVideoMode(RESOLUTION_INFO& res, struct gbm_bo *bo) override;
   virtual bool SetActive(bool active) override;
   virtual bool InitDrm() override;
 

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -193,7 +193,7 @@ bool CDRMUtils::SetProperty(struct drm_object *object, const char *name, uint64_
   if (!property_id)
     return false;
 
-  if (drmModeObjectSetProperty(m_fd, object->id, object->type, property_id, value))
+  if (drmModeObjectSetProperty(m_fd, object->id, object->type, property_id, value) < 0)
   {
     CLog::Log(LOGERROR, "CDRMUtils::%s - could not set property %s", __FUNCTION__, name);
     return false;

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -53,7 +53,7 @@ void CDRMUtils::WaitVBlank()
   drmWaitVBlank(m_fd, &vbl);
 }
 
-bool CDRMUtils::SetMode(RESOLUTION_INFO res)
+bool CDRMUtils::SetMode(RESOLUTION_INFO& res)
 {
   m_mode = &m_connector->connector->modes[atoi(res.strId.c_str())];
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -69,7 +69,7 @@ public:
   CDRMUtils();
   virtual ~CDRMUtils() = default;
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) {};
-  virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) { return false; };
+  virtual bool SetVideoMode(RESOLUTION_INFO& res, struct gbm_bo *bo) { return false; };
   virtual bool SetActive(bool active) { return false; };
   virtual bool InitDrm();
   virtual void DestroyDrm();
@@ -78,7 +78,7 @@ public:
   std::string GetDevicePath() const { return m_device_path; }
 
   bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
-  bool SetMode(RESOLUTION_INFO res);
+  bool SetMode(RESOLUTION_INFO& res);
   void WaitVBlank();
 
   bool AddProperty(drmModeAtomicReqPtr req, struct drm_object *object, const char *name, uint64_t value);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -215,7 +215,11 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   }
 
   auto result = m_DRM->SetVideoMode(res, bo);
-  m_GBM->ReleaseBuffer();
+
+  if (!m_DRM->m_req)
+  {
+    m_GBM->ReleaseBuffer();
+  }
 
   int delay = CServiceBroker::GetSettings().GetInt("videoscreen.delayrefreshchange");
   if (delay > 0)

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -138,6 +138,8 @@ bool CWinSystemGbm::CreateNewWindow(const std::string& name,
     return false;
   }
 
+  m_bFullScreen = fullScreen;
+
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - initialized GBM", __FUNCTION__);
   return true;
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -52,6 +52,7 @@ public:
   void FlipPage(bool rendered, bool videoLayer);
   void WaitVBlank();
 
+  bool CanDoWindowed() override { return false; }
   void UpdateResolutions() override;
 
   bool UseLimitedColor() override;


### PR DESCRIPTION
## Description
This PR updates fullscreen flag and signals that gbm cannot do windowed, makes resolution show as full screen in system information

It also contains some nit-pick fixes:
- fix DRMUtils SetProperty error check to be more future proof
- keep buffer locking and release calls even in SetFullScreen
- pass RESOLUTION_INFO by reference like other windowing systems

## Motivation and Context
Show resolution as full screen in system information

## How Has This Been Tested?
Running Kodi on Rock64 + LibreELEC

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
