### PR TITLE
[RetroPlayer][Linux] add RPRendererGBM

### DIFF
--- a/cmake/modules/FindGBM.cmake
+++ b/cmake/modules/FindGBM.cmake
@@ -29,11 +29,24 @@ find_package_handle_standard_args(GBM
                                   REQUIRED_VARS GBM_LIBRARY GBM_INCLUDE_DIR
                                   VERSION_VAR GBM_VERSION)
 
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES ${GBM_LIBRARY})
+check_c_source_compiles("#include <gbm.h>
+
+                         int main()
+                         {
+                           gbm_bo_map(NULL, 0, 0, 0, 0, GBM_BO_TRANSFER_WRITE, NULL, NULL);
+                         }
+                         " GBM_HAS_BO_MAP)
+
 if(GBM_FOUND)
   set(GBM_LIBRARIES ${GBM_LIBRARY})
   set(GBM_INCLUDE_DIRS ${GBM_INCLUDE_DIR})
   set(GBM_DEFINITIONS -DHAVE_GBM=1)
-    if(NOT TARGET GBM::GBM)
+  if(GBM_HAS_BO_MAP)
+    list(APPEND GBM_DEFINITIONS -DHAS_GBM_BO_MAP=1)
+  endif()
+  if(NOT TARGET GBM::GBM)
     add_library(GBM::GBM UNKNOWN IMPORTED)
     set_target_properties(GBM::GBM PROPERTIES
                                    IMPORTED_LOCATION "${GBM_LIBRARY}"

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -56,7 +56,8 @@ CRPProcessInfo::CRPProcessInfo(std::string platformName) :
   for (auto &rendererFactory : m_rendererFactories)
   {
     RenderBufferPoolVector bufferPools = rendererFactory->CreateBufferPools(*m_renderContext);
-    m_renderBufferManager->RegisterPools(rendererFactory.get(), std::move(bufferPools));
+    if (!bufferPools.empty())
+      m_renderBufferManager->RegisterPools(rendererFactory.get(), std::move(bufferPools));
   }
 
   // Initialize default scaling method

--- a/xbmc/cores/RetroPlayer/process/gbm/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/process/gbm/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(SOURCES RPProcessInfoGbm.cpp)
-
 set(HEADERS RPProcessInfoGbm.h)
+
+if(GBM_HAS_BO_MAP)
+  list(APPEND SOURCES RenderBufferGBM.cpp
+                      RenderBufferPoolGBM.cpp)
+  list(APPEND HEADERS RenderBufferGBM.h
+                      RenderBufferPoolGBM.h)
+endif()
 
 core_add_library(rp-process-gbm)

--- a/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.cpp
@@ -1,0 +1,128 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RenderBufferGBM.h"
+#include "ServiceBroker.h"
+#include "utils/EGLImage.h"
+#include "utils/GBMBufferObject.h"
+
+#include "windowing/gbm/WinSystemGbmGLESContext.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CRenderBufferGBM::CRenderBufferGBM(CRenderContext &context,
+                                   int fourcc,
+                                   int bpp) :
+  m_context(context),
+  m_fourcc(fourcc),
+  m_bpp(bpp),
+  m_egl(new CEGLImage(dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem())->GetEGLDisplay())),
+  m_bo(new CGBMBufferObject(fourcc))
+{
+}
+
+CRenderBufferGBM::~CRenderBufferGBM()
+{
+  DeleteTexture();
+}
+
+bool CRenderBufferGBM::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
+{
+  // Initialize IRenderBuffer
+  m_format = format;
+  m_width = width;
+  m_height = height;
+
+  m_bo->CreateBufferObject(m_width, m_height);
+
+  return true;
+}
+
+size_t CRenderBufferGBM::GetFrameSize() const
+{
+  return m_bo->GetStride() * m_height;
+}
+
+uint8_t *CRenderBufferGBM::GetMemory()
+{
+  return m_bo->GetMemory();
+}
+
+void CRenderBufferGBM::ReleaseMemory()
+{
+  m_bo->ReleaseMemory();
+}
+
+void CRenderBufferGBM::CreateTexture()
+{
+  glGenTextures(1, &m_textureId);
+
+  glBindTexture(m_textureTarget, m_textureId);
+
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  glBindTexture(m_textureTarget, 0);
+}
+
+bool CRenderBufferGBM::UploadTexture()
+{
+  if (m_bo->GetFd() < 0)
+    return false;
+
+  if (!glIsTexture(m_textureId))
+    CreateTexture();
+
+  glBindTexture(m_textureTarget, m_textureId);
+
+  std::array<CEGLImage::EglPlane, CEGLImage::MAX_NUM_PLANES> planes;
+
+  planes[0].fd = m_bo->GetFd();
+  planes[0].offset = 0;
+  planes[0].pitch = m_bo->GetStride();
+  planes[0].modifier = m_bo->GetModifier();
+
+  CEGLImage::EglAttrs attribs;
+
+  attribs.width = m_width;
+  attribs.height = m_height;
+  attribs.format = m_fourcc;
+  attribs.planes = planes;
+
+  if (m_egl->CreateImage(attribs))
+    m_egl->UploadImage(m_textureTarget);
+
+  m_egl->DestroyImage();
+
+  glBindTexture(m_textureTarget, 0);
+
+  return true;
+}
+
+void CRenderBufferGBM::DeleteTexture()
+{
+  if (glIsTexture(m_textureId))
+    glDeleteTextures(1, &m_textureId);
+
+  m_textureId = 0;
+}

--- a/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.h
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "cores/RetroPlayer/buffers/BaseRenderBuffer.h"
+
+#include "system_gl.h"
+
+#include <memory>
+
+class CEGLImage;
+class CGBMBufferObject;
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CRenderContext;
+
+  class CRenderBufferGBM : public CBaseRenderBuffer
+  {
+  public:
+    CRenderBufferGBM(CRenderContext &context,
+                     int fourcc,
+                     int bpp);
+    ~CRenderBufferGBM() override;
+
+    // implementation of IRenderBuffer via CRenderBufferSysMem
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
+    size_t GetFrameSize() const override;
+    uint8_t *GetMemory() override;
+    void ReleaseMemory() override;
+
+    // implementation of IRenderBuffer
+    bool UploadTexture() override;
+
+    GLuint TextureID() const { return m_textureId; }
+
+  protected:
+    // Construction parameters
+    CRenderContext &m_context;
+    const int m_fourcc = 0;
+    const int m_bpp;
+
+    const GLenum m_textureTarget = GL_TEXTURE_EXTERNAL_OES;
+    GLuint m_textureId = 0;
+
+  private:
+    void CreateTexture();
+    void DeleteTexture();
+
+    std::unique_ptr<CEGLImage> m_egl;
+    std::unique_ptr<CGBMBufferObject> m_bo;
+  };
+}
+}

--- a/xbmc/cores/RetroPlayer/process/gbm/RenderBufferPoolGBM.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RenderBufferPoolGBM.cpp
@@ -1,0 +1,78 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RenderBufferPoolGBM.h"
+#include "RenderBufferGBM.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h"
+
+#include <drm_fourcc.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+CRenderBufferPoolGBM::CRenderBufferPoolGBM(CRenderContext &context)
+  : m_context(context)
+{
+}
+
+bool CRenderBufferPoolGBM::IsCompatible(const CRenderVideoSettings &renderSettings) const
+{
+  if (!CRPRendererGBM::SupportsScalingMethod(renderSettings.GetScalingMethod()))
+    return false;
+
+  return true;
+}
+
+
+IRenderBuffer *CRenderBufferPoolGBM::CreateRenderBuffer(void *header /* = nullptr */)
+{
+  return new CRenderBufferGBM(m_context,
+                              m_fourcc,
+                              m_bpp);
+}
+
+bool CRenderBufferPoolGBM::ConfigureInternal()
+{
+  switch (m_format)
+  {
+    case AV_PIX_FMT_0RGB32:
+    {
+      m_fourcc = DRM_FORMAT_ARGB8888;
+      m_bpp = sizeof(uint32_t);
+      return true;
+    }
+    case AV_PIX_FMT_RGB555:
+    {
+      m_fourcc = DRM_FORMAT_RGBA5551;
+      m_bpp = sizeof(uint16_t);
+      return true;
+    }
+    case AV_PIX_FMT_RGB565:
+    {
+      m_fourcc = DRM_FORMAT_RGB565;
+      m_bpp = sizeof(uint16_t);
+      return true;
+    }
+    default:
+      break; // we shouldn't even get this far if we are given an unsupported pixel format
+  }
+
+  return false;
+}

--- a/xbmc/cores/RetroPlayer/process/gbm/RenderBufferPoolGBM.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RenderBufferPoolGBM.h
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "cores/RetroPlayer/buffers/BaseRenderBufferPool.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CRenderContext;
+
+  class CRenderBufferPoolGBM : public CBaseRenderBufferPool
+  {
+  public:
+    CRenderBufferPoolGBM(CRenderContext &context);
+    ~CRenderBufferPoolGBM() override = default;
+
+    // implementation of IRenderBufferPool via CBaseRenderBufferPool
+    bool IsCompatible(const CRenderVideoSettings &renderSettings) const override;
+
+  protected:
+    // implementation of CBaseRenderBufferPool
+    IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
+    bool ConfigureInternal();
+
+    // Construction parameters
+    CRenderContext &m_context;
+
+    // Configuration parameters
+    int m_fourcc = 0;
+    int m_bpp = 0;
+  };
+}
+}

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -84,6 +84,9 @@ static ESHADERMETHOD TranslateShaderMethod(GL_SHADER_METHOD method)
   {
   case GL_SHADER_METHOD::DEFAULT: return SM_DEFAULT;
   case GL_SHADER_METHOD::TEXTURE: return SM_TEXTURE;
+#if defined(HAS_GLES)
+  case GL_SHADER_METHOD::TEXTURE_RGBA_OES: return SM_TEXTURE_RGBA_OES;
+#endif
   default:
     break;
   }

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -39,6 +39,7 @@ enum class GL_SHADER_METHOD
 {
   DEFAULT,
   TEXTURE,
+  TEXTURE_RGBA_OES,
 };
 
 namespace KODI

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/CMakeLists.txt
@@ -27,4 +27,9 @@ if(MMAL_FOUND)
                       RPRendererMMAL.h)
 endif()
 
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
+  list(APPEND SOURCES RPRendererGBM.cpp)
+  list(APPEND HEADERS RPRendererGBM.h)
+endif()
+
 core_add_library(rp-videorenderers)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
@@ -1,0 +1,155 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RPRendererGBM.h"
+
+#include "cores/RetroPlayer/process/gbm/RenderBufferGBM.h"
+#include "cores/RetroPlayer/process/gbm/RenderBufferPoolGBM.h"
+#include "cores/RetroPlayer/rendering/RenderContext.h"
+#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
+#include "utils/GLUtils.h"
+
+#include <cassert>
+#include <cstddef>
+
+using namespace KODI;
+using namespace RETRO;
+
+// --- CRendererFactoryGBM ------------------------------------------------
+
+std::string CRendererFactoryGBM::RenderSystemName() const
+{
+  return "GBM";
+}
+
+CRPBaseRenderer *CRendererFactoryGBM::CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool)
+{
+  return new CRPRendererGBM(settings, context, std::move(bufferPool));
+}
+
+RenderBufferPoolVector CRendererFactoryGBM::CreateBufferPools(CRenderContext &context)
+{
+  return {
+#if defined(HAS_GBM_BO_MAP)
+    std::make_shared<CRenderBufferPoolGBM>(context)
+#endif
+  };
+}
+
+// --- CRPRendererGBM -----------------------------------------------------
+
+CRPRendererGBM::CRPRendererGBM(const CRenderSettings &renderSettings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) :
+  CRPRendererOpenGLES(renderSettings, context, std::move(bufferPool))
+{
+  m_textureTarget = GL_TEXTURE_EXTERNAL_OES;
+}
+
+CRPRendererGBM::~CRPRendererGBM()
+{
+  Deinitialize();
+}
+
+void CRPRendererGBM::Render(uint8_t alpha)
+{
+  CRenderBufferGBM *renderBuffer = static_cast<CRenderBufferGBM*>(m_renderBuffer);
+  assert(renderBuffer != nullptr);
+
+  CRect rect = m_sourceRect;
+
+  rect.x1 /= m_sourceWidth;
+  rect.x2 /= m_sourceWidth;
+  rect.y1 /= m_sourceHeight;
+  rect.y2 /= m_sourceHeight;
+
+  const uint32_t color = (alpha << 24) | 0xFFFFFF;
+
+  glBindTexture(m_textureTarget, renderBuffer->TextureID());
+
+  GLint filter = GL_NEAREST;
+  if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
+    filter = GL_LINEAR;
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE_RGBA_OES);
+
+  GLubyte colour[4];
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+  GLuint vertexVBO;
+  GLuint indexVBO;
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  } vertex[4];
+
+  GLint vertLoc = m_context.GUIShaderGetPos();
+  GLint loc = m_context.GUIShaderGetCoord0();
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+
+  // Setup color values
+  colour[0] = static_cast<GLubyte>(GET_R(color));
+  colour[1] = static_cast<GLubyte>(GET_G(color));
+  colour[2] = static_cast<GLubyte>(GET_B(color));
+  colour[3] = static_cast<GLubyte>(GET_A(color));
+
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    // Setup vertex position values
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
+
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLuint*>(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLuint*>(offsetof(PackedVertex, u1)));
+
+  glEnableVertexAttribArray(vertLoc);
+  glEnableVertexAttribArray(loc);
+
+  glGenBuffers(1, &indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
+
+  glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f), (colour[3] / 255.0f));
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+  glDisableVertexAttribArray(vertLoc);
+  glDisableVertexAttribArray(loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &indexVBO);
+
+  m_context.DisableGUIShader();
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h
@@ -1,0 +1,50 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "RPRendererOpenGLES.h"
+
+#include <memory>
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CRendererFactoryGBM : public IRendererFactory
+  {
+  public:
+    // implementation of IRendererFactory
+    std::string RenderSystemName() const override;
+    CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
+    RenderBufferPoolVector CreateBufferPools(CRenderContext &context) override;
+  };
+
+  class CRPRendererGBM : public CRPRendererOpenGLES
+  {
+  public:
+    CRPRendererGBM(const CRenderSettings &renderSettings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool);
+    ~CRPRendererGBM() override;
+
+  protected:
+    // implementation of CRPRendererOpenGLES
+    void Render(uint8_t alpha) override;
+  };
+}
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -85,6 +85,8 @@ void CRenderBufferOpenGLES::CreateTexture()
   glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  glBindTexture(m_textureTarget, 0);
 }
 
 bool CRenderBufferOpenGLES::UploadTexture()
@@ -124,6 +126,8 @@ bool CRenderBufferOpenGLES::UploadTexture()
     for (unsigned int y = 0; y < m_height; ++y, pixels += stride)
       glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelformat, m_pixeltype, pixels);
   }
+
+  glBindTexture(m_textureTarget, 0);
 
   return true;
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -137,7 +137,7 @@ namespace RETRO
      */
     void DrawBlackBars();
 
-    void Render(uint8_t alpha);
+    virtual void Render(uint8_t alpha);
 
     GLenum m_textureTarget = GL_TEXTURE_2D;
     float m_clearColour = 0.0f;

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -109,6 +109,7 @@ set(HEADERS ActorProtocol.h
             HttpRangeUtils.h
             HttpResponse.h
             IArchivable.h
+            IBufferObject.h
             ILocalizer.h
             InfoLoader.h
             IRssObserver.h
@@ -195,6 +196,11 @@ endif()
 if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
   list(APPEND SOURCES EGLImage.cpp)
   list(APPEND HEADERS EGLImage.h)
+
+  if(GBM_HAS_BO_MAP)
+    list(APPEND SOURCES GBMBufferObject.cpp)
+    list(APPEND HEADERS GBMBufferObject.h)
+  endif()
 endif()
 
 core_add_library(utils)

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -46,6 +46,22 @@ namespace
     EGL_DMA_BUF_PLANE1_PITCH_EXT,
     EGL_DMA_BUF_PLANE2_PITCH_EXT,
   };
+
+#if defined(EGL_EXT_image_dma_buf_import_modifiers)
+  const EGLint eglDmabufPlaneModifierLoAttr[CEGLImage::MAX_NUM_PLANES] =
+  {
+    EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT,
+    EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT,
+    EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT,
+  };
+
+  const EGLint eglDmabufPlaneModifierHiAttr[CEGLImage::MAX_NUM_PLANES] =
+  {
+    EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT,
+    EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT,
+    EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT,
+  };
+#endif
 } // namespace
 
 CEGLImage::CEGLImage(EGLDisplay display) :
@@ -76,6 +92,12 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
       attribs.Add({{eglDmabufPlaneFdAttr[i], imageAttrs.planes[i].fd},
                    {eglDmabufPlaneOffsetAttr[i], imageAttrs.planes[i].offset},
                    {eglDmabufPlanePitchAttr[i], imageAttrs.planes[i].pitch}});
+
+#if defined(EGL_EXT_image_dma_buf_import_modifiers)
+      if (imageAttrs.planes[i].modifier != DRM_FORMAT_MOD_INVALID)
+        attribs.Add({{eglDmabufPlaneModifierLoAttr[i], static_cast<EGLint>(imageAttrs.planes[i].modifier & 0xFFFFFFFF)},
+                     {eglDmabufPlaneModifierHiAttr[i], static_cast<EGLint>(imageAttrs.planes[i].modifier >> 32)}});
+#endif
     }
   }
 

--- a/xbmc/utils/EGLImage.h
+++ b/xbmc/utils/EGLImage.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <drm_fourcc.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
@@ -36,6 +37,7 @@ public:
     int fd{0};
     int offset{0};
     int pitch{0};
+    uint64_t modifier{DRM_FORMAT_MOD_INVALID};
   };
 
   struct EglAttrs

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -1,0 +1,96 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GBMBufferObject.h"
+
+#include "ServiceBroker.h"
+#include "windowing/gbm/WinSystemGbmGLESContext.h"
+
+#include <gbm.h>
+
+CGBMBufferObject::CGBMBufferObject(int format) :
+  m_format(format)
+{
+  m_device = static_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem())->GetGBMDevice();
+}
+
+CGBMBufferObject::~CGBMBufferObject()
+{
+  ReleaseMemory();
+  DestroyBufferObject();
+}
+
+bool CGBMBufferObject::CreateBufferObject(int width, int height)
+{
+  m_width = width;
+  m_height = height;
+
+  m_bo = gbm_bo_create(m_device, m_width, m_height, m_format, GBM_BO_USE_LINEAR);
+
+  if (!m_bo)
+    return false;
+
+  m_fd = gbm_bo_get_fd(m_bo);
+
+  return true;
+}
+
+void CGBMBufferObject::DestroyBufferObject()
+{
+  if (m_bo)
+    gbm_bo_destroy(m_bo);
+}
+
+uint8_t* CGBMBufferObject::GetMemory()
+{
+  if (m_bo)
+  {
+    m_map = static_cast<uint8_t*>(gbm_bo_map(m_bo, 0, 0, m_width, m_height, GBM_BO_TRANSFER_WRITE, &m_stride, &m_map_data));
+    if (m_map)
+      return m_map;
+  }
+
+  return nullptr;
+}
+
+void CGBMBufferObject::ReleaseMemory()
+{
+  if (m_bo && m_map)
+  {
+    gbm_bo_unmap(m_bo, m_map_data);
+    m_map_data = nullptr;
+    m_map = nullptr;
+  }
+}
+
+int CGBMBufferObject::GetFd()
+{
+  return m_fd;
+}
+
+int CGBMBufferObject::GetStride()
+{
+  return m_stride;
+}
+
+uint64_t CGBMBufferObject::GetModifier()
+{
+  return gbm_bo_get_modifier(m_bo);
+}

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "utils/IBufferObject.h"
+
+#include <stdint.h>
+
+struct gbm_bo;
+struct gbm_device;
+
+class CGBMBufferObject : public IBufferObject
+{
+public:
+  CGBMBufferObject(int format);
+  virtual ~CGBMBufferObject() override;
+
+  bool CreateBufferObject(int width, int height) override;
+  void DestroyBufferObject() override;
+  uint8_t* GetMemory() override;
+  void ReleaseMemory() override;
+  int GetFd() override;
+  int GetStride() override;
+  uint64_t GetModifier();
+
+private:
+  gbm_device *m_device = nullptr;
+
+  int m_format = 0;
+  int m_fd = -1;
+  uint32_t m_stride = 0;
+  uint8_t *m_map = nullptr;
+  void *m_map_data = nullptr;
+  gbm_bo *m_bo = nullptr;
+};

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -1,0 +1,40 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+class IBufferObject
+{
+public:
+  virtual ~IBufferObject() = default;
+
+  virtual bool CreateBufferObject(int width, int height) = 0;
+  virtual void DestroyBufferObject() { }
+  virtual uint8_t *GetMemory() = 0;
+  virtual void ReleaseMemory() { }
+  virtual int GetFd() { return -1; }
+  virtual int GetStride() = 0;
+
+protected:
+  int m_width = 0;
+  int m_height = 0;
+};

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -65,6 +65,8 @@ public:
   std::string GetModule() const { return m_DRM->GetModule(); }
   std::string GetDevicePath() const { return m_DRM->GetDevicePath(); }
 
+  gbm_device *GetGBMDevice() const { return m_GBM->m_device; }
+
   std::shared_ptr<CDRMUtils> m_DRM;
 
 protected:

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -23,6 +23,7 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h"
 
 #include "cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
@@ -44,6 +45,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
 {
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfoGbm::Register();
+  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryGBM);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   if (!CWinSystemGbm::InitWindowSystem())


### PR DESCRIPTION
This allows using GBM buffer objects. GBM buffer objects allow dma-buf and are needed for a proper zero-copy path. We still need to implement proper SW buffer support in Retroplayer for proper zero-copy but that will come later after HW buffer support.

Modifiers are needed but aren't available on all platforms (some libmali versions).
`gbm_map_bo` support is needed which isn't available on all platforms (some libmali versions).

I guard for `gbm_map_bo` because without that it isn't possible to use this.

I implemented a IBufferObject interface because someone may want to implement other types of buffer objects (like dumb buffers). Then the renderer could probably be generic but for now I'll leave it specific to GBM.

