### PR TITLE
mdns: add a txt record for http & json services containing 'uuid' and 'txtvers'

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1620,6 +1620,18 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="3">
+      <requirement>HAS_ZEROCONF</requirement>
+        <setting id="services.deviceuuid" type="string">
+          <visible>false</visible>
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string" />
+        </setting>
+      </group>
     </category>
     <category id="control" label="14223" help="36327">
       <group id="1" label="33101">

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -545,6 +545,9 @@ bool CNetworkServices::StartWebserver()
 
 #ifdef HAS_ZEROCONF
   std::vector<std::pair<std::string, std::string> > txt;
+  txt.push_back(std::make_pair("txtvers", "1"));
+  txt.push_back(std::make_pair("uuid", CServiceBroker::GetSettings().GetString(CSettings::SETTING_SERVICES_DEVICEUUID)));
+
   // publish web frontend and API services
 #ifdef HAS_WEB_INTERFACE
   CZeroconf::GetInstance()->PublishService("servers.webserver", "_http._tcp", CSysInfo::GetDeviceName(), webPort, txt);
@@ -709,6 +712,9 @@ bool CNetworkServices::StartJSONRPCServer()
 
 #ifdef HAS_ZEROCONF
   std::vector<std::pair<std::string, std::string> > txt;
+  txt.push_back(std::make_pair("txtvers", "1"));
+  txt.push_back(std::make_pair("uuid", CServiceBroker::GetSettings().GetString(CSettings::SETTING_SERVICES_DEVICEUUID)));
+
   CZeroconf::GetInstance()->PublishService("servers.jsonrpc-tpc", "_xbmc-jsonrpc._tcp", CSysInfo::GetDeviceName(), g_advancedSettings.m_jsonTcpPort, txt);
 #endif // HAS_ZEROCONF
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -306,6 +306,7 @@ const std::string CSettings::SETTING_WEATHER_CURRENTLOCATION = "weather.currentl
 const std::string CSettings::SETTING_WEATHER_ADDON = "weather.addon";
 const std::string CSettings::SETTING_WEATHER_ADDONSETTINGS = "weather.addonsettings";
 const std::string CSettings::SETTING_SERVICES_DEVICENAME = "services.devicename";
+const std::string CSettings::SETTING_SERVICES_DEVICEUUID = "services.deviceuuid";
 const std::string CSettings::SETTING_SERVICES_UPNP = "services.upnp";
 const std::string CSettings::SETTING_SERVICES_UPNPSERVER = "services.upnpserver";
 const std::string CSettings::SETTING_SERVICES_UPNPANNOUNCE = "services.upnpannounce";
@@ -659,6 +660,14 @@ void CSettings::InitializeDefaults()
 
   if (g_application.IsStandAlone())
     std::static_pointer_cast<CSettingInt>(GetSettingsManager()->GetSetting(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE))->SetDefault(POWERSTATE_SHUTDOWN);
+
+  // Initialize deviceUUID if not already set, used in zeroconf advertisements.
+  std::shared_ptr<CSettingString> deviceUUID = std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_SERVICES_DEVICEUUID));
+  if (deviceUUID->GetValue().empty())
+  {
+    const std::string& uuid = StringUtils::CreateUUID();
+    std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_SERVICES_DEVICEUUID))->SetValue(uuid);
+  }
 }
 
 void CSettings::InitializeOptionFillers()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -260,6 +260,7 @@ public:
   static const std::string SETTING_WEATHER_ADDON;
   static const std::string SETTING_WEATHER_ADDONSETTINGS;
   static const std::string SETTING_SERVICES_DEVICENAME;
+  static const std::string SETTING_SERVICES_DEVICEUUID;
   static const std::string SETTING_SERVICES_UPNP;
   static const std::string SETTING_SERVICES_UPNPSERVER;
   static const std::string SETTING_SERVICES_UPNPANNOUNCE;


### PR DESCRIPTION
## Description
Allows distinguishing between kodi installations without resorting to making any API calls.
This is also useful as kodi sends advertisements for every bound interface, causing duplicate
advertisements from a single host.

The change follows works similarly to code below in the same file for airplay support.
'txtvers' as per RFC 6763 is added for possible future extensions (web interface path? information about required authentication?)

## Motivation and Context
Currently Kodi advertises its API endpoint on all interfaces, without a possibility to distinguish a single instance without using API calls (which are cumbersome due to responding 'Busy' in their first call, e.g., when trying to fetch the mac address.
Considering mDNS/DNS-SD has a possibility for txt records, which are already used for other advertised services (where this code is adapted), it makes sense to add this information to help upstream users (e.g. netdisco and homeassistant) to automatically discovery the instance without creating duplicates due to multiple advertisements for different IP addresses.

## How Has This Been Tested?
Tested to work with `avahi-browse -ar`:
```
= docker0 IPv4 Kodi (nuc)                                    Web Site             local
   hostname = [nuc.local]
   address = [172.17.0.1]
   port = [8080]
   txt = ["txtvers=1" "mac=F8:63:XX:XX:XX:XX"]
```
and netdisco:
```
kodi:
[{'host': '172.17.0.1',
  'hostname': 'nuc.local.',
  'mac_address': 'F8:63:XX:XX:XX:XX',
  'port': 8080,
  'properties': {'mac': 'F8:63:XX:XX:XX:XX', 'txtvers': '1'}}]
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
