### PR TITLE
Revert "addons/AddonEvents: remove virtual destructor"

### DIFF
--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -28,10 +28,7 @@ namespace ADDON
   {
     std::string id;
     explicit AddonEvent(std::string id) : id(std::move(id)) {};
-
-  protected:
-    /* make sure nobody deletes a pointer to this class */
-    ~AddonEvent() = default;
+    virtual ~AddonEvent() = default;
   };
 
   namespace AddonEvents

--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -28,6 +28,10 @@ namespace ADDON
   {
     std::string id;
     explicit AddonEvent(std::string id) : id(std::move(id)) {};
+
+    // Note: Do not remove the virtual dtor. There are types derived from AddonEvent (see below)
+    //       and there are several places where 'typeid' is used to determine the runtime type of
+    //       AddonEvent references. And 'typeid' only works for polymorphic objects.
     virtual ~AddonEvent() = default;
   };
 


### PR DESCRIPTION
This reverts commit 28145f1498a8fbf41ec21dcbedd17762f8fa1f25.

@MaxKellermann 

This change breaks update of binary addons - and there is high risk that it breaks other functionality. 

> No derived class instance is ever allocated dynamically.

 Right, but there are lots of `typeid` calls on instances derived from `AddonEvent` and removing the virtual dtor from the base struct removes the vtable and as a consequence `typeid`is not working anymore. AFAIK, `typeid`only works for polymorphic types.

 Example: https://github.com/xbmc/xbmc/blob/master/xbmc/addons/BinaryAddonCache.cpp#L102