### PR TITLE
Fix event server keypress input

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -244,7 +244,7 @@ bool CInputManager::ProcessEventServer(int windowId, float frameTime)
       CKey key;
       if (wKeyID & ES_FLAG_UNICODE)
       {
-        key = CKey((uint8_t)0, wKeyID & ~ES_FLAG_UNICODE, 0, 0, 0);
+        key = CKey(0u, 0u, static_cast<wchar_t>(wKeyID & ~ES_FLAG_UNICODE), 0, 0, 0, 0);
         return OnKey(key);
       }
 


### PR DESCRIPTION
Fixing a regression introduced by the input modernisation #13354. Key press input simulated by the event server was being ignored.

The create CKey call in `CInputManager::ProcessEventServer` was overlooked when the creator parameters were changed resulting in the wrong creator being called.

@garbear as discussed on Slack

Tested using a modified version of https://github.com/xbmc/xbmc/blob/master/tools/EventClients/Clients/KodiSend/kodi-send.py to send key presses to a text box via event server
