### PR TITLE
[RetroPlayer] Add basic resolution changing

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -147,6 +147,8 @@ namespace RETRO
 
     CRenderVideoSettings GetEffectiveSettings(const IGUIRenderSettings *settings) const;
 
+    void CheckFlush();
+
     // Construction parameters
     CRPProcessInfo &m_processInfo;
     CRenderContext &m_renderContext;
@@ -163,6 +165,7 @@ namespace RETRO
     {
       UNCONFIGURED,
       CONFIGURING,
+      RECONFIGURING,
       CONFIGURED,
     };
     RENDER_STATE m_state = RENDER_STATE::UNCONFIGURED;
@@ -175,6 +178,7 @@ namespace RETRO
     std::map<AVPixelFormat, SwsContext*> m_scalers;
     bool m_bHasCachedFrame = false;
     bool m_bTriggerUpdateResolution = false;
+    std::atomic<bool> m_bFlush = {false};
     CCriticalSection m_stateMutex;
     CCriticalSection m_bufferMutex;
   };

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -68,7 +68,7 @@ namespace RETRO
    *
    * Special behavior is needed when the game is paused. As no new frames are
    * delivered, a newly created renderer will stay black. For this scenario,
-   * when we detect a pause event, the frame is premptively cached so that a
+   * when we detect a pause event, the frame is preemptively cached so that a
    * newly created renderer will have something to display.
    */
   class CRPRenderManager : public IRenderManager,
@@ -138,6 +138,29 @@ namespace RETRO
      */
     void CreateRenderBuffer(IRenderBufferPool *bufferPool);
 
+    /*!
+     * \brief Create a render buffer and copy the cached data into it
+     *
+     * The cached frame is accessed by both the game and rendering threads,
+     * and therefore requires synchronization.
+     *
+     * However, assuming the memory copy is expensive, we must avoid holding
+     * the mutex during the copy.
+     *
+     * To allow for this, the function is permitted to invalidate its
+     * cachedFrame parameter, as long as it is restored upon exit. While the
+     * mutex is exited inside this function, cachedFrame is guaranteed to be
+     * empty.
+     *
+     * \param cachedFrame The cached frame
+     * \param bufferPool The buffer pool used to create the render buffer
+     * \param mutex The locked mutex, to be unlocked during memory copy
+     *
+     * \return The render buffer if one was created from the cached frame,
+     *         otherwise nullptr
+     */
+    IRenderBuffer *CreateFromCache(std::vector<uint8_t> &cachedFrame, IRenderBufferPool *bufferPool, CCriticalSection &mutex);
+
     void UpdateResolution();
 
     /*!
@@ -153,6 +176,10 @@ namespace RETRO
     CRPProcessInfo &m_processInfo;
     CRenderContext &m_renderContext;
 
+    // Subsystems
+    std::shared_ptr<IGUIRenderSettings> m_renderSettings;
+    std::shared_ptr<CGUIRenderTargetFactory> m_renderControlFactory;
+
     // Stream properties
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
     unsigned int m_maxWidth = 0;
@@ -160,7 +187,13 @@ namespace RETRO
     unsigned int m_width = 0; //! @todo Remove me when dimension changing is implemented
     unsigned int m_height = 0; //! @todo Remove me when dimension changing is implemented
 
-    // Render properties
+    // Render resources
+    std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
+    std::vector<IRenderBuffer*> m_renderBuffers;
+    std::map<AVPixelFormat, SwsContext*> m_scalers;
+    std::vector<uint8_t> m_cachedFrame;
+
+    // State parameters
     enum class RENDER_STATE
     {
       UNCONFIGURED,
@@ -169,16 +202,15 @@ namespace RETRO
       CONFIGURED,
     };
     RENDER_STATE m_state = RENDER_STATE::UNCONFIGURED;
-    std::atomic<double> m_speed;
-    std::shared_ptr<IGUIRenderSettings> m_renderSettings;
-    std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
-    std::shared_ptr<CGUIRenderTargetFactory> m_renderControlFactory;
-    std::vector<IRenderBuffer*> m_renderBuffers;
-    std::vector<uint8_t> m_cachedFrame;
-    std::map<AVPixelFormat, SwsContext*> m_scalers;
-    bool m_bHasCachedFrame = false;
+    bool m_bHasCachedFrame = false; // Invariant: m_cachedFrame is empty if false
+    std::set<std::string> m_failedShaderPresets;
     bool m_bTriggerUpdateResolution = false;
     std::atomic<bool> m_bFlush = {false};
+
+    // Playback parameters
+    std::atomic<double> m_speed = {1.0};
+
+    // Synchronization parameters
     CCriticalSection m_stateMutex;
     CCriticalSection m_bufferMutex;
   };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Adds basic resolution changing support to RetroPlayer.

## Motivation and Context
RetroPlayer does not currently render after a resolution change.

## How Has This Been Tested?
Device: Odroid-C2
Emulators: PCSX, GenesisPlus
Example: FFVII on PCSX changes resolution when the in-game menu is accessed

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
