### PR TITLE
Settings: GBM - hide "Display mode" setting

### DIFF
--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -31,6 +31,9 @@
   <section id="system">
     <category id="display">
       <group id="1">
+        <setting id="videoscreen.screen">
+          <visible>false</visible>
+        </setting>
         <setting id="videoscreen.limitedrange" type="boolean" label="36042" help="36359">
           <level>3</level>
           <default>false</default>


### PR DESCRIPTION
I think this setting makes no sense for gbm.

## Description
Settings show something like `<?0?>` for me and kodi locks up in a black screen if you change it.

## Motivation and Context
Windowed mode in GBM is not possible right?

## How Has This Been Tested?
Linux GBM -> Setting is not there anymore

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@lrusak not sure how it was handled before, maybe you have another idea?