### PR TITLE
[docs] fix README.raspberrypi to make depends build succeed on Ubuntu 16.04

### DIFF
--- a/docs/README.raspberrypi
+++ b/docs/README.raspberrypi
@@ -16,14 +16,14 @@ image which includes Linux.
 2. Building Kodi for the Raspberry Pi
 -----------------------------------------------------------------------------
 
-The following steps were tested with Ubuntu 14.04 x64. (Note that building on
+The following steps were tested with Ubuntu 16.04 x64. (Note that building on
 a 32 bit machine requires slightly different setting).
 
 The following commands build for newer Raspberry Pi 2 generation. In order to
 build for the first Raspberry Pi, the commands have to be adapted to use
 `--with-platform=raspberry-pi` instead of `--with-platform=raspberry-pi2`.
 
-    $ sudo apt-get install git autoconf curl g++ zlib1g-dev libcurl4-openssl-dev gawk gperf libtool autopoint swig default-jre
+    $ sudo apt-get install git autoconf curl g++ zlib1g-dev libcurl4-openssl-dev gawk gperf libtool autopoint swig default-jre bison make
 
     $ RPI_DEV=$PWD
     $ git clone https://github.com/raspberrypi/tools
@@ -38,7 +38,6 @@ build for the first Raspberry Pi, the commands have to be adapted to use
        --with-toolchain=$RPI_DEV/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf \
        --with-firmware=$RPI_DEV/firmware \
        --with-platform=raspberry-pi2 \
-       --build=i686-linux \
        --disable-debug
 
     $ make


### PR DESCRIPTION
## Description
Added minimal changes to README.raspberrypi to make the depends build succeed
on Ubuntu 16.04.
14.04 is of no use because its ancient g++ lacks proper regex support.
Also added bison and make to apt-get install list because these packages are missing
on the default ubuntu 16.04.4 server install.

## Motivation and Context
Using the current README.raspberrypi as is won't lead to a successful build.

## How Has This Been Tested?
Successfully built kodi using depends system on Ubuntu 16.04 x64. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
