### PR TITLE
[c-pluff] kill another implicit function declaration warning

### DIFF
--- a/lib/cpluff/console/cmdinput_readline.c
+++ b/lib/cpluff/console/cmdinput_readline.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <string.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "console.h"

--- a/lib/cpluff/patches/0013-Kill-implicit-function-declaration-warning-2.patch
+++ b/lib/cpluff/patches/0013-Kill-implicit-function-declaration-warning-2.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/cpluff/console/cmdinput_readline.c b/lib/cpluff/console/cmdinput_readline.c
+index e383c8faba..b8d78af005 100644
+--- a/lib/cpluff/console/cmdinput_readline.c
++++ b/lib/cpluff/console/cmdinput_readline.c
+@@ -26,6 +26,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <ctype.h>
++#include <string.h>
+ #include <readline/readline.h>
+ #include <readline/history.h>
+ #include "console.h"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Silence another implicit function declaration warning while building c-pluff.

## Motivation and Context
While building with gcc 8.1 noticed this:
```
cmdinput_readline.c:32:1:
+#include <string.h>

cmdinput_readline.c:41:13:
   textlen = strlen(text);
             ^~~~~~
cmdinput_readline.c:43:43: warning: implicit declaration of function ‘strncmp’ [-Wimplicit-function-declaration]
  while (commands[counter].name != NULL && strncmp(text, commands[counter].name, textlen)) {
                                           ^~~~~~~
cmdinput_readline.c:49:18: warning: implicit declaration of function ‘strdup’ [-Wimplicit-function-declaration]
   char *buffer = strdup(commands[counter].name);
                  ^~~~~~
cmdinput_readline.c:49:18: warning: incompatible implicit declaration of built-in function ‘strdup’
cmdinput_readline.c: In function ‘cp_console_compl_flagsgen’:
cmdinput_readline.c:61:13: warning: incompatible implicit declaration of built-in function ‘strlen’
   textlen = strlen(text);
             ^~~~~~
cmdinput_readline.c:61:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:69:18: warning: incompatible implicit declaration of built-in function ‘strdup’
   char *buffer = strdup(load_flags[counter].name);
                  ^~~~~~
cmdinput_readline.c: In function ‘cp_console_compl_loggen’:
cmdinput_readline.c:81:13: warning: incompatible implicit declaration of built-in function ‘strlen’
   textlen = strlen(text);
             ^~~~~~
cmdinput_readline.c:81:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:89:18: warning: incompatible implicit declaration of built-in function ‘strdup’
   char *buffer = strdup(log_levels[counter].name);
                  ^~~~~~
cmdinput_readline.c: In function ‘cp_console_compl_plugingen’:
cmdinput_readline.c:101:13: warning: incompatible implicit declaration of built-in function ‘strlen’
   textlen = strlen(text);
             ^~~~~~
cmdinput_readline.c:101:13: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
cmdinput_readline.c:116:19: warning: incompatible implicit declaration of built-in function ‘strdup’
    char *buffer = strdup(plugins[counter]->identifier);
                   ^~~~~~
```
Let's make it happy.

## How Has This Been Tested?
Built for linux with gcc 8.1.
Warnings are gone.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
