### PR TITLE
[windows] use recompiled zlib for x64

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -39,4 +39,4 @@ shairplay-ce80e00-x64-vc140.7z
 sqlite-3.17.0-x64-vc140.7z
 taglib-1.11.1-x64-vc140.7z
 tinyxmlstl-2.6.2-x64-vc140.7z
-zlib-1.2.11-x64-vc140.7z
+zlib-1.2.11-x64-v141.7z


### PR DESCRIPTION
## Motivation and Context
fixes https://trac.kodi.tv/ticket/17800
It seems like something went wrong during the initial x64 compilation, as a simple recompile was enough.

## How Has This Been Tested?
tested with the images from the trac ticket

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
