### PR TITLE
Do not reuse pvr channel string

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5083,7 +5083,11 @@ msgctxt "#10126"
 msgid "File browser"
 msgstr ""
 
-#empty string with id 10127
+#. Audio Channel count
+#: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+msgctxt "#10127"
+msgid "Channels"
+msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10128"
@@ -8255,7 +8259,6 @@ msgstr ""
 
 #. pvr "channels" settings group label
 #: system/settings/settings.xml
-#: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#14301"
 msgid "Channels"
 msgstr ""
@@ -20402,7 +20405,7 @@ msgstr ""
 
 #: system/settings/rbp.xml
 msgctxt "#37018"
-msgid "Boost centre channel when downmixing"
+msgid "Boost center channel when downmixing"
 msgstr ""
 
 #empty string with id 37019

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -309,7 +309,7 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(SettingConstPtr setting, 
 {
   int audioStreamCount = g_application.GetAppPlayer().GetAudioStreamCount();
 
-  std::string strFormat = "%s - %s - %d " + g_localizeStrings.Get(14301);
+  std::string strFormat = "%s - %s - %d " + g_localizeStrings.Get(10127);
   std::string strUnknown = "[" + g_localizeStrings.Get(13205) + "]";
 
   // cycle through each audio stream and add it to our list control
@@ -322,7 +322,7 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(SettingConstPtr setting, 
     g_application.GetAppPlayer().GetAudioStreamInfo(i, info);
 
     if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
-      strLanguage = g_localizeStrings.Get(13205); // Unknown
+      strLanguage = strUnknown;
 
     if (info.name.length() == 0)
       info.name = strUnknown;


### PR DESCRIPTION
## Description
Fixes wrong string reusage from #14042 
String 14301 is used for PVR channels and cannot be used for Audio Channels

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
