### PR TITLE
reusepython off by default

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -170,9 +170,9 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s','%s')", __FUNCTION__, m_addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str(), argv[3].c_str());
   bool success = false;
   std::string file = m_addon->LibPath();
-  bool reuseLanguageInvoker = true;
+  bool reuseLanguageInvoker = false;
   if (m_addon->ExtraInfo().find("reuselanguageinvoker") != m_addon->ExtraInfo().end())
-    reuseLanguageInvoker = m_addon->ExtraInfo().at("reuselanguageinvoker") != "false";
+    reuseLanguageInvoker = m_addon->ExtraInfo().at("reuselanguageinvoker") == "true";
 
   int id = CScriptInvocationManager::GetInstance().ExecuteAsync(file, m_addon, argv, reuseLanguageInvoker, handle);
   if (id >= 0)


### PR DESCRIPTION
## Description
If addons want to get the performance boost provided by reusepython (PR #13814 ) addon devs need to enable this in addon.xml:

```
<extension point="xbmc.addon.metadata">
  <reuselanguageinvoker>true</reuselanguageinvoker>
</extension>
```

Reason for disabling it by default is that many addons are not jet ready for it.

## Motivation and Context
Coming under enemy fire in the original PR.
