### PR TITLE
Add CGUIViewStateFromItems::AutoPlay feature for Videos

### DIFF
--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -587,6 +587,19 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
   LoadViewState(items.GetPath(), CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());
 }
 
+bool CGUIViewStateFromItems::AutoPlayNextItem()
+{
+  if (m_items.GetContent() == "musicvideos" ||
+    m_items.GetContent() == "tvshows" ||
+    m_items.GetContent() == "episodes" ||
+    m_items.GetContent() == "movies")
+  {
+    return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM);
+  }
+
+  return false;
+}
+
 void CGUIViewStateFromItems::SaveViewState()
 {
   SaveViewToDb(m_items.GetPath(), CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -119,6 +119,7 @@ class CGUIViewStateFromItems : public CGUIViewState
 {
 public:
   explicit CGUIViewStateFromItems(const CFileItemList& items);
+  bool AutoPlayNextItem() override;
 
 protected:
   void SaveViewState() override;


### PR DESCRIPTION
## Description
For listItem's from addons "Player::PlayNext" is not working.
Reason is that  CGUIViewStateFromItems is selected because addon listItem directories contain sometimes own sort options.
 
Using this PR the Settings::Player::PlayNext is working

## Motivation and Context
1.) Be able to continue seasons without user interaction
2.) Allow skipping to next season (SkipNext command)

## How Has This Been Tested?
Win10 / amazon addon / select any serie

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
