### PR TITLE
AESinkAudiotrack: Don't enforce audio - we are no camera system sound

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -186,7 +186,6 @@ jni::CJNIAudioTrack *CAESinkAUDIOTRACK::CreateAudioTrack(int stream, int sampleR
     {
       CJNIAudioAttributesBuilder attrBuilder;
       attrBuilder.setUsage(CJNIAudioAttributes::USAGE_MEDIA);
-      attrBuilder.setFlags(CJNIAudioAttributes::FLAG_AUDIBILITY_ENFORCED);
 
       CJNIAudioFormatBuilder fmtBuilder;
       fmtBuilder.setChannelMask(channelMask);


### PR DESCRIPTION
Fixes volume after the ctor change.

For reference: https://forum.kodi.tv/showthread.php?tid=333160
Thx @koying for showing the right direction.