### PR TITLE
[PVR] Addon API 5.10.0: New API function GetStreamReadChunkSize.

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1024,6 +1024,13 @@ PVR_ERROR CPVRClient::GetTimerTypes(CPVRTimerTypes& results) const
   return PVR_ERROR_NO_ERROR;
 }
 
+PVR_ERROR CPVRClient::GetStreamReadChunkSize(int& iChunkSize)
+{
+  return DoAddonCall(__FUNCTION__, [&iChunkSize](const AddonInstance* addon) {
+    return addon->GetStreamReadChunkSize(&iChunkSize);
+  }, m_clientCapabilities.SupportsRecordings() || m_clientCapabilities.HandlesInputStream());
+}
+
 PVR_ERROR CPVRClient::ReadLiveStream(void* lpBuf, int64_t uiBufSize, int &iRead)
 {
   iRead = -1;

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -858,6 +858,13 @@ namespace PVR
     void SetPriority(int iPriority);
 
     /*!
+     * @brief Obtain the chunk size to use when reading streams.
+     * @param iChunkSize the chunk size in bytes.
+     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+     */
+    PVR_ERROR GetStreamReadChunkSize(int &iChunkSize);
+
+    /*!
      * @brief Get the interface table used between addon and Kodi.
      * @todo This function will be removed after old callback library system is removed.
      */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -109,8 +109,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.9.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "5.9.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.10.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "5.10.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \
                                                       "xbmc_pvr_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -520,6 +520,17 @@ extern "C"
    */
   //@{
   /*!
+   * Obtain the chunk size to use when reading streams.
+   * @param chunksize must be filled with the chunk size in bytes.
+   * @return PVR_ERROR_NO_ERROR if the chunk size has been fetched successfully.
+   * @remarks Optional, and only used if not reading from demuxer (=> DemuxRead) and
+   *          PVR_ADDON_CAPABILITIES::bSupportsRecordings is true (=> ReadRecordedStream) or
+   *          PVR_ADDON_CAPABILITIES::bHandlesInputStream is true (=> ReadLiveStream).
+   *          Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function. In this case Kodi will decide on the chunk size to use.
+   */
+  PVR_ERROR GetStreamReadChunkSize(int* chunksize);
+
+  /*!
    * Open a stream to a recording on the backend.
    * @param recording The recording to open.
    * @return True if the stream has been opened successfully, false otherwise.
@@ -561,6 +572,7 @@ extern "C"
    *          Return -1 if this add-on won't provide this function.
    */
   long long LengthRecordedStream(void);
+
   //@}
 
   /** @name PVR demultiplexer methods
@@ -773,5 +785,7 @@ extern "C"
     pClient->toAddon.OnPowerSavingActivated         = OnPowerSavingActivated;
     pClient->toAddon.OnPowerSavingDeactivated       = OnPowerSavingDeactivated;
     pClient->toAddon.GetStreamTimes                 = GetStreamTimes;
+
+    pClient->toAddon.GetStreamReadChunkSize         = GetStreamReadChunkSize;
   };
 };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -706,6 +706,7 @@ extern "C" {
     void (__cdecl* OnPowerSavingActivated)(void);
     void (__cdecl* OnPowerSavingDeactivated)(void);
     PVR_ERROR (__cdecl* GetStreamTimes)(PVR_STREAM_TIMES*);
+    PVR_ERROR (__cdecl* GetStreamReadChunkSize)(int*);
   } KodiToAddonFuncTable_PVR;
 
   typedef struct AddonInstance_PVR

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -195,6 +195,11 @@ int64_t CDVDInputStreamPVRManager::GetLength()
   return CServiceBroker::GetPVRManager().Clients()->GetStreamLength();
 }
 
+int CDVDInputStreamPVRManager::GetBlockSize()
+{
+  return CServiceBroker::GetPVRManager().Clients()->GetStreamReadChunkSize(m_item);
+}
+
 bool CDVDInputStreamPVRManager::GetTimes(Times &times)
 {
   PVR_STREAM_TIMES streamTimes;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -53,6 +53,7 @@ public:
   bool Pause(double dTime) override { return false; }
   bool IsEOF() override;
   int64_t GetLength() override;
+  int GetBlockSize() override;
 
   ENextStream NextStream() override;
   bool IsRealtime() override;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -559,6 +559,26 @@ std::string CPVRClients::GetBackendHostnameByClientId(int iClientId) const
   return name;
 }
 
+int CPVRClients::GetStreamReadChunkSize(const CFileItem &item)
+{
+  int iChunkSize = 0;
+  int iClientID = PVR_INVALID_CLIENT_ID;
+
+  if (item.HasPVRChannelInfoTag())
+    iClientID = item.GetPVRChannelInfoTag()->ClientID();
+  else if (item.HasPVRRecordingInfoTag())
+    iClientID = item.GetPVRRecordingInfoTag()->m_iClientId;
+
+  if (iClientID != PVR_INVALID_CLIENT_ID)
+  {
+    ForCreatedClient(__FUNCTION__, iClientID, [&iChunkSize](const CPVRClientPtr &client) {
+      return client->GetStreamReadChunkSize(iChunkSize);
+    });
+  }
+
+  return iChunkSize;
+}
+
 bool CPVRClients::OpenStream(const CPVRChannelPtr &channel)
 {
   CloseStream();

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -274,6 +274,13 @@ namespace PVR
     void CloseStream(void);
 
     /*!
+     * @brief Return the read chunk size to use when playing a stream.
+     * @param item The item providing the stream (channel or recording).
+     * @return The chunk size in bytes or 0 in case of an error.
+     */
+    int GetStreamReadChunkSize(const CFileItem &item);
+
+    /*!
      * @brief Read from an open stream.
      * @param lpBuf Target buffer.
      * @param uiBufSize The size of the buffer.


### PR DESCRIPTION
@FernetMenta as discussed.

I already adapted pvr.hts and setting chunk size to 64K solved all my buffering problems when playing recordings. ;-)