### PR TITLE
RetroPlayer: Fix segfault when loading game

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -60,7 +60,10 @@ CGameClientInput::~CGameClientInput()
 void CGameClientInput::Initialize()
 {
   LoadTopology();
+}
 
+void CGameClientInput::Start()
+{
   // Open keyboard
   //! @todo Move to player manager
   if (SupportsKeyboard())
@@ -103,6 +106,11 @@ void CGameClientInput::Initialize()
 }
 
 void CGameClientInput::Deinitialize()
+{
+  Stop();
+}
+
+void CGameClientInput::Stop()
 {
   m_hardware.reset();
 

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -60,6 +60,9 @@ namespace GAME
     void Initialize();
     void Deinitialize();
 
+    void Start();
+    void Stop();
+
     // Input functions
     bool AcceptsInput() const;
 

--- a/xbmc/games/addons/streams/GameClientStreamAudio.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamAudio.cpp
@@ -52,8 +52,11 @@ bool CGameClientStreamAudio::OpenStream(RETRO::IRetroPlayerStream* stream, const
 
 void CGameClientStreamAudio::CloseStream()
 {
-  m_stream->CloseStream();
-  m_stream = nullptr;
+  if (m_stream != nullptr)
+  {
+    m_stream->CloseStream();
+    m_stream = nullptr;
+  }
 }
 
 void CGameClientStreamAudio::AddData(const game_stream_packet &packet)

--- a/xbmc/games/addons/streams/GameClientStreamAudio.h
+++ b/xbmc/games/addons/streams/GameClientStreamAudio.h
@@ -40,7 +40,7 @@ class CGameClientStreamAudio : public IGameClientStream
 {
 public:
   CGameClientStreamAudio(double sampleRate);
-  ~CGameClientStreamAudio() override = default;
+  ~CGameClientStreamAudio() override { CloseStream(); }
 
   // Implementation of IGameClientStream
   bool OpenStream(RETRO::IRetroPlayerStream* stream,
@@ -53,10 +53,10 @@ private:
   static RETRO::AudioStreamProperties* TranslateProperties(const game_stream_audio_properties &properties, double sampleRate);
 
   // Construction parameters
-  double m_sampleRate;
+  const double m_sampleRate;
 
   // Stream parameters
-  RETRO::IRetroPlayerStream* m_stream;
+  RETRO::IRetroPlayerStream* m_stream = nullptr;
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/streams/GameClientStreamVideo.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamVideo.cpp
@@ -47,8 +47,11 @@ bool CGameClientStreamVideo::OpenStream(RETRO::IRetroPlayerStream* stream, const
 
 void CGameClientStreamVideo::CloseStream()
 {
-  m_stream->CloseStream();
-  m_stream = nullptr;
+  if (m_stream != nullptr)
+  {
+    m_stream->CloseStream();
+    m_stream = nullptr;
+  }
 }
 
 void CGameClientStreamVideo::AddData(const game_stream_packet& packet)

--- a/xbmc/games/addons/streams/GameClientStreamVideo.h
+++ b/xbmc/games/addons/streams/GameClientStreamVideo.h
@@ -39,7 +39,7 @@ class CGameClientStreamVideo : public IGameClientStream
 {
 public:
   CGameClientStreamVideo() = default;
-  ~CGameClientStreamVideo() override = default;
+  ~CGameClientStreamVideo() override { CloseStream(); }
 
   // Implementation of IGameClientStream
   bool OpenStream(RETRO::IRetroPlayerStream* stream,
@@ -52,7 +52,7 @@ private:
   static RETRO::VideoStreamProperties* TranslateProperties(const game_stream_video_properties &properties);
 
   // Stream parameters
-  RETRO::IRetroPlayerStream* m_stream;
+  RETRO::IRetroPlayerStream* m_stream = nullptr;
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/streams/GameClientStreams.cpp
+++ b/xbmc/games/addons/streams/GameClientStreams.cpp
@@ -90,6 +90,8 @@ void CGameClientStreams::CloseStream(IGameClientStream *stream)
   if (stream != nullptr)
   {
     std::unique_ptr<IGameClientStream> streamHolder(stream);
+    streamHolder->CloseStream();
+
     m_streamManager->CloseStream(std::move(m_streams[stream]));
     m_streams.erase(stream);
   }


### PR DESCRIPTION
This fixes a segfault that occurs when connecting a controller before loading a game in some cores.

This is valid behavior according to the libretro API, however multiple cores fail to fully allocate input resources until after the game is loaded, leading to segfaults. To fix this, we just defer connecting controllers until after loading the game.

A second fix for a potential segfault (only observed while testing) is also included.

## How Has This Been Tested?
Tested on OSX with Beetle-PSX

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
