### PR TITLE
CHelper_libXBMC_addon: Avoid buffer overflow in Log

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
@@ -203,14 +203,18 @@ namespace ADDON
      * @brief Add a message to XBMC's log.
      * @param loglevel The log level of the message.
      * @param format The format of the message to pass to XBMC.
+     * @note This method uses limited buffer (16k) for the formatted output.
+     * So data, which will not fit into it, will be silently discarded.
      */
     void Log(const addon_log_t loglevel, const char *format, ... )
     {
       char buffer[16384];
+      static constexpr size_t len = sizeof (buffer) - 1;
       va_list args;
       va_start (args, format);
-      vsprintf (buffer, format, args);
+      vsnprintf (buffer, len, format, args);
       va_end (args);
+      buffer[len] = '\0'; // to be sure it's null-terminated
       m_Callbacks->Log(m_Handle->addonData, loglevel, buffer);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description
<!--- Describe your change in detail -->
Simple change to avoid possible buffer overflow in log method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Do not allow plugin to crash kodi. E. g. kodi-pvr/pvr.iptvsimple#173

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
It builds and doesn't break API/ABI.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
