### PR TITLE
Revert "utils/IXmlDeserializable: drop useless interface"

### DIFF
--- a/xbmc/settings/lib/SettingConditions.h
+++ b/xbmc/settings/lib/SettingConditions.h
@@ -55,7 +55,7 @@ public:
   { }
   ~CSettingConditionItem() override = default;
 
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
   const char* GetTag() const override { return SETTING_XML_ELM_CONDITION; }
   bool Check() const override;
 

--- a/xbmc/settings/lib/SettingDependency.h
+++ b/xbmc/settings/lib/SettingDependency.h
@@ -60,7 +60,7 @@ public:
                               CSettingsManager *settingsManager = nullptr);
   ~CSettingDependencyCondition() override = default;
 
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
   bool Check() const override;
 
   const std::string& GetName() const { return m_name; }
@@ -94,7 +94,7 @@ public:
   }
   ~CSettingDependencyConditionCombination() override = default;
 
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
 
   const std::set<std::string>& GetSettings() const { return m_settings; }
 
@@ -115,7 +115,7 @@ public:
   CSettingDependency(SettingDependencyType type, CSettingsManager *settingsManager = nullptr);
   ~CSettingDependency() override = default;
 
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
 
   SettingDependencyType GetType() const { return m_type; }
   std::set<std::string> GetSettings() const;

--- a/xbmc/utils/BooleanLogic.h
+++ b/xbmc/utils/BooleanLogic.h
@@ -25,14 +25,14 @@
 
 #include <memory>
 
-class TiXmlNode;
+#include "utils/IXmlDeserializable.h"
 
 typedef enum {
   BooleanLogicOperationOr = 0,
   BooleanLogicOperationAnd
 } BooleanLogicOperation;
 
-class CBooleanLogicValue
+class CBooleanLogicValue : public IXmlDeserializable
 {
 public:
   CBooleanLogicValue(const std::string &value = "", bool negated = false)
@@ -40,7 +40,7 @@ public:
   { }
   virtual ~CBooleanLogicValue() = default;
 
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
 
   virtual const std::string& GetValue() const { return m_value; }
   virtual bool IsNegated() const { return m_negated; }
@@ -61,7 +61,7 @@ class CBooleanLogicOperation;
 typedef std::shared_ptr<CBooleanLogicOperation> CBooleanLogicOperationPtr;
 typedef std::vector<CBooleanLogicOperationPtr> CBooleanLogicOperations;
 
-class CBooleanLogicOperation
+class CBooleanLogicOperation : public IXmlDeserializable
 {
 public:
   explicit CBooleanLogicOperation(BooleanLogicOperation op = BooleanLogicOperationAnd)
@@ -69,7 +69,7 @@ public:
   { }
   virtual ~CBooleanLogicOperation() = default;
 
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
 
   virtual BooleanLogicOperation GetOperation() const { return m_operation; }
   virtual const CBooleanLogicOperations& GetOperations() const { return m_operations; }
@@ -86,14 +86,14 @@ protected:
   CBooleanLogicValues m_values;
 };
 
-class CBooleanLogic
+class CBooleanLogic : public IXmlDeserializable
 {
 protected:
   /* make sure nobody deletes a pointer to this class */
   ~CBooleanLogic() = default;
 
 public:
-  bool Deserialize(const TiXmlNode *node);
+  bool Deserialize(const TiXmlNode *node) override;
 
   const CBooleanLogicOperationPtr& Get() const { return m_operation; }
   CBooleanLogicOperationPtr Get() { return m_operation; }

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -114,6 +114,7 @@ set(HEADERS ActorProtocol.h
             IRssObserver.h
             ISerializable.h
             ISortable.h
+            IXmlDeserializable.h
             Job.h
             JobManager.h
             JSONVariantParser.h

--- a/xbmc/utils/IXmlDeserializable.h
+++ b/xbmc/utils/IXmlDeserializable.h
@@ -1,0 +1,31 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+class TiXmlNode;
+
+class IXmlDeserializable
+{
+public:
+  virtual ~IXmlDeserializable() = default;
+
+  virtual bool Deserialize(const TiXmlNode *node) = 0;
+};


### PR DESCRIPTION
This reverts commit f8217890e24de9db7a95825681de0efc66aa7872.

@MaxKellermann this breaks the "Component Specific Loggin"-Toggle in Settings for me.
I have just bisected it and this revert fixes it, however I did not look how this commit could break it.

## How Has This Been Tested?
Tested on Linux X11.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
