### PR TITLE
[Estuary] increase space for sysinfo

### DIFF
--- a/addons/skin.estuary/xml/Font.xml
+++ b/addons/skin.estuary/xml/Font.xml
@@ -122,9 +122,9 @@
 			<size>120</size>
 		</font>
 		<font>
-			<name>Mono30</name>
+			<name>Mono26</name>
 			<filename>NotoMono-Regular.ttf</filename>
-			<size>30</size>
+			<size>26</size>
 		</font>
 	</fontset>
 	<fontset id="Arial" idloc="31053">
@@ -237,9 +237,9 @@
 			<style>bold</style>
 		</font>
 		<font>
-			<name>Mono30</name>
+			<name>Mono26</name>
 			<filename>arial.ttf</filename>
-			<size>30</size>
+			<size>26</size>
 		</font>
 	</fontset>
 </fonts>

--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -16,72 +16,72 @@
 			<visible>!Player.HasMedia + !String.IsEmpty(Skin.String(HomeFanart.path))</visible>
 		</control>
 		<control type="group">
-			<left>60</left>
+			<left>40</left>
 			<top>70</top>
 			<include>OpenClose_Right</include>
 			<control type="grouplist">
-				<left>430</left>
+				<left>420</left>
 				<top>105</top>
 				<height>550</height>
 				<orientation>vertical</orientation>
 				<control type="label" id="2">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="3">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="4">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="5">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="6">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="7">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="8">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="9">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="10">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="11">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 				<control type="label" id="12">
 					<height>47</height>
-					<width>1370</width>
-					<font>Mono30</font>
+					<width>1400</width>
+					<font>Mono26</font>
 				</control>
 			</control>
 			<control type="textbox" id="30">
-				<left>430</left>
+				<left>420</left>
 				<right>50</right>
 				<top>100</top>
 				<bottom>315</bottom>
@@ -105,7 +105,7 @@
 				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 			</control>
 			<control type="image">
-				<left>360</left>
+				<left>380</left>
 				<top>90</top>
 				<right>0</right>
 				<height>3</height>
@@ -115,14 +115,14 @@
 				<bottom>0</bottom>
 				<height>330</height>
 				<control type="image">
-					<left>360</left>
+					<left>380</left>
 					<top>20</top>
 					<right>0</right>
 					<height>3</height>
 					<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
 				</control>
 				<control type="grouplist">
-					<left>430</left>
+					<left>420</left>
 					<orientation>vertical</orientation>
 					<control type="label">
 						<description>CPU Text</description>
@@ -172,7 +172,7 @@
 					<itemgap>10</itemgap>
 					<top>80</top>
 					<left>1210</left>
-					<width>800</width>
+					<width>820</width>
 					<height>45</height>
 					<orientation>horizontal</orientation>
 					<control type="label">

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -886,9 +886,9 @@ std::string CCPUInfo::GetCoresUsageString() const
       if (!strCores.empty())
         strCores += ' ';
       if (it->second.m_fPct < 10.0)
-        strCores += StringUtils::Format("CPU%d: %1.1f%%", it->first, it->second.m_fPct);
+        strCores += StringUtils::Format("#%d: %1.1f%%", it->first, it->second.m_fPct);
       else
-        strCores += StringUtils::Format("CPU%d: %3.0f%%", it->first, it->second.m_fPct);
+        strCores += StringUtils::Format("#%d: %3.0f%%", it->first, it->second.m_fPct);
     }
   }
   else


### PR DESCRIPTION
various small tweaks to decrease the risk of truncated labels in the sysinfo window.

before:
![before](https://user-images.githubusercontent.com/687265/41814402-47530298-774b-11e8-9a9d-37f2aa3d2794.jpg)


after:
![after](https://user-images.githubusercontent.com/687265/41814404-4b0ecd18-774b-11e8-82da-a8fd62375caf.jpg)
