### PR TITLE
[gui] Kill g_colorManager

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1550,7 +1550,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CServiceBroker::GetWinSystem()->GetGfxContext().SetMediaDir(skin->Path());
   g_directoryCache.ClearSubPaths(skin->Path());
 
-  g_colorManager.Load(m_ServiceManager->GetSettings().GetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS));
+  CServiceBroker::GetGUI()->GetColorManager().Load(m_ServiceManager->GetSettings().GetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS));
 
   g_SkinInfo->LoadIncludes();
 
@@ -1654,7 +1654,7 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
 
   g_fontManager.Clear();
 
-  g_colorManager.Clear();
+  CServiceBroker::GetGUI()->GetColorManager().Clear();
 
   CServiceBroker::GetGUI()->GetInfoManager().Clear();
 

--- a/xbmc/guilib/GUIColorManager.cpp
+++ b/xbmc/guilib/GUIColorManager.cpp
@@ -29,8 +29,6 @@
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
 
-CGUIColorManager g_colorManager;
-
 CGUIColorManager::CGUIColorManager(void) = default;
 
 CGUIColorManager::~CGUIColorManager(void)

--- a/xbmc/guilib/GUIColorManager.h
+++ b/xbmc/guilib/GUIColorManager.h
@@ -33,6 +33,8 @@
 #include <map>
 #include <string>
 
+#include "GUIComponent.h"
+#include "ServiceBroker.h"
 #include "utils/Color.h"
 
 class CXBMCTinyXML;
@@ -54,10 +56,3 @@ protected:
 
   std::map<std::string, UTILS::Color> m_colors;
 };
-
-/*!
- \ingroup textures
- \brief
- */
-extern CGUIColorManager g_colorManager;
-

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIComponent.h"
+#include "GUIColorManager.h"
 #include "GUIInfoManager.h"
 #include "GUILargeTextureManager.h"
 #include "GUIWindowManager.h"
@@ -35,6 +36,7 @@ CGUIComponent::CGUIComponent()
   m_pLargeTextureManager.reset(new CGUILargeTextureManager());
   m_stereoscopicsManager.reset(new CStereoscopicsManager(CServiceBroker::GetSettings()));
   m_guiInfoManager.reset(new CGUIInfoManager());
+  m_guiColorManager.reset(new CGUIColorManager());
 }
 
 CGUIComponent::~CGUIComponent()
@@ -84,6 +86,11 @@ CStereoscopicsManager &CGUIComponent::GetStereoscopicsManager()
 CGUIInfoManager &CGUIComponent::GetInfoManager()
 {
   return *m_guiInfoManager;
+}
+
+CGUIColorManager &CGUIComponent::GetColorManager()
+{
+  return *m_guiColorManager;
 }
 
 bool CGUIComponent::ConfirmDelete(std::string path)

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -28,6 +28,7 @@ class CGUITextureManager;
 class CGUILargeTextureManager;
 class CStereoscopicsManager;
 class CGUIInfoManager;
+class CGUIColorManager;
 
 class CGUIComponent
 {
@@ -42,6 +43,7 @@ public:
   CGUILargeTextureManager& GetLargeTextureManager();
   CStereoscopicsManager &GetStereoscopicsManager();
   CGUIInfoManager &GetInfoManager();
+  CGUIColorManager &GetColorManager();
 
   bool ConfirmDelete(std::string path);
 
@@ -52,4 +54,5 @@ protected:
   std::unique_ptr<CGUILargeTextureManager> m_pLargeTextureManager;
   std::unique_ptr<CStereoscopicsManager> m_stereoscopicsManager;
   std::unique_ptr<CGUIInfoManager> m_guiInfoManager;
+  std::unique_ptr<CGUIColorManager> m_guiColorManager;
 };

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -546,7 +546,7 @@ bool CGUIControlFactory::GetColor(const TiXmlNode *control, const char *strTag, 
   const TiXmlElement* node = control->FirstChildElement(strTag);
   if (node && node->FirstChild())
   {
-    value = g_colorManager.GetColor(node->FirstChild()->Value());
+    value = CServiceBroker::GetGUI()->GetColorManager().GetColor(node->FirstChild()->Value());
     return true;
   }
   return false;

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -427,7 +427,7 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
       {
         std::string t;
         g_charsetConverter.wToUTF8(text.substr(pos + 5, finish - pos - 5), t);
-        UTILS::Color color = g_colorManager.GetColor(t);
+        UTILS::Color color = CServiceBroker::GetGUI()->GetColorManager().GetColor(t);
         const auto& it = std::find(colors.begin(), colors.end(), color);
         if (it == colors.end())
         { // create new color

--- a/xbmc/guilib/guiinfo/GUIInfoColor.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.cpp
@@ -35,7 +35,7 @@ bool CGUIInfoColor::Update()
 
   // Expand the infolabel, and then convert it to a color
   std::string infoLabel(CServiceBroker::GetGUI()->GetInfoManager().GetLabel(m_info));
-  UTILS::Color color = !infoLabel.empty() ? g_colorManager.GetColor(infoLabel.c_str()) : 0;
+  UTILS::Color color = !infoLabel.empty() ? CServiceBroker::GetGUI()->GetColorManager().GetColor(infoLabel.c_str()) : 0;
   if (m_color != color)
   {
     m_color = color;
@@ -68,5 +68,5 @@ void CGUIInfoColor::Parse(const std::string &label, int context)
 
   m_info = infoMgr.TranslateString(label2);
   if (!m_info)
-    m_color = g_colorManager.GetColor(label);
+    m_color = CServiceBroker::GetGUI()->GetColorManager().GetColor(label);
 }


### PR DESCRIPTION
## Motivation and Context
Kill a global following @FernetMenta's https://github.com/xbmc/xbmc/pull/13724 example.

## How Has This Been Tested?
Runtime tested on Ubuntu and Win10 x64.