### PR TITLE
[PVR] Fix deadlock on Kodi startup - trac#15952

### DIFF
--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -310,15 +310,18 @@ bool CPVREpg::Load(void)
     return bReturn;
   }
 
-  int iEntriesLoaded = database->Get(*this);
+  const std::vector<CPVREpgInfoTagPtr> result = database->Get(*this);
 
   CSingleLock lock(m_critSection);
-  if (iEntriesLoaded <= 0)
+  if (result.empty())
   {
     CLog::LogFC(LOGDEBUG, LOGEPG, "No database entries found for table '%s'.", m_strName.c_str());
   }
   else
   {
+    for (const auto& entry : result)
+      AddEntry(*entry);
+
     m_lastScanTime = GetLastScanTime();
     bReturn = true;
   }

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -204,7 +204,7 @@ namespace PVR
      * @param tag The epg tag containing the updated data
      * @param eNewState The kind of change (CREATED, UPDATED, DELETED)
      */
-    void UpdateFromClient(const CPVREpgInfoTagPtr tag, EPG_EVENT_STATE eNewState);
+    void UpdateFromClient(const CPVREpgInfoTagPtr &tag, EPG_EVENT_STATE eNewState);
 
     /*!
      * @brief Get the number of past days to show in the guide and to import from backends.
@@ -253,7 +253,7 @@ namespace PVR
      */
     void LoadFromDB(void);
 
-    void InsertFromDatabase(int iEpgID, const std::string &strName, const std::string &strScraperName);
+    void InsertFromDatabase(const CPVREpgPtr &newEpg);
 
     CPVREpgDatabasePtr m_database; /*!< the EPG database */
 

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -111,17 +111,17 @@ namespace PVR
 
     /*!
      * @brief Get all EPG tables from the database. Does not get the EPG tables' entries.
-     * @param container The container to fill.
-     * @return The amount of entries that was added.
+     * @param container The container to get the EPG tables for.
+     * @return The entries.
      */
-    int Get(CPVREpgContainer &container);
+    std::vector<CPVREpgPtr> Get(const CPVREpgContainer &container);
 
     /*!
      * @brief Get all EPG entries for a table.
      * @param epg The EPG table to get the entries for.
-     * @return The amount of entries that was added.
+     * @return The entries.
      */
-    int Get(CPVREpg &epg);
+    std::vector<CPVREpgInfoTagPtr> Get(const CPVREpg &epg);
 
     /*!
      * @brief Get the last stored EPG scan time.


### PR DESCRIPTION
Fixes a deadlock reported on trac: https://trac.kodi.tv/ticket/17952

<pre>
Callstack for Thread 10 (Thread Id: 22204 (0x56bc)):
 Index  Function
--------------------------------------------------------------------------------
 1      [External Code]
 2      kodi.exe!XbmcThreads::CountingLockable<std::recursive_mutex>::lock() Line 63
 3      kodi.exe!XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock<CCriticalSection>(CCriticalSection & lockable={...}) Line 132
 4      kodi.exe!CSingleLock::CSingleLock(const CCriticalSection & cs={...}) Line 40
=> wants pvr mgr lock
 5      kodi.exe!PVR::CPVRManager::Timers() Line 196
 6      kodi.exe!PVR::CPVREpg::AddEntry(const PVR::CPVREpgInfoTag & tag={...}) Line 297
=> has epg db lock
 7      kodi.exe!PVR::CPVREpgDatabase::Get(PVR::CPVREpg & epg={...}) Line 293
 8      kodi.exe!PVR::CPVREpg::Load() Line 313
 9      kodi.exe!PVR::CPVREpgContainer::LoadFromDB() Line 330
 10     kodi.exe!PVR::CPVREpgContainer::Start(bool bAsync=false) Line 253
 11     kodi.exe!PVR::CPVREpgContainerStartJob::DoWork() Line 223
 12     kodi.exe!CJobWorker::Process() Line 67
 13     kodi.exe!CThread::Action() Line 212
 14     kodi.exe!CThread::staticThread(void * data=0x00000185f410f040) Line 131
 15     [External Code]


Callstack for Thread 12 (Thread Id: 20744 (0x5108)):
 Index  Function
--------------------------------------------------------------------------------
 1      [External Code]
*2      kodi.exe!XbmcThreads::CountingLockable<std::recursive_mutex>::lock() Line 63
 3      kodi.exe!XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock<CCriticalSection>(CCriticalSection & lockable={...}) Line 132
 4      kodi.exe!CSingleLock::CSingleLock(CCriticalSection & cs={...}) Line 39
=> wants epg db lock
 5      kodi.exe!PVR::CPVREpgDatabase::Close() Line 44
 6      kodi.exe!PVR::CPVREpgContainer::Stop() Line 281
 7      kodi.exe!PVR::CPVREpgContainer::Clear(bool bClearDb=false) Line 177
 8      kodi.exe!PVR::CPVRManager::Clear() Line 247
 => has pvr mgr lock
 9      kodi.exe!PVR::CPVRManager::ResetProperties() Line 264
 10     kodi.exe!PVR::CPVRManager::Stop() Line 340
 11     kodi.exe!PVR::CPVRManager::Start() Line 293
 12     kodi.exe!PVR::CPVRClients::ConnectionStateChange(PVR::CPVRClient * client=0x00000185fb67b840, std::basic_string<char,std::char_traits<char>,std::allocator<char> > & strConnectionString={...}, PVR_CONNECTION_STATE newState=PVR_CONNECTION_STATE_CONNECTED, std::basic_string<char,std::char_traits<char>,std::allocator<char> > & strMessage={...}) Line 653
 13     kodi.exe!PVR::CPVRClientConnectionJob::DoWork() Line 119
 14     kodi.exe!CJobWorker::Process() Line 67
 15     kodi.exe!CThread::Action() Line 212
 16     kodi.exe!CThread::staticThread(void * data=0x00000185f905cf00) Line 131
 17     [External Code]
</pre>

Gist of the fix is not to modify the epg instance while reading from db, but to compile a vector with the result and to modify the epg after reading all data from db.

@ace20022 fyi