### PR TITLE
[scanner] Change exclusion to differentiate between files and folders

### DIFF
--- a/xbmc/InfoScanner.cpp
+++ b/xbmc/InfoScanner.cpp
@@ -31,14 +31,19 @@ bool CInfoScanner::HasNoMedia(const std::string &strDirectory) const
   return XFILE::CFile::Exists(noMediaFile);
 }
 
-bool CInfoScanner::IsExcluded(const std::string& strDirectory, const std::vector<std::string> &regexps)
+bool CInfoScanner::IsFileExcluded(const std::string& file, const std::vector<std::string>& regexps) const
 {
-  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+  return CUtil::ExcludeFileOrFolder(file, regexps) || IsDirectoryExcluded(URIUtils::GetDirectory(file), regexps);
+}
+
+bool CInfoScanner::IsDirectoryExcluded(const std::string& directory, const std::vector<std::string>& regexps) const
+{
+  if (CUtil::ExcludeFileOrFolder(directory, regexps))
     return true;
 
-  if (!URIUtils::IsPlugin(strDirectory) && HasNoMedia(strDirectory))
+  if (!URIUtils::IsPlugin(directory) && HasNoMedia(directory))
   {
-    CLog::Log(LOGWARNING, "Skipping item '%s' with '.nomedia' file in parent directory, it won't be added to the library.", CURL::GetRedacted(strDirectory).c_str());
+    CLog::Log(LOGWARNING, "Skipping items in '%s' due to '.nomedia' file in directory, they won't be added to the library.", CURL::GetRedacted(directory).c_str());
     return true;
   }
   return false;

--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -63,11 +63,17 @@ public:
   virtual bool DoScan(const std::string& strDirectory) = 0;
 
   /*! \brief Check if the folder is excluded from scanning process
-   \param strDirectory Directory to scan
+   \param directory Directory to scan
    \param regexps Regular expression to exclude from the scan
    \return true if there is a .nomedia file or one of the regexps is a match
    */
-  bool IsExcluded(const std::string& strDirectory, const std::vector<std::string> &regexps);
+  bool IsDirectoryExcluded(const std::string& strDirectory, const std::vector<std::string> &regexps) const;
+  /*! \brief Check if the file is excluded from scanning process
+   \param file to scan
+   \param regexps Regular expression to exclude from the scan
+   \return true if there is a .nomedia file in the parent directory or one of the regexps is a match
+   */
+  bool IsFileExcluded(const std::string& file, const std::vector<std::string>& regexps) const;
 
   //! \brief Set whether or not to show a progress dialog.
   void ShowDialog(bool show) { m_showDialog = show; }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -483,7 +483,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   // Discard all excluded files defined by m_musicExcludeRegExps
   const std::vector<std::string> &regexps = g_advancedSettings.m_audioExcludeFromScanRegExps;
 
-  if (IsExcluded(strDirectory, regexps))
+  if (IsDirectoryExcluded(strDirectory, regexps))
     return true;
 
   // load subfolder

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -262,7 +262,7 @@ namespace VIDEO
     const std::vector<std::string> &regexps = content == CONTENT_TVSHOWS ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
                                                          : g_advancedSettings.m_moviesExcludeFromScanRegExps;
 
-    if (IsExcluded(strDirectory, regexps))
+    if (IsDirectoryExcluded(strDirectory, regexps))
       return true;
 
     bool ignoreFolder = !m_scanAll && settings.noupdate;
@@ -412,6 +412,7 @@ namespace VIDEO
     m_database.Open();
 
     bool FoundSomeInfo = false;
+    auto const& regexps = (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps : g_advancedSettings.m_moviesExcludeFromScanRegExps;
     std::vector<int> seenPaths;
     for (int i = 0; i < (int)items.Size(); ++i)
     {
@@ -423,8 +424,7 @@ namespace VIDEO
         continue;
 
       // Discard all exclude files defined by regExExclude
-      if (IsExcluded(pItem->GetPath(), (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
-                                                                    : g_advancedSettings.m_moviesExcludeFromScanRegExps))
+      if (IsFileExcluded(pItem->GetPath(), regexps))
         continue;
 
       if (info2->Content() == CONTENT_MOVIES || info2->Content() == CONTENT_MUSICVIDEOS)
@@ -966,7 +966,7 @@ namespace VIDEO
         continue;
 
       // Discard all exclude files defined by regExExcludes
-      if (IsExcluded(items[i]->GetPath(), regexps))
+      if (IsFileExcluded(items[i]->GetPath(), regexps))
         continue;
 
       /*


### PR DESCRIPTION
## Description

Checking for `<file path>/.nomedia` makes no sense, this leads to
probing files such as `/some/directory/video.mp4/.nomedia`. Also, if
`/some/directory/.nomedia` would indeed exist, it would not be
detected.
Solve this by clearly distinguishing between file and folder checks
and resolving to the folder path for file checks.

## Motivation and Context
Discovered while investigating https://forum.kodi.tv/showthread.php?tid=331918

## How Has This Been Tested?
Build/run on Linux x64
