### PR TITLE
Prevent Basecontainer to scroll animated after reset

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1075,6 +1075,11 @@ void CGUIBaseContainer::ScrollToOffset(int offset)
     else
       m_scrollTimer.Stop();
   }
+  else
+  {
+    m_scrollTimer.Stop();
+    m_scroller.Update(~0U);
+  }
   SetOffset(offset);
 }
 


### PR DESCRIPTION
## Description
See title

## Motivation and Context
If a GUIBaseContainer is displayed after reset / refill, it scrolls to its cached position (animated).
This looks funky, but not wanted because subsequent displays do not scroll.

## How Has This Been Tested?
Win10 / Estuary / Open TV channellist

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
