### PR TITLE
gbm/windowing: reset planes on startup

### DIFF
--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -36,6 +36,7 @@ public:
 
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
+  bool ResetPlanes();
 
   bool m_need_modeset;
   bool m_active = true;

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -134,7 +134,7 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
   return fb;
 }
 
-static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object)
+bool CDRMUtils::GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object)
 {
   drmModeObjectPropertiesPtr props = drmModeObjectGetProperties(fd, id, type);
   if (!props)
@@ -151,7 +151,7 @@ static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object 
   return true;
 }
 
-static void FreeProperties(struct drm_object *object)
+void CDRMUtils::FreeProperties(struct drm_object *object)
 {
   if (object->props_info)
   {

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -101,6 +101,8 @@ protected:
   bool OpenDrm();
   uint32_t GetPropertyId(struct drm_object *object, const char *name);
   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
+  static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object);
+  static void FreeProperties(struct drm_object *object);
 
   int m_fd;
   struct connector *m_connector = nullptr;


### PR DESCRIPTION
We want to clear the frame buffer upon startup as there is the possibility that it is displaying something. Since we now run the Kodi GUI on the overlay plane all the time there is the possibility that we can see something on the primary plane.

@Kwiboo for review