### PR TITLE
Do not log postdata

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -561,6 +561,23 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
   if( m_strProtocolOptions.length() > 0 )
     strURL += "|"+m_strProtocolOptions;
 
+  size_t idxPostData = strURL.find("postdata=");
+  if (idxPostData != std::string::npos)
+  {
+    size_t endPostDataIdx = strURL.find("&", idxPostData);
+    size_t idxPipe = strURL.find("|", idxPostData);
+    if (idxPipe != std::string::npos && (endPostDataIdx == std::string::npos || idxPipe < endPostDataIdx))
+    {
+      endPostDataIdx = idxPipe;
+    }
+    std::string strUrlWithoutPostData = strURL.substr(0, idxPostData + 9) + "<removed>";
+    if (endPostDataIdx != std::string::npos)
+    {
+      strUrlWithoutPostData += strURL.substr(endPostDataIdx);
+    }
+    strURL = strUrlWithoutPostData;
+  }
+
   return strURL;
 }
 


### PR DESCRIPTION
## Description
Postdata may contain user information (login and password) and should therefore not be logged.

## Motivation and Context
The following error log might expose login data in the log file:
CCurlFile::Open failed with code 503 for https://...&postdata=...:
The problem has already been discussed with @peak3d but not yet this implementation.

## How Has This Been Tested?
Tested locally in the context of pvr.zattoo

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
