### PR TITLE
Fix playback of playlists

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1456,9 +1456,9 @@ void CFileItem::FillInMimeType(bool lookup /*= true*/)
       m_mimetype = "x-directory/normal";
     else if( m_pvrChannelInfoTag )
       m_mimetype = m_pvrChannelInfoTag->InputFormat();
-    else if( StringUtils::StartsWithNoCase(m_strPath, "shout://")
-          || StringUtils::StartsWithNoCase(m_strPath, "http://")
-          || StringUtils::StartsWithNoCase(m_strPath, "https://"))
+    else if( StringUtils::StartsWithNoCase(GetDynPath(), "shout://")
+          || StringUtils::StartsWithNoCase(GetDynPath(), "http://")
+          || StringUtils::StartsWithNoCase(GetDynPath(), "https://"))
     {
       // If lookup is false, bail out early to leave mime type empty
       if (!lookup)
@@ -1488,8 +1488,14 @@ void CFileItem::FillInMimeType(bool lookup /*= true*/)
   }
 
   // change protocol to mms for the following mime-type.  Allows us to create proper FileMMS.
-  if( StringUtils::StartsWithNoCase(m_mimetype, "application/vnd.ms.wms-hdr.asfv1") || StringUtils::StartsWithNoCase(m_mimetype, "application/x-mms-framed") )
-    StringUtils::Replace(m_strPath, "http:", "mms:");
+  if(StringUtils::StartsWithNoCase(m_mimetype, "application/vnd.ms.wms-hdr.asfv1") || 
+     StringUtils::StartsWithNoCase(m_mimetype, "application/x-mms-framed"))
+  {
+    if (m_strDynPath.empty())
+      m_strDynPath = m_strPath;
+
+    StringUtils::Replace(m_strDynPath, "http:", "mms:");
+  }
 }
 
 void CFileItem::SetMimeTypeForInternetFile()

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -73,8 +73,6 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
   }
 
   std::string path = item.GetDynPath();
-  if (path.empty())
-    path = item.GetPath();
 
   std::string extension = URIUtils::GetExtension(path);
   StringUtils::ToLower(extension);


### PR DESCRIPTION
This fixes a condition that looks like a freeze of kodi when one wants to play a m3u playlist with http-streams in it.

After https://github.com/xbmc/xbmc/commit/22b1e1e4cc861c8eb4e1b36746ac70213cafb5dd a FileItem inside a playlist holds the path of the playlist as m_strPath and the item as m_strDynPath.
Whithin the CPlayList::Expand method we may create another playlist.
The check if an item within a playlist is another playlist or not, is done by checking it's mimetype.
For the reasons above we need to check m_strDynPath to get the mimetype  instead of m_strPath.
Otherwise we may treat a livestream as a playlist and read it endlessly.

## How Has This Been Tested?
Tested playback of a m3u with a normal http stream in it on linux x11.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@FernetMenta Shall I use m_strDynPath directly or would it be better to use the getter that falls back to m_strPath if m_strDynPath is empty?