### PR TITLE
[lang] Uniformize "not available" string usage

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -685,10 +685,7 @@ msgctxt "#160"
 msgid "Free"
 msgstr ""
 
-#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
-msgctxt "#161"
-msgid "Unavailable"
-msgstr ""
+#empty string with id 161
 
 msgctxt "#162"
 msgid "Tray open"
@@ -1958,11 +1955,7 @@ msgctxt "#415"
 msgid "Downloading thumbnail..."
 msgstr ""
 
-#: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
-msgctxt "#416"
-msgid "Not available"
-msgstr ""
+#empty string with id 416
 
 msgctxt "#417"
 msgid "View: Big icons"
@@ -4785,7 +4778,23 @@ msgctxt "#10004"
 msgid "Settings"
 msgstr ""
 
-#empty strings from id 10005 to 10006
+#: addons/skin.estouchy/xml/DialogAddonInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogSeekBar.xml
+#: xbmc/LangInfo.cpp
+#: xbmc/addons/Scraper.cpp
+#: xbmc/addons/addons/GUIDialogAddonInfo.cpp
+#: xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+#: xbmc/utils/SystemInfo.cpp
+msgctxt "#10005"
+msgid "Not available"
+msgstr ""
+
+#. Abbreviation of "Not Available"
+#: xbmc/utils/SystemInfo.cpp
+msgctxt "#10006"
+msgid "N/A"
+msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10007"

--- a/addons/skin.estouchy/xml/DialogAddonInfo.xml
+++ b/addons/skin.estouchy/xml/DialogAddonInfo.xml
@@ -106,7 +106,7 @@
 					<posy>0</posy>
 					<width>730</width>
 					<height>25</height>
-					<label fallback="416">$INFO[ListItem.AddonType]</label>
+					<label fallback="10005">$INFO[ListItem.AddonType]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font20</font>
@@ -129,7 +129,7 @@
 					<posy>30</posy>
 					<width>730</width>
 					<height>25</height>
-					<label fallback="416">$INFO[ListItem.AddonCreator]</label>
+					<label fallback="10005">$INFO[ListItem.AddonCreator]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font20</font>
@@ -152,7 +152,7 @@
 					<posy>60</posy>
 					<width>730</width>
 					<height>25</height>
-					<label fallback="416">$INFO[ListItem.AddonVersion]</label>
+					<label fallback="10005">$INFO[ListItem.AddonVersion]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font20</font>
@@ -175,7 +175,7 @@
 					<posy>90</posy>
 					<width>730</width>
 					<height>25</height>
-					<label fallback="416">$INFO[ListItem.AddonSummary]</label>
+					<label fallback="10005">$INFO[ListItem.AddonSummary]</label>
 					<align>left</align>
 					<aligny>center</aligny>
 					<font>font20</font>

--- a/addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
@@ -34,7 +34,7 @@
 					<width>704</width>
 					<height>25</height>
 					<aligny>center</aligny>
-					<label fallback="161">$INFO[RDS.Artist]</label>
+					<label fallback="10005">$INFO[RDS.Artist]</label>
 					<scrollout>false</scrollout>
 					<pauseatend>2000</pauseatend>
 					<visible>String.IsEmpty(RDS.Band)</visible>
@@ -93,7 +93,7 @@
 					<width>704</width>
 					<height>25</height>
 					<aligny>center</aligny>
-					<label fallback="161">$INFO[RDS.Title]</label>
+					<label fallback="10005">$INFO[RDS.Title]</label>
 					<scrollout>false</scrollout>
 					<pauseatend>2000</pauseatend>
 				</control>
@@ -137,7 +137,7 @@
 					<width>704</width>
 					<height>25</height>
 					<aligny>center</aligny>
-					<label fallback="161">$INFO[RDS.Composer]</label>
+					<label fallback="10005">$INFO[RDS.Composer]</label>
 					<scrollout>false</scrollout>
 					<pauseatend>2000</pauseatend>
 				</control>
@@ -157,7 +157,7 @@
 					<width>704</width>
 					<height>25</height>
 					<aligny>center</aligny>
-					<label fallback="161">$INFO[RDS.Title]</label>
+					<label fallback="10005">$INFO[RDS.Title]</label>
 					<scrollout>false</scrollout>
 					<pauseatend>2000</pauseatend>
 				</control>
@@ -178,7 +178,7 @@
 					<width>704</width>
 					<height>29</height>
 					<pagecontrol></pagecontrol>
-					<label fallback="161">$INFO[RDS.Artist]</label>
+					<label fallback="10005">$INFO[RDS.Artist]</label>
 					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
 					<visible>String.IsEmpty(RDS.Band) + !String.IsEmpty(RDS.Artist)</visible>
 				</control>
@@ -242,7 +242,7 @@
 					<width>300</width>
 					<height>25</height>
 					<aligny>center</aligny>
-					<label fallback="161">$INFO[RDS.Conductor]</label>
+					<label fallback="10005">$INFO[RDS.Conductor]</label>
 					<scrollout>false</scrollout>
 					<pauseatend>2000</pauseatend>
 					<visible>!String.IsEmpty(RDS.Conductor)</visible>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -324,7 +324,7 @@
 						<top>-207</top>
 						<right>80</right>
 						<height>290</height>
-						<label fallback="416">$INFO[VideoPlayer.Tagline,[B],[/B][CR]]$INFO[VideoPlayer.Plot]</label>
+						<label fallback="10005">$INFO[VideoPlayer.Tagline,[B],[/B][CR]]$INFO[VideoPlayer.Plot]</label>
 						<align>left</align>
 						<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
 					</control>

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -452,7 +452,7 @@ bool CLangInfo::Load(const std::string& strLanguage)
       CRegion region(m_defaultRegion);
       region.m_strName = XMLUtils::GetAttribute(pRegion, "name");
       if (region.m_strName.empty())
-        region.m_strName="N/A";
+        region.m_strName=g_localizeStrings.Get(10005); // Not available
 
       if (pRegion->Attribute("locale"))
         region.m_strRegionLocaleName = pRegion->Attribute("locale");
@@ -916,7 +916,7 @@ void CLangInfo::GetRegionNames(std::vector<std::string>& array)
   {
     std::string strName=region.first;
     if (strName=="N/A")
-      strName=g_localizeStrings.Get(416);
+      strName=g_localizeStrings.Get(10005); // Not available
     array.emplace_back(std::move(strName));
   }
 }

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -510,7 +510,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::Dependency
     else
     {
       CFileItemPtr item(new CFileItem(it.id));
-      item->SetLabel2(g_localizeStrings.Get(161));
+      item->SetLabel2(g_localizeStrings.Get(10005)); // Not available
       items.Add(item);
     }
   }

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -1243,7 +1243,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
         ep.iEpisode = atoi(strEpNum.c_str());
         ep.iSubepisode = (dot != std::string::npos) ? atoi(strEpNum.substr(dot + 1).c_str()) : 0;
         if (!XMLUtils::GetString(pxeMovie, "title", scurlEp.strTitle) || scurlEp.strTitle.empty())
-          scurlEp.strTitle = g_localizeStrings.Get(416);
+          scurlEp.strTitle = g_localizeStrings.Get(10005); // Not available
         XMLUtils::GetString(pxeMovie, "id", scurlEp.strId);
 
         for (; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -77,9 +77,9 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
   switch(info)
   {
     case SYSTEM_CPU_TEMPERATURE:
-      return m_cpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_cpuTemp) : "?";
+      return m_cpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_cpuTemp) : g_localizeStrings.Get(10005); // Not available
     case SYSTEM_GPU_TEMPERATURE:
-      return m_gpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_gpuTemp) : "?";
+      return m_gpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_gpuTemp) : g_localizeStrings.Get(10005);
     case SYSTEM_FAN_SPEED:
       text = StringUtils::Format("%i%%", m_fanSpeed * 2);
       break;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -1051,9 +1051,9 @@ std::string CSysInfo::GetHddSpaceInfo(int& percent, int drive, bool shortText)
   else
   {
     if (shortText)
-      strRet = "N/A";
+      strRet = g_localizeStrings.Get(10006); // N/A
     else
-      strRet = g_localizeStrings.Get(161);
+      strRet = g_localizeStrings.Get(10005); // Not available
   }
   return strRet;
 }


### PR DESCRIPTION
## Description
* `N/A`, `Not available`, `Unavailable` and `?` are now `Not available` except where `N/A` is requested (`CSysInfo::GetHddSpaceInfo`).
* Removed hardcoded `N/A` except on CCPUInfo. Will be dealt with later.
* Made `N/A` translatable. In my native language that would be `N/D`
* Deprecated a couple of very low strings (161 and 416) ~~but kept them because they might be used by older skins.~~

What's the policy? Drop deprecated strings completely and force the use of the new string?

## Motivation and Context
Noticed this while looking at `CSysInfo`and `CCPUInfo` spaghetti.

## How Has This Been Tested?
Run time tested under Ubuntu and Win x64.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
