### PR TITLE
[WIP] WinSystem: pass RESOLUTION_INFO as const reference where applicable

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -187,7 +187,7 @@ void DX::DeviceResources::SetViewPort(D3D11_VIEWPORT& viewPort) const
   m_deferrContext->RSSetViewports(1, &realViewPort);
 }
 
-bool DX::DeviceResources::SetFullScreen(bool fullscreen, RESOLUTION_INFO& res)
+bool DX::DeviceResources::SetFullScreen(bool fullscreen, const RESOLUTION_INFO& res)
 {
   if (!m_bDeviceCreated)
     return false;

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -98,7 +98,7 @@ namespace DX
     void CreateBackBuffer();
     void ResizeBuffers();
 
-    bool SetFullScreen(bool fullscreen, RESOLUTION_INFO& res);
+    bool SetFullScreen(bool fullscreen, const RESOLUTION_INFO& res);
 
     // DX resources registration
     void Register(ID3DResource *resource);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -48,10 +48,10 @@ public:
   // windowing interfaces
   virtual bool InitWindowSystem();
   virtual bool DestroyWindowSystem();
-  virtual bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) = 0;
+  virtual bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) = 0;
   virtual bool DestroyWindow(){ return false; }
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) = 0;
-  virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) = 0;
+  virtual bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) = 0;
   virtual bool MoveWindow(int topLeft, int topRight){return false;}
   virtual void FinishModeChange(RESOLUTION res){}
   virtual void FinishWindowResize(int newWidth, int newHeight) {ResizeWindow(newWidth, newHeight, -1, -1);}

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -88,7 +88,7 @@ bool CWinSystemX11::DestroyWindowSystem()
   return true;
 }
 
-bool CWinSystemX11::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemX11::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   if(!SetFullScreen(fullScreen, res, false))
     return false;
@@ -198,7 +198,7 @@ void CWinSystemX11::FinishWindowResize(int newWidth, int newHeight)
   m_nHeight = newHeight;
 }
 
-bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemX11::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   XOutput out;
   XMode mode;

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -31,11 +31,11 @@ public:
   // CWinSystemBase
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   void FinishWindowResize(int newWidth, int newHeight) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void UpdateResolutions() override;
   void ShowOSMouse(bool show) override;
 

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -165,7 +165,7 @@ bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, c
   return true;
 }
 
-bool CWinSystemX11GLContext::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemX11GLContext::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   if(!CWinSystemX11::CreateNewWindow(name, fullScreen, res))
     return false;
@@ -196,7 +196,7 @@ void CWinSystemX11GLContext::FinishWindowResize(int newWidth, int newHeight)
     g_application.ReloadSkin();
 }
 
-bool CWinSystemX11GLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemX11GLContext::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   m_newGlContext = false;
   CWinSystemX11::SetFullScreen(fullScreen, res, blankOtherDisplays);

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -26,10 +26,10 @@ public:
 
   // Implementation of CWinSystem via CWinSystemX11
   CRenderSystemBase *GetRenderSystem() override { return this; }
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   void FinishWindowResize(int newWidth, int newHeight) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   bool DestroyWindowSystem() override;
   bool DestroyWindow() override;
 

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -101,7 +101,7 @@ bool CWinSystemAmlogic::DestroyWindowSystem()
 
 bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
                                     bool fullScreen,
-                                    RESOLUTION_INFO& res)
+                                    const RESOLUTION_INFO& res)
 {
   RESOLUTION_INFO current_resolution;
   current_resolution.iWidth = current_resolution.iHeight = 0;

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.h
@@ -29,7 +29,7 @@ public:
 
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool DestroyWindow() override;
   void UpdateResolutions() override;

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
@@ -46,7 +46,7 @@ bool CWinSystemAmlogicGLESContext::InitWindowSystem()
 
 bool CWinSystemAmlogicGLESContext::CreateNewWindow(const std::string& name,
                                                bool fullScreen,
-                                               RESOLUTION_INFO& res)
+                                               const RESOLUTION_INFO& res)
 {
   m_pGLContext.DestroySurface();
 
@@ -87,7 +87,7 @@ bool CWinSystemAmlogicGLESContext::ResizeWindow(int newWidth, int newHeight, int
   return true;
 }
 
-bool CWinSystemAmlogicGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemAmlogicGLESContext::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.h
@@ -24,10 +24,10 @@ public:
   bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -93,7 +93,7 @@ bool CWinSystemAndroid::DestroyWindowSystem()
 
 bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
                                     bool fullScreen,
-                                    RESOLUTION_INFO& res)
+                                    const RESOLUTION_INFO& res)
 {
   RESOLUTION_INFO current_resolution;
   current_resolution.iWidth = current_resolution.iHeight = 0;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -29,7 +29,7 @@ public:
 
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool DestroyWindow() override;
   void UpdateResolutions() override;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -46,7 +46,7 @@ bool CWinSystemAndroidGLESContext::InitWindowSystem()
 
 bool CWinSystemAndroidGLESContext::CreateNewWindow(const std::string& name,
                                                bool fullScreen,
-                                               RESOLUTION_INFO& res)
+                                               const RESOLUTION_INFO& res)
 {
   m_pGLContext.DestroySurface();
 
@@ -82,7 +82,7 @@ bool CWinSystemAndroidGLESContext::ResizeWindow(int newWidth, int newHeight, int
   return true;
 }
 
-bool CWinSystemAndroidGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemAndroidGLESContext::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.h
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.h
@@ -24,10 +24,10 @@ public:
   bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -116,7 +116,7 @@ bool CWinSystemGbm::DestroyWindowSystem()
 
 bool CWinSystemGbm::CreateNewWindow(const std::string& name,
                                     bool fullScreen,
-                                    RESOLUTION_INFO& res)
+                                    const RESOLUTION_INFO& res)
 {
   //Notify other subsystems that we change resolution
   OnLostDevice();
@@ -198,7 +198,7 @@ bool CWinSystemGbm::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   return true;
 }
 
-bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemGbm::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   // Notify other subsystems that we will change resolution
   OnLostDevice();

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -30,12 +30,12 @@ public:
 
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool DestroyWindow() override;
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   void FlipPage(bool rendered, bool videoLayer);
   void WaitVBlank();

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -40,7 +40,7 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
 
 bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
                                               bool fullScreen,
-                                              RESOLUTION_INFO& res)
+                                              const RESOLUTION_INFO& res)
 {
   m_eglContext.DestroySurface();
 

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -22,7 +22,7 @@ public:
   bool DestroyWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   EGLDisplay GetEGLDisplay() const;
   EGLSurface GetEGLSurface() const;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -66,7 +66,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   return true;
 }
 
-bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   if (res.iWidth != m_nWidth ||
       res.iHeight != m_nHeight)

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -24,7 +24,7 @@ public:
   // Implementation of CWinSystemBase via CWinSystemGbm
   CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRender(bool rendered, bool videoLayer) override;
 protected:
   void SetVSyncImpl(bool enable) override { return; };

--- a/xbmc/windowing/osx/WinSystemIOS.h
+++ b/xbmc/windowing/osx/WinSystemIOS.h
@@ -30,10 +30,10 @@ public:
   CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void UpdateResolutions() override;
   bool CanDoWindowed() override { return false; }
 

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -116,7 +116,7 @@ bool CWinSystemIOS::DestroyWindowSystem()
   return true;
 }
 
-bool CWinSystemIOS::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemIOS::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   //NSLog(@"%s", __PRETTY_FUNCTION__);
 
@@ -172,7 +172,7 @@ bool CWinSystemIOS::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   return true;
 }
 
-bool CWinSystemIOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemIOS::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   //NSLog(@"%s", __PRETTY_FUNCTION__);
 

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -33,11 +33,11 @@ public:
   // CWinSystemBase
   virtual bool InitWindowSystem() override;
   virtual bool DestroyWindowSystem() override;
-  virtual bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  virtual bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override;
   virtual bool DestroyWindow() override;
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool         ResizeWindowInternal(int newWidth, int newHeight, int newLeft, int newTop, void *additional);
-  virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  virtual bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   virtual void UpdateResolutions() override;
   virtual void NotifyAppFocusChange(bool bGaining) override;
   virtual void ShowOSMouse(bool show) override;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -713,7 +713,7 @@ bool CWinSystemOSX::DestroyWindowSystem()
   return true;
 }
 
-bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   // force initial window creation to be windowed, if fullscreen, it will switch to it below
   // fixes the white screen of death if starting fullscreen and switching to windowed.
@@ -872,7 +872,7 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
 
 static bool needtoshowme = true;
 
-bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemOSX::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   static NSWindow* windowedFullScreenwindow = NULL;
   static NSScreen* last_window_screen = NULL;
@@ -897,7 +897,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   {
     needtoshowme = false;
     ShowHideNSWindow([last_view window], needtoshowme);
-    RESOLUTION_INFO& window = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
+    const RESOLUTION_INFO& window = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
     CWinSystemOSX::SetFullScreen(false, window, blankOtherDisplays);
     needtoshowme = true;
   }

--- a/xbmc/windowing/osx/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/WinSystemOSXGL.h
@@ -21,7 +21,7 @@ public:
   // Implementation of CWinSystemBase via CWinSystemOSX
   CRenderSystemBase *GetRenderSystem() override { return this; }
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  virtual bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
 protected:
   virtual void PresentRenderImpl(bool rendered) override;

--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -67,7 +67,7 @@ bool CWinSystemOSXGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int
   return true;
 }
 
-bool CWinSystemOSXGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemOSXGL::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CWinSystemOSX::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight);

--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -73,7 +73,7 @@ bool CWinSystemRpi::DestroyWindowSystem()
 
 bool CWinSystemRpi::CreateNewWindow(const std::string& name,
                                     bool fullScreen,
-                                    RESOLUTION_INFO& res)
+                                    const RESOLUTION_INFO& res)
 {
   RESOLUTION_INFO current_resolution;
   current_resolution.iWidth = current_resolution.iHeight = 0;

--- a/xbmc/windowing/rpi/WinSystemRpi.h
+++ b/xbmc/windowing/rpi/WinSystemRpi.h
@@ -30,7 +30,7 @@ public:
 
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool DestroyWindow() override;
   void UpdateResolutions() override;

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -69,7 +69,7 @@ bool CWinSystemRpiGLESContext::InitWindowSystem()
 
 bool CWinSystemRpiGLESContext::CreateNewWindow(const std::string& name,
                                                bool fullScreen,
-                                               RESOLUTION_INFO& res)
+                                               const RESOLUTION_INFO& res)
 {
   m_pGLContext.DestroySurface();
 
@@ -110,7 +110,7 @@ bool CWinSystemRpiGLESContext::ResizeWindow(int newWidth, int newHeight, int new
   return true;
 }
 
-bool CWinSystemRpiGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemRpiGLESContext::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.h
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.h
@@ -23,10 +23,10 @@ public:
   bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -255,7 +255,7 @@ bool CWinSystemWayland::DestroyWindowSystem()
 
 bool CWinSystemWayland::CreateNewWindow(const std::string& name,
                                         bool fullScreen,
-                                        RESOLUTION_INFO& res)
+                                        const RESOLUTION_INFO& res)
 {
   CLog::LogF(LOGINFO, "Starting %s size %dx%d", fullScreen ? "full screen" : "windowed", res.iWidth, res.iHeight);
 
@@ -528,7 +528,7 @@ std::shared_ptr<COutput> CWinSystemWayland::FindOutputByWaylandOutput(wayland::o
  *         when already in full screen mode since the application cannot
  *         set the size then
  */
-bool CWinSystemWayland::SetResolutionExternal(bool fullScreen, RESOLUTION_INFO const& res)
+bool CWinSystemWayland::SetResolutionExternal(bool fullScreen, const RESOLUTION_INFO const& res)
 {
   // In fullscreen modes, we never change the surface size on Kodi's request,
   // but only when the compositor tells us to. At least xdg_shell specifies
@@ -620,7 +620,7 @@ bool CWinSystemWayland::ResizeWindow(int, int, int, int)
   return SetResolutionExternal(false, res);
 }
 
-bool CWinSystemWayland::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool)
+bool CWinSystemWayland::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool)
 {
   return SetResolutionExternal(fullScreen, res);
 }

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -55,12 +55,12 @@ public:
 
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
 
   bool DestroyWindow() override;
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void FinishModeChange(RESOLUTION res) override;
   void FinishWindowResize(int newWidth, int newHeight) override;
 

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -42,7 +42,7 @@ bool CWinSystemWaylandEGLContext::InitWindowSystemEGL(EGLint renderableType, EGL
 
 bool CWinSystemWaylandEGLContext::CreateNewWindow(const std::string& name,
                                                   bool fullScreen,
-                                                  RESOLUTION_INFO& res)
+                                                  const RESOLUTION_INFO& res)
 {
   if (!CWinSystemWayland::CreateNewWindow(name, fullScreen, res))
   {

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -28,7 +28,7 @@ public:
 
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
-                       RESOLUTION_INFO& res) override;
+                       const RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
   bool DestroyWindowSystem() override;
 

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -97,7 +97,7 @@ bool CWinSystemWin10::CanDoWindowed()
   return CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Desktop;
 }
 
-bool CWinSystemWin10::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemWin10::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   UpdateStates(fullScreen);
   // initialize the state
@@ -197,7 +197,7 @@ void CWinSystemWin10::AdjustWindow()
   }
 }
 
-bool CWinSystemWin10::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemWin10::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CWinSystemWin10::UpdateStates(fullScreen);
   WINDOW_STATE state = GetState(fullScreen);
@@ -423,7 +423,7 @@ bool CWinSystemWin10::AddResolution(const RESOLUTION_INFO &res)
 {
   for (unsigned int i = RES_CUSTOM; i < CDisplaySettings::GetInstance().ResolutionInfoSize(); i++)
   {
-    RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(i);
+    const RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(i);
     if ( info.iWidth == res.iWidth
       && info.iHeight == res.iHeight
       && info.iScreenWidth == res.iScreenWidth

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -86,7 +86,7 @@ public:
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 
   bool WindowedMode() const { return m_state != WINDOW_STATE_FULLSCREEN; }
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   // CWinSystemWin10
   bool IsAlteringWindow() const { return m_IsAlteringWindow; }
@@ -100,10 +100,10 @@ public:
   bool MessagePump() override;
 
 protected:
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override = 0;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override = 0;
   virtual void UpdateStates(bool fullScreen);
   WINDOW_STATE GetState(bool fullScreen) const;
-  virtual void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) = 0;
+  virtual void SetDeviceFullScreen(bool fullScreen, const RESOLUTION_INFO& res) = 0;
   virtual void ReleaseBackBuffer() = 0;
   virtual void CreateBackBuffer() = 0;
   virtual void ResizeDeviceBuffers() = 0;

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -40,7 +40,7 @@ void CWinSystemWin10DX::PresentRenderImpl(bool rendered)
     Sleep(40);
 }
 
-bool CWinSystemWin10DX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemWin10DX::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   const MONITOR_DETAILS* monitor = GetDefaultMonitor();
   if (!monitor)
@@ -77,7 +77,7 @@ void CWinSystemWin10DX::ShowSplash(const std::string & message)
     m_coreWindow.Dispatcher().ProcessEvents(winrt::Windows::UI::Core::CoreProcessEventsOption::ProcessAllIfPresent);
 }
 
-void CWinSystemWin10DX::SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res)
+void CWinSystemWin10DX::SetDeviceFullScreen(bool fullScreen, const RESOLUTION_INFO& res)
 {
   m_deviceResources->SetFullScreen(fullScreen, res);
 }
@@ -138,7 +138,7 @@ void CWinSystemWin10DX::OnResize(int width, int height)
     CreateBackBuffer();
 }
 
-bool CWinSystemWin10DX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemWin10DX::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   bool const result = CWinSystemWin10::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemDX::OnResize();

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -19,9 +19,9 @@ public:
 
   // Implementation of CWinSystemBase via CWinSystemWin10
   CRenderSystemBase *GetRenderSystem() override { return this; }
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRenderImpl(bool rendered) override;
   bool DPIChanged(WORD dpi, RECT windowRect) const override;
   bool DestroyRenderSystem() override;
@@ -62,7 +62,7 @@ public:
   void ShowSplash(const std::string& message) override;
 
 protected:
-  void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;
+  void SetDeviceFullScreen(bool fullScreen, const RESOLUTION_INFO& res) override;
   void ReleaseBackBuffer() override;
   void CreateBackBuffer() override;
   void ResizeDeviceBuffers() override;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -104,7 +104,7 @@ bool CWinSystemWin32::DestroyWindowSystem()
   return true;
 }
 
-bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   using KODI::PLATFORM::WINDOWS::ToW;
   auto nameW = ToW(name);
@@ -290,7 +290,7 @@ bool CWinSystemWin32::BlankNonActiveMonitors(bool bBlank)
 
 bool CWinSystemWin32::CenterWindow()
 {
-  RESOLUTION_INFO DesktopRes = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+  const RESOLUTION_INFO DesktopRes = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
 
   m_nLeft = (DesktopRes.iWidth / 2) - (m_nWidth / 2);
   m_nTop = (DesktopRes.iHeight / 2) - (m_nHeight / 2);
@@ -426,7 +426,7 @@ void CWinSystemWin32::CenterCursor() const
   SetCursorPos(x, y);
 }
 
-bool CWinSystemWin32::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemWin32::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CWinSystemWin32::UpdateStates(fullScreen);
   WINDOW_STATE state = GetState(fullScreen);
@@ -927,7 +927,7 @@ bool CWinSystemWin32::AddResolution(const RESOLUTION_INFO &res)
 {
   for (unsigned int i = RES_CUSTOM; i < CDisplaySettings::GetInstance().ResolutionInfoSize(); i++)
   {
-    RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(i);
+    const RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(i);
     if (info.iWidth        == res.iWidth
      && info.iHeight       == res.iHeight
      && info.iScreenWidth  == res.iScreenWidth

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -100,7 +100,7 @@ public:
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 
   bool WindowedMode() const { return m_state != WINDOW_STATE_FULLSCREEN; }
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   // CWinSystemWin32
   HWND GetHwnd() const { return m_hWnd; }
@@ -127,10 +127,10 @@ public:
   bool MessagePump() override;
 
 protected:
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override = 0;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override = 0;
   virtual void UpdateStates(bool fullScreen);
   WINDOW_STATE GetState(bool fullScreen) const;
-  virtual void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) = 0;
+  virtual void SetDeviceFullScreen(bool fullScreen, const RESOLUTION_INFO& res) = 0;
   virtual void ReleaseBackBuffer() = 0;
   virtual void CreateBackBuffer() = 0;
   virtual void ResizeDeviceBuffers() = 0;

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -69,7 +69,7 @@ void CWinSystemWin32DX::PresentRenderImpl(bool rendered)
     Sleep(40);
 }
 
-bool CWinSystemWin32DX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
+bool CWinSystemWin32DX::CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res)
 {
   const MONITOR_DETAILS* monitor = GetDisplayDetails(CServiceBroker::GetSettings().GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
   if (!monitor)
@@ -97,7 +97,7 @@ bool CWinSystemWin32DX::DestroyRenderSystem()
   return true;
 }
 
-void CWinSystemWin32DX::SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res)
+void CWinSystemWin32DX::SetDeviceFullScreen(bool fullScreen, const RESOLUTION_INFO& res)
 {
   m_deviceResources->SetFullScreen(fullScreen, res);
 }
@@ -181,7 +181,7 @@ void CWinSystemWin32DX::OnResize(int width, int height)
     CreateBackBuffer();
 }
 
-bool CWinSystemWin32DX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+bool CWinSystemWin32DX::SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   bool const result = CWinSystemWin32::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemDX::OnResize();

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -23,9 +23,9 @@ public:
 
   // Implementation of CWinSystemBase via CWinSystemWin32
   CRenderSystemBase *GetRenderSystem() override { return this; }
-  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
+  bool CreateNewWindow(const std::string& name, bool fullScreen, const RESOLUTION_INFO& res) override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
-  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool SetFullScreen(bool fullScreen, const RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRenderImpl(bool rendered) override;
   bool DPIChanged(WORD dpi, RECT windowRect) const override;
   void SetWindow(HWND hWnd) const;
@@ -65,7 +65,7 @@ public:
   void FixRefreshRateIfNecessary(const D3D10DDIARG_CREATERESOURCE* pResource) const;
 
 protected:
-  void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;
+  void SetDeviceFullScreen(bool fullScreen, const RESOLUTION_INFO& res) override;
   void ReleaseBackBuffer() override;
   void CreateBackBuffer() override;
   void ResizeDeviceBuffers() override;


### PR DESCRIPTION
These methods are not supposed to edit the object.

NOTE: I did not build many of the modified WinSystems; Jenkins may find build failures, and I'll fix them. Don't merge just yet until Jenkins is green.