### PR TITLE
Refine Video::Autoplay options

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3,10 +3,22 @@
   <section id="player" label="14200" help="38100">
     <category id="videoplayer" label="14215" help="38103">
       <group id="1" label="14230">
-        <setting id="videoplayer.autoplaynextitem" type="boolean" label="13433" help="36152">
+        <setting id="videoplayer.autoplaynextitem" type="list[integer]" label="13433" help="36152">
+          <constraints>
+            <options>
+              <option label="20389">0</option> <!-- musicvideos -->
+              <option label="20343">1</option> <!-- tvshows -->
+              <option label="20360">2</option> <!-- episodes -->
+              <option label="20342">3</option> <!-- movies -->
+            </options>
+            <delimiter>,</delimiter>
+          </constraints>
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default></default>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+            <hidevalue>false</hidevalue>
+          </control>
         </setting>
         <setting id="videoplayer.seeksteps" type="list[integer]" label="13556" help="37042">
           <level>1</level>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -430,6 +430,11 @@ const std::string CSettings::SETTING_GAMES_ENABLE = "gamesgeneral.enable";
 const std::string CSettings::SETTING_GAMES_ENABLEREWIND = "gamesgeneral.enablerewind";
 const std::string CSettings::SETTING_GAMES_REWINDTIME = "gamesgeneral.rewindtime";
 
+const int CSettings::SETTING_AUTOPLAYNEXT_MUSICVIDEOS = 0;
+const int CSettings::SETTING_AUTOPLAYNEXT_TVSHOWS = 1;
+const int CSettings::SETTING_AUTOPLAYNEXT_EPISODES = 2;
+const int CSettings::SETTING_AUTOPLAYNEXT_MOVIES = 3;
+
 bool CSettings::Initialize()
 {
   CSingleLock lock(m_critical);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -383,6 +383,11 @@ public:
   static const std::string SETTING_GAMES_ENABLEREWIND;
   static const std::string SETTING_GAMES_REWINDTIME;
 
+  static const int SETTING_AUTOPLAYNEXT_MUSICVIDEOS;
+  static const int SETTING_AUTOPLAYNEXT_TVSHOWS;
+  static const int SETTING_AUTOPLAYNEXT_EPISODES;
+  static const int SETTING_AUTOPLAYNEXT_MOVIES;
+
   /*!
    \brief Creates a new settings wrapper around a new settings manager.
 

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -175,6 +175,14 @@ void CSettingsBase::UnregisterCallback(ISettingCallback* callback)
   m_settingsManager->UnregisterCallback(callback);
 }
 
+bool CSettingsBase::FindIntInList(const std::string &id, int value)
+{
+  if (id.empty())
+    return nullptr;
+
+  return m_settingsManager->FindIntInList(id, value);
+}
+
 SettingPtr CSettingsBase::GetSetting(const std::string& id) const
 {
   if (id.empty())

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -111,6 +111,15 @@ public:
   void UnregisterCallback(ISettingCallback* callback);
 
   /*!
+  \brief Search in a list of Ints for a given value.
+
+  \param id Setting identifier
+  \param value value to search for
+  \return True if value was found in list, false otherwise
+  */
+  bool FindIntInList(const std::string &id, int value);
+
+  /*!
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -714,6 +714,20 @@ bool CSettingsManager::SetList(const std::string &id, const std::vector< std::sh
   return std::static_pointer_cast<CSettingList>(setting)->SetValue(value);
 }
 
+bool CSettingsManager::FindIntInList(const std::string &id, int value)
+{
+  CSharedLock lock(m_settingsCritical);
+  SettingPtr setting = GetSetting(id);
+  if (setting == nullptr || setting->GetType() != SettingType::List)
+    return false;
+
+  for (auto item : std::static_pointer_cast<CSettingList>(setting)->GetValue())
+    if (item->GetType() == SettingType::Integer && std::static_pointer_cast<CSettingInt>(item)->GetValue() == value)
+      return true;
+
+  return false;
+}
+
 bool CSettingsManager::SetDefault(const std::string &id)
 {
   CSharedLock lock(m_settingsCritical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -416,6 +416,15 @@ public:
   bool SetList(const std::string &id, const std::vector< std::shared_ptr<CSetting> > &value);
 
   /*!
+   \brief Search in a list of Ints for a given value.
+
+   \param id Setting identifier
+   \param value value to search for
+   \return True if value was found in list, false otherwise
+  */
+  bool FindIntInList(const std::string &id, int value);
+
+  /*!
    \brief Sets the value of the setting to its default.
 
    \param id Setting identifier

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -398,7 +398,17 @@ bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
   if (params.GetContentType() == VIDEODB_CONTENT_MUSICVIDEOS || params.GetContentType() == 6) // recently added musicvideos
     return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICPLAYER_AUTOPLAYNEXTITEM);
 
-  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM);
+  int settingValue(-1);
+  if (m_items.GetContent() == "musicvideos")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_MUSICVIDEOS;
+  if (m_items.GetContent() == "tvshows")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_TVSHOWS;
+  if (m_items.GetContent() == "episodes")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_EPISODES;
+  if (m_items.GetContent() == "movies")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_MOVIES;
+
+  return settingValue >= 0 && CServiceBroker::GetSettings().FindIntInList(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM, settingValue);
 }
 
 CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileItemList& items) : CGUIViewStateWindowVideo(items)

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -589,15 +589,17 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
 
 bool CGUIViewStateFromItems::AutoPlayNextItem()
 {
-  if (m_items.GetContent() == "musicvideos" ||
-    m_items.GetContent() == "tvshows" ||
-    m_items.GetContent() == "episodes" ||
-    m_items.GetContent() == "movies")
-  {
-    return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM);
-  }
+  int settingValue(-1);
+  if (m_items.GetContent() == "musicvideos")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_MUSICVIDEOS;
+  if (m_items.GetContent() == "tvshows")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_TVSHOWS;
+  if (m_items.GetContent() == "episodes")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_EPISODES;
+  if (m_items.GetContent() == "movies")
+    settingValue = CSettings::SETTING_AUTOPLAYNEXT_MOVIES;
 
-  return false;
+  return settingValue >= 0 && CServiceBroker::GetSettings().FindIntInList(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM, settingValue);
 }
 
 void CGUIViewStateFromItems::SaveViewState()


### PR DESCRIPTION
## Description
see title

## Motivation and Context
Users want to have more control in regards of Autoplay.
For example Episodes should be continued, Movies not.

## How Has This Been Tested?
Win10 / amazon addon / enabled Episodes in Settings and:
- played Movise -> No Autoplay
- played Episode -> Autoplay works

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
