### PR TITLE
[Webinterface.Default] Escape control characters above 0x7e in css url()

### DIFF
--- a/addons/webinterface.default/js/kodi-webinterface.js
+++ b/addons/webinterface.default/js/kodi-webinterface.js
@@ -14965,7 +14965,7 @@ this.Kodi.module("LandingApp.Show", function(Show, App, Backbone, Marionette, $,
       }
       if ($hero.is(':visible') && this.rendered === this.settings.sections.length && this.fanarts.length > 0) {
         randomModel = this.fanarts[Math.floor(Math.random() * this.fanarts.length)];
-        $hero.css('background-image', 'url(' + randomModel.fanart + ')').attr('href', '#' + randomModel.url).attr('title', randomModel.title);
+        $hero.css('background-image', 'url("' + randomModel.fanart + '")').attr('href', '#' + randomModel.url).attr('title', randomModel.title);
         return $('body').removeClass('landing-loading');
       }
     };


### PR DESCRIPTION
## Description
The upper banner (fanart) is not shown in the movie and series view.

## Motivation and Context
The upper banner (fanart) is displayed again. Control characters are now enclosed by double quotes.
from:
```css
background-image: url(/image/image%3A%2F%2Fsmb%253a%252f%252fHTPC%252fDISK%252fMovies%252fB%252fBright%2520Collection%252fTESTMOVIE-(tt1234546)-fanart.jpg%2F);
```
to: 
```css
background-image: url("/image/image%3A%2F%2Fsmb%253a%252f%252fHTPC%252fDISK%252fMovies%252fB%252fBright%2520Collection%252fTESTMOVIE-(tt1234546)-fanart.jpg%2F");
```
## How Has This Been Tested?
Firefox, Ege, Chrome with two users.

## Screenshots (if appropriate):
![1](https://user-images.githubusercontent.com/5448179/41508179-ba1dfba8-7240-11e8-993e-14911379ea57.jpg)
![2](https://user-images.githubusercontent.com/5448179/41508180-ba363c36-7240-11e8-9fff-aafff4ce15c0.jpg)

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
