### PR TITLE
[PVR] CPVRClients cleanup.

### DIFF
--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -117,6 +117,13 @@ namespace PVR
     std::shared_ptr<CPVRClient> GetClient(const CFileItem &item) const;
 
     /*!
+     * @brief Get the instance of a client that matches the given id.
+     * @param iClientId The id of a PVR client.
+     * @return the requested client on success, nullptr otherwise.
+     */
+    std::shared_ptr<CPVRClient> GetClient(int iClientId) const;
+
+    /*!
      * @brief Get access to the pvr gui actions.
      * @return The gui actions.
      */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -21,9 +21,7 @@
 #include "PVRClients.h"
 
 #include <utility>
-#include <functional>
 
-#include "Application.h"
 #include "ServiceBroker.h"
 #include "addons/BinaryAddonCache.h"
 #include "guilib/LocalizeStrings.h"
@@ -33,10 +31,6 @@
 #include "pvr/PVRJobs.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
-#include "pvr/channels/PVRChannelGroups.h"
-#include "pvr/epg/EpgInfoTag.h"
-#include "pvr/recordings/PVRRecordings.h"
-#include "pvr/timers/PVRTimers.h"
 
 using namespace ADDON;
 using namespace PVR;
@@ -436,49 +430,9 @@ int CPVRClients::EnabledClientAmount(void) const
   return iReturn;
 }
 
-bool CPVRClients::GetClientFriendlyName(int iClientId, std::string &strName) const
-{
-  return ForCreatedClient(__FUNCTION__, iClientId, [&strName](const CPVRClientPtr &client) {
-    strName = client->GetFriendlyName();
-    return PVR_ERROR_NO_ERROR;
-  }) == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRClients::GetClientAddonName(int iClientId, std::string &strName) const
-{
-  return ForCreatedClient(__FUNCTION__, iClientId, [&strName](const CPVRClientPtr &client) {
-    strName = client->Name();
-    return PVR_ERROR_NO_ERROR;
-  }) == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRClients::GetClientAddonIcon(int iClientId, std::string &strIcon) const
-{
-  return ForCreatedClient(__FUNCTION__, iClientId, [&strIcon](const CPVRClientPtr &client) {
-    strIcon = client->Icon();
-    return PVR_ERROR_NO_ERROR;
-  }) == PVR_ERROR_NO_ERROR;
-}
-
-std::string CPVRClients::GetClientAddonId(int iClientId) const
-{
-  CPVRClientPtr client;
-  return GetClient(iClientId, client) ? client->ID() : "";
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // client API calls
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-CPVRClientCapabilities CPVRClients::GetClientCapabilities(int iClientId) const
-{
-  CPVRClientCapabilities caps;
-  ForCreatedClient(__FUNCTION__, iClientId, [&caps](const CPVRClientPtr &client) {
-    caps = client->GetClientCapabilities();
-    return PVR_ERROR_NO_ERROR;
-  });
-  return caps;
-}
 
 std::vector<SBackend> CPVRClients::GetBackendProperties() const
 {
@@ -513,37 +467,6 @@ std::vector<SBackend> CPVRClients::GetBackendProperties() const
   return backendProperties;
 }
 
-std::string CPVRClients::GetBackendHostnameByClientId(int iClientId) const
-{
-  std::string name;
-  ForCreatedClient(__FUNCTION__, iClientId, [&name](const CPVRClientPtr &client) {
-    name = client->GetBackendHostname();
-    return PVR_ERROR_NO_ERROR;
-  });
-  return name;
-}
-
-bool CPVRClients::FillChannelStreamFileItem(CFileItem &fileItem)
-{
-  return ForCreatedClient(__FUNCTION__, fileItem.GetPVRChannelInfoTag()->ClientID(), [&fileItem](const CPVRClientPtr &client) {
-    return client->FillChannelStreamFileItem(fileItem);
-  }) == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRClients::FillRecordingStreamFileItem(CFileItem &fileItem)
-{
-  return ForCreatedClient(__FUNCTION__, fileItem.GetPVRRecordingInfoTag()->ClientID(), [&fileItem](const CPVRClientPtr &client) {
-    return client->FillRecordingStreamFileItem(fileItem);
-  }) == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRClients::FillEpgTagStreamFileItem(CFileItem &fileItem)
-{
-  return ForCreatedClient(__FUNCTION__, fileItem.GetEPGInfoTag()->ClientID(), [&fileItem](const CPVRClientPtr &client) {
-    return client->FillEpgTagStreamFileItem(fileItem);
-  }) == PVR_ERROR_NO_ERROR;
-}
-
 bool CPVRClients::SupportsTimers() const
 {
   bool bReturn = false;
@@ -562,37 +485,9 @@ bool CPVRClients::GetTimers(CPVRTimersContainer *timers, std::vector<int> &faile
   }, failedClients) == PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR CPVRClients::AddTimer(const CPVRTimerInfoTag &timer)
-{
-  return ForCreatedClient(__FUNCTION__, timer.m_iClientId, [&timer](const CPVRClientPtr &client) {
-    return client->AddTimer(timer);
-  });
-}
-
-PVR_ERROR CPVRClients::UpdateTimer(const CPVRTimerInfoTag &timer)
-{
-  return ForCreatedClient(__FUNCTION__, timer.m_iClientId, [&timer](const CPVRClientPtr &client) {
-    return client->UpdateTimer(timer);
-  });
-}
-
-PVR_ERROR CPVRClients::DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce)
-{
-  return ForCreatedClient(__FUNCTION__, timer.m_iClientId, [&timer, bForce](const CPVRClientPtr &client) {
-    return client->DeleteTimer(timer, bForce);
-  });
-}
-
 PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results) const
 {
   return ForCreatedClients(__FUNCTION__, [&results](const CPVRClientPtr &client) {
-    return client->GetTimerTypes(results);
-  });
-}
-
-PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results, int iClientId) const
-{
-  return ForCreatedClient(__FUNCTION__, iClientId, [&results](const CPVRClientPtr &client) {
     return client->GetTimerTypes(results);
   });
 }
@@ -604,30 +499,6 @@ PVR_ERROR CPVRClients::GetRecordings(CPVRRecordings *recordings, bool deleted)
   });
 }
 
-PVR_ERROR CPVRClients::RenameRecording(const CPVRRecording &recording)
-{
-  return ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording](const CPVRClientPtr &client) {
-    return client->RenameRecording(recording);
-  });
-}
-
-PVR_ERROR CPVRClients::DeleteRecording(const CPVRRecording &recording)
-{
-  return ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording](const CPVRClientPtr &client) {
-    return client->DeleteRecording(recording);
-  });
-}
-
-PVR_ERROR CPVRClients::UndeleteRecording(const CPVRRecording &recording)
-{
-  if (!recording.IsDeleted())
-    return PVR_ERROR_REJECTED;
-
-  return ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording](const CPVRClientPtr &client) {
-    return client->UndeleteRecording(recording);
-  });
-}
-
 PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
 {
   return ForCreatedClients(__FUNCTION__, [](const CPVRClientPtr &client) {
@@ -635,82 +506,10 @@ PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
   });
 }
 
-bool CPVRClients::SetRecordingLifetime(const CPVRRecording &recording, PVR_ERROR *error)
-{
-  *error = ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording](const CPVRClientPtr &client) {
-    return client->SetRecordingLifetime(recording);
-  });
-  return *error == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRClients::SetRecordingPlayCount(const CPVRRecording &recording, int count, PVR_ERROR *error)
-{
-  *error = ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording, count](const CPVRClientPtr &client) {
-    return client->SetRecordingPlayCount(recording, count);
-  });
-  return *error == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRClients::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVR_ERROR *error)
-{
-  *error = ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording, lastplayedposition](const CPVRClientPtr &client) {
-    return client->SetRecordingLastPlayedPosition(recording, lastplayedposition);
-  });
-  return *error == PVR_ERROR_NO_ERROR;
-}
-
-int CPVRClients::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
-{
-  int iPos = 0;
-  ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording, &iPos](const CPVRClientPtr &client) {
-    return client->GetRecordingLastPlayedPosition(recording, iPos);
-  });
-  return iPos;
-}
-
-std::vector<PVR_EDL_ENTRY> CPVRClients::GetRecordingEdl(const CPVRRecording &recording)
-{
-  std::vector<PVR_EDL_ENTRY> edls;
-  ForCreatedClient(__FUNCTION__, recording.ClientID(), [&recording, &edls](const CPVRClientPtr &client) {
-    return client->GetRecordingEdl(recording, edls);
-  });
-  return edls;
-}
-
-std::vector<PVR_EDL_ENTRY> CPVRClients::GetEpgTagEdl(const CConstPVREpgInfoTagPtr &epgTag)
-{
-  std::vector<PVR_EDL_ENTRY> edls;
-  ForCreatedClient(__FUNCTION__, epgTag->ClientID(), [&epgTag, &edls](const CPVRClientPtr &client) {
-    return client->GetEpgTagEdl(epgTag, edls);
-  });
-  return edls;
-}
-
-PVR_ERROR CPVRClients::GetEPGForChannel(const CPVRChannelPtr &channel, CPVREpg *epg, time_t start, time_t end)
-{
-  return ForCreatedClient(__FUNCTION__, channel->ClientID(), [&channel, epg, start, end](const CPVRClientPtr &client) {
-    return client->GetEPGForChannel(channel, epg, start, end);
-  });
-}
-
 PVR_ERROR CPVRClients::SetEPGTimeFrame(int iDays)
 {
   return ForCreatedClients(__FUNCTION__, [iDays](const CPVRClientPtr &client) {
     return client->SetEPGTimeFrame(iDays);
-  });
-}
-
-PVR_ERROR CPVRClients::IsRecordable(const CConstPVREpgInfoTagPtr& tag, bool &bIsRecordable) const
-{
-  return ForCreatedClient(__FUNCTION__, tag->ClientID(), [&tag, &bIsRecordable](const CPVRClientPtr &client) {
-    return client->IsRecordable(tag, bIsRecordable);
-  });
-}
-
-PVR_ERROR CPVRClients::IsPlayable(const CConstPVREpgInfoTagPtr& tag, bool &bIsPlayable) const
-{
-  return ForCreatedClient(__FUNCTION__, tag->ClientID(), [&tag, &bIsPlayable](const CPVRClientPtr &client) {
-    return client->IsPlayable(tag, bIsPlayable);
   });
 }
 
@@ -735,20 +534,6 @@ PVR_ERROR CPVRClients::GetChannelGroupMembers(CPVRChannelGroup *group, std::vect
   }, failedClients);
 }
 
-PVR_ERROR CPVRClients::DeleteChannel(const CPVRChannelPtr &channel)
-{
-  return ForCreatedClient(__FUNCTION__, channel->ClientID(), [&channel](const CPVRClientPtr &client) {
-    return client->DeleteChannel(channel);
-  });
-}
-
-bool CPVRClients::RenameChannel(const CPVRChannelPtr &channel)
-{
-  return ForCreatedClient(__FUNCTION__, channel->ClientID(), [&channel](const CPVRClientPtr &client) {
-    return client->RenameChannel(channel);
-  });
-}
-
 std::vector<CPVRClientPtr> CPVRClients::GetClientsSupportingChannelScan(void) const
 {
   std::vector<CPVRClientPtr> possibleScanClients;
@@ -771,30 +556,6 @@ std::vector<CPVRClientPtr> CPVRClients::GetClientsSupportingChannelSettings(bool
     return PVR_ERROR_NO_ERROR;
   });
   return possibleSettingsClients;
-}
-
-PVR_ERROR CPVRClients::OpenDialogChannelAdd(const CPVRChannelPtr &channel)
-{
-  return ForCreatedClient(__FUNCTION__, channel->ClientID(), [&channel](const CPVRClientPtr &client) {
-    return client->OpenDialogChannelAdd(channel);
-  });
-}
-
-PVR_ERROR CPVRClients::OpenDialogChannelSettings(const CPVRChannelPtr &channel)
-{
-  return ForCreatedClient(__FUNCTION__, channel->ClientID(), [&channel](const CPVRClientPtr &client) {
-    return client->OpenDialogChannelSettings(channel);
-  });
-}
-
-bool CPVRClients::HasMenuHooks(int iClientID, PVR_MENUHOOK_CAT cat)
-{
-  bool bHasMenuHooks = false;
-  ForCreatedClient(__FUNCTION__, iClientID, [cat, &bHasMenuHooks](const CPVRClientPtr &client) {
-    bHasMenuHooks = client->HasMenuHooks(cat);
-    return PVR_ERROR_NO_ERROR;
-  });
-  return bHasMenuHooks;
 }
 
 void CPVRClients::OnSystemSleep()
@@ -930,23 +691,4 @@ PVR_ERROR CPVRClients::ForCreatedClients(const char* strFunctionName, PVRClientF
     }
   }
   return lastError;
-}
-
-PVR_ERROR CPVRClients::ForCreatedClient(const char* strFunctionName, int iClientId, PVRClientFunction function) const
-{
-  PVR_ERROR error = PVR_ERROR_UNKNOWN;
-  CPVRClientPtr client;
-  if (GetCreatedClient(iClientId, client))
-  {
-    error = function(client);
-
-    if (error != PVR_ERROR_NO_ERROR && error != PVR_ERROR_NOT_IMPLEMENTED)
-      CLog::Log(LOGERROR, "CPVRClients - %s - client '%s' returned an error: %s",
-                strFunctionName, client->GetFriendlyName().c_str(), CPVRClient::ToString(error));
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "CPVRClients - %s - no created client with id '%d'", strFunctionName, iClientId);
-  }
-  return error;
 }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -20,16 +20,15 @@
 
 #pragma once
 
-#include <deque>
 #include <functional>
+#include <map>
+#include <string>
 #include <vector>
 
+#include "addons/AddonManager.h"
 #include "addons/PVRClient.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "threads/CriticalSection.h"
-#include "threads/Thread.h"
-#include "utils/Observer.h"
-
-#include "pvr/PVRTypes.h"
 
 namespace ADDON
 {
@@ -38,11 +37,14 @@ namespace ADDON
 
 namespace PVR
 {
-  class CPVREpg;
   class CPVRChannelGroupInternal;
+  class CPVRChannelGroup;
+  class CPVRChannelGroups;
+  class CPVREpg;
+  class CPVRRecordings;
+  class CPVRTimersContainer;
 
   typedef std::map<int, CPVRClientPtr> CPVRClientMap;
-  typedef std::map<int, PVR_STREAM_PROPERTIES> STREAMPROPS;
 
   /**
    * Holds generic data about a backend (number of channels etc.)
@@ -170,77 +172,14 @@ namespace PVR
      */
     int EnabledClientAmount(void) const;
 
-    /*!
-     * @brief Get the friendly name for the client with the given id.
-     * @param iClientId The id of the client.
-     * @param strName The friendly name of the client or an empty string when it wasn't found.
-     * @return True if the client was found, false otherwise.
-     */
-    bool GetClientFriendlyName(int iClientId, std::string &strName) const;
-
-    /*!
-     * @brief Get the addon name for the client with the given id.
-     * @param iClientId The id of the client.
-     * @param strName The addon name of the client or an empty string when it wasn't found.
-     * @return True if the client was found, false otherwise.
-     */
-    bool GetClientAddonName(int iClientId, std::string &strName) const;
-
-    /*!
-     * @brief Get the addon icon for the client with the given id.
-     * @param iClientId The id of the client.
-     * @param strIcon The path to the addon icon of the client or an empty string when it wasn't found.
-     * @return True if the client was found, false otherwise.
-     */
-    bool GetClientAddonIcon(int iClientId, std::string &strIcon) const;
-
-    /*!
-     * Get the add-on ID of the client
-     * @param iClientId The db id of the client
-     * @return The add-on id
-     */
-    std::string GetClientAddonId(int iClientId) const;
-
     /*! @name general methods */
     //@{
-
-    /*!
-     * @brief Query the the given client's capabilities.
-     * @param iClientId The client id.
-     * @return The capabilities.
-     */
-    CPVRClientCapabilities GetClientCapabilities(int iClientId) const;
 
     /*!
      * @brief Returns properties about all created clients
      * @return the properties
      */
     std::vector<SBackend> GetBackendProperties() const;
-
-    /*!
-     * @brief Returns the client's backend host name.
-     * @return the host name or an empty string, if the client does not have a backend host.
-     */
-    std::string GetBackendHostnameByClientId(int iClientId) const;
-
-    //@}
-
-    /*! @name stream methods */
-    //@{
-
-    /*!
-     * @brief Fill the file item for a channel with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled.
-     * @return True if the stream properties have been set, false otherwiese.
-     */
-    bool FillChannelStreamFileItem(CFileItem &fileItem);
-
-    /*!
-     * @brief Fill the file item for a recording with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled.
-     * @return True if the stream properties have been set, false otherwiese.
-     */
-    bool FillRecordingStreamFileItem(CFileItem &fileItem);
 
     //@}
 
@@ -262,41 +201,11 @@ namespace PVR
     bool GetTimers(CPVRTimersContainer *timers, std::vector<int> &failedClients);
 
     /*!
-     * @brief Add a new timer to a backend.
-     * @param timer The timer to add.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR AddTimer(const CPVRTimerInfoTag &timer);
-
-    /*!
-     * @brief Update a timer on the backend.
-     * @param timer The timer to update.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR UpdateTimer(const CPVRTimerInfoTag &timer);
-
-    /*!
-     * @brief Delete a timer from the backend.
-     * @param timer The timer to delete.
-     * @param bForce Also delete when currently recording if true.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR DeleteTimer(const CPVRTimerInfoTag &timer, bool bForce);
-
-    /*!
      * @brief Get all supported timer types.
      * @param results The container to store the result in.
      * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
      */
     PVR_ERROR GetTimerTypes(CPVRTimerTypes& results) const;
-
-    /*!
-     * @brief Get all timer types supported by a certain client.
-     * @param results The container to store the result in.
-     * @param iClientId The id of the client.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR GetTimerTypes(CPVRTimerTypes& results, int iClientId) const;
 
     //@}
 
@@ -312,78 +221,10 @@ namespace PVR
     PVR_ERROR GetRecordings(CPVRRecordings *recordings, bool deleted);
 
     /*!
-     * @brief Rename a recording on the backend.
-     * @param recording The recording to rename.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR RenameRecording(const CPVRRecording &recording);
-
-    /*!
-     * @brief Delete a recording from the backend.
-     * @param recording The recording to delete.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR DeleteRecording(const CPVRRecording &recording);
-
-    /*!
-     * @brief Undelete a recording from the backend.
-     * @param recording The recording to undelete.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR UndeleteRecording(const CPVRRecording &recording);
-
-    /*!
      * @brief Delete all "soft" deleted recordings permanently on the backend.
      * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
      */
     PVR_ERROR DeleteAllRecordingsFromTrash();
-
-    /*!
-     * @brief Set the lifetime of a recording on the backend.
-     * @param recording The recording to set the lifetime for. recording.m_iLifetime contains the new lifetime value.
-     * @param error An error if it occured.
-     * @return True if the recording's lifetime was set successfully, false otherwise.
-     */
-    bool SetRecordingLifetime(const CPVRRecording &recording, PVR_ERROR *error);
-
-    /*!
-     * @brief Set play count of a recording on the backend.
-     * @param recording The recording to set the play count.
-     * @param count Play count.
-     * @param error An error if it occured.
-     * @return True if the recording's play count was set successfully, false otherwise.
-     */
-    bool SetRecordingPlayCount(const CPVRRecording &recording, int count, PVR_ERROR *error);
-
-    /*!
-     * @brief Set the last watched position of a recording on the backend.
-     * @param recording The recording.
-     * @param position The last watched position in seconds
-     * @param error An error if it occured.
-     * @return True if the last played position was updated successfully, false otherwise.
-    */
-    bool SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition, PVR_ERROR *error);
-
-    /*!
-    * @brief Retrieve the last watched position of a recording on the backend.
-    * @param recording The recording.
-    * @return The last watched position in seconds.
-    */
-    int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
-
-    /*!
-    * @brief Retrieve the edit decision list (EDL) for a given recording from the backend.
-    * @param recording The recording.
-    * @return The edit decision list (empty on error).
-    */
-    std::vector<PVR_EDL_ENTRY> GetRecordingEdl(const CPVRRecording &recording);
-
-    /*!
-    * @brief Retrieve the edit decision list (EDL) for a given EPG tag from the backend.
-    * @param epgTag The EPG tag.
-    * @return The edit decision list (empty on error).
-    */
-    std::vector<PVR_EDL_ENTRY> GetEpgTagEdl(const CConstPVREpgInfoTagPtr &epgTag);
 
     //@}
 
@@ -391,46 +232,13 @@ namespace PVR
     //@{
 
     /*!
-     * @brief Get the EPG table for a channel.
-     * @param channel The channel to get the EPG table for.
-     * @param epg Store the EPG in this container.
-     * @param start Get entries after this start time.
-     * @param end Get entries before this end time.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR GetEPGForChannel(const CPVRChannelPtr &channel, CPVREpg *epg, time_t start, time_t end);
-
-    /*!
-     * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously
+     * Tell all clients the time frame to use when notifying epg events back to Kodi. The clients might push epg events asynchronously
      * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
-     * client needs to know about the epg time frame Kodi uses.
+     * clients need to know about the epg time frame Kodi uses.
      * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
      * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
      */
     PVR_ERROR SetEPGTimeFrame(int iDays);
-
-    /*
-     * @brief Check if an epg tag can be recorded.
-     * @param tag The epg tag.
-     * @param bIsRecordable Set to true if the tag can be recorded.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR IsRecordable(const CConstPVREpgInfoTagPtr &tag, bool &bIsRecordable) const;
-
-    /*
-     * @brief Check if an epg tag can be played.
-     * @param tag The epg tag.
-     * @param bIsPlayable Set to true if the tag can be played.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR IsPlayable(const CConstPVREpgInfoTagPtr &tag, bool &bIsPlayable) const;
-
-    /*!
-     * @brief Fill the file item for an epg tag with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled.
-     * @return True if the stream properties have been set, false otherwiese.
-     */
-    bool FillEpgTagStreamFileItem(CFileItem &fileItem);
 
     //@}
 
@@ -462,20 +270,6 @@ namespace PVR
     PVR_ERROR GetChannelGroupMembers(CPVRChannelGroup *group, std::vector<int> &failedClients);
 
     /*!
-     * @brief Delete a channel on the backend.
-     * @param channel The channel to delete.
-     * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
-     */
-    PVR_ERROR DeleteChannel(const CPVRChannelPtr &channel);
-
-    /*!
-     * @brief Rename the given channel on the backend.
-     * @param channel The channel to rename.
-     * @return True if the operation was successful, false otherwise.
-     */
-    bool RenameChannel(const CPVRChannelPtr &channel);
-
-    /*!
      * @brief Get a list of clients providing a channel scan dialog.
      * @return All clients supporting channel scan.
      */
@@ -486,33 +280,6 @@ namespace PVR
      * @return All clients supporting channel settings.
      */
     std::vector<CPVRClientPtr> GetClientsSupportingChannelSettings(bool bRadio) const;
-
-    /*!
-     * @brief Open addon settings dialog to add a channel.
-     * @param channel The channel to add.
-     * @return PVR_ERROR_NO_ERROR if the dialog was opened successfully, the respective error code otherwise.
-     */
-    PVR_ERROR OpenDialogChannelAdd(const CPVRChannelPtr &channel);
-
-    /*!
-     * @brief Open addon channel settings dialog to edit channel properties.
-     * @param channel The channel to edit.
-     * @return PVR_ERROR_NO_ERROR if the dialog was opened successfully, the respective error code otherwise.
-     */
-    PVR_ERROR OpenDialogChannelSettings(const CPVRChannelPtr &channel);
-
-    //@}
-
-    /*! @name Menu hook methods */
-    //@{
-
-    /*!
-     * @brief Check whether a client provides PVR client specific menu entries.
-     * @param iClientId The ID of the client to get the menu entries for. Get the menu for the active channel if iClientId < 0.
-     * @param cat The menu hook category.
-     * @return True if the client provides menu hooks, false otherwise.
-     */
-    bool HasMenuHooks(int iClientId, PVR_MENUHOOK_CAT cat);
 
     //@}
 
@@ -599,15 +366,6 @@ namespace PVR
      * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
      */
     PVR_ERROR ForCreatedClients(const char* strFunctionName, PVRClientFunction function, std::vector<int> &failedClients) const;
-
-    /*!
-     * @brief Wraps a call to a created client in order to do common pre and post function invocation actions.
-     * @param strFunctionName The function name, for logging purposes.
-     * @param iClientId The id of the client to call.
-     * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a CPVRClientPtr as parameter.
-     * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
-     */
-    PVR_ERROR ForCreatedClient(const char* strFunctionName, int iClientId, PVRClientFunction function) const;
 
     CCriticalSection m_critSection;
     CPVRClientMap m_clientMap;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -24,6 +24,7 @@
 
 #include "Application.h"
 #include "ServiceBroker.h"
+#include "addons/PVRClient.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -34,7 +35,6 @@
 
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
-#include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
@@ -225,12 +225,15 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
       bHideRecord = false;
     }
   }
-  else if (m_progItem->Channel() && CServiceBroker::GetPVRManager().Clients()->GetClientCapabilities(m_progItem->Channel()->ClientID()).SupportsTimers() &&
-           m_progItem->IsRecordable())
+  else if (m_progItem->Channel() && m_progItem->IsRecordable())
   {
-    SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264);     /* Record */
-    bHideRecord = false;
-    bHideAddTimer = false;
+    const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_progItem->ClientID());
+    if (client && client->GetClientCapabilities().SupportsTimers())
+    {
+      SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264);     /* Record */
+      bHideRecord = false;
+      bHideAddTimer = false;
+    }
   }
 
   if (!m_progItem->IsPlayable())

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -21,6 +21,7 @@
 #include "PVRTimerType.h"
 
 #include "ServiceBroker.h"
+#include "addons/PVRClient.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -45,14 +46,17 @@ const CPVRTimerTypePtr CPVRTimerType::GetFirstAvailableType()
 
 CPVRTimerTypePtr CPVRTimerType::CreateFromIds(unsigned int iTypeId, int iClientId)
 {
-  std::vector<CPVRTimerTypePtr> types;
-  PVR_ERROR error = CServiceBroker::GetPVRManager().Clients()->GetTimerTypes(types, iClientId);
-  if (error == PVR_ERROR_NO_ERROR)
+  const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(iClientId);
+  if (client)
   {
-    for (const auto &type : types)
+    std::vector<CPVRTimerTypePtr> types;
+    if (client->GetTimerTypes(types) == PVR_ERROR_NO_ERROR)
     {
-      if (type->GetTypeId() == iTypeId)
-        return type;
+      for (const auto &type : types)
+      {
+        if (type->GetTypeId() == iTypeId)
+          return type;
+      }
     }
   }
 
@@ -63,15 +67,18 @@ CPVRTimerTypePtr CPVRTimerType::CreateFromIds(unsigned int iTypeId, int iClientI
 CPVRTimerTypePtr CPVRTimerType::CreateFromAttributes(
   unsigned int iMustHaveAttr, unsigned int iMustNotHaveAttr, int iClientId)
 {
-  std::vector<CPVRTimerTypePtr> types;
-  PVR_ERROR error = CServiceBroker::GetPVRManager().Clients()->GetTimerTypes(types, iClientId);
-  if (error == PVR_ERROR_NO_ERROR)
+  const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(iClientId);
+  if (client)
   {
-    for (const auto &type : types)
+    std::vector<CPVRTimerTypePtr> types;
+    if (client->GetTimerTypes(types) == PVR_ERROR_NO_ERROR)
     {
-      if (((type->m_iAttributes & iMustHaveAttr)    == iMustHaveAttr) &&
-          ((type->m_iAttributes & iMustNotHaveAttr) == 0))
-        return type;
+      for (const auto &type : types)
+      {
+        if (((type->m_iAttributes & iMustHaveAttr)    == iMustHaveAttr) &&
+            ((type->m_iAttributes & iMustNotHaveAttr) == 0))
+          return type;
+      }
     }
   }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -25,6 +25,7 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "addons/PVRClient.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
@@ -354,17 +355,15 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer &timers, const std::vec
       /* queue notifications / fill eventlog */
       for (const auto &entry : timerNotifications)
       {
-        std::string strName;
-        CServiceBroker::GetPVRManager().Clients()->GetClientAddonName(entry.first, strName);
-
-        std::string strIcon;
-        CServiceBroker::GetPVRManager().Clients()->GetClientAddonIcon(entry.first, strIcon);
-
-        job->AddEvent(m_settings.GetBoolValue(CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS),
-                      false, // info, no error
-                      strName,
-                      entry.second,
-                      strIcon);
+        const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(entry.first);
+        if (client)
+        {
+          job->AddEvent(m_settings.GetBoolValue(CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS),
+                        false, // info, no error
+                        client->Name(),
+                        entry.second,
+                        client->Icon());
+        }
       }
 
       CJobManager::GetInstance().AddJob(job, nullptr);


### PR DESCRIPTION
Removed another 400 lines of boilerplate code from class `CPVRClients`. No functional changes. Runtime-tested on macOS, latest kodi master.

@Jalle19 mind taking a look.