### PR TITLE
[guiinfo] Fix after 2cef6e4 - skin.string label broken

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6058,7 +6058,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           if (prop.num_params() == 2)
             return AddMultiInfo(CGUIInfo(SKIN_STRING_IS_EQUAL, CSkinSettings::GetInstance().TranslateString(prop.param(0)), prop.param(1)));
           else
-            return AddMultiInfo(CGUIInfo(SKIN_STRING_NOT_EMPTY, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
+            return AddMultiInfo(CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
         if (prop.name == "hassetting")
           return AddMultiInfo(CGUIInfo(SKIN_BOOL, CSkinSettings::GetInstance().TranslateBool(prop.param(0))));

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -361,7 +361,6 @@
 #define SKIN_BOOL                   600
 #define SKIN_STRING                 601
 #define SKIN_STRING_IS_EQUAL        602
-#define SKIN_STRING_NOT_EMPTY       603
 #define SKIN_THEME                  604
 #define SKIN_COLOUR_THEME           605
 #define SKIN_HAS_THEME              606

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
@@ -111,7 +111,7 @@ bool CSkinGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWi
       value = StringUtils::EqualsNoCase(CSkinSettings::GetInstance().GetString(info.GetData1()), info.GetData3());
       return true;
     }
-    case SKIN_STRING_NOT_EMPTY:
+    case SKIN_STRING:
     {
       value = !CSkinSettings::GetInstance().GetString(info.GetData1()).empty();
       return true;


### PR DESCRIPTION
Problem was reported and fix confirmed in the forum https://forum.kodi.tv/showthread.php?tid=330696&pid=2740760#pid2740760