### PR TITLE
libinput: check max pointers

### DIFF
--- a/xbmc/platform/linux/input/LibInputTouch.h
+++ b/xbmc/platform/linux/input/LibInputTouch.h
@@ -38,5 +38,12 @@ public:
   void ProcessTouchFrame(libinput_event_touch *e);
 
 private:
-  std::vector<std::pair<TouchInput, CPoint>> m_points;
+  void CheckSlot(int slot);
+  TouchInput GetEvent(int slot);
+  void SetEvent(int slot, TouchInput event);
+  void SetPosition(int slot, CPoint point);
+  int GetX(int slot) { return m_points.at(slot).second.x; }
+  int GetY(int slot) { return m_points.at(slot).second.y; }
+
+  std::vector<std::pair<TouchInput, CPoint>> m_points{std::make_pair(TouchInputUnchanged, CPoint(0, 0))};
 };


### PR DESCRIPTION
This fixes a crash when you placed more than 2 fingers on the screen. Basically we want to check if `m_points` has enough slots to hold the amount of pointer positions. Kodi can only handle 2 pointers but this makes it scalable if we ever add support for more.