### PR TITLE
[estuary] CPU/RAM/version info reworked

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -171,10 +171,7 @@ msgctxt "#31030"
 msgid "System memory usage"
 msgstr ""
 
-#: /xml/SettingsSystemInfo.xml
-msgctxt "#31031"
-msgid "Version info"
-msgstr ""
+#empty string with id 31031
 
 #: /xml/EventLog.xml /xml/Includes_MediaMenu.xml /xml/SmartPlaylistEditor.xml
 msgctxt "#31032"

--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -126,63 +126,51 @@
 					<orientation>vertical</orientation>
 					<control type="label">
 						<description>CPU Text</description>
-						<width>730</width>
+						<width>1420</width>
 						<height>80</height>
-						<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
+						<label>[B]$LOCALIZE[13271][/B] $INFO[System.CPUUsage]</label>
 						<aligny>top</aligny>
 						<textoffsety>40</textoffsety>
 						<shadowcolor>black</shadowcolor>
-						<font>font27</font>
+						<font>font10</font>
 					</control>
 					<control type="progress">
 						<description>CPU BAR</description>
-						<width>730</width>
+						<width>1420</width>
 						<height>16</height>
 						<info>System.CPUUsage</info>
 					</control>
 					<control type="label">
 						<description>Memory Text</description>
-						<width>730</width>
+						<width>1420</width>
 						<height>40</height>
-						<label>$LOCALIZE[31030]: $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
-						<aligny>center</aligny>
+						<label>[B]$LOCALIZE[31030]:[/B] $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
+						<aligny>top</aligny>
 						<shadowcolor>black</shadowcolor>
-						<font>font27</font>
+						<font>font10</font>
 					</control>
 					<control type="progress">
 						<description>Memory BAR</description>
-						<width>730</width>
+						<width>1420</width>
 						<height>16</height>
 						<info>system.memory(used)</info>
 					</control>
 				</control>
-				<control type="label">
-					<top>34</top>
-					<left>1210</left>
-					<width>auto</width>
-					<height>50</height>
-					<aligny>bottom</aligny>
-					<textoffsety>10</textoffsety>
-					<label>$LOCALIZE[31031]:</label>
-					<shadowcolor>black</shadowcolor>
-					<font>font25_title</font>
-				</control>
 				<control type="grouplist">
 					<description>Kodi build version</description>
 					<itemgap>10</itemgap>
-					<top>80</top>
-					<left>1210</left>
-					<width>820</width>
-					<height>45</height>
+					<top>150</top>
+					<left>420</left>
+					<width>1420</width>
 					<orientation>horizontal</orientation>
 					<control type="label">
 						<description>Build label</description>
 						<width>auto</width>
 						<height>50</height>
 						<aligny>bottom</aligny>
-						<font>font12</font>
+						<font>font10</font>
 						<textoffsety>10</textoffsety>
-						<label>$LOCALIZE[144]</label>
+						<label>[B]$LOCALIZE[144][/B]</label>
 						<shadowcolor>black</shadowcolor>
 					</control>
 					<control type="label" id="52">
@@ -190,7 +178,7 @@
 						<height>50</height>
 						<aligny>bottom</aligny>
 						<textoffsety>10</textoffsety>
-						<font>font12</font>
+						<font>font10</font>
 						<width>auto</width>
 						<textcolor>button_focus</textcolor>
 						<shadowcolor>black</shadowcolor>
@@ -199,22 +187,29 @@
 				<control type="grouplist">
 					<description>Build date</description>
 					<itemgap>10</itemgap>
-					<top>125</top>
-					<left>1210</left>
-					<width>800</width>
+					<top>150</top>
+					<left>1440</left>
+					<width>400</width>
+					<align>right</align>
 					<orientation>horizontal</orientation>
 					<control type="label">
 						<description>kodi Compiled Text</description>
 						<width>auto</width>
-						<height>25</height>
-						<label>$LOCALIZE[174]</label>
-						<font>font12</font>
+						<height>50</height>
+						<align>right</align>
+						<aligny>bottom</aligny>
+						<font>font10</font>
+						<textoffsety>10</textoffsety>
+						<label>[B]$LOCALIZE[174][/B]</label>
 						<shadowcolor>black</shadowcolor>
 					</control>
 					<control type="label" id="53">
 						<description>Kodi Build Date</description>
+						<height>50</height>
+						<aligny>bottom</aligny>
+						<textoffsety>10</textoffsety>
+						<font>font10</font>
 						<width>auto</width>
-						<font>font12</font>
 						<textcolor>button_focus</textcolor>
 						<shadowcolor>black</shadowcolor>
 					</control>

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -885,10 +885,8 @@ std::string CCPUInfo::GetCoresUsageString() const
     {
       if (!strCores.empty())
         strCores += ' ';
-      if (it->second.m_fPct < 10.0)
-        strCores += StringUtils::Format("#%d: %1.0f%%", it->first, it->second.m_fPct);
-      else
-        strCores += StringUtils::Format("#%d: %3.0f%%", it->first, it->second.m_fPct);
+
+      strCores += StringUtils::Format("#%d: %3.0f%%", it->first, it->second.m_fPct);
     }
   }
   else

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -886,7 +886,7 @@ std::string CCPUInfo::GetCoresUsageString() const
       if (!strCores.empty())
         strCores += ' ';
       if (it->second.m_fPct < 10.0)
-        strCores += StringUtils::Format("#%d: %1.1f%%", it->first, it->second.m_fPct);
+        strCores += StringUtils::Format("#%d: %1.0f%%", it->first, it->second.m_fPct);
       else
         strCores += StringUtils::Format("#%d: %3.0f%%", it->first, it->second.m_fPct);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Rework CPU/RAM/version info

## Motivation and Context
Do not truncate multicore CPU info. Not really possible for new CPU's crazy core/thread count but looks better IMO.

## How Has This Been Tested?
Runtime tested on Ubuntu.

## Screenshots (if appropriate):

### BEFORE:
![screenshot001](https://user-images.githubusercontent.com/516183/41996598-4b404e88-7a4d-11e8-96d2-f722aebda181.png)

### AFTER:
![screenshot000](https://user-images.githubusercontent.com/516183/41996596-499a39d6-7a4d-11e8-84d3-0079c47816b6.png)

### AFTER (no decimal):
![screenshot004](https://user-images.githubusercontent.com/516183/41999720-5d82afec-7a56-11e8-977e-219bc1a0473f.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
