### PR TITLE
[guiinfo] Fix 'Slideshow.File(Name|Path|Size|Date)' and 'Slideshow.Index' labels - trac#17956.

### DIFF
--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -131,11 +131,11 @@ bool CPicturesGUIInfo::InitCurrentItem(CFileItem *item)
 
 bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
-  ///////////////////////////////////////////////////////////////////////////////////////////////
-  // LISTITEM_* / SLIDESHOW_* (values directly supported by PictureInfoTag)
-  ///////////////////////////////////////////////////////////////////////////////////////////////
   if (item->IsPicture() && info.m_info >= LISTITEM_PICTURE_START && info.m_info <= LISTITEM_PICTURE_END)
   {
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // LISTITEM_*
+    ///////////////////////////////////////////////////////////////////////////////////////////////
     const auto& it = listitem2slideshow_map.find(info.m_info);
     if (it != listitem2slideshow_map.end())
     {
@@ -153,8 +153,56 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
   }
   else if (m_currentSlide && info.m_info >= SLIDESHOW_LABELS_START && info.m_info <= SLIDESHOW_LABELS_END)
   {
-    value = m_currentSlide->GetPictureInfoTag()->GetInfo(info.m_info);
-    return true;
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // SLIDESHOW_*
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    switch (info.m_info)
+    {
+      case SLIDESHOW_FILE_NAME:
+      {
+        value = URIUtils::GetFileName(m_currentSlide->GetPath());
+        return true;
+      }
+      case SLIDESHOW_FILE_PATH:
+      {
+        const std::string path = URIUtils::GetDirectory(m_currentSlide->GetPath());
+        value = CURL(path).GetWithoutUserDetails();
+        return true;
+      }
+      case SLIDESHOW_FILE_SIZE:
+      {
+        if (!m_currentSlide->m_bIsFolder || m_currentSlide->m_dwSize)
+        {
+          value = StringUtils::SizeToString(m_currentSlide->m_dwSize);
+          return true;
+        }
+        break;
+      }
+      case SLIDESHOW_FILE_DATE:
+      {
+        if (m_currentSlide->m_dateTime.IsValid())
+        {
+          value = m_currentSlide->m_dateTime.GetAsLocalizedDate();
+          return true;
+        }
+        break;
+      }
+      case SLIDESHOW_INDEX:
+      {
+        CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
+        if (slideshow && slideshow->NumSlides())
+        {
+          value = StringUtils::Format("%d/%d", slideshow->CurrentSlide(), slideshow->NumSlides());
+          return true;
+        }
+        break;
+      }
+      default:
+      {
+        value = m_currentSlide->GetPictureInfoTag()->GetInfo(info.m_info);
+        return true;
+      }
+    }
   }
 
   if (item->IsPicture())
@@ -173,62 +221,6 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
         }
         break;
       }
-    }
-  }
-
-  if (item->HasPictureInfoTag())
-  {
-    switch (info.m_info)
-    {
-      ///////////////////////////////////////////////////////////////////////////////////////////////
-      // SLIDESHOW_* (values not directly supported by PictureInfoTag)
-      ///////////////////////////////////////////////////////////////////////////////////////////////
-      case SLIDESHOW_FILE_NAME:
-      {
-        value = URIUtils::GetFileName(item->GetPath());
-        return true;
-      }
-      case SLIDESHOW_FILE_PATH:
-      {
-        const std::string path = URIUtils::GetDirectory(item->GetPath());
-        value = CURL(path).GetWithoutUserDetails();
-        return true;
-      }
-      case SLIDESHOW_FILE_SIZE:
-      {
-        if (!item->m_bIsFolder || item->m_dwSize)
-        {
-          value = StringUtils::SizeToString(item->m_dwSize);
-          return true;
-        }
-        break;
-      }
-      case SLIDESHOW_FILE_DATE:
-      {
-        if (item->m_dateTime.IsValid())
-        {
-          value = item->m_dateTime.GetAsLocalizedDate();
-          return true;
-        }
-        break;
-      }
-    }
-  }
-
-  switch (info.m_info)
-  {
-    ///////////////////////////////////////////////////////////////////////////////////////////////
-    // SLIDESHOW_*
-    ///////////////////////////////////////////////////////////////////////////////////////////////
-    case SLIDESHOW_INDEX:
-    {
-      CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      if (slideshow && slideshow->NumSlides())
-      {
-        value = StringUtils::Format("%d/%d", slideshow->CurrentSlide(), slideshow->NumSlides());
-        return true;
-      }
-      break;
     }
   }
 


### PR DESCRIPTION
Fixes https://trac.kodi.tv/ticket/17956 - a regression introduced with #13754 

@scott967 fyi

@Jalle19 the diff is hard to read. The change is basically that I moved the code handling SLIDESHOW_FILE_* and SLIDESHOW_INDEX up into the else case where all SLIDESHOW labels are handled (`else if (m_currentSlide && info.m_info >= SLIDESHOW_LABELS_START && info.m_info <= SLIDESHOW_LABELS_END)`) as the affected labels are within that range but were not handled there before.