### PR TITLE
Fix occasional buffering for http live streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -161,6 +161,13 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
 
     if (URIUtils::IsProtocol(finalFileitem.GetPath(), "udp"))
       return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(finalFileitem));
+
+    if (StringUtils::StartsWithNoCase(fileitem.GetPath(), "pvr://") && URIUtils::IsProtocol(finalFileitem.GetDynPath(), "http"))
+    {
+      auto inputStream = std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(finalFileitem));
+      inputStream->SetRealtime(true);
+      return inputStream;
+    }
   }
 
   // our file interface handles all these types of streams

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -139,7 +139,7 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
           finalUrl.SetProtocolOptions(origUrl.GetProtocolOptions());
           finalUrl.SetUserName(origUrl.GetUserName());
           finalUrl.SetPassword(origUrl.GetPassWord());
-          finalFileitem.SetPath(finalUrl.Get());
+          finalFileitem.SetDynPath(finalUrl.Get());
         }
         curlFile.Close();
       }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -30,9 +30,7 @@
 #ifdef HAVE_LIBBLURAY
 #include "DVDInputStreamBluray.h"
 #endif
-#ifdef ENABLE_DVDINPUTSTREAM_STACK
 #include "DVDInputStreamStack.h"
-#endif
 #include "FileItem.h"
 #include "storage/MediaManager.h"
 #include "URL.h"
@@ -97,33 +95,32 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
 
   if (fileitem.IsDVDFile(false, true))
     return std::shared_ptr<CDVDInputStreamNavigator>(new CDVDInputStreamNavigator(pPlayer, fileitem));
-  else if (fileitem.IsPVRChannel() && file.substr(0, 6) == "pvr://")
+  else if (fileitem.IsPVRChannel() && StringUtils::StartsWithNoCase(file, "pvr://"))
     return std::shared_ptr<CInputStreamPVRChannel>(new CInputStreamPVRChannel(pPlayer, fileitem));
-  else if (fileitem.IsUsablePVRRecording() && file.substr(0, 6) == "pvr://")
+  else if (fileitem.IsUsablePVRRecording() && StringUtils::StartsWithNoCase(file, "pvr://"))
     return std::shared_ptr<CInputStreamPVRRecording>(new CInputStreamPVRRecording(pPlayer, fileitem));
 #ifdef HAVE_LIBBLURAY
-  else if (fileitem.IsType(".bdmv") || fileitem.IsType(".mpls") || file.substr(0, 7) == "bluray:")
+  else if (fileitem.IsType(".bdmv") || fileitem.IsType(".mpls") || StringUtils::StartsWithNoCase(file, "bluray:"))
     return std::shared_ptr<CDVDInputStreamBluray>(new CDVDInputStreamBluray(pPlayer, fileitem));
 #endif
-  else if(file.substr(0, 6) == "rtp://"
-       || file.substr(0, 7) == "rtsp://"
-       || file.substr(0, 6) == "sdp://"
-       || file.substr(0, 6) == "udp://"
-       || file.substr(0, 6) == "tcp://"
-       || file.substr(0, 6) == "mms://"
-       || file.substr(0, 7) == "mmst://"
-       || file.substr(0, 7) == "mmsh://")
+  else if(StringUtils::StartsWithNoCase(file, "rtp://") ||
+          StringUtils::StartsWithNoCase(file, "rtsp://") ||
+          StringUtils::StartsWithNoCase(file, "sdp://") ||
+          StringUtils::StartsWithNoCase(file, "udp://") ||
+          StringUtils::StartsWithNoCase(file, "tcp://") ||
+          StringUtils::StartsWithNoCase(file, "mms://") ||
+          StringUtils::StartsWithNoCase(file, "mmst://") ||
+          StringUtils::StartsWithNoCase(file, "mmsh://") ||
+          StringUtils::StartsWithNoCase(file, "rtmp://") ||
+          StringUtils::StartsWithNoCase(file, "rtmpt://") ||
+          StringUtils::StartsWithNoCase(file, "rtmpe://") ||
+          StringUtils::StartsWithNoCase(file, "rtmpte://") ||
+          StringUtils::StartsWithNoCase(file, "rtmps://"))
+  {
     return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(fileitem));
-#ifdef ENABLE_DVDINPUTSTREAM_STACK
-  else if(file.substr(0, 8) == "stack://")
+  }
+  else if(StringUtils::StartsWithNoCase(file, "stack://"))
     return std::shared_ptr<CDVDInputStreamStack>(new CDVDInputStreamStack(fileitem));
-#endif
-  else if(file.substr(0, 7) == "rtmp://"
-       || file.substr(0, 8) == "rtmpt://"
-       || file.substr(0, 8) == "rtmpe://"
-       || file.substr(0, 9) == "rtmpte://"
-       || file.substr(0, 8) == "rtmps://")
-    return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(fileitem));
 
   CFileItem finalFileitem(fileitem);
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -189,7 +189,7 @@ public:
 
   virtual bool IsRealtime() { return m_realtime; }
 
-  void SetRealtime(bool realtime) { m_realtime = realtime; }
+  virtual void SetRealtime(bool realtime) { m_realtime = realtime; }
 
   // interfaces
   virtual IDemux* GetIDemux() { return nullptr; }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -155,3 +155,10 @@ std::string CDVDInputStreamFFmpeg::GetFileName()
   }
   return CDVDInputStream::GetFileName();
 }
+
+void CDVDInputStreamFFmpeg::SetRealtime(bool realtime)
+{
+    m_can_pause = false;
+    m_can_seek = false;
+    m_realtime = true;
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -34,11 +34,15 @@ using PLAYLIST::CPlayListM3U;
 
 CDVDInputStreamFFmpeg::CDVDInputStreamFFmpeg(const CFileItem& fileitem)
   : CDVDInputStream(DVDSTREAM_TYPE_FFMPEG, fileitem)
-  , m_can_pause(false)
-  , m_can_seek(false)
+  , m_can_pause(true)
+  , m_can_seek(true)
   , m_aborted(false)
 {
+  if (StringUtils::StartsWithNoCase(m_item.GetDynPath(), "udp://") || StringUtils::StartsWithNoCase(m_item.GetDynPath(), "rtp://"))
+    SetRealtime(true);
 
+  if(StringUtils::StartsWithNoCase(m_item.GetDynPath(), "tcp://"))
+    m_can_seek  = false;
 }
 
 CDVDInputStreamFFmpeg::~CDVDInputStreamFFmpeg()
@@ -56,27 +60,7 @@ bool CDVDInputStreamFFmpeg::IsEOF()
 
 bool CDVDInputStreamFFmpeg::Open()
 {
-  if (!CDVDInputStream::Open())
-    return false;
-
-  m_can_pause = true;
-  m_can_seek  = true;
-  m_aborted   = false;
-
-  if(strnicmp(m_item.GetDynPath().c_str(), "udp://", 6) == 0 ||
-     strnicmp(m_item.GetDynPath().c_str(), "rtp://", 6) == 0)
-  {
-    m_can_pause = false;
-    m_can_seek = false;
-    m_realtime = true;
-  }
-
-  if(strnicmp(m_item.GetDynPath().c_str(), "tcp://", 6) == 0)
-  {
-    m_can_pause = true;
-    m_can_seek  = false;
-  }
-  return true;
+  return CDVDInputStream::Open();
 }
 
 // close file and reset everything

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -44,6 +44,7 @@ public:
 
   bool CanSeek() override { return m_can_seek; }
   bool CanPause() override { return m_can_pause; }
+  void SetRealtime(bool realtime) override;
 
   std::string GetProxyType() const;
   std::string GetProxyHost() const;


### PR DESCRIPTION
When watching live http streams often the stream starts (taking ~4sec) and after a few seconds of playback we run out of data and buffer again for around 5 seconds.
My usecase is mostly about playback through pvr.iptvsimple, when using this pvr addon the FileItem's Path is set to pvr:// while the actual item (=DynPath) is the http:// stream.
I let InputStreamFFmpeg handle those and set the Realtime flag which removes the buffering issue.

While looking at it I tried to do minor cleanup as well.
Additionally I found that the InputStreamFactory modifies the FileItem's path while this must not be done afaik.

## How Has This Been Tested?
Tested on linux x11:

- Playback of http streams using a m3u playlist -> no change to current behaviour.
- Playback of http streams using pvr.iptvsimple -> InputStreamFFmpeg is used and VP treats it as realtime stream
- Playback of nfs mkv -> no change

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)