### PR TITLE
RetroPlayer: Fix memory leak on Windows

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -141,13 +141,16 @@ bool CWinRenderBuffer::UploadTexture()
 
 bool CWinRenderBuffer::CreateScalingContext()
 {
-  m_swsContext = sws_getContext(m_width, m_height, m_pixFormat, m_width, m_height, m_targetPixFormat,
-    SWS_FAST_BILINEAR, NULL, NULL, NULL);
-
   if (m_swsContext == nullptr)
   {
-    CLog::Log(LOGERROR, "WinRenderer: Failed to create swscale context");
-    return false;
+    m_swsContext = sws_getContext(m_width, m_height, m_pixFormat, m_width, m_height, m_targetPixFormat,
+      SWS_FAST_BILINEAR, NULL, NULL, NULL);
+
+    if (m_swsContext == nullptr)
+    {
+      CLog::Log(LOGERROR, "WinRenderer: Failed to create swscale context");
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
Fixes a memory leak on Windows during gameplay.

## Motivation and Context
Report: https://forum.kodi.tv/showthread.php?tid=173361&pid=2741503#pid2741503

## How Has This Been Tested?
Test builds: https://forum.kodi.tv/showthread.php?tid=173361

Tested on Windows 10 with 2048.

## Screenshots (if appropriate):

![memleak](https://user-images.githubusercontent.com/531482/41125012-7afaed2c-6a58-11e8-9801-855c17c620bb.png)

ouch.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
