### PR TITLE
Log redacted URL in case of CURL failure

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1032,7 +1032,7 @@ bool CCurlFile::Open(const CURL& url)
       ReadString(&error[0], 255);
     }
 
-    CLog::Log(LOGERROR, "CCurlFile::Open failed with code %li for %s:\n%s", m_httpresponse, url.GetRedacted().c_str(), error.c_str());
+    CLog::Log(LOGERROR, "CCurlFile::Open failed with code %li for %s:\n%s", m_httpresponse, redactPath.c_str(), error.c_str());
 
     return false;
   }


### PR DESCRIPTION
## Description
In case CURL::Open fails, we log out the complete URL + options + protocoloptions
Header / postdata could contain sensible data and should not be logged (therefore we have the libCURL component log option)

## Motivation and Context
credentials are visible in addons, if they are passed in postdata and connection fails

## How Has This Been Tested?
zattoo addon

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
