### PR TITLE
[gui] Kill g_audioManager

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1584,8 +1584,8 @@ bool CApplication::LoadSkin(const std::string& skinID)
   //@todo should be done by GUIComponents
   CServiceBroker::GetGUI()->GetWindowManager().Initialize();
   CTextureCache::GetInstance().Initialize();
-  g_audioManager.Enable(true);
-  g_audioManager.Load();
+  CServiceBroker::GetGUI()->GetAudioManager().Enable(true);
+  CServiceBroker::GetGUI()->GetAudioManager().Load();
 
   if (g_SkinInfo->HasSkinFile("DialogFullScreenInfo.xml"))
     CServiceBroker::GetGUI()->GetWindowManager().Add(new CGUIDialogFullScreenInfo);
@@ -1641,7 +1641,7 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
   else if (!m_saveSkinOnUnloading)
     m_saveSkinOnUnloading = true;
 
-  g_audioManager.Enable(false);
+  CServiceBroker::GetGUI()->GetAudioManager().Enable(false);
 
   CServiceBroker::GetGUI()->GetWindowManager().DeInitialize();
   CTextureCache::GetInstance().Deinitialize();
@@ -2096,7 +2096,9 @@ bool CApplication::OnAction(const CAction &action)
       if (!m_appPlayer.IsPaused() && m_appPlayer.GetPlaySpeed() != 1)
         m_appPlayer.SetPlaySpeed(1);
 
-      g_audioManager.Enable(m_appPlayer.IsPaused());
+      CGUIComponent *gui = CServiceBroker::GetGUI();
+      if (gui)
+        gui->GetAudioManager().Enable(m_appPlayer.IsPaused());
       return true;
     }
     // play: unpause or set playspeed back to normal
@@ -2156,7 +2158,10 @@ bool CApplication::OnAction(const CAction &action)
       {
         // unpause, and set the playspeed back to normal
         m_appPlayer.Pause();
-        g_audioManager.Enable(m_appPlayer.IsPaused());
+
+        CGUIComponent *gui = CServiceBroker::GetGUI();
+        if (gui)
+          gui->GetAudioManager().Enable(m_appPlayer.IsPaused());
 
         m_appPlayer.SetPlaySpeed(1);
         return true;
@@ -2869,7 +2874,10 @@ void CApplication::Stop(int exitCode)
     UnregisterActionListener(&m_appPlayer.GetSeekHandler());
     UnregisterActionListener(&CPlayerController::GetInstance());
 
-    g_audioManager.DeInitialize();
+    CGUIComponent *gui = CServiceBroker::GetGUI();
+    if (gui)
+      gui->GetAudioManager().DeInitialize();
+
     // shutdown the AudioEngine
     CServiceBroker::UnregisterAE();
     m_pActiveAE->Shutdown();
@@ -3205,7 +3213,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   m_appPlayer.SetMute(m_muted);
 
 #if !defined(TARGET_POSIX)
-  g_audioManager.Enable(false);
+  CGUIComponent *gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetAudioManager().Enable(false);
 #endif
 
   if (item.HasPVRChannelInfoTag())
@@ -3218,7 +3228,9 @@ void CApplication::PlaybackCleanup()
 {
   if (!m_appPlayer.IsPlaying())
   {
-    g_audioManager.Enable(true);
+    CGUIComponent *gui = CServiceBroker::GetGUI();
+    if (gui)
+      CServiceBroker::GetGUI()->GetAudioManager().Enable(true);
     m_appPlayer.OpenNext(m_ServiceManager->GetPlayerCoreFactory());
   }
 

--- a/xbmc/addons/UISoundsResource.cpp
+++ b/xbmc/addons/UISoundsResource.cpp
@@ -41,8 +41,9 @@ bool CUISoundsResource::IsInUse() const
 
 void CUISoundsResource::OnPostInstall(bool update, bool modal)
 {
-  if (IsInUse())
-    g_audioManager.Load();
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (IsInUse() && gui)
+    gui->GetAudioManager().Load();
 }
 
 }

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -304,9 +304,14 @@ bool CGUIDialogGamepad::ShowAndVerifyInput(std::string& strToVerify, const std::
   else
     pDialog->SetLine(2, CVariant{atoi(dlgLine2.c_str())});
 
-  g_audioManager.Enable(false); // dont do sounds during pwd input
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetAudioManager().Enable(false); // don't do sounds during pwd input
+
   pDialog->Open();
-  g_audioManager.Enable(true);
+
+  if (gui)
+    gui->GetAudioManager().Enable(true);
 
   if (bGetUserInput && !pDialog->IsCanceled())
   {

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -35,8 +35,6 @@
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "utils/log.h"
 
-CGUIAudioManager g_audioManager;
-
 CGUIAudioManager::CGUIAudioManager()
 {
   m_bEnabled = false;

--- a/xbmc/guilib/GUIAudioManager.h
+++ b/xbmc/guilib/GUIAudioManager.h
@@ -23,6 +23,8 @@
 #include <map>
 #include <string>
 
+#include "GUIComponent.h"
+#include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AESound.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
@@ -93,4 +95,3 @@ private:
   IAESound* LoadWindowSound(TiXmlNode* pWindowNode, const std::string& strIdentifier);
 };
 
-extern CGUIAudioManager g_audioManager;

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "GUIAudioManager.h"
 #include "GUIComponent.h"
 #include "GUIColorManager.h"
 #include "GUIInfoManager.h"
@@ -37,6 +38,7 @@ CGUIComponent::CGUIComponent()
   m_stereoscopicsManager.reset(new CStereoscopicsManager(CServiceBroker::GetSettings()));
   m_guiInfoManager.reset(new CGUIInfoManager());
   m_guiColorManager.reset(new CGUIColorManager());
+  m_guiAudioManager.reset(new CGUIAudioManager());
 }
 
 CGUIComponent::~CGUIComponent()
@@ -91,6 +93,11 @@ CGUIInfoManager &CGUIComponent::GetInfoManager()
 CGUIColorManager &CGUIComponent::GetColorManager()
 {
   return *m_guiColorManager;
+}
+
+CGUIAudioManager &CGUIComponent::GetAudioManager()
+{
+  return *m_guiAudioManager;
 }
 
 bool CGUIComponent::ConfirmDelete(std::string path)

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -29,6 +29,7 @@ class CGUILargeTextureManager;
 class CStereoscopicsManager;
 class CGUIInfoManager;
 class CGUIColorManager;
+class CGUIAudioManager;
 
 class CGUIComponent
 {
@@ -44,6 +45,7 @@ public:
   CStereoscopicsManager &GetStereoscopicsManager();
   CGUIInfoManager &GetInfoManager();
   CGUIColorManager &GetColorManager();
+  CGUIAudioManager &GetAudioManager();
 
   bool ConfirmDelete(std::string path);
 
@@ -55,4 +57,5 @@ protected:
   std::unique_ptr<CStereoscopicsManager> m_stereoscopicsManager;
   std::unique_ptr<CGUIInfoManager> m_guiInfoManager;
   std::unique_ptr<CGUIColorManager> m_guiColorManager;
+  std::unique_ptr<CGUIAudioManager> m_guiAudioManager;
 };

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -394,7 +394,7 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
     if (!m_closing)
     {
       if (enableSound && IsSoundEnabled())
-        g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
+        CServiceBroker::GetGUI()->GetAudioManager().PlayWindowSound(GetID(), SOUND_DEINIT);
 
       // Perform the window out effect
       QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
@@ -541,7 +541,7 @@ void CGUIWindow::OnInitWindow()
 {
   //  Play the window specific init sound
   if (IsSoundEnabled())
-    g_audioManager.PlayWindowSound(GetID(), SOUND_INIT);
+    CServiceBroker::GetGUI()->GetAudioManager().PlayWindowSound(GetID(), SOUND_INIT);
 
   // set our rendered state
   m_hasProcessed = false;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -840,7 +840,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   if (!force && HasModalDialog(true))
   {
     CLog::Log(LOGINFO, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
-    g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
+    CServiceBroker::GetGUI()->GetAudioManager().PlayActionSound(CAction(ACTION_ERROR));
     return;
   }
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -690,18 +690,21 @@ bool CInputManager::AlwaysProcess(const CAction& action)
 bool CInputManager::ExecuteInputAction(const CAction &action)
 {
   bool bResult = false;
+  CGUIComponent* gui = CServiceBroker::GetGUI();
 
   // play sound before the action unless the button is held,
   // where we execute after the action as held actions aren't fired every time.
   if (action.GetHoldTime())
   {
     bResult = g_application.OnAction(action);
-    if (bResult)
-      g_audioManager.PlayActionSound(action);
+    if (bResult && gui)
+      gui->GetAudioManager().PlayActionSound(action);
   }
   else
   {
-    g_audioManager.PlayActionSound(action);
+    if (gui)
+      gui->GetAudioManager().PlayActionSound(action);
+
     bResult = g_application.OnAction(action);
   }
   return bResult;

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -111,7 +111,9 @@ void CJoystickEasterEgg::OnFinish(void)
   gameSettings.ToggleGames();
 
   WINDOW_SOUND sound = gameSettings.GamesEnabled() ? SOUND_INIT : SOUND_DEINIT;
-  g_audioManager.PlayWindowSound(WINDOW_DIALOG_KAI_TOAST, sound);
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetAudioManager().PlayWindowSound(WINDOW_DIALOG_KAI_TOAST, sound);
 
   //! @todo Shake screen
 }

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -52,7 +52,10 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
   if(!wakeScreensaver || !handleScreenSaver())
   {
     g_application.ResetSystemIdleTimer();
-    g_audioManager.PlayActionSound(actionID);
+    CGUIComponent* gui = CServiceBroker::GetGUI();
+    if (gui)
+      gui->GetAudioManager().PlayActionSound(actionID);
+
     if (waitResult)
       CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(actionID)));
     else

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -342,9 +342,10 @@ namespace XBMCAddon
       if (!filename)
         return;
 
-      if (XFILE::CFile::Exists(filename))
+      CGUIComponent* gui = CServiceBroker::GetGUI();
+      if (XFILE::CFile::Exists(filename) && gui)
       {
-        g_audioManager.PlayPythonSound(filename,useCached);
+        gui->GetAudioManager().PlayPythonSound(filename,useCached);
       }
     }
 
@@ -352,13 +353,17 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       DelayedCallGuard dg;
-      g_audioManager.Stop();
+      CGUIComponent* gui = CServiceBroker::GetGUI();
+      if (gui)
+        gui->GetAudioManager().Stop();
     }
 
     void enableNavSounds(bool yesNo)
     {
       XBMC_TRACE;
-      g_audioManager.Enable(yesNo);
+      CGUIComponent* gui = CServiceBroker::GetGUI();
+      if (gui)
+        gui->GetAudioManager().Enable(yesNo);
     }
 
     bool getCondVisibility(const char *condition)

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -347,7 +347,10 @@ bool CEventServer::ExecuteNextAction()
           unsigned int actionID;
           CActionTranslator::TranslateString(actionEvent.actionName, actionID);
           CAction action(actionID, 1.0f, 0.0f, actionEvent.actionName);
-          g_audioManager.PlayActionSound(action);
+          CGUIComponent* gui = CServiceBroker::GetGUI();
+          if (gui)
+            gui->GetAudioManager().PlayActionSound(action);
+
           g_application.OnAction(action);
         }
         break;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -28,7 +28,6 @@
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "filesystem/File.h"
-#include "guilib/GUIAudioManager.h"
 #include "guilib/GUIFontManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "GUIPassword.h"
@@ -810,7 +809,6 @@ void CSettings::UninitializeISettingsHandlers()
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application.GetAppPlayer().GetSeekHandler());
   GetSettingsManager()->UnregisterCallback(&g_application);
-  GetSettingsManager()->UnregisterCallback(&g_audioManager);
   GetSettingsManager()->UnregisterCallback(&g_charsetConverter);
   GetSettingsManager()->UnregisterCallback(&g_langInfo);
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);
@@ -914,10 +912,6 @@ void CSettings::InitializeISettingCallbacks()
   GetSettingsManager()->RegisterCallback(&g_application, settingSet);
 
   settingSet.clear();
-  settingSet.insert(CSettings::SETTING_LOOKANDFEEL_SOUNDSKIN);
-  GetSettingsManager()->RegisterCallback(&g_audioManager, settingSet);
-
-  settingSet.clear();
   settingSet.insert(CSettings::SETTING_SUBTITLES_CHARSET);
   settingSet.insert(CSettings::SETTING_LOCALE_CHARSET);
   GetSettingsManager()->RegisterCallback(&g_charsetConverter, settingSet);
@@ -981,7 +975,6 @@ void CSettings::UninitializeISettingCallbacks()
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application.GetAppPlayer().GetSeekHandler());
   GetSettingsManager()->UnregisterCallback(&g_application);
-  GetSettingsManager()->UnregisterCallback(&g_audioManager);
   GetSettingsManager()->UnregisterCallback(&g_charsetConverter);
   GetSettingsManager()->UnregisterCallback(&g_langInfo);
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);


### PR DESCRIPTION
## Motivation and Context
Kill a global following @FernetMenta's https://github.com/xbmc/xbmc/pull/13724 example.

## How Has This Been Tested?
Runtime tested on Ubuntu and Win10 x64.