### PR TITLE
[Estuary] Customize Estuary Home Screen and Widgets

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -759,3 +759,10 @@ msgstr ""
 msgctxt "#31166"
 msgid "Profile avatar"
 msgstr ""
+
+#. Label for the menu item selection prompt
+#: /xml/SkinSettings.xml
+msgctxt "#40166"
+msgid "Select menu item to display"
+msgstr ""
+

--- a/addons/skin.estuary/playlists/unwatched_inprogress_tvshows.xsp
+++ b/addons/skin.estuary/playlists/unwatched_inprogress_tvshows.xsp
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<smartplaylist type="tvshows">
+    <name>Unwatched and in Progress TV shows</name>
+    <match>all</match>
+    <rule field="playcount" operator="is">
+        <value>0</value>
+    </rule>
+    <limit>15</limit>
+    <order direction="ascending">random</order>
+</smartplaylist>

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot1))">Skin.SetString(homemenu_slot1,1)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot2))">Skin.SetString(homemenu_slot2,2)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot3))">Skin.SetString(homemenu_slot3,3)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot4))">Skin.SetString(homemenu_slot4,4)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot5))">Skin.SetString(homemenu_slot5,5)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot6))">Skin.SetString(homemenu_slot6,6)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot7))">Skin.SetString(homemenu_slot7,7)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot8))">Skin.SetString(homemenu_slot8,8)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot9))">Skin.SetString(homemenu_slot9,9)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot10))">Skin.SetString(homemenu_slot10,10)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot11))">Skin.SetString(homemenu_slot11,11)</onload>
+	<onload condition="String.IsEmpty(Skin.String(homemenu_slot12))">Skin.SetString(homemenu_slot12,12)</onload>
 	<defaultcontrol>9000</defaultcontrol>
 	<backgroundcolor>background</backgroundcolor>
 	<controls>
@@ -51,37 +63,43 @@
 					<control type="grouplist" id="5001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>5010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(movies) + !Skin.HasSetting(home_no_categories_widget)">
+						<include condition="[String.IsEmpty(Skin.String(movie_categories)) | String.IsEqual(Skin.String(movie_categories),0)] + Library.HasContent(movies)" content="WidgetListCategories">
 							<param name="content_path" value="library://video/movies/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5900"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(movies)">
+						<include condition="String.IsEqual(Skin.String(movie_categories),1) + Library.HasContent(movies)" content="WidgetListCategoriesIcons">
+							<param name="content_path" value="library://video/movies/"/>
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="widget_target" value="videos"/>
+							<param name="list_id" value="5900"/>
+						</include>
+						<include condition="!Skin.HasSetting(no_movie_inprogress) + Library.HasContent(movies)" content="WidgetListPoster">
 							<param name="content_path" value="special://skin/playlists/inprogress_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31010]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5100"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(movies)">
+						<include condition="!Skin.HasSetting(no_movie_recent) + Library.HasContent(movies)" content="WidgetListPoster">
 							<param name="content_path" value="special://skin/playlists/recent_unwatched_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[20386]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5200"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(movies)">
+						<include condition="!Skin.HasSetting(no_movie_unwatched) + Library.HasContent(movies)" content="WidgetListPoster">
 							<param name="content_path" value="special://skin/playlists/unwatched_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31007]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5300"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(movies)">
+						<include condition="!Skin.HasSetting(no_movie_random) + Library.HasContent(movies)" content="WidgetListPoster">
 							<param name="content_path" value="special://skin/playlists/random_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31006]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5400"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(movies)">
+						<include condition="!Skin.HasSetting(no_movie_genres) + Library.HasContent(movies)" content="WidgetListCategories">
 							<param name="content_path" value="videodb://movies/genres/"/>
 							<param name="widget_header" value="$LOCALIZE[135]"/>
 							<param name="widget_target" value="videos"/>
@@ -89,7 +107,7 @@
 							<param name="icon" value="$VAR[WidgetGenreIconVar]"/>
 							<param name="icon_height" value="70"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(movies)">
+						<include condition="!Skin.HasSetting(no_movie_sets) + Library.HasContent(movies)" content="WidgetListPoster">
 							<param name="content_path" value="videodb://movies/sets/"/>
 							<param name="widget_header" value="$LOCALIZE[31075]"/>
 							<param name="widget_target" value="videos"/>
@@ -102,7 +120,7 @@
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,files,return)"/>
 						<param name="button_id" value="5500"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoMovieButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="5010"/>
@@ -115,14 +133,19 @@
 					</include>
 					<control type="grouplist" id="6001">
 						<include>WidgetGroupListCommon</include>
-						<pagecontrol>6010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(tvshows) + !Skin.HasSetting(home_no_categories_widget)">
+						<include condition="[String.IsEmpty(Skin.String(tv_categories)) | String.IsEqual(Skin.String(tv_categories),0)] + Library.HasContent(tvshows)" content="WidgetListCategories">
 							<param name="content_path" value="library://video/tvshows/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6900"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(tvshows)">
+						<include condition="String.IsEqual(Skin.String(tv_categories),1) + Library.HasContent(tvshows)" content="WidgetListCategoriesIcons">
+							<param name="content_path" value="library://video/tvshows/"/>
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="widget_target" value="videos"/>
+							<param name="list_id" value="6900"/>
+						</include>
+						<include condition="!Skin.HasSetting(no_tv_inprogress) + Library.HasContent(tvshows)" content="WidgetListPoster">
 							<param name="content_path" value="videodb://inprogresstvshows"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
@@ -130,19 +153,25 @@
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6100"/>
 						</include>
-						<include content="WidgetListEpisodes" condition="Library.HasContent(tvshows)">
+						<include condition="!Skin.HasSetting(no_tv_recent) + Library.HasContent(tvshows)" content="WidgetListEpisodes">
 							<param name="content_path" value="special://skin/playlists/recent_unwatched_episodes.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[20387]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6200"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(tvshows)">
+						<include condition="!Skin.HasSetting(no_tv_unwatched) + Library.HasContent(tvshows)" content="WidgetListPoster">
 							<param name="content_path" value="special://skin/playlists/unwatched_tvshows.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31122]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6300"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(tvshows)">
+						<include condition="Skin.HasSetting(tv_unwatched_inprogress) + Library.HasContent(tvshows)" content="WidgetListPoster">
+							<param name="content_path" value="special://skin/playlists/unwatched_inprogress_tvshows.xsp"/>
+							<param name="widget_header" value="$LOCALIZE[31122] / $LOCALIZE[626]"/>
+							<param name="widget_target" value="videos"/>
+							<param name="list_id" value="6300"/>
+						</include>
+						<include condition="!Skin.HasSetting(no_tv_genres) + Library.HasContent(tvshows)" content="WidgetListCategories">
 							<param name="content_path" value="videodb://tvshows/genres/"/>
 							<param name="widget_header" value="$LOCALIZE[135]"/>
 							<param name="widget_target" value="videos"/>
@@ -150,7 +179,7 @@
 							<param name="icon" value="$VAR[WidgetGenreIconVar]"/>
 							<param name="icon_height" value="70"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(tvshows)">
+						<include condition="!Skin.HasSetting(no_tv_studios) + Library.HasContent(tvshows)" content="WidgetListCategories">
 							<param name="content_path" value="videodb://tvshows/studios/"/>
 							<param name="widget_header" value="$LOCALIZE[20388]"/>
 							<param name="widget_target" value="videos"/>
@@ -164,7 +193,7 @@
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,files,return)"/>
 						<param name="button_id" value="6400"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoTVShowButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="6010"/>
@@ -177,49 +206,54 @@
 					</include>
 					<control type="grouplist" id="7001">
 						<include>WidgetGroupListCommon</include>
-						<pagecontrol>7010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(music) + !Skin.HasSetting(home_no_categories_widget)">
+						<include condition="[String.IsEmpty(Skin.String(music_categories)) | String.IsEqual(Skin.String(music_categories),0)] + Library.HasContent(music)" content="WidgetListCategories">
 							<param name="content_path" value="library://music/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7900"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
+						<include condition="String.IsEqual(Skin.String(music_categories),1) + Library.HasContent(music)" content="WidgetListCategoriesIcons">
+							<param name="content_path" value="library://music/"/>
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="widget_target" value="music"/>
+							<param name="list_id" value="7900"/>
+						</include>
+						<include condition="!Skin.HasSetting(no_music_recentlyplayed) + Library.HasContent(music)" content="WidgetListSquare">
 							<param name="content_path" value="musicdb://recentlyplayedalbums"/>
 							<param name="widget_header" value="$LOCALIZE[517]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7100"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
+						<include condition="!Skin.HasSetting(no_music_recentlyadded) + Library.HasContent(music)" content="WidgetListSquare">
 							<param name="content_path" value="musicdb://recentlyaddedalbums/"/>
 							<param name="widget_header" value="$LOCALIZE[359]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7200"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
+						<include condition="!Skin.HasSetting(no_music_randomalbums) + Library.HasContent(music)" content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/random_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31012]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7300"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
+						<include condition="!Skin.HasSetting(no_music_randomartists) + Library.HasContent(music)" content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/random_artists.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31013]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7400"/>
 							<param name="fallback_icon" value="DefaultMusicArtists.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
+						<include condition="!Skin.HasSetting(no_music_unplayed) + Library.HasContent(music)" content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/unplayed_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31014]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7500"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
+						<include condition="!Skin.HasSetting(no_music_mostplayed) + Library.HasContent(music)" content="WidgetListSquare">
 							<param name="content_path" value="special://skin/playlists/mostplayed_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31011]"/>
 							<param name="widget_target" value="music"/>
@@ -234,7 +268,7 @@
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(music,files)"/>
 						<param name="button_id" value="7600"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoMusicButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="7010"/>
@@ -247,15 +281,21 @@
 					</include>
 					<control type="grouplist" id="8001">
 						<include>WidgetGroupListCommon</include>
-						<pagecontrol>8010</pagecontrol>
-						<include content="WidgetListCategories" condition="!Skin.HasSetting(home_no_categories_widget)" >
+						<include content="WidgetListCategories">
 							<param name="content_path" value="addons://"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="addonbrowser"/>
 							<param name="list_id" value="8900"/>
-							<param name="visible" value="Integer.IsGreater(Container(8100).NumItems,0) | Integer.IsGreater(Container(8200).NumItems,0) | Integer.IsGreater(Container(8300).NumItems,0) | Integer.IsGreater(Container(8400).NumItems,0) | Integer.IsGreater(Container(8500).NumItems,0) | Integer.IsGreater(Container(8700).NumItems,0)"/>
+							<param name="visible" value="[String.IsEmpty(Skin.String(addon_categories)) | String.IsEqual(Skin.String(addon_categories),0)]  + [[Integer.IsGreater(Container(8100).NumItems,0) | Skin.HasSetting(no_addon_video)] | [Integer.IsGreater(Container(8200).NumItems,0) | Skin.HasSetting(no_addon_audio)] | [Integer.IsGreater(Container(8300).NumItems,0) | Skin.HasSetting(no_addon_program)] | [Integer.IsGreater(Container(8400).NumItems,0) | [System.Platform.Android + Skin.HasSetting(no_addon_android)]] | [Integer.IsGreater(Container(8500).NumItems,0) | Skin.HasSetting(no_addon_image)] | [Integer.IsGreater(Container(8700).NumItems,0) | Skin.HasSetting(no_addon_games)]]" />
 						</include>
-						<include content="WidgetListSquare">
+						<include content="WidgetListCategoriesIcons">
+							<param name="content_path" value="addons://"/>
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="widget_target" value="addonbrowser"/>
+							<param name="list_id" value="8900"/>
+							<param name="visible" value="String.IsEqual(Skin.String(addon_categories),1) + [[Integer.IsGreater(Container(8100).NumItems,0) | Skin.HasSetting(no_addon_video)] | [Integer.IsGreater(Container(8200).NumItems,0) | Skin.HasSetting(no_addon_audio)] | [Integer.IsGreater(Container(8300).NumItems,0) | Skin.HasSetting(no_addon_program)] | [Integer.IsGreater(Container(8400).NumItems,0) | [System.Platform.Android + Skin.HasSetting(no_addon_android)]] | [Integer.IsGreater(Container(8500).NumItems,0) | Skin.HasSetting(no_addon_image)] | [Integer.IsGreater(Container(8700).NumItems,0) | Skin.HasSetting(no_addon_games)]]" />
+						</include>
+						<include condition="!Skin.HasSetting(no_addon_video)" content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/video/"/>
 							<param name="widget_header" value="$LOCALIZE[1037]"/>
 							<param name="widget_target" value="videos"/>
@@ -264,7 +304,7 @@
 							<param name="list_id" value="8100"/>
 							<param name="fallback_icon" value="DefaultAddon.png"/>
 						</include>
-						<include content="WidgetListSquare">
+						<include condition="!Skin.HasSetting(no_addon_audio)" content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/audio/"/>
 							<param name="widget_header" value="$LOCALIZE[1038]"/>
 							<param name="widget_target" value="music"/>
@@ -273,7 +313,7 @@
 							<param name="list_id" value="8200"/>
 							<param name="fallback_icon" value="DefaultAddon.png"/>
 						</include>
-						<include content="WidgetListSquare">
+						<include condition="!Skin.HasSetting(no_addon_games) + System.GetBool(gamesgeneral.enable)" content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/game/"/>
 							<param name="widget_header" value="$LOCALIZE[35049]"/>
 							<param name="widget_target" value="games"/>
@@ -281,9 +321,8 @@
 							<param name="sortorder" value="descending"/>
 							<param name="list_id" value="8700"/>
 							<param name="fallback_icon" value="DefaultAddonGame.png"/>
-							<param name="visible" value="System.GetBool(gamesgeneral.enable)"/>
 						</include>
-						<include content="WidgetListSquare">
+						<include condition="!Skin.HasSetting(no_addon_program)" content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/executable/"/>
 							<param name="widget_header" value="$LOCALIZE[1043]"/>
 							<param name="widget_target" value="programs"/>
@@ -292,7 +331,7 @@
 							<param name="list_id" value="8300"/>
 							<param name="fallback_icon" value="DefaultAddon.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="System.Platform.Android">
+						<include content="WidgetListSquare" condition="System.Platform.Android + !Skin.HasSetting(no_addon_android)">
 							<param name="content_path" value="androidapp://sources/apps/"/>
 							<param name="widget_header" value="$LOCALIZE[20244]"/>
 							<param name="widget_target" value="programs"/>
@@ -301,7 +340,7 @@
 							<param name="list_id" value="8400"/>
 							<param name="fallback_icon" value="DefaultAddon.png"/>
 						</include>
-						<include content="WidgetListSquare">
+						<include condition="!Skin.HasSetting(no_addon_image)" content="WidgetListSquare">
 							<param name="content_path" value="addons://sources/image/"/>
 							<param name="widget_header" value="$LOCALIZE[1039]"/>
 							<param name="widget_target" value="pictures"/>
@@ -314,9 +353,9 @@
 						<param name="text_label" value="$LOCALIZE[31119]" />
 						<param name="button_label" value="$LOCALIZE[31118]" />
 						<param name="button_onclick" value="ActivateWindow(addonbrowser)"/>
-						<param name="button_id" value="8600"/>
-						<param name="visible" value="!Integer.IsGreater(Container(8001).NumItems,0)"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoProgramsButton)"/>
+						<param name="button_id" value="8800"/>
+						<param name="visible" value="[!Integer.IsGreater(Container(8001).NumItems,0)] | String.IsEqual(Skin.String(addon_categories),0)] | Skin.HasSetting(no_addon_video) | Skin.HasSetting(no_addon_audio) | Skin.HasSetting(no_addon_program) | Skin.HasSetting(no_addon_image) | Skin.HasSetting(no_addon_games) | [System.Platform.Android + Skin.HasSetting(no_addon_android)]"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="8010"/>
@@ -330,19 +369,19 @@
 					<control type="grouplist" id="11001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>11010</pagecontrol>
-						<include content="WidgetListCategories">
+						<include condition="!Skin.HasSetting(no_video_categories) + Library.HasContent(video)" content="WidgetListCategories">
 							<param name="content_path" value="library://video/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="11900"/>
 						</include>
-						<include content="WidgetListCategories">
+						<include condition="!Skin.HasSetting(no_video_sources) + Library.HasContent(video)" content="WidgetListCategories">
 							<param name="content_path" value="sources://video/"/>
 							<param name="widget_header" value="$LOCALIZE[20094]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="11100"/>
 						</include>
-						<include content="WidgetListCategories">
+						<include condition="!Skin.HasSetting(no_video_playlists) + Library.HasContent(video)" content="WidgetListCategories">
 							<param name="content_path" value="special://videoplaylists/"/>
 							<param name="widget_header" value="$LOCALIZE[136]"/>
 							<param name="widget_target" value="videos"/>
@@ -355,8 +394,8 @@
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,root)"/>
 						<param name="button_id" value="11300"/>
-						<param name="visible" value="!Integer.IsGreater(Container(11001).NumItems,0)"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoVideosButton)"/>
+						<param name="visible" value="!Library.HasContent(video)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="11010"/>
@@ -399,13 +438,19 @@
 								</include>
 							</control>
 						</control>
-						<include content="WidgetListCategories" condition="System.HasPVRAddon">
+						<include condition="[String.IsEmpty(Skin.String(pvr_categories)) | String.IsEqual(Skin.String(pvr_categories),0)] + System.HasPVRAddon" content="WidgetListCategories">
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="list_id" value="12900"/>
 							<param name="pvr_submenu" value="true"/>
 							<param name="pvr_type" value="TV"/>
 						</include>
-						<include content="WidgetListChannels" condition="System.HasPVRAddon">
+						<include condition="String.IsEqual(Skin.String(pvr_categories),1) + System.HasPVRAddon" content="WidgetListCategoriesIcons">
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="list_id" value="12900"/>
+							<param name="pvr_submenu" value="true"/>
+							<param name="pvr_type" value="TV"/>
+						</include>
+						<include content="WidgetListChannels" condition="!Skin.HasSetting(no_pvr_channels) + System.HasPVRAddon">
 							<param name="content_path" value="pvr://channels/tv/*?view=lastplayed"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
@@ -413,7 +458,7 @@
 							<param name="widget_target" value="pvr"/>
 							<param name="list_id" value="12200"/>
 						</include>
-						<include content="WidgetListChannels" condition="System.HasPVRAddon">
+						<include content="WidgetListChannels" condition="!Skin.HasSetting(no_pvr_recordings) + System.HasPVRAddon">
 							<param name="content_path" value="pvr://recordings/tv/active?view=flat"/>
 							<param name="sortby" value="date"/>
 							<param name="sortorder" value="descending"/>
@@ -429,7 +474,7 @@
 						<param name="button_label" value="$LOCALIZE[31144]" />
 						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://user/xbmc.pvrclient,return)"/>
 						<param name="button_id" value="12400"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoTVButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="12010"/>
@@ -472,13 +517,20 @@
 								</include>
 							</control>
 						</control>
-						<include content="WidgetListCategories" condition="System.HasPVRAddon">
+						<include condition="[String.IsEmpty(Skin.String(radio_categories)) | String.IsEqual(Skin.String(radio_categories),0)] + System.HasPVRAddon" content="WidgetListCategories">
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="list_id" value="13900"/>
 							<param name="pvr_submenu" value="true"/>
 							<param name="pvr_type" value="Radio"/>
 						</include>
-						<include content="WidgetListChannels" condition="System.HasPVRAddon">
+						<include condition="String.IsEqual(Skin.String(radio_categories),1) + System.HasPVRAddon" content="WidgetListCategoriesIcons">
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="list_id" value="13900"/>
+							<param name="pvr_submenu" value="true"/>
+							<param name="pvr_type" value="Radio"/>
+						</include>
+
+						<include content="WidgetListChannels" condition="!Skin.HasSetting(no_radio_channels) + System.HasPVRAddon">
 							<param name="content_path" value="pvr://channels/radio/*?view=lastplayed"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
@@ -486,7 +538,7 @@
 							<param name="widget_target" value="files"/>
 							<param name="list_id" value="13200"/>
 						</include>
-						<include content="WidgetListChannels" condition="System.HasPVRAddon">
+						<include content="WidgetListChannels" condition="!Skin.HasSetting(no_radio_recordings) + System.HasPVRAddon">
 							<param name="content_path" value="pvr://recordings/radio/active?view=flat"/>
 							<param name="sortby" value="date"/>
 							<param name="sortorder" value="descending"/>
@@ -502,7 +554,7 @@
 						<param name="button_label" value="$LOCALIZE[31144]" />
 						<param name="button_onclick" value="ActivateWindow(addonbrowser,addons://user/xbmc.pvrclient,return)"/>
 						<param name="button_id" value="13400"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoRadioButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="13010"/>
@@ -557,7 +609,7 @@
 						<param name="button_id" value="5500"/>
 						<param name="visible" value="!Integer.IsGreater(Container(14100).NumItems,0) + !Container(14100).IsUpdating"/>
 						<param name="visible_1" value="false"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoFavButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="14010"/>
@@ -655,7 +707,7 @@
 						<param name="button_label" value="$LOCALIZE[31121]" />
 						<param name="button_onclick" value="ActivateWindow(servicesettings,weather)"/>
 						<param name="button_id" value="15300"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoWeatherButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="15010"/>
@@ -669,13 +721,19 @@
 					<control type="grouplist" id="16001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>16010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(home_no_categories_widget)">
+						<include content="WidgetListCategories" condition="[String.IsEmpty(Skin.String(musicvideo_categories)) | String.IsEqual(Skin.String(musicvideo_categories),0)] + Library.HasContent(musicvideos)">
 							<param name="content_path" value="library://video/musicvideos/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="16900"/>
 						</include>
-						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos)">
+						<include condition="String.IsEqual(Skin.String(musicvideo_categories),1) + Library.HasContent(musicvideos)" content="WidgetListCategoriesIcons">
+							<param name="content_path" value="library://music/musicvideos/"/>
+							<param name="widget_header" value="$LOCALIZE[31148]"/>
+							<param name="widget_target" value="videos"/>
+							<param name="list_id" value="16900"/>
+						</include>
+						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(no_musicvideo_recent)">
 							<param name="content_path" value="videodb://recentlyaddedmusicvideos/"/>
 							<param name="widget_header" value="$LOCALIZE[20390]"/>
 							<param name="widget_target" value="videos"/>
@@ -685,7 +743,7 @@
 							<param name="fallback_image" value="DefaultMusicSongs.png" />
 							<param name="list_id" value="16300"/>
 						</include>
-						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos)">
+						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(no_musicvideo_unwatched)">
 							<param name="content_path" value="special://skin/playlists/unwatched_musicvideos.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31151]"/>
 							<param name="widget_target" value="videos"/>
@@ -695,14 +753,14 @@
 							<param name="fallback_image" value="DefaultMusicSongs.png" />
 							<param name="list_id" value="16400"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(musicvideos)">
+						<include content="WidgetListSquare" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(no_mvartist_random)">
 							<param name="content_path" value="special://skin/playlists/random_musicvideo_artists.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31013]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="16200"/>
 							<param name="widget_limit" value="10"/>
 						</include>
-						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos)">
+						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(no_musicvideo_random)">
 							<param name="content_path" value="special://skin/playlists/random_musicvideos.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31152]"/>
 							<param name="widget_target" value="videos"/>
@@ -712,7 +770,7 @@
 							<param name="fallback_image" value="DefaultMusicSongs.png" />
 							<param name="list_id" value="16500"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos)">
+						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(no_musicvideo_studio)">
 							<param name="content_path" value="videodb://musicvideos/studios/"/>
 							<param name="widget_header" value="$LOCALIZE[20388]"/>
 							<param name="widget_target" value="music"/>
@@ -726,7 +784,7 @@
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,files,return)"/>
 						<param name="button_id" value="16800"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoMusicVideoButton)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="16010"/>
@@ -739,7 +797,13 @@
 					</include>
 					<control type="grouplist" id="4001">
 						<include>WidgetGroupListCommon</include>
-						<include content="WidgetListCategories" condition="!Skin.HasSetting(HomeMenuNoPicturesButton)">
+						<include content="WidgetListCategories" condition="[String.IsEmpty(Skin.String(picture_sources)) | String.IsEqual(Skin.String(picture_sources),0)]">
+							<param name="content_path" value="sources://pictures/"/>
+							<param name="widget_header" value="$LOCALIZE[20094]"/>
+							<param name="widget_target" value="pictures"/>
+							<param name="list_id" value="4100"/>
+						</include>
+						<include condition="String.IsEqual(Skin.String(picture_sources),1)" content="WidgetListCategoriesIcons">
 							<param name="content_path" value="sources://pictures/"/>
 							<param name="widget_header" value="$LOCALIZE[20094]"/>
 							<param name="widget_target" value="pictures"/>
@@ -755,7 +819,7 @@
 					<control type="grouplist" id="17001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>17010</pagecontrol>
-						<include content="WidgetListSquare">
+						<include content="WidgetListSquare" condition="!Skin.HasSetting(no_games)">
 							<param name="content_path" value="addons://sources/game/"/>
 							<param name="widget_header" value="$LOCALIZE[35049]"/>
 							<param name="widget_target" value="games"/>
@@ -770,8 +834,8 @@
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(games)"/>
 						<param name="button_id" value="17100"/>
-						<param name="visible" value="!Integer.IsGreater(Container(17001).NumItems,0)"/>
-						<param name="button2_onclick" value="Skin.SetBool(HomeMenuNoGamesButton)"/>
+						<param name="visible" value="!Integer.IsGreater(Container(17001).NumItems,0) + !Skin.HasSetting(no_games)"/>
+						<param name="button2_onclick" value="ActivateWindow(skinsettings)"/> 
 					</include>
 					<include content="WidgetScrollbar" condition="Skin.HasSetting(touchmode)">
 						<param name="scrollbar_id" value="17010"/>
@@ -877,34 +941,42 @@
 						</control>
 					</itemlayout>
 					<content>
-						<item>
-							<label>$LOCALIZE[342]</label>
-							<onclick condition="Library.HasContent(movies) + Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://movies/,return)</onclick>
-							<onclick condition="Library.HasContent(movies) + !Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://movies/titles/,return)</onclick>
-							<onclick condition="!Library.HasContent(movies)">ActivateWindow(Videos,sources://video/,return)</onclick>
-							<property name="menu_id">$NUMBER[5000]</property>
-							<thumb>icons/sidemenu/movies.png</thumb>
-							<property name="id">movies</property>
-							<visible>!Skin.HasSetting(HomeMenuNoMovieButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[20343]</label>
-							<onclick condition="Library.HasContent(tvshows) + Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://tvshows/,return)</onclick>
-							<onclick condition="Library.HasContent(tvshows) + !Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
-							<onclick condition="!Library.HasContent(tvshows)">ActivateWindow(Videos,sources://video/,return)</onclick>
-							<property name="menu_id">$NUMBER[6000]</property>
-							<thumb>icons/sidemenu/tv.png</thumb>
-							<property name="id">tvshows</property>
-							<visible>!Skin.HasSetting(HomeMenuNoTVShowButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[2]</label>
-							<onclick>ActivateWindow(Music,root,return)</onclick>
-							<property name="menu_id">$NUMBER[7000]</property>
-							<thumb>icons/sidemenu/music.png</thumb>
-							<property name="id">music</property>
-							<visible>!Skin.HasSetting(HomeMenuNoMusicButton)</visible>
-						</item>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot1)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot2)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot3)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot4)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot5)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot6)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot7)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot8)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot9)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot10)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot11)" />
+						</include>
+						<include content="HomeMenuItem">
+							<param name="menuitem_number" value="Skin.String(homemenu_slot12)" />
+						</include>
 						<item>
 							<label>$LOCALIZE[427]</label>
 							<onclick>PlayDisc</onclick>
@@ -913,80 +985,7 @@
 							<property name="id">disc</property>
 							<visible>System.HasMediaDVD</visible>
 						</item>
-						<item>
-							<label>$LOCALIZE[20389]</label>
-							<property name="menu_id">$NUMBER[16000]</property>
-							<onclick>ActivateWindow(Videos,musicvideos,return)</onclick>
-							<thumb>icons/sidemenu/musicvideos.png</thumb>
-							<property name="id">musicvideos</property>
-							<visible>!Skin.HasSetting(HomeMenuNoMusicVideoButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[19020]</label>
-							<property name="menu_id">$NUMBER[12000]</property>
-							<onclick>ActivateWindow(TVChannels)</onclick>
-							<thumb>icons/sidemenu/livetv.png</thumb>
-							<property name="id">livetv</property>
-							<visible>!Skin.HasSetting(HomeMenuNoTVButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[19021]</label>
-							<property name="menu_id">$NUMBER[13000]</property>
-							<onclick>ActivateWindow(RadioChannels)</onclick>
-							<thumb>icons/sidemenu/radio.png</thumb>
-							<property name="id">radio</property>
-							<visible>!Skin.HasSetting(HomeMenuNoRadioButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[15016]</label>
-							<property name="menu_id">$NUMBER[17000]</property>
-							<onclick>ActivateWindow(Games)</onclick>
-							<thumb>icons/sidemenu/games.png</thumb>
-							<property name="id">games</property>
-							<visible>System.GetBool(gamesgeneral.enable) + !Skin.HasSetting(HomeMenuNoGamesButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[24001]</label>
-							<property name="menu_id">$NUMBER[8000]</property>
-							<onclick>ActivateWindow(1100)</onclick>
-							<thumb>icons/sidemenu/addons.png</thumb>
-							<property name="id">addons</property>
-							<visible>!Skin.HasSetting(HomeMenuNoProgramsButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[1]</label>
-							<onclick>ActivateWindow(Pictures)</onclick>
-							<property name="menu_id">$NUMBER[4000]</property>
-							<thumb>icons/sidemenu/pictures.png</thumb>
-							<property name="id">pictures</property>
-							<visible>!Skin.HasSetting(HomeMenuNoPicturesButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[3]</label>
-							<onclick>ActivateWindow(Videos,root)</onclick>
-							<property name="menu_id">$NUMBER[11000]</property>
-							<thumb>icons/sidemenu/videos.png</thumb>
-							<property name="id">video</property>
-							<visible>!Skin.HasSetting(HomeMenuNoVideosButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[10134]</label>
-							<onclick>ActivateWindow(favourites)</onclick>
-							<property name="menu_id">$NUMBER[14000]</property>
-							<thumb>icons/sidemenu/favourites.png</thumb>
-							<property name="id">favorites</property>
-							<visible>!Skin.HasSetting(HomeMenuNoFavButton)</visible>
-						</item>
-						<item>
-							<label>$LOCALIZE[8]</label>
-							<onclick condition="!String.IsEmpty(Weather.Plugin)">ActivateWindow(Weather)</onclick>
-							<onclick condition="String.IsEmpty(Weather.Plugin)">ReplaceWindow(servicesettings,weather)</onclick>
-							<property name="menu_id">$NUMBER[15000]</property>
-							<thumb>icons/sidemenu/weather.png</thumb>
-							<property name="id">weather</property>
-							<visible>!Skin.HasSetting(HomeMenuNoWeatherButton)</visible>
-						</item>
-					</content>
+				</content>
 				</control>
 				<control type="grouplist" id="700">
 					<orientation>horizontal</orientation>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -403,6 +403,92 @@
 			</control>
 		</definition>
 	</include>
+	<include name="WidgetListCategoriesIcons">
+		<param name="item_limit">20</param>
+		<param name="icon">$INFO[ListItem.Icon]</param>
+		<param name="icon_height">80</param>
+		<param name="pvr_submenu">false</param>
+		<param name="pvr_type">TV</param>
+		<param name="visible">true</param>
+		<definition>
+			<include content="CategoryLabel">
+				<param name="label">$PARAM[widget_header]</param>
+				<param name="list_id" value="$PARAM[list_id]"/>
+				<param name="visible" value="$PARAM[visible] + !Control.HasFocus($PARAM[list_id])"/>
+			</include>
+			<include content="CategoryLabel">
+				<param name="label">$PARAM[widget_header]: $INFO[Container($PARAM[list_id]).Listitem.Label]</param>
+				<param name="list_id" value="$PARAM[list_id]"/>
+				<param name="visible" value="$PARAM[visible] + Control.HasFocus($PARAM[list_id])"/>
+			</include>
+			<include content="BusyListSpinner">
+				<param name="list_id" value="$PARAM[list_id]"/>
+				<param name="visible" value="$PARAM[visible]"/>
+			</include>
+			<control type="panel" id="$PARAM[list_id]">
+				<left></left>
+				<top>110</top>
+				<right>0</right>
+				<height>180</height>
+				<include content="WidgetListCommon">
+					<param name="list_id" value="$PARAM[list_id]"/>
+				</include>
+				<visible>$PARAM[visible]</visible>
+				<visible>Integer.IsGreater(Container($PARAM[list_id]).NumItems,0) | Container($PARAM[list_id]).IsUpdating</visible>
+				<itemlayout width="95" height="115">
+					<control type="group">
+						<left>90</left>
+						<top>10</top>
+						<control type="image">
+							<width>80</width>
+							<height>80</height>
+							<texture>dialogs/dialog-bg-nobo.png</texture>
+							<bordertexture border="21">overlays/shadow.png</bordertexture>
+						</control>
+						<control type="image">
+							<width>80</width>
+							<height>$PARAM[icon_height]</height>
+							<texture fallback="DefaultFolder.png">$PARAM[icon]</texture>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</control>
+				</itemlayout>
+				<focusedlayout width="80" height="115">
+					<control type="group">
+						<depth>DepthContentPopout</depth>
+						<left>90</left>
+						<top>10</top>
+						<control type="image">
+							<width>80</width>
+							<height>80</height>
+							<texture>dialogs/dialog-bg-nobo.png</texture>
+							<bordertexture border="21">overlays/shadow.png</bordertexture>
+						</control>
+						<control type="image">
+							<width>80</width>
+							<height>80</height>
+							<texture colordiffuse="button_focus">colors/grey.png</texture>
+							<include>Animation_FocusTextureFade</include>
+						</control>
+						<control type="image">
+							<width>80</width>
+							<height>$PARAM[icon_height]</height>
+							<texture fallback="DefaultFolder.png">$PARAM[icon]</texture>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</control>
+				</focusedlayout>
+				<include condition="!$PARAM[pvr_submenu]" content="SubmenuContent">
+					<param name="widget_target" value="$PARAM[widget_target]"/>
+					<param name="item_limit" value="$PARAM[item_limit]"/>
+					<param name="content_path" value="$PARAM[content_path]"/>
+				</include>
+				<include condition="$PARAM[pvr_submenu]" content="PVRSubMenuContent">
+					<param name="pvr_type" value="$PARAM[pvr_type]"/>
+				</include>
+			</control>
+		</definition>
+	</include>
 	<include name="SubmenuContent">
 		<content target="$PARAM[widget_target]" limit="$PARAM[item_limit]">$PARAM[content_path]</content>
 	</include>
@@ -942,5 +1028,109 @@
 				<animation effect="slide" end="6,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus($PARAM[scrollbar_id])">conditional</animation>
 			</control>
 		</control>
+	</include>
+	<include name="HomeMenuItem">
+		<param name="menuitem_number" />
+		<definition>
+			<item>
+				<label>$LOCALIZE[342]</label>
+				<onclick condition="Library.HasContent(movies)">ActivateWindow(Videos,videodb://movies/titles/,return)</onclick>
+				<onclick condition="!Library.HasContent(movies)">ActivateWindow(Videos,sources://video/,return)</onclick>
+				<property name="menu_id">$NUMBER[5000]</property>
+				<thumb>icons/sidemenu/movies.png</thumb>
+				<property name="id">movies</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],1)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[20343]</label>
+				<onclick condition="Library.HasContent(tvshows)">ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
+				<onclick condition="!Library.HasContent(tvshows)">ActivateWindow(Videos,sources://video/,return)</onclick>
+				<property name="menu_id">$NUMBER[6000]</property>
+				<thumb>icons/sidemenu/tv.png</thumb>
+				<property name="id">tvshows</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],2)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[2]</label>
+				<onclick>ActivateWindow(Music,root,return)</onclick>
+				<property name="menu_id">$NUMBER[7000]</property>
+				<thumb>icons/sidemenu/music.png</thumb>
+				<property name="id">music</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],3)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[20389]</label>
+				<property name="menu_id">$NUMBER[16000]</property>
+				<onclick>ActivateWindow(Videos,musicvideos,return)</onclick>
+				<thumb>icons/sidemenu/musicvideos.png</thumb>
+				<property name="id">musicvideos</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],4)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[19020]</label>
+				<property name="menu_id">$NUMBER[12000]</property>
+				<onclick>ActivateWindow(TVChannels)</onclick>
+				<thumb>icons/sidemenu/livetv.png</thumb>
+				<property name="id">livetv</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],5)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[19021]</label>
+				<property name="menu_id">$NUMBER[13000]</property>
+				<onclick>ActivateWindow(RadioChannels)</onclick>
+				<thumb>icons/sidemenu/radio.png</thumb>
+				<property name="id">radio</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],6)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[15016]</label>
+				<onclick>ActivateWindow(games)</onclick>
+				<property name="menu_id">$NUMBER[17000]</property>
+				<thumb>icons/sidemenu/games.png</thumb>
+				<property name="id">games</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],7) + System.GetBool(gamesgeneral.enable)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[24001]</label>
+				<property name="menu_id">$NUMBER[8000]</property>
+				<onclick>ActivateWindow(1100)</onclick>
+				<thumb>icons/sidemenu/addons.png</thumb>
+				<property name="id">addons</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],8)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[1]</label>
+				<onclick>ActivateWindow(Pictures)</onclick>
+				<property name="menu_id">$NUMBER[4000]</property>
+				<thumb>icons/sidemenu/pictures.png</thumb>
+				<property name="id">pictures</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],9)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[3]</label>
+				<onclick>ActivateWindow(Videos,root)</onclick>
+				<property name="menu_id">$NUMBER[11000]</property>
+				<thumb>icons/sidemenu/videos.png</thumb>
+				<property name="id">video</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],10)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[10134]</label>
+				<onclick>ActivateWindow(favourites)</onclick>
+				<property name="menu_id">$NUMBER[14000]</property>
+				<thumb>icons/sidemenu/favourites.png</thumb>
+				<property name="id">favorites</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],11)</visible>
+			</item>
+			<item>
+				<label>$LOCALIZE[8]</label>
+				<onclick condition="!String.IsEmpty(Weather.Plugin)">ActivateWindow(Weather)</onclick>
+				<onclick condition="String.IsEmpty(Weather.Plugin)">ReplaceWindow(servicesettings,weather)</onclick>
+				<property name="menu_id">$NUMBER[15000]</property>
+				<thumb>icons/sidemenu/weather.png</thumb>
+				<property name="id">weather</property>
+				<visible>String.IsEqual($PARAM[menuitem_number],12)</visible>
+			</item>
+		</definition>
 	</include>
 </includes>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -83,7 +83,7 @@
 				<onright>60</onright>
 				<onup>600</onup>
 				<ondown>600</ondown>
-				<visible>Container(9000).HasFocus(3)</visible>
+				<visible>Container(9000).HasFocus(4)</visible>
 				<control type="radiobutton" id="605">
 					<label>$LOCALIZE[31002]</label>
 					<include>DefaultSettingButton</include>
@@ -138,105 +138,623 @@
 				<pagecontrol>60</pagecontrol>
 				<ondown>610</ondown>
 				<visible>Container(9000).HasFocus(2)</visible>
-				<control type="radiobutton" id="621">
-					<label>$LOCALIZE[31008]</label>
+				<control type="button" id="611">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot1Var]</label2>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(home_no_categories_widget)</selected>
-					<onclick>Skin.ToggleSetting(home_no_categories_widget)</onclick>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot1),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),0)">Skin.SetString(homemenu_slot1,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),1)">Skin.SetString(homemenu_slot1,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),2)">Skin.SetString(homemenu_slot1,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),3)">Skin.SetString(homemenu_slot1,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),4)">Skin.SetString(homemenu_slot1,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),5)">Skin.SetString(homemenu_slot1,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot1,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot1,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),7)">Skin.SetString(homemenu_slot1,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),8)">Skin.SetString(homemenu_slot1,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),9)">Skin.SetString(homemenu_slot1,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),10)">Skin.SetString(homemenu_slot1,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),11)">Skin.SetString(homemenu_slot1,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot1),12)">Skin.SetString(homemenu_slot1,0)</onclick>
 				</control>
-				<control type="radiobutton" id="611">
-					<label>$LOCALIZE[342]</label>
+				<control type="button" id="612">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot2Var]</label2>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoMovieButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoMovieButton)</onclick>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot2),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),0)">Skin.SetString(homemenu_slot2,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),1)">Skin.SetString(homemenu_slot2,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),2)">Skin.SetString(homemenu_slot2,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),3)">Skin.SetString(homemenu_slot2,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),4)">Skin.SetString(homemenu_slot2,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),5)">Skin.SetString(homemenu_slot2,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot2,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot2,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),7)">Skin.SetString(homemenu_slot2,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),8)">Skin.SetString(homemenu_slot2,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),9)">Skin.SetString(homemenu_slot2,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),10)">Skin.SetString(homemenu_slot2,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),11)">Skin.SetString(homemenu_slot2,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot2),12)">Skin.SetString(homemenu_slot2,0)</onclick>
 				</control>
-				<control type="button" id="6110">
-					<label>- $LOCALIZE[31157]</label>
+				<control type="button" id="613">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot3Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot3),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),0)">Skin.SetString(homemenu_slot3,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),1)">Skin.SetString(homemenu_slot3,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),2)">Skin.SetString(homemenu_slot3,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),3)">Skin.SetString(homemenu_slot3,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),4)">Skin.SetString(homemenu_slot3,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),5)">Skin.SetString(homemenu_slot3,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot3,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot3,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),7)">Skin.SetString(homemenu_slot3,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),8)">Skin.SetString(homemenu_slot3,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),9)">Skin.SetString(homemenu_slot3,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),10)">Skin.SetString(homemenu_slot3,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),11)">Skin.SetString(homemenu_slot3,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot3),12)">Skin.SetString(homemenu_slot3,0)</onclick>
+				</control>
+				<control type="button" id="614">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot4Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot4),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),0)">Skin.SetString(homemenu_slot4,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),1)">Skin.SetString(homemenu_slot4,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),2)">Skin.SetString(homemenu_slot4,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),3)">Skin.SetString(homemenu_slot4,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),4)">Skin.SetString(homemenu_slot4,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),5)">Skin.SetString(homemenu_slot4,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot4,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot4,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),7)">Skin.SetString(homemenu_slot4,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),8)">Skin.SetString(homemenu_slot4,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),9)">Skin.SetString(homemenu_slot4,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),10)">Skin.SetString(homemenu_slot4,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),11)">Skin.SetString(homemenu_slot4,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot4),12)">Skin.SetString(homemenu_slot4,0)</onclick>
+				</control>
+				<control type="button" id="615">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot5Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot5),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),0)">Skin.SetString(homemenu_slot5,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),1)">Skin.SetString(homemenu_slot5,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),2)">Skin.SetString(homemenu_slot5,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),3)">Skin.SetString(homemenu_slot5,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),4)">Skin.SetString(homemenu_slot5,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),5)">Skin.SetString(homemenu_slot5,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot5,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot5,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),7)">Skin.SetString(homemenu_slot5,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),8)">Skin.SetString(homemenu_slot5,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),9)">Skin.SetString(homemenu_slot5,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),10)">Skin.SetString(homemenu_slot5,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),11)">Skin.SetString(homemenu_slot5,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot5),12)">Skin.SetString(homemenu_slot5,0)</onclick>
+				</control>
+				<control type="button" id="616">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot6Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot6),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),0)">Skin.SetString(homemenu_slot6,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),1)">Skin.SetString(homemenu_slot6,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),2)">Skin.SetString(homemenu_slot6,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),3)">Skin.SetString(homemenu_slot6,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),4)">Skin.SetString(homemenu_slot6,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),5)">Skin.SetString(homemenu_slot6,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot6,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot6,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),7)">Skin.SetString(homemenu_slot6,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),8)">Skin.SetString(homemenu_slot6,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),9)">Skin.SetString(homemenu_slot6,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),10)">Skin.SetString(homemenu_slot6,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),11)">Skin.SetString(homemenu_slot6,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot6),12)">Skin.SetString(homemenu_slot6,0)</onclick>
+				</control>
+				<control type="button" id="617">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot7Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot7),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),0)">Skin.SetString(homemenu_slot7,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),1)">Skin.SetString(homemenu_slot7,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),2)">Skin.SetString(homemenu_slot7,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),3)">Skin.SetString(homemenu_slot7,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),4)">Skin.SetString(homemenu_slot7,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),5)">Skin.SetString(homemenu_slot7,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot7,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot7,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),7)">Skin.SetString(homemenu_slot7,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),8)">Skin.SetString(homemenu_slot7,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),9)">Skin.SetString(homemenu_slot7,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),10)">Skin.SetString(homemenu_slot7,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),11)">Skin.SetString(homemenu_slot7,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot7),12)">Skin.SetString(homemenu_slot7,0)</onclick>
+				</control>
+				<control type="button" id="618">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot8Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot8),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),0)">Skin.SetString(homemenu_slot8,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),1)">Skin.SetString(homemenu_slot8,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),2)">Skin.SetString(homemenu_slot8,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),3)">Skin.SetString(homemenu_slot8,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),4)">Skin.SetString(homemenu_slot8,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),5)">Skin.SetString(homemenu_slot8,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot8,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot8,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),7)">Skin.SetString(homemenu_slot8,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),8)">Skin.SetString(homemenu_slot8,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),9)">Skin.SetString(homemenu_slot8,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),10)">Skin.SetString(homemenu_slot8,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),11)">Skin.SetString(homemenu_slot8,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot8),12)">Skin.SetString(homemenu_slot8,0)</onclick>
+				</control>
+				<control type="button" id="619">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot9Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot9),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),0)">Skin.SetString(homemenu_slot9,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),1)">Skin.SetString(homemenu_slot9,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),2)">Skin.SetString(homemenu_slot9,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),3)">Skin.SetString(homemenu_slot9,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),4)">Skin.SetString(homemenu_slot9,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),5)">Skin.SetString(homemenu_slot9,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot9,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot9,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),7)">Skin.SetString(homemenu_slot9,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),8)">Skin.SetString(homemenu_slot9,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),9)">Skin.SetString(homemenu_slot9,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),10)">Skin.SetString(homemenu_slot9,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),11)">Skin.SetString(homemenu_slot9,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot9),12)">Skin.SetString(homemenu_slot9,0)</onclick>
+				</control>
+				<control type="button" id="620">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot10Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot10),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),0)">Skin.SetString(homemenu_slot10,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),1)">Skin.SetString(homemenu_slot10,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),2)">Skin.SetString(homemenu_slot10,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),3)">Skin.SetString(homemenu_slot10,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),4)">Skin.SetString(homemenu_slot10,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),5)">Skin.SetString(homemenu_slot10,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot10,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot10,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),7)">Skin.SetString(homemenu_slot10,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),8)">Skin.SetString(homemenu_slot10,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),9)">Skin.SetString(homemenu_slot10,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),10)">Skin.SetString(homemenu_slot10,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),11)">Skin.SetString(homemenu_slot10,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot10),12)">Skin.SetString(homemenu_slot10,0)</onclick>
+				</control>
+				<control type="button" id="621">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot11Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot11),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),0)">Skin.SetString(homemenu_slot11,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),1)">Skin.SetString(homemenu_slot11,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),2)">Skin.SetString(homemenu_slot11,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),3)">Skin.SetString(homemenu_slot11,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),4)">Skin.SetString(homemenu_slot11,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),5)">Skin.SetString(homemenu_slot11,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot11,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot11,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),7)">Skin.SetString(homemenu_slot11,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),8)">Skin.SetString(homemenu_slot11,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),9)">Skin.SetString(homemenu_slot11,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),10)">Skin.SetString(homemenu_slot11,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),11)">Skin.SetString(homemenu_slot11,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot11),12)">Skin.SetString(homemenu_slot11,0)</onclick>
+				</control>
+				<control type="button" id="622">
+					<label>$LOCALIZE[40166]</label>
+					<label2>$VAR[HomeMenuSlot12Var]</label2>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable) | !String.IsEqual(Skin.String(homemenu_slot12),7)</visible>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),0)">Skin.SetString(homemenu_slot12,1)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),1)">Skin.SetString(homemenu_slot12,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),2)">Skin.SetString(homemenu_slot12,3)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),3)">Skin.SetString(homemenu_slot12,4)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),4)">Skin.SetString(homemenu_slot12,5)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),5)">Skin.SetString(homemenu_slot12,6)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),6) + System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot12,7)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),6) + !System.GetBool(gamesgeneral.enable)">Skin.SetString(homemenu_slot12,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),7)">Skin.SetString(homemenu_slot12,8)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),8)">Skin.SetString(homemenu_slot12,9)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),9)">Skin.SetString(homemenu_slot12,10)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),10)">Skin.SetString(homemenu_slot12,11)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),11)">Skin.SetString(homemenu_slot12,12)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(homemenu_slot12),12)">Skin.SetString(homemenu_slot12,0)</onclick>
+				</control>
+			</control>
+			<control type="grouplist" id="800">
+				<top>160</top>
+				<left>0</left>
+				<right>0</right>
+				<bottom>140</bottom>
+				<onleft>9000</onleft>
+				<onright>60</onright>
+				<onup>800</onup>
+				<ondown>800</ondown>
+				<pagecontrol>60</pagecontrol>
+				<visible>Container(9000).HasFocus(3)</visible>
+				<control type="button" id="801">
+					<label>$LOCALIZE[20342]</label>
+					<include>DefaultSettingButton</include>
+				</control>
+				<control type="button" id="8010">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[MovieCategoriesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(movie_categories))">Skin.SetString(movie_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(movie_categories),2)">Skin.SetString(movie_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(movie_categories),1)">Skin.SetString(movie_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(movie_categories),0)">Skin.SetString(movie_categories,1)</onclick>
+				</control>
+				<control type="button" id="8017">
+					<label>-- $LOCALIZE[31157]</label>
 					<include>DefaultSettingButton</include>
 					<onclick condition="System.HasAddon(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=video,return)</onclick>
 					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
 					<enable>!Skin.HasSetting(HomeMenuNoMovieButton)</enable>
 				</control>
-				<control type="radiobutton" id="612">
+				<control type="radiobutton" id="8011">
+					<label>- $LOCALIZE[31010]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_movie_inprogress)</selected>
+					<onclick>Skin.ToggleSetting(no_movie_inprogress)</onclick>
+				</control>
+				<control type="radiobutton" id="8012">
+					<label>- $LOCALIZE[20386]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_movie_recent)</selected>
+					<onclick>Skin.ToggleSetting(no_movie_recent)</onclick>
+				</control>
+				<control type="radiobutton" id="8013">
+					<label>- $LOCALIZE[31007]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_movie_unwatched)</selected>
+					<onclick>Skin.ToggleSetting(no_movie_unwatched)</onclick>
+				</control>
+				<control type="radiobutton" id="8014">
+					<label>- $LOCALIZE[31006]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_movie_random)</selected>
+					<onclick>Skin.ToggleSetting(no_movie_random)</onclick>
+				</control>
+				<control type="radiobutton" id="8015">
+					<label>- $LOCALIZE[135]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_movie_genres)</selected>
+					<onclick>Skin.ToggleSetting(no_movie_genres)</onclick>
+				</control>
+				<control type="radiobutton" id="8016">
+					<label>- $LOCALIZE[31075]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_movie_sets)</selected>
+					<onclick>Skin.ToggleSetting(no_movie_sets)</onclick>
+				</control>
+				<control type="button" id="802">
 					<label>$LOCALIZE[20343]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoTVShowButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoTVShowButton)</onclick>
 				</control>
-				<control type="button" id="6120">
-					<label>- $LOCALIZE[31157]</label>
+				<control type="button" id="8020">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[TVCategoriesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(tv_categories))">Skin.SetString(tv_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(tv_categories),2)">Skin.SetString(tv_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(tv_categories),1)">Skin.SetString(tv_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(tv_categories),0)">Skin.SetString(tv_categories,1)</onclick>
+				</control>
+				<control type="button" id="8027">
+					<label>-- $LOCALIZE[31157]</label>
 					<include>DefaultSettingButton</include>
 					<onclick condition="System.HasAddon(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=video,return)</onclick>
 					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
 					<enable>!Skin.HasSetting(HomeMenuNoTVShowButton)</enable>
 				</control>
-				<control type="radiobutton" id="613">
+				<control type="radiobutton" id="8021">
+					<label>- $LOCALIZE[626]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_tv_inprogress)</selected>
+					<onclick>Skin.ToggleSetting(no_tv_inprogress)</onclick>
+				</control>
+				<control type="radiobutton" id="8022">
+					<label>- $LOCALIZE[20387]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_tv_recent)</selected>
+					<onclick>Skin.ToggleSetting(no_tv_recent)</onclick>
+				</control>
+				<control type="radiobutton" id="8023">
+					<label>- $LOCALIZE[31122]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_tv_unwatched)</selected>
+					<onclick>Skin.ToggleSetting(no_tv_unwatched)</onclick>
+				</control>
+				<control type="radiobutton" id="8024">
+					<label>- $LOCALIZE[31122] / $LOCALIZE[626]</label>
+					<include>DefaultSettingButton</include>
+					<selected>Skin.HasSetting(tv_unwatched_inprogress)</selected>
+					<onclick>Skin.ToggleSetting(tv_unwatched_inprogress)</onclick>
+				</control>
+				<control type="radiobutton" id="8025">
+					<label>- $LOCALIZE[135]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_tv_genres)</selected>
+					<onclick>Skin.ToggleSetting(no_tv_genres)</onclick>
+				</control>
+				<control type="radiobutton" id="8026">
+					<label>- $LOCALIZE[20388]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_tv_studios)</selected>
+					<onclick>Skin.ToggleSetting(no_tv_studios)</onclick>
+				</control>
+				<control type="button" id="803">
 					<label>$LOCALIZE[2]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoMusicButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoMusicButton)</onclick>
 				</control>
-				<control type="button" id="6130">
-					<label>- $LOCALIZE[31157]</label>
+				<control type="button" id="8030">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[MusicCategoriesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(music_categories))">Skin.SetString(music_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(music_categories),2)">Skin.SetString(music_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(music_categories),1)">Skin.SetString(music_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(music_categories),0)">Skin.SetString(music_categories,1)</onclick>
+				</control>
+				<control type="button" id="8037">
+					<label>-- $LOCALIZE[31157]</label>
 					<include>DefaultSettingButton</include>
 					<onclick condition="System.HasAddon(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=music,return)</onclick>
 					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
 					<enable>!Skin.HasSetting(HomeMenuNoMusicButton)</enable>
 				</control>
-				<control type="radiobutton" id="6131">
-					<label>$LOCALIZE[20389]</label>
+				<control type="radiobutton" id="8031">
+					<label>- $LOCALIZE[517]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoMusicVideoButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoMusicVideoButton)</onclick>
+					<selected>!Skin.HasSetting(no_music_recentlyplayed)</selected>
+					<onclick>Skin.ToggleSetting(no_music_recentlyplayed)</onclick>
 				</control>
-				<control type="radiobutton" id="618">
+				<control type="radiobutton" id="8032">
+					<label>- $LOCALIZE[359]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_music_recentlyadded)</selected>
+					<onclick>Skin.ToggleSetting(no_music_recentlyadded)</onclick>
+				</control>
+				<control type="radiobutton" id="8033">
+					<label>- $LOCALIZE[31012]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_music_randomalbums)</selected>
+					<onclick>Skin.ToggleSetting(no_music_randomalbums)</onclick>
+				</control>
+				<control type="radiobutton" id="8034">
+					<label>- $LOCALIZE[31013]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_music_randomartists)</selected>
+					<onclick>Skin.ToggleSetting(no_music_randomartists)</onclick>
+				</control>
+				<control type="radiobutton" id="8035">
+					<label>- $LOCALIZE[31014]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_music_unplayed)</selected>
+					<onclick>Skin.ToggleSetting(no_music_unplayed)</onclick>
+				</control>
+				<control type="radiobutton" id="8036">
+					<label>- $LOCALIZE[31011]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_music_mostplayed)</selected>
+					<onclick>Skin.ToggleSetting(no_music_mostplayed)</onclick>
+				</control>
+				<control type="button" id="806">
+					<label>20389</label>
+					<include>DefaultSettingButton</include>
+				</control>
+				<control type="button" id="8060">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[MusicVideoCategoriesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(musicvideo_categories))">Skin.SetString(musicvideo_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(musicvideo_categories),2)">Skin.SetString(musicvideo_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(musicvideo_categories),1)">Skin.SetString(musicvideo_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(musicvideo_categories),0)">Skin.SetString(musicvideo_categories,1)</onclick>
+				</control>
+				<control type="button" id="8066">
+					<label>-- $LOCALIZE[31157]</label>
+					<include>DefaultSettingButton</include>
+					<onclick condition="System.HasAddon(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=music,return)</onclick>
+					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
+					<enable>!Skin.HasSetting(HomeMenuNoMusicVideoButton)</enable>
+				</control>
+				<control type="radiobutton" id="8061">
+					<label>- $LOCALIZE[20390]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_musicvideo_recent)</selected>
+					<onclick>Skin.ToggleSetting(no_musicvideo_recent)</onclick>
+				</control>
+				<control type="radiobutton" id="8062">
+					<label>- $LOCALIZE[31151]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_musicvideo_unwatched)</selected>
+					<onclick>Skin.ToggleSetting(no_musicvideo_unwatched)</onclick>
+				</control>
+				<control type="radiobutton" id="8063">
+					<label>- $LOCALIZE[31013]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_mvartist_random)</selected>
+					<onclick>Skin.ToggleSetting(no_mvartist_random)</onclick>
+				</control>
+				<control type="radiobutton" id="8064">
+					<label>- $LOCALIZE[31152]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_musicvideo_random)</selected>
+					<onclick>Skin.ToggleSetting(no_musicvideo_random)</onclick>
+				</control>
+				<control type="radiobutton" id="8065">
+					<label>- $LOCALIZE[20388]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_musicvideo_studio)</selected>
+					<onclick>Skin.ToggleSetting(no_musicvideo_studio)</onclick>
+				</control>
+				<control type="button" id="804">
 					<label>$LOCALIZE[19020]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoTVButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoTVButton)</onclick>
 				</control>
-				<control type="radiobutton" id="619">
+				<control type="button" id="8040">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[PVRCategoriesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(pvr_categories))">Skin.SetString(pvr_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(pvr_categories),2)">Skin.SetString(pvr_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_categories),1)">Skin.SetString(pvr_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(pvr_categories),0)">Skin.SetString(pvr_categories,1)</onclick>
+				</control>
+				<control type="radiobutton" id="8041">
+					<label>- $LOCALIZE[31016]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_pvr_channels)</selected>
+					<onclick>Skin.ToggleSetting(no_pvr_channels)</onclick>
+				</control>
+				<control type="radiobutton" id="8042">
+					<label>- $LOCALIZE[31015]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_pvr_recordings)</selected>
+					<onclick>Skin.ToggleSetting(no_pvr_recordings)</onclick>
+				</control>
+				<control type="button" id="807">
 					<label>$LOCALIZE[19021]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoRadioButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoRadioButton)</onclick>
 				</control>
-				<control type="radiobutton" id="614">
-					<label>$LOCALIZE[24001]</label>
+				<control type="button" id="8070">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[RadioCategoriesTypeVar]</label2>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoProgramsButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoProgramsButton)</onclick>
+					<onclick condition="String.IsEmpty(Skin.String(radio_categories))">Skin.SetString(radio_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(radio_categories),2)">Skin.SetString(radio_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(radio_categories),1)">Skin.SetString(radio_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(radio_categories),0)">Skin.SetString(radio_categories,1)</onclick>
 				</control>
-				<control type="radiobutton" id="615">
+				<control type="radiobutton" id="8071">
+					<label>- $LOCALIZE[31016]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_radio_channels)</selected>
+					<onclick>Skin.ToggleSetting(no_radio_channels)</onclick>
+				</control>
+				<control type="radiobutton" id="8072">
+					<label>- $LOCALIZE[31015]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_radio_recordings)</selected>
+					<onclick>Skin.ToggleSetting(no_radio_recordings)</onclick>
+				</control>
+				<control type="button" id="808">
+					<label>$LOCALIZE[10821]</label>
+					<include>DefaultSettingButton</include>
+					<visible>System.GetBool(gamesgeneral.enable)</visible>
+				</control>				
+				<control type="radiobutton" id="8081">
+					<label>- $LOCALIZE[35049]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_games)</selected>
+					<onclick>Skin.ToggleSetting(no_games)</onclick>
+					<visible>System.GetBool(gamesgeneral.enable)</visible>
+				</control>
+				<control type="button" id="805">
+					<label>$LOCALIZE[24000]</label>
+					<include>DefaultSettingButton</include>
+				</control>
+				<control type="button" id="8050">
+					<label>- $LOCALIZE[31148]</label>
+					<label2>$VAR[AddonCategoriesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(addon_categories))">Skin.SetString(addon_categories,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(addon_categories),2)">Skin.SetString(addon_categories,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(addon_categories),1)">Skin.SetString(addon_categories,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(addon_categories),0)">Skin.SetString(addon_categories,1)</onclick>
+				</control>
+				<control type="radiobutton" id="8051">
+					<label>- $LOCALIZE[1037]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_addon_video)</selected>
+					<onclick>Skin.ToggleSetting(no_addon_video)</onclick>
+				</control>
+				<control type="radiobutton" id="8052">
+					<label>- $LOCALIZE[1038]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_addon_audio)</selected>
+					<onclick>Skin.ToggleSetting(no_addon_audio)</onclick>
+				</control>
+				<control type="radiobutton" id="8053">
+					<label>- $LOCALIZE[35049]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_addon_games)</selected>
+					<onclick>Skin.ToggleSetting(no_addon_games)</onclick>
+					<visible>System.GetBool(gamesgeneral.enable)</visible>
+				</control>
+				<control type="radiobutton" id="8054">
+					<label>- $LOCALIZE[1043]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_addon_program)</selected>
+					<onclick>Skin.ToggleSetting(no_addon_program)</onclick>
+				</control>
+				<control type="radiobutton" id="8055">
+					<label>- $LOCALIZE[20244]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_addon_android)</selected>
+					<onclick>Skin.ToggleSetting(no_addon_android)</onclick>
+					<visible>System.Platform.Android</visible>
+				</control>
+				<control type="radiobutton" id="8056">
+					<label>- $LOCALIZE[1039]</label>
+					<include>DefaultSettingButton</include>
+					<selected>!Skin.HasSetting(no_addon_image)</selected>
+					<onclick>Skin.ToggleSetting(no_addon_image)</onclick>
+				</control>
+				<control type="button" id="809">
 					<label>$LOCALIZE[1]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoPicturesButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoPicturesButton)</onclick>
 				</control>
-				<control type="radiobutton" id="616">
+				<control type="button" id="8090">
+					<label>- $LOCALIZE[20094]</label>
+					<label2>$VAR[PictureSourcesTypeVar]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="String.IsEmpty(Skin.String(picture_sources))">Skin.SetString(picture_sources,1)</onclick>					
+					<onclick condition="String.IsEqual(Skin.String(picture_sources),2)">Skin.SetString(picture_sources,0)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(picture_sources),1)">Skin.SetString(picture_sources,2)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(picture_sources),0)">Skin.SetString(picture_sources,1)</onclick>
+				</control>
+				<control type="button" id="810">
 					<label>$LOCALIZE[3]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoVideosButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoVideosButton)</onclick>
 				</control>
-				<control type="radiobutton" id="620">
-					<label>$LOCALIZE[15016]</label>
-					<visible>System.GetBool(gamesgeneral.enable)</visible>
+				<control type="radiobutton" id="8100">
+					<label>- $LOCALIZE[31148]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoGamesButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoGamesButton)</onclick>
+					<selected>!Skin.HasSetting(no_video_categories)</selected>
+					<onclick>Skin.ToggleSetting(no_video_categories)</onclick>
 				</control>
-				<control type="radiobutton" id="6160">
-					<label>$LOCALIZE[10134]</label>
+				<control type="radiobutton" id="8101">
+					<label>- $LOCALIZE[20094]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoFavButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoFavButton)</onclick>
+					<selected>!Skin.HasSetting(no_video_sources)</selected>
+					<onclick>Skin.ToggleSetting(no_video_sources)</onclick>
 				</control>
-				<control type="radiobutton" id="617">
-					<label>$LOCALIZE[8]</label>
+				<control type="radiobutton" id="8103">
+					<label>- $LOCALIZE[136]</label>
 					<include>DefaultSettingButton</include>
-					<selected>!Skin.HasSetting(HomeMenuNoWeatherButton)</selected>
-					<onclick>Skin.ToggleSetting(HomeMenuNoWeatherButton)</onclick>
+					<selected>!Skin.HasSetting(no_video_playlists)</selected>
+					<onclick>Skin.ToggleSetting(no_video_playlists)</onclick>
 				</control>
 			</control>
 			<control type="image">
@@ -309,6 +827,10 @@
 						<onclick>noop</onclick>
 					</item>
 					<item id="3">
+						<label>$LOCALIZE[31148]</label>
+						<onclick>noop</onclick>
+					</item>
+					<item id="4">
 						<label>$LOCALIZE[31159]</label>
 						<onclick>noop</onclick>
 					</item>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -435,4 +435,250 @@
 		<value condition="!System.IsMaster">$LOCALIZE[20045]</value>
 		<value>$LOCALIZE[20046]</value>
 	</variable>
+	<variable name="TVCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(tv_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(tv_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(tv_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(tv_categories),2)">$LOCALIZE[351]</value> <!-- this is OFF -->
+	</variable>
+	<variable name="MovieCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(movie_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(movie_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(movie_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(movie_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="MusicCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(music_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(music_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(music_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(music_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="MusicVideoCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(musicvideo_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(musicvideo_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(musicvideo_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(musicvideo_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="PVRCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(pvr_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(pvr_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(pvr_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="RadioCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(radio_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(radio_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(radio_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(radio_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="AddonCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(addon_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(addon_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(addon_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(addon_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="PictureSourcesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(picture_sources))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(picture_sources),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(picture_sources),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(picture_sources),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="VideoCategoriesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(video_categories))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(video_categories),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(video_categories),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(video_categories),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="VideoSourcesTypeVar">
+		<value condition="String.IsEmpty(Skin.String(video_sources))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(video_sources),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(video_sources),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(video_sources),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="VideoPlaylistsTypeVar">
+		<value condition="String.IsEmpty(Skin.String(video_playlists))">$LOCALIZE[602]</value>		
+		<value condition="String.IsEqual(Skin.String(video_playlists),0)">$LOCALIZE[602]</value>
+		<value condition="String.IsEqual(Skin.String(video_playlists),1)">$LOCALIZE[536]</value>
+		<value condition="String.IsEqual(Skin.String(video_playlists),2)">$LOCALIZE[351]</value>
+	</variable>
+	<variable name="HomeMenuSlot1Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot1),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot2Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot2),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot3Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot3),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot4Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot4),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot5Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot5),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot6Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot6),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot7Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot7),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot8Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot8),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot9Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot9),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot10Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot10),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot11Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot11),12)">$LOCALIZE[8]</value>
+	</variable>
+	<variable name="HomeMenuSlot12Var">
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),0)">$LOCALIZE[351]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),1)">$LOCALIZE[342]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),2)">$LOCALIZE[20343]</value>	
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),3)">$LOCALIZE[2]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),4)">$LOCALIZE[20389]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),5)">$LOCALIZE[19020]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),6)">$LOCALIZE[19021]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),7)">$LOCALIZE[15016]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),8)">$LOCALIZE[24001]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),9)">$LOCALIZE[1]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),10)">$LOCALIZE[3]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),11)">$LOCALIZE[10134]</value>
+		<value condition="String.IsEqual(Skin.String(homemenu_slot12),12)">$LOCALIZE[8]</value>
+	</variable>
 </includes>


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Pull Request title above -->

## Description
<!--- Describe your change in detail -->
This modification to Estuary provides new options to:
1- have home screen menu items reordered
2- have home menu item widgets disabled
3- have category widgets show as small icons
3- show a TV Show widget the Unwatched/In Progress TV Shows

By default these mods provide the exact same setup as Estuary does currently, including game support. The one thing that is less intuitive is if you have a home section with no content, the DISABLE THIS MENU ITEM button goes to the skin settings instead of just disabling the option. The old way of disabling wouldn't work because of the option to reorder home menu items, and I couldn't find a way for the button to take you right to the menu options skin settings section.

There is currently no "upgrade" from the old settings, so Estuary would reset to its default.  I have thought of a way to do a one time settings read of home menu items, but it's a fair amount of work that I'd rather not do unless the PR is accepted.

These modifications require no additional addons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I've seen a notable number of folks on the forums that really like Estuary but wish they could reorder the home menu and enable/disable widgets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
This code is currently in use in my Kodi 17 and Kodi 18 Estuary mods, so it's been tested by myself and at least a handful of other Kodi users.  I've made adjustments and fixes based on forum feedback.

## Screenshots (if appropriate):
https://github.com/pkscout/repository.skins.pkscout/raw/helix/estuarymods/mainmenuitems-default.png
https://github.com/pkscout/repository.skins.pkscout/raw/helix/estuarymods/mainmenuitems-customized.png
https://github.com/pkscout/repository.skins.pkscout/raw/helix/estuarymods/categories-default.png
https://github.com/pkscout/repository.skins.pkscout/raw/helix/estuarymods/categories-customized.png
https://github.com/pkscout/repository.skins.pkscout/raw/helix/estuarymods/homescreen-customized.png

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

(I called it a breaking change because of the fact that Estuary would revert to the default setup, but I think there's a work around for that)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ x ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x ] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ? ] I have added tests to cover my change
- [ ? ] All new and existing tests passed

(For the last two I'm not sure there are automated tests for skin changes. For the documentation change, I'm happy to do that if this is accepted, but I wasn't sure about changing the Estuary documentation at this stage)
