### PR TITLE
[ios] Fix external/tvout monitor support

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2008,6 +2008,7 @@
               <condition>HAVE_WAYLAND</condition>
               <condition>HAVE_OSX</condition>
               <condition>HAS_DX</condition>
+              <condition>HAVE_IOS</condition>
             </or>
           </requirement>
           <level>0</level>

--- a/xbmc/platform/darwin/ios/IOSExternalTouchController.mm
+++ b/xbmc/platform/darwin/ios/IOSExternalTouchController.mm
@@ -52,6 +52,22 @@ const CGFloat timeFadeSecs                    = 2.0;
     [_touchView setMultipleTouchEnabled:YES];
     [_touchView setContentMode:UIViewContentModeCenter];
 
+    //load the splash image
+    std::string strUserSplash = CUtil::GetSplashPath();
+    xbmcLogo = [UIImage imageWithContentsOfFile:[NSString stringWithUTF8String:strUserSplash.c_str()]];
+    
+    //make a view with the image
+    xbmcLogoView = [[UIImageView alloc] initWithImage:xbmcLogo];
+    //center the image and add it to the view
+    [xbmcLogoView setFrame:frame];
+    [xbmcLogoView setContentMode:UIViewContentModeScaleAspectFill];
+    //autoresize the image frame
+    [xbmcLogoView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
+    [xbmcLogoView setAutoresizesSubviews:YES];
+    [_touchView addSubview:xbmcLogoView];
+    //send the image to the background
+    [_touchView sendSubviewToBack:xbmcLogoView];
+    [xbmcLogoView release];
 
     CGRect labelRect = frame;
     labelRect.size.height/=2;
@@ -83,23 +99,6 @@ const CGFloat timeFadeSecs                    = 2.0;
     [descriptionLabel setAutoresizesSubviews:YES];
     [_touchView addSubview:descriptionLabel];
     [descriptionLabel release];
-
-    //load the splash image
-    std::string strUserSplash = CUtil::GetSplashPath();
-    xbmcLogo = [UIImage imageWithContentsOfFile:[NSString stringWithUTF8String:strUserSplash.c_str()]];
-
-    //make a view with the image
-    xbmcLogoView = [[UIImageView alloc] initWithImage:xbmcLogo];
-    //center the image and add it to the view
-    [xbmcLogoView setFrame:frame];
-    [xbmcLogoView setContentMode:UIViewContentModeCenter];
-    //autoresize the image frame
-    [xbmcLogoView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
-    [xbmcLogoView setAutoresizesSubviews:YES];
-    [_touchView addSubview:xbmcLogoView];
-    //send the image to the background
-    [_touchView sendSubviewToBack:xbmcLogoView];
-    [xbmcLogoView release];
 
     [[self view] addSubview: _touchView];
 

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -280,9 +280,10 @@ static CEvent screenChangeEvent;
 //--------------------------------------------------------------
 + (void) updateResolutions
 {
-  if (CServiceBroker::GetWinSystem() != nullptr)
+  CWinSystemBase *winSystem = CServiceBroker::GetWinSystem();
+  if (winSystem != nullptr)
   {
-    CServiceBroker::GetWinSystem()->UpdateResolutions();
+    winSystem->UpdateResolutions();
   }
 }
 //--------------------------------------------------------------

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -280,7 +280,10 @@ static CEvent screenChangeEvent;
 //--------------------------------------------------------------
 + (void) updateResolutions
 {
-  CServiceBroker::GetWinSystem()->UpdateResolutions();
+  if (CServiceBroker::GetWinSystem() != nullptr)
+  {
+    CServiceBroker::GetWinSystem()->UpdateResolutions();
+  }
 }
 //--------------------------------------------------------------
 - (void) dealloc

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -26,6 +26,7 @@
 #include "threads/Event.h"
 #include "Application.h"
 #include "windowing/WinSystem.h"
+#include "windowing/osx/WinSystemIOS.h"
 #include "settings/DisplaySettings.h"
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
@@ -271,10 +272,13 @@ static CEvent screenChangeEvent;
 {
   //if we are on external screen and he was disconnected
   //change back to internal screen
-  if([[UIScreen screens] count] == 1 && _screenIdx != 0)
+  if (_screenIdx != 0)
   {
-    RESOLUTION_INFO res = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);//internal screen default res
-    CServiceBroker::GetWinSystem()->SetFullScreen(true, res, false);
+    CWinSystemIOS *winSystem = (CWinSystemIOS *)CServiceBroker::GetWinSystem();
+    if (winSystem != nullptr)
+    {
+      winSystem->MoveToTouchscreen();
+    }
   }
 }
 //--------------------------------------------------------------

--- a/xbmc/platform/darwin/ios/XBMCApplication.mm
+++ b/xbmc/platform/darwin/ios/XBMCApplication.mm
@@ -88,7 +88,7 @@ XBMCController *m_xbmcController;
 
 - (void)screenDidDisconnect:(NSNotification *)aNotification
 {
-  [IOSScreenManager updateResolutions];
+  [[IOSScreenManager sharedInstance] screenDisconnect];
 }
 
 - (void)registerScreenNotifications:(BOOL)bRegister

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -760,8 +760,19 @@ XBMCController *g_xbmcController;
 //--------------------------------------------------------------
 - (CGSize) getScreenSize
 {
-  screensize.width  = m_glView.bounds.size.width * screenScale;
-  screensize.height = m_glView.bounds.size.height * screenScale;
+  __block CGSize tmp;
+  if ([NSThread isMainThread]) {
+    tmp.width  = m_glView.bounds.size.width * screenScale;
+    tmp.height = m_glView.bounds.size.height * screenScale;
+  }
+  else
+  {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      tmp.width  = m_glView.bounds.size.width * screenScale;
+      tmp.height = m_glView.bounds.size.height * screenScale;
+    });
+  }
+  screensize = tmp;
   return screensize;
 }
 //--------------------------------------------------------------

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -761,7 +761,8 @@ XBMCController *g_xbmcController;
 - (CGSize) getScreenSize
 {
   __block CGSize tmp;
-  if ([NSThread isMainThread]) {
+  if ([NSThread isMainThread])
+  {
     tmp.width  = m_glView.bounds.size.width * screenScale;
     tmp.height = m_glView.bounds.size.height * screenScale;
   }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -52,6 +52,8 @@
 #include "windowing/X11/WinSystemX11.h"
 #elif defined(TARGET_DARWIN_OSX)
 #include "windowing/osx/WinSystemOSX.h"
+#elif defined(TARGET_DARWIN_IOS)
+#include "windowing/osx/WinSystemIOS.h"
 #elif defined(HAVE_WAYLAND)
 #include "windowing/wayland/WinSystemWayland.h"
 #elif defined(TARGET_WINDOWS_DESKTOP)
@@ -777,7 +779,7 @@ void CDisplaySettings::SettingOptionsScreensFiller(SettingConstPtr setting, std:
   if (g_advancedSettings.m_canWindowed && CServiceBroker::GetWinSystem()->CanDoWindowed())
     list.push_back(std::make_pair(g_localizeStrings.Get(242), DM_WINDOWED));
 
-#if defined(HAVE_X11) || defined(HAVE_WAYLAND) || defined(TARGET_DARWIN_OSX) || defined(TARGET_WINDOWS)
+#if defined(HAVE_X11) || defined(HAVE_WAYLAND) || defined(TARGET_DARWIN_OSX) || defined(TARGET_WINDOWS) || defined(TARGET_DARWIN_IOS)
   list.push_back(std::make_pair(g_localizeStrings.Get(244), 0));
 #else
 
@@ -831,13 +833,15 @@ void CDisplaySettings::SettingOptionsPreferredStereoscopicViewModesFiller(Settin
 
 void CDisplaySettings::SettingOptionsMonitorsFiller(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
 {
-#if defined(HAVE_X11) || defined(TARGET_DARWIN_OSX)
+#if defined(HAVE_X11) || defined(TARGET_DARWIN_OSX) || defined(TARGET_DARWIN_IOS)
   std::vector<std::string> monitors;
 
 #if defined(HAVE_X11)
   CWinSystemX11 *winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
 #elif defined(TARGET_DARWIN_OSX)
   CWinSystemOSX *winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
+#elif defined(TARGET_DARWIN_IOS)
+  CWinSystemIOS *winSystem = dynamic_cast<CWinSystemIOS*>(CServiceBroker::GetWinSystem());
 #endif
   winSystem->GetConnectedOutputs(&monitors);
   std::string currentMonitor = CServiceBroker::GetSettings().GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -333,6 +333,9 @@ void CSettingConditions::Initialize(const CProfilesManager &profileManager)
 #ifdef TARGET_DARWIN_OSX
   m_simpleConditions.insert("have_osx");
 #endif
+#ifdef TARGET_DARWIN_IOS
+  m_simpleConditions.insert("have_ios");
+#endif
 #ifdef HAS_LIBAMCODEC
   if (aml_present())
     m_simpleConditions.insert("have_amcodec");

--- a/xbmc/windowing/osx/WinSystemIOS.h
+++ b/xbmc/windowing/osx/WinSystemIOS.h
@@ -75,6 +75,7 @@ public:
   bool IsBackgrounded() const { return m_bIsBackgrounded; }
   void* GetEAGLContextObj();
   void GetConnectedOutputs(std::vector<std::string> *outputs);
+  void MoveToTouchscreen();
 
   // winevents override
   bool MessagePump() override;

--- a/xbmc/windowing/osx/WinSystemIOS.h
+++ b/xbmc/windowing/osx/WinSystemIOS.h
@@ -37,6 +37,7 @@ public:
   CWinSystemIOS();
   virtual ~CWinSystemIOS();
 
+  int GetDisplayIndexFromSettings();
   // Implementation of CWinSystemBase
   CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
@@ -66,9 +67,6 @@ public:
   void Register(IDispResource *resource) override;
   void Unregister(IDispResource *resource) override;
 
-  int GetNumScreens() override;
-  int GetCurrentScreen() override;
-
   virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 
   bool InitDisplayLink(CVideoSyncIos *syncImpl);
@@ -76,6 +74,7 @@ public:
   void OnAppFocusChange(bool focus);
   bool IsBackgrounded() const { return m_bIsBackgrounded; }
   void* GetEAGLContextObj();
+  void GetConnectedOutputs(std::vector<std::string> *outputs);
 
   // winevents override
   bool MessagePump() override;
@@ -95,8 +94,8 @@ protected:
 
 private:
   bool GetScreenResolution(int* w, int* h, double* fps, int screenIdx);
-  void FillInVideoModes();
-  bool SwitchToVideoMode(int width, int height, double refreshrate, int screenIdx);
+  void FillInVideoModes(int screenIdx);
+  bool SwitchToVideoMode(int width, int height, double refreshrate);
   CADisplayLinkWrapper *m_pDisplayLink;
 };
 

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -250,13 +250,14 @@ bool CWinSystemIOS::GetScreenResolution(int* w, int* h, double* fps, int screenI
     *h = firstMode.size.height;
   }
 
-  //for mainscreen use the eagl bounds
+  //for mainscreen exchange w and h
   //because mainscreen is build in
   //in 90° rotated
   if(screenIdx == 0)
   {
-    *w = [g_xbmcController getScreenSize].width;
-    *h = [g_xbmcController getScreenSize].height;
+    int tmp = *w;
+    *w = *h;
+    *h = tmp;
   }
   CLog::Log(LOGDEBUG,"Current resolution Screen: %i with %i x %i",screenIdx, *w, *h);
   return true;

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -315,18 +315,6 @@ void CWinSystemIOS::FillInVideoModes(int screenIdx)
     UpdateDesktopResolution(res, 0, w, h, refreshrate);
     CLog::Log(LOGNOTICE, "Found possible resolution for display %d with %d x %d\n", screenIdx, w, h);
 
-    //overwrite the mode str because  UpdateDesktopResolution adds a
-    //"Full Screen". Since the current resolution is there twice
-    //this would lead to 2 identical resolution entrys in the guisettings.xml.
-    //That would cause problems with saving screen overscan calibration
-    //because the wrong entry is picked on load.
-    //So we just use UpdateDesktopResolutions for the current DESKTOP_RESOLUTIONS
-    //in UpdateResolutions. And on all other resolutions make a unique
-    //mode str by doing it without appending "Full Screen".
-    //this is what linux does - though it feels that there shouldn't be
-    //the same resolution twice... - thats why i add a FIXME here.
-    res.strMode = StringUtils::Format("%dx%d @ %.2f", w, h, refreshrate);
-
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
     CDisplaySettings::GetInstance().AddResolutionInfo(res);
   }

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -94,8 +94,7 @@ int CWinSystemIOS::GetDisplayIndexFromSettings()
     else// screen 1 is setup but not connected
     {
       // force internal screen
-      CDisplaySettings::GetInstance().SetMonitor(CONST_TOUCHSCREEN);
-      UpdateResolutions();
+      MoveToTouchscreen();
     }
   }
   
@@ -513,6 +512,11 @@ void CWinSystemIOS::GetConnectedOutputs(std::vector<std::string> *outputs)
   {
     outputs->push_back(CONST_EXTERNAL);
   }
+}
+
+void CWinSystemIOS::MoveToTouchscreen()
+{
+  CDisplaySettings::GetInstance().SetMonitor(CONST_TOUCHSCREEN);
 }
 
 std::unique_ptr<CVideoSync> CWinSystemIOS::GetVideoSync(void *clock)

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -192,7 +192,7 @@ bool CWinSystemIOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   m_nWidth      = res.iWidth;
   m_nHeight     = res.iHeight;
   m_bFullScreen = fullScreen;
-  
+
   CLog::Log(LOGDEBUG, "About to switch to %i x %i on screen %i",m_nWidth, m_nHeight, res.iScreen);
   SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);


### PR DESCRIPTION
Since the change in handling of multi monitors - ios tvout was broken.

## Description
This changes WinSystemIOS and related classes to obey the new scheme of supporting multi monitors.
It also has some fixes for the external touch controller (splash screen scaling and instruction text fixups).

## Motivation and Context
For judging PR #14048 i need to test with tvout. So i need to fix this first.

## How Has This Been Tested?
Tested on iPhone SE with airplay monitor attached.
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
