### PR TITLE
RetroPlayer: Fix segfault on subsequent failure

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -193,6 +193,8 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   }
   else
   {
+    if (m_gameClient)
+      m_gameClient->Unload();
     m_gameClient.reset();
     m_input.reset();
     m_streamManager.reset();


### PR DESCRIPTION
This fixes a segfault that results from initializing a game add-on twice.

## How Has This Been Tested?
Tested a Magnavox Odyssey² game that failed on open. Before: segfault on subsequent failure. After: No segfault after failing twice. Tested on OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
