### PR TITLE
[RetroPlayer] Set AML GPU to ignore alpha channel

### DIFF
--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -150,6 +150,15 @@ namespace RETRO
      * \brief Get the default scaling method for this rendering system
      */
     SCALINGMETHOD GetDefaultScalingMethod() const { return m_defaultScalingMethod; }
+
+    /*!
+     * \brief Configure the render system
+     *
+     * \param format The pixel format of the video stream, or AV_PIX_FMT_NONE
+     *        if the stream has ended
+     */
+    virtual void ConfigureRenderSystem(AVPixelFormat format) { }
+
     ///}
 
     /// @name Player video info

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "RPProcessInfoAmlogic.h"
+#include "utils/AMLUtils.h"
+#include "utils/log.h"
 
 using namespace KODI;
 using namespace RETRO;
@@ -36,4 +38,23 @@ CRPProcessInfo* CRPProcessInfoAmlogic::Create()
 void CRPProcessInfoAmlogic::Register()
 {
   CRPProcessInfo::RegisterProcessControl(CRPProcessInfoAmlogic::Create);
+}
+
+void CRPProcessInfoAmlogic::ConfigureRenderSystem(AVPixelFormat format)
+{
+  if (format == AV_PIX_FMT_0RGB32 || format == AV_PIX_FMT_0BGR32)
+  {
+    /*  Set the Amlogic chip to ignore the alpha channel.
+     *  The proprietary OpenGL lib does not (currently)
+     *  handle this, potentially resulting in a black screen.
+     *  This capability is only present in S905 chips and higher.
+     */
+    if (aml_set_reg_ignore_alpha())
+      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Amlogic set to ignore alpha");
+  }
+  else
+  {
+    if (aml_unset_reg_ignore_alpha())
+      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Amlogic unset to ignore alpha");
+  }
 }

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
@@ -33,6 +33,10 @@ namespace RETRO
 
     static CRPProcessInfo* Create();
     static void Register();
+
+    // Implementation of CRPProcessInfo
+    void ConfigureRenderSystem(AVPixelFormat format) override;
+
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -64,6 +64,9 @@ void CRPRenderManager::Deinitialize()
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Deinitializing render manager");
 
+  // Required to reset Amlogic chip to default state
+  m_processInfo.ConfigureRenderSystem(AV_PIX_FMT_NONE);
+
   for (auto &pixelScaler : m_scalers)
   {
     if (pixelScaler.second != nullptr)
@@ -174,6 +177,8 @@ void CRPRenderManager::FrameMove()
 
     if (m_state == RENDER_STATE::CONFIGURING)
     {
+      m_processInfo.ConfigureRenderSystem(m_format);
+
       MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
       m_state = RENDER_STATE::CONFIGURED;
 

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -77,4 +77,7 @@ void aml_enable_freeScale(const RESOLUTION_INFO &res);
 void aml_disable_freeScale();
 void aml_set_framebuffer_resolution(const RESOLUTION_INFO &res, std::string framebuffer_name);
 void aml_set_framebuffer_resolution(int width, int height, std::string framebuffer_name);
-
+bool aml_read_reg(const std::string &reg, uint32_t &reg_val);
+bool aml_has_capability_ignore_alpha();
+bool aml_set_reg_ignore_alpha();
+bool aml_unset_reg_ignore_alpha();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Set an Amlogic GPU to ignore the alpha channel in color spaces where it should be ignored. The proprietary OpenGL lib and driver do not (currently) handle this, potentially resulting in a black screen. This capability is only present in S905 chips and higher.

## Motivation and Context
Black screen on some AML devices when color space contains alpha channel which should be ignored.

## How Has This Been Tested?
Odroid-C2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
