### PR TITLE
[threads] remove const constructor from C(Exclusive|Shared|Single)Lock 

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -499,7 +499,7 @@ protected:
   std::vector<std::string> m_incompatibleAddons;  /*!< Result of addon migration */
 
 private:
-  CCriticalSection m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
+  mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
 
   CCriticalSection m_frameMoveGuard;              /*!< critical section for synchronizing GUI actions from inside and outside (python) */
   std::atomic_uint m_WaitingExternalCalls;        /*!< counts threads wich are waiting to be processed in FrameMove */

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -168,7 +168,7 @@ private:
   void CloseFile(bool reopen = false);
 
   std::shared_ptr<IPlayer> m_pPlayer;
-  CCriticalSection m_playerLock;
+  mutable CCriticalSection m_playerLock;
   CSeekHandler m_seekHandler;
 
   // cache player state

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -60,7 +60,7 @@ private:
 
   ADDON::CAddonMgr& m_addonMgr;
 
-  CCriticalSection m_criticalSection;
+  mutable CCriticalSection m_criticalSection;
   std::vector<CContextMenuItem> m_addonItems;
   std::vector<std::shared_ptr<IContextMenuItem>> m_items;
 };

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -810,5 +810,5 @@ private:
 
   std::vector<GUIViewSortDetails> m_sortDetails;
 
-  CCriticalSection m_lock;
+  mutable CCriticalSection m_lock;
 };

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -146,7 +146,7 @@ private:
   void PrunePackageCache();
   int64_t EnumeratePackageFolder(std::map<std::string,CFileItemList*>& result);
 
-  CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
   JobMap m_downloadJobs;
   CEvent m_idle;
 };

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -309,7 +309,7 @@ namespace ADDON
     std::set<std::string> m_disabled;
     std::set<std::string> m_updateBlacklist;
     static std::map<TYPE, IAddonMgrCallback*> m_managers;
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     CAddonDatabase m_database;
     CEventSource<AddonEvent> m_events;
     CBlockingEventSource<AddonEvent> m_unloadEvents;

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -1103,7 +1103,7 @@ namespace PVR
     std::string            m_strUserPath;         /*!< @brief translated path to the user profile */
     std::string            m_strClientPath;       /*!< @brief translated path to this add-on */
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
 
     AddonInstance_PVR m_struct;
   };

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -149,7 +149,7 @@ namespace ADDON
     void DisableEvent(const std::string& addonId);
     void InstalledChangeEvent();
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
 
     typedef std::map<std::string, BinaryAddonBasePtr> BinaryAddonMgrBaseList;
     BinaryAddonMgrBaseList m_installedAddons;

--- a/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.h
+++ b/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.h
@@ -71,7 +71,7 @@ namespace RETRO
     std::deque<std::unique_ptr<IRenderBuffer>> m_free;
 
     std::vector<CRPBaseRenderer*> m_renderers;
-    CCriticalSection m_rendererMutex;
+    mutable CCriticalSection m_rendererMutex;
     CCriticalSection m_bufferMutex;
   };
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferManager.h
@@ -57,7 +57,7 @@ namespace RETRO
     };
 
     std::vector<RenderBufferPools> m_pools;
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.h
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettings.h
@@ -61,7 +61,7 @@ namespace RETRO
     CRenderSettings m_renderSettings;
 
     // Synchronization parameters
-    CCriticalSection m_mutex;
+    mutable CCriticalSection m_mutex;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.h
@@ -62,7 +62,7 @@ namespace RETRO
     CRect m_renderDimensions;
 
     // Synchronization parameters
-    CCriticalSection m_mutex;
+    mutable CCriticalSection m_mutex;
   };
 }
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -517,7 +517,7 @@ protected:
 
   struct SContent
   {
-    CCriticalSection m_section;
+    mutable CCriticalSection m_section;
     CSelectionStreams m_selectionStreams;
     std::vector<ProgramInfo> m_programs;
     int m_program;
@@ -582,7 +582,7 @@ protected:
   } m_dvd;
 
   SPlayerState m_State;
-  CCriticalSection m_StateSection;
+  mutable CCriticalSection m_StateSection;
   XbmcThreads::EndTime m_syncTimer;
 
   CEdl m_Edl;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -114,7 +114,7 @@ protected:
     bool             passthrough = false;
   };
 
-  CCriticalSection m_info_section;
+  mutable CCriticalSection m_info_section;
   SInfo            m_info;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.h
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.h
@@ -62,7 +62,7 @@ class CVideoReferenceClock : CThread
 
     CEvent m_vsyncStopEvent;
 
-    CCriticalSection m_CritSection;
+    mutable CCriticalSection m_CritSection;
 
     std::unique_ptr<CVideoSync> m_pVideoSync;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -147,7 +147,7 @@ protected:
   CBaseRenderer *m_pRenderer = nullptr;
   OVERLAY::CRenderer m_overlays;
   CDebugRenderer m_debugRenderer;
-  CCriticalSection m_statelock;
+  mutable CCriticalSection m_statelock;
   CCriticalSection m_presentlock;
   CCriticalSection m_datalock;
   bool m_bTriggerUpdateResolution = false;

--- a/xbmc/cores/omxplayer/OMXAudio.h
+++ b/xbmc/cores/omxplayer/OMXAudio.h
@@ -180,5 +180,5 @@ protected:
   COMXCoreTunnel    m_omx_tunnel_splitter_analog;
   COMXCoreTunnel    m_omx_tunnel_splitter_hdmi;
 
-  CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
 };

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -76,5 +76,5 @@ private:
 
   std::vector<CPlayerCoreConfig *> m_vecPlayerConfigs;
   std::vector<CPlayerSelectionRule *> m_vecCoreSelectionRules;
-  CCriticalSection m_section;
+  mutable CCriticalSection m_section;
 };

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.h
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.h
@@ -48,7 +48,7 @@ public:
   void SetProgress(int currentItem, int itemCount);
 
 private:
-  CCriticalSection  m_critSection;
+  mutable CCriticalSection m_critSection;
   float             m_fPercentage;
   std::string       m_strTitle;
   std::string       m_strText;

--- a/xbmc/dialogs/GUIDialogVolumeBar.h
+++ b/xbmc/dialogs/GUIDialogVolumeBar.h
@@ -42,5 +42,5 @@ public:
 
 private:
   std::set<IGUIVolumeBarCallback*> m_callbacks;
-  CCriticalSection m_callbackMutex;
+  mutable CCriticalSection m_callbackMutex;
 };

--- a/xbmc/events/EventLog.h
+++ b/xbmc/events/EventLog.h
@@ -70,5 +70,5 @@ private:
   typedef std::map<std::string, EventPtr> EventsMap;
   EventsList m_events;
   EventsMap m_eventsMap;
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 };

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -61,6 +61,6 @@ private:
   std::string m_userDataFolder;
   CFileItemList m_favourites;
   CEventSource<FavouritesUpdated> m_events;
-  CCriticalSection m_criticalSection;
+  mutable CCriticalSection m_criticalSection;
 };
 

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -73,7 +73,7 @@ namespace XFILE
     typedef std::map<std::string, CDir*>::const_iterator ciCache;
     void Delete(iCache i);
 
-    CCriticalSection m_cs;
+    mutable CCriticalSection m_cs;
 
     unsigned int m_accessCounter;
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -1038,7 +1038,7 @@ void CGUIWindow::SetProperty(const std::string &strKey, const CVariant &value)
 
 CVariant CGUIWindow::GetProperty(const std::string &strKey) const
 {
-  CSingleLock lock(*this);
+  CSingleLock lock(const_cast<CGUIWindow&>(*this));
   std::map<std::string, CVariant, icompare>::const_iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
     return CVariant(CVariant::VariantTypeNull);

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -73,7 +73,7 @@ protected:
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;
   typedef std::map<uint32_t, LocStr>::iterator       iStrings;
 
-  CSharedSection m_stringsMutex;
+  mutable CSharedSection m_stringsMutex;
   CSharedSection m_addonStringsMutex;
 };
 

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -158,5 +158,5 @@ private:
 
   std::map<std::string, int> m_scriptPaths;
   int m_nextId = 0;
-  CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
 };

--- a/xbmc/interfaces/python/pythreadstate.h
+++ b/xbmc/interfaces/python/pythreadstate.h
@@ -68,6 +68,6 @@ class CPyThreadState
 class GilSafeSingleLock : public CPyThreadState, public CSingleLock
 {
 public:
-  explicit GilSafeSingleLock(const CCriticalSection& critSec) : CPyThreadState(true), CSingleLock(critSec) { CPyThreadState::Restore(); }
+  explicit GilSafeSingleLock(CCriticalSection& critSec) : CPyThreadState(true), CSingleLock(critSec) { CPyThreadState::Restore(); }
 };
 

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -84,7 +84,7 @@ private:
   unsigned int     m_currentLimit;
   std::vector<CGUIStaticItemPtr> m_items;
   std::vector<InfoTagType> m_itemTypes;
-  CCriticalSection m_section;
+  mutable CCriticalSection m_section;
 
   bool UpdateURL();
   bool UpdateLimit();

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -133,6 +133,6 @@ private:
   std::string m_authenticationPassword;
   std::string m_key;
   std::string m_cert;
-  CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
   std::vector<IHTTPRequestHandler *> m_requestHandlers;
 };

--- a/xbmc/network/upnp/UPnPSettings.h
+++ b/xbmc/network/upnp/UPnPSettings.h
@@ -61,5 +61,5 @@ private:
   std::string m_rendererUUID;
   int m_rendererPort;
 
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 };

--- a/xbmc/peripherals/EventScanner.h
+++ b/xbmc/peripherals/EventScanner.h
@@ -82,7 +82,7 @@ namespace PERIPHERALS
     std::set<void*> m_activeLocks;
     CEvent m_scanEvent;
     CEvent m_scanFinishedEvent;
-    CCriticalSection m_handleMutex;
+    mutable CCriticalSection m_handleMutex;
     CCriticalSection m_lockMutex;
     CCriticalSection m_pollMutex; // Prevent two poll handles from polling at once
   };

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -358,7 +358,7 @@ namespace PERIPHERALS
     std::vector<PeripheralBusPtr> m_busses;
     std::vector<PeripheralDeviceMapping> m_mappings;
     std::unique_ptr<CEventScanner> m_eventScanner;
-    CCriticalSection m_critSectionBusses;
-    CCriticalSection m_critSectionMappings;
+    mutable CCriticalSection m_critSectionBusses;
+    mutable CCriticalSection m_critSectionMappings;
   };
 }

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -169,6 +169,6 @@ namespace PERIPHERALS
     FeatureMap          m_features;
     DriverMap           m_driverMap;
     JoystickPrimitiveVector m_ignoredPrimitives;
-    CCriticalSection    m_mutex;
+    mutable CCriticalSection m_mutex;
   };
 }

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -176,7 +176,7 @@ namespace PERIPHERALS
     CCriticalSection m_buttonMapMutex;
 
     /* @brief Thread synchronization */
-    CCriticalSection    m_critSection;
+    mutable CCriticalSection m_critSection;
 
     AddonInstance_Peripheral m_struct;
 

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -197,7 +197,7 @@ namespace PERIPHERALS
     bool                       m_bNeedsPolling; /*!< true when this bus needs to be polled for new devices, false when it uses callbacks to notify this bus of changed */
     CPeripherals&              m_manager;
     const PeripheralBusType    m_type;
-    CCriticalSection           m_critSection;
+    mutable CCriticalSection   m_critSection;
     CEvent                     m_triggerEvent;
   };
   using PeripheralBusPtr = std::shared_ptr<CPeripheralBus>;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -171,7 +171,7 @@ namespace PERIPHERALS
     bool m_bDeviceRemoved;
     CPeripheralCecAdapterUpdateThread*m_queryThread;
     CEC::ICECCallbacks m_callbacks;
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     CEC::libcec_configuration m_configuration;
     bool m_bActiveSourcePending;
     bool m_bStandbyPending;

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
@@ -59,6 +59,6 @@ private:
 
   CPeripherals *m_manager = nullptr;
   CFileItemList m_peripherals;
-  CCriticalSection m_peripheralsMutex;
+  mutable CCriticalSection m_peripheralsMutex;
 };
 }

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -215,7 +215,7 @@ private:
   unsigned int m_lastUsedProfile;
   unsigned int m_currentProfile; // do not modify directly, use SetCurrentProfileId() function instead
   int m_nextProfileId; // for tracking the next available id to give to a new profile to ensure id's are not re-used
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 
   // Event properties
   std::unique_ptr<CEventLogManager> m_eventLogs;

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -98,7 +98,7 @@ protected:
    */
   size_t GetCurrentDigitCount() const { return m_inputBuffer.size(); }
 
-  CCriticalSection m_mutex;
+  mutable CCriticalSection m_mutex;
 
 private:
   void ExecuteAction();

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -494,7 +494,7 @@ namespace PVR
     bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
     bool IsNextEventWithinBackendIdleTime(void) const;
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
     bool m_bChannelScanRunning = false;
     CPVRSettings m_settings;

--- a/xbmc/pvr/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/PVRGUIChannelNavigator.h
@@ -113,7 +113,7 @@ namespace PVR
      */
     void ShowInfo(bool bForce);
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     CPVRChannelPtr m_playingChannel;
     CPVRChannelPtr m_currentChannel;
     int m_iChannelEntryJobId = -1;

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -191,7 +191,7 @@ namespace PVR
     time_t                          m_iTimeshiftPlayTime;
     unsigned int                    m_iTimeshiftOffset;
 
-    CCriticalSection                m_critSection;
+    mutable CCriticalSection m_critSection;
 
     /**
      * The various backend-related fields will only be updated when this

--- a/xbmc/pvr/PVRGUITimerInfo.h
+++ b/xbmc/pvr/PVRGUITimerInfo.h
@@ -81,7 +81,7 @@ namespace PVR
     unsigned int m_iTimerInfoToggleStart;
     unsigned int m_iTimerInfoToggleCurrent;
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
   };
 
   class CPVRGUIAnyTimerInfo : public CPVRGUITimerInfo

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -532,11 +532,11 @@ namespace PVR
     CPVRManagerJobQueue             m_pendingUpdates;              /*!< vector of pending pvr updates */
 
     CPVRDatabasePtr                 m_database;                    /*!< the database for all PVR related data */
-    CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
+    mutable CCriticalSection        m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
     bool                            m_bFirstStart = true;                 /*!< true when the PVR manager was started first, false otherwise */
     bool                            m_bEpgsCreated = false;                /*!< true if epg data for channels has been created */
 
-    CCriticalSection                m_managerStateMutex;
+    mutable CCriticalSection        m_managerStateMutex;
     ManagerState                    m_managerState = ManagerStateStopped;
     std::unique_ptr<CStopWatch>     m_parentalTimer;
 

--- a/xbmc/pvr/PVRSettings.h
+++ b/xbmc/pvr/PVRSettings.h
@@ -59,7 +59,7 @@ namespace PVR
 
     void Init(const std::set<std::string> &settingNames);
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     std::map<std::string, std::shared_ptr<CSetting>> m_settings;
   };
 }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -367,7 +367,7 @@ namespace PVR
      */
     PVR_ERROR ForCreatedClients(const char* strFunctionName, PVRClientFunction function, std::vector<int> &failedClients) const;
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     CPVRClientMap m_clientMap;
   };
 }

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -469,6 +469,6 @@ namespace PVR
     std::string      m_strClientEncryptionName; /*!< the name of the encryption system used by this channel */
     //@}
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
   };
 }

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -537,7 +537,7 @@ namespace PVR
     int              m_iPosition = 0;                   /*!< the position of this group within the group list */
     PVR_CHANNEL_GROUP_SORTED_MEMBERS m_sortedMembers; /*!< members sorted by channel number */
     PVR_CHANNEL_GROUP_MEMBERS        m_members;       /*!< members with key clientid+uniqueid */
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClientsForChannels;
     std::vector<int> m_failedClientsForChannelGroupMembers;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -222,7 +222,7 @@ namespace PVR
     bool                             m_bRadio;         /*!< true if this is a container for radio channels, false if it is for tv channels */
     CPVRChannelGroupPtr              m_selectedGroup;  /*!< the group that's currently selected in the UI */
     std::vector<CPVRChannelGroupPtr> m_groups;         /*!< the groups in this container */
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClientsForChannelGroups;
   };
 }

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -341,7 +341,7 @@ namespace PVR
 
     PVR::CPVRChannelPtr                 m_pvrChannel;      /*!< the channel this EPG belongs to */
 
-    CCriticalSection                    m_critSection;     /*!< critical section for changes in this table */
+    mutable CCriticalSection            m_critSection;     /*!< critical section for changes in this table */
     bool                                m_bUpdateLastScanTime = false;
   };
 }

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -272,7 +272,7 @@ namespace PVR
     EPGMAP       m_epgs;                   /*!< the EPGs in this container */
     //@}
 
-    CCriticalSection               m_critSection;    /*!< a critical section for changes to this container */
+    mutable CCriticalSection       m_critSection;    /*!< a critical section for changes to this container */
     CEvent                         m_updateEvent;    /*!< trigger when an update finishes */
 
     std::list<CEpgUpdateRequest> m_updateRequests; /*!< list of update requests triggered by addon */

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -533,7 +533,7 @@ namespace PVR
     unsigned int             m_iFlags;             /*!< the flags applicable to this EPG entry */
     std::string              m_strSeriesLink;      /*!< series link */
 
-    CCriticalSection         m_critSection;
+    mutable CCriticalSection m_critSection;
     PVR::CPVRChannelPtr      m_channel;
     PVR::CPVRRecordingPtr    m_recording;
   };

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -100,7 +100,7 @@ namespace PVR
     typedef PVR_RECORDINGMAP::iterator PVR_RECORDINGMAP_ITR;
     typedef PVR_RECORDINGMAP::const_iterator PVR_RECORDINGMAP_CITR;
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     bool m_bIsUpdating = false;
     PVR_RECORDINGMAP m_recordings;
     unsigned int m_iLastId = 0;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -315,7 +315,7 @@ namespace PVR
     std::string GetWeekdaysString() const;
     void UpdateEpgInfoTag(void);
 
-    CCriticalSection      m_critSection;
+    mutable CCriticalSection m_critSection;
     CDateTime             m_StartTime; /*!< start time */
     CDateTime             m_StopTime;  /*!< stop time */
     CDateTime             m_FirstDay;  /*!< if it is a manual timer rule the first date it starts */

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -71,7 +71,7 @@ namespace PVR
   protected:
     void InsertTimer(const CPVRTimerInfoTagPtr &newTimer);
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     unsigned int m_iLastId = 0;
     MapTags m_tags;
   };

--- a/xbmc/pvr/windows/GUIEPGGridContainer.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.h
@@ -234,7 +234,7 @@ namespace PVR
     float m_channelScrollSpeed;
     float m_channelScrollOffset;
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
     std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
     std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
     std::unique_ptr<CGUIEPGGridContainerModel> m_outdatedGridModel;

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -136,5 +136,5 @@ private:
   bool  m_nonLinearStretched;   // current non-linear stretch
 
   bool m_resolutionChangeAborted;
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 };

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -125,5 +125,5 @@ private:
   int m_musicNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
   int m_videoNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)
 
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 };

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -293,7 +293,7 @@ protected:
 
   bool m_initialized = false;
   CSettingsManager* m_settingsManager;
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 private:
   CSettingsBase(const CSettingsBase&) = delete;
   CSettingsBase& operator=(const CSettingsBase&) = delete;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -117,7 +117,7 @@ protected:
   SettingDependencies m_dependencies;
   std::set<CSettingUpdate> m_updates;
   bool m_changed = false;
-  CSharedSection m_critical;
+  mutable CSharedSection m_critical;
 };
 
 template<typename TValue, SettingType TSettingType>

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -547,6 +547,6 @@ private:
   using SettingOptionsFillerMap = std::map<std::string, SettingOptionsFiller>;
   SettingOptionsFillerMap m_optionsFillers;
 
-  CSharedSection m_critical;
-  CSharedSection m_settingsCritical;
+  mutable CSharedSection m_critical;
+  mutable CSharedSection m_settingsCritical;
 };

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -61,7 +61,6 @@ class CExclusiveLock : public XbmcThreads::UniqueLock<CSharedSection>
 {
 public:
   inline explicit CExclusiveLock(CSharedSection& cs) : XbmcThreads::UniqueLock<CSharedSection>(cs) {}
-  inline explicit CExclusiveLock(const CSharedSection& cs) : XbmcThreads::UniqueLock<CSharedSection> ((CSharedSection&)cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
   inline void Leave() { unlock(); }

--- a/xbmc/threads/SharedSection.h
+++ b/xbmc/threads/SharedSection.h
@@ -51,7 +51,6 @@ class CSharedLock : public XbmcThreads::SharedLock<CSharedSection>
 {
 public:
   inline explicit CSharedLock(CSharedSection& cs) : XbmcThreads::SharedLock<CSharedSection>(cs) {}
-  inline explicit CSharedLock(const CSharedSection& cs) : XbmcThreads::SharedLock<CSharedSection>((CSharedSection&)cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
   inline void Enter() { lock(); }

--- a/xbmc/threads/SingleLock.h
+++ b/xbmc/threads/SingleLock.h
@@ -37,7 +37,6 @@ class CSingleLock : public XbmcThreads::UniqueLock<CCriticalSection>
 {
 public:
   inline explicit CSingleLock(CCriticalSection& cs) : XbmcThreads::UniqueLock<CCriticalSection>(cs) {}
-  inline explicit CSingleLock(const CCriticalSection& cs) : XbmcThreads::UniqueLock<CCriticalSection> ((CCriticalSection&)cs) {}
 
   inline void Leave() { unlock(); }
   inline void Enter() { lock(); }

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -185,7 +185,7 @@ private:
 
   unsigned int m_jobsAtOnce;
   CJob::PRIORITY m_priority;
-  CCriticalSection m_section;
+  mutable CCriticalSection m_section;
   bool m_lifo;
 };
 
@@ -378,7 +378,7 @@ private:
   Processing m_processing;
   Workers    m_workers;
 
-  CCriticalSection m_section;
+  mutable CCriticalSection m_section;
   CEvent           m_jobEvent;
   bool             m_running;
 };

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -111,5 +111,5 @@ protected:
 
   std::atomic<bool>       m_bObservableChanged{false}; /*!< true when the observable is marked as changed, false otherwise */
   std::vector<Observer *> m_observers;                 /*!< all observers */
-  CCriticalSection        m_obsCritSection;            /*!< mutex */
+  mutable CCriticalSection m_obsCritSection; /*!< mutex */
 };

--- a/xbmc/view/ViewStateSettings.h
+++ b/xbmc/view/ViewStateSettings.h
@@ -68,7 +68,7 @@ private:
   SettingLevel m_settingLevel = SettingLevel::Standard;
   EventLevel m_eventLevel = EventLevel::Basic;
   bool m_eventShowHigherLevels = true;
-  CCriticalSection m_critical;
+  mutable CCriticalSection m_critical;
 
   void AddViewState(const std::string& strTagName, int defaultView = DEFAULT_VIEW_LIST, SortBy defaultSort = SortByLabel);
 };

--- a/xbmc/windowing/wayland/Output.h
+++ b/xbmc/windowing/wayland/Output.h
@@ -143,8 +143,8 @@ private:
   wayland::output_t m_output;
   std::function<void()> m_doneHandler;
 
-  CCriticalSection m_geometryCriticalSection;
-  CCriticalSection m_iteratorCriticalSection;
+  mutable CCriticalSection m_geometryCriticalSection;
+  mutable CCriticalSection m_iteratorCriticalSection;
 
   CPointInt m_position;
   CSizeInt m_physicalSize;

--- a/xbmc/windowing/wayland/SeatSelection.h
+++ b/xbmc/windowing/wayland/SeatSelection.h
@@ -53,7 +53,7 @@ private:
   std::vector<std::string> m_mimeTypeOffers;
   std::string m_matchedMimeType;
 
-  CCriticalSection m_currentSelectionMutex;
+  mutable CCriticalSection m_currentSelectionMutex;
 };
 
 }


### PR DESCRIPTION
## Description
Instead of casting constness away, mark the lock variables mutable if they are used in const functions.

## Motivation and Context
Although casting away the constness of CCriticalSection is allowed in this cases (as the variables aren't declared as const), it still is a hack.

## How Has This Been Tested?
compiled for android, ios, linux, osx and windows

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
