### PR TITLE
[pvr] PVR Addon API 5.10.1: Add PVR_STREAM_PROPERTY_ISREALTIMESTREAM.

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -110,7 +110,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.10.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.10.1"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "5.10.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -79,7 +79,8 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_PROPERTIES     20
 #define PVR_STREAM_PROPERTY_STREAMURL "streamurl" /*!< @brief the URL of the stream that should be played. */
 #define PVR_STREAM_PROPERTY_INPUTSTREAMADDON  "inputstreamaddon" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by PVR_STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities. */
-#define PVR_STREAM_PROPERTY_MIMETYPE "mimetype" /*!< @brief the Mime-Type of the stream that should be played. */
+#define PVR_STREAM_PROPERTY_MIMETYPE "mimetype" /*!< @brief the MIME type of the stream that should be played. */
+#define PVR_STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream" /*!< @brief "true" to denote that the stream that should be played is a realtime stream. Any other value indicates that this is no realtime stream.*/
 
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -26,7 +26,7 @@ CDVDInputStream::CDVDInputStream(DVDStreamType streamType, const CFileItem& file
 {
   m_streamType = streamType;
   m_contentLookup = true;
-  m_realtime = false;
+  m_realtime = fileitem.GetProperty("isrealtimestream").asBoolean(false);
   m_item = fileitem;
 }
 


### PR DESCRIPTION
@FernetMenta @a1rwulf as discussed internally, we need a new stream property.

Thanks @a1rwulf for runtime-testing.

This super-seeds #14070 (at least the non-cleanup parts).

I will open PRs for all affected addons. 

Note: As this is an ABI compatible API bump, not all addons will need to be recompiled.