### PR TITLE
Games window: Fix error playing standalone cores

### DIFF
--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -33,6 +33,7 @@
 #include "guilib/WindowIDs.h"
 #include "GUIPassword.h"
 #include "input/Key.h"
+#include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -336,5 +337,6 @@ void CGUIWindowGames::OnItemInfo(int itemNumber)
 
 bool CGUIWindowGames::PlayGame(const CFileItem &item)
 {
-  return g_application.PlayFile(item, "");
+  CFileItem itemCopy(item);
+  return g_application.PlayMedia(itemCopy, "", PLAYLIST_NONE);
 }


### PR DESCRIPTION
This fixes standalone game add-ons, such as 2048 and Mr.Boom, launching from the Games -> Game Add-ons window.

## Motivation and Context
Reported here: https://github.com/garbear/xbmc/issues/92

## How Has This Been Tested?
Tested on Windows 10. 2048 launches from the following windows:

* Games tab on Home window
* Add-ons tab on Home window 
* Game add-ons tab on Add-ons window
* Add-on manager -> Game add-ons -> Standalone games -> 2048
* Games -> Game add-ons

## Screenshots (if appropriate):
Error message:

![errormsg](https://user-images.githubusercontent.com/531482/41063699-3c5b613e-698e-11e8-8567-c2e769f4e46f.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
