### PR TITLE
[video library] Use one of the original item url to get url options

### DIFF
--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -78,7 +78,7 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
         pItem->SetPath(basePath);
       else
       {
-        videoUrl.AddOptions(itemsUrl.GetOptionsString());
+        videoUrl.AddOptions((*set->second.begin())->GetURL().GetOptions());
         pItem->SetPath(videoUrl.ToString());
       }
       pItem->m_bIsFolder = true;


### PR DESCRIPTION
fixes https://forum.kodi.tv/showthread.php?tid=333086&pid=2747125
## Description
If we add some movie  that belong to a movie collection to a tag and then we go to the tag we found the collection but entering the collection we have the whole collection, not only the movies tagged

## Motivation and Context
When we navigate to a tag (or a genre, actor,  year, director etc etc) in CVideoDatabase::GetVideoNav an option gets added for filtering (for example videodb://movies/tags/1/ become videodb://movies/tags/1/?tagid=1). the problem is that when we group movie collections we need to rewrite path for the collection and we used the original path that doesn't have the option filter needed because the id is in the path and not in the option.

## How Has This Been Tested?
Tested adding partially a collection to tags. now it still groups in the movie collection but only with movie that honor the filter

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
