### PR TITLE
Games: Fix standalone games creating savestate files in app dir

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -308,7 +308,7 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
     return false;
   }
 
-  if (!InitializeGameplay(ID(), streamManager, input))
+  if (!InitializeGameplay("", streamManager, input))
     return false;
 
   return true;

--- a/xbmc/games/addons/savestates/SavestateWriter.cpp
+++ b/xbmc/games/addons/savestates/SavestateWriter.cpp
@@ -42,6 +42,13 @@ CSavestateWriter::~CSavestateWriter() = default;
 
 bool CSavestateWriter::Initialize(const CGameClient* gameClient, uint64_t frameHistoryCount)
 {
+  //! @todo Handle savestates for standalone game clients
+  if (gameClient->GetGamePath().empty())
+  {
+    CLog::Log(LOGERROR, "Savestates not implemented for standalone game clients");
+    return false;
+  }
+
   m_savestate.Reset();
   m_fps = 0.0;
 
@@ -59,8 +66,6 @@ bool CSavestateWriter::Initialize(const CGameClient* gameClient, uint64_t frameH
   m_savestate.SetPlaytimeWallClock(frameHistoryCount / m_fps); //! @todo Accumulate playtime instead of deriving it
 
   m_savestate.SetPath(CSavestateUtils::MakePath(m_savestate));
-  if (m_savestate.Path().empty())
-    CLog::Log(LOGDEBUG, "Failed to calculate savestate path");
 
   if (m_fps == 0.0)
     return false; // Sanity check


### PR DESCRIPTION
This fixes standalone game clients, such as 2048 and Mr.Boom, from creating savestate files in the app root.

Currently, we lack a savestate database, so savestates are created alongside ROMs. With standalone game clients there's no ROM, so prevent standalone savestates until we have a way of storing these.

## Motivation and Context
Reported here: https://github.com/garbear/xbmc/issues/93

## How Has This Been Tested?
Log output after applying fix:

```
DEBUG: RetroPlayer[PLAYER]: Closing file
ERROR: Savestates not implemented for standalone game clients
DEBUG: RetroPlayer[SAVE]: Failed to save state at close
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
