### PR TITLE
Add headless modesetting for linux gbm

### DIFF
--- a/xbmc/windowing/gbm/CMakeLists.txt
+++ b/xbmc/windowing/gbm/CMakeLists.txt
@@ -3,14 +3,16 @@ set(SOURCES OptionalsReg.cpp
             GBMUtils.cpp
             DRMUtils.cpp
             DRMLegacy.cpp
-            DRMAtomic.cpp)
+            DRMAtomic.cpp
+            OffScreenModeSetting.cpp)
 
 set(HEADERS OptionalsReg.h
             WinSystemGbm.h
             GBMUtils.h
             DRMUtils.h
             DRMLegacy.h
-            DRMAtomic.h)
+            DRMAtomic.h
+            OffScreenModeSetting.h)
 
 if(OPENGLES_FOUND)
   list(APPEND SOURCES WinSystemGbmGLESContext.cpp)

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -137,7 +137,7 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
 
 bool CDRMAtomic::InitDrm()
 {
-  if (!CDRMUtils::OpenDrm())
+  if (!CDRMUtils::OpenDrm(true))
   {
     return false;
   }

--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -160,7 +160,7 @@ void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
 
 bool CDRMLegacy::InitDrm()
 {
-  if (!CDRMUtils::OpenDrm())
+  if (!CDRMUtils::OpenDrm(true))
   {
     return false;
   }

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -89,16 +89,16 @@ public:
   struct plane* GetOverlayPlane() const { return m_overlay_plane; }
   struct crtc* GetCrtc() const { return m_crtc; }
 
-  RESOLUTION_INFO GetCurrentMode();
-  std::vector<RESOLUTION_INFO> GetModes();
-  bool SetMode(const RESOLUTION_INFO& res);
-  void WaitVBlank();
+  virtual RESOLUTION_INFO GetCurrentMode();
+  virtual std::vector<RESOLUTION_INFO> GetModes();
+  virtual bool SetMode(const RESOLUTION_INFO& res);
+  virtual void WaitVBlank();
 
   virtual bool AddProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
   virtual bool SetProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
 
 protected:
-  bool OpenDrm();
+  bool OpenDrm(bool needConnector);
   uint32_t GetPropertyId(struct drm_object *object, const char *name);
   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
 

--- a/xbmc/windowing/gbm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/OffScreenModeSetting.cpp
@@ -1,0 +1,42 @@
+#include "OffScreenModeSetting.h"
+#include "utils/log.h"
+
+bool COffScreenModeSetting::InitDrm()
+{
+  if (!CDRMUtils::OpenDrm(false))
+  {
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "COffScreenModeSetting::%s - initialized offscreen DRM", __FUNCTION__);
+  return true;
+}
+
+void COffScreenModeSetting::DestroyDrm()
+{
+  close(m_fd);
+  m_fd = -1;
+}
+
+std::vector<RESOLUTION_INFO> COffScreenModeSetting::GetModes()
+{
+    std::vector<RESOLUTION_INFO> resolutions;
+    resolutions.push_back(GetCurrentMode());
+    return resolutions;
+}
+
+RESOLUTION_INFO COffScreenModeSetting::GetCurrentMode()
+{
+  RESOLUTION_INFO res;
+  res.iScreenWidth = DISPLAY_WIDTH;
+  res.iWidth = DISPLAY_WIDTH;
+  res.iScreenHeight = DISPLAY_HEIGHT;
+  res.iHeight = DISPLAY_HEIGHT;
+  res.fRefreshRate = DISPLAY_REFRESH;
+  res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
+  res.fPixelRatio = 1.0f;
+  res.bFullScreen = true;
+  res.strId = "0";
+
+  return res;
+}

--- a/xbmc/windowing/gbm/OffScreenModeSetting.h
+++ b/xbmc/windowing/gbm/OffScreenModeSetting.h
@@ -1,0 +1,49 @@
+  /*
+ *      Copyright (C) 2005-2018 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "DRMUtils.h"
+
+#ifdef TARGET_POSIX
+#include "platform/linux/XTimeUtils.h"
+#endif
+
+class COffScreenModeSetting : public CDRMUtils
+{
+public:
+  COffScreenModeSetting() = default;
+  ~COffScreenModeSetting() { DestroyDrm(); };
+  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+  bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
+  bool SetActive(bool active) override { return false; }
+  bool InitDrm() override;
+  void DestroyDrm() override;
+
+  RESOLUTION_INFO GetCurrentMode() override;
+  std::vector<RESOLUTION_INFO> GetModes() override;
+  bool SetMode(const RESOLUTION_INFO& res) override { return true; }
+  void WaitVBlank() override { Sleep(20); }
+
+private:
+  const int DISPLAY_WIDTH = 1280;
+  const int  DISPLAY_HEIGHT= 720;
+  const float DISPLAY_REFRESH = 50.0f;
+};

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -34,6 +34,7 @@
 #include "utils/StringUtils.h"
 #include "DRMAtomic.h"
 #include "DRMLegacy.h"
+#include "OffScreenModeSetting.h"
 #include "messaging/ApplicationMessenger.h"
 
 
@@ -95,7 +96,14 @@ bool CWinSystemGbm::InitWindowSystem()
     {
       CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize Legacy DRM", __FUNCTION__);
       m_DRM.reset();
-      return false;
+
+      m_DRM = std::make_shared<COffScreenModeSetting>();
+      if (!m_DRM->InitDrm())
+      {
+        CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize off screen DRM", __FUNCTION__);
+        m_DRM.reset();
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
This is a rework of my headless/hotplug proof of concept for linux gbm.

## Description
In order to run kodi in headless mode I've extended the modesetting initialization.
The order of init tries is now as follows:
* try init drm atomic
* try init drm legacy
* try to grab a rendernode and run headless

## Motivation and Context
My plan is to detect hdmi connects/disconnects and reinit on the fly, which is actually
meant to be a userspace hotplug implementation.
Furthermore this allows you to run kodi without a screen, if you set audio to analog you
can for example control kodi via kore and use it as a music player.

## How Has This Been Tested
Tested headless music playback and normal video playback on linux gbm (Intel NUC).

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@lrusak or @Kwiboo you may give it a shot on other gbm devices - however the DRMPrimeRenderer will fail hard if hdmi is not attached and you try to play a movie.