### PR TITLE
RendererDRMPRIME: use ServiceBroker to get WinSystem

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -96,7 +96,7 @@ void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, 
 
 void CRendererDRMPRIME::Reset()
 {
-  for (int i = 0; i < m_numRenderBuffers; i++)
+  for (int i = 0; i < NUM_BUFFERS; i++)
     ReleaseBuffer(i);
 
   m_iLastRenderBuffer = -1;
@@ -125,9 +125,7 @@ bool CRendererDRMPRIME::NeedBuffer(int index)
 CRenderInfo CRendererDRMPRIME::GetRenderInfo()
 {
   CRenderInfo info;
-  info.max_buffer_size = m_numRenderBuffers;
-  info.optimal_buffer_size = m_numRenderBuffers;
-  info.opaque_pointer = (void*)this;
+  info.max_buffer_size = NUM_BUFFERS;
   return info;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -29,8 +29,6 @@
 
 const std::string SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
 
-static CWinSystemGbmGLESContext *m_pWinSystem;
-
 CRendererDRMPRIME::CRendererDRMPRIME(std::shared_ptr<CDRMUtils> drm)
   : m_DRM(drm)
 {
@@ -43,19 +41,20 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 {
-  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer))
+  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer) &&
+      CServiceBroker::GetSettings().GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
-    if (CServiceBroker::GetSettings().GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
-      return new CRendererDRMPRIME(m_pWinSystem->m_DRM);
+    CWinSystemGbmGLESContext* winSystem = dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
+    if (winSystem)
+      return new CRendererDRMPRIME(winSystem->m_DRM);
   }
 
   return nullptr;
 }
 
-bool CRendererDRMPRIME::Register(CWinSystemGbmGLESContext *winSystem)
+bool CRendererDRMPRIME::Register()
 {
   VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
-  m_pWinSystem = winSystem;
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -33,7 +33,7 @@ public:
 
   // Registration
   static CBaseRenderer* Create(CVideoBuffer* buffer);
-  static bool Register(CWinSystemGbmGLESContext *winSystem);
+  static bool Register();
 
   // Player functions
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -61,13 +61,11 @@ private:
 
   bool m_bConfigured = false;
   int m_iLastRenderBuffer = -1;
-  static const int m_numRenderBuffers = 4;
 
   std::shared_ptr<CDRMUtils> m_DRM;
 
   struct BUFFER
   {
-    BUFFER() : videoBuffer(nullptr) {};
-    CVideoBuffer* videoBuffer;
-  } m_buffers[m_numRenderBuffers];
+    CVideoBuffer* videoBuffer = nullptr;
+  } m_buffers[NUM_BUFFERS];
 };

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -69,7 +69,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   }
 
   CRendererDRMPRIMEGLES::Register();
-  CRendererDRMPRIME::Register(this);
+  CRendererDRMPRIME::Register();
   CDVDVideoCodecDRMPRIME::Register();
 
   return true;


### PR DESCRIPTION
## Description
This changes RendererDRMPRIME to use ServiceBroker to get WinSystem.
It also changes to support up to `NUM_BUFFERS` video buffers instead of 4.

## Motivation and Context
Similar cleanup that was made during review of #14026 
Support up to `NUM_BUFFERS` video buffers, same number that RenderManager can support.

## How Has This Been Tested?
Running Kodi master + LibreELEC on my Rock64 and Tinker Board S.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
