### PR TITLE
Boost center channel

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20837,6 +20837,21 @@ msgstr ""
 #empty strings from id 38074 to 38099
 #strings 38074 to 38099 reserved for music library
 
+#: system/settings/settings.xml
+msgctxt "#38007"
+msgid "Boost centre channel when downmixing"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38008"
+msgid "Increase this value to make the dialogue louder compared to background sounds when downmixing multichannel audio"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#38009"
+msgid "{0:d} dB"
+msgstr ""
+
 #. Description of section #14200 "Player""
 #: system/settings/settings.xml
 msgctxt "#38100"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2418,6 +2418,18 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="audiooutput.boostcenter" type="integer" label="38007" help="38008">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>30</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>38009</formatlabel>
+          </control>
+        </setting>
         <setting id="audiooutput.processquality" type="integer" label="13505" help="36169">
           <requirement>HAS_AE_QUALITY_LEVELS</requirement>
           <level>2</level>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1603,7 +1603,7 @@ void CActiveAE::ChangeResamplers()
   std::list<CActiveAEStream*>::iterator it;
   for(it=m_streams.begin(); it!=m_streams.end(); ++it)
   {
-    (*it)->m_processingBuffers->ConfigureResampler(m_settings.normalizelevels, m_settings.stereoupmix, m_settings.resampleQuality);
+    (*it)->m_processingBuffers->ConfigureResampler(m_settings.normalizelevels, m_settings.stereoupmix, m_settings.resampleQuality, m_settings.boostcenter);
   }
 }
 
@@ -2592,6 +2592,7 @@ void CActiveAE::LoadSettings()
   m_settings.stereoupmix = IsSettingVisible(CSettings::SETTING_AUDIOOUTPUT_STEREOUPMIX) ? CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_STEREOUPMIX) : false;
   m_settings.normalizelevels = !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME);
   m_settings.guisoundmode = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOOUTPUT_GUISOUNDMODE);
+  m_settings.boostcenter = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOOUTPUT_BOOSTCENTER);
 
   m_settings.passthrough = m_settings.config == AE_CONFIG_FIXED ? false : CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
   if (!m_sink.HasPassthroughDevice())
@@ -3166,6 +3167,7 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
                   true,
                   outChannels.Count() > 0 ? &outChannels : NULL,
                   m_settings.resampleQuality,
+                  m_settings.boostcenter,
                   false);
 
   dst_samples = resampler->CalcDstSampleCount(sound->GetSound(true)->nb_samples,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -72,6 +72,7 @@ struct AudioSettings
   double atempoThreshold;
   bool streamNoise;
   int silenceTimeout;
+  int boostcenter;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -167,6 +167,7 @@ CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(const AEAudioFormat& in
   m_forceResampler = false;
   m_stereoUpmix = false;
   m_normalize = true;
+  m_boostcenter = AE_OUTPUT_BOOST_CENTER_OFF;
   m_changeResampler = false;
   m_lastSamplePts = 0;
 }
@@ -215,6 +216,7 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
                                 m_normalize,
                                 remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality,
+                                m_boostcenter,
                                 m_forceResampler);
 
     m_changeResampler = false;
@@ -247,6 +249,7 @@ void CActiveAEBufferPoolResample::ChangeResampler()
                                 m_normalize,
                                 m_remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality,
+                                m_boostcenter,
                                 m_forceResampler);
 
   m_changeResampler = false;
@@ -399,7 +402,7 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
   return busy;
 }
 
-void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality)
+void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality, int boostcenter)
 {
   bool normalize = true;
   if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count()) && !normalizelevels)
@@ -412,6 +415,10 @@ void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool 
     m_changeResampler = true;
   }
 
+  if (m_boostcenter != boostcenter)
+    m_changeResampler = true;
+
+  m_boostcenter = boostcenter;
   m_resampleQuality = quality;
   m_normalize = normalize;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -99,7 +99,7 @@ public:
   using CActiveAEBufferPool::Create;
   bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true);
   bool ResampleBuffers(int64_t timestamp = 0);
-  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality);
+  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality, int boostcenter);
   float GetDelay();
   void Flush();
   void SetDrain(bool drain);
@@ -125,6 +125,7 @@ protected:
   double m_resampleRatio;
   bool m_fillPackets;
   bool m_normalize;
+  int m_boostcenter;
   bool m_changeResampler;
   bool m_forceResampler;
   AEQuality m_resampleQuality;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
@@ -41,7 +41,7 @@ CActiveAEResampleFFMPEG::~CActiveAEResampleFFMPEG()
   swr_free(&m_pContext);
 }
 
-bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample)
+bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, int boostcenter, bool force_resample)
 {
   m_dst_chan_layout = dst_chan_layout;
   m_dst_channels = dst_channels;
@@ -103,6 +103,11 @@ bool CActiveAEResampleFFMPEG::Init(uint64_t dst_chan_layout, int dst_channels, i
       !remapLayout && normalize)
   {
      av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
+  }
+  if (boostcenter)
+  {
+    float gain = pow(10.0f, (static_cast<float>(-3 + boostcenter))/20.0f);
+    av_opt_set_double(m_pContext, "center_mix_level", gain, 0);
   }
 
   if (remapLayout)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
@@ -39,7 +39,7 @@ public:
   const char *GetName() override { return "ActiveAEResampleFFMPEG"; }
   CActiveAEResampleFFMPEG();
   ~CActiveAEResampleFFMPEG() override;
-  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample) override;
+  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, int boostcenter, bool force_resample) override;
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio) override;
   int64_t GetDelay(int64_t base) override;
   int GetBufferedSamples() override;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.cpp
@@ -107,7 +107,7 @@ static int format_to_bits(AVSampleFormat fmt)
   return 0;
 }
 
-bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample)
+bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, int boostcenter, bool force_resample)
 {
   LOGTIMEINIT("x");
 
@@ -165,6 +165,11 @@ bool CActiveAEResamplePi::Init(uint64_t dst_chan_layout, int dst_channels, int d
   if (!remapLayout && normalize)
   {
     av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
+  }
+  if (boostcenter)
+  {
+    float gain = pow(10.0f, (static_cast<float>(-3 + boostcenter))/20.0f);
+    av_opt_set_double(m_pContext, "center_mix_level", gain, 0);
   }
 
   if (remapLayout)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResamplePi.h
@@ -31,7 +31,7 @@ public:
   const char *GetName() { return "ActiveAEResamplePi"; }
   CActiveAEResamplePi();
   virtual ~CActiveAEResamplePi();
-  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample);
+  bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, int boostcenter, bool force_resample);
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio);
   int64_t GetDelay(int64_t base);
   int GetBufferedSamples();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -60,6 +60,7 @@ CActiveAESettings::CActiveAESettings(CActiveAE &ae) : m_audioEngine(ae)
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_BOOSTCENTER);
   CServiceBroker::GetSettings().GetSettingsManager()->RegisterCallback(this, settingSet);
 
   CServiceBroker::GetSettings().GetSettingsManager()->RegisterSettingOptionsFiller("aequalitylevels",
@@ -70,6 +71,8 @@ CActiveAESettings::CActiveAESettings(CActiveAE &ae) : m_audioEngine(ae)
                                                                                    SettingOptionsAudioDevicesPassthroughFiller);
   CServiceBroker::GetSettings().GetSettingsManager()->RegisterSettingOptionsFiller("audiostreamsilence",
                                                                                    SettingOptionsAudioStreamsilenceFiller);
+  CServiceBroker::GetSettings().GetSettingsManager()->RegisterSettingOptionsFiller("audioboostcenter",
+                                                                                   SettingOptionsAudioBoostCenterFiller);
 }
 
 CActiveAESettings::~CActiveAESettings()
@@ -79,6 +82,7 @@ CActiveAESettings::~CActiveAESettings()
   CServiceBroker::GetSettings().GetSettingsManager()->UnregisterSettingOptionsFiller("audiodevices");
   CServiceBroker::GetSettings().GetSettingsManager()->UnregisterSettingOptionsFiller("audiodevicespassthrough");
   CServiceBroker::GetSettings().GetSettingsManager()->UnregisterSettingOptionsFiller("audiostreamsilence");
+  CServiceBroker::GetSettings().GetSettingsManager()->UnregisterSettingOptionsFiller("audioboostcenter");
   CServiceBroker::GetSettings().GetSettingsManager()->UnregisterCallback(this);
   m_instance = nullptr;
 }
@@ -119,6 +123,17 @@ void CActiveAESettings::SettingOptionsAudioQualityLevelsFiller(SettingConstPtr s
     list.push_back(std::make_pair(g_localizeStrings.Get(13509), AE_QUALITY_REALLYHIGH));
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_GPU))
     list.push_back(std::make_pair(g_localizeStrings.Get(38010), AE_QUALITY_GPU));
+}
+
+void CActiveAESettings::SettingOptionsAudioBoostCenterFiller(SettingConstPtr setting,
+                                                             std::vector< std::pair<std::string, int> > &list,
+                                                             int &current, void *data)
+{
+  CSingleLock lock(m_instance->m_cs);
+  for (int i = 0; i <= 30; i++)
+  {
+    list.push_back(std::make_pair(StringUtils::Format(g_localizeStrings.Get(38009), i), i));
+  }
 }
 
 void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(SettingConstPtr setting,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h
@@ -50,6 +50,8 @@ public:
                                                           std::string &current, void *data);
   static void SettingOptionsAudioQualityLevelsFiller(std::shared_ptr<const CSetting> setting,
                                                      std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+  static void SettingOptionsAudioBoostCenterFiller(std::shared_ptr<const CSetting> setting,
+                                                     std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static void SettingOptionsAudioStreamsilenceFiller(std::shared_ptr<const CSetting> setting,
                                                      std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static bool IsSettingVisible(const std::string &condition, const std::string &value,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1101,7 +1101,7 @@ void CActiveAESink::GenerateNoise()
                  AV_SAMPLE_FMT_FLT,
                  CAEUtil::DataFormatToUsedBits(m_sinkFormat.m_dataFormat),
                  CAEUtil::DataFormatToDitherBits(m_sinkFormat.m_dataFormat),
-                 false, false, nullptr, AE_QUALITY_UNKNOWN, false);
+                 false, false, nullptr, AE_QUALITY_UNKNOWN, AE_OUTPUT_BOOST_CENTER_OFF, false);
   resampler->Resample(m_sampleOfSilence.pkt->data, m_sampleOfSilence.pkt->max_nb_samples,
                      (uint8_t**)&noise, m_sampleOfSilence.pkt->max_nb_samples, 1.0);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -165,6 +165,7 @@ void CActiveAEStream::InitRemapper()
                      false,
                      &remapLayout,
                      AE_QUALITY_LOW, // not used for remapping
+                     AE_OUTPUT_BOOST_CENTER_OFF,
                      false);
 
     // extra sound packet, we can't resample to the same buffer
@@ -654,9 +655,9 @@ bool CActiveAEStreamBuffers::ProcessBuffers()
   return busy;
 }
 
-void CActiveAEStreamBuffers::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality)
+void CActiveAEStreamBuffers::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality, int boostcenter)
 {
-  m_resampleBuffers->ConfigureResampler(normalizelevels, stereoupmix, quality);
+  m_resampleBuffers->ConfigureResampler(normalizelevels, stereoupmix, quality, boostcenter);
 }
 
 float CActiveAEStreamBuffers::GetDelay()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -105,7 +105,7 @@ public:
   bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true);
   void SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
   bool ProcessBuffers();
-  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality);
+  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality, int boostcenter);
   bool HasInputLevel(int level);
   float GetDelay();
   void Flush();

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -47,6 +47,8 @@ class CAEStreamInfo;
 #define AE_CONFIG_AUTO  2
 #define AE_CONFIG_MATCH 3
 
+#define AE_OUTPUT_BOOST_CENTER_OFF 0
+
 enum AEQuality
 {
   AE_QUALITY_UNKNOWN    = -1, /* Unset, unknown or incorrect quality level */

--- a/xbmc/cores/AudioEngine/Interfaces/AEResample.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEResample.h
@@ -35,7 +35,7 @@ public:
   virtual const char *GetName() = 0;
   IAEResample() = default;
   virtual ~IAEResample() = default;
-  virtual bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample) = 0;
+  virtual bool Init(uint64_t dst_chan_layout, int dst_channels, int dst_rate, AVSampleFormat dst_fmt, int dst_bits, int dst_dither, uint64_t src_chan_layout, int src_channels, int src_rate, AVSampleFormat src_fmt, int src_bits, int src_dither, bool upmix, bool normalize, CAEChannelInfo *remapLayout, AEQuality quality, int boostcenter, bool force_resample) = 0;
   virtual int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio) = 0;
   virtual int64_t GetDelay(int64_t base) = 0;
   virtual int GetBufferedSamples() = 0;

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -637,6 +637,12 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
     {
        av_opt_set_double(m_pContext, "rematrix_maxval", 1.0, 0);
     }
+    int boost_center = CServiceBroker::GetSettings().GetInt("audiooutput.boostcenter");
+    if (boost_center)
+    {
+      float gain = pow(10.0f, (static_cast<float>(-3 + boost_center))/20.0f);
+      av_opt_set_double(m_pContext, "center_mix_level", gain, 0);
+    }
 
     // stereo upmix
     if (upmix && m_src_channels == 2 && m_dst_channels > 2)

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -277,6 +277,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
                        false,
                        NULL,
                        AE_QUALITY_UNKNOWN,
+                       AE_OUTPUT_BOOST_CENTER_OFF,
                        false);
 
     m_planes = AE_IS_PLANAR(m_srcFormat.m_dataFormat) ? m_channels : 1;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -362,6 +362,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY = "audiooutput.p
 const std::string CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD = "audiooutput.atempothreshold";
 const std::string CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE = "audiooutput.streamsilence";
 const std::string CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE = "audiooutput.streamnoise";
+const std::string CSettings::SETTING_AUDIOOUTPUT_BOOSTCENTER = "audiooutput.boostcenter";
 const std::string CSettings::SETTING_AUDIOOUTPUT_GUISOUNDMODE = "audiooutput.guisoundmode";
 const std::string CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH = "audiooutput.passthrough";
 const std::string CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE = "audiooutput.passthroughdevice";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -315,6 +315,7 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD;
   static const std::string SETTING_AUDIOOUTPUT_STREAMSILENCE;
   static const std::string SETTING_AUDIOOUTPUT_STREAMNOISE;
+  static const std::string SETTING_AUDIOOUTPUT_BOOSTCENTER;
   static const std::string SETTING_AUDIOOUTPUT_GUISOUNDMODE;
   static const std::string SETTING_AUDIOOUTPUT_PASSTHROUGH;
   static const std::string SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE;


### PR DESCRIPTION
Use-Case:

- 5.1 Output with the center being too low
- 5.1 Formats without metadata (AAC, FLAC, etc.) that need custom control
- Workaround for non existing ADSP in v18

Take-Over from Popcornmix's 4 year old patch and adjusted to AE Settings / Interface infrastructure.

Status: Tested

Everyone is free to pick it up.

