### PR TITLE
Fix segfault on shutdown caused by busy python addons

### DIFF
--- a/xbmc/interfaces/generic/LanguageInvokerThread.cpp
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.cpp
@@ -85,9 +85,9 @@ bool CLanguageInvokerThread::stop(bool wait)
   {
     // stop the language-specific invoker
     result = m_invoker->Stop(wait);
-    // stop the thread
-    CThread::StopThread(wait);
   }
+  // stop the thread
+  CThread::StopThread(wait);
 
   return result;
 }

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -115,9 +115,11 @@ void CScriptInvocationManager::Uninitialize()
     if (!it->done)
       it->thread->Stop(true);
   }
-  tempList.clear();
 
   lock.Enter();
+
+  tempList.clear();
+
   // uninitialize all invocation handlers and then remove them
   for (LanguageInvocationHandlerMap::iterator it = m_invocationHandlers.begin(); it != m_invocationHandlers.end(); ++it)
     it->second->Uninitialize();


### PR DESCRIPTION
## Description
If (python) addons take > 5 secs for termination, kodi tries to terminates them by raising a SysExit on the py threads. Waiting for the final termination was broken and lead to segfault (working with an freed thread)

## Motivation and Context
Reduce segfaults / dump messages

## How Has This Been Tested?
amazon addon, Clode kodi immedeately after startup

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
