### PR TITLE
center -> centre revert / lowercase channels

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5086,7 +5086,7 @@ msgstr ""
 #. Audio Channel count
 #: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
 msgctxt "#10127"
-msgid "Channels"
+msgid "channels"
 msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
@@ -20405,7 +20405,7 @@ msgstr ""
 
 #: system/settings/rbp.xml
 msgctxt "#37018"
-msgid "Boost center channel when downmixing"
+msgid "Boost centre channel when downmixing"
 msgstr ""
 
 #empty string with id 37019


### PR DESCRIPTION
revert wrong renaming centre -> center done by failure in #14043
lowercase audio channel

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
