### PR TITLE
VAAPIGL[ES]: Only unmap if interop is active

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -298,6 +298,9 @@ void CRendererVAAPI::ReleaseBuffer(int idx)
     glDeleteSync(m_fences[idx]);
     m_fences[idx] = GL_NONE;
   }
-  m_vaapiTextures[idx]->Unmap();
+  if (m_isVAAPIBuffer)
+  {
+    m_vaapiTextures[idx]->Unmap();
+  }
   CLinuxRendererGL::ReleaseBuffer(idx);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -292,6 +292,9 @@ void CRendererVAAPI::ReleaseBuffer(int idx)
     glDeleteSync(m_fences[idx]);
     m_fences[idx] = GL_NONE;
   }
-  m_vaapiTextures[idx]->Unmap();
+  if (m_isVAAPIBuffer)
+  {
+    m_vaapiTextures[idx]->Unmap();
+  }
   CLinuxRendererGLES::ReleaseBuffer(idx);
 }


### PR DESCRIPTION
This fixes a regression introduced here: https://github.com/xbmc/xbmc/commit/b73d078a1c754f81a8ec04a5730efd5a790e4a35