### PR TITLE
[Estuary] Fix header of rating dialog in skin settings

### DIFF
--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -64,7 +64,7 @@
 				<control type="button" id="706">
 					<label>$LOCALIZE[31024]</label>
 					<include>DefaultSettingButton</include>
-					<onclick>Skin.SelectBool($LOCALIZE[31024], 38018|circle_userrating, 563|circle_rating, 16018|)</onclick>
+					<onclick>Skin.SelectBool(31024, 38018|circle_userrating, 563|circle_rating, 16018|)</onclick>
 					<label2>$VAR[RatingSettingLabel2Var]</label2>
 				</control>
 			</control>


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
This PR changes the label at the dialog of the rating settings at the skin configuration from "Programs" to what I guess the header should have been

## Description
<!--- Describe your change in detail -->
Due to the wiki documentation one doesn't obviously need `$LOCALIZE[<some_nr>]` for `Skin.SelectBool(....)`. The string-ID itself seems to be enough. Therefore I changed 

`<onclick>Skin.SelectBool($LOCALIZE[31024], 38018|circle_userrating, 563|circle_rating, 16018|)</onclick>`

to 

`<onclick>Skin.SelectBool(31024, 38018|circle_userrating, 563|circle_rating, 16018|)</onclick>`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The header at the rating-setting dialog in the skin configuration was shown as "Programs". My guess it, that the header should be what that dialog is for. 

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Fresh compiled on Ubuntu 16.04 and 18.04 and the changes have the specific effect.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

Before:

![rating_wrong](https://user-images.githubusercontent.com/7235787/41306403-4ed6ac50-6e76-11e8-862a-79b025a419db.png)

After:
![rating-correct](https://user-images.githubusercontent.com/7235787/41306409-56ab4256-6e76-11e8-8766-6597d462fde4.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
