### PR TITLE
[Subtitles] Background color and background opacity settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3359,7 +3359,9 @@ msgctxt "#745"
 msgid "Background colour"
 msgstr ""
 
-#empty string 746
+msgctxt "#746"
+msgid "Background opacity"
+msgstr ""
 
 msgctxt "#747"
 msgid "Error loading image"
@@ -18494,7 +18496,11 @@ msgctxt "#36229"
 msgid "Display signal quality information in the codec information window (if supported by the add-on and backend)."
 msgstr ""
 
-#empty string with id 36230
+#. Description of setting with label #746 "Background Opacity"
+#: system/settings/settings.xml
+msgctxt "#36230"
+msgid "Set the the subtitle background opacity."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36231"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3286,7 +3286,10 @@ msgctxt "#730"
 msgid "Port"
 msgstr ""
 
-#empty string with id 731
+#: system/settings/settings.xml
+msgctxt "#731"
+msgid "Black"
+msgstr ""
 
 msgctxt "#732"
 msgid "Save & apply"
@@ -3351,7 +3354,12 @@ msgctxt "#744"
 msgid "Files"
 msgstr ""
 
-#empty strings from id 745 to 746
+#: system/settings/settings.xml
+msgctxt "#745"
+msgid "Background colour"
+msgstr ""
+
+#empty string 746
 
 msgctxt "#747"
 msgid "Error loading image"
@@ -18475,7 +18483,11 @@ msgctxt "#36227"
 msgid "Switch to full screen display when starting playback of channels and recordings."
 msgstr ""
 
-#empty string with id 36228
+#. Description of setting with label #745 "Background Colour"
+#: system/settings/settings.xml
+msgctxt "#36228"
+msgid "Set the colour to be used for the subtitle background."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36229"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -657,6 +657,14 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="subtitles.bgopacity" type="integer" parent="subtitles.font" label="746" help="36230">
+          <level>3</level>
+          <default>0</default>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
+          <control type="slider" format="percentage" range="0,100" />
+        </setting>
         <setting id="subtitles.overrideassfonts" type="boolean" label="21368" help="36190">
           <level>3</level>
           <default>false</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -640,6 +640,23 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="subtitles.bgcolor" type="integer" parent="subtitles.font" label="745" help="36228">
+          <level>3</level>
+          <default>0</default> <!-- Black -->
+          <constraints>
+            <options>
+              <option label="731">0</option> <!-- Black -->
+              <option label="760">1</option> <!-- Yellow -->
+              <option label="761">2</option> <!-- White -->
+              <option label="766">3</option> <!-- Light grey -->
+              <option label="767">4</option> <!-- Grey -->
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
+          <control type="list" format="string" />
+        </setting>
         <setting id="subtitles.overrideassfonts" type="boolean" label="21368" help="36190">
           <level>3</level>
           <default>false</default>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -121,7 +121,7 @@ void CDebugRenderer::CRenderer::Render(int idx)
 
     COverlayText *text = dynamic_cast<COverlayText*>(o);
     if (text)
-      text->PrepareRender("arial.ttf", 1, 16, 0, m_font, m_fontBorder);
+      text->PrepareRender("arial.ttf", 1, 16, 0, m_font, m_fontBorder, UTILS::COLOR::NONE);
 
     RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -33,6 +33,7 @@
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
+#include "utils/ColorUtils.h"
 #include "utils/MathUtils.h"
 #include "OverlayRendererUtil.h"
 #include "OverlayRendererGUI.h"
@@ -43,6 +44,12 @@
 #endif
 
 using namespace OVERLAY;
+
+static UTILS::Color bgcolors[5] = { UTILS::COLOR::BLACK,
+  UTILS::COLOR::YELLOW,
+  UTILS::COLOR::WHITE,
+  UTILS::COLOR::LIGHTGREY,
+  UTILS::COLOR::GREY };
 
 COverlay::COverlay()
 {
@@ -177,11 +184,24 @@ void CRenderer::Render(int idx)
     COverlayText *text = dynamic_cast<COverlayText*>(*it);
     if (text)
     {
+      
+      // Compute the color to be used for the overlay background (depending on the opacity)
+      UTILS::Color bgcolor = bgcolors[CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SUBTITLES_BGCOLOR)];
+      int bgopacity = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SUBTITLES_BGOPACITY);
+      if (bgopacity > 0 && bgopacity < 100)
+      {
+        bgcolor = ColorUtils::ChangeOpacity(bgcolor, bgopacity / 100.0f);
+      }
+      else if (bgopacity == 0)
+      {
+        bgcolor = UTILS::COLOR::NONE;
+      }
+      
       text->PrepareRender(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_FONT),
                           CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SUBTITLES_COLOR),
                           CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SUBTITLES_HEIGHT),
                           CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SUBTITLES_STYLE),
-                          m_font, m_fontBorder);
+                          m_font, m_fontBorder, bgcolor);
       o = text;
     }
     else

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
@@ -35,14 +35,20 @@
 
 using namespace OVERLAY;
 
-static UTILS::Color colors[8] = { 0xFFFFFF00
-                                , 0xFFFFFFFF
-                                , 0xFF0099FF
-                                , 0xFF00FF00
-                                , 0xFFCCFF00
-                                , 0xFF00FFFF
-                                , 0xFFE5E5E5
-                                , 0xFFC0C0C0 };
+static UTILS::Color colors[8] = { UTILS::COLOR::YELLOW,
+                                  UTILS::COLOR::WHITE,
+                                  UTILS::COLOR::BLUE,
+                                  UTILS::COLOR::BRIGHTGREEN,
+                                  UTILS::COLOR::YELLOWGREEN,
+                                  UTILS::COLOR::CYAN,
+                                  UTILS::COLOR::LIGHTGREY,
+                                  UTILS::COLOR::GREY };
+
+static UTILS::Color bgcolors[5] = { UTILS::COLOR::BLACK,
+                                    UTILS::COLOR::YELLOW,
+                                    UTILS::COLOR::WHITE,
+                                    UTILS::COLOR::LIGHTGREY,
+                                    UTILS::COLOR::GREY };
 
 CGUITextLayout* COverlayText::GetFontLayout(const std::string &font, int color, int height, int style,
                                             const std::string &fontcache, const std::string &fontbordercache)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "OverlayRenderer.h"
+#include "utils/Color.h"
 #include <string>
 
 enum SubtitleAlign
@@ -45,14 +46,15 @@ public:
   ~COverlayText() override;
   void Render(SRenderState& state) override;
   using COverlay::PrepareRender;
-  void PrepareRender(const std::string &font, int color, int height, int style,
-                     const std::string &fontcache, const std::string &fontbordercache);
+  void PrepareRender(const std::string &font, int color, int height, int style, const std::string &fontcache,
+                     const std::string &fontbordercache, const UTILS::Color bgcolor);
   virtual CGUITextLayout* GetFontLayout(const std::string &font, int color, int height, int style,
                                         const std::string &fontcache, const std::string &fontbordercache);
 
   CGUITextLayout* m_layout;
   std::string m_text;
   int m_subalign;
+  UTILS::Color m_bgcolor = UTILS::COLOR::NONE;
 };
 
 }

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -87,6 +87,12 @@ public:
   float GetTextWidth() const { return m_textWidth; };
 
   float GetTextWidth(const std::wstring &text) const;
+  
+  /*! \brief Returns the precalculated height of the text to be rendered (in constant time).
+   \return height of text
+  */
+  float GetTextHeight() const { return m_textHeight; };
+  
   bool Update(const std::string &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
   bool UpdateW(const std::wstring &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -188,6 +188,7 @@ const std::string CSettings::SETTING_SUBTITLES_HEIGHT = "subtitles.height";
 const std::string CSettings::SETTING_SUBTITLES_STYLE = "subtitles.style";
 const std::string CSettings::SETTING_SUBTITLES_COLOR = "subtitles.color";
 const std::string CSettings::SETTING_SUBTITLES_BGCOLOR = "subtitles.bgcolor";
+const std::string CSettings::SETTING_SUBTITLES_BGOPACITY = "subtitles.bgopacity";
 const std::string CSettings::SETTING_SUBTITLES_CHARSET = "subtitles.charset";
 const std::string CSettings::SETTING_SUBTITLES_OVERRIDEASSFONTS = "subtitles.overrideassfonts";
 const std::string CSettings::SETTING_SUBTITLES_LANGUAGES = "subtitles.languages";

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -187,6 +187,7 @@ const std::string CSettings::SETTING_SUBTITLES_FONT = "subtitles.font";
 const std::string CSettings::SETTING_SUBTITLES_HEIGHT = "subtitles.height";
 const std::string CSettings::SETTING_SUBTITLES_STYLE = "subtitles.style";
 const std::string CSettings::SETTING_SUBTITLES_COLOR = "subtitles.color";
+const std::string CSettings::SETTING_SUBTITLES_BGCOLOR = "subtitles.bgcolor";
 const std::string CSettings::SETTING_SUBTITLES_CHARSET = "subtitles.charset";
 const std::string CSettings::SETTING_SUBTITLES_OVERRIDEASSFONTS = "subtitles.overrideassfonts";
 const std::string CSettings::SETTING_SUBTITLES_LANGUAGES = "subtitles.languages";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -141,6 +141,7 @@ public:
   static const std::string SETTING_SUBTITLES_HEIGHT;
   static const std::string SETTING_SUBTITLES_STYLE;
   static const std::string SETTING_SUBTITLES_COLOR;
+  static const std::string SETTING_SUBTITLES_BGCOLOR;
   static const std::string SETTING_SUBTITLES_CHARSET;
   static const std::string SETTING_SUBTITLES_OVERRIDEASSFONTS;
   static const std::string SETTING_SUBTITLES_LANGUAGES;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -142,6 +142,7 @@ public:
   static const std::string SETTING_SUBTITLES_STYLE;
   static const std::string SETTING_SUBTITLES_COLOR;
   static const std::string SETTING_SUBTITLES_BGCOLOR;
+  static const std::string SETTING_SUBTITLES_BGOPACITY;
   static const std::string SETTING_SUBTITLES_CHARSET;
   static const std::string SETTING_SUBTITLES_OVERRIDEASSFONTS;
   static const std::string SETTING_SUBTITLES_LANGUAGES;

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES ActorProtocol.cpp
             BooleanLogic.cpp
             CharsetConverter.cpp
             CharsetDetection.cpp
+            ColorUtils.cpp
             CPUInfo.cpp
             Crc32.cpp
             CryptThreading.cpp
@@ -88,6 +89,7 @@ set(HEADERS ActorProtocol.h
             CharsetDetection.h
             CPUInfo.h
             Color.h
+            ColorUtils.h
             Crc32.h
             CryptThreading.h
             DatabaseUtils.h

--- a/xbmc/utils/Color.h
+++ b/xbmc/utils/Color.h
@@ -27,4 +27,17 @@ namespace UTILS
 
   typedef uint32_t Color;
 
+namespace COLOR
+{
+  static const Color NONE = 0x00000000;
+  static const Color BLACK = 0xFF000000;
+  static const Color YELLOW = 0xFFFFFF00;
+  static const Color WHITE = 0xFFFFFFFF;
+  static const Color LIGHTGREY = 0xFFE5E5E5;
+  static const Color GREY = 0xFFC0C0C0;
+  static const Color BLUE = 0xFF0099FF;
+  static const Color BRIGHTGREEN = 0xFF00FF00;
+  static const Color YELLOWGREEN = 0xFFCCFF00;
+  static const Color CYAN = 0xFF00FFFF;
+} // namespace COLOR
 } // namespace UTILS

--- a/xbmc/utils/ColorUtils.cpp
+++ b/xbmc/utils/ColorUtils.cpp
@@ -1,0 +1,29 @@
+/*
+ *      Copyright (C) 2005-2018 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Color.h"
+#include "ColorUtils.h"
+#include "math.h"
+
+UTILS::Color ColorUtils::ChangeOpacity(const UTILS::Color color, const float opacity)
+{
+  int newAlpha = ceil( ((color >> 24) & 0xff) * opacity);
+  return color + (newAlpha << 24);
+};

--- a/xbmc/utils/ColorUtils.h
+++ b/xbmc/utils/ColorUtils.h
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2005-2018 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "Color.h"
+
+class ColorUtils
+{
+  public:
+    /*! \brief Change the opacity of a given color
+     
+     \param color The original color
+     \param opacity The opacity value as a float
+     \return the original color with the changed opacity/alpha value
+     */
+    static UTILS::Color ChangeOpacity(const UTILS::Color color, const float opacity);
+};


### PR DESCRIPTION
This pull requests adds two new settings in Player/Language settings. It enables Kodi to display subtitles with a background color (pre-defined list of colors) and an opacity percentage value.

## Description
This is a feature present in major media players and have been requested in our forums several times. Requests for implementation date back to 2013 (e.g. https://forum.kodi.tv/showthread.php?tid=178478). Background is provided via an opaque texture drawn below the rendered glyphs. This is only enabled if the opacity of the background is not set to 0% otherwise behaviour stays exactly the same as before.

## Motivation and Context
Some media files have embed subtitles in the video stream - having subtitles with an opaque background makes the watching experience more pleasant. Furthermore a few users reported that even with the outline border in the subtitle font sometimes they can't read the subtitles correctly when the background is too bright. Furthermore, there are some addons in the forum that just re-write the original subtitle addons to convert the subtitles to ASS format so they can have a background.

## How Has This Been Tested?
Run time tested in OSX with 2 different subtitle fonts and multiple combinations of the settings.

## Screenshots (if appropriate):
- Before:

![before](https://s33.postimg.cc/i729lxc1r/screenshot_before.png
 "Before")

- After:
![after1](https://s33.postimg.cc/t5dj4fdlb/screenshot000.png
 "After 1")
![after2](https://s33.postimg.cc/a0a9uoecv/screenshot002.png
 "After 3")
![after2](https://s33.postimg.cc/3ml6rf1r3/screenshot004.png
 "After 3")

I am no C++ developer so let me know if anything can be improved. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
