### PR TITLE
fix videosettings for items not stored in db

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3520,14 +3520,18 @@ void CApplication::RequestVideoSettings(const CFileItem &fileItem)
 
 void CApplication::StoreVideoSettings(const CFileItem &fileItem, CVideoSettings vs)
 {
-  if (vs != CMediaSettings::GetInstance().GetDefaultVideoSettings())
+  CVideoDatabase dbs;
+  if (dbs.Open())
   {
-    CVideoDatabase dbs;
-    if (dbs.Open())
+    if (vs != CMediaSettings::GetInstance().GetDefaultVideoSettings())
     {
       dbs.SetVideoSettings(fileItem, vs);
-      dbs.Close();
     }
+    else
+    {
+      dbs.EraseVideoSettings(fileItem);
+    }
+    dbs.Close();
   }
 }
 

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1599,8 +1599,8 @@ namespace PVR
 
       if (videoDatabase.Open())
       {
-        videoDatabase.EraseVideoSettings("pvr://channels/");
-        videoDatabase.EraseVideoSettings(CPVRRecordingsPath::PATH_RECORDINGS);
+        videoDatabase.EraseAllVideoSettings("pvr://channels/");
+        videoDatabase.EraseAllVideoSettings(CPVRRecordingsPath::PATH_RECORDINGS);
         videoDatabase.Close();
       }
     }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -600,11 +600,21 @@ public:
   void SetVideoSettings(int idFile, const CVideoSettings &settings);
 
   /**
-   * Erases settings for all files beginning with the specified path. Defaults
-   * to an empty path, meaning all settings will be erased.
-   * @param path partial path, e.g. pvr://channels
+   * Erases video settings for file item
+   * @param fileitem
    */
-  void EraseVideoSettings(const std::string &path = "");
+  void EraseVideoSettings(const CFileItem &item);
+
+  /**
+   * Erases all video settings
+   */
+  void EraseAllVideoSettings();
+
+  /**
+   * Erases video settings for files starting with path
+   * @param path pattern
+   */
+  void EraseAllVideoSettings(std::string path);
 
   bool GetStackTimes(const std::string &filePath, std::vector<uint64_t> &times);
   void SetStackTimes(const std::string &filePath, const std::vector<uint64_t> &times);

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -172,7 +172,7 @@ void CGUIDialogAudioSettings::Save()
   if (!db.Open())
     return;
 
-  db.EraseVideoSettings();
+  db.EraseAllVideoSettings();
   db.Close();
 
   CMediaSettings::GetInstance().GetDefaultVideoSettings() = g_application.GetAppPlayer().GetVideoSettings();

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -199,7 +199,7 @@ void CGUIDialogSubtitleSettings::Save()
   if (!db.Open())
     return;
 
-  db.EraseVideoSettings();
+  db.EraseAllVideoSettings();
   db.Close();
 
   CMediaSettings::GetInstance().GetDefaultVideoSettings() = g_application.GetAppPlayer().GetVideoSettings();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -241,7 +241,7 @@ void CGUIDialogVideoSettings::Save()
     CVideoDatabase db;
     if (!db.Open())
       return;
-    db.EraseVideoSettings();
+    db.EraseAllVideoSettings();
     db.Close();
 
     CMediaSettings::GetInstance().GetDefaultVideoSettings() = g_application.GetAppPlayer().GetVideoSettings();


### PR DESCRIPTION
fixes video settings for file items like PVR, that don't have an entry in db other than vs. save/restore failed because of missing idFile.