### PR TITLE
[Estuary] Add setting to show profilename

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -743,3 +743,21 @@ msgstr ""
 msgctxt "#31163"
 msgid "Show Fanart background"
 msgstr ""
+
+#. Choose profile identifier
+#: /xml/SkinSettings.xml
+msgctxt "#31164"
+msgid "Choose kind of profile identification"
+msgstr ""
+
+#. Label for the kind of profile identification
+#: /xml/SkinSettings.xml
+msgctxt "#31165"
+msgid "Profile name"
+msgstr ""
+
+#. Label for the kind of profile identification
+#: /xml/SkinSettings.xml
+msgctxt "#31166"
+msgid "Profile avatar"
+msgstr ""

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -893,6 +893,31 @@
 							<align>right</align>
 						</control>
 					</control>
+					<control type="group">
+						<visible>Integer.IsGreater(System.ProfileCount,1) + !Player.HasMedia</visible>
+						<control type="image">
+							<visible>Skin.HasSetting(show_profileavatar)</visible>
+							<top>25</top>
+							<left>-70</left>
+							<width>50</width>
+							<height>50</height>
+							<animation effect="fade" start="100" end="0" time="300" condition="Window.Next(screencalibration)">WindowClose</animation>
+							<texture>$INFO[System.ProfileThumb]</texture>
+							<aspectratio>scale</aspectratio>
+						</control>
+						<control type="label">
+							<visible>Skin.HasSetting(show_profilename)</visible>
+							<font>font45</font>
+							<align>right</align>
+							<left>-630</left>
+							<shadowcolor>text_shadow</shadowcolor>
+							<aligny>center</aligny>
+							<height>110</height>
+							<width max="600">auto</width>
+							<animation effect="fade" start="100" end="0" time="300" condition="Window.Next(screencalibration)">WindowClose</animation>
+							<label>$INFO[System.ProfileName]</label>
+						</control>
+					</control>
 					<control type="label">
 						<font>font_clock</font>
 						<shadowcolor>text_shadow</shadowcolor>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -67,6 +67,12 @@
 					<onclick>Skin.SelectBool($LOCALIZE[31024], 38018|circle_userrating, 563|circle_rating, 16018|)</onclick>
 					<label2>$VAR[RatingSettingLabel2Var]</label2>
 				</control>
+				<control type="button" id="707">
+					<label>$LOCALIZE[31164]</label>
+					<include>DefaultSettingButton</include>
+					<onclick>Skin.SelectBool(31164, 31165|show_profilename, 31166|show_profileavatar, 16018|show_none)</onclick>
+					<label2>$VAR[ProfileIdentificationLabel2Var]</label2>
+				</control>
 			</control>
 			<control type="grouplist" id="600">
 				<top>160</top>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -141,6 +141,11 @@
 		<value condition="Skin.HasSetting(circle_userrating)">$LOCALIZE[38018]</value>
 		<value>$LOCALIZE[16018]</value>
 	</variable>
+	<variable name="ProfileIdentificationLabel2Var">
+		<value condition="Skin.HasSetting(show_profilename)">$LOCALIZE[31165]</value>
+		<value condition="Skin.HasSetting(show_profileavatar)">$LOCALIZE[31166]</value>
+		<value>$LOCALIZE[16018]</value>
+	</variable>
 	<variable name="AddonsListIconVar">
 		<value condition="!String.IsEmpty(ListItem.AddonBroken)">icons/addonstatus/disable.png</value>
 		<value condition="ListItem.Property(addon.orphaned)">icons/addonstatus/orphan.png</value>


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
This PR adds a settings to show the profilename next to the clock.

## Description
<!--- Describe your change in detail -->
The profilename is only shown if the profile count is >1 and if the setting is enabled. I also added `max=600` to avoid movement of other items become out of bounds if the profilename is too long.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If users use additional proifiles, there's currently no way to see which profile is the actual one. Let's say users seperate kids movies from movies 18+ and are using different profiles and different sources for each profile, you will only see at which profile you are if you either look at the shutdownmenu (l'og off' section) or try to compare the movies in the library. This addition changes that 'problem' and users are able to see which profile is in use while browsing the GUI

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
I tested if the conditions will match. 

I created and deleted profiles to see if the profilename is either shown or not:

if `System.Profilecount > 1` and `Skin.HasSetting(show_profilename)` is enabled, then the profilename is shown

if `System.Profilecount > 1` and `Skin.HasSetting(show_profilename)` is disabled, then the profilename is not shown.

if `System.Profilecount = 1` and `Skin.HasSetting(show_profilename)` is enabled, then the profilename is not shown.

if the profilename is too long, it will be cut and the last characters will be presented with `...`

<!--- Include details of your testing environment, and the tests you ran to -->
I tried compiling on Ubuntu 16.04 and 18.04. I also ziped that skin and installed it as an additional skin (changed IDs for testing purposes) on Kodi installed from the nightly-ppa. 

<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
![profilename](https://user-images.githubusercontent.com/7235787/41188351-2f621114-6bbc-11e8-84a9-4fe19674c77d.png)

![profilename2](https://user-images.githubusercontent.com/7235787/41188354-3ed09328-6bbc-11e8-8f2c-e7b62474b97c.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
       ^^ I will edit the wiki myself if that change will be merged.
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
