### PR TITLE
guiinfo: PicturesGUIInfo - fix possible crash if an item has no info …

### DIFF
--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -139,8 +139,11 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
     const auto& it = listitem2slideshow_map.find(info.m_info);
     if (it != listitem2slideshow_map.end())
     {
-      value = item->GetPictureInfoTag()->GetInfo(it->second);
-      return true;
+      if (item->HasPictureInfoTag())
+      {
+        value = item->GetPictureInfoTag()->GetInfo(it->second);
+        return true;
+      }
     }
     else
     {


### PR DESCRIPTION
…tag.

@ksooo ping