### PR TITLE
 windowing/gbm: allow different gui and screen size

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -24,9 +24,11 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "ServiceBroker.h"
+#include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "windowing/gbm/DRMAtomic.h"
+#include "windowing/GraphicContext.h"
 
 const std::string SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
 
@@ -80,6 +82,20 @@ bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsign
 
   m_bConfigured = true;
   return true;
+}
+
+void CRendererDRMPRIME::ManageRenderArea()
+{
+  CBaseRenderer::ManageRenderArea();
+
+  RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+  if (info.iScreenWidth != info.iWidth)
+  {
+    CalcNormalRenderRect(0, 0, info.iScreenWidth, info.iScreenHeight,
+                         GetAspectRatio() * CDisplaySettings::GetInstance().GetPixelRatio(),
+                         CDisplaySettings::GetInstance().GetZoomAmount(),
+                         CDisplaySettings::GetInstance().GetVerticalShift());
+  }
 }
 
 void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, double currentClock)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -55,6 +55,9 @@ public:
   bool Supports(ERENDERFEATURE feature) override;
   bool Supports(ESCALINGMETHOD method) override;
 
+protected:
+  void ManageRenderArea() override;
+
 private:
   void Reset();
   void SetVideoPlane(CVideoBufferDRMPRIME* buffer);

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -78,8 +78,8 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
     AddProperty(plane, "CRTC_ID", m_crtc->crtc->crtc_id);
     AddProperty(plane, "SRC_X", 0);
     AddProperty(plane, "SRC_Y", 0);
-    AddProperty(plane, "SRC_W", m_mode->hdisplay << 16);
-    AddProperty(plane, "SRC_H", m_mode->vdisplay << 16);
+    AddProperty(plane, "SRC_W", m_width << 16);
+    AddProperty(plane, "SRC_H", m_height << 16);
     AddProperty(plane, "CRTC_X", 0);
     AddProperty(plane, "CRTC_Y", 0);
     AddProperty(plane, "CRTC_W", m_mode->hdisplay);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -671,6 +671,11 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
   return res;
 }
 
+RESOLUTION_INFO CDRMUtils::GetCurrentMode()
+{
+  return GetResolutionInfo(m_mode);
+}
+
 std::vector<RESOLUTION_INFO> CDRMUtils::GetModes()
 {
   std::vector<RESOLUTION_INFO> resolutions;

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -56,6 +56,8 @@ void CDRMUtils::WaitVBlank()
 bool CDRMUtils::SetMode(const RESOLUTION_INFO& res)
 {
   m_mode = &m_connector->connector->modes[atoi(res.strId.c_str())];
+  m_width = res.iWidth;
+  m_height = res.iHeight;
 
   CLog::Log(LOGDEBUG, "CDRMUtils::%s - found crtc mode: %dx%d%s @ %d Hz",
             __FUNCTION__,

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -114,6 +114,7 @@ private:
   bool FindPreferredMode();
   bool RestoreOriginalMode();
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
+  RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
 
   int m_crtc_index;
   std::string m_module;

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -102,6 +102,9 @@ protected:
   struct plane *m_overlay_plane = nullptr;
   drmModeModeInfo *m_mode = nullptr;
 
+  int m_width = 0;
+  int m_height = 0;
+
 private:
   bool GetResources();
   bool FindConnector();

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -80,8 +80,8 @@ public:
   struct plane* GetPrimaryPlane() const { return m_primary_plane; }
   struct plane* GetOverlayPlane() const { return m_overlay_plane; }
   struct crtc* GetCrtc() const { return m_crtc; }
-  drmModeModeInfo* GetCurrentMode() const { return m_mode; }
 
+  RESOLUTION_INFO GetCurrentMode();
   std::vector<RESOLUTION_INFO> GetModes();
   bool SetMode(const RESOLUTION_INFO& res);
   void WaitVBlank();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -132,13 +132,16 @@ bool CWinSystemGbm::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if(!m_GBM->CreateSurface(m_DRM->GetCurrentMode()->hdisplay, m_DRM->GetCurrentMode()->vdisplay))
+  if(!m_GBM->CreateSurface(res.iWidth, res.iHeight))
   {
     CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize GBM", __FUNCTION__);
     return false;
   }
 
   m_bFullScreen = fullScreen;
+  m_nWidth = res.iWidth;
+  m_nHeight = res.iHeight;
+  m_fRefreshRate = res.fRefreshRate;
 
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - initialized GBM", __FUNCTION__);
   return true;

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -157,13 +157,7 @@ bool CWinSystemGbm::DestroyWindow()
 
 void CWinSystemGbm::UpdateResolutions()
 {
-  CWinSystemBase::UpdateResolutions();
-
-  UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP),
-                          0,
-                          m_DRM->GetCurrentMode()->hdisplay,
-                          m_DRM->GetCurrentMode()->vdisplay,
-                          m_DRM->GetCurrentMode()->vrefresh);
+  RESOLUTION_INFO current = m_DRM->GetCurrentMode();
 
   auto resolutions = m_DRM->GetModes();
   if (resolutions.empty())
@@ -178,6 +172,16 @@ void CWinSystemGbm::UpdateResolutions()
     {
       CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
       CDisplaySettings::GetInstance().AddResolutionInfo(res);
+
+      if (current.iScreenWidth == res.iScreenWidth &&
+          current.iScreenHeight == res.iScreenHeight &&
+          current.iWidth == res.iWidth &&
+          current.iHeight == res.iHeight &&
+          current.fRefreshRate == res.fRefreshRate &&
+          current.dwFlags == res.dwFlags)
+      {
+        CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = res;
+      }
 
       CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz",
                 res.iWidth,

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -133,8 +133,8 @@ bool CWinSystemGbmGLESContext::CreateNewWindow(const std::string& name,
 
 bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
-  if (res.iWidth != m_DRM->GetCurrentMode()->hdisplay ||
-      res.iHeight != m_DRM->GetCurrentMode()->vdisplay)
+  if (res.iWidth != m_nWidth ||
+      res.iHeight != m_nHeight)
   {
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::%s - resolution changed, creating a new window", __FUNCTION__);
     CreateNewWindow("", fullScreen, res);


### PR DESCRIPTION
## Description
This PR prepares for allowing HW scaling of GUI plane when using 4k resolutions.
~~Also changes to prefer 1080p@60hz as a fallback resolution when the preferred mode is unavailable.~~

Options that makes use of this feature will follow in a later PR, work-in-progress at https://github.com/xbmc/xbmc/compare/master...Kwiboo:gbm-gui-size-settings

## Motivation and Context
This makes it possible to limit GUI to 720p/1080p and use HW scaling of gui plane while video is playing at 4k as GPU or memory bandwidth constrains may not allow for 4k rendering of GUI on some embedded SoCs.

## How Has This Been Tested?
Running on Tinker Board S and Rock64 + LibreELEC and https://github.com/xbmc/xbmc/compare/master...Kwiboo:gbm-gui-size-settings

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
