### PR TITLE
[depends] use MAKE variable instead of make command

### DIFF
--- a/tools/depends/target/libssh/Makefile
+++ b/tools/depends/target/libssh/Makefile
@@ -38,10 +38,10 @@ endif
 	cd $(PLATFORM)/build; $(CMAKE) -DWITH_STATIC_LIB=1 -DWITH_EXAMPLES=0 -DTHREADS_PTHREAD_ARG=0 $(CMAKE_EXTRAFLAGS) -DWITH_GSSAPI=0 VERBOSE=1 ..
 
 $(LIBDYLIB): $(PLATFORM)
-	make -j 1 -C $(PLATFORM)/build
+	$(MAKE) -j 1 -C $(PLATFORM)/build
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	make -C $(PLATFORM)/build install
+	$(MAKE) -C $(PLATFORM)/build install
 	rm -f $(PREFIX)/lib/libssh.so $(PREFIX)/lib/libssh.so.4.3.0 $(PREFIX)/lib/libssh.so.4
 	rm -f $(PREFIX)/lib/libssh.*dylib*
 	rm -f $(PREFIX)/lib/libssh_threads.*dylib*

--- a/tools/depends/target/rapidjson/Makefile
+++ b/tools/depends/target/rapidjson/Makefile
@@ -36,7 +36,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 ifeq ($(PREFIX),)
 	@echo
-	@echo "ERROR: please set PREFIX to the kodi install path e.g. make PREFIX=/usr/local"
+	@echo "ERROR: please set PREFIX to the kodi install path e.g. $(MAKE) PREFIX=/usr/local"
 	@exit 1
 endif
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
@@ -46,8 +46,8 @@ endif
 	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_OPTIONS) ..
 
 .installed-$(PLATFORM): $(PLATFORM)
-	make -C $(PLATFORM)/build
-	make -C $(PLATFORM)/build install
+	$(MAKE) -C $(PLATFORM)/build
+	$(MAKE) -C $(PLATFORM)/build install
 	rm -rf $(PREFIX)/share/doc/RapidJSON
 	touch $@
 

--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -55,7 +55,7 @@ distclean:
 	mkdir -p $(PLATFORM)
 ifeq ($(PREFIX),)
 	@echo
-	@echo "ERROR: please set PREFIX to the xbmc install path e.g. make PREFIX=/usr/local"
+	@echo "ERROR: please set PREFIX to the xbmc install path e.g. $(MAKE) PREFIX=/usr/local"
 	@exit 1
 endif
 ifeq ($(CROSS_COMPILING),yes)
@@ -66,7 +66,7 @@ endif
          $(CMAKE) -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX) $(CMAKE_EXTRA) \
          $(TOOLCHAIN) $(SRC_OVERRIDE) \
          -DADDONS_TO_BUILD="$(ADDONS)" $(ADDON_PROJECT_DIR) -DBUILD_DIR=$(BUILDDIR)/$(PLATFORM)/build ;\
-         for addon in $$(make supported_addons | awk '/^ALL_ADDONS_BUILDING: .*$$/ { first = $$1; $$1 = ""; print $$0 }'); do \
+         for addon in $$($(MAKE) supported_addons | awk '/^ALL_ADDONS_BUILDING: .*$$/ { first = $$1; $$1 = ""; print $$0 }'); do \
            $(MAKE) $$addon && echo $$addon >> $(ADDON_PROJECT_DIR)/.success || echo $$addon >> $(ADDON_PROJECT_DIR)/.failure ;\
          done
 ifneq ($(CROSS_COMPILING),yes)


### PR DESCRIPTION
## Description
fixes building binary addons on FreeBSD, by using gmake for getting supported_addons too

## Motivation and Context
stop @hudokkow telling building binary addons is broken, even if it is unrelated to the current way of building them

## How Has This Been Tested?
build binary addons on FreeBSD and Linux with `(g)make -C tools/depends/target/binary-addons PREFIX=<...>`

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
