### PR TITLE
Fix erratic input when entering cheat code

### DIFF
--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -77,26 +77,31 @@ bool CJoystickEasterEgg::OnButtonPress(const FeatureName& feature)
   {
     const auto& sequence = it->second;
 
-    // Update state
+    // Reset state if it previously finished
+    if (m_state >= sequence.size())
+      m_state = 0;
+
     if (feature == sequence[m_state])
       m_state++;
     else
       m_state = 0;
 
-    // Capture input when finished with arrows (2 x up/down/left/right)
-    if (m_state > 8)
+    if (IsCapturing())
     {
       bHandled = true;
 
       if (m_state >= sequence.size())
-      {
         OnFinish();
-        m_state = 0;
-      }
     }
   }
 
   return bHandled;
+}
+
+bool CJoystickEasterEgg::IsCapturing()
+{
+  // Capture input when finished with arrows (2 x up/down/left/right)
+  return m_state > 8;
 }
 
 void CJoystickEasterEgg::OnFinish(void)

--- a/xbmc/input/joysticks/JoystickEasterEgg.h
+++ b/xbmc/input/joysticks/JoystickEasterEgg.h
@@ -40,7 +40,8 @@ namespace JOYSTICK
     virtual ~CJoystickEasterEgg() = default;
 
     // implementation of IButtonSequence
-    virtual bool OnButtonPress(const FeatureName& feature) override;
+    bool OnButtonPress(const FeatureName& feature) override;
+    bool IsCapturing() override;
 
     static void OnFinish(void);
 

--- a/xbmc/input/joysticks/interfaces/IButtonSequence.h
+++ b/xbmc/input/joysticks/interfaces/IButtonSequence.h
@@ -32,6 +32,12 @@ namespace JOYSTICK
     virtual ~IButtonSequence() = default;
 
     virtual bool OnButtonPress(const FeatureName& feature) = 0;
+
+    /*!
+     * \brief Returns true if a sequence is being captured to prevent input
+     *        from falling through to the application
+     */
+    virtual bool IsCapturing() = 0;
   };
 }
 }

--- a/xbmc/input/joysticks/keymaps/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/keymaps/KeymapHandler.cpp
@@ -98,6 +98,9 @@ bool CKeymapHandler::OnButtonPress(const FeatureName& feature, bool bPressed)
 
 void CKeymapHandler::OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs)
 {
+  if (m_easterEgg && m_easterEgg->IsCapturing())
+    return;
+
   const std::string keyName = CJoystickUtils::MakeKeyName(feature);
 
   IKeyHandler *handler = GetKeyHandler(keyName);


### PR DESCRIPTION
Before the keymap system was rewritten in #12366 to handle button holding and combos, the cheat code absorbed A and B presses to avoid unintended behavior in the GUI. After the rewrite, this broke, causing A and B to open and close things unexpectedly.

## Motivation and Context
Fix a regression.

## How Has This Been Tested?
Tested by entering cheat code with a 360 controller on Windows 10.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
