### PR TITLE
VideoPlayer: handle tempo and realtime dynamically

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -94,7 +94,6 @@ public:
     disabled = false;
     changes = 0;
     flags = StreamFlags::FLAG_NONE;
-    realtime = false;
   }
 
   virtual ~CDemuxStream()
@@ -113,7 +112,6 @@ public:
   int level;   // encoder level of the stream reported by the decoder. used to qualify hw decoders.
   StreamType type;
   int source;
-  bool realtime;
 
   int iDuration; // in mseconds
   void* pPrivate; // private pointer for the demuxer

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -552,8 +552,6 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
   toStream->externalInterfaces = stream->externalInterfaces;
   toStream->language = stream->language;
 
-  toStream->realtime = stream->realtime;
-
   CLog::Log(LOGDEBUG,"CDVDDemuxClient::RequestStream(): added/updated stream %d with codec_id %d",
       toStream->uniqueId,
       toStream->codec);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1616,7 +1616,6 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     stream->codec_fourcc = pStream->codecpar->codec_tag;
     stream->profile = pStream->codecpar->profile;
     stream->level = pStream->codecpar->level;
-    stream->realtime = m_pInput->IsRealtime();
 
     stream->source = STREAM_SOURCE_DEMUX;
     stream->pPrivate = pStream;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -351,7 +351,6 @@ void CInputStreamPVRBase::UpdateStreamMap()
     dStream->codec = (AVCodecID)stream.iCodecId;
     dStream->uniqueId = stream.iPID;
     dStream->language = stream.strLanguage;
-    dStream->realtime = true;
 
     newStreamMap[stream.iPID] = dStream;
   }

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -41,7 +41,6 @@ void CDVDStreamInfo::Clear()
   codec = AV_CODEC_ID_NONE;
   type = STREAM_NONE;
   uniqueId = -1;
-  realtime = false;
   codecOptions = 0;
   codec_tag  = 0;
   flags = 0;
@@ -86,7 +85,6 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
   ||  type      != right.type
   ||  uniqueId  != right.uniqueId
   ||  demuxerId != right.demuxerId
-  ||  realtime  != right.realtime
   ||  codec_tag != right.codec_tag
   ||  flags     != right.flags)
     return false;
@@ -150,7 +148,6 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   type = right.type;
   uniqueId = right.uniqueId;
   demuxerId = right.demuxerId;
-  realtime = right.realtime;
   codec_tag = right.codec_tag;
   flags = right.flags;
   filename = right.filename;
@@ -211,11 +208,10 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
   type = right.type;
   uniqueId = right.uniqueId;
   demuxerId = right.demuxerId;
-  realtime = right.realtime;
   codec_tag = right.codec_fourcc;
-  profile   = right.profile;
-  level     = right.level;
-  flags     = right.flags;
+  profile = right.profile;
+  level = right.level;
+  flags = right.flags;
 
   if (withextradata && right.ExtraSize)
   {

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -52,7 +52,6 @@ public:
   StreamType type;
   int uniqueId;
   int demuxerId = -1;
-  bool realtime;
   int flags;
   std::string filename;
   bool dvd;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -489,6 +489,20 @@ bool CProcessInfo::IsSeeking()
   return m_stateSeeking;
 }
 
+void CProcessInfo::SetStateRealtime(bool state)
+{
+  CSingleLock lock(m_renderSection);
+
+  m_realTimeStream = state;
+}
+
+bool CProcessInfo::IsRealtimeStream()
+{
+  CSingleLock lock(m_stateSection);
+
+  return m_realTimeStream;
+}
+
 void CProcessInfo::SetSpeed(float speed)
 {
   CSingleLock lock(m_stateSection);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -95,6 +95,8 @@ public:
   // player states
   void SetStateSeeking(bool active);
   bool IsSeeking();
+  void SetStateRealtime(bool state);
+  bool IsRealtimeStream();
   void SetSpeed(float speed);
   void SetNewSpeed(float speed);
   float GetNewSpeed();
@@ -170,6 +172,7 @@ protected:
   int64_t m_time;
   int64_t m_timeMax;
   int64_t m_timeMin;
+  bool m_realTimeStream;
 
   // settings
   CCriticalSection m_settingsSection;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4728,8 +4728,10 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     state.canpause = m_pInputStream->CanPause();
     state.canseek = m_pInputStream->CanSeek();
 
+    bool realtime = m_pInputStream->IsRealtime();
+
     if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK) &&
-        !m_pInputStream->IsRealtime())
+        !realtime)
     {
       state.cantempo = true;
     }
@@ -4737,6 +4739,8 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     {
       state.cantempo = false;
     }
+
+    m_processInfo->SetStateRealtime(realtime);
   }
 
   if (m_Edl.HasCut())

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -660,7 +660,6 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
   m_offset_pts = 0.0;
   m_playSpeed = DVD_PLAYSPEED_NORMAL;
   m_streamPlayerSpeed = DVD_PLAYSPEED_NORMAL;
-  m_canTempo = false;
   m_caching = CACHESTATE_DONE;
   m_HasVideo = false;
   m_HasAudio = false;
@@ -777,7 +776,6 @@ bool CVideoPlayer::CloseFile(bool reopen)
 
   m_HasVideo = false;
   m_HasAudio = false;
-  m_canTempo = false;
 
   CLog::Log(LOGNOTICE, "VideoPlayer: finished waiting");
   m_renderManager.UnInit();
@@ -865,16 +863,6 @@ bool CVideoPlayer::OpenInputStream()
   m_clock.Reset();
   m_dvd.Clear();
   m_errorCount = 0;
-
-  if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK) &&
-      !m_pInputStream->IsRealtime())
-  {
-    m_canTempo = true;
-  }
-  else
-  {
-    m_canTempo = false;
-  }
 
   return true;
 }
@@ -2208,6 +2196,16 @@ void CVideoPlayer::HandlePlaySpeed()
       }
     }
   }
+  
+  // reset tempo
+  if (!m_State.cantempo)
+  {
+    float currentTempo = m_processInfo->GetNewTempo();
+    if (currentTempo != 1.0)
+    {
+      SetTempo(1.0);
+    }
+  }
 }
 
 bool CVideoPlayer::CheckPlayerInit(CCurrentStream& current)
@@ -3511,7 +3509,7 @@ void CVideoPlayer::FrameAdvance(int frames)
 
 bool CVideoPlayer::SupportsTempo()
 {
-  return m_canTempo;
+  return m_State.cantempo;
 }
 
 bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iStream, int source, bool reset /*= true*/)
@@ -4627,8 +4625,8 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
 
 void CVideoPlayer::UpdatePlayState(double timeout)
 {
-  if(m_State.timestamp != 0 &&
-     m_State.timestamp + DVD_MSEC_TO_TIME(timeout) > m_clock.GetAbsoluteClock())
+  if (m_State.timestamp != 0 &&
+      m_State.timestamp + DVD_MSEC_TO_TIME(timeout) > m_clock.GetAbsoluteClock())
     return;
 
   SPlayerState state(m_State);
@@ -4729,6 +4727,16 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
     state.canpause = m_pInputStream->CanPause();
     state.canseek = m_pInputStream->CanSeek();
+
+    if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK) &&
+        !m_pInputStream->IsRealtime())
+    {
+      state.cantempo = true;
+    }
+    else
+    {
+      state.cantempo = false;
+    }
   }
 
   if (m_Edl.HasCut())

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -104,6 +104,7 @@ struct SPlayerState
     chapters.clear();
     canpause = false;
     canseek = false;
+    cantempo = false;
     caching = false;
     cache_bytes = 0;
     cache_level = 0.0;
@@ -133,6 +134,7 @@ struct SPlayerState
 
   bool canpause;            // pvr: can pause the current playing item
   bool canseek;             // pvr: can seek in the current playing item
+  bool cantempo;
   bool caching;
 
   int64_t cache_bytes;   // number of bytes current's cached
@@ -534,7 +536,6 @@ protected:
     double lastseekpts;
     double lastabstime;
   } m_SpeedState;
-  std::atomic_bool m_canTempo;
 
   int m_errorCount;
   double m_offset_pts;


### PR DESCRIPTION
- handle cantempo dynamically: allows setting tempo after a realtime stream was paused

- switch to resample if an inputstream becomes realtime