### PR TITLE
[cmake] fix building with internal fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ endif()
 
 # main library (used for main binary and tests)
 add_library(lib${APP_NAME_LC} STATIC $<TARGET_OBJECTS:compileinfo>)
-add_dependencies(lib${APP_NAME_LC} libcpluff ffmpeg dvdnav crossguid ${PLATFORM_GLOBAL_TARGET_DEPS})
+add_dependencies(lib${APP_NAME_LC} libcpluff ffmpeg dvdnav crossguid fmt ${PLATFORM_GLOBAL_TARGET_DEPS})
 set_target_properties(lib${APP_NAME_LC} PROPERTIES PREFIX "")
 
 # Other files (IDE)

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -90,14 +90,13 @@ if(FMT_FOUND)
   set(FMT_LIBRARIES ${FMT_LIBRARY})
   set(FMT_INCLUDE_DIRS ${FMT_INCLUDE_DIR})
 
-  if(NOT TARGET Fmt::Fmt)
-    add_library(Fmt::Fmt UNKNOWN IMPORTED)
-    set_target_properties(Fmt::Fmt PROPERTIES
-                                     IMPORTED_LOCATION "${FMT_LIBRARY}"
-                                     INTERFACE_INCLUDE_DIRECTORIES "${FMT_INCLUDE_DIR}")
+  if(NOT TARGET fmt)
+    add_library(fmt UNKNOWN IMPORTED)
+    set_target_properties(fmt PROPERTIES
+                               IMPORTED_LOCATION "${FMT_LIBRARY}"
+                               INTERFACE_INCLUDE_DIRECTORIES "${FMT_INCLUDE_DIR}")
   endif()
 endif()
 
-mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)
-
 endif()
+mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Pull Request title above -->
fixes a build issue with internal fmt, see https://forum.kodi.tv/showthread.php?tid=333879


## Description
<!--- Describe your change in detail -->
make the kodi target depend on fmt

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
built with and without internal libfmt on ubuntu

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

