### PR TITLE
[droid] Don't restart Kodi when you switch window/fullsize on chromebook

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -51,7 +51,7 @@
         android:logo="@drawable/banner">
         <activity
             android:name=".Splash"
-            android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen|screenLayout|screenSize"
+            android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen|screenLayout|screenSize|smallestScreenSize"
             android:finishOnTaskLaunch="true"
             android:launchMode="singleInstance"
             android:screenOrientation="sensorLandscape"


### PR DESCRIPTION
When you now switch the Kodi screen on a chromebook it now restarts the app while it's not needed. With this addition it will do this on the fly