### PR TITLE
CURL: Disable FAILONERROR only for Open() calls

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -521,7 +521,7 @@ void CCurlFile::SetCommonOptions(CReadState* state)
   // resolves. Unfortunately, c-ares does not yet support IPv6.
   g_curlInterface.easy_setopt(h, CURLOPT_NOSIGNAL, CURL_ON);
 
-  if (!g_advancedSettings.CanLogComponent(LOGCURL))
+  if (m_state->m_failOnError)
   {
     // not interested in failed requests
     g_curlInterface.easy_setopt(h, CURLOPT_FAILONERROR, 1);
@@ -1014,6 +1014,7 @@ bool CCurlFile::Open(const CURL& url)
                                 &m_state->m_multiHandle);
 
   // setup common curl options
+  m_state->m_failOnError = !g_advancedSettings.CanLogComponent(LOGCURL);
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
   m_state->m_sendRange = m_seekable;

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -126,6 +126,7 @@ namespace XFILE
           bool m_sendRange;
           bool m_bLastError;
           bool m_bRetry;
+          bool m_failOnError = true;
 
           char* m_readBuffer;
 


### PR DESCRIPTION
## Description
Fix issues introduced with #13821, only don't fail on error for Open() call if libCURL component logging enabled, never disable FAILONERROR for other calls than Open()

## Motivation and Context
internal discussion / @yol knows more :-)

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
