### PR TITLE
Implement SDK21 AudioTrack constructor

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=3c0e79e4f1fd497434bf8cfda520c10af9009ce5
+VERSION=bfe01d03cfcef423ffbf3cd9aafef4a5a3539201
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -185,11 +185,8 @@ jni::CJNIAudioTrack *CAESinkAUDIOTRACK::CreateAudioTrack(int stream, int sampleR
     if (CJNIBase::GetSDKVersion() >= 21)
     {
       CJNIAudioAttributesBuilder attrBuilder;
-      attrBuilder.setContentType(stream == CJNIAudioManager::STREAM_MUSIC
-        ? CJNIAudioAttributes::CONTENT_TYPE_MUSIC
-        : CJNIAudioAttributes::CONTENT_TYPE_MOVIE);
       attrBuilder.setUsage(CJNIAudioAttributes::USAGE_MEDIA);
-//      attrBuilder.setFlags(CJNIAudioAttributes::FLAG_AUDIBILITY_ENFORCED);
+      attrBuilder.setFlags(CJNIAudioAttributes::FLAG_AUDIBILITY_ENFORCED);
 
       CJNIAudioFormatBuilder fmtBuilder;
       fmtBuilder.setChannelMask(channelMask);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -54,7 +54,7 @@ public:
   static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
 
 protected:
-  jni::CJNIAudioTrack *CreateAudioTrack(int stream, int sampleRate, int channelMask, int encoding, int bufferSize);
+  static jni::CJNIAudioTrack *CreateAudioTrack(int stream, int sampleRate, int channelMask, int encoding, int bufferSize);
   static bool IsSupported(int sampleRateInHz, int channelConfig, int audioFormat);
   static bool VerifySinkConfiguration(int sampleRate, int channelMask, int encoding);
   static bool HasAmlHD();


### PR DESCRIPTION
## Description
Implement new Audiotrack ctor because the current one is marked deprecated beginning with API 26.

## Motivation and Context
Investigating AudioTrack creation issues with Android O

## How Has This Been Tested?
Android 6 + 7 / PCM + PT

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
