### PR TITLE
Clear EDL when opening a new FileItem

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1261,6 +1261,11 @@ void CVideoPlayer::Prepare()
   m_processInfo->SetSpeed(1.0);
   m_processInfo->SetTempo(1.0);
   m_State.Clear();
+  m_CurrentVideo.Clear();
+  m_CurrentAudio.Clear();
+  m_CurrentSubtitle.Clear();
+  m_CurrentTeletext.Clear();
+  m_CurrentRadioRDS.Clear();
   memset(&m_SpeedState, 0, sizeof(m_SpeedState));
   m_offset_pts = 0;
   m_CurrentAudio.lastdts = DVD_NOPTS_VALUE;


### PR DESCRIPTION
## Description
If a new FileItem is opened while a previous one is still running, the EDL needs to be reloaded even if the "hint" is the same.

## Motivation and Context
If the stream does not have a file name, the old EDL would be used for the new stream.

## How Has This Been Tested?
Tested locally in the context of pvr.zattoo (replay and live stream)

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
