### PR TITLE
[win10] update cppwinrt to a version which comes with VS v15.7

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-win10-arm.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-arm.list
@@ -6,7 +6,7 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cppwinrt-10.0.16299.0.7z
+cppwinrt-10.0.17134.0.7z
 crossguid-fef89a4-win10-ARM-v140.7z
 curl-7.59.0-win10-ARM-v141.7z
 expat-2.2.0-win10-ARM-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-win32.list
@@ -6,7 +6,7 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cppwinrt-10.0.16299.0.7z
+cppwinrt-10.0.17134.0.7z
 crossguid-fef89a4-win10-Win32-v140.7z
 curl-7.59.0-win10-Win32-v141.7z
 expat-2.2.0-win10-Win32-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-x64.list
@@ -6,7 +6,7 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cppwinrt-10.0.16299.0.7z
+cppwinrt-10.0.17134.0.7z
 crossguid-fef89a4-win10-x64-v140.7z
 curl-7.59.0-win10-x64-v141.7z
 expat-2.2.0-win10-x64-v140.7z

--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -183,7 +183,9 @@ void App::OnSuspending(const winrt::IInspectable&, const SuspendingEventArgs& ar
 
   Concurrency::create_task([this, deferral]()
   {
-    DX::Windowing()->TrimDevice();
+    auto windowing = DX::Windowing();
+    if (windowing)
+      windowing->TrimDevice();
     // Insert your code here.
     deferral.Complete();
   });

--- a/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
@@ -384,14 +384,14 @@ StorageFile CWinLibraryFile::GetFile(const CURL& url)
 bool CWinLibraryFile::IsInList(const CURL& url, const IStorageItemAccessList& list)
 {
   auto token = GetTokenFromList(url, list);
-  return token != nullptr && !token.empty();
+  return !token.empty();
 }
 
 winrt::hstring CWinLibraryFile::GetTokenFromList(const CURL& url, const IStorageItemAccessList& list)
 {
   AccessListEntryView listview = list.Entries();
   if (listview.Size() == 0)
-    return nullptr;
+    return winrt::hstring();
 
   using KODI::PLATFORM::WINDOWS::ToW;
   std::wstring filePathW = ToW(url.Get());
@@ -404,7 +404,7 @@ winrt::hstring CWinLibraryFile::GetTokenFromList(const CURL& url, const IStorage
     }
   }
 
-  return nullptr;
+  return winrt::hstring();
 }
 
 int CWinLibraryFile::Stat(const StorageFile& file, struct __stat64* statData)

--- a/xbmc/platform/win10/network/NetworkWin10.cpp
+++ b/xbmc/platform/win10/network/NetworkWin10.cpp
@@ -415,7 +415,7 @@ void CNetworkWin10::queryInterfaceList()
 
       wchar_t* guidStr = nullptr;
       StringFromIID(adapter.NetworkAdapterId(), &guidStr);
-      adapters[guidStr] = winrt::detach_abi(adapter);
+      adapters[guidStr] = reinterpret_cast<IUnknown*>(winrt::detach_abi(adapter));
 
       CoTaskMemFree(guidStr);
     }

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -380,7 +380,7 @@ void DX::DeviceResources::CreateDeviceResources()
     ComPtr<ID3D11InfoQueue> d3dInfoQueue;
     if (SUCCEEDED(m_d3dDebug.As(&d3dInfoQueue)))
     {
-      D3D11_MESSAGE_ID hide[] =
+      std::vector<D3D11_MESSAGE_ID> hide =
       {
         D3D11_MESSAGE_ID_GETVIDEOPROCESSORFILTERRANGE_UNSUPPORTED,        // avoid GETVIDEOPROCESSORFILTERRANGE_UNSUPPORTED (dx bug)
         D3D11_MESSAGE_ID_DEVICE_RSSETSCISSORRECTS_NEGATIVESCISSOR         // avoid warning for some labels out of screen
@@ -389,8 +389,8 @@ void DX::DeviceResources::CreateDeviceResources()
 
       D3D11_INFO_QUEUE_FILTER filter;
       ZeroMemory(&filter, sizeof(filter));
-      filter.DenyList.NumIDs = _countof(hide);
-      filter.DenyList.pIDList = hide;
+      filter.DenyList.NumIDs = hide.size();
+      filter.DenyList.pIDList = hide.data();
       d3dInfoQueue->AddStorageFilterEntries(&filter);
     }
   }
@@ -504,7 +504,7 @@ HRESULT DX::DeviceResources::CreateSwapChain(DXGI_SWAP_CHAIN_DESC1& desc, DXGI_S
 #else
   hr = m_dxgiFactory->CreateSwapChainForCoreWindow(
     m_d3dDevice.Get(),
-    winrt::get_abi(m_coreWindow),
+    winrt::get_unknown(m_coreWindow),
     &desc,
     nullptr,
     ppSwapChain

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -82,9 +82,9 @@ public:
   static std::string Format(const std::string& fmt, Args&&... args)
   {
     // coverity[fun_call_w_exception : FALSE]
-    auto result = fmt::format(fmt, std::forward<Args>(args)...);
+    auto result = ::fmt::format(fmt, std::forward<Args>(args)...);
     if (result == fmt)
-      result = fmt::sprintf(fmt, std::forward<Args>(args)...);
+      result = ::fmt::sprintf(fmt, std::forward<Args>(args)...);
 
     return result;
   }
@@ -92,9 +92,9 @@ public:
   static std::wstring Format(const std::wstring& fmt, Args&&... args)
   {
     // coverity[fun_call_w_exception : FALSE]
-    auto result = fmt::format(fmt, std::forward<Args>(args)...);
+    auto result = ::fmt::format(fmt, std::forward<Args>(args)...);
     if (result == fmt)
-      result = fmt::sprintf(fmt, std::forward<Args>(args)...);
+      result = ::fmt::sprintf(fmt, std::forward<Args>(args)...);
 
     return result;
   }

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -642,11 +642,6 @@ void CWinEventsWin10::Announce(AnnouncementFlag flag, const char * sender, const
     {
       try
       {
-        // if something wrong with main view then Activated() will throw an 
-        // exception instead of std::terminate what Dispatcher() does
-        auto token = CoreApplication::MainView().Activated([](auto&&, auto&&) {});
-        CoreApplication::MainView().Activated(token);
-
         auto dispatcher = CoreApplication::MainView().Dispatcher();
         if (dispatcher)
         {


### PR DESCRIPTION
see title.

## Description
The update of cppwinrt package to a version which comes with Visual Studio v15.7.

## Motivation and Context
The main reason for this update is old version uses `std::terminate` in some cases as error handler. The new one doesn't follow this approach and throws an exception instead. this allows us to remove some workarounds and make the code more safety. 

Some of old workarounds causes a hang (see the last commit for details) <-- @DaveTBlake 

## How Has This Been Tested?
Tested in run-time on desktop uwp.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
