### PR TITLE
Refine Video::Autoplay options

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12636,6 +12636,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/media/MediaTypes.cpp
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#20342"
 msgid "Movies"
 msgstr ""
@@ -12646,6 +12647,7 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#20343"
 msgid "TV shows"
 msgstr ""
@@ -12738,6 +12740,7 @@ msgstr ""
 #: xbmc/playlists/SmartPlaylist.cpp
 #: addons/skin.estuary/xml/View_51_Poster.xml
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#20360"
 msgid "Episodes"
 msgstr ""
@@ -12880,6 +12883,7 @@ msgstr ""
 #: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
 #: xbmc/media/MediaTypes.cpp
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/view/GUIViewState.cpp
 msgctxt "#20389"
 msgid "Music videos"
 msgstr ""
@@ -13358,7 +13362,13 @@ msgctxt "#21344"
 msgid "If mp4 or mkv files have tags, use this for library metadata"
 msgstr ""
 
-#empty strings from id 21345 to 21357
+#. Used in AutoPlayNextItem dialogs for not categorized listItem directories
+#: xbmc/view/GUIViewState.cpp
+msgctxt "#21345"
+msgid "Uncategorized"
+msgstr ""
+
+#empty strings from id 21346 to 21357
 
 #: system/settings/settings.xml
 msgctxt "#21358"
@@ -17964,7 +17974,7 @@ msgstr ""
 #. Description of setting with label #13433 "Play next video automatically"
 #: system/settings/settings.xml
 msgctxt "#36152"
-msgid "Enable automatic playback of the next file in the list."
+msgid "Enable automatic playback of the next file in the list for selected playlist types."
 msgstr ""
 
 #. Description of setting with label #13415 "Render method"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3,10 +3,23 @@
   <section id="player" label="14200" help="38100">
     <category id="videoplayer" label="14215" help="38103">
       <group id="1" label="14230">
-        <setting id="videoplayer.autoplaynextitem" type="boolean" label="13433" help="36152">
+        <setting id="videoplayer.autoplaynextitem" type="list[integer]" label="13433" help="36152">
+          <constraints>
+            <options>
+              <option label="20389">0</option> <!-- musicvideos -->
+              <option label="20343">1</option> <!-- tvshows -->
+              <option label="20360">2</option> <!-- episodes -->
+              <option label="20342">3</option> <!-- movies -->
+              <option label="21345">4</option> <!-- uncategorized -->
+            </options>
+            <delimiter>,</delimiter>
+          </constraints>
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default></default>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+            <hidevalue>false</hidevalue>
+          </control>
         </setting>
         <setting id="videoplayer.seeksteps" type="list[integer]" label="13556" help="37042">
           <level>1</level>

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -39,7 +39,7 @@
 using namespace XFILE;
 using namespace MUSICDATABASEDIRECTORY;
 
-int CGUIViewStateWindowMusic::GetPlaylist()
+int CGUIViewStateWindowMusic::GetPlaylist() const
 {
   //return PLAYLIST_MUSIC_TEMP;
   return PLAYLIST_MUSIC;
@@ -580,7 +580,7 @@ void CGUIViewStateWindowMusicPlaylist::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_PLAYLIST);
 }
 
-int CGUIViewStateWindowMusicPlaylist::GetPlaylist()
+int CGUIViewStateWindowMusicPlaylist::GetPlaylist() const
 {
   return PLAYLIST_MUSIC;
 }

--- a/xbmc/music/GUIViewStateMusic.h
+++ b/xbmc/music/GUIViewStateMusic.h
@@ -28,7 +28,7 @@ public:
   explicit CGUIViewStateWindowMusic(const CFileItemList& items) : CGUIViewState(items) {}
 protected:
   VECSOURCES& GetSources() override;
-  int GetPlaylist() override;
+  int GetPlaylist() const override;
   bool AutoPlayNextItem() override;
   std::string GetLockType() override;
   std::string GetExtensions() override;
@@ -90,7 +90,7 @@ public:
 
 protected:
   void SaveViewState() override;
-  int GetPlaylist() override;
+  int GetPlaylist() const override;
   bool AutoPlayNextItem() override;
   bool HideParentDirItems() override;
   VECSOURCES& GetSources() override;

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -175,6 +175,14 @@ void CSettingsBase::UnregisterCallback(ISettingCallback* callback)
   m_settingsManager->UnregisterCallback(callback);
 }
 
+bool CSettingsBase::FindIntInList(const std::string &id, int value) const
+{
+  if (id.empty())
+    return false;
+
+  return m_settingsManager->FindIntInList(id, value);
+}
+
 SettingPtr CSettingsBase::GetSetting(const std::string& id) const
 {
   if (id.empty())

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -111,6 +111,15 @@ public:
   void UnregisterCallback(ISettingCallback* callback);
 
   /*!
+  \brief Search in a list of Ints for a given value.
+
+  \param id Setting identifier
+  \param value value to search for
+  \return True if value was found in list, false otherwise
+  */
+  bool FindIntInList(const std::string &id, int value) const;
+
+  /*!
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -714,6 +714,20 @@ bool CSettingsManager::SetList(const std::string &id, const std::vector< std::sh
   return std::static_pointer_cast<CSettingList>(setting)->SetValue(value);
 }
 
+bool CSettingsManager::FindIntInList(const std::string &id, int value) const
+{
+  CSharedLock lock(m_settingsCritical);
+  SettingPtr setting = GetSetting(id);
+  if (setting == nullptr || setting->GetType() != SettingType::List)
+    return false;
+
+  for (const auto item : std::static_pointer_cast<CSettingList>(setting)->GetValue())
+    if (item->GetType() == SettingType::Integer && std::static_pointer_cast<CSettingInt>(item)->GetValue() == value)
+      return true;
+
+  return false;
+}
+
 bool CSettingsManager::SetDefault(const std::string &id)
 {
   CSharedLock lock(m_settingsCritical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -416,6 +416,15 @@ public:
   bool SetList(const std::string &id, const std::vector< std::shared_ptr<CSetting> > &value);
 
   /*!
+   \brief Search in a list of Ints for a given value.
+
+   \param id Setting identifier
+   \param value value to search for
+   \return True if value was found in list, false otherwise
+  */
+  bool FindIntInList(const std::string &id, int value) const;
+
+  /*!
    \brief Sets the value of the setting to its default.
 
    \param id Setting identifier

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -47,7 +47,7 @@ std::string CGUIViewStateWindowVideo::GetExtensions()
   return CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
 }
 
-int CGUIViewStateWindowVideo::GetPlaylist()
+int CGUIViewStateWindowVideo::GetPlaylist() const
 {
   return PLAYLIST_VIDEO;
 }
@@ -57,6 +57,13 @@ VECSOURCES& CGUIViewStateWindowVideo::GetSources()
   AddLiveTVSources();
   return CGUIViewState::GetSources();
 }
+
+bool CGUIViewStateWindowVideo::AutoPlayNextItem()
+{
+  return AutoPlayNextVideoItem();
+}
+
+/***************************/
 
 CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
@@ -398,7 +405,7 @@ bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
   if (params.GetContentType() == VIDEODB_CONTENT_MUSICVIDEOS || params.GetContentType() == 6) // recently added musicvideos
     return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICPLAYER_AUTOPLAYNEXTITEM);
 
-  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM);
+  return CGUIViewStateWindowVideo::AutoPlayNextItem();
 }
 
 CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileItemList& items) : CGUIViewStateWindowVideo(items)

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -30,8 +30,9 @@ public:
 protected:
   VECSOURCES& GetSources() override;
   std::string GetLockType() override;
-  int GetPlaylist() override;
+  int GetPlaylist() const override;
   std::string GetExtensions() override;
+  bool AutoPlayNextItem() override;
 };
 
 class CGUIViewStateWindowVideoNav : public CGUIViewStateWindowVideo

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -55,7 +55,7 @@ public:
   virtual bool HideParentDirItems();
   virtual bool DisableAddSourceButtons();
 
-  virtual int GetPlaylist();
+  virtual int GetPlaylist() const;
   const std::string& GetPlaylistDirectory();
   void SetPlaylistDirectory(const std::string& strDirectory);
   bool IsCurrentPlaylistDirectory(const std::string& strDirectory);
@@ -93,6 +93,8 @@ protected:
   void SetSortMethod(SortBy sortBy, SortOrder sortOrder = SortOrderNone);
   void SetSortMethod(SortDescription sortDescription);
   void SetSortOrder(SortOrder sortOrder);
+
+  bool AutoPlayNextVideoItem() const;
 
   const CFileItemList& m_items;
 


### PR DESCRIPTION
## Description
see title

## Motivation and Context
Users want to have more control in regards of Autoplay.
For example Episodes should be continued, Movies not.

## How Has This Been Tested?
Win10 / amazon addon / enabled Episodes in Settings and:
- played Movise -> No Autoplay
- played Episode -> Autoplay works

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)