### PR TITLE
Fix Season no. displayed for launcher Channels.

### DIFF
--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -297,7 +297,7 @@ public class SyncProgramsJobService extends JobService
       }
       if (media instanceof TVEpisode)
       {
-        builder.setSeasonNumber(((TVEpisode)media).getEpisode());
+        builder.setSeasonNumber(((TVEpisode)media).getSeason());
         builder.setEpisodeNumber(((TVEpisode)media).getEpisode());
       }
 


### PR DESCRIPTION
This fixes the issue of the Season number being the same as the Episode number when adding Channel for TV episodes in the Android TV Home launcher.

