### PR TITLE
Fix ocassional playback in background

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -851,12 +851,6 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
       delete item;
       return;
     }
-    // restore to previous window if needed
-    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW ||
-      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
-      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
-      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION)
-      CServiceBroker::GetGUI()->GetWindowManager().PreviousWindow();
 
     g_application.ResetScreenSaver();
     g_application.WakeUpScreenSaverAndDPMS();


### PR DESCRIPTION
This fixes playback behind the main menu, when started from an remote control app or
chorus2 interface.

## Description
I couldn't think of a case why we want to restore previous gui when we start playback.
Whoever knows the use case behind this code - please clarify.

## Motivation and Context
Found this while using chorus2 and it is quite annoying.

## How Has This Been Tested?
Tested various playback scenarios on linux gbm.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@FernetMenta @ksooo @DaveTBlake maybe anyone of you knows the use case behind those lines of code?