### PR TITLE
RetroPlayer: Zero-copy support

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.h
+++ b/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.h
@@ -41,17 +41,15 @@ namespace RETRO
     void RegisterRenderer(CRPBaseRenderer *renderer) override;
     void UnregisterRenderer(CRPBaseRenderer *renderer) override;
     bool HasVisibleRenderer() const override;
-    bool Configure(AVPixelFormat format, unsigned int width, unsigned int height) override;
+    bool Configure(AVPixelFormat format) override;
     bool IsConfigured() const override { return m_bConfigured; }
-    IRenderBuffer *GetBuffer(size_t size) override;
+    IRenderBuffer *GetBuffer(unsigned int width, unsigned int height) override;
     void Return(IRenderBuffer *buffer) override;
-    void Prime(size_t bufferSize) override;
+    void Prime(unsigned int width, unsigned int height) override;
     void Flush() override;
 
+    // Buffer properties
     AVPixelFormat Format() const { return m_format; }
-    unsigned int Width() const { return m_width; }
-    unsigned int Height() const { return m_height; }
-    size_t FrameSize() const { return m_frameSize; }
 
   protected:
     virtual IRenderBuffer *CreateRenderBuffer(void *header = nullptr) = 0;
@@ -67,11 +65,6 @@ namespace RETRO
     // Configuration parameters
     bool m_bConfigured = false;
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
-    unsigned int m_width = 0;
-    unsigned int m_height = 0;
-
-    // Stream properties
-    size_t m_frameSize = 0; // Initially unknown, set on first call to GetBuffer()
 
   private:
     // Buffer properties

--- a/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
@@ -45,7 +45,7 @@ namespace RETRO
     virtual IRenderBufferPool *GetPool() = 0;
 
     // Buffer functions
-    virtual bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) = 0;
+    virtual bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) = 0;
     virtual void Update() { } //! @todo Remove me
     virtual size_t GetFrameSize() const = 0;
     virtual uint8_t *GetMemory() = 0;

--- a/xbmc/cores/RetroPlayer/buffers/IRenderBufferPool.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBufferPool.h
@@ -45,7 +45,7 @@ namespace RETRO
     virtual void UnregisterRenderer(CRPBaseRenderer *renderer) = 0;
     virtual bool HasVisibleRenderer() const = 0;
 
-    virtual bool Configure(AVPixelFormat format, unsigned int width, unsigned int height) = 0;
+    virtual bool Configure(AVPixelFormat format) = 0;
 
     virtual bool IsConfigured() const = 0;
 
@@ -54,16 +54,21 @@ namespace RETRO
     /*!
      * \brief Get a free buffer from the pool, sets ref count to 1
      *
-     * \param Buffer size, must remain constant
+     * \param width The horizontal pixel count of the buffer
+     * \param height The vertical pixel could of the buffer
+     *
+     * \return The allocated buffer, or nullptr on failure
      */
-    virtual IRenderBuffer *GetBuffer(size_t size) = 0;
+    virtual IRenderBuffer *GetBuffer(unsigned int width, unsigned int height) = 0;
 
     /*!
      * \brief Called by buffer when ref count goes to zero
+     *
+     * \param buffer A fully dereferenced buffer
      */
     virtual void Return(IRenderBuffer *buffer) = 0;
 
-    virtual void Prime(size_t bufferSize) = 0;
+    virtual void Prime(unsigned int width, unsigned int height) = 0;
 
     virtual void Flush() = 0;
 

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.cpp
@@ -29,7 +29,7 @@ CRenderBufferGuiTexture::CRenderBufferGuiTexture(SCALINGMETHOD scalingMethod) :
   m_textureFormat = XB_FMT_A8R8G8B8;
 }
 
-bool CRenderBufferGuiTexture::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
+bool CRenderBufferGuiTexture::Allocate(AVPixelFormat format, unsigned int width, unsigned int height)
 {
   // Initialize IRenderBuffer
   m_format = TranslateFormat(m_textureFormat);

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
@@ -38,7 +38,7 @@ namespace RETRO
     virtual ~CRenderBufferGuiTexture() = default;
 
     // implementation of IRenderBuffer via CBaseRenderBuffer
-    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
     size_t GetFrameSize() const override;
     uint8_t *GetMemory() override;
     bool UploadTexture() override;

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.cpp
@@ -19,16 +19,19 @@
  */
 
 #include "RenderBufferSysMem.h"
+#include "cores/RetroPlayer/rendering/RenderTranslator.h"
 
 using namespace KODI;
 using namespace RETRO;
 
-bool CRenderBufferSysMem::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
+bool CRenderBufferSysMem::Allocate(AVPixelFormat format, unsigned int width, unsigned int height)
 {
   // Initialize IRenderBuffer
   m_format = format;
   m_width = width;
   m_height = height;
+
+  const size_t size = GetBufferSize(format, width, height);
 
   if (m_format != AV_PIX_FMT_NONE && size > 0)
   {
@@ -48,4 +51,12 @@ size_t CRenderBufferSysMem::GetFrameSize() const
 uint8_t *CRenderBufferSysMem::GetMemory()
 {
   return m_data.data();
+}
+
+size_t CRenderBufferSysMem::GetBufferSize(AVPixelFormat format, unsigned int width, unsigned int height)
+{
+  const size_t bufferStride = CRenderTranslator::TranslateWidthToBytes(width, format);
+  const size_t bufferSize = bufferStride * height;
+
+  return bufferSize;
 }

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.h
@@ -25,6 +25,10 @@
 #include <stdint.h>
 #include <vector>
 
+extern "C" {
+#include "libavutil/pixfmt.h"
+}
+
 namespace KODI
 {
 namespace RETRO
@@ -36,9 +40,12 @@ namespace RETRO
     virtual ~CRenderBufferSysMem() = default;
 
     // implementation of IRenderBuffer
-    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
     size_t GetFrameSize() const override;
     uint8_t *GetMemory() override;
+
+    // Utility functions
+    static size_t GetBufferSize(AVPixelFormat format, unsigned int width, unsigned int height);
 
   protected:
     std::vector<uint8_t> m_data;

--- a/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.cpp
@@ -44,7 +44,7 @@ CRenderBufferGBM::~CRenderBufferGBM()
   DeleteTexture();
 }
 
-bool CRenderBufferGBM::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
+bool CRenderBufferGBM::Allocate(AVPixelFormat format, unsigned int width, unsigned int height)
 {
   // Initialize IRenderBuffer
   m_format = format;

--- a/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RenderBufferGBM.h
@@ -44,7 +44,7 @@ namespace RETRO
     ~CRenderBufferGBM() override;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
-    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
     size_t GetFrameSize() const override;
     uint8_t *GetMemory() override;
     void ReleaseMemory() override;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -159,9 +159,9 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
       if (!m_bHasCachedFrame)
       {
         // In this case, cachedFrame is definitely empty (see invariant for
-        // m_bHasCachedFrame). Otherwise, cachedFrame may be empty if the frame is being
-        // copied in the rendering thread. In that case, we would want to leave cached frame
-        // empty to avoid caching another frame.
+        // m_bHasCachedFrame). Otherwise, cachedFrame may be empty if the frame
+        // is being copied in the rendering thread. In that case, we would want
+        // to leave cached frame empty to avoid caching another frame.
 
         cachedFrame.resize(size);
         m_bHasCachedFrame = true;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -91,11 +91,14 @@ bool CRPRenderManager::Configure(AVPixelFormat format, unsigned int nominalWidth
             maxWidth,
             maxHeight);
 
+  // Immutable parameters
   m_format = format;
   m_maxWidth = maxWidth;
   m_maxHeight = maxHeight;
-  m_width = nominalWidth; //! @todo Allow dimension changes
-  m_height = nominalHeight; //! @todo Allow dimension changes
+
+  // Mutable parameters
+  m_width = nominalWidth;
+  m_height = nominalHeight;
 
   CSingleLock lock(m_stateMutex);
 
@@ -133,14 +136,12 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
     if (!bufferPool->HasVisibleRenderer())
       continue;
 
-    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(size);
+    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(width, height);
     if (renderBuffer != nullptr)
     {
       CopyFrame(renderBuffer, m_format, data, size, width, height);
       renderBuffers.emplace_back(renderBuffer);
     }
-    else
-      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Unable to get render buffer for frame");
   }
 
   {
@@ -522,7 +523,7 @@ IRenderBuffer *CRPRenderManager::CreateFromCache(std::vector<uint8_t> &cachedFra
   {
     CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating render buffer for renderer");
 
-    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(ownedFrame.size());
+    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(m_width, m_height);
     if (renderBuffer != nullptr)
     {
       CSingleExit exit(mutex);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -88,6 +88,7 @@ namespace RETRO
 
     // Functions called from game loop
     bool Configure(AVPixelFormat format, unsigned int nominalWidth, unsigned int nominalHeight, unsigned int maxWidth, unsigned int maxHeight);
+    bool GetVideoBuffer(unsigned int width, unsigned int height, AVPixelFormat &format, uint8_t *&data, size_t &size);
     void AddFrame(const uint8_t* data, size_t size, unsigned int width, unsigned int height, unsigned int orientationDegCW);
 
     // Functions called from the player
@@ -189,6 +190,7 @@ namespace RETRO
 
     // Render resources
     std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
+    std::vector<IRenderBuffer*> m_pendingBuffers; // Only access from game thread
     std::vector<IRenderBuffer*> m_renderBuffers;
     std::map<AVPixelFormat, SwsContext*> m_scalers;
     std::vector<uint8_t> m_cachedFrame;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -36,14 +36,6 @@ CRPBaseRenderer::CRPBaseRenderer(const CRenderSettings &renderSettings, CRenderC
   m_bufferPool(std::move(bufferPool)),
   m_renderSettings(renderSettings)
 {
-  m_oldDestRect.SetRect(0.0f, 0.0f, 0.0f, 0.0f);
-
-  for(int i=0; i < 4; i++)
-  {
-    m_rotatedDestCoords[i].x = 0;
-    m_rotatedDestCoords[i].y = 0;
-  }
-
   m_bufferPool->RegisterRenderer(this);
 }
 
@@ -180,7 +172,8 @@ void CRPBaseRenderer::ManageRenderArea()
   CRenderUtils::CalculateViewMode(viewMode, rotationDegCCW, m_sourceWidth, m_sourceHeight, screenWidth, screenHeight, pixelRatio, zoomAmount);
 
   // Calculate destination dimensions
-  CRenderUtils::CalcNormalRenderRect(viewRect, GetAspectRatio() * pixelRatio, zoomAmount, m_dimensions);
+  CRect destRect;
+  CRenderUtils::CalcNormalRenderRect(viewRect, GetAspectRatio() * pixelRatio, zoomAmount, destRect);
 
   m_sourceRect.x1 = 0.0f;
   m_sourceRect.y1 = 0.0f;
@@ -189,17 +182,10 @@ void CRPBaseRenderer::ManageRenderArea()
 
   // Clip as needed
   if (!(m_context.IsFullScreenVideo() || m_context.IsCalibrating()))
-    CRenderUtils::ClipRect(viewRect, m_sourceRect, m_dimensions);
+    CRenderUtils::ClipRect(viewRect, m_sourceRect, destRect);
 
-  const CRect &destRect = m_dimensions;
-  if (m_oldDestRect != destRect || m_oldRenderOrientation != rotationDegCCW)
-  {
-    // Adapt the drawing rect points if we have to rotate and either destRect
-    // or orientation changed
-    m_rotatedDestCoords = CRenderUtils::ReorderDrawPoints(destRect, rotationDegCCW, GetAspectRatio());
-    m_oldDestRect = destRect;
-    m_oldRenderOrientation = rotationDegCCW;
-  }
+  // Adapt the drawing rect points if we have to rotate
+  m_rotatedDestCoords = CRenderUtils::ReorderDrawPoints(destRect, rotationDegCCW, GetAspectRatio());
 }
 
 void CRPBaseRenderer::MarkDirty()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -65,7 +65,7 @@ bool CRPBaseRenderer::Configure(AVPixelFormat format, unsigned int width, unsign
   {
     CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Configuring buffer pool");
 
-    if (!m_bufferPool->Configure(format, width, height))
+    if (!m_bufferPool->Configure(format))
     {
       CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Failed to configure buffer pool");
       return false;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -105,23 +105,13 @@ namespace RETRO
     unsigned int m_sourceHeight = 0;
     unsigned int m_renderOrientation = 0; // Degrees counter-clockwise
 
-    /*!
-     * \brief Orientation of the previous frame
-     *
-     * For drawing the texture with glVertex4f (holds all 4 corner points of the
-     * destination rect with correct orientation based on m_renderOrientation.
-     */
-    unsigned int m_oldRenderOrientation = 0;
-
     // Rendering properties
     CRenderSettings m_renderSettings;
-    CRect m_dimensions;
     IRenderBuffer *m_renderBuffer = nullptr;
 
     // Geometry properties
-    std::array<CPoint, 4> m_rotatedDestCoords;
-    CRect m_oldDestRect; // destrect of the previous frame
-    CRect m_sourceRect; // original size of the video
+    CRect m_sourceRect;
+    std::array<CPoint, 4> m_rotatedDestCoords{};
 
   private:
     /*!

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -48,16 +48,12 @@ CRenderBufferOpenGL::CRenderBufferOpenGL(CRenderContext &context,
                                          GLuint pixeltype,
                                          GLuint internalformat,
                                          GLuint pixelformat,
-                                         GLuint bpp,
-                                         unsigned int width,
-                                         unsigned int height) :
+                                         GLuint bpp) :
   CRenderBufferOpenGLES(context,
                         pixeltype,
                         internalformat,
                         pixelformat,
-                        bpp,
-                        width,
-                        height)
+                        bpp)
 {
 }
 
@@ -92,9 +88,7 @@ IRenderBuffer *CRenderBufferPoolOpenGL::CreateRenderBuffer(void *header /* = nul
                                  m_pixeltype,
                                  m_internalformat,
                                  m_pixelformat,
-                                 m_bpp,
-                                 m_width,
-                                 m_height);
+                                 m_bpp);
 }
 
 bool CRenderBufferPoolOpenGL::ConfigureInternal()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -49,9 +49,7 @@ namespace RETRO
                         GLuint pixeltype,
                         GLuint internalformat,
                         GLuint pixelformat,
-                        GLuint bpp,
-                        unsigned int width,
-                        unsigned int height);
+                        GLuint bpp);
     ~CRenderBufferOpenGL() override = default;
 
     // implementation of IRenderBuffer via CRenderBufferOpenGLES

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -55,16 +55,12 @@ CRenderBufferOpenGLES::CRenderBufferOpenGLES(CRenderContext &context,
                                              GLuint pixeltype,
                                              GLuint internalformat,
                                              GLuint pixelformat,
-                                             GLuint bpp,
-                                             unsigned int width,
-                                             unsigned int height) :
+                                             GLuint bpp) :
   m_context(context),
   m_pixeltype(pixeltype),
   m_internalformat(internalformat),
   m_pixelformat(pixelformat),
-  m_bpp(bpp),
-  m_width(width),
-  m_height(height)
+  m_bpp(bpp)
 {
 }
 
@@ -161,9 +157,7 @@ IRenderBuffer *CRenderBufferPoolOpenGLES::CreateRenderBuffer(void *header /* = n
                                    m_pixeltype,
                                    m_internalformat,
                                    m_pixelformat,
-                                   m_bpp,
-                                   m_width,
-                                   m_height);
+                                   m_bpp);
 }
 
 bool CRenderBufferPoolOpenGLES::ConfigureInternal()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -54,9 +54,7 @@ namespace RETRO
                           GLuint pixeltype,
                           GLuint internalformat,
                           GLuint pixelformat,
-                          GLuint bpp,
-                          unsigned int width,
-                          unsigned int height);
+                          GLuint bpp);
     ~CRenderBufferOpenGLES() override;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
@@ -71,8 +69,6 @@ namespace RETRO
     const GLuint m_internalformat;
     const GLuint m_pixelformat;
     const GLuint m_bpp;
-    const unsigned int m_width;
-    const unsigned int m_height;
 
     const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo
     GLuint m_textureId = 0;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -56,11 +56,9 @@ RenderBufferPoolVector CWinRendererFactory::CreateBufferPools(CRenderContext &co
 
 // --- CWinRenderBuffer --------------------------------------------------------
 
-CWinRenderBuffer::CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat, unsigned int width, unsigned int height) :
+CWinRenderBuffer::CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat) :
   m_pixFormat(pixFormat),
   m_targetDxFormat(dxFormat),
-  m_width(width),
-  m_height(height),
   m_targetPixFormat(GetPixFormat(dxFormat))
 {
 }
@@ -185,7 +183,7 @@ bool CWinRenderBufferPool::IsCompatible(const CRenderVideoSettings &renderSettin
 
 IRenderBuffer *CWinRenderBufferPool::CreateRenderBuffer(void *header /* = nullptr */)
 {
-  return new CWinRenderBuffer(m_format, m_targetDxFormat, m_width, m_height);
+  return new CWinRenderBuffer(m_format, m_targetDxFormat);
 }
 
 bool CWinRenderBufferPool::ConfigureDX(DXGI_FORMAT dxFormat)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -54,7 +54,7 @@ namespace RETRO
   class CWinRenderBuffer : public CRenderBufferSysMem
   {
   public:
-    CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat, unsigned int width, unsigned int height);
+    CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat);
     ~CWinRenderBuffer() override = default;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
@@ -75,8 +75,6 @@ namespace RETRO
     // Construction parameters
     const AVPixelFormat m_pixFormat;
     const DXGI_FORMAT m_targetDxFormat;
-    const unsigned int m_width;
-    const unsigned int m_height;
 
     AVPixelFormat m_targetPixFormat;
     std::unique_ptr<CD3DTexture> m_intermediateTarget;

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
@@ -52,12 +52,9 @@ StreamPtr CRPStreamManager::CreateStream(StreamType streamType)
     return StreamPtr(m_audioStream);
   }
   case StreamType::VIDEO:
-  {
-    return StreamPtr(new CRetroPlayerVideo(m_renderManager, m_processInfo));
-  }
   case StreamType::SW_BUFFER:
   {
-    //return StreamPtr(new CRetroPlayerSoftware(m_renderManager, m_processInfo)); //! @todo
+    return StreamPtr(new CRetroPlayerVideo(m_renderManager, m_processInfo));
   }
   case StreamType::HW_BUFFER:
   {

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -52,7 +52,7 @@ CRetroPlayerAudio::~CRetroPlayerAudio()
 
 bool CRetroPlayerAudio::OpenStream(const StreamProperties& properties)
 {
-  const AudioStreamProperties& audioProperties = reinterpret_cast<const AudioStreamProperties&>(properties);
+  const AudioStreamProperties& audioProperties = static_cast<const AudioStreamProperties&>(properties);
 
   const AEDataFormat pcmFormat = CAudioTranslator::TranslatePCMFormat(audioProperties.format);
   if (pcmFormat == AE_FMT_INVALID)
@@ -118,7 +118,7 @@ bool CRetroPlayerAudio::OpenStream(const StreamProperties& properties)
 
 void CRetroPlayerAudio::AddStreamData(const StreamPacket &packet)
 {
-  const AudioStreamPacket& audioPacket = reinterpret_cast<const AudioStreamPacket&>(packet);
+  const AudioStreamPacket& audioPacket = static_cast<const AudioStreamPacket&>(packet);
 
   if (m_bAudioEnabled)
   {

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
@@ -32,15 +32,28 @@ namespace RETRO
 {
   class CRPProcessInfo;
 
-  struct AudioStreamProperties
+  struct AudioStreamProperties : public StreamProperties
   {
+    AudioStreamProperties(PCMFormat format, double sampleRate, AudioChannelMap channelMap) :
+      format(format),
+      sampleRate(sampleRate),
+      channelMap(channelMap)
+    {
+    }
+
     PCMFormat format;
     double sampleRate;
     AudioChannelMap channelMap;
   };
 
-  struct AudioStreamPacket
+  struct AudioStreamPacket : public StreamPacket
   {
+    AudioStreamPacket(const uint8_t* data, size_t size) :
+      data(data),
+      size(size)
+    {
+    }
+
     const uint8_t* data;
     size_t size;
   };

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
@@ -46,7 +46,7 @@ CRetroPlayerVideo::~CRetroPlayerVideo()
 
 bool CRetroPlayerVideo::OpenStream(const StreamProperties& properties)
 {
-  const VideoStreamProperties& videoProperties = reinterpret_cast<const VideoStreamProperties&>(properties);
+  const VideoStreamProperties& videoProperties = static_cast<const VideoStreamProperties&>(properties);
 
   if (m_bOpen)
   {
@@ -77,9 +77,25 @@ bool CRetroPlayerVideo::OpenStream(const StreamProperties& properties)
   return m_bOpen;
 }
 
+bool CRetroPlayerVideo::GetStreamBuffer(unsigned int width, unsigned int height, StreamBuffer& buffer)
+{
+  VideoStreamBuffer& videoBuffer = static_cast<VideoStreamBuffer&>(buffer);
+
+  if (m_bOpen)
+  {
+    return m_renderManager.GetVideoBuffer(width,
+                                          height,
+                                          videoBuffer.pixfmt,
+                                          videoBuffer.data,
+                                          videoBuffer.size);
+  }
+
+  return false;
+}
+
 void CRetroPlayerVideo::AddStreamData(const StreamPacket &packet)
 {
-  const VideoStreamPacket& videoPacket = reinterpret_cast<const VideoStreamPacket&>(packet);
+  const VideoStreamPacket& videoPacket = static_cast<const VideoStreamPacket&>(packet);
 
   if (m_bOpen)
   {

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
@@ -33,8 +33,18 @@ namespace RETRO
   class CRPProcessInfo;
   class CRPRenderManager;
 
-  struct VideoStreamProperties
+  struct VideoStreamProperties : public StreamProperties
   {
+    VideoStreamProperties(AVPixelFormat pixfmt, unsigned int nominalWidth, unsigned int nominalHeight, unsigned int maxWidth, unsigned int maxHeight, float pixelAspectRatio) :
+      pixfmt(pixfmt),
+      nominalWidth(nominalWidth),
+      nominalHeight(nominalHeight),
+      maxWidth(maxWidth),
+      maxHeight(maxHeight),
+      pixelAspectRatio(pixelAspectRatio)
+    {
+    }
+
     AVPixelFormat pixfmt;
     unsigned int nominalWidth;
     unsigned int nominalHeight;
@@ -43,8 +53,24 @@ namespace RETRO
     float pixelAspectRatio;
   };
 
-  struct VideoStreamPacket
+  struct VideoStreamBuffer : public StreamBuffer
   {
+    AVPixelFormat pixfmt;
+    uint8_t *data;
+    size_t size;
+  };
+
+  struct VideoStreamPacket: public StreamPacket
+  {
+    VideoStreamPacket(unsigned int width, unsigned int height, VideoRotation rotation, const uint8_t *data, size_t size) :
+      width(width),
+      height(height),
+      rotation(rotation),
+      data(data),
+      size(size)
+    {
+    }
+
     unsigned int width;
     unsigned int height;
     VideoRotation rotation;
@@ -65,7 +91,7 @@ namespace RETRO
 
     // implementation of IRetroPlayerStream
     bool OpenStream(const StreamProperties& properties) override;
-    bool GetStreamBuffer(unsigned int width, unsigned int height, StreamBuffer& buffer) override { return false; }
+    bool GetStreamBuffer(unsigned int width, unsigned int height, StreamBuffer& buffer) override;
     void AddStreamData(const StreamPacket &packet) override;
     void CloseStream() override;
 

--- a/xbmc/games/addons/GameClientTranslator.cpp
+++ b/xbmc/games/addons/GameClientTranslator.cpp
@@ -94,6 +94,19 @@ AVPixelFormat CGameClientTranslator::TranslatePixelFormat(GAME_PIXEL_FORMAT form
   return AV_PIX_FMT_NONE;
 }
 
+GAME_PIXEL_FORMAT CGameClientTranslator::TranslatePixelFormat(AVPixelFormat format)
+{
+  switch (format)
+  {
+  case AV_PIX_FMT_0RGB32: return GAME_PIXEL_FORMAT_0RGB8888;
+  case AV_PIX_FMT_RGB565: return GAME_PIXEL_FORMAT_RGB565;
+  case AV_PIX_FMT_RGB555: return GAME_PIXEL_FORMAT_0RGB1555;
+  default:
+    break;
+  }
+  return GAME_PIXEL_FORMAT_UNKNOWN;
+}
+
 RETRO::PCMFormat CGameClientTranslator::TranslatePCMFormat(GAME_PCM_FORMAT format)
 {
   switch (format)

--- a/xbmc/games/addons/GameClientTranslator.h
+++ b/xbmc/games/addons/GameClientTranslator.h
@@ -74,6 +74,13 @@ namespace GAME
     static AVPixelFormat TranslatePixelFormat(GAME_PIXEL_FORMAT format);
 
     /*!
+     * \brief Translate pixel format (RetroPlayer/FFMPEG to Game API).
+     * \param format The pixel format to translate.
+     * \return Translated pixel format.
+     */
+    static GAME_PIXEL_FORMAT TranslatePixelFormat(AVPixelFormat format);
+
+    /*!
      * \brief Translate audio PCM format (Game API to RetroPlayer).
      * \param format The audio PCM format to translate.
      * \return Translated audio PCM format.

--- a/xbmc/games/addons/streams/CMakeLists.txt
+++ b/xbmc/games/addons/streams/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES GameClientStreamAudio.cpp
             GameClientStreams.cpp
+            GameClientStreamSwFramebuffer.cpp
             GameClientStreamVideo.cpp
 )
 
 set(HEADERS GameClientStreamAudio.h
             GameClientStreams.h
+            GameClientStreamSwFramebuffer.h
             GameClientStreamVideo.h
             IGameClientStream.h
 )

--- a/xbmc/games/addons/streams/GameClientStreamAudio.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamAudio.cpp
@@ -43,7 +43,7 @@ bool CGameClientStreamAudio::OpenStream(RETRO::IRetroPlayerStream* stream, const
   std::unique_ptr<RETRO::AudioStreamProperties> audioProperties(TranslateProperties(properties.audio, m_sampleRate));
   if (audioProperties)
   {
-    if (audioStream->OpenStream(reinterpret_cast<const RETRO::StreamProperties&>(*audioProperties)))
+    if (audioStream->OpenStream(static_cast<const RETRO::StreamProperties&>(*audioProperties)))
       m_stream = stream;
   }
 
@@ -73,7 +73,7 @@ void CGameClientStreamAudio::AddData(const game_stream_packet &packet)
       audio.size
     };
 
-    m_stream->AddStreamData(reinterpret_cast<RETRO::StreamPacket&>(audioPacket));
+    m_stream->AddStreamData(static_cast<RETRO::StreamPacket&>(audioPacket));
   }
 }
 

--- a/xbmc/games/addons/streams/GameClientStreamSwFramebuffer.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamSwFramebuffer.cpp
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameClientStreamSwFramebuffer.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "cores/RetroPlayer/streams/RetroPlayerVideo.h"
+#include "games/addons/GameClientTranslator.h"
+
+using namespace KODI;
+using namespace GAME;
+
+bool CGameClientStreamSwFramebuffer::GetBuffer(unsigned int width, unsigned int height, game_stream_buffer &buffer)
+{
+  if (m_stream != nullptr)
+  {
+    RETRO::VideoStreamBuffer streamBuffer;
+    if (m_stream->GetStreamBuffer(width, height, static_cast<RETRO::StreamBuffer&>(streamBuffer)))
+    {
+      buffer.type = GAME_STREAM_SW_FRAMEBUFFER;
+
+      game_stream_sw_framebuffer_buffer& framebuffer = buffer.sw_framebuffer;
+
+      framebuffer.format = CGameClientTranslator::TranslatePixelFormat(streamBuffer.pixfmt);
+      framebuffer.data = streamBuffer.data;
+      framebuffer.size = streamBuffer.size;
+
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/xbmc/games/addons/streams/GameClientStreamSwFramebuffer.h
+++ b/xbmc/games/addons/streams/GameClientStreamSwFramebuffer.h
@@ -17,43 +17,23 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-
 #pragma once
 
-#include "IGameClientStream.h"
-
-struct game_stream_video_properties;
+#include "GameClientStreamVideo.h"
 
 namespace KODI
 {
-namespace RETRO
-{
-  class IRetroPlayerStream;
-  struct VideoStreamProperties;
-}
-
 namespace GAME
 {
 
-class CGameClientStreamVideo : public IGameClientStream
+class CGameClientStreamSwFramebuffer : public CGameClientStreamVideo
 {
 public:
-  CGameClientStreamVideo() = default;
-  ~CGameClientStreamVideo() override { CloseStream(); }
+  CGameClientStreamSwFramebuffer() = default;
+  ~CGameClientStreamSwFramebuffer() override = default;
 
-  // Implementation of IGameClientStream
-  bool OpenStream(RETRO::IRetroPlayerStream* stream,
-                  const game_stream_properties& properties) override;
-  void CloseStream() override;
-  void AddData(const game_stream_packet& packet) override;
-
-protected:
-  // Stream parameters
-  RETRO::IRetroPlayerStream* m_stream = nullptr;
-
-private:
-  // Utility functions
-  static RETRO::VideoStreamProperties* TranslateProperties(const game_stream_video_properties &properties);
+  // Implementation of IGameClientStream via CGameClientStreamVideo
+  bool GetBuffer(unsigned int width, unsigned int height, game_stream_buffer &buffer) override;
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/streams/GameClientStreamVideo.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamVideo.cpp
@@ -38,7 +38,7 @@ bool CGameClientStreamVideo::OpenStream(RETRO::IRetroPlayerStream* stream, const
   std::unique_ptr<RETRO::VideoStreamProperties> videoProperties(TranslateProperties(properties.video));
   if (videoProperties)
   {
-    if (videoStream->OpenStream(reinterpret_cast<const RETRO::StreamProperties&>(*videoProperties)))
+    if (videoStream->OpenStream(static_cast<const RETRO::StreamProperties&>(*videoProperties)))
       m_stream = stream;
   }
 
@@ -56,7 +56,7 @@ void CGameClientStreamVideo::CloseStream()
 
 void CGameClientStreamVideo::AddData(const game_stream_packet& packet)
 {
-  if (packet.type != GAME_STREAM_VIDEO)
+  if (packet.type != GAME_STREAM_VIDEO && packet.type != GAME_STREAM_SW_FRAMEBUFFER)
     return;
 
   if (m_stream != nullptr)
@@ -73,7 +73,7 @@ void CGameClientStreamVideo::AddData(const game_stream_packet& packet)
       video.size,
     };
 
-    m_stream->AddStreamData(reinterpret_cast<const RETRO::StreamPacket&>(videoPacket));
+    m_stream->AddStreamData(static_cast<const RETRO::StreamPacket&>(videoPacket));
   }
 }
 

--- a/xbmc/games/addons/streams/GameClientStreams.cpp
+++ b/xbmc/games/addons/streams/GameClientStreams.cpp
@@ -20,6 +20,7 @@
 
 #include "GameClientStreams.h"
 #include "GameClientStreamAudio.h"
+#include "GameClientStreamSwFramebuffer.h"
 #include "GameClientStreamVideo.h"
 #include "cores/RetroPlayer/streams/IRetroPlayerStream.h"
 #include "cores/RetroPlayer/streams/IStreamManager.h"
@@ -111,6 +112,11 @@ std::unique_ptr<IGameClientStream> CGameClientStreams::CreateStream(GAME_STREAM_
   case GAME_STREAM_VIDEO:
   {
     gameStream.reset(new CGameClientStreamVideo);
+    break;
+  }
+  case GAME_STREAM_SW_FRAMEBUFFER:
+  {
+    gameStream.reset(new CGameClientStreamSwFramebuffer);
     break;
   }
   default:


### PR DESCRIPTION
Zero-copy support was added to the Game API in https://github.com/xbmc/xbmc/pull/13976 and to the libretro wrapper in https://github.com/kodi-game/game.libretro/pull/43. This extends zero-copy support to RetroPlayer.

Zero-copy allows the core to render directly into video memory, avoiding the extra bandwidth cost incurred by an additional memory copy on the CPU.

## Description
Zero-copy support is opt-in for the core by calling the [`RETRO_ENVIRONMENT_GET_CURRENT_SOFTWARE_FRAMEBUFFER`](https://github.com/kodi-game/game.libretro/blob/82039bb/src/libretro/libretro.h#L924) libretro environment command each frame. This command returns a preallocated framebuffer that the core can use to write video memory.

## Motivation and Context
Needed to fully enable zero-copy after GBM rendering was added in https://github.com/xbmc/xbmc/pull/14079.

## How Has This Been Tested?
Tested with https://github.com/kodi-game/game.libretro.vram-test, a sample add-on that renders a checkerboard pattern to a zero-copy buffer.

## Screenshots (if appropriate):
VRAM Test add-on:

![vram-test-addon](https://user-images.githubusercontent.com/531482/42302225-a837a038-7fce-11e8-912a-1d135fb4f7da.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## TODO
- [x] Fix strict aliasing warnings