### PR TITLE
[Estuary] assign unique id to the TouchBackButton

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -789,7 +789,7 @@
 					<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
 					<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 					<animation effect="slide" end="0,16" time="200" reversible="true" condition="String.IsEmpty(Control.GetLabel(18900))">Conditional</animation>
-					<animation effect="slide" end="70,0" time="200" reversible="true" condition="Control.IsVisible(701)">Conditional</animation>
+					<animation effect="slide" end="70,0" time="200" reversible="true" condition="Control.IsVisible(799)">Conditional</animation>
 					<control type="label">
 						<label>$PARAM[breadcrumbs_label]</label>
 						<include>BreadcrumbsLabel</include>
@@ -841,7 +841,7 @@
 					<width>900</width>
 					<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
 					<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
-					<animation effect="slide" end="70,0" time="200" reversible="true" condition="Control.IsVisible(701)">Conditional</animation>
+					<animation effect="slide" end="70,0" time="200" reversible="true" condition="Control.IsVisible(799)">Conditional</animation>
 				</control>
 				<control type="grouplist">
 					<top>0</top>
@@ -1303,7 +1303,7 @@
 		</control>
 	</include>
 	<include name="TouchBackButton">
-		<control type="radiobutton" id="701">
+		<control type="radiobutton" id="799">
 			<left>-10</left>
 			<top>-10</top>
 			<width>120</width>


### PR DESCRIPTION
there was a conflict with another control with the same id, causing the header label to be misaligned.

before:
![before](https://user-images.githubusercontent.com/687265/41313214-aa748bf0-6e89-11e8-8edb-63dce639b7a8.jpg)


after:
![after](https://user-images.githubusercontent.com/687265/41313219-ae5f0aec-6e89-11e8-90d6-fd312d52c5c7.jpg)
