### PR TITLE
Fix focus issue in VideoOSD (flickering when using mouse)

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -65,6 +65,8 @@ bool CGUIDialogVideoOSD::OnAction(const CAction &action)
     Close();
     return true;
   }
+  else if (action.GetID() == ACTION_TRIGGER_OSD)
+    return true;
 
   return CGUIDialog::OnAction(action);
 }


### PR DESCRIPTION
## Description
When moving mouse while VideoOSD is open, the default focus item (play / pause button) flickers between focused / unfocused.

Reason is that onMouseMove triggers an ACTION_TRIGGER_OSD which opens the OSD and selects the default item.

This PR stops further processing in OSD dialog if it is already open.

## Motivation and Context
Issue was mentioned here and there.

## How Has This Been Tested?
Win10 / play Video / move mouse cursor in bottom third part of the screen (over OSD Dialog area)

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
