### PR TITLE
[CURL] Rework failonerror

### DIFF
--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -126,7 +126,6 @@ namespace XFILE
           bool m_sendRange;
           bool m_bLastError;
           bool m_bRetry;
-          bool m_failOnError = true;
 
           char* m_readBuffer;
 
@@ -154,7 +153,7 @@ namespace XFILE
 
     protected:
       void ParseAndCorrectUrl(CURL &url);
-      void SetCommonOptions(CReadState* state);
+      void SetCommonOptions(CReadState* state, bool failOnError = true);
       void SetRequestHeaders(CReadState* state);
       void SetCorrectHeaders(CReadState* state);
       bool Service(const std::string& strURL, std::string& strHTML);
@@ -199,6 +198,7 @@ namespace XFILE
       bool m_postdataset;
       bool m_allowRetry;
       bool m_verifyPeer = true;
+      bool m_failOnError = true;
 
       CRingBuffer m_buffer; // our ringhold buffer
       char* m_overflowBuffer; // in the rare case we would overflow the above buffer


### PR DESCRIPTION
## Description
To allow the retrieval of a HTTP response code even on HTTP codes >= 400, the CURL session must return that the Open call was successful to avoid that File container closes the instance.

This PR allows addons to pass "failonerror" protocol option, and if set to false, CURL connections which are responded by HTTP response codes >=400 are treated as valid.

## Motivation and Context
Streams with expired access token return code 403. inputstream.adaptive can call python addon callback if 403 arrives to renew the URL with a new token to be able continuing retieving media segments.

## How Has This Been Tested?
localhost environment forced to 403 errors

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
