### PR TITLE
[Music]Sources filtering ignore drives without paths

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -665,6 +665,12 @@ private:
   */
   bool CheckSources(VECSOURCES& sources);
 
+  /*! \brief Initially fills source table from sources.xml for use only at
+  migration of db from an earlier version than 72
+  returns true when successfuly done
+  */
+  bool MigrateSources();
+
   bool m_translateBlankArtist;
 
   // Fields should be ordered as they

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -55,8 +55,8 @@ public:
 
   /*! \brief Once a music source is added, store source in library, and prompt
   the user to scan this folder into the library
-  \param strPath the music source path
-  \param strName the name of the music source
+  \param oldName the original music source name 
+  \param source details of the music source (just added or edited)
   */
   static void OnAssignContent(const std::string& oldName, const CMediaSource& source);
 


### PR DESCRIPTION
A follow up to #14012 to alow for  dynamic automatically mounted sources e.g. CD drive,  that appear in the media source list but **don't have a path**. These were incorrectly being takens as a source for all music items.

On database migration from earlier versions populate the sources table (accidentally omitted before)
So some other very minor code fixes, thanks @phate89 
