### PR TITLE
fix mimetype of items expanded from playlists

### DIFF
--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -536,7 +536,7 @@ std::string CMime::GetMimeType(const std::string &extension)
 
 std::string CMime::GetMimeType(const CFileItem &item)
 {
-  std::string path = item.GetPath();
+  std::string path = item.GetDynPath();
   if (item.HasVideoInfoTag() && !item.GetVideoInfoTag()->GetPath().empty())
     path = item.GetVideoInfoTag()->GetPath();
   else if (item.HasMusicInfoTag() && !item.GetMusicInfoTag()->GetURL().empty())


### PR DESCRIPTION
Use DynPath instead of Path in MimeType resolution.

## Description
Use DynPath instead of Path in MimeType resolution.

## Motivation and Context
This fixes the problem that playlists could not be played when started via PlayMedia('special://profile/pllaylists/music/playlistname.m3u').

There is no open issue (to my knowledge) but  #14054 is similar.

## How Has This Been Tested?
Tested under Ubuntu 18.04, debug build. Function triggered using Yatse app on Android.

## Types of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
- [ x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ x] All new and existing tests passed
