### PR TITLE
Silence some type conversion warnings and fix a possible bug.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -342,8 +342,8 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
   else if (url.IsProtocol("shout"))
   {
     const std::string strFileNameAndPath = url.Get();
-    const int genre = strFileNameAndPath.find_first_of('=');
-    if(genre <0)
+    const size_t genre = strFileNameAndPath.find_first_of('=');
+    if(genre == std::string::npos)
       strFilename = g_localizeStrings.Get(260);
     else
       strFilename = g_localizeStrings.Get(260) + " - " + strFileNameAndPath.substr(genre+1).c_str();
@@ -1971,7 +1971,7 @@ int CUtil::ScanArchiveForAssociatedItems(const std::string& strArchivePath,
     std::string strExt = URIUtils::GetExtension(strPathInRar);
 
     // check that the found filename matches the movie filename
-    int fnl = videoNameNoExt.size();
+    size_t fnl = videoNameNoExt.size();
     if (fnl && !StringUtils::StartsWithNoCase(URIUtils::GetFileName(strPathInRar), videoNameNoExt))
       continue;
 
@@ -2051,8 +2051,8 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
 
   ScanPathsForAssociatedItems(strSubtitle, items, exts, vecSubtitles);
 
-  int iSize = vecSubtitles.size();
-  for (int i = 0; i < iSize; i++)
+  size_t iSize = vecSubtitles.size();
+  for (size_t i = 0; i < iSize; i++)
   {
     if (URIUtils::HasExtension(vecSubtitles[i], ".smi"))
     {
@@ -2066,7 +2066,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
         {
           for (const auto &lang : TagConv.m_Langclass)
           {
-            std::string strDest = StringUtils::Format("special://temp/subtitle.%s.%d.smi", lang.Name.c_str(), i);
+            std::string strDest = StringUtils::Format("special://temp/subtitle.%s.%zu.smi", lang.Name.c_str(), i);
             if (CFile::Copy(vecSubtitles[i], strDest))
             {
               CLog::Log(LOGINFO, " cached subtitle %s->%s\n", CURL::GetRedacted(vecSubtitles[i]).c_str(), strDest.c_str());

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1806,7 +1806,7 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 
     if(startpts)
     {
-      *startpts = DVD_SEC_TO_TIME(ich->GetChapterPos(chapter));
+      *startpts = DVD_SEC_TO_TIME(static_cast<double>(ich->GetChapterPos(chapter)));
     }
 
     Flush();

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -63,7 +63,7 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
       if (totalread == buf.size())
         buf.resize(buf.size() + chunksize);
 
-      read = pInputStream->Read((uint8_t*)buf.get() + totalread, buf.size() - totalread);
+      read = pInputStream->Read((uint8_t*)buf.get() + totalread, static_cast<int>(buf.size() - totalread));
       if (read > 0)
         totalread += read;
     } while (read > 0);
@@ -109,7 +109,7 @@ bool CDVDSubtitleStream::IsIncompatible(CDVDInputStream* pInputStream, XUTILS::a
 
   static const uint8_t vobsub[] = { 0x00, 0x00, 0x01, 0xBA };
 
-  int read = pInputStream->Read((uint8_t*)buf.get(), buf.size());
+  int read = pInputStream->Read(reinterpret_cast<uint8_t*>(buf.get()), static_cast<int>(buf.size()));
 
   if (read < 0)
   {

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -97,7 +97,7 @@ static int mem_file_read(void *h, uint8_t* buf, int size)
   size_t tocopy = std::min((size_t)size, (size_t)unread);
   memcpy(buf, mbuf->data + mbuf->pos, tocopy);
   mbuf->pos += tocopy;
-  return tocopy;
+  return static_cast<int>(tocopy);
 }
 
 static int64_t mem_file_seek(void *h, int64_t pos, int whence)
@@ -164,7 +164,7 @@ bool CFFmpegImage::LoadImageFromMemory(unsigned char* buffer, unsigned int bufSi
   return !(m_pFrame == nullptr);
 }
 
-bool CFFmpegImage::Initialize(unsigned char* buffer, unsigned int bufSize)
+bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
 {
   int bufferSize = 4096;
   uint8_t* fbuffer = (uint8_t*)av_malloc(bufferSize + AV_INPUT_BUFFER_PADDING_SIZE);

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -82,7 +82,7 @@ public:
                                   unsigned int &bufferoutSize) override;
   void ReleaseThumbnailBuffer() override;
 
-  bool Initialize(unsigned char* buffer, unsigned int bufSize);
+  bool Initialize(unsigned char* buffer, size_t bufSize);
 
   std::shared_ptr<Frame> ReadFrame();
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -530,7 +530,7 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
   // don't use an iterator for this loop, as some messages mean that m_activeDialogs is altered,
   // which will invalidate any iterator
   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-  unsigned int topWindow = m_activeDialogs.size();
+  size_t topWindow = m_activeDialogs.size();
   while (topWindow)
   {
     CGUIWindow* dialog = m_activeDialogs[--topWindow];
@@ -1079,7 +1079,7 @@ bool CGUIWindowManager::OnAction(const CAction &action) const
 bool CGUIWindowManager::HandleAction(CAction const& action) const
 {
   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-  unsigned int topmost = m_activeDialogs.size();
+  size_t topmost = m_activeDialogs.size();
   while (topmost)
   {
     CGUIWindow *dialog = m_activeDialogs[--topmost];
@@ -1463,7 +1463,7 @@ void CGUIWindowManager::DispatchThreadMessages()
 
   CSingleLock lock(m_critSection);
 
-  for(int msgCount = m_vecThreadMessages.size(); !m_vecThreadMessages.empty() && msgCount > 0; --msgCount)
+  while (!m_vecThreadMessages.empty())
   {
     // pop up one message per time to make messages be processed by order.
     // this will ensure rule No.2 & No.3


### PR DESCRIPTION
Please have a special look at the commits prefixed [RFC].
2a35535 might not fix a real bug, since the cast for npos might wrap to a negative integer.