### PR TITLE
VideoPlayer: fix/improve audio stalls of realtime streams

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2056,8 +2056,11 @@ void CVideoPlayer::HandlePlaySpeed()
         if (m_CurrentVideo.starttime != DVD_NOPTS_VALUE && (m_CurrentVideo.packets > 0))
         {
           if (m_CurrentVideo.starttime - m_CurrentVideo.cachetotal < clock)
+          {
             clock = m_CurrentVideo.starttime - m_CurrentVideo.cachetotal;
-          else if (m_CurrentVideo.starttime > m_CurrentAudio.starttime)
+          }
+          else if (m_CurrentVideo.starttime > m_CurrentAudio.starttime &&
+                   !m_pInputStream->IsRealtime())
           {
             int audioLevel = m_VideoPlayerAudio->GetLevel();
             //@todo hardcoded 8 seconds in message queue

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -282,7 +282,6 @@ void CVideoPlayerAudio::Process()
       if (priority)
         continue;
 
-      // Flush as the audio output may keep looping if we don't
       if (m_processInfo.IsTempoAllowed(static_cast<float>(m_speed)/DVD_PLAYSPEED_NORMAL) &&
           !m_stalled && m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
       {
@@ -364,7 +363,10 @@ void CVideoPlayerAudio::Process()
         if (speed != m_speed)
         {
           if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
+          {
             m_audioSink.Resume();
+            m_stalled = false;
+          }
         }
       }
       else


### PR DESCRIPTION
- clock was set wrong for realtime streams
- improve behaviour in case of stalled audio stream