### PR TITLE
[cmake] fix HandleDepends if only some dependencies have hash checking

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -239,6 +239,9 @@ function(add_addon_depends addon searchpath)
               if(TARBALL_DIR)
                 set(DOWNLOAD_DIR ${TARBALL_DIR})
               endif()
+            else()
+              unset(URL_HASH_COMMAND)
+              message(AUTHOR_WARNING "${dir}/${id}.sha256 is missing")
             endif()
 
             externalproject_add(${id}


### PR DESCRIPTION
## Description
If only a subset of dependencies have a hash file (`*.sha256`) the previous value would be used for dependencies which don't have it.
In case the file doesn't exist unset `URL_HASH_COMMAND` which may have a value from previous loop iteration.
Also output a warning if the file doesn't exits, which may convince the addon maintainers to add the file.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
