### PR TITLE
Games: Fix segfault when opening a game

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
@@ -19,8 +19,8 @@
  */
 
 #include "RetroPlayerInput.h"
-#include "peripherals/Peripherals.h"
 #include "peripherals/EventPollHandle.h"
+#include "peripherals/Peripherals.h"
 #include "utils/log.h"
 
 using namespace KODI;

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -34,6 +34,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/JoystickTypes.h"
+#include "peripherals/EventLockHandle.h"
 #include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
@@ -392,8 +393,11 @@ bool CGameClientInput::OpenJoystick(const std::string &portAddress, const Contro
 
   if (bSuccess)
   {
+    PERIPHERALS::EventLockHandlePtr lock = CServiceBroker::GetPeripherals().RegisterEventLock();
+
     m_joysticks[portAddress].reset(new CGameClientJoystick(m_gameClient, portAddress, controller, m_struct.toAddon));
     ProcessJoysticks();
+
     return true;
   }
 
@@ -407,7 +411,12 @@ void CGameClientInput::CloseJoystick(const std::string &portAddress)
   {
     std::unique_ptr<CGameClientJoystick> joystick = std::move(it->second);
     m_joysticks.erase(it);
-    ProcessJoysticks();
+    {
+      PERIPHERALS::EventLockHandlePtr lock = CServiceBroker::GetPeripherals().RegisterEventLock();
+
+      ProcessJoysticks();
+      joystick.reset();
+    }
   }
 
   {
@@ -467,7 +476,10 @@ void CGameClientInput::Notify(const Observable& obs, const ObservableMessage msg
   {
   case ObservableMessagePeripheralsChanged:
   {
+    PERIPHERALS::EventLockHandlePtr lock = CServiceBroker::GetPeripherals().RegisterEventLock();
+
     ProcessJoysticks();
+
     break;
   }
   default:

--- a/xbmc/peripherals/CMakeLists.txt
+++ b/xbmc/peripherals/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES EventLockHandle.cpp
 set(HEADERS EventLockHandle.h
             EventPollHandle.h
             EventScanner.h
+            IEventScannerCallback.h
             Peripherals.h
             PeripheralTypes.h)
 

--- a/xbmc/peripherals/CMakeLists.txt
+++ b/xbmc/peripherals/CMakeLists.txt
@@ -1,8 +1,10 @@
-set(SOURCES EventPollHandle.cpp
+set(SOURCES EventLockHandle.cpp
+            EventPollHandle.cpp
             EventScanner.cpp
             Peripherals.cpp)
 
-set(HEADERS EventPollHandle.h
+set(HEADERS EventLockHandle.h
+            EventPollHandle.h
             EventScanner.h
             Peripherals.h
             PeripheralTypes.h)

--- a/xbmc/peripherals/EventLockHandle.cpp
+++ b/xbmc/peripherals/EventLockHandle.cpp
@@ -1,0 +1,33 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "EventLockHandle.h"
+
+using namespace PERIPHERALS;
+
+CEventLockHandle::CEventLockHandle(IEventLockCallback &callback) :
+  m_callback(callback)
+{
+}
+
+CEventLockHandle::~CEventLockHandle(void)
+{
+  m_callback.ReleaseLock(*this);
+}

--- a/xbmc/peripherals/EventLockHandle.h
+++ b/xbmc/peripherals/EventLockHandle.h
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+namespace PERIPHERALS
+{
+  class CEventLockHandle;
+
+  /*!
+   * \brief Callback implemented by event scanner
+   */
+  class IEventLockCallback
+  {
+  public:
+    virtual ~IEventLockCallback(void) = default;
+
+    virtual void ReleaseLock(CEventLockHandle *handle) = 0;
+  };
+
+  /*!
+   * \brief Handle returned by the event scanner to disable event processing
+   *
+   * When held, this disables event processing.
+   */
+  class CEventLockHandle
+  {
+  public:
+    /*!
+     * \brief Create an event lock handle
+     */
+    CEventLockHandle(IEventLockCallback &callback);
+
+    /*!
+     * \brief Handle is automatically released when this class is destructed
+     */
+    ~CEventLockHandle(void);
+
+  private:
+    // Construction parameters
+    IEventLockCallback &m_callback;
+  };
+}

--- a/xbmc/peripherals/EventPollHandle.cpp
+++ b/xbmc/peripherals/EventPollHandle.cpp
@@ -20,32 +20,29 @@
 
 #include "EventPollHandle.h"
 
-#include <assert.h>
-
 using namespace PERIPHERALS;
 
-CEventPollHandle::CEventPollHandle(IEventPollCallback* callback) :
+CEventPollHandle::CEventPollHandle(IEventPollCallback &callback) :
   m_callback(callback)
 {
-  assert(m_callback != nullptr);
 }
 
 CEventPollHandle::~CEventPollHandle(void)
 {
-  m_callback->Release(this);
+  m_callback.Release(*this);
 }
 
 void CEventPollHandle::Activate()
 {
-  m_callback->Activate(this);
+  m_callback.Activate(*this);
 }
 
 void CEventPollHandle::Deactivate()
 {
-  m_callback->Deactivate(this);
+  m_callback.Deactivate(*this);
 }
 
 void CEventPollHandle::HandleEvents(bool bWait)
 {
-  m_callback->HandleEvents(bWait);
+  m_callback.HandleEvents(bWait);
 }

--- a/xbmc/peripherals/EventPollHandle.h
+++ b/xbmc/peripherals/EventPollHandle.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include <memory>
-
 namespace PERIPHERALS
 {
   class CEventPollHandle;
@@ -34,10 +32,10 @@ namespace PERIPHERALS
   public:
     virtual ~IEventPollCallback(void) = default;
 
-    virtual void Activate(CEventPollHandle *handle) = 0;
-    virtual void Deactivate(CEventPollHandle *handle) = 0;
+    virtual void Activate(CEventPollHandle &handle) = 0;
+    virtual void Deactivate(CEventPollHandle &handle) = 0;
     virtual void HandleEvents(bool bWait) = 0;
-    virtual void Release(CEventPollHandle *handle) = 0;
+    virtual void Release(CEventPollHandle &handle) = 0;
   };
 
   /*!
@@ -52,12 +50,12 @@ namespace PERIPHERALS
     /*!
      * \brief Create an active polling handle
      */
-    CEventPollHandle(IEventPollCallback* callback);
+    CEventPollHandle(IEventPollCallback &callback);
 
     /*!
      * \brief Handle is automatically released when this class is destructed
      */
-    ~CEventPollHandle(void);
+    ~CEventPollHandle();
 
     /*!
      * \brief Activate handle
@@ -77,6 +75,6 @@ namespace PERIPHERALS
     void HandleEvents(bool bWait);
 
   private:
-    IEventPollCallback* const m_callback;
+    IEventPollCallback &m_callback;
   };
 }

--- a/xbmc/peripherals/EventScanner.h
+++ b/xbmc/peripherals/EventScanner.h
@@ -31,13 +31,7 @@
 
 namespace PERIPHERALS
 {
-  class IEventScannerCallback
-  {
-  public:
-    virtual ~IEventScannerCallback(void) = default;
-
-    virtual void ProcessEvents(void) = 0;
-  };
+  class IEventScannerCallback;
 
   /*!
    * \brief Class to scan for peripheral events
@@ -50,12 +44,12 @@ namespace PERIPHERALS
                         protected CThread
   {
   public:
-    explicit CEventScanner(IEventScannerCallback* callback);
+    explicit CEventScanner(IEventScannerCallback &callback);
 
-    ~CEventScanner(void) override = default;
+    ~CEventScanner() override = default;
 
-    void Start(void);
-    void Stop(void);
+    void Start();
+    void Stop();
 
     EventPollHandlePtr RegisterPollHandle();
 
@@ -65,28 +59,31 @@ namespace PERIPHERALS
     EventLockHandlePtr RegisterLock();
 
     // implementation of IEventPollCallback
-    void Activate(CEventPollHandle *handle) override;
-    void Deactivate(CEventPollHandle *handle) override;
+    void Activate(CEventPollHandle &handle) override;
+    void Deactivate(CEventPollHandle &handle) override;
     void HandleEvents(bool bWait) override;
-    void Release(CEventPollHandle *handle) override;
+    void Release(CEventPollHandle &handle) override;
 
     // implementation of IEventLockCallback
-    void ReleaseLock(CEventLockHandle *handle) override;
+    void ReleaseLock(CEventLockHandle &handle) override;
 
   protected:
     // implementation of CThread
-    void Process(void) override;
+    void Process() override;
 
   private:
-    double GetScanIntervalMs(void) const;
+    double GetScanIntervalMs() const;
 
-    IEventScannerCallback* const m_callback;
-    std::set<void*>              m_activeHandles;
-    std::set<void*>              m_activeLocks;
-    CEvent                       m_scanEvent;
-    CEvent                       m_scanFinishedEvent;
-    CCriticalSection             m_handleMutex;
-    CCriticalSection             m_lockMutex;
-    CCriticalSection             m_pollMutex; // Prevent two poll handles from polling at once
+    // Construction parameters
+    IEventScannerCallback &m_callback;
+
+    // Event parameters
+    std::set<void*> m_activeHandles;
+    std::set<void*> m_activeLocks;
+    CEvent m_scanEvent;
+    CEvent m_scanFinishedEvent;
+    CCriticalSection m_handleMutex;
+    CCriticalSection m_lockMutex;
+    CCriticalSection m_pollMutex; // Prevent two poll handles from polling at once
   };
 }

--- a/xbmc/peripherals/IEventScannerCallback.h
+++ b/xbmc/peripherals/IEventScannerCallback.h
@@ -21,39 +21,11 @@
 
 namespace PERIPHERALS
 {
-  class CEventLockHandle;
-
-  /*!
-   * \brief Callback implemented by event scanner
-   */
-  class IEventLockCallback
+  class IEventScannerCallback
   {
   public:
-    virtual ~IEventLockCallback(void) = default;
+    virtual ~IEventScannerCallback(void) = default;
 
-    virtual void ReleaseLock(CEventLockHandle &handle) = 0;
-  };
-
-  /*!
-   * \brief Handle returned by the event scanner to disable event processing
-   *
-   * When held, this disables event processing.
-   */
-  class CEventLockHandle
-  {
-  public:
-    /*!
-     * \brief Create an event lock handle
-     */
-    CEventLockHandle(IEventLockCallback &callback);
-
-    /*!
-     * \brief Handle is automatically released when this class is destructed
-     */
-    ~CEventLockHandle(void);
-
-  private:
-    // Construction parameters
-    IEventLockCallback &m_callback;
+    virtual void ProcessEvents(void) = 0;
   };
 }

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -84,15 +84,15 @@ namespace PERIPHERALS
   };
 
   class CPeripheral;
-  typedef std::shared_ptr<CPeripheral> PeripheralPtr;
-  typedef std::vector<PeripheralPtr>   PeripheralVector;
+  using PeripheralPtr = std::shared_ptr<CPeripheral>;
+  using PeripheralVector = std::vector<PeripheralPtr>;
 
   class CPeripheralAddon;
-  typedef std::shared_ptr<CPeripheralAddon> PeripheralAddonPtr;
-  typedef std::vector<PeripheralAddonPtr>   PeripheralAddonVector;
+  using PeripheralAddonPtr = std::shared_ptr<CPeripheralAddon>;
+  using PeripheralAddonVector = std::vector<PeripheralAddonPtr>;
 
   class CEventPollHandle;
-  typedef std::unique_ptr<CEventPollHandle> EventPollHandlePtr;
+  using EventPollHandlePtr = std::unique_ptr<CEventPollHandle>;
 
   class CEventLockHandle;
   using EventLockHandlePtr = std::unique_ptr<CEventLockHandle>;

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -94,6 +94,9 @@ namespace PERIPHERALS
   class CEventPollHandle;
   typedef std::unique_ptr<CEventPollHandle> EventPollHandlePtr;
 
+  class CEventLockHandle;
+  using EventLockHandlePtr = std::unique_ptr<CEventLockHandle>;
+
   struct PeripheralID
   {
     int m_iVendorId;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -777,6 +777,11 @@ bool CPeripherals::GetNextKeypress(float frameTime, CKey &key)
   return false;
 }
 
+EventLockHandlePtr CPeripherals::RegisterEventLock()
+{
+  return m_eventScanner.RegisterLock();
+}
+
 void CPeripherals::OnUserNotification()
 {
   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_INPUT_RUMBLENOTIFY))

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -239,6 +239,12 @@ namespace PERIPHERALS
     EventPollHandlePtr RegisterEventPoller() { return m_eventScanner.RegisterPollHandle(); }
 
     /*!
+     * @brief Register with the event scanner to disable event processing
+     * @return A handle that unregisters itself when expired
+     */
+    EventLockHandlePtr RegisterEventLock();
+
+    /*!
      * 
      */
     void OnUserNotification();

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -20,9 +20,10 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
-#include "EventScanner.h"
+#include "IEventScannerCallback.h"
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
 #include "interfaces/IAnnouncer.h"
@@ -60,6 +61,8 @@ namespace ANNOUNCEMENT
 
 namespace PERIPHERALS
 {
+  class CEventScanner;
+
   class CPeripherals :  public ISettingCallback,
                         public Observable,
                         public KODI::MESSAGING::IMessageTarget,
@@ -236,7 +239,7 @@ namespace PERIPHERALS
      * @brief Register with the event scanner to control scan timing
      * @return A handle that unregisters itself when expired
      */
-    EventPollHandlePtr RegisterEventPoller() { return m_eventScanner.RegisterPollHandle(); }
+    EventPollHandlePtr RegisterEventPoller();
 
     /*!
      * @brief Register with the event scanner to disable event processing
@@ -350,12 +353,12 @@ namespace PERIPHERALS
     KODI::GAME::CControllerManager &m_controllerProfiles;
 
 #if !defined(HAVE_LIBCEC)
-    bool                                 m_bMissingLibCecWarningDisplayed = false;
+    bool m_bMissingLibCecWarningDisplayed = false;
 #endif
-    std::vector<PeripheralBusPtr>        m_busses;
+    std::vector<PeripheralBusPtr> m_busses;
     std::vector<PeripheralDeviceMapping> m_mappings;
-    CEventScanner                        m_eventScanner;
-    CCriticalSection                     m_critSectionBusses;
-    CCriticalSection                     m_critSectionMappings;
+    std::unique_ptr<CEventScanner> m_eventScanner;
+    CCriticalSection m_critSectionBusses;
+    CCriticalSection m_critSectionMappings;
   };
 }


### PR DESCRIPTION
This fixes a segfault that occurs when moving an analog stick on game open. The analog stick event is delivered while joysticks are being connected/disconnected.

## How Has This Been Tested?
Tested by using the controller while opening a game on Windows 10.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
