### PR TITLE
[Android] Remove AudioTrack ENFORCE flag / set LegacyStreamType

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -186,7 +186,8 @@ jni::CJNIAudioTrack *CAESinkAUDIOTRACK::CreateAudioTrack(int stream, int sampleR
     {
       CJNIAudioAttributesBuilder attrBuilder;
       attrBuilder.setUsage(CJNIAudioAttributes::USAGE_MEDIA);
-      attrBuilder.setFlags(CJNIAudioAttributes::FLAG_AUDIBILITY_ENFORCED);
+      attrBuilder.setContentType(CJNIAudioAttributes::CONTENT_TYPE_MUSIC);
+      attrBuilder.setLegacyStreamType(CJNIAudioManager::STREAM_MUSIC);
 
       CJNIAudioFormatBuilder fmtBuilder;
       fmtBuilder.setChannelMask(channelMask);


### PR DESCRIPTION
## Description
Remove AudioTrack ENFORCE flag / set LegacyStreamType

## Motivation and Context
Currently there is no possibility to control audio volume on phones / tablets
It was introduced by failure with using the new AudioTrack ctor.

## How Has This Been Tested?
Android 7 / Mobile phone
Play video, change media volume.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
