### PR TITLE
Display #channels in audio selection list

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6334,6 +6334,7 @@ msgstr ""
 #: xbmc/pvr/PVRGUIInfo.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 #: xbmc/video/PlayerController.cpp
+#: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#13205"
 msgid "Unknown"
 msgstr ""
@@ -8254,6 +8255,7 @@ msgstr ""
 
 #. pvr "channels" settings group label
 #: system/settings/settings.xml
+#: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#14301"
 msgid "Channels"
 msgstr ""

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -309,6 +309,9 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(SettingConstPtr setting, 
 {
   int audioStreamCount = g_application.GetAppPlayer().GetAudioStreamCount();
 
+  std::string strFormat = "%s - %s - %d " + g_localizeStrings.Get(14301);
+  std::string strUnknown = "[" + g_localizeStrings.Get(13205) + "]";
+
   // cycle through each audio stream and add it to our list control
   for (int i = 0; i < audioStreamCount; ++i)
   {
@@ -322,9 +325,9 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(SettingConstPtr setting, 
       strLanguage = g_localizeStrings.Get(13205); // Unknown
 
     if (info.name.length() == 0)
-      strItem = strLanguage;
-    else
-      strItem = StringUtils::Format("%s - %s", strLanguage.c_str(), info.name.c_str());
+      info.name = strUnknown;
+
+    strItem = StringUtils::Format(strFormat, strLanguage.c_str(), info.name.c_str(), info.channels);
 
     strItem += FormatFlags(info.flags);
     strItem += StringUtils::Format(" (%i/%i)", i + 1, audioStreamCount);


### PR DESCRIPTION
## Description
Streams may have audio tracks with same codec (=name) but different channel count.
This PR makes channel count visible in settings::Audiosettings::Audiostreams list.

## Motivation and Context
amazon for example provides 2.0 and 5.1 EAC3 streams, and look same without this PR

## How Has This Been Tested?
Win10 / amazon addon / baywatch movie

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
