### PR TITLE
Games: Add setting to disable autosave

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17437,7 +17437,17 @@ msgctxt "#35252"
 msgid "Edit game source"
 msgstr ""
 
-#empty strings from id 35253 to 35255
+#: system/settings/settings.xml
+msgctxt "#35253"
+msgid "Enable autosave if supported"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#35254"
+msgid "Save the game automatically during game play, if supported. Resume playing where you left off."
+msgstr ""
+
+#empty string with id 35255
 
 #. Error message when a game client fails to install when a game is being launched
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1974,6 +1974,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="gamesgeneral.enableautosave" type="boolean" label="35253" help="35254">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="gamesgeneral.enablerewind" type="boolean" label="35203" help="35204">
           <level>0</level>
           <default>true</default>

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -37,6 +37,7 @@ struct TextCacheStruct_t;
 class TiXmlElement;
 class CStreamDetails;
 class CAction;
+class IPlayerCallback;
 
 class CPlayerOptions
 {

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -37,6 +37,7 @@
 #include "games/dialogs/osd/DialogGameVideoSelect.h"
 #include "games/tags/GameInfoTag.h"
 #include "games/GameServices.h"
+#include "games/GameSettings.h"
 #include "games/GameUtils.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -171,7 +172,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
       }
     }
 
-    if (bSuccess)
+    if (bSuccess && m_gameServices.GameSettings().AutosaveEnabled())
     {
       std::string redactedSavestatePath = CURL::GetRedacted(savestatePath);
       CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Loading savestate %s", redactedSavestatePath.c_str());
@@ -188,7 +189,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
     m_callback.OnPlayBackStarted(fileCopy);
     m_callback.OnAVStarted(fileCopy);
     if (!bStandalone)
-      m_autoSave.reset(new CRetroPlayerAutoSave(*m_gameClient));
+      m_autoSave.reset(new CRetroPlayerAutoSave(*m_gameClient, m_gameServices.GameSettings()));
     m_processInfo->SetVideoFps(static_cast<float>(m_gameClient->GetFrameRate()));
   }
   else
@@ -213,7 +214,7 @@ bool CRetroPlayer::CloseFile(bool reopen /* = false */)
 
   CSingleLock lock(m_mutex);
 
-  if (m_gameClient)
+  if (m_gameClient && m_gameServices.GameSettings().AutosaveEnabled())
   {
     std::string savePath = m_gameClient->GetPlayback()->CreateSavestate();
     if (!savePath.empty())

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -21,6 +21,7 @@
 #include "RetroPlayerAutoSave.h"
 #include "games/addons/GameClient.h"
 #include "games/addons/playback/IGameClientPlayback.h"
+#include "games/GameSettings.h"
 #include "utils/log.h"
 #include "URL.h"
 
@@ -29,9 +30,11 @@ using namespace RETRO;
 
 #define AUTOSAVE_DURATION_SECS    10 // Auto-save every 10 seconds
 
-CRetroPlayerAutoSave::CRetroPlayerAutoSave(GAME::CGameClient &gameClient) :
+CRetroPlayerAutoSave::CRetroPlayerAutoSave(GAME::CGameClient &gameClient,
+                                           GAME::CGameSettings &settings) :
   CThread("CRetroPlayerAutoSave"),
-  m_gameClient(gameClient)
+  m_gameClient(gameClient),
+  m_settings(settings)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Initializing autosave");
 
@@ -55,6 +58,9 @@ void CRetroPlayerAutoSave::Process()
 
     if (m_bStop)
       break;
+
+    if (!m_settings.AutosaveEnabled())
+      continue;
 
     if (m_gameClient.GetPlayback()->GetSpeed() > 0.0)
     {

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
@@ -20,17 +20,23 @@
 
 #pragma once
 
-#include "games/GameTypes.h"
 #include "threads/Thread.h"
 
 namespace KODI
 {
+namespace GAME
+{
+  class CGameClient;
+  class CGameSettings;
+}
+
 namespace RETRO
 {
   class CRetroPlayerAutoSave : protected CThread
   {
   public:
-    explicit CRetroPlayerAutoSave(GAME::CGameClient &gameClient);
+    explicit CRetroPlayerAutoSave(GAME::CGameClient &gameClient,
+                                  GAME::CGameSettings &settings);
 
     ~CRetroPlayerAutoSave() override;
 
@@ -39,8 +45,9 @@ namespace RETRO
     virtual void Process() override;
 
   private:
-    // Construction parameter
+    // Construction parameters
     GAME::CGameClient &m_gameClient;
+    GAME::CGameSettings &m_settings;
   };
 }
 }

--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -30,6 +30,7 @@ using namespace GAME;
 namespace
 {
   const std::string SETTING_GAMES_ENABLE = "gamesgeneral.enable";
+  const std::string SETTING_GAMES_ENABLEAUTOSAVE = "gamesgeneral.enableautosave";
   const std::string SETTING_GAMES_ENABLEREWIND = "gamesgeneral.enablerewind";
   const std::string SETTING_GAMES_REWINDTIME = "gamesgeneral.rewindtime";
 }
@@ -56,6 +57,11 @@ bool CGameSettings::GamesEnabled()
 void CGameSettings::ToggleGames()
 {
   m_settings.ToggleBool(SETTING_GAMES_ENABLE);
+}
+
+bool CGameSettings::AutosaveEnabled()
+{
+  return m_settings.GetBool(SETTING_GAMES_ENABLEAUTOSAVE);
 }
 
 bool CGameSettings::RewindEnabled()

--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -22,21 +22,52 @@
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 
+#include <algorithm>
+
 using namespace KODI;
 using namespace GAME;
+
+namespace
+{
+  const std::string SETTING_GAMES_ENABLE = "gamesgeneral.enable";
+  const std::string SETTING_GAMES_ENABLEREWIND = "gamesgeneral.enablerewind";
+  const std::string SETTING_GAMES_REWINDTIME = "gamesgeneral.rewindtime";
+}
 
 CGameSettings::CGameSettings(CSettings &settings) :
   m_settings(settings)
 {
   m_settings.RegisterCallback(this, {
-    CSettings::SETTING_GAMES_ENABLEREWIND,
-    CSettings::SETTING_GAMES_REWINDTIME,
+    SETTING_GAMES_ENABLEREWIND,
+    SETTING_GAMES_REWINDTIME,
   });
 }
 
 CGameSettings::~CGameSettings()
 {
   m_settings.UnregisterCallback(this);
+}
+
+bool CGameSettings::GamesEnabled()
+{
+  return m_settings.GetBool(SETTING_GAMES_ENABLE);
+}
+
+void CGameSettings::ToggleGames()
+{
+  m_settings.ToggleBool(SETTING_GAMES_ENABLE);
+}
+
+bool CGameSettings::RewindEnabled()
+{
+  return m_settings.GetBool(SETTING_GAMES_ENABLEREWIND);
+}
+
+unsigned int CGameSettings::MaxRewindTimeSec()
+{
+  int rewindTimeSec = m_settings.GetInt(SETTING_GAMES_REWINDTIME);
+
+  return static_cast<unsigned int>(std::max(rewindTimeSec, 0));
 }
 
 void CGameSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
@@ -46,8 +77,8 @@ void CGameSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 
   const std::string& settingId = setting->GetId();
 
-  if (settingId == CSettings::SETTING_GAMES_ENABLEREWIND ||
-      settingId == CSettings::SETTING_GAMES_REWINDTIME)
+  if (settingId == SETTING_GAMES_ENABLEREWIND ||
+      settingId == SETTING_GAMES_REWINDTIME)
   {
     SetChanged();
     NotifyObservers(ObservableMessageSettingsChanged);

--- a/xbmc/games/GameSettings.h
+++ b/xbmc/games/GameSettings.h
@@ -38,6 +38,12 @@ public:
   CGameSettings(CSettings &settings);
   ~CGameSettings() override;
 
+  // General settings
+  bool GamesEnabled();
+  void ToggleGames();
+  bool RewindEnabled();
+  unsigned int MaxRewindTimeSec();
+
   // Inherited from ISettingCallback
   virtual void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
 

--- a/xbmc/games/GameSettings.h
+++ b/xbmc/games/GameSettings.h
@@ -41,6 +41,7 @@ public:
   // General settings
   bool GamesEnabled();
   void ToggleGames();
+  bool AutosaveEnabled();
   bool RewindEnabled();
   unsigned int MaxRewindTimeSec();
 

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
@@ -28,7 +28,6 @@
 #include "games/addons/savestates/SavestateWriter.h"
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
-#include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
 #include "ServiceBroker.h"
@@ -54,7 +53,8 @@ CGameClientReversiblePlayback::CGameClientReversiblePlayback(CGameClient* gameCl
 {
   UpdateMemoryStream();
 
-  CServiceBroker::GetGameServices().GameSettings().RegisterObserver(this);
+  CGameSettings &gameSettings = CServiceBroker::GetGameServices().GameSettings();
+  gameSettings.RegisterObserver(this);
 
   m_gameLoop.Start();
 }
@@ -303,12 +303,16 @@ void CGameClientReversiblePlayback::UpdateMemoryStream()
 
   bool bRewindEnabled = false;
 
+  CGameSettings &gameSettings = CServiceBroker::GetGameServices().GameSettings();
+
+  gameSettings.UnregisterObserver(this);
+
   if (m_gameClient->SerializeSize() > 0)
-    bRewindEnabled = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_GAMES_ENABLEREWIND);
+    bRewindEnabled = gameSettings.RewindEnabled();
 
   if (bRewindEnabled)
   {
-    unsigned int rewindBufferSec = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_GAMES_REWINDTIME);
+    unsigned int rewindBufferSec = gameSettings.MaxRewindTimeSec();
     if (rewindBufferSec < 10)
       rewindBufferSec = 10; // Sanity check
 

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -21,9 +21,10 @@
 #include "JoystickEasterEgg.h"
 #include "ServiceBroker.h"
 #include "games/controllers/ControllerIDs.h"
+#include "games/GameServices.h"
+#include "games/GameSettings.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/WindowIDs.h"
-#include "settings/Settings.h"
 
 using namespace KODI;
 using namespace JOYSTICK;
@@ -106,9 +107,10 @@ bool CJoystickEasterEgg::IsCapturing()
 
 void CJoystickEasterEgg::OnFinish(void)
 {
-  CServiceBroker::GetSettings().ToggleBool(CSettings::SETTING_GAMES_ENABLE);
+  GAME::CGameSettings &gameSettings = CServiceBroker::GetGameServices().GameSettings();
+  gameSettings.ToggleGames();
 
-  WINDOW_SOUND sound = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_GAMES_ENABLE) ? SOUND_INIT : SOUND_DEINIT;
+  WINDOW_SOUND sound = gameSettings.GamesEnabled() ? SOUND_INIT : SOUND_DEINIT;
   g_audioManager.PlayWindowSound(WINDOW_DIALOG_KAI_TOAST, sound);
 
   //! @todo Shake screen

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -426,9 +426,6 @@ const std::string CSettings::SETTING_GENERAL_ADDONBROKENFILTER = "general.addonb
 const std::string CSettings::SETTING_SOURCE_VIDEOS = "source.videos";
 const std::string CSettings::SETTING_SOURCE_MUSIC = "source.music";
 const std::string CSettings::SETTING_SOURCE_PICTURES = "source.pictures";
-const std::string CSettings::SETTING_GAMES_ENABLE = "gamesgeneral.enable";
-const std::string CSettings::SETTING_GAMES_ENABLEREWIND = "gamesgeneral.enablerewind";
-const std::string CSettings::SETTING_GAMES_REWINDTIME = "gamesgeneral.rewindtime";
 
 bool CSettings::Initialize()
 {

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -380,9 +380,6 @@ public:
   static const std::string SETTING_SOURCE_VIDEOS;
   static const std::string SETTING_SOURCE_MUSIC;
   static const std::string SETTING_SOURCE_PICTURES;
-  static const std::string SETTING_GAMES_ENABLE;
-  static const std::string SETTING_GAMES_ENABLEREWIND;
-  static const std::string SETTING_GAMES_REWINDTIME;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.


### PR DESCRIPTION
How autosave works:

If a game supports serialization, it is autosaved alongside the rom (e.g. Mario.smc creates Mario.sav and Mario.xml).

This happens when the game is closed. It also happens every 10 seconds in case of power outage. When the game is resumed, the last savestate is loaded.

This PR adds a setting to disable autosave.

Also includes:

* refactor to avoid polluting settings source folder
* a missing forward-declaration that was interfering with code completion

## Motivation and Context
Reported in March: https://forum.kodi.tv/showthread.php?tid=173361&pid=2709320#pid2709320

## How Has This Been Tested?
Tested on Linux x64 with several GBA cores. When disabled, no autosaves are created or loaded.

## Screenshots (if appropriate):
![autosave setting](https://user-images.githubusercontent.com/531482/42524996-f3bca1dc-8426-11e8-88af-7802a745bfa9.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
