### PR TITLE
[PVR] Update EPG on relative time change

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <cstdlib>
+#include <atomic>
 
 #include "XBDateTime.h"
 #include "LangInfo.h"
@@ -894,18 +895,18 @@ bool CDateTime::SetFromUTCDateTime(const CDateTime &dateTime)
   return m_state == valid;
 }
 
-static bool bGotTimezoneBias = false;
+static std::atomic<bool> bGotTimezoneBias(false);
 
 void CDateTime::ResetTimezoneBias(void)
 {
   bGotTimezoneBias = false;
 }
 
-CDateTimeSpan CDateTime::GetTimezoneBias(void)
+CDateTimeSpan CDateTime::GetTimezoneBias(bool forceUpdate /* = false */ )
 {
   static CDateTimeSpan timezoneBias;
 
-  if (!bGotTimezoneBias)
+  if (forceUpdate || !bGotTimezoneBias)
   {
     bGotTimezoneBias = true;
     TIME_ZONE_INFORMATION tz;

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -220,7 +220,7 @@ public:
   bool IsValid() const;
 
   static void ResetTimezoneBias(void);
-  static CDateTimeSpan GetTimezoneBias(void);
+  static CDateTimeSpan GetTimezoneBias(bool forceUpdate = false);
 
 private:
   bool ToFileTime(const SYSTEMTIME& time, FILETIME& fileTime) const;

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -270,6 +270,7 @@ namespace PVR
     time_t       m_iNextEpgActiveTagCheck; /*!< the time the EPG will be checked for active tag updates */
     unsigned int m_iNextEpgId;             /*!< the next epg ID that will be given to a new table when the db isn't being used */
     EPGMAP       m_epgs;                   /*!< the EPGs in this container */
+    CDateTimeSpan m_lastTimeBias;          /*!< the timezone bias of the last EPG update (includes daylight savings) */
     //@}
 
     CCriticalSection               m_critSection;    /*!< a critical section for changes to this container */


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Update the EPG (grid) when the relative time changes (timezone or daylight savings).

## Motivation and Context
The EPG grid is not updated when the time bias (timezone or daylight savings) changes. On embedded or other platforms which rely on external time sources, the time bias may not be correct when Kodi initially loads and the EPG grid is initially created.

## How Has This Been Tested?
OdroidC2

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
