### PR TITLE
[linux] windowing/gbm: plane selection rework

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -25,6 +25,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "ServiceBroker.h"
 #include "settings/DisplaySettings.h"
+#include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "windowing/gbm/DRMAtomic.h"
@@ -55,10 +56,17 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
   return nullptr;
 }
 
-bool CRendererDRMPRIME::Register()
+void CRendererDRMPRIME::Register()
 {
-  VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
-  return true;
+  CWinSystemGbmGLESContext* winSystem = dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
+  if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane)
+  {
+    VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
+    return;
+  }
+
+  CServiceBroker::GetSettings().SetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER, 1);
+  CServiceBroker::GetSettings().GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)->SetVisible(false);
 }
 
 bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsigned int orientation)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -59,7 +59,8 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 void CRendererDRMPRIME::Register()
 {
   CWinSystemGbmGLESContext* winSystem = dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
-  if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane)
+  if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane &&
+      std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
   {
     VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
     return;
@@ -258,30 +259,15 @@ void CRendererDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer)
     uint32_t src_w = buffer->GetWidth() << 16;
     uint32_t src_h = buffer->GetHeight() << 16;
 
-    if(std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
-    {
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "FB_ID",   buffer->m_fb_id);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_X",   src_x);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_Y",   src_y);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_W",   src_w);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_H",   src_h);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_X",  crtc_x);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_Y",  crtc_y);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_W",  crtc_w);
-      m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_H",  crtc_h);
-    }
-    else
-    {
-      // show the video frame FB on the video plane
-      ret = drmModeSetPlane(m_DRM->GetFileDescriptor(), m_DRM->GetPrimaryPlane()->plane->plane_id, m_DRM->GetCrtc()->crtc->crtc_id, buffer->m_fb_id, 0,
-                            crtc_x, crtc_y, crtc_w, crtc_h,
-                            src_x, src_y, src_w, src_h);
-      if (ret < 0)
-      {
-        CLog::Log(LOGERROR, "CRendererDRMPRIME::%s - failed to set drm plane %d, buffer = %d, ret = %d", __FUNCTION__, m_DRM->GetPrimaryPlane()->plane->plane_id, buffer->m_fb_id, ret);
-        return;
-      }
-    }
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "FB_ID",   buffer->m_fb_id);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_X",   src_x);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_Y",   src_y);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_W",   src_w);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "SRC_H",   src_h);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_X",  crtc_x);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_Y",  crtc_y);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_W",  crtc_w);
+    m_DRM->AddProperty(m_DRM->GetPrimaryPlane(), "CRTC_H",  crtc_h);
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -33,7 +33,7 @@ public:
 
   // Registration
   static CBaseRenderer* Create(CVideoBuffer* buffer);
-  static bool Register();
+  static void Register();
 
   // Player functions
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -39,10 +39,9 @@ CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
   return nullptr;
 }
 
-bool CRendererDRMPRIMEGLES::Register()
+void CRendererDRMPRIMEGLES::Register()
 {
   VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime_gles", CRendererDRMPRIMEGLES::Create);
-  return true;
 }
 
 bool CRendererDRMPRIMEGLES::Configure(const VideoPicture &picture, float fps, unsigned int orientation)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -31,7 +31,7 @@ public:
 
   // Registration
   static CBaseRenderer* Create(CVideoBuffer* buffer);
-  static bool Register();
+  static void Register();
 
   // CLinuxRendererGLES overrides
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <drm_fourcc.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <gbm.h>
@@ -27,6 +28,12 @@
 
 #include "windowing/Resolution.h"
 #include "GBMUtils.h"
+
+enum EPLANETYPE
+{
+  VIDEO_PLANE,
+  GUI_PLANE
+};
 
 struct drm_object
 {
@@ -39,7 +46,7 @@ struct drm_object
 struct plane : drm_object
 {
   drmModePlanePtr plane = nullptr;
-  uint32_t format;
+  uint32_t format = DRM_FORMAT_XRGB8888;
 };
 
 struct connector : drm_object
@@ -61,6 +68,7 @@ struct drm_fb
 {
   struct gbm_bo *bo = nullptr;
   uint32_t fb_id;
+  uint32_t format;
 };
 
 class CDRMUtils
@@ -106,6 +114,9 @@ protected:
   int m_height = 0;
 
 private:
+  static bool SupportsFormat(drmModePlanePtr plane, uint32_t format);
+  drmModePlanePtr FindPlane(drmModePlaneResPtr resources, int crtc_index, int type);
+
   bool GetResources();
   bool FindConnector();
   bool FindEncoder();


### PR DESCRIPTION
This rework now allows us to find a dedicated plane for video and a dedicated plane for the gui. Before we would swap the gui back and forth between planes depending if a video was playing. That behaviour isn't needed and now we can run the gui on the overlay full time.

We have to track the fb format and use an alpha format when a video is playing and a non-alpha format when no video is playing. When the format changes the fb is validated and destroyed so a new fb can be created.

This also allows us to add dependencies to the primary plane. For example in the DRMPRIME renderer we can disable it if no primary plane is available.

We check for three formats currently:
1) `YUV420` -> for RPi
2) `YUYV` -> for i.MX6
3) `NV12`  -> for basically everything else

more formats can be added in the future if needed.

tested on amd, intel, dragonboard, i.MX6, amlogic