### PR TITLE
[cleanup][win10] remove drive letter hacks

### DIFF
--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -205,26 +205,6 @@ StorageFolder CWinLibraryDirectory::GetFolder(const CURL& url)
 
   // find inner folder
   std::string folderPath = URIUtils::FixSlashesAndDups(url.GetFileName(), '\\');
-  if (url.GetHostName() == "removable")
-  {
-    // here path has the form e\path where first segment is drive letter
-    // we should make path form like regular e:\path
-    auto index = folderPath.find('\\');
-    if (index != std::string::npos)
-    {
-      folderPath = folderPath.insert(index, 1, ':');
-    }
-    // win-lib://removable/F -> folderPath contains only drive letter
-    else if (index == std::string::npos && folderPath.length() == 1)
-    {
-      folderPath += ":\\";
-    }
-    else
-    {
-      return nullptr;
-    }
-  }
-
   if (!folderPath.empty())
   {
     try

--- a/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
@@ -340,20 +340,6 @@ StorageFile CWinLibraryFile::GetFile(const CURL& url)
       return nullptr;
 
     std::string filePath = URIUtils::FixSlashesAndDups(url.GetFileName(), '\\');
-    if (url.GetHostName() == "removable")
-    {
-      // here filePath has the form e\path\file.ext where first segment is
-      // drive letter, we should make path form like regular e:\path\file.ext
-      auto index = filePath.find('\\');
-      if (index == std::string::npos)
-      {
-        CLog::LogF(LOGDEBUG, "wrong file path '%s'", url.GetRedacted().c_str());
-        return nullptr;
-      }
-
-      filePath = filePath.insert(index, 1, ':');
-    }
-
     try
     {
       std::wstring wpath = ToW(filePath);

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -101,20 +101,21 @@ void CStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
     auto devicesView = Wait(winrt::Windows::Storage::KnownFolders::RemovableDevices().GetFoldersAsync());
     for (unsigned i = 0; i < devicesView.Size(); i++)
     {
-      CMediaSource source;
       auto device = devicesView.GetAt(i);
+      if (device.Path().empty())
+        continue;
+      CMediaSource source;
       source.strName = FromW(device.DisplayName().c_str());
-      std::string driveLetter = FromW(device.Name().c_str()).substr(0, 1);
-      std::string root = driveLetter + ":\\";
+      std::string driveLetter = FromW(device.Path().c_str());
 
       // skip exiting in case if we have direct access
-      auto exiting = std::find_if(removableDrives.begin(), removableDrives.end(), [&root](CMediaSource& m) {
-        return m.strPath == root;
+      auto exiting = std::find_if(removableDrives.begin(), removableDrives.end(), [&driveLetter](CMediaSource& m) {
+        return m.strPath == driveLetter;
       });
       if (exiting != removableDrives.end())
         continue;
 
-      UINT uDriveType = GetDriveTypeA(root.c_str());
+      UINT uDriveType = GetDriveTypeA(driveLetter.c_str());
       source.strPath = "win-lib://removable/" + driveLetter + "/";
       source.m_iDriveType = (
         (uDriveType == DRIVE_FIXED) ? CMediaSource::SOURCE_TYPE_LOCAL :


### PR DESCRIPTION
## Motivation and Context
Kodi crashes if I have plugged in my phone, as it is returned as RemovableDevice, but doesn't have a single letter drive letter.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
