### PR TITLE
LinuxRendererGLES: remove early exit from Flush

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -203,6 +203,11 @@ int CLinuxRendererGLES::NextYV12Texture()
 void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   CPictureBuffer &buf = m_buffers[index];
+  if (buf.videoBuffer)
+  {
+    CLog::LogF(LOGERROR, "unreleased video buffer");
+    buf.videoBuffer->Release();
+  }
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
   buf.loaded = false;
@@ -344,9 +349,6 @@ void CLinuxRendererGLES::LoadPlane(YUVPLANE& plane, int type,
 
 void CLinuxRendererGLES::Flush()
 {
-  if (!m_bValidated)
-    return;
-
   glFinish();
 
   for (int i = 0 ; i < m_NumYV12Buffers ; i++)


### PR DESCRIPTION
## Description
Fixes an issue with unreleased video buffers when `AddVideoPicture` is called between `Flush` and `ValidateRenderTarget`
Also log about unreleased video buffer in `AddVideoPicture` to help catch potential future issues

## Motivation and Context
Issue with unreleased video buffer (and video buffer pool) was seen when reviewing #14026, the issue could be replicated with software decoding

## How Has This Been Tested?
Running on my Tinker Board S with Kodi master + LibreELEC

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
