### PR TITLE
Keep protocol options in path databases

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -629,6 +629,8 @@ private:
    */
   virtual void CreateViews();
 
+  void SplitPath(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
+
   CSong GetSongFromDataset();
   CSong GetSongFromDataset(const dbiplus::sql_record* const record, int offset = 0);
   CArtist GetArtistFromDataset(dbiplus::Dataset* pDS, int offset = 0, bool needThumb = true);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -226,7 +226,7 @@ void URIUtils::Split(const std::string& strFileNameAndPath,
     while (i > 0)
     {
       char ch = strFileName[i];
-      if (ch == '?') break;
+      if (ch == '?' || ch == '|') break;
       else i--;
     }
     if (i > 0)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9629,7 +9629,16 @@ void CVideoDatabase::SplitPath(const std::string& strFileNameAndPath, std::strin
     strFileName = strFileNameAndPath;
   }
   else
-    URIUtils::Split(strFileNameAndPath,strPath, strFileName);
+  {
+    URIUtils::Split(strFileNameAndPath, strPath, strFileName);
+    // Keep protocol options as part of the path
+    if (URIUtils::IsURL(strFileNameAndPath))
+    {
+      CURL url(strFileNameAndPath);
+      if (!url.GetProtocolOptions().empty())
+        strPath += "|" + url.GetProtocolOptions();
+    }
+  }
 }
 
 void CVideoDatabase::InvalidatePathHash(const std::string& strPath)


### PR DESCRIPTION
The code was inconsistent as to whether protocol options that may be present in source URIs are written to the paths table in the database.
Mostly there were two paths, one with and one without protocol options, leading to duplicated data.
This patch tries to fix this by settling on the version with protocol options at all times.

I hope this doesn't break too much other stuff, can't say really :-/