### PR TITLE
[Android] Release Surface Buffers 1.5 VSYNC in future and use CLOCK_MONOTONIC

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -53,7 +53,7 @@ public:
   // Player functions
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) = 0;
   virtual bool IsConfigured() = 0;
-  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) = 0;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index) = 0;
   virtual bool IsPictureHW(const VideoPicture &picture) { return false; };
   virtual void UnInit() = 0;
   virtual bool Flush(bool saveBuffers) { return false; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -901,7 +901,7 @@ void CMMALRenderer::UpdateFramerateStats(double pts)
     CLog::Log(LOGDEBUG, "%s::%s pts:%.3f diff:%.3f m_frameInterval:%.6f m_frameIntervalDiff:%.6f", CLASSNAME, __func__, pts*1e-6, diff * 1e-6 , m_frameInterval * 1e-6, m_frameIntervalDiff *1e-6);
 }
 
-void CMMALRenderer::AddVideoPicture(const VideoPicture& pic, int id, double currentClock)
+void CMMALRenderer::AddVideoPicture(const VideoPicture& pic, int id)
 {
   CMMALBuffer *buffer = dynamic_cast<CMMALBuffer*>(pic.videoBuffer);
   assert(buffer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -144,7 +144,7 @@ public:
   virtual void         UnInit();
   virtual bool         Flush(bool saveBuffers) override;
   virtual bool         IsConfigured() override { return m_bConfigured; }
-  virtual void         AddVideoPicture(const VideoPicture& pic, int index, double currentClock) override;
+  virtual void         AddVideoPicture(const VideoPicture& pic, int index) override;
   virtual bool         IsPictureHW(const VideoPicture &picture) override { return false; };
   virtual CRenderInfo GetRenderInfo() override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -82,7 +82,7 @@ bool CRendererAML::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
-void CRendererAML::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
+void CRendererAML::AddVideoPicture(const VideoPicture &picture, int index)
 {
   ReleaseBuffer(index);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -21,7 +21,7 @@ public:
   static bool Register();
 
   virtual bool RenderCapture(CRenderCapture* capture) override;
-  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
   virtual void ReleaseBuffer(int idx) override;
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
   virtual bool IsConfigured() override { return m_bConfigured; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -89,7 +89,7 @@ void CRendererDRMPRIME::ManageRenderArea()
   }
 }
 
-void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, double currentClock)
+void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index)
 {
   BUFFER& buf = m_buffers[index];
   if (buf.videoBuffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -50,7 +50,7 @@ public:
   // Player functions
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
   bool IsConfigured() override { return m_bConfigured; };
-  void AddVideoPicture(const VideoPicture& picture, int index, double currentClock) override;
+  void AddVideoPicture(const VideoPicture& picture, int index) override;
   void UnInit() override {};
   bool Flush(bool saveBuffers) override;
   void ReleaseBuffer(int idx) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -57,7 +57,7 @@ bool CRendererMediaCodec::Register()
   return true;
 }
 
-void CRendererMediaCodec::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
+void CRendererMediaCodec::AddVideoPicture(const VideoPicture &picture, int index)
 {
   CPictureBuffer &buf = m_buffers[index];
   CMediaCodecVideoBuffer *videoBuffer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h
@@ -21,7 +21,7 @@ public:
   static bool Register();
 
   // Player functions
-  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
   virtual void ReleaseBuffer(int idx) override;
 
   // Feature support

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -23,13 +23,13 @@
 #include <chrono>
 
 CRendererMediaCodecSurface::CRendererMediaCodecSurface()
- : m_bConfigured(false)
 {
   CLog::Log(LOGNOTICE, "Instancing CRendererMediaCodecSurface");
 }
 
 CRendererMediaCodecSurface::~CRendererMediaCodecSurface()
 {
+  Reset();
 }
 
 CBaseRenderer* CRendererMediaCodecSurface::Create(CVideoBuffer *buffer)
@@ -81,16 +81,37 @@ bool CRendererMediaCodecSurface::RenderCapture(CRenderCapture* capture)
 
 void CRendererMediaCodecSurface::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
-  if (m_bConfigured && dynamic_cast<CMediaCodecVideoBuffer*>(picture.videoBuffer))
+  ReleaseBuffer(index);
+
+  BUFFER &buf(m_buffers[index]);
+  if (picture.videoBuffer)
   {
-    int64_t nanodiff(static_cast<int64_t>((picture.pts - currentClock) * 1000));
-    dynamic_cast<CMediaCodecVideoBuffer*>(picture.videoBuffer)->RenderUpdate(m_surfDestRect,
-      CurrentHostCounter() + nanodiff);
+    buf.videoBuffer = picture.videoBuffer;
+    buf.videoBuffer->Acquire();
+  }
+}
+
+void CRendererMediaCodecSurface::ReleaseVideoBuffer(int idx, bool render)
+{
+  BUFFER &buf(m_buffers[idx]);
+  if (buf.videoBuffer)
+  {
+    CMediaCodecVideoBuffer *mcvb(dynamic_cast<CMediaCodecVideoBuffer*>(buf.videoBuffer));
+    if (mcvb)
+    {
+      if (render && m_bConfigured)
+        mcvb->RenderUpdate(m_surfDestRect, CXBMCApp::GetNextFrameTime());
+      else
+        mcvb->ReleaseOutputBuffer(render, 0);
+    }
+    buf.videoBuffer->Release();
+    buf.videoBuffer = nullptr;
   }
 }
 
 void CRendererMediaCodecSurface::ReleaseBuffer(int idx)
 {
+  ReleaseVideoBuffer(idx, false);
 }
 
 bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
@@ -104,9 +125,15 @@ bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
   return false;
 }
 
+void CRendererMediaCodecSurface::Reset()
+{
+  for (int i = 0 ; i < 4 ; ++i)
+    ReleaseVideoBuffer(i, false);
+  m_lastIndex = -1;
+}
+
 void CRendererMediaCodecSurface::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
-  CXBMCApp::get()->WaitVSync(100);
   m_bConfigured = true;
 
   // this hack is needed to get the 2D mode of a 3D movie going
@@ -134,6 +161,12 @@ void CRendererMediaCodecSurface::RenderUpdate(int index, int index2, bool clear,
       break;
     default:
       break;
+  }
+
+  if (index != m_lastIndex)
+  {
+    ReleaseVideoBuffer(index, true);
+    m_lastIndex = index;
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -79,7 +79,7 @@ bool CRendererMediaCodecSurface::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
-void CRendererMediaCodecSurface::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
+void CRendererMediaCodecSurface::AddVideoPicture(const VideoPicture &picture, int index)
 {
   ReleaseBuffer(index);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -44,6 +44,15 @@ protected:
   virtual void ReorderDrawPoints() override;
 
 private:
-  bool m_bConfigured;
+  void Reset();
+  void ReleaseVideoBuffer(int idx, bool render);
+
+  bool m_bConfigured = false;
   CRect m_surfDestRect;
+  int m_lastIndex = -1;
+
+  struct BUFFER
+  {
+    CVideoBuffer *videoBuffer = nullptr;
+  } m_buffers[4];
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -22,7 +22,7 @@ public:
   static bool Register();
 
   virtual bool RenderCapture(CRenderCapture* capture) override;
-  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
   virtual void ReleaseBuffer(int idx) override;
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
   virtual bool IsConfigured() override { return m_bConfigured; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -272,7 +272,7 @@ bool CLinuxRendererGL::ConfigChanged(const VideoPicture &picture)
   return false;
 }
 
-void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
+void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index)
 {
   CPictureBuffer &buf = m_buffers[index];
   if (buf.videoBuffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -76,7 +76,7 @@ public:
   // Player functions
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
   bool IsConfigured() override { return m_bConfigured; }
-  void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
+  void AddVideoPicture(const VideoPicture &picture, int index) override;
   void UnInit() override;
   bool Flush(bool saveBuffers) override;
   void SetBufferSize(int numBuffers) override { m_NumYV12Buffers = numBuffers; }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -181,7 +181,7 @@ int CLinuxRendererGLES::NextYV12Texture()
   return (m_iYV12RenderBuffer + 1) % m_NumYV12Buffers;
 }
 
-void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
+void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index)
 {
   CPictureBuffer &buf = m_buffers[index];
   if (buf.videoBuffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -94,7 +94,7 @@ public:
   // Player functions
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
   virtual bool IsConfigured() override { return m_bConfigured; }
-  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
   virtual void UnInit() override;
   virtual bool Flush(bool saveBuffers) override;
   virtual void ReorderDrawPoints() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -908,7 +908,7 @@ bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::
     if (!m_pRenderer)
       return false;
 
-    m_pRenderer->AddVideoPicture(picture, index, m_dvdClock.GetClock());
+    m_pRenderer->AddVideoPicture(picture, index);
   }
 
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -259,7 +259,7 @@ int CWinRenderer::NextBuffer() const
   return -1;
 }
 
-void CWinRenderer::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
+void CWinRenderer::AddVideoPicture(const VideoPicture &picture, int index)
 {
   m_renderBuffers[index].AppendPicture(picture);
   m_renderBuffers[index].frameIdx = m_frameIdx;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -47,7 +47,7 @@ public:
 
   // Player functions
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
-  void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
+  void AddVideoPicture(const VideoPicture &picture, int index) override;
   void UnInit() override;
   bool IsConfigured() override { return m_bConfigured; }
   bool Flush(bool saveBuffers) override;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -152,7 +152,7 @@ public:
   static void SetSystemVolume(float percent);
 
   static void SetRefreshRate(float rate);
-  static void SetDisplayMode(int mode);
+  static void SetDisplayMode(int mode, float rate);
   static int GetDPI();
 
   static CRect MapRenderToDroid(const CRect& srcRect);
@@ -184,6 +184,7 @@ public:
   void ProcessSlow();
 
   static bool WaitVSync(unsigned int milliSeconds);
+  static int64_t GetNextFrameTime(){ return m_frameTimeNanos; };
 
   bool getVideosurfaceInUse();
   void setVideosurfaceInUse(bool videosurfaceInUse);
@@ -237,6 +238,8 @@ private:
   bool XBMC_SetupDisplay();
 
   static uint32_t m_playback_state;
+  static int64_t m_frameTimeNanos;
+  static float m_refreshRate;
 
 public:
   // CJNISurfaceHolderCallback interface

--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -22,7 +22,7 @@
 
 int64_t CurrentHostCounter(void)
 {
-#if   defined(TARGET_DARWIN)
+#if defined(TARGET_DARWIN)
   return( (int64_t)CVGetCurrentHostTime() );
 #elif defined(TARGET_WINDOWS)
   LARGE_INTEGER PerformanceCount;
@@ -30,11 +30,11 @@ int64_t CurrentHostCounter(void)
   return( (int64_t)PerformanceCount.QuadPart );
 #else
   struct timespec now;
-#ifdef CLOCK_MONOTONIC_RAW
+#if defined(CLOCK_MONOTONIC_RAW) && !defined(TARGET_ANDROID)
   clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 #else
   clock_gettime(CLOCK_MONOTONIC, &now);
-#endif // CLOCK_MONOTONIC_RAW
+#endif // CLOCK_MONOTONIC_RAW && !TARGET_ANDROID
   return( ((int64_t)now.tv_sec * 1000000000L) + now.tv_nsec );
 #endif
 }

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -232,7 +232,7 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
 
   if (s_hasModeApi)
   {
-    CXBMCApp::SetDisplayMode(atoi(res.strId.c_str()));
+    CXBMCApp::SetDisplayMode(atoi(res.strId.c_str()), res.fRefreshRate);
     s_res_cur_displayMode = res;
   }
   else if (std::abs(currentRefreshRate() - res.fRefreshRate) > 0.0001)

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -10,6 +10,7 @@
 #include "WinSystemAndroidGLESContext.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
+#include "platform/android/activity/XBMCApp.h"
 
 std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
 {
@@ -91,12 +92,8 @@ bool CWinSystemAndroidGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INF
 
 void CWinSystemAndroidGLESContext::SetVSyncImpl(bool enable)
 {
-  m_iVSyncMode = enable ? 10:0;
-  if (!m_pGLContext.SetVSync(enable))
-  {
-    m_iVSyncMode = 0;
-    CLog::Log(LOGERROR, "%s,Could not set egl vsync", __FUNCTION__);
-  }
+  // We use Choreographer for timing
+  m_pGLContext.SetVSync(false);
 }
 
 void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
@@ -109,16 +106,14 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();
   }
-  if (!rendered)
-    return;
-
   // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
   // we can't actually do anything about it
-  if (!m_pGLContext.TrySwapBuffers() && eglGetError() != EGL_BAD_SURFACE)
+  if (rendered && !m_pGLContext.TrySwapBuffers() && eglGetError() != EGL_BAD_SURFACE)
   {
     CEGLUtils::LogError("eglSwapBuffers failed");
     throw std::runtime_error("eglSwapBuffers failed");
   }
+  CXBMCApp::get()->WaitVSync(1000);
 }
 
 EGLDisplay CWinSystemAndroidGLESContext::GetEGLDisplay() const


### PR DESCRIPTION
## Description

Commit1: Use Choreographer::doFrame callback to evaluate the time, when the next Buffer has to be rendered (Surface only).
Now() at time of doFrame + 1.5 VBLANK times places the frame into a safe position where it is played ~ 2 VSYNCS after the call.
Refering to (libstagefright/VideoFrameScheduler) android uses the CLOCK_MONOTONIC instead CLOCK_MONOTONIC_RAW which kodi uses. This leads to playback issues after some time having the device bootet, because the two clocks differ slightly. For android this PR switches to CLOCK_MONOTONIC now.

Commit2: currentClock parameter of CBaseRenderer::AddVideoPicture was introduced only for android and the Render step which is reworked here. Because the parammeter is not used anymore, the commit removes it.

## Motivation and Context
Fix several posts regarding audio sync adjusting / remove stutter

## How Has This Been Tested?
Shield / AFTV 4K / Wetek HUB

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
