### PR TITLE
[linux] windowing/gbm: move mouse cursor in the lower left corner

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -595,6 +595,11 @@ bool CDRMUtils::InitDrm()
   return true;
 }
 
+void CDRMUtils::HideCursor()
+{
+  drmModeMoveCursor(m_fd, m_crtc->crtc->crtc_id, 0, m_mode->hdisplay);
+}
+
 bool CDRMUtils::RestoreOriginalMode()
 {
   if(!m_orig_crtc)

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -73,6 +73,7 @@ public:
   virtual bool SetActive(bool active) { return false; };
   virtual bool InitDrm();
   virtual void DestroyDrm();
+  virtual void HideCursor();
 
   std::string GetModule() const { return m_module; }
   std::string GetDevicePath() const { return m_device_path; }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -100,6 +100,9 @@ bool CWinSystemGbm::InitWindowSystem()
     }
   }
 
+  /* move mouse cursor of underlying window system in the lower left corner */
+  m_DRM->HideCursor();
+
   if (!m_GBM->CreateDevice(m_DRM->m_fd))
   {
     m_GBM.reset();


### PR DESCRIPTION
## Description

If DRM-PRIME render is used and OS (i.e x11) has active mouse cursor it will stay there visible as the top most layer on GUI or Video Layer, which is very annoying.

## Motivation and Context

It is very annoying to have a mouse cursor on top of your movie so when kodi starts we just move the mouse cursor in the lower left side of the screen where it remains hidden.

## How Has This Been Tested?
ODROID-N1 running Debian with X11/LXDE 

## Types of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
