### PR TITLE
RendererDRMPRIME: release video buffers after flush

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -83,7 +83,7 @@ class CVideoBufferPoolDRMPRIME
   : public IVideoBufferPool
 {
 public:
-  ~CVideoBufferPoolDRMPRIME() override;
+  ~CVideoBufferPoolDRMPRIME();
   void Return(int id) override;
   CVideoBuffer* Get() override;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -363,11 +363,12 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
     pVideoPicture->iDisplayHeight = ((int)lrint(pVideoPicture->iWidth / aspect_ratio)) & -3;
   }
 
-  pVideoPicture->color_range = m_pFrame->color_range;
+  pVideoPicture->color_range = m_pFrame->color_range == AVCOL_RANGE_JPEG ? 1 : 0;
   pVideoPicture->color_primaries = m_pFrame->color_primaries;
   pVideoPicture->color_transfer = m_pFrame->color_trc;
   pVideoPicture->color_space = m_pFrame->colorspace;
 
+  pVideoPicture->iRepeatPicture = 0;
   pVideoPicture->iFlags = 0;
   pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
   pVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST: 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -37,7 +37,7 @@ class CVideoBufferDRMPRIME
 {
 public:
   CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id);
-  virtual ~CVideoBufferDRMPRIME();
+  ~CVideoBufferDRMPRIME();
   void SetRef(AVFrame* frame);
   void Unref();
 
@@ -57,7 +57,7 @@ class CDVDVideoCodecDRMPRIME
 {
 public:
   explicit CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo);
-  ~CDVDVideoCodecDRMPRIME() override;
+  ~CDVDVideoCodecDRMPRIME();
 
   static CDVDVideoCodec* Create(CProcessInfo& processInfo);
   static void Register();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -78,6 +78,12 @@ bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsign
 void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, double currentClock)
 {
   BUFFER& buf = m_buffers[index];
+
+  // delay Release of videoBuffer after a Flush call to prevent drmModeRmFB of a videoBuffer tied to a drm plane
+  // TODO: move Release to Flush once current videoBuffer tied to a drm plane is reference counted
+  if (buf.videoBuffer)
+    buf.videoBuffer->Release();
+
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
 }
@@ -90,14 +96,17 @@ void CRendererDRMPRIME::Reset()
   m_iLastRenderBuffer = -1;
 }
 
+void CRendererDRMPRIME::Flush()
+{
+  m_iLastRenderBuffer = -1;
+}
+
 void CRendererDRMPRIME::ReleaseBuffer(int index)
 {
   BUFFER& buf = m_buffers[index];
   if (buf.videoBuffer)
   {
-    CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
-    if (buffer)
-      buffer->Release();
+    buf.videoBuffer->Release();
     buf.videoBuffer = nullptr;
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -29,7 +29,7 @@ class CRendererDRMPRIME
 {
 public:
   CRendererDRMPRIME(std::shared_ptr<CDRMUtils> drm);
-  virtual ~CRendererDRMPRIME();
+  ~CRendererDRMPRIME();
 
   // Registration
   static CBaseRenderer* Create(CVideoBuffer* buffer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -40,6 +40,7 @@ public:
   bool IsConfigured() override { return m_bConfigured; };
   void AddVideoPicture(const VideoPicture& picture, int index, double currentClock) override;
   void UnInit() override {};
+  void Flush() override;
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
   bool IsGuiLayer() override { return false; };


### PR DESCRIPTION
## Description
This PR fixes a leak of AVFrame (video buffers) and stalled video using RendererDRMPRIME.

## Motivation and Context
Fixes video buffer and video buffer pool leak after render manager makes a Flush call.
Also fixes stalled video after a Flush call or use of uninitialized iRepeatPicture.

~~Unusual nextFramePts can be seen in A/V timing debug logs even when video codec always set proper pts.
`nextFramePts: 5714210702664009105337883776014638214130495562162101884065277216588220643083327355436890770015766941100908080523945603259752984551726898686331406795657880409056094484939032126274458472512670320569807338447004032694277645696292734360182499080257922924544.000000`
`nextFramePts: -3429978449449829381157260441441042040285482044900332944707601209004516666209880432582333383265363956854653933465998316116411007460523207625177359482136722347997097235720548778890900365580714573089773857218111323294232445263896076015828865810779407894771138560000.000000`~~

~~`CVideoBuffer: initialize members` should probably fix same issue as seen in https://github.com/xbmc/xbmc/pull/13594~~

ping @lrusak @FernetMenta @popcornmix

## How Has This Been Tested?
Playing mpeg2 and other videos on my Rock64 + LibreELEC

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
