### PR TITLE
Screenshot rework and split up

### DIFF
--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -21,11 +21,13 @@ endif()
 
 if(CORE_PLATFORM_NAME_LC STREQUAL rbpi)
   list(APPEND SOURCES RBP.cpp
-                      OMXCore.cpp)
+                      OMXCore.cpp
+                      ScreenshotSurfaceRBP.cpp)
   list(APPEND HEADERS RBP.h
                       DllBCM.h
                       DllOMX.h
-                      OMXCore.h)
+                      OMXCore.h
+                      ScreenshotSurfaceRBP.h)
 endif()
 
 core_add_library(linuxsupport)

--- a/xbmc/platform/linux/ScreenshotSurfaceRBP.cpp
+++ b/xbmc/platform/linux/ScreenshotSurfaceRBP.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ScreenshotSurfaceRBP.h"
+
+#include "platform/linux/RBP.h"
+#include "utils/Screenshot.h"
+
+void CScreenshotSurfaceRBP::Register()
+{
+  CScreenShot::Register(CScreenshotSurfaceRBP::CreateSurface);
+}
+
+std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceRBP::CreateSurface()
+{
+  return std::unique_ptr<CScreenshotSurfaceRBP>(new CScreenshotSurfaceRBP());
+}
+
+bool CScreenshotSurfaceRBP::Capture()
+{
+  g_RBP.GetDisplaySize(m_width, m_height);
+  m_buffer = g_RBP.CaptureDisplay(m_width, m_height, &m_stride, true, false);
+  if (!m_buffer)
+    return false;
+
+  return true;
+}

--- a/xbmc/platform/linux/ScreenshotSurfaceRBP.h
+++ b/xbmc/platform/linux/ScreenshotSurfaceRBP.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/IScreenshotSurface.h"
+
+#include <memory>
+
+class CScreenshotSurfaceRBP : public IScreenshotSurface
+{
+public:
+  static void Register();
+  static std::unique_ptr<IScreenshotSurface> CreateSurface();
+
+  bool Capture() override;
+};

--- a/xbmc/rendering/dx/CMakeLists.txt
+++ b/xbmc/rendering/dx/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES DeviceResources.cpp
-            RenderSystemDX.cpp)
+            RenderSystemDX.cpp
+            ScreenshotSurfaceWindows.cpp)
 
 set(HEADERS DeviceResources.h
             DirectXHelper.h
             RenderContext.h
-            RenderSystemDX.h)
+            RenderSystemDX.h
+            ScreenshotSurfaceWindows.h)
 
 core_add_library(rendering_dx)

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ScreenshotSurfaceWindows.h"
+
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "rendering/dx/DeviceResources.h"
+#include "ServiceBroker.h"
+#include "threads/SingleLock.h"
+#include "utils/log.h"
+#include "utils/Screenshot.h"
+#include "windowing/GraphicContext.h"
+
+#include <wrl/client.h>
+
+using namespace Microsoft::WRL;
+
+void CScreenshotSurfaceWindows::Register()
+{
+  CScreenShot::Register(CScreenshotSurfaceWindows::CreateSurface);
+}
+
+std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceWindows::CreateSurface()
+{
+  return std::unique_ptr<CScreenshotSurfaceWindows>(new CScreenshotSurfaceWindows());
+}
+
+bool CScreenshotSurfaceWindows::Capture()
+{
+  CWinSystemBase* winsystem = CServiceBroker::GetWinSystem();
+  if (!winsystem)
+    return false;
+
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return false;
+
+  CSingleLock lock(winsystem->GetGfxContext());
+  gui->GetWindowManager().Render();
+
+  auto deviceResources = DX::DeviceResources::Get();
+  deviceResources->FinishCommandList();
+
+  ComPtr<ID3D11DeviceContext> pImdContext = deviceResources->GetImmediateContext();
+  ComPtr<ID3D11Device> pDevice = deviceResources->GetD3DDevice();
+  CD3DTexture& backbuffer = deviceResources->GetBackBuffer();
+  if (!backbuffer.Get())
+    return false;
+
+  D3D11_TEXTURE2D_DESC desc = { 0 };
+  backbuffer.GetDesc(&desc);
+  desc.Usage = D3D11_USAGE_STAGING;
+  desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+  desc.BindFlags = 0;
+
+  ComPtr<ID3D11Texture2D> pCopyTexture = nullptr;
+  if (SUCCEEDED(pDevice->CreateTexture2D(&desc, nullptr, &pCopyTexture)))
+  {
+    // take copy
+    pImdContext->CopyResource(pCopyTexture.Get(), backbuffer.Get());
+
+    D3D11_MAPPED_SUBRESOURCE res;
+    if (SUCCEEDED(pImdContext->Map(pCopyTexture.Get(), 0, D3D11_MAP_READ, 0, &res)))
+    {
+      m_width = desc.Width;
+      m_height = desc.Height;
+      m_stride = res.RowPitch;
+      m_buffer = new unsigned char[m_height * m_stride];
+      if (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM)
+      {
+        // convert R10G10B10A2 -> B8G8R8A8
+        for (int y = 0; y < m_height; y++)
+        {
+          uint32_t* pixels10 = reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(res.pData) + y * res.RowPitch);
+          uint8_t* pixels8 = m_buffer + y * m_stride;
+
+          for (int x = 0; x < m_width; x++, pixels10++, pixels8 += 4)
+          {
+            // actual bit per channel is A2B10G10R10
+            uint32_t pixel = *pixels10;
+            // R
+            pixels8[2] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
+            // G
+            pixel >>= 10;
+            pixels8[1] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
+            // B
+            pixel >>= 10;
+            pixels8[0] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
+            // A
+            pixels8[3] = 0xFF;
+          }
+        }
+      }
+      else
+        memcpy(m_buffer, res.pData, m_height * m_stride);
+      pImdContext->Unmap(pCopyTexture.Get(), 0);
+    }
+    else
+      CLog::LogFunction(LOGERROR, __FUNCTION__, "MAP_READ failed.");
+  }
+
+  return m_buffer != nullptr;
+}

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/IScreenshotSurface.h"
+
+#include <memory>
+
+class CScreenshotSurfaceWindows : public IScreenshotSurface
+{
+public:
+  static void Register();
+  static std::unique_ptr<IScreenshotSurface> CreateSurface();
+
+  bool Capture() override;
+};

--- a/xbmc/rendering/gl/CMakeLists.txt
+++ b/xbmc/rendering/gl/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(SOURCES RenderSystemGL.cpp
+            ScreenshotSurfaceGL.cpp
             ../MatrixGL.cpp
             GLShader.cpp)
 
 set(HEADERS RenderSystemGL.h
+            ScreenshotSurfaceGL.h
             ../MatrixGL.h
             GLShader.h)
 

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ScreenshotSurfaceGL.h"
+
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "ServiceBroker.h"
+#include "threads/SingleLock.h"
+#include "utils/Screenshot.h"
+#include "windowing/GraphicContext.h"
+
+#include "system_gl.h"
+
+#include <vector>
+
+void CScreenshotSurfaceGL::Register()
+{
+  CScreenShot::Register(CScreenshotSurfaceGL::CreateSurface);
+}
+
+std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGL::CreateSurface()
+{
+  return std::unique_ptr<CScreenshotSurfaceGL>(new CScreenshotSurfaceGL());
+}
+
+bool CScreenshotSurfaceGL::Capture()
+{
+  CWinSystemBase* winsystem = CServiceBroker::GetWinSystem();
+  if (!winsystem)
+    return false;
+
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return false;
+
+  CSingleLock lock(winsystem->GetGfxContext());
+  gui->GetWindowManager().Render();
+
+  glReadBuffer(GL_BACK);
+
+  // get current viewport
+  GLint viewport[4];
+  glGetIntegerv(GL_VIEWPORT, viewport);
+
+  m_width = viewport[2] - viewport[0];
+  m_height = viewport[3] - viewport[1];
+  m_stride = m_width * 4;
+  std::vector<uint8_t> surface(m_stride * m_height);
+
+  // read pixels from the backbuffer
+  glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_BGRA, GL_UNSIGNED_BYTE, static_cast<GLvoid*>(surface.data()));
+
+  // make a new buffer and copy the read image to it with the Y axis inverted
+  m_buffer = new unsigned char[m_stride * m_height];
+  for (int y = 0; y < m_height; y++)
+    memcpy(m_buffer + y * m_stride, surface.data() + (m_height - y - 1) * m_stride, m_stride);
+
+  return m_buffer != nullptr;
+}

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.h
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/IScreenshotSurface.h"
+
+#include <memory>
+
+class CScreenshotSurfaceGL : public IScreenshotSurface
+{
+public:
+  static void Register();
+  static std::unique_ptr<IScreenshotSurface> CreateSurface();
+
+  bool Capture() override;
+};

--- a/xbmc/rendering/gles/CMakeLists.txt
+++ b/xbmc/rendering/gles/CMakeLists.txt
@@ -1,9 +1,11 @@
 if(OPENGLES_FOUND)
   set(SOURCES RenderSystemGLES.cpp
+              ScreenshotSurfaceGLES.cpp
               ../MatrixGL.cpp
               GLESShader.cpp)
 
   set(HEADERS RenderSystemGLES.h
+              ScreenshotSurfaceGLES.h
               ../MatrixGL.h
               GLESShader.h)
 

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ScreenshotSurfaceGLES.h"
+
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "ServiceBroker.h"
+#include "threads/SingleLock.h"
+#include "utils/Screenshot.h"
+#include "windowing/GraphicContext.h"
+
+#include "system_gl.h"
+
+#include <vector>
+
+void CScreenshotSurfaceGLES::Register()
+{
+  CScreenShot::Register(CScreenshotSurfaceGLES::CreateSurface);
+}
+
+std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGLES::CreateSurface()
+{
+  return std::unique_ptr<CScreenshotSurfaceGLES>(new CScreenshotSurfaceGLES());
+}
+
+bool CScreenshotSurfaceGLES::Capture()
+{
+  CWinSystemBase* winsystem = CServiceBroker::GetWinSystem();
+  if (!winsystem)
+    return false;
+
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return false;
+
+  CSingleLock lock(winsystem->GetGfxContext());
+  gui->GetWindowManager().Render();
+
+  //get current viewport
+  GLint viewport[4];
+  glGetIntegerv(GL_VIEWPORT, viewport);
+
+  m_width = viewport[2] - viewport[0];
+  m_height = viewport[3] - viewport[1];
+  m_stride = m_width * 4;
+  std::vector<uint8_t> surface(m_stride * m_height);
+
+  //read pixels from the backbuffer
+  glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE, static_cast<GLvoid*>(surface.data()));
+
+  //make a new buffer and copy the read image to it with the Y axis inverted
+  m_buffer = new unsigned char[m_stride * m_height];
+  for (int y = 0; y < m_height; y++)
+  {
+    // we need to save in BGRA order so XOR Swap RGBA -> BGRA
+    unsigned char* swap_pixels = surface.data() + (m_height - y - 1) * m_stride;
+    for (int x = 0; x < m_width; x++, swap_pixels += 4)
+    {
+      std::swap(swap_pixels[0], swap_pixels[2]);
+    }
+
+    memcpy(m_buffer + y * m_stride, surface.data() + (m_height - y - 1) * m_stride, m_stride);
+  }
+
+  return m_buffer != nullptr;
+}

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/IScreenshotSurface.h"
+
+#include <memory>
+
+class CScreenshotSurfaceGLES : public IScreenshotSurface
+{
+public:
+  static void Register();
+  static std::unique_ptr<IScreenshotSurface> CreateSurface();
+
+  bool Capture() override;
+};

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -113,6 +113,7 @@ set(HEADERS ActorProtocol.h
             ILocalizer.h
             InfoLoader.h
             IRssObserver.h
+            IScreenshotSurface.h
             ISerializable.h
             ISortable.h
             IXmlDeserializable.h

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class IScreenshotSurface
+{
+public:
+  virtual ~IScreenshotSurface() = default;
+  virtual bool Capture() { return false; }
+  virtual void CaptureVideo(bool blendToBuffer) { };
+
+  int GetWidth() const { return m_width; }
+  int GetHeight() const { return m_height; }
+  int GetStride() const { return m_stride; }
+  unsigned char* GetBuffer() const { return m_buffer; }
+  void ReleaseBuffer()
+  {
+    if (m_buffer)
+    {
+      delete m_buffer;
+      m_buffer = nullptr;
+    }
+  };
+
+protected:
+  int m_width{0};
+  int m_height{0};
+  int m_stride{0};
+  unsigned char* m_buffer{nullptr};
+};

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -8,203 +8,65 @@
 
 #include "Screenshot.h"
 
-#include "system_gl.h"
-#include <vector>
-
-#include "ServiceBroker.h"
-#include "Util.h"
-#include "URL.h"
-
-#include "pictures/Picture.h"
-
-#ifdef TARGET_RASPBERRY_PI
-#include "platform/linux/RBP.h"
-#endif
-
 #include "filesystem/File.h"
-#include "guilib/GUIComponent.h"
-#include "windowing/GraphicContext.h"
-#include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
-
-#include "utils/JobManager.h"
-#include "utils/URIUtils.h"
-#include "utils/log.h"
+#include "pictures/Picture.h"
+#include "ServiceBroker.h"
 #include "settings/SettingPath.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/windows/GUIControlSettings.h"
 
-#if defined(TARGET_WINDOWS)
-#include "rendering/dx/DeviceResources.h"
-#include <wrl/client.h>
-using namespace Microsoft::WRL;
-#endif
+#include "URL.h"
+#include "Util.h"
+#include "utils/JobManager.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
 
 using namespace XFILE;
 
-CScreenshotSurface::CScreenshotSurface()
+std::vector<std::function<std::unique_ptr<IScreenshotSurface>()>> CScreenShot::m_screenShotSurfaces;
+
+void CScreenShot::Register(std::function<std::unique_ptr<IScreenshotSurface>()> createFunc)
 {
-  m_width = 0;
-  m_height = 0;
-  m_stride = 0;
-  m_buffer = NULL;
+  m_screenShotSurfaces.emplace_back(createFunc);
 }
 
-CScreenshotSurface::~CScreenshotSurface()
+void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
 {
-  delete m_buffer;
-}
+  auto surface = m_screenShotSurfaces.back()();
 
-bool CScreenshotSurface::capture()
-{
-#if defined(TARGET_RASPBERRY_PI)
-  g_RBP.GetDisplaySize(m_width, m_height);
-  m_buffer = g_RBP.CaptureDisplay(m_width, m_height, &m_stride, true, false);
-  if (!m_buffer)
-    return false;
-#elif defined(TARGET_WINDOWS)
-
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-
-  CServiceBroker::GetGUI()->GetWindowManager().Render();
-
-  auto deviceResources = DX::DeviceResources::Get();
-  deviceResources->FinishCommandList();
-
-  ComPtr<ID3D11DeviceContext> pImdContext = deviceResources->GetImmediateContext();
-  ComPtr<ID3D11Device> pDevice = deviceResources->GetD3DDevice();
-  CD3DTexture& backbuffer = deviceResources->GetBackBuffer();
-  if (!backbuffer.Get())
-    return false;
-
-  D3D11_TEXTURE2D_DESC desc = { 0 };
-  backbuffer.GetDesc(&desc);
-  desc.Usage = D3D11_USAGE_STAGING;
-  desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-  desc.BindFlags = 0;
-
-  ComPtr<ID3D11Texture2D> pCopyTexture = nullptr;
-  if (SUCCEEDED(pDevice->CreateTexture2D(&desc, nullptr, &pCopyTexture)))
+  if (!surface)
   {
-    // take copy
-    pImdContext->CopyResource(pCopyTexture.Get(), backbuffer.Get());
-
-    D3D11_MAPPED_SUBRESOURCE res;
-    if (SUCCEEDED(pImdContext->Map(pCopyTexture.Get(), 0, D3D11_MAP_READ, 0, &res)))
-    {
-      m_width = desc.Width;
-      m_height = desc.Height;
-      m_stride = res.RowPitch;
-      m_buffer = new unsigned char[m_height * m_stride];
-      if (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM)
-      {
-        // convert R10G10B10A2 -> B8G8R8A8
-        for (int y = 0; y < m_height; y++)
-        {
-          uint32_t* pixels10 = reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(res.pData) + y * res.RowPitch);
-          uint8_t* pixels8 = m_buffer + y * m_stride;
-
-          for (int x = 0; x < m_width; x++, pixels10++, pixels8 += 4)
-          {
-            // actual bit per channel is A2B10G10R10
-            uint32_t pixel = *pixels10;
-            // R
-            pixels8[2] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
-            // G
-            pixel >>= 10;
-            pixels8[1] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
-            // B
-            pixel >>= 10;
-            pixels8[0] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
-            // A
-            pixels8[3] = 0xFF;
-          }
-        }
-      }
-      else
-        memcpy(m_buffer, res.pData, m_height * m_stride);
-      pImdContext->Unmap(pCopyTexture.Get(), 0);
-    }
-    else
-      CLog::LogFunction(LOGERROR, __FUNCTION__, "MAP_READ failed.");
-  }
-#elif defined(HAS_GL) || defined(HAS_GLES)
-
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-  CServiceBroker::GetGUI()->GetWindowManager().Render();
-#ifndef HAS_GLES
-  glReadBuffer(GL_BACK);
-#endif
-  //get current viewport
-  GLint viewport[4];
-  glGetIntegerv(GL_VIEWPORT, viewport);
-
-  m_width  = viewport[2] - viewport[0];
-  m_height = viewport[3] - viewport[1];
-  m_stride = m_width * 4;
-  unsigned char* surface = new unsigned char[m_stride * m_height];
-
-  //read pixels from the backbuffer
-#if HAS_GLES >= 2
-  glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*)surface);
-#else
-  glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_BGRA, GL_UNSIGNED_BYTE, (GLvoid*)surface);
-#endif
-
-  //make a new buffer and copy the read image to it with the Y axis inverted
-  m_buffer = new unsigned char[m_stride * m_height];
-  for (int y = 0; y < m_height; y++)
-  {
-#ifdef HAS_GLES
-    // we need to save in BGRA order so XOR Swap RGBA -> BGRA
-    unsigned char* swap_pixels = surface + (m_height - y - 1) * m_stride;
-    for (int x = 0; x < m_width; x++, swap_pixels+=4)
-    {
-      std::swap(swap_pixels[0], swap_pixels[2]);
-    }
-#endif
-    memcpy(m_buffer + y * m_stride, surface + (m_height - y - 1) *m_stride, m_stride);
+    CLog::Log(LOGERROR, "failed to create screenshot surface");
+    return;
   }
 
-  delete [] surface;
-
-#else
-  //nothing to take a screenshot from
-  return false;
-#endif
-
-  return true;
-}
-
-void CScreenShot::TakeScreenshot(const std::string &filename, bool sync)
-{
-
-  CScreenshotSurface surface;
-  if (!surface.capture())
+  if (!surface->Capture())
   {
     CLog::Log(LOGERROR, "Screenshot %s failed", CURL::GetRedacted(filename).c_str());
     return;
   }
 
+  surface->CaptureVideo(true);
+
   CLog::Log(LOGDEBUG, "Saving screenshot %s", CURL::GetRedacted(filename).c_str());
 
   //set alpha byte to 0xFF
-  for (int y = 0; y < surface.m_height; y++)
+  for (int y = 0; y < surface->GetHeight(); y++)
   {
-    unsigned char* alphaptr = surface.m_buffer - 1 + y * surface.m_stride;
-    for (int x = 0; x < surface.m_width; x++)
+    unsigned char* alphaptr = surface->GetBuffer() - 1 + y * surface->GetStride();
+    for (int x = 0; x < surface->GetWidth(); x++)
       *(alphaptr += 4) = 0xFF;
   }
 
   //if sync is true, the png file needs to be completely written when this function returns
   if (sync)
   {
-    if (!CPicture::CreateThumbnailFromSurface(surface.m_buffer, surface.m_width, surface.m_height, surface.m_stride, filename))
+    if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename))
       CLog::Log(LOGERROR, "Unable to write screenshot %s", CURL::GetRedacted(filename).c_str());
 
-    delete [] surface.m_buffer;
-    surface.m_buffer = NULL;
+    surface->ReleaseBuffer();
   }
   else
   {
@@ -217,9 +79,8 @@ void CScreenShot::TakeScreenshot(const std::string &filename, bool sync)
 
     //write .png file asynchronous with CThumbnailWriter, prevents stalling of the render thread
     //buffer is deleted from CThumbnailWriter
-    CThumbnailWriter* thumbnailwriter = new CThumbnailWriter(surface.m_buffer, surface.m_width, surface.m_height, surface.m_stride, filename);
+    CThumbnailWriter* thumbnailwriter = new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename);
     CJobManager::GetInstance().AddJob(thumbnailwriter, NULL);
-    surface.m_buffer = NULL;
   }
 }
 

--- a/xbmc/utils/Screenshot.h
+++ b/xbmc/utils/Screenshot.h
@@ -8,26 +8,21 @@
 
 #pragma once
 
+#include "IScreenshotSurface.h"
+
+#include <functional>
+#include <memory>
 #include <string>
-
-class CScreenshotSurface
-{
-
-public:
-  int            m_width;
-  int            m_height;
-  int            m_stride;
-  unsigned char* m_buffer;
-
-  CScreenshotSurface(void);
-  ~CScreenshotSurface();
-  bool capture( void );
-};
+#include <vector>
 
 class CScreenShot
 {
-
 public:
+  static void Register(std::function<std::unique_ptr<IScreenshotSurface>()> createFunc);
+
   static void TakeScreenshot();
   static void TakeScreenshot(const std::string &filename, bool sync);
+
+private:
+  static std::vector<std::function<std::unique_ptr<IScreenshotSurface>()>> m_screenShotSurfaces;
 };

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -29,6 +29,7 @@
 
 #include "OptionalsReg.h"
 #include "platform/linux/OptionalsReg.h"
+#include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "X11DPMSSupport.h"
 
 using namespace KODI;
@@ -268,6 +269,8 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
   CDVDFactoryCodec::ClearHWAccels();
   VIDEOPLAYER::CRendererFactory::ClearRenderer();
   CLinuxRendererGL::Register();
+
+  CScreenshotSurfaceGL::Register();
 
   std::string gpuvendor;
   const char* vend = (const char*) glGetString(GL_VENDOR);

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -28,6 +28,7 @@
 #include "platform/android/media/drm/MediaDrmCryptoSession.h"
 #include "platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.h"
 #include "platform/android/activity/XBMCApp.h"
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "ServiceBroker.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -85,6 +86,9 @@ bool CWinSystemAndroid::InitWindowSystem()
   ADDON::Interface_Android::Register();
   DRM::CMediaDrmCryptoSession::Register();
   VIDEOPLAYER::CProcessInfoAndroid::Register();
+
+  CScreenshotSurfaceGLES::Register();
+
   return CWinSystemBase::InitWindowSystem();
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -17,6 +17,7 @@
 #include "WinSystemGbmGLContext.h"
 #include "OptionalsReg.h"
 #include "platform/posix/XTimeUtils.h"
+#include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::GBM;
@@ -53,6 +54,8 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   {
     VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
+
+  CScreenshotSurfaceGL::Register();
 
   return true;
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -20,6 +20,7 @@
 
 #include "OptionalsReg.h"
 #include "platform/posix/XTimeUtils.h"
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "utils/log.h"
 #include "WinSystemGbmGLESContext.h"
 
@@ -67,6 +68,8 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   CRendererDRMPRIME::Register();
   CDVDVideoCodecDRMPRIME::Register();
   VIDEOPLAYER::CProcessInfoGBM::Register();
+
+  CScreenshotSurfaceGLES::Register();
 
   return true;
 }

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -18,6 +18,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.h"
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "utils/log.h"
 #include "filesystem/SpecialProtocol.h"
 #include "settings/DisplaySettings.h"
@@ -148,6 +149,7 @@ bool CWinSystemIOS::CreateNewWindow(const std::string& name, bool fullScreen, RE
   VIDEOPLAYER::CProcessInfoIOS::Register();
   RETRO::CRPProcessInfoIOS::Register();
   RETRO::CRPProcessInfoIOS::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
+  CScreenshotSurfaceGLES::Register();
 
   return true;
 }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -26,6 +26,7 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.h"
 #include "guilib/DispResource.h"
 #include "guilib/GUIWindowManager.h"
+#include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -835,6 +836,8 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   VIDEOPLAYER::CProcessInfoOSX::Register();
   RETRO::CRPProcessInfoOSX::Register();
   RETRO::CRPProcessInfoOSX::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
+  CScreenshotSurfaceGL::Register();
+
   return true;
 }
 

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -11,6 +11,8 @@
 #include "WinSystemRpiGLESContext.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "platform/linux/ScreenshotSurfaceRBP.h"
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "ServiceBroker.h"
 #include "utils/log.h"
 #include "cores/RetroPlayer/process/rbpi/RPProcessInfoPi.h"
@@ -69,6 +71,8 @@ bool CWinSystemRpiGLESContext::InitWindowSystem()
   MMAL::CMMALVideo::Register();
   VIDEOPLAYER::CRendererFactory::ClearRenderer();
   MMAL::CMMALRenderer::Register();
+  CScreenshotSurfaceGLES::Register();
+  CScreenshotSurfaceRBP::Register();
 
   return true;
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -15,6 +15,7 @@
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
+#include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::WAYLAND;
@@ -44,6 +45,8 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   {
     ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
+
+  CScreenshotSurfaceGL::Register();
 
   return true;
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -15,6 +15,7 @@
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::WAYLAND;
@@ -44,6 +45,8 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
   {
     ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
+
+  CScreenshotSurfaceGLES::Register();
 
   return true;
 }

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -16,6 +16,7 @@
 #include "platform/win32/CharsetConverter.h"
 #include "rendering/dx/DirectXHelper.h"
 #include "rendering/dx/RenderContext.h"
+#include "rendering/dx/ScreenshotSurfaceWindows.h"
 #include "ServiceBroker.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -58,6 +59,8 @@ CWinSystemWin10::CWinSystemWin10()
 
   AE::CAESinkFactory::ClearSinks();
   CAESinkXAudio::Register();
+  CScreenshotSurfaceWindows::Register();
+
   if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Desktop)
   {
     CAESinkWASAPI::Register();

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -18,6 +18,7 @@
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/input/IRServerSuite.h"
 #include "platform/win32/powermanagement/Win32PowerSyscall.h"
+#include "rendering/dx/ScreenshotSurfaceWindows.h"
 #include "resource.h"
 #include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
@@ -69,6 +70,8 @@ CWinSystemWin32::CWinSystemWin32()
   CAESinkDirectSound::Register();
   CAESinkWASAPI::Register();
   CWin32PowerSyscall::Register();
+  CScreenshotSurfaceWindows::Register();
+
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bScanIRServer)
   {
     m_irss.reset(new CIRServerSuite());


### PR DESCRIPTION
I want to add the ability to take a screenshot from GBM using two different planes. In order to do that I'll need some sort of capture for the video plane. In order to do that work I wanted to clean up the screenshot interface and make it more manageable.

I tested this on GBM and GLES just capturing the kodi gui. It will need work for the other platforms.

I tried to keep much of the existing code the same but just added c++ inheritance. There is still ifdeffery but it's much cleaner now.