### PR TITLE
[VideoLibrary] Do not scan unsupported plugin sources + fix database cleaning

### DIFF
--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -5,6 +5,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element name="provides" type="providesList"/>
+        <xs:element name="medialibraryscanpath" type="pathType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
@@ -28,5 +29,21 @@
   <xs:simpleType name="providesList">
     <xs:list itemType="providesType"/>
   </xs:simpleType>
+  <xs:simpleType name="contentType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="albums"/>
+      <xs:enumeration value="artists"/>
+      <xs:enumeration value="movies"/>
+      <xs:enumeration value="tvshows"/>
+      <xs:enumeration value="musicvideos"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="pathType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="content" type="contentType" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
 </xs:schema>
 

--- a/xbmc/addons/PluginSource.h
+++ b/xbmc/addons/PluginSource.h
@@ -25,6 +25,8 @@
 namespace ADDON
 {
 
+typedef std::map<std::string, std::vector<std::string>> ContentPathMap;
+
 class CPluginSource : public CAddon
 {
 public:
@@ -48,6 +50,11 @@ public:
     return m_providedContent.size() > 1;
   }
 
+  const ContentPathMap& MediaLibraryScanPaths() const
+  {
+    return m_mediaLibraryScanPaths;
+  }
+
   static Content Translate(const std::string &content);
 private:
   /*! \brief Set the provided content for this plugin
@@ -56,6 +63,7 @@ private:
    */
   void SetProvides(const std::string &content);
   std::set<Content> m_providedContent;
+  ContentPathMap m_mediaLibraryScanPaths;
 };
 
 } /*namespace ADDON*/

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -53,6 +53,21 @@ public:
   static bool RunScriptWithParams(const std::string& strPath, bool resume);
   static bool GetPluginResult(const std::string& strPath, CFileItem &resultItem, bool resume);
 
+  /*! \brief Check whether a plugin supports media library scanning.
+  \param content content type - movies, tvshows, musicvideos.
+  \param strPath full plugin url.
+  \return true if scanning at specified url is allowed, false otherwise.
+  */
+  static bool IsMediaLibraryScanningAllowed(const std::string& content, const std::string& strPath);
+
+  /*! \brief Check whether a plugin url exists by calling the plugin and checking result.
+  Applies only to plugins that support media library scanning.
+  \param content content type - movies, tvshows, musicvideos.
+  \param strPath full plugin url.
+  \return true if the plugin supports scanning and specified url exists, false otherwise.
+  */
+  static bool CheckExists(const std::string& content, const std::string& strPath);
+
   // callbacks from python
   static bool AddItem(int handle, const CFileItem *item, int totalItems);
   static bool AddItems(int handle, const CFileItemList *items, int totalItems);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -39,6 +39,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
+#include "filesystem/PluginDirectory.h"
 #include "filesystem/StackDirectory.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "GUIInfoManager.h"
@@ -8463,6 +8464,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
   {
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDS2.get()) return;
 
     unsigned int time = XbmcThreads::SystemClockMillis();
     CLog::Log(LOGNOTICE, "%s: Starting videodatabase cleanup ..", __FUNCTION__);
@@ -8480,8 +8482,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       sql += PrepareSQL(" AND path.idPath IN (%s)", strPaths.substr(1).c_str());
     }
 
-    m_pDS->query(sql);
-    if (m_pDS->num_rows() == 0) return;
+    m_pDS2->query(sql);
+    if (m_pDS2->num_rows() == 0) return;
 
     if (handle)
     {
@@ -8507,13 +8509,13 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
     VECSOURCES videoSources(*CMediaSourceSettings::GetInstance().GetSources("video"));
     g_mediaManager.GetRemovableDrives(videoSources);
 
-    int total = m_pDS->num_rows();
+    int total = m_pDS2->num_rows();
     int current = 0;
 
-    while (!m_pDS->eof())
+    while (!m_pDS2->eof())
     {
-      std::string path = m_pDS->fv("path.strPath").get_asString();
-      std::string fileName = m_pDS->fv("files.strFileName").get_asString();
+      std::string path = m_pDS2->fv("path.strPath").get_asString();
+      std::string fileName = m_pDS2->fv("files.strFileName").get_asString();
       std::string fullPath;
       ConstructPath(fullPath, path, fileName);
 
@@ -8525,11 +8527,25 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       if (URIUtils::IsInArchive(fullPath))
         fullPath = CURL(fullPath).GetHostName();
 
-      // remove optical, non-existing files, files with no matching source
-      bool bIsSource;
-      if (URIUtils::IsOnDVD(fullPath) || !CFile::Exists(fullPath, false) ||
-          CUtil::GetMatchingSource(fullPath, videoSources, bIsSource) < 0)
-        filesToTestForDelete += m_pDS->fv("files.idFile").get_asString() + ",";
+      bool del = true;
+      if (URIUtils::IsPlugin(fullPath))
+      {
+        SScanSettings settings;
+        bool foundDirectly = false;
+        ScraperPtr scraper = GetScraperForPath(fullPath, settings, foundDirectly);
+        if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), fullPath))
+          del = false;
+      }
+      else
+      {
+        // remove optical, non-existing files, files with no matching source
+        bool bIsSource;
+        if (!URIUtils::IsOnDVD(fullPath) && CFile::Exists(fullPath, false) &&
+            CUtil::GetMatchingSource(fullPath, videoSources, bIsSource) >= 0)
+          del = false;
+      }
+      if (del)
+        filesToTestForDelete += m_pDS2->fv("files.idFile").get_asString() + ",";
 
       if (handle == NULL && progress != NULL)
       {
@@ -8542,7 +8558,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
         if (progress->IsCanceled())
         {
           progress->Close();
-          m_pDS->close();
+          m_pDS2->close();
           ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
           return;
         }
@@ -8550,10 +8566,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
       else if (handle != NULL)
         handle->SetPercentage(current * 100 / (float)total);
 
-      m_pDS->next();
+      m_pDS2->next();
       current++;
     }
-    m_pDS->close();
+    m_pDS2->close();
 
     std::string filesToDelete;
 
@@ -8629,22 +8645,36 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
                    "AND (strSettings IS NULL OR strSettings = '') "
                    "AND (strHash IS NULL OR strHash = '') "
                    "AND (exclude IS NULL OR exclude != 1))";
-    m_pDS->query(sql);
+    m_pDS2->query(sql);
     std::string strIds;
-    while (!m_pDS->eof())
+    while (!m_pDS2->eof())
     {
-      auto pathsDeleteDecision = pathsDeleteDecisions.find(m_pDS->fv(0).get_asInt());
+      auto pathsDeleteDecision = pathsDeleteDecisions.find(m_pDS2->fv(0).get_asInt());
       // Check if we have a decision for the parent path
-      auto pathsDeleteDecisionByParent = pathsDeleteDecisions.find(m_pDS->fv(2).get_asInt());
+      auto pathsDeleteDecisionByParent = pathsDeleteDecisions.find(m_pDS2->fv(2).get_asInt());
+      std::string path = m_pDS2->fv(1).get_asString();
+
+      bool exists = false;
+      if (URIUtils::IsPlugin(path))
+      {
+        SScanSettings settings;
+        bool foundDirectly = false;
+        ScraperPtr scraper = GetScraperForPath(path, settings, foundDirectly);
+        if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), path))
+          exists = true;
+      }
+      else
+        exists = CDirectory::Exists(path, false);
+
       if (((pathsDeleteDecision != pathsDeleteDecisions.end() && pathsDeleteDecision->second) ||
-           (pathsDeleteDecision == pathsDeleteDecisions.end() && !CDirectory::Exists(m_pDS->fv(1).get_asString(), false))) &&
+           (pathsDeleteDecision == pathsDeleteDecisions.end() && !exists)) &&
           ((pathsDeleteDecisionByParent != pathsDeleteDecisions.end() && pathsDeleteDecisionByParent->second) ||
            (pathsDeleteDecisionByParent == pathsDeleteDecisions.end())))
-        strIds += m_pDS->fv(0).get_asString() + ",";
+        strIds += m_pDS2->fv(0).get_asString() + ",";
 
-      m_pDS->next();
+      m_pDS2->next();
     }
-    m_pDS->close();
+    m_pDS2->close();
 
     if (!strIds.empty())
     {
@@ -9693,16 +9723,9 @@ void CVideoDatabase::InvalidatePathHash(const std::string& strPath)
   {
     if (info->Content() == CONTENT_TVSHOWS || settings.parent_name_root)
     {
-      if (URIUtils::IsPlugin(strPath))
-      {
-        // Check if we are already at plugin root
-        CURL url(strPath);
-        if (url.GetWithoutFilename() == strPath)
-          return;
-      }
       std::string strParent;
-      URIUtils::GetParentPath(strPath,strParent);
-      SetPathHash(strParent,"");
+      if (URIUtils::GetParentPath(strPath, strParent) && (!URIUtils::IsPlugin(strPath) || !CURL(strParent).GetHostName().empty()))
+        SetPathHash(strParent, "");
     }
   }
 }

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -27,6 +27,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "filesystem/PluginDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -79,6 +80,12 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
   ADDON::ScraperPtr scraper = db.GetScraperForPath(m_item->GetPath(), scanSettings);
   if (scraper == nullptr)
     return false;
+
+  if (URIUtils::IsPlugin(m_item->GetPath()) && !XFILE::CPluginDirectory::IsMediaLibraryScanningAllowed(ADDON::TranslateContent(scraper->Content()), m_item->GetPath()))
+  {
+    CLog::Log(LOGNOTICE, "CVideoLibraryRefreshingJob: Plugin '%s' does not support media library scanning and refreshing", CURL::GetRedacted(m_item->GetPath()).c_str());
+    return false;
+  }
 
   // copy the scraper in case we need it again
   ADDON::ScraperPtr originalScraper(scraper);


### PR DESCRIPTION
Continue #13566:
* Implemented protection: plugins without media library scanning support will not be scanned and refreshed even if they are used as video source
* Fix video library database cleaning for plugin sources
* Other minor fixes

## Description
### [VideoLibrary] Do not scan and refresh unsupported plugin sources
Video library scanning and refreshing is allowed only for plugin URLs that indicated in addon.xml (within extension point "xbmc.python.pluginsource"). These URLs are root paths for specified content. If no URLs are specified, then scanning is completely disabled for such plugin. Different URLs with the same content can be specified multiple times.
```XML
    <extension point="xbmc.python.pluginsource" library="default.py">
        <provides>video</provides>
        <medialibraryscanpath content="movies">movies/</medialibraryscanpath>
        <medialibraryscanpath content="tvshows">tvshows/</medialibraryscanpath>
    </extension>
```
Currently content attribute can be "movies", "tvshows" or "musicvideos".
Path (URL) can be absolute or relative.

```
In the addon.xml example above at following pathes:
plugin://my.favorite.plugin/ - scanning and refreshing is forbidden for any content
plugin://my.favorite.plugin/?mode=movies - forbidden for any content
plugin://my.favorite.plugin/play/movie/123/ - forbidden for any content
plugin://my.favorite.plugin/movies/ - allowed only for movies
plugin://my.favorite.plugin/movies/12345/ - allowed only for movies
plugin://my.favorite.plugin/tvshows/?id=12345 - allowed only for tvshows
plugin://my.favorite.plugin/tvshows/play/?episode_id=777 - allowed only for tvshows
```
In practice, it's desirable that addon developers provide a special plugin url (node), which is intended for scanning, and specify it in addon.xml, so that scanning can be performed only on this special url. For example:
* plugin://my.favorite.plugin/ - standard plugin operation mode
* plugin://my.favorite.plugin/library/ - this path is used only for library scanning and must be added to addon.xml

Note: this is a breaking change. Scanning unsupported plugins is disabled by default. All plugins with media library scanning support must have corresponding entries in addon.xml.

### [VideoLibrary] Fix database cleaning for plugin sources
Applies only to plugins that support media library scanning. In order to check existance of some plugin URL, video database cleaner calls plugin at specified path with option "kodi_action=check_exists" and examines result. Plugin must check whether specified path exists (e.g. using cache) and return result with setResolvedUrl(). Simplified example:
```Python
if args['kodi_action'] == 'check_exists':
    xbmcplugin.setResolvedUrl(handle, check(path), xbmcgui.ListItem())
```
Plugins must correctly handle this mode - just check the existence and don't play video, open dialogs or something else.

### [VideoLibrary] Other minor fixes
* Correctly handle empty hash for tvshow folder (i.e. no episodes) calculated by plugin
* Case insensitive compare for tvshow folder hashes
* Optimize plugin root check in InvalidatePathHash

## Motivation and Context
As tamland said:
> Since plugins are allowed to do anything this will cause all kind of weird and possibly dangerous side-effects... And it's absolutely dangerous because for starters plugins can be unbound, they can open dialog, start playback and whatever as a side-effect of opening directories; and many do. There is no way a user can know this.

## How Has This Been Tested?
* Build tested on Windows and Linux
* Functionality tested with special [test plugin](https://github.com/AkariDN/plugin.video.testlib)

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
