### PR TITLE
PVR: fix possible crash

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -250,8 +250,8 @@ void CPVRGUIInfo::UpdateDescrambleData(void)
 
 void CPVRGUIInfo::UpdateMisc(void)
 {
+  CSingleLock lock(m_critSection);
   bool bStarted = CServiceBroker::GetPVRManager().IsStarted();
-  /* safe to fetch these unlocked, since they're updated from the same thread as this one */
   std::string strPlayingClientName     = bStarted ? CServiceBroker::GetPVRManager().GetPlayingClientName() : "";
   bool       bHasTVRecordings          = bStarted && CServiceBroker::GetPVRManager().Recordings()->GetNumTVRecordings() > 0;
   bool       bHasRadioRecordings       = bStarted && CServiceBroker::GetPVRManager().Recordings()->GetNumRadioRecordings() > 0;
@@ -267,7 +267,6 @@ void CPVRGUIInfo::UpdateMisc(void)
   std::string strPlayingTVGroup        = (bStarted && bIsPlayingTV) ? CServiceBroker::GetPVRManager().GetPlayingGroup(false)->GroupName() : "";
   std::string strPlayingRadioGroup     = (bStarted && bIsPlayingRadio) ? CServiceBroker::GetPVRManager().GetPlayingGroup(true)->GroupName() : "";
 
-  CSingleLock lock(m_critSection);
   m_strPlayingClientName      = strPlayingClientName;
   m_bHasTVRecordings          = bHasTVRecordings;
   m_bHasRadioRecordings       = bHasRadioRecordings;


### PR DESCRIPTION
Seems like there's a possibility that ChannelGroups()
is unsafe when you have EPG enabled.

## Description
```
Thread 2 (Thread 0x7f5d8b7fe700 (LWP 15988)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f5dea796671 in __GI_abort () at abort.c:79
#2  0x00007f5dea78e3aa in __assert_fail_base (fmt=0x7f5dea8d5cf0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x7f5dee931830 "INTERNAL_SYSCALL_ERRNO (e, __err) != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", file=file@entry=0x7f5dee9317f5 "../nptl/pthread_mutex_lock.c", line=line@entry=422, function=function@entry=0x7f5dee931960 <__PRETTY_FUNCTION__.8905> "__pthread_mutex_lock_full") at assert.c:92
#3  0x00007f5dea78e422 in __GI___assert_fail (assertion=assertion@entry=0x7f5dee931830 "INTERNAL_SYSCALL_ERRNO (e, __err) != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", file=file@entry=0x7f5dee9317f5 "../nptl/pthread_mutex_lock.c", line=line@entry=422, function=function@entry=0x7f5dee931960 <__PRETTY_FUNCTION__.8905> "__pthread_mutex_lock_full") at assert.c:101
#4  0x00007f5dee927aa7 in __pthread_mutex_lock_full (mutex=0x2ed6060) at ../nptl/pthread_mutex_lock.c:420
#5  0x000000000115d535 in ?? ()
#6  0x0000000000f6c61b in PVR::CPVRManager::ChannelGroups() const ()
#7  0x0000000000f7833e in PVR::CPVRGUIInfo::UpdateMisc() ()
#8  0x0000000000f92aa4 in PVR::CPVRGUIInfo::Process() ()
#9  0x0000000000fb20cb in CThread::Action() ()
#10 0x0000000000fd8edf in CThread::staticThread(void*) ()
#11 0x00007f5dee9254f7 in start_thread (arg=0x7f5d8b7fe700) at pthread_create.c:463
#12 0x00007f5dea852eff in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 1 (Thread 0x7f5dd6ffd700 (LWP 15989)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f5dea796671 in __GI_abort () at abort.c:79
#2  0x00007f5dea78e3aa in __assert_fail_base (fmt=0x7f5dea8d5cf0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x7f5dee931830 "INTERNAL_SYSCALL_ERRNO (e, __err) != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", file=file@entry=0x7f5dee9317f5 "../nptl/pthread_mutex_lock.c", line=line@entry=422, function=function@entry=0x7f5dee931960 <__PRETTY_FUNCTION__.8905> "__pthread_mutex_lock_full") at assert.c:92
#3  0x00007f5dea78e422 in __GI___assert_fail (assertion=assertion@entry=0x7f5dee931830 "INTERNAL_SYSCALL_ERRNO (e, __err) != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", file=file@entry=0x7f5dee9317f5 "../nptl/pthread_mutex_lock.c", line=line@entry=422, function=function@entry=0x7f5dee931960 <__PRETTY_FUNCTION__.8905> "__pthread_mutex_lock_full") at assert.c:101
#4  0x00007f5dee927aa7 in __pthread_mutex_lock_full (mutex=0x7f5da80b1cb0) at ../nptl/pthread_mutex_lock.c:420
#5  0x000000000115d535 in ?? ()
#6  0x0000000000f5a6fb in PVR::CPVRGUIInfo::ResetPlayingTag() ()
#7  0x0000000000f5a75a in PVR::CPVRManager::ResetPlayingTag() ()
#8  0x0000000000f9ce65 in PVR::CPVREpg::Update(long, long, int, bool) ()
#9  0x0000000000fa0725 in PVR::CPVREpgContainer::UpdateEPG(bool) ()
#10 0x0000000000fa0b27 in PVR::CPVREpgContainer::Process() ()
#11 0x0000000000fb20cb in CThread::Action() ()
#12 0x0000000000fd8edf in CThread::staticThread(void*) ()
#13 0x00007f5dee9254f7 in start_thread (arg=0x7f5dd6ffd700) at pthread_create.c:463
#14 0x00007f5dea852eff in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
############# END STACK TRACE ###############
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@ksooo Please have a look. The comment in code explicitly says it's safe to call those unguarded but I'm not sure about it.