### PR TITLE
[linux] windowing/gbm: add drm modifiers

### DIFF
--- a/cmake/modules/FindGBM.cmake
+++ b/cmake/modules/FindGBM.cmake
@@ -39,12 +39,23 @@ check_c_source_compiles("#include <gbm.h>
                          }
                          " GBM_HAS_BO_MAP)
 
+check_c_source_compiles("#include <gbm.h>
+
+                         int main()
+                         {
+                           gbm_surface_create_with_modifiers(NULL, 0, 0, 0, NULL, 0);
+                         }
+                         " GBM_HAS_MODIFIERS)
+
 if(GBM_FOUND)
   set(GBM_LIBRARIES ${GBM_LIBRARY})
   set(GBM_INCLUDE_DIRS ${GBM_INCLUDE_DIR})
   set(GBM_DEFINITIONS -DHAVE_GBM=1)
   if(GBM_HAS_BO_MAP)
     list(APPEND GBM_DEFINITIONS -DHAS_GBM_BO_MAP=1)
+  endif()
+  if(GBM_HAS_MODIFIERS)
+    list(APPEND GBM_DEFINITIONS -DHAS_GBM_MODIFIERS=1)
   endif()
   if(NOT TARGET GBM::GBM)
     add_library(GBM::GBM UNKNOWN IMPORTED)

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -92,5 +92,9 @@ int CGBMBufferObject::GetStride()
 
 uint64_t CGBMBufferObject::GetModifier()
 {
+#if defined(HAS_GBM_MODIFIERS)
   return gbm_bo_get_modifier(m_bo);
+#else
+  return 0;
+#endif
 }

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -105,22 +105,40 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
            strides[4] = {0},
            offsets[4] = {0};
 
+  uint64_t modifiers[4] = {0};
+
   width = gbm_bo_get_width(bo);
   height = gbm_bo_get_height(bo);
 
+#if defined(HAS_GBM_MODIFIERS)
+  for (int i = 0; i < gbm_bo_get_plane_count(bo); i++)
+  {
+    handles[i] = gbm_bo_get_handle_for_plane(bo, i).u32;
+    strides[i] = gbm_bo_get_stride_for_plane(bo, i);
+    offsets[i] = gbm_bo_get_offset(bo, i);
+    modifiers[i] = gbm_bo_get_modifier(bo);
+  }
+#else
   handles[0] = gbm_bo_get_handle(bo).u32;
   strides[0] = gbm_bo_get_stride(bo);
   memset(offsets, 0, 16);
+#endif
 
-  auto ret = drmModeAddFB2(m_fd,
-                           width,
-                           height,
-                           fb->format,
-                           handles,
-                           strides,
-                           offsets,
-                           &fb->fb_id,
-                           0);
+  if (modifiers[0] == DRM_FORMAT_MOD_INVALID)
+    modifiers[0] = DRM_FORMAT_MOD_LINEAR;
+
+  CLog::Log(LOGDEBUG, "CDRMUtils::%s - using modifier: %lli", __FUNCTION__, modifiers[0]);
+
+  auto ret = drmModeAddFB2WithModifiers(m_fd,
+                                        width,
+                                        height,
+                                        fb->format,
+                                        handles,
+                                        strides,
+                                        offsets,
+                                        modifiers,
+                                        &fb->fb_id,
+                                        (modifiers[0] > 0) ? DRM_MODE_FB_MODIFIERS : 0);
 
   if(ret)
   {
@@ -414,6 +432,11 @@ bool CDRMUtils::FindPlanes()
       CLog::Log(LOGERROR, "CDRMUtils::%s - could not get primary plane %u properties: %s", __FUNCTION__, m_primary_plane->plane->plane_id, strerror(errno));
       return false;
     }
+
+    if (!FindModifiersForPlane(m_primary_plane))
+    {
+      CLog::Log(LOGDEBUG, "CDRMUtils::%s - no drm modifiers present for the primary plane", __FUNCTION__);
+    }
   }
 
   // overlay plane should always be available
@@ -422,6 +445,50 @@ bool CDRMUtils::FindPlanes()
     CLog::Log(LOGERROR, "CDRMUtils::%s - could not get overlay plane %u properties: %s", __FUNCTION__, m_overlay_plane->plane->plane_id, strerror(errno));
     return false;
   }
+
+  if (!FindModifiersForPlane(m_overlay_plane))
+  {
+    CLog::Log(LOGDEBUG, "CDRMUtils::%s - no drm modifiers present for the overlay plane", __FUNCTION__);
+  }
+
+  return true;
+}
+
+bool CDRMUtils::FindModifiersForPlane(struct plane *object)
+{
+  uint64_t blob_id = 0;
+
+  for (uint32_t i = 0; i < object->props->count_props; i++)
+  {
+    if (strcmp(object->props_info[i]->name, "IN_FORMATS") == 0)
+      blob_id = object->props->prop_values[i];
+  }
+
+  if (blob_id == 0)
+    return false;
+
+  drmModePropertyBlobPtr blob = drmModeGetPropertyBlob(m_fd, blob_id);
+  if (!blob)
+    return false;
+
+  drm_format_modifier_blob *header = static_cast<drm_format_modifier_blob*>(blob->data);
+  uint32_t *formats = reinterpret_cast<uint32_t*>(reinterpret_cast<char*>(header) + header->formats_offset);
+  drm_format_modifier *mod = reinterpret_cast<drm_format_modifier*>(reinterpret_cast<char*>(header) + header->modifiers_offset);
+
+  for (uint32_t i = 0; i < header->count_formats; i++)
+  {
+    std::vector<uint64_t> modifiers;
+    for (uint32_t j = 0; j < header->count_modifiers; j++)
+    {
+      if (mod[j].formats & 1ULL << i)
+        modifiers.emplace_back(mod[j].modifier);
+    }
+
+    object->modifiers_map.emplace(formats[i], modifiers);
+  }
+
+  if (blob)
+    drmModeFreePropertyBlob(blob);
 
   return true;
 }

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -24,6 +24,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <gbm.h>
+#include <map>
 #include <vector>
 
 #include "windowing/Resolution.h"
@@ -47,6 +48,7 @@ struct plane : drm_object
 {
   drmModePlanePtr plane = nullptr;
   uint32_t format = DRM_FORMAT_XRGB8888;
+  std::map<uint32_t, std::vector<uint64_t>> modifiers_map;
 };
 
 struct connector : drm_object
@@ -87,6 +89,8 @@ public:
   int GetFileDescriptor() const { return m_fd; }
   struct plane* GetPrimaryPlane() const { return m_primary_plane; }
   struct plane* GetOverlayPlane() const { return m_overlay_plane; }
+  std::vector<uint64_t> *GetPrimaryPlaneModifiersForFormat(uint32_t format) { return &m_primary_plane->modifiers_map[format]; }
+  std::vector<uint64_t> *GetOverlayPlaneModifiersForFormat(uint32_t format) { return &m_overlay_plane->modifiers_map[format]; }
   struct crtc* GetCrtc() const { return m_crtc; }
 
   virtual RESOLUTION_INFO GetCurrentMode();
@@ -124,6 +128,7 @@ private:
   bool FindEncoder();
   bool FindCrtc();
   bool FindPlanes();
+  bool FindModifiersForPlane(struct plane *object);
   bool FindPreferredMode();
   bool RestoreOriginalMode();
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -48,16 +48,25 @@ void CGBMUtils::DestroyDevice()
   }
 }
 
-bool CGBMUtils::CreateSurface(int width, int height)
+bool CGBMUtils::CreateSurface(int width, int height, const uint64_t *modifiers, const int modifiers_count)
 {
   if (m_surface)
     CLog::Log(LOGWARNING, "CGBMUtils::%s - surface already created", __FUNCTION__);
 
+#if defined(HAS_GBM_MODIFIERS)
+  m_surface = gbm_surface_create_with_modifiers(m_device,
+                                                width,
+                                                height,
+                                                GBM_FORMAT_ARGB8888,
+                                                modifiers,
+                                                modifiers_count);
+#else
   m_surface = gbm_surface_create(m_device,
                                  width,
                                  height,
                                  GBM_FORMAT_ARGB8888,
                                  GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+#endif
 
   if (!m_surface)
   {

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -29,7 +29,7 @@ public:
   ~CGBMUtils() = default;
   bool CreateDevice(int fd);
   void DestroyDevice();
-  bool CreateSurface(int width, int height);
+  bool CreateSurface(int width, int height, const uint64_t *modifiers, const int modifiers_count);
   void DestroySurface();
   struct gbm_bo *LockFrontBuffer();
   void ReleaseBuffer();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -139,7 +139,9 @@ bool CWinSystemGbm::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if(!m_GBM->CreateSurface(res.iWidth, res.iHeight))
+  std::vector<uint64_t> *modifiers = m_DRM->GetOverlayPlaneModifiersForFormat(m_DRM->GetOverlayPlane()->format);
+
+  if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, modifiers->data(), modifiers->size()))
   {
     CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize GBM", __FUNCTION__);
     return false;


### PR DESCRIPTION
This add support for DRM modifiers.

DRM modifiers allow us to take advantage of special tiling methods present in certain hardware. This allows us to save bandwidth by using more efficient buffer layouts and/or compression (if available).

This code is completely generic and should work for all platforms (even those that don't have modifiers or support for modifiers).

This work is only for the Kodi GUI but may provide some benefit for Intel hardware using VAAPI in 4k

I've only tested on an AMD 6870 (which doesn't have any modifiers) and iMX6 (which supports [DRM_FORMAT_MOD_VIVANTE_SUPER_TILED](https://github.com/etnaviv/etna_viv/blob/master/doc/hardware.md#texture-tiling)).

I'll have to do a build for my Intel NUC.
All the modifiers present are defined [here](https://github.com/torvalds/linux/blob/master/include/uapi/drm/drm_fourcc.h#L166)

GBM must support modifiers so I had to add guards for this because no version of `libMali` supports GBM modifiers.

So there ends up with 3 code paths:
1) No GBM modifier support at all.
2) No DRM modifiers present.
3) DRM modifiers present

~One thing that can be improved is that this work assumes that the primary and overlay planes support the same modifiers which may or may not be true (I'm not sure).~

The code was taken from [libdrm](https://cgit.freedesktop.org/mesa/drm/tree/tests/modetest/modetest.c#n298) and modified to c++ but some of it might be able to be improved.

references:
1) https://www.collabora.com/news-and-blog/blog/2017/02/09/notes-on-drm-format-modifiers/
2) https://www.x.org/wiki/Events/XDC2017/widawsky_fb_modifiers.pdf
