### PR TITLE
 RetroPlayer: Remove width and height state from renderers

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -527,18 +527,6 @@ void CRetroPlayer::Render(bool clear, uint32_t alpha /* = 255 */, bool gui /* = 
   // Performed by callbacks
 }
 
-void CRetroPlayer::FlushRenderer()
-{
-  if (m_renderManager)
-    m_renderManager->Flush();
-}
-
-void CRetroPlayer::TriggerUpdateResolution()
-{
-  if (m_renderManager)
-    m_renderManager->TriggerUpdateResolution();
-}
-
 bool CRetroPlayer::IsRenderingVideo()
 {
   return true;

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -50,10 +50,7 @@ namespace RETRO
     ~CRetroPlayer() override;
 
     // implementation of IPlayer
-    //virtual bool Initialize(TiXmlElement* pConfig) override { return true; }
     bool OpenFile(const CFileItem& file, const CPlayerOptions& options) override;
-    //virtual bool QueueNextFile(const CFileItem &file) override { return false; }
-    //virtual void OnNothingToQueueNotify() override { }
     bool CloseFile(bool reopen = false) override;
     bool IsPlaying() const override;
     bool CanPause() override;
@@ -61,75 +58,20 @@ namespace RETRO
     bool HasVideo() const override { return true; }
     bool HasAudio() const override { return true; }
     bool HasGame() const override { return true; }
-    //virtual bool HasRDS() const override { return false; }
-    //virtual bool IsPassthrough() const override { return false;}
     bool CanSeek() override;
     void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) override;
-    //virtual bool SeekScene(bool bPlus = true) override { return false; }
     void SeekPercentage(float fPercent = 0) override;
     float GetCachePercentage() override;
     void SetMute(bool bOnOff) override;
-    //virtual void SetVolume(float volume) override { }
-    //virtual void SetDynamicRangeCompression(long drc) override { }
-    //virtual void SetAVDelay(float fValue = 0.0f) override { return; }
-    //virtual float GetAVDelay() override { return 0.0f; }
-    //virtual void SetSubTitleDelay(float fValue = 0.0f) override { }
-    //virtual float GetSubTitleDelay() override { return 0.0f; }
-    //virtual int GetSubtitleCount() override { return 0; }
-    //virtual int GetSubtitle() override { return -1; }
-    //virtual void GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info) override { }
-    //virtual void SetSubtitle(int iStream) override { }
-    //virtual bool GetSubtitleVisible() override { return false; }
-    //virtual void SetSubtitleVisible(bool bVisible) override { }
-    //virtual void AddSubtitle(const std::string& strSubPath) override { }
-    //virtual int GetAudioStreamCount() override { return 0; }
-    //virtual int GetAudioStream() override { return -1; }
-    //virtual void SetAudioStream(int iStream) override { }
-    //virtual void GetAudioStreamInfo(int index, AudioStreamInfo &info) override { }
-    //virtual int GetVideoStream() const override { return -1; }
-    //virtual int GetVideoStreamCount() const override { return 0; }
-    //virtual void GetVideoStreamInfo(int streamId, VideoStreamInfo &info) override { }
-    //virtual void SetVideoStream(int iStream) override { }
-    //virtual TextCacheStruct_t* GetTeletextCache() override { return NULL; }
-    //virtual void LoadPage(int p, int sp, unsigned char* buffer) override { }
-    //virtual std::string GetRadioText(unsigned int line) override { return ""; }
-    //virtual int GetChapterCount() override { return 0; }
-    //virtual int GetChapter() override { return -1; }
-    //virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) override { return; }
-    //virtual int64_t GetChapterPos(int chapterIdx = -1) override { return 0; }
-    //virtual int SeekChapter(int iChapter) override { return -1; }
-    //virtual float GetActualFPS() override { return 0.0f; }
     void SeekTime(int64_t iTime = 0) override;
     bool SeekTimeRelative(int64_t iTime) override;
-    //virtual void SetTotalTime(int64_t time) override { } // Only used by Air Tunes Server
     void SetSpeed(float speed) override;
-    //virtual bool IsCaching() const override { return false; }
-    //virtual int GetCacheLevel() const override { return -1; }
-    //virtual bool IsInMenu() const override { return false; }
-    //virtual bool HasMenu() const override { return false; }
-    //virtual void DoAudioWork() override { }
-    //virtual bool OnAction(const CAction &action) override { return false; }
     bool OnAction(const CAction &action) override;
     std::string GetPlayerState() override;
     bool SetPlayerState(const std::string& state) override;
-    //virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) override { return false; }
-    //virtual void GetAudioCapabilities(std::vector<int> &audioCaps) override { audioCaps.assign(1,IPC_AUD_ALL); }
-    //virtual void GetSubtitleCapabilities(std::vector<int> &subCaps) override { subCaps.assign(1,IPC_SUBS_ALL); }
     void FrameMove() override;
     void Render(bool clear, uint32_t alpha = 255, bool gui = true) override;
-    void FlushRenderer() override;
-    //void SetRenderViewMode(int mode) override { } // Must go through render callback
-    //float GetRenderAspectRatio() override { return 1.0f; }
-    void TriggerUpdateResolution() override;
     bool IsRenderingVideo() override;
-    //bool Supports(EINTERLACEMETHOD method) override { return false; } // Must go through render callback
-    //EINTERLACEMETHOD GetDeinterlacingMethodDefault() override { return EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE; } // Must go through render callback
-    //bool Supports(ESCALINGMETHOD method) override { return false; } // Must go through render callback
-    //bool Supports(ERENDERFEATURE feature) override { return false; } // Must go through render callback
-    //unsigned int RenderCaptureAlloc() override { return 0; }
-    //void RenderCaptureRelease(unsigned int captureId) override { }
-    //void RenderCapture(unsigned int captureId, unsigned int width, unsigned int height, int flags) override { }
-    //bool RenderCaptureGetPixels(unsigned int captureId, unsigned int millis, uint8_t *buffer, unsigned int size) override { return false; }
 
     // Implementation of IGameCallback
     std::string GameClientID() const override;

--- a/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
@@ -62,6 +62,8 @@ namespace RETRO
     void SetLoaded(bool bLoaded) { m_bLoaded = bLoaded; }
     bool IsRendered() const { return m_bRendered; }
     void SetRendered(bool bRendered) { m_bRendered = bRendered; }
+    unsigned int GetRotation() const { return m_rotationDegCCW; }
+    void SetRotation(unsigned int rotationDegCCW) { m_rotationDegCCW = rotationDegCCW; }
 
   protected:
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
@@ -69,6 +71,7 @@ namespace RETRO
     unsigned int m_height = 0;
     bool m_bLoaded = false;
     bool m_bRendered = false;
+    unsigned int m_rotationDegCCW = 0;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -95,24 +95,14 @@ bool CRPRenderManager::Configure(AVPixelFormat format, unsigned int nominalWidth
             maxWidth,
             maxHeight);
 
-  CSingleLock lock(m_stateMutex);
-
   // Immutable parameters
   m_format = format;
   m_maxWidth = maxWidth;
   m_maxHeight = maxHeight;
 
-  // Mutable parameters
-  m_width = nominalWidth;
-  m_height = nominalHeight;
+  CSingleLock lock(m_stateMutex);
 
-  if (m_state == RENDER_STATE::UNCONFIGURED)
-    m_state = RENDER_STATE::CONFIGURING;
-  else if (m_state != RENDER_STATE::CONFIGURING)
-  {
-    Flush();
-    m_state = RENDER_STATE::RECONFIGURING;
-  }
+  m_state = RENDER_STATE::CONFIGURING;
 
   return true;
 }
@@ -125,13 +115,6 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width, unsigned int height, A
 
   if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
     return false;
-
-  if (width != m_width || height != m_height)
-  {
-    // Reconfigure
-    Configure(m_format, width, height, m_maxWidth, m_maxHeight);
-    return false;
-  }
 
   // Get buffers from visible renderers
   for (IRenderBufferPool *bufferPool : m_processInfo.GetBufferManager().GetBufferPools())
@@ -167,13 +150,6 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
   // Validate parameters
   if (data == nullptr || size == 0 || width == 0 || height == 0)
     return;
-
-  if (width != m_width || height != m_height)
-  {
-    // Reconfigure
-    Configure(m_format, width, height, m_maxWidth, m_maxHeight);
-    return;
-  }
 
   // Get render buffers to copy the frame into
   std::vector<IRenderBuffer*> renderBuffers;
@@ -239,6 +215,8 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
           std::memcpy(cachedFrame.data(), data, size);
         }
         m_cachedFrame = std::move(cachedFrame);
+        m_cachedWidth = width;
+        m_cachedHeight = height;
       }
     }
   }
@@ -268,16 +246,6 @@ void CRPRenderManager::FrameMove()
 
       CLog::Log(LOGINFO, "RetroPlayer[RENDER]: Renderer configured on first frame");
     }
-    else if (m_state == RENDER_STATE::RECONFIGURING)
-    {
-      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Reconfiguring %u renderer(s)", m_renderers.size());
-
-      // Reconfigure any existing renderers
-      for (auto &renderer : m_renderers)
-        renderer->Configure(m_format, m_width, m_height);
-
-      m_state = RENDER_STATE::CONFIGURED;
-    }
 
     if (m_state == RENDER_STATE::CONFIGURED)
       bIsConfigured = true;
@@ -301,6 +269,8 @@ void CRPRenderManager::CheckFlush()
       m_renderBuffers.clear();
 
       m_cachedFrame.clear();
+      m_cachedWidth = 0;
+      m_cachedHeight = 0;
 
       m_bHasCachedFrame = false;
     }
@@ -502,7 +472,7 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(IRenderBufferPool
               m_processInfo.GetRenderSystemName(bufferPool).c_str());
 
     renderer.reset(m_processInfo.CreateRenderer(bufferPool, renderSettings));
-    if (renderer && renderer->Configure(m_format, m_width, m_height))
+    if (renderer && renderer->Configure(m_format))
     {
       // Ensure we have a render buffer for this renderer
       CreateRenderBuffer(renderer->GetBufferPool());
@@ -567,13 +537,13 @@ void CRPRenderManager::CreateRenderBuffer(IRenderBufferPool *bufferPool)
 
   if (!HasRenderBuffer(bufferPool) && m_bHasCachedFrame)
   {
-    IRenderBuffer *renderBuffer = CreateFromCache(m_cachedFrame, bufferPool, m_bufferMutex);
+    IRenderBuffer *renderBuffer = CreateFromCache(m_cachedFrame, m_cachedWidth, m_cachedHeight, bufferPool, m_bufferMutex);
     if (renderBuffer != nullptr)
       m_renderBuffers.emplace_back(renderBuffer);
   }
 }
 
-IRenderBuffer *CRPRenderManager::CreateFromCache(std::vector<uint8_t> &cachedFrame, IRenderBufferPool *bufferPool, CCriticalSection &mutex)
+IRenderBuffer *CRPRenderManager::CreateFromCache(std::vector<uint8_t> &cachedFrame, unsigned int width, unsigned int height, IRenderBufferPool *bufferPool, CCriticalSection &mutex)
 {
   // Take ownership of cached frame
   std::vector<uint8_t> ownedFrame = std::move(cachedFrame);
@@ -582,11 +552,11 @@ IRenderBuffer *CRPRenderManager::CreateFromCache(std::vector<uint8_t> &cachedFra
   {
     CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating render buffer for renderer");
 
-    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(m_width, m_height);
+    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(width, height);
     if (renderBuffer != nullptr)
     {
       CSingleExit exit(mutex);
-      CopyFrame(renderBuffer, m_format, ownedFrame.data(), ownedFrame.size(), m_width, m_height);
+      CopyFrame(renderBuffer, m_format, ownedFrame.data(), ownedFrame.size(), width, height);
     }
 
     // Return ownership of cached frame

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -192,6 +192,10 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
       renderBuffer->Release();
     m_renderBuffers = std::move(renderBuffers);
 
+    // Apply rotation to render buffers
+    for (auto renderBuffer : m_renderBuffers)
+      renderBuffer->SetRotation(orientationDegCCW);
+
     // Cache frame if it arrived after being paused
     if (m_speed == 0.0)
     {

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -320,11 +320,6 @@ void CRPRenderManager::Flush()
   m_bFlush = true;
 }
 
-void CRPRenderManager::TriggerUpdateResolution()
-{
-  m_bTriggerUpdateResolution = true;
-}
-
 void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO &coordsRes)
 {
   std::shared_ptr<CRPBaseRenderer> renderer = GetRenderer(nullptr);
@@ -605,25 +600,6 @@ IRenderBuffer *CRPRenderManager::CreateFromCache(std::vector<uint8_t> &cachedFra
   }
 
   return nullptr;
-}
-
-void CRPRenderManager::UpdateResolution()
-{
-  /* @todo
-  if (m_bTriggerUpdateResolution)
-  {
-    if (m_renderContext.IsFullScreenVideo() && m_renderContext.IsFullScreenRoot())
-    {
-      if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
-      {
-        RESOLUTION res = CResolutionUtils::ChooseBestResolution(static_cast<float>(m_framerate), 0, false);
-        m_renderContext.SetVideoResolution(res);
-      }
-      m_bTriggerUpdateResolution = false;
-      m_playerPort->VideoParamsChange();
-    }
-  }
-  */
 }
 
 void CRPRenderManager::CopyFrame(IRenderBuffer *renderBuffer, AVPixelFormat format, const uint8_t *data, size_t size, unsigned int width, unsigned int height)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -153,13 +153,15 @@ namespace RETRO
      * empty.
      *
      * \param cachedFrame The cached frame
+     * \param width The width of the cached frame
+     * \param height The height of the cached frame
      * \param bufferPool The buffer pool used to create the render buffer
      * \param mutex The locked mutex, to be unlocked during memory copy
      *
      * \return The render buffer if one was created from the cached frame,
      *         otherwise nullptr
      */
-    IRenderBuffer *CreateFromCache(std::vector<uint8_t> &cachedFrame, IRenderBufferPool *bufferPool, CCriticalSection &mutex);
+    IRenderBuffer *CreateFromCache(std::vector<uint8_t> &cachedFrame, unsigned int width, unsigned int height, IRenderBufferPool *bufferPool, CCriticalSection &mutex);
 
     /*!
      * \brief Utility function to copy a frame and rescale pixels if necessary
@@ -182,8 +184,6 @@ namespace RETRO
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
     unsigned int m_maxWidth = 0;
     unsigned int m_maxHeight = 0;
-    unsigned int m_width = 0; //! @todo Remove me when dimension changing is implemented
-    unsigned int m_height = 0; //! @todo Remove me when dimension changing is implemented
 
     // Render resources
     std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
@@ -191,13 +191,14 @@ namespace RETRO
     std::vector<IRenderBuffer*> m_renderBuffers;
     std::map<AVPixelFormat, SwsContext*> m_scalers;
     std::vector<uint8_t> m_cachedFrame;
+    unsigned int m_cachedWidth = 0;
+    unsigned int m_cachedHeight = 0;
 
     // State parameters
     enum class RENDER_STATE
     {
       UNCONFIGURED,
       CONFIGURING,
-      RECONFIGURING,
       CONFIGURED,
     };
     RENDER_STATE m_state = RENDER_STATE::UNCONFIGURED;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -97,7 +97,6 @@ namespace RETRO
     // Functions called from render thread
     void FrameMove();
     void Flush();
-    void TriggerUpdateResolution();
 
     // Implementation of IRenderManager
     void RenderWindow(bool bClear, const RESOLUTION_INFO &coordsRes) override;
@@ -162,8 +161,6 @@ namespace RETRO
      */
     IRenderBuffer *CreateFromCache(std::vector<uint8_t> &cachedFrame, IRenderBufferPool *bufferPool, CCriticalSection &mutex);
 
-    void UpdateResolution();
-
     /*!
      * \brief Utility function to copy a frame and rescale pixels if necessary
      */
@@ -206,7 +203,6 @@ namespace RETRO
     RENDER_STATE m_state = RENDER_STATE::UNCONFIGURED;
     bool m_bHasCachedFrame = false; // Invariant: m_cachedFrame is empty if false
     std::set<std::string> m_failedShaderPresets;
-    bool m_bTriggerUpdateResolution = false;
     std::atomic<bool> m_bFlush = {false};
 
     // Playback parameters

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -90,13 +90,13 @@ namespace RETRO
     bool Configure(AVPixelFormat format, unsigned int nominalWidth, unsigned int nominalHeight, unsigned int maxWidth, unsigned int maxHeight);
     bool GetVideoBuffer(unsigned int width, unsigned int height, AVPixelFormat &format, uint8_t *&data, size_t &size);
     void AddFrame(const uint8_t* data, size_t size, unsigned int width, unsigned int height, unsigned int orientationDegCW);
+    void Flush();
 
     // Functions called from the player
     void SetSpeed(double speed);
 
     // Functions called from render thread
     void FrameMove();
-    void Flush();
 
     // Implementation of IRenderManager
     void RenderWindow(bool bClear, const RESOLUTION_INFO &coordsRes) override;

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
@@ -176,7 +176,7 @@ void CRenderUtils::ClipRect(const CRect &viewRect, CRect &sourceRect, CRect &des
   }
 }
 
-std::array<CPoint, 4> CRenderUtils::ReorderDrawPoints(const CRect &destRect, unsigned int orientationDegCCW, float aspectRatio)
+std::array<CPoint, 4> CRenderUtils::ReorderDrawPoints(const CRect &destRect, unsigned int orientationDegCCW)
 {
   std::array<CPoint, 4> rotatedDestCoords{};
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
@@ -34,7 +34,7 @@ namespace RETRO
     static void CalculateViewMode(VIEWMODE viewMode, unsigned int rotationDegCCW, unsigned int sourceWidth, unsigned int sourceHeight, float screenWidth, float screenHeight, float &pixelRatio, float &zoomAmount);
     static void CalcNormalRenderRect(const CRect &viewRect, float outputFrameRatio, float zoomAmount, CRect &destRect);
     static void ClipRect(const CRect &viewRect, CRect &sourceRect, CRect &destRect);
-    static std::array<CPoint, 4> ReorderDrawPoints(const CRect &destRect, unsigned int orientationDegCCW, float aspectRatio);
+    static std::array<CPoint, 4> ReorderDrawPoints(const CRect &destRect, unsigned int orientationDegCCW);
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -185,7 +185,7 @@ void CRPBaseRenderer::ManageRenderArea()
     CRenderUtils::ClipRect(viewRect, m_sourceRect, destRect);
 
   // Adapt the drawing rect points if we have to rotate
-  m_rotatedDestCoords = CRenderUtils::ReorderDrawPoints(destRect, rotationDegCCW, GetAspectRatio());
+  m_rotatedDestCoords = CRenderUtils::ReorderDrawPoints(destRect, rotationDegCCW);
 }
 
 void CRPBaseRenderer::MarkDirty()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -57,7 +57,6 @@ bool CRPBaseRenderer::IsCompatible(const CRenderVideoSettings &settings) const
 bool CRPBaseRenderer::Configure(AVPixelFormat format)
 {
   m_format = format;
-  m_renderOrientation = 0; //! @todo
 
   if (!m_bufferPool->IsConfigured())
   {
@@ -144,7 +143,7 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer &renderBuffer)
   // Get texture parameters
   const unsigned int sourceWidth = renderBuffer.GetWidth();
   const unsigned int sourceHeight = renderBuffer.GetHeight();
-  const unsigned int sourceRotationDegCCW = m_renderOrientation; //! @todo
+  const unsigned int sourceRotationDegCCW = renderBuffer.GetRotation();
   const float sourceAspectRatio = static_cast<float>(sourceWidth) / static_cast<float>(sourceHeight);
 
   const VIEWMODE viewMode = m_renderSettings.VideoSettings().GetRenderViewMode();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -52,7 +52,7 @@ namespace RETRO
     IRenderBufferPool *GetBufferPool() { return m_bufferPool.get(); }
 
     // Player functions
-    bool Configure(AVPixelFormat format, unsigned int width, unsigned int height);
+    bool Configure(AVPixelFormat format);
     void FrameMove();
     /*!
      * \brief Performs whatever necessary before rendering the frame
@@ -86,14 +86,6 @@ namespace RETRO
     virtual void RenderInternal(bool clear, uint8_t alpha) = 0;
     virtual void FlushInternal() { }
 
-    /*!
-     * \brief Calculate driven dimensions
-     */
-    virtual void ManageRenderArea();
-
-    float GetAspectRatio() const;
-    unsigned int GetRotationDegCCW() const;
-
     // Construction parameters
     CRenderContext &m_context;
     std::shared_ptr<IRenderBufferPool> m_bufferPool;
@@ -101,8 +93,6 @@ namespace RETRO
     // Stream properties
     bool m_bConfigured = false;
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
-    unsigned int m_sourceWidth = 0;
-    unsigned int m_sourceHeight = 0;
     unsigned int m_renderOrientation = 0; // Degrees counter-clockwise
 
     // Rendering properties
@@ -114,6 +104,11 @@ namespace RETRO
     std::array<CPoint, 4> m_rotatedDestCoords{};
 
   private:
+    /*!
+     * \brief Calculate driven dimensions
+     */
+    virtual void ManageRenderArea(const IRenderBuffer &renderBuffer);
+
     /*!
      * \brief Performs whatever nessesary after a frame has been rendered
      */

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -93,7 +93,6 @@ namespace RETRO
     // Stream properties
     bool m_bConfigured = false;
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
-    unsigned int m_renderOrientation = 0; // Degrees counter-clockwise
 
     // Rendering properties
     CRenderSettings m_renderSettings;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
@@ -73,10 +73,10 @@ void CRPRendererGBM::Render(uint8_t alpha)
 
   CRect rect = m_sourceRect;
 
-  rect.x1 /= m_sourceWidth;
-  rect.x2 /= m_sourceWidth;
-  rect.y1 /= m_sourceHeight;
-  rect.y2 /= m_sourceHeight;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
 
   const uint32_t color = (alpha << 24) | 0xFFFFFF;
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -102,10 +102,10 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
 
   CRect rect = m_sourceRect;
 
-  rect.x1 /= m_sourceWidth;
-  rect.x2 /= m_sourceWidth;
-  rect.y1 /= m_sourceHeight;
-  rect.y2 /= m_sourceHeight;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
 
   float u1 = rect.x1;
   float u2 = rect.x2;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -418,10 +418,10 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
 
   CRect rect = m_sourceRect;
 
-  rect.x1 /= m_sourceWidth;
-  rect.x2 /= m_sourceWidth;
-  rect.y1 /= m_sourceHeight;
-  rect.y2 /= m_sourceHeight;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
 
   const uint32_t color = (alpha << 24) | 0xFFFFFF;
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -308,7 +308,7 @@ void CRPWinRenderer::Render(CD3DTexture *target)
       // Use the picked output shader to render to the target
       if (outputShader != nullptr)
       {
-        outputShader->Render(*intermediateTarget, m_sourceWidth, m_sourceHeight,
+        outputShader->Render(*intermediateTarget,
           m_sourceRect, destPoints, viewPort, target,
           m_context.UseLimitedColor() ? 1 : 0);
       }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.cpp
@@ -55,10 +55,10 @@ bool CRPWinOutputShader::Create(SCALINGMETHOD scalingMethod)
   return CWinShader::CreateInputLayout(layout, ARRAYSIZE(layout));
 }
 
-void CRPWinOutputShader::Render(CD3DTexture& sourceTexture, unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4]
+void CRPWinOutputShader::Render(CD3DTexture& sourceTexture, CRect sourceRect, const CPoint points[4]
   , CRect &viewPort, CD3DTexture *target, unsigned range)
 {
-  PrepareParameters(sourceWidth, sourceHeight, sourceRect, points);
+  PrepareParameters(sourceTexture.GetWidth(), sourceTexture.GetHeight(), sourceRect, points);
   SetShaderParameters(sourceTexture, range, viewPort);
   Execute({ target }, 4);
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.h
@@ -34,7 +34,7 @@ public:
   ~CRPWinOutputShader() = default;
 
   bool Create(SCALINGMETHOD scalingMethod);
-  void Render(CD3DTexture &sourceTexture, unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4]
+  void Render(CD3DTexture &sourceTexture, CRect sourceRect, const CPoint points[4]
     , CRect &viewPort, CD3DTexture *target, unsigned range = 0);
 
 private:


### PR DESCRIPTION
Instead of storing width and height in the render manager and each renderer, we read width and height from the values passed in-band with the video frames. This allows us to drop width and height from the renderer/render manager state, which avoids the need to reconfigure when dimensions change.

Also, this exposes the emulator's rotation to the renderers. I made the same change for Aspect Ratio, but for every core I tried, square pixels looked better than the forced aspect ratios, so I dropped that change.

Includes #14194.

## Motivation and Context
After #13976, width and height are no longer properties of the stream, but properties of each video frame. At the time, I didn't extend this model to Render Manager because the math wasn't abstracted. #14019 fixed this, so this PR is now possible.

## How Has This Been Tested?
Tested with PCSX (changes dimensions) on Windows 7 and OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
