### PR TITLE
[linux][gbm] add RendererDRMPRIMEGLES

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7191,7 +7191,31 @@ msgctxt "#13461"
 msgid "Enable this option to use hardware acceleration for the HEVC codec. If disabled the CPU will be used instead."
 msgstr ""
 
-#empty strings from id 13462 to 13504
+#. Option for setting the PRIME render method
+#: system/settings/settings.xml
+msgctxt "#13462"
+msgid "PRIME Render Method"
+msgstr ""
+
+#. Description of setting with label #13462 "PRIME Render Method"
+#: system/settings/settings.xml
+msgctxt "#13463"
+msgid "This option switches between direct-to-plane and EGL rendering methods."
+msgstr ""
+
+#. String for options 1 of setting with label #13462 "PRIME Render Method"
+#: system/settings/settings.xml
+msgctxt "#13464"
+msgid "Direct To Plane"
+msgstr ""
+
+#. String for options 2 of setting with label #13462 "PRIME Render Method"
+#: system/settings/settings.xml
+msgctxt "#13465"
+msgid "EGL"
+msgstr ""
+
+#empty strings from id 13466 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -8,6 +8,23 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.useprimerenderer" type="integer" label="13462" help="13463">
+          <visible>true</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useprimedecoder" operator="is">true</condition>
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13464">0</option> <!-- DIRECT -->
+              <option label="13465">1</option> <!-- GLES -->
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
       </group>
     </category>
   </section>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
@@ -50,8 +50,12 @@ if(CORE_SYSTEM_NAME STREQUAL android)
 endif()
 
 if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
-  list(APPEND SOURCES RendererDRMPRIME.cpp)
-  list(APPEND HEADERS RendererDRMPRIME.h)
+  list(APPEND SOURCES RendererDRMPRIME.cpp
+                      RendererDRMPRIMEGLES.cpp
+                      DRMPRIMEEGL.cpp)
+  list(APPEND HEADERS RendererDRMPRIME.h
+                      RendererDRMPRIMEGLES.h
+                      DRMPRIMEEGL.h)
 endif()
 
 # we might want to build on linux systems

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -1,0 +1,87 @@
+/*
+ *      Copyright (C) 2007-2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DRMPRIMEEGL.h"
+
+void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
+{
+  m_eglImage.reset(new CEGLImage(eglDisplay));
+}
+
+bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME *buffer)
+{
+  if (m_primebuffer)
+    return true;
+
+  m_texWidth = buffer->GetWidth();
+  m_texHeight = buffer->GetHeight();
+
+  AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
+  if (descriptor && descriptor->nb_layers)
+  {
+    AVDRMLayerDescriptor* layer = &descriptor->layers[0];
+
+    std::array<CEGLImage::EglPlane, CEGLImage::MAX_NUM_PLANES> planes;
+
+    for (int i = 0; i < layer->nb_planes; i++)
+    {
+      planes[i].fd = descriptor->objects[layer->planes[i].object_index].fd;
+      planes[i].offset = layer->planes[i].offset;
+      planes[i].pitch = layer->planes[i].pitch;
+    }
+
+    CEGLImage::EglAttrs attribs;
+
+    attribs.width = m_texWidth;
+    attribs.height = m_texHeight;
+    attribs.format = layer->format;
+    attribs.planes = planes;
+
+    if (!m_eglImage->CreateImage(attribs))
+      return false;
+
+    glGenTextures(1, &m_texture);
+    glBindTexture(m_textureTarget, m_texture);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    m_eglImage->UploadImage(m_textureTarget);
+    glBindTexture(m_textureTarget, 0);
+  }
+
+  m_primebuffer = buffer;
+  m_primebuffer->Acquire();
+
+  return true;
+}
+
+void CDRMPRIMETexture::Unmap()
+{
+  if (!m_primebuffer)
+    return;
+
+  m_eglImage->DestroyImage();
+
+  glDeleteTextures(1, &m_texture);
+
+  m_primebuffer->Release();
+  m_primebuffer = nullptr;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -1,0 +1,46 @@
+/*
+ *      Copyright (C) 2007-2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "utils/EGLImage.h"
+
+#include "system_gl.h"
+
+class CDRMPRIMETexture
+{
+public:
+  bool Map(CVideoBufferDRMPRIME *buffer);
+  void Unmap();
+  void Init(EGLDisplay eglDisplay);
+
+  GLuint GetTexture() { return m_texture; }
+  CSizeInt GetTextureSize() { return { m_texWidth, m_texHeight }; }
+
+protected:
+  CVideoBufferDRMPRIME *m_primebuffer{nullptr};
+  std::unique_ptr<CEGLImage> m_eglImage;
+
+  const GLenum m_textureTarget{GL_TEXTURE_EXTERNAL_OES};
+  GLuint m_texture{0};
+  int m_texWidth{0};
+  int m_texHeight{0};
+};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -23,7 +23,11 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
 #include "utils/log.h"
+
+const std::string SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
 
 static CWinSystemGbmGLESContext *m_pWinSystem;
 
@@ -40,7 +44,10 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 {
   if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer))
-    return new CRendererDRMPRIME(m_pWinSystem->m_DRM);
+  {
+    if (CServiceBroker::GetSettings().GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
+      return new CRendererDRMPRIME(m_pWinSystem->m_DRM);
+  }
 
   return nullptr;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -1,0 +1,200 @@
+/*
+ *      Copyright (C) 2007-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RendererDRMPRIMEGLES.h"
+
+#include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "ServiceBroker.h"
+#include "utils/log.h"
+#include "windowing/gbm/WinSystemGbmGLESContext.h"
+
+CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
+{
+  for (int i = 0; i < NUM_BUFFERS; ++i)
+    DeleteTexture(i);
+}
+
+CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
+{
+  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer))
+    return new CRendererDRMPRIMEGLES();
+
+  return nullptr;
+}
+
+bool CRendererDRMPRIMEGLES::Register()
+{
+  VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime_gles", CRendererDRMPRIMEGLES::Create);
+  return true;
+}
+
+bool CRendererDRMPRIMEGLES::Configure(const VideoPicture &picture, float fps, unsigned int orientation)
+{
+  CWinSystemGbmGLESContext* winSystem = dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return false;
+
+  for (auto &texture : m_DRMPRIMETextures)
+    texture.Init(winSystem->GetEGLDisplay());
+
+  return CLinuxRendererGLES::Configure(picture, fps, orientation);
+}
+
+void CRendererDRMPRIMEGLES::ReleaseBuffer(int index)
+{
+  m_DRMPRIMETextures[index].Unmap();
+  CLinuxRendererGLES::ReleaseBuffer(index);
+}
+
+bool CRendererDRMPRIMEGLES::CreateTexture(int index)
+{
+  CPictureBuffer &buf = m_buffers[index];
+  YuvImage &im = buf.image;
+  YUVPLANE &plane = buf.fields[0][0];
+
+  DeleteTexture(index);
+
+  std::memset(&im, 0, sizeof(im));
+  std::memset(&plane, 0, sizeof(YUVPLANE));
+  im.height = m_sourceHeight;
+  im.width  = m_sourceWidth;
+  im.cshift_x = 1;
+  im.cshift_y = 1;
+
+  plane.id = 1;
+
+  return true;
+}
+
+void CRendererDRMPRIMEGLES::DeleteTexture(int index)
+{
+  ReleaseBuffer(index);
+
+  CPictureBuffer &buf = m_buffers[index];
+  buf.fields[0][0].id = 0;
+}
+
+bool CRendererDRMPRIMEGLES::UploadTexture(int index)
+{
+  CPictureBuffer &buf = m_buffers[index];
+
+  CVideoBufferDRMPRIME *buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
+
+  if (!buffer)
+  {
+    CLog::Log(LOGNOTICE, "CRendererDRMPRIMEGLES::%s - no buffer", __FUNCTION__);
+    return false;
+  }
+
+  m_DRMPRIMETextures[index].Map(buffer);
+
+  YUVPLANE &plane = buf.fields[0][0];
+
+  auto size = m_DRMPRIMETextures[index].GetTextureSize();
+  plane.texwidth  = size.Width();
+  plane.texheight = size.Height();
+  plane.pixpertex_x = 1;
+  plane.pixpertex_y = 1;
+
+  plane.id = m_DRMPRIMETextures[index].GetTexture();
+
+  CalculateTextureSourceRects(index, 1);
+
+  return true;
+}
+
+bool CRendererDRMPRIMEGLES::LoadShadersHook()
+{
+  CLog::Log(LOGNOTICE, "Using DRMPRIMEGLES render method");
+  m_textureTarget = GL_TEXTURE_2D;
+  m_renderMethod = RENDER_CUSTOM;
+  return true;
+}
+
+bool CRendererDRMPRIMEGLES::RenderHook(int index)
+{
+  CRenderSystemGLES *renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+  assert(renderSystem);
+
+  YUVPLANE &plane = m_buffers[index].fields[0][0];
+
+  glDisable(GL_DEPTH_TEST);
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_EXTERNAL_OES, plane.id);
+
+  renderSystem->EnableGUIShader(SM_TEXTURE_RGBA_OES);
+
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+  GLuint vertexVBO;
+  GLuint indexVBO;
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  } vertex[4];
+
+  GLint vertLoc = renderSystem->GUIShaderGetPos();
+  GLint loc = renderSystem->GUIShaderGetCoord0();
+
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    // Setup vertex position values
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = plane.rect.x1;
+  vertex[0].v1 = vertex[1].v1 = plane.rect.y1;
+  vertex[1].u1 = vertex[2].u1 = plane.rect.x2;
+  vertex[2].v1 = vertex[3].v1 = plane.rect.y2;
+
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
+
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+
+  glEnableVertexAttribArray(vertLoc);
+  glEnableVertexAttribArray(loc);
+
+  glGenBuffers(1, &indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+  glDisableVertexAttribArray(vertLoc);
+  glDisableVertexAttribArray(loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &indexVBO);
+
+  renderSystem->DisableGUIShader();
+
+  glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
+
+  return true;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2007-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+#include "DRMPRIMEEGL.h"
+
+class CRendererDRMPRIMEGLES : public CLinuxRendererGLES
+{
+public:
+  CRendererDRMPRIMEGLES() = default;
+  ~CRendererDRMPRIMEGLES();
+
+  // Registration
+  static CBaseRenderer* Create(CVideoBuffer* buffer);
+  static bool Register();
+
+  // CLinuxRendererGLES overrides
+  bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
+  void ReleaseBuffer(int index) override;
+
+protected:
+  // CLinuxRendererGLES overrides
+  bool LoadShadersHook() override;
+  bool RenderHook(int index) override;
+  bool UploadTexture(int index) override;
+  void DeleteTexture(int index) override;
+  bool CreateTexture(int index) override;
+
+  CDRMPRIMETexture m_DRMPRIMETextures[NUM_BUFFERS];
+};

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -192,6 +192,11 @@ if(AML_FOUND)
   list(APPEND HEADERS ScreenshotAML.h)
 endif()
 
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
+  list(APPEND SOURCES EGLImage.cpp)
+  list(APPEND HEADERS EGLImage.h)
+endif()
+
 core_add_library(utils)
 
 if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -1,0 +1,101 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "EGLImage.h"
+#include "EGLUtils.h"
+#include "log.h"
+
+/* --- CEGLImage -------------------------------------------*/
+
+namespace
+{
+  const EGLint eglDmabufPlaneFdAttr[CEGLImage::MAX_NUM_PLANES] =
+  {
+    EGL_DMA_BUF_PLANE0_FD_EXT,
+    EGL_DMA_BUF_PLANE1_FD_EXT,
+    EGL_DMA_BUF_PLANE2_FD_EXT,
+  };
+
+  const EGLint eglDmabufPlaneOffsetAttr[CEGLImage::MAX_NUM_PLANES] =
+  {
+    EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+    EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+    EGL_DMA_BUF_PLANE2_OFFSET_EXT,
+  };
+
+  const EGLint eglDmabufPlanePitchAttr[CEGLImage::MAX_NUM_PLANES] =
+  {
+    EGL_DMA_BUF_PLANE0_PITCH_EXT,
+    EGL_DMA_BUF_PLANE1_PITCH_EXT,
+    EGL_DMA_BUF_PLANE2_PITCH_EXT,
+  };
+} // namespace
+
+CEGLImage::CEGLImage(EGLDisplay display) :
+  m_display(display)
+{
+  m_eglCreateImageKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLCREATEIMAGEKHRPROC>("eglCreateImageKHR");
+  m_eglDestroyImageKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLDESTROYIMAGEKHRPROC>("eglDestroyImageKHR");
+  m_glEGLImageTargetTexture2DOES = CEGLUtils::GetRequiredProcAddress<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>("glEGLImageTargetTexture2DOES");
+}
+
+bool CEGLImage::CreateImage(EglAttrs imageAttrs)
+{
+  CEGLAttributes<22> attribs;
+  attribs.Add({{EGL_WIDTH, imageAttrs.width},
+               {EGL_HEIGHT, imageAttrs.height},
+               {EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(imageAttrs.format)}});
+
+  /* this should be configurable at a later point */
+  attribs.Add({{EGL_YUV_COLOR_SPACE_HINT_EXT, EGL_ITU_REC709_EXT},
+               {EGL_SAMPLE_RANGE_HINT_EXT, EGL_YUV_NARROW_RANGE_EXT},
+               {EGL_YUV_CHROMA_VERTICAL_SITING_HINT_EXT, EGL_YUV_CHROMA_SITING_0_EXT},
+               {EGL_YUV_CHROMA_HORIZONTAL_SITING_HINT_EXT, EGL_YUV_CHROMA_SITING_0_EXT}});
+
+  for (int i = 0; i < MAX_NUM_PLANES; i++)
+  {
+    if (imageAttrs.planes[i].fd != 0)
+    {
+      attribs.Add({{eglDmabufPlaneFdAttr[i], imageAttrs.planes[i].fd},
+                   {eglDmabufPlaneOffsetAttr[i], imageAttrs.planes[i].offset},
+                   {eglDmabufPlanePitchAttr[i], imageAttrs.planes[i].pitch}});
+    }
+  }
+
+  m_image = m_eglCreateImageKHR(m_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attribs.Get());
+
+  if(!m_image)
+  {
+    CLog::Log(LOGERROR, "CEGLImage::%s - failed to import buffer into EGL image: %d", __FUNCTION__, eglGetError());
+    return false;
+  }
+
+  return true;
+}
+
+void CEGLImage::UploadImage(GLenum textureTarget)
+{
+  m_glEGLImageTargetTexture2DOES(textureTarget, m_image);
+}
+
+void CEGLImage::DestroyImage()
+{
+  m_eglDestroyImageKHR(m_display, m_image);
+}

--- a/xbmc/utils/EGLImage.h
+++ b/xbmc/utils/EGLImage.h
@@ -1,0 +1,65 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+#include "system_gl.h"
+
+#include <array>
+
+class CEGLImage
+{
+public:
+  static const int MAX_NUM_PLANES{3};
+
+  struct EglPlane
+  {
+    int fd{0};
+    int offset{0};
+    int pitch{0};
+  };
+
+  struct EglAttrs
+  {
+    int width{0};
+    int height{0};
+    uint32_t format{0};
+    std::array<EglPlane, MAX_NUM_PLANES> planes;
+  };
+
+  explicit CEGLImage(EGLDisplay display);
+
+  CEGLImage(CEGLImage const& other) = delete;
+  CEGLImage& operator=(CEGLImage const& other) = delete;
+
+  bool CreateImage(EglAttrs imageAttrs);
+  void UploadImage(GLenum textureTarget);
+  void DestroyImage();
+
+private:
+  EGLDisplay m_display{nullptr};
+  EGLImageKHR m_image{nullptr};
+
+  PFNEGLCREATEIMAGEKHRPROC m_eglCreateImageKHR{nullptr};
+  PFNEGLDESTROYIMAGEKHRPROC m_eglDestroyImageKHR{nullptr};
+  PFNGLEGLIMAGETARGETTEXTURE2DOESPROC m_glEGLImageTargetTexture2DOES{nullptr};
+};

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -20,6 +20,7 @@
 
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h"
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h"
 
 #include "cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
@@ -67,6 +68,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
     GBM::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
 
+  CRendererDRMPRIMEGLES::Register();
   CRendererDRMPRIME::Register(this);
   CDVDVideoCodecDRMPRIME::Register();
 


### PR DESCRIPTION
This PR adds a couple things:

1. A new `CEGLImage` class
2. The new `CRendererDRMPRIMEGLES` renderer
3. Settings to switch between using `CRendererDRMPRIMEGLES` and `CRendererDRMPRIME`

First, the `CEGLImage` class was crafted with much help from @pkerling, thanks for that!
This allows a common place to create, upload, and destroy an external egl image. I left out the modifiers work for now as it's not needed at this time and adds complexity. This work was done because it will be needed for some upcoming egl/gbm work in retroplayer.

Second, the new `CRendererDRMPRIMEGLES` is different from `CRendererDRMPRIME` because it does an EGL import instead of direct to plane for the frame. This is less performant however it is needed for some devices (meson DRM driver doesn't support NV12 yet and i.MX6 doesn't support plane scaling).

Third, the settings allows switching between the two renderers. Ideally I would like to have `CRendererDRMPRIME` test if it's possible to use and fall back to `CRendererDRMPRIMEGLES` if it's not, however, this requires a bit of require of the DRM code to properly detect planes and such. This will come in the future.

This code has been tested on i.MX6, Dragonboard (snapdragon 410) and amlogic (S905).

PS. I could probably use better strings. Please suggest changes.

@Kwiboo for a general review.