### PR TITLE
Fix unsafe usage of last invoker thread

### DIFF
--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -276,10 +276,12 @@ int CScriptInvocationManager::ExecuteAsync(const std::string &script,
     if (addon != NULL)
       m_lastInvokerThread->SetAddon(addon);
 
+    // After we leave the lock, m_lastInvokerThread can be released -> copy!
+    CLanguageInvokerThreadPtr invokerThread = m_lastInvokerThread;
     lock.Leave();
-    m_lastInvokerThread->Execute(script, arguments);
+    invokerThread->Execute(script, arguments);
 
-    return m_lastInvokerThread->GetId();
+    return invokerThread->GetId();
   }
 
   m_lastInvokerThread = CLanguageInvokerThreadPtr(new CLanguageInvokerThread(languageInvoker, this, reuseable));
@@ -295,10 +297,12 @@ int CScriptInvocationManager::ExecuteAsync(const std::string &script,
   LanguageInvokerThread thread = { m_lastInvokerThread, script, false };
   m_scripts.insert(std::make_pair(m_lastInvokerThread->GetId(), thread));
   m_scriptPaths.insert(std::make_pair(script, m_lastInvokerThread->GetId()));
+  // After we leave the lock, m_lastInvokerThread can be released -> copy!
+  CLanguageInvokerThreadPtr invokerThread = m_lastInvokerThread;
   lock.Leave();
-  m_lastInvokerThread->Execute(script, arguments);
+  invokerThread->Execute(script, arguments);
 
-  return m_lastInvokerThread->GetId();
+  return invokerThread->GetId();
 }
 
 int CScriptInvocationManager::ExecuteSync(const std::string &script,


### PR DESCRIPTION
## Description
Fix for current segfaults reported by windows store.

00 (Inline Function) --------`-------- kodi!ILanguageInvoker::GetId [d:\jenkins\workspace\win-uwp-64\xbmc\interfaces\generic\ilanguageinvoker.h @ 53] 

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
