### PR TITLE
[gui][pvr][fix] Prevent the modification of the provider list while using its iterator.

### DIFF
--- a/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
@@ -22,6 +22,7 @@
 #include "guilib/guiinfo/IGUIInfoProvider.h"
 
 #include <algorithm>
+#include "threads/SingleLock.h"
 
 using namespace KODI::GUILIB::GUIINFO;
 
@@ -59,6 +60,8 @@ CGUIInfoProviders::~CGUIInfoProviders()
 
 void CGUIInfoProviders::RegisterProvider(IGUIInfoProvider *provider, bool bAppend /* = true */)
 {
+  CSingleLock lock(m_providerSection);
+
   auto it = std::find(m_providers.begin(), m_providers.end(), provider);
   if (it == m_providers.end())
   {
@@ -71,6 +74,8 @@ void CGUIInfoProviders::RegisterProvider(IGUIInfoProvider *provider, bool bAppen
 
 void CGUIInfoProviders::UnregisterProvider(IGUIInfoProvider *provider)
 {
+  CSingleLock lock(m_providerSection);
+
   auto it = std::find(m_providers.begin(), m_providers.end(), provider);
   if (it != m_providers.end())
     m_providers.erase(it);
@@ -78,6 +83,7 @@ void CGUIInfoProviders::UnregisterProvider(IGUIInfoProvider *provider)
 
 bool CGUIInfoProviders::InitCurrentItem(CFileItem *item)
 {
+  CSingleLock lock(m_providerSection);
   bool bReturn = false;
 
   for (const auto& provider : m_providers)
@@ -89,6 +95,8 @@ bool CGUIInfoProviders::InitCurrentItem(CFileItem *item)
 
 bool CGUIInfoProviders::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
+  CSingleLock lock(m_providerSection);
+
   for (const auto& provider : m_providers)
   {
     if (provider->GetLabel(value, item, contextWindow, info, fallback))
@@ -99,6 +107,8 @@ bool CGUIInfoProviders::GetLabel(std::string& value, const CFileItem *item, int 
 
 bool CGUIInfoProviders::GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const
 {
+  CSingleLock lock(m_providerSection);
+
   for (const auto& provider : m_providers)
   {
     if (provider->GetInt(value, item, contextWindow, info))
@@ -109,6 +119,8 @@ bool CGUIInfoProviders::GetInt(int& value, const CGUIListItem *item, int context
 
 bool CGUIInfoProviders::GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const
 {
+  CSingleLock lock(m_providerSection);
+
   for (const auto& provider : m_providers)
   {
     if (provider->GetBool(value, item, contextWindow, info))
@@ -119,6 +131,8 @@ bool CGUIInfoProviders::GetBool(bool& value, const CGUIListItem *item, int conte
 
 void CGUIInfoProviders::UpdateAVInfo(const AudioStreamInfo& audioInfo, const VideoStreamInfo& videoInfo)
 {
+  CSingleLock lock(m_providerSection);
+
   for (const auto& provider : m_providers)
   {
     provider->UpdateAVInfo(audioInfo, videoInfo);

--- a/xbmc/guilib/guiinfo/GUIInfoProviders.h
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.h
@@ -36,6 +36,8 @@
 #include "guilib/guiinfo/VisualisationGUIInfo.h"
 #include "guilib/guiinfo/WeatherGUIInfo.h"
 
+#include "threads/CriticalSection.h"
+
 class CFileItem;
 class CGUIListItem;
 
@@ -147,6 +149,7 @@ public:
   CLibraryGUIInfo& GetLibraryInfoProvider() { return m_libraryGUIInfo; }
 
 private:
+  CCriticalSection m_providerSection;
   std::vector<IGUIInfoProvider *> m_providers;
 
   CAddonsGUIInfo m_addonsGUIInfo;


### PR DESCRIPTION
When the pvr provider gets inserted and the timing is bad the iterator in CGUIInfoProviders::GetLabel gets invalidated.