### PR TITLE
Add cryptoSession when comparing hints (DVDStreamInfo)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -21,6 +21,7 @@
 #include "DVDStreamInfo.h"
 
 #include "DVDDemuxers/DVDDemux.h"
+#include "cores/VideoPlayer/Interface/Addon/DemuxCrypto.h"
 
 CDVDStreamInfo::CDVDStreamInfo()                                                     { extradata = NULL; Clear(); }
 CDVDStreamInfo::CDVDStreamInfo(const CDVDStreamInfo &right, bool withextradata )     { extradata = NULL; Clear(); Assign(right, withextradata); }
@@ -123,6 +124,13 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
     return false;
 
   // SUBTITLE
+
+  // Crypto
+  if ((cryptoSession.get() == nullptr) != (right.cryptoSession.get() == nullptr))
+    return false;
+
+  if (cryptoSession && !(*cryptoSession.get() == *right.cryptoSession.get()))
+    return false;
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/Interface/Addon/DemuxCrypto.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/DemuxCrypto.h
@@ -48,6 +48,13 @@ struct DemuxCryptoSession
     delete[] sessionId;
   }
 
+  bool operator == (const DemuxCryptoSession &other) const
+  {
+    return sessionIdSize == other.sessionIdSize &&
+      keySystem == other.keySystem &&
+      memcmp(sessionId, other.sessionId, sessionIdSize) == 0;
+  };
+
   // encryped stream infos
   char * sessionId;
   uint16_t sessionIdSize;


### PR DESCRIPTION
## Description
When switching to another stream with same video properties as currently running one, the current decoder is reused. This fails for encrypted media if the new stream requres a separate crypto session.

This PR adds cryptoSession to the == / Equal operators to force decoder recreation on stream change.

## Motivation and Context
Switching between seasons (automatic / manual) lead to VP stall (black screen with running busy sign)

## How Has This Been Tested?
Win10 / amazon / any episode

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
