### PR TITLE
allow selecting resolutions with non standard aspect ratio

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -686,7 +686,7 @@ RESOLUTION CRenderManager::GetResolution()
     return res;
 
   if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
-    res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, !m_stereomode.empty());
+    res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, m_height, !m_stereomode.empty());
 
   return res;
 }
@@ -875,7 +875,7 @@ void CRenderManager::UpdateResolution()
     {
       if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
-        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, !m_stereomode.empty());
+        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, m_height, !m_stereomode.empty());
         CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
         UpdateLatencyTweak();
         if (m_pRenderer)

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -64,7 +64,7 @@ float RESOLUTION_INFO::DisplayRatio() const
   return iWidth * fPixelRatio / iHeight;
 }
 
-RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, bool is3D)
+RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int height, bool is3D)
 {
   RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
   float weight;
@@ -73,7 +73,7 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, bool is3
   {
     if (!FindResolutionFromOverride(fps, width, is3D, res, weight, true)) //if that fails find it from a fallback
     {
-      FindResolutionFromWhitelist(fps, width, is3D, res); //find a refreshrate from whitelist
+      FindResolutionFromWhitelist(fps, width, height, is3D, res); //find a refreshrate from whitelist
     }
   }
 
@@ -82,7 +82,7 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, bool is3
   return res;
 }
 
-void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is3D, RESOLUTION &resolution)
+void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution)
 {
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
 
@@ -96,8 +96,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact and have the correct refresh rate
-    if (info.iScreenWidth == width &&
-        info.iScreen == curr.iScreen &&
+    if (((height == info.iScreenHeight && width <= info.iScreenWidth) ||
+         (width == info.iScreenWidth && height <= info.iScreenHeight)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
@@ -115,8 +115,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact and have double the refresh rate
-    if (info.iScreenWidth == width &&
-        info.iScreen == curr.iScreen &&
+    if (((height == info.iScreenHeight && width <= info.iScreenWidth) ||
+         (width == info.iScreenWidth && height <= info.iScreenHeight)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
     {
@@ -137,7 +137,6 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
 
     // allow resolutions that are desktop resolution but have the correct refresh rate
     if (info.iScreenWidth == desktop_info.iWidth &&
-        info.iScreen == desktop_info.iScreen &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
@@ -158,7 +157,6 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
 
     // allow resolutions that are desktop resolution but have double the refresh rate
     if (info.iScreenWidth == desktop_info.iWidth &&
-        info.iScreen == desktop_info.iScreen &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
     {

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -100,10 +100,10 @@ public:
 class CResolutionUtils
 {
 public:
-  static RESOLUTION ChooseBestResolution(float fps, int width, bool is3D);
+  static RESOLUTION ChooseBestResolution(float fps, int width, int height, bool is3D);
   static bool HasWhitelist();
 protected:
-  static void FindResolutionFromWhitelist(float fps, int width, bool is3D, RESOLUTION &resolution);
+  static void FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution);
   static bool FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback);
   static float RefreshWeight(float refresh, float fps);
 };

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -235,7 +235,7 @@ bool CWinSystemWin10::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
   // entering to stereo mode, limit resolution to 1080p@23.976
   if (stereoChange && !IsStereoEnabled() && res.iWidth > 1280)
   {
-    res = CDisplaySettings::GetInstance().GetResolutionInfo(CResolutionUtils::ChooseBestResolution(24.f / 1.001f, 1920, true));
+    res = CDisplaySettings::GetInstance().GetResolutionInfo(CResolutionUtils::ChooseBestResolution(24.f / 1.001f, 1920, 1080, true));
   }
 
   if (m_state == WINDOW_STATE_WINDOWED)

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -471,7 +471,7 @@ bool CWinSystemWin32::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
   // entering to stereo mode, limit resolution to 1080p@23.976
   if (stereoChange && !IsStereoEnabled() && res.iWidth > 1280)
   {
-    res = CDisplaySettings::GetInstance().GetResolutionInfo(CResolutionUtils::ChooseBestResolution(24.f / 1.001f, 1920, true));
+    res = CDisplaySettings::GetInstance().GetResolutionInfo(CResolutionUtils::ChooseBestResolution(24.f / 1.001f, 1920, 1080, true));
   }
 
   if (m_state == WINDOW_STATE_WINDOWED)


### PR DESCRIPTION
if we render i.e. 704x480, we can select 720x480

if either height or width matches, we don't scale when allowing no error for aspect ratio

