### PR TITLE
RetroPlayer: Fix left-shifted pixels on Windows

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -63,11 +63,11 @@ namespace RETRO
 
   private:
     bool CreateTexture();
-    uint8_t *GetTexture();
+    bool GetTexture(uint8_t*& data, unsigned int& stride);
     bool ReleaseTexture();
 
     bool CreateScalingContext();
-    void ScalePixels(uint8_t *source, size_t sourceSize, uint8_t *target, size_t targetSize);
+    void ScalePixels(uint8_t *source, unsigned int sourceStride, uint8_t *target, unsigned int targetStride);
 
     static AVPixelFormat GetPixFormat(DXGI_FORMAT dxFormat);
 


### PR DESCRIPTION
This fixes some emulators which broke after the UWP merge in #12942. Non-multiple-of-16 textures are now padded to 16 pixels. This broke games like 2048, which has a width of 376 (multiple of 8). DirectX would allocate a texture of width 384, causing successive lines of pixels to be left-shifted by 8 pixels.

We fix this by reading the resulting stride and passing it to swscale.

## Motivation and Context
Report: https://forum.kodi.tv/showthread.php?tid=173361&pid=2653394#pid2653394

## How Has This Been Tested?
Test builds: https://forum.kodi.tv/showthread.php?tid=173361

Tested 2048 on Windows 10 (see below).

## Screenshots (if appropriate):
Before:

![before](https://user-images.githubusercontent.com/531482/41018505-f2e8a8a6-690e-11e8-8bde-d8453cd3cb4f.png)

![after](https://user-images.githubusercontent.com/531482/41018508-f65e9d6a-690e-11e8-82be-dd54dfe8eb06.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
