### PR TITLE
Rework FindXkbcommon.cmake

### DIFF
--- a/cmake/modules/FindXkbcommon.cmake
+++ b/cmake/modules/FindXkbcommon.cmake
@@ -7,15 +7,34 @@
 # XKBCOMMON_FOUND        - the system has libxkbcommon
 # XKBCOMMON_INCLUDE_DIRS - the libxkbcommon include directory
 # XKBCOMMON_LIBRARIES    - the libxkbcommon libraries
-# XKBCOMMON_DEFINITIONS  - the libxkbcommon definitions
 
-pkg_check_modules (XKBCOMMON xkbcommon)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_XKBCOMMON xkbcommon QUIET)
+endif()
 
-include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (Xkbcommon
-  REQUIRED_VARS
-  XKBCOMMON_FOUND)
 
-set(XKBCOMMON_DEFINITIONS -DHAVE_XKBCOMMON=1)
-set(XKBCOMMON_LIBRARIES ${XKBCOMMON_LDFLAGS})
-set(XKBCOMMON_INCLUDE_DIRS ${XKBCOMMON_INCLUDEDIR})
+find_path(XKBCOMMON_INCLUDE_DIR NAMES xkbcommon/xkbcommon.h
+                           PATHS ${PC_XKBCOMMON_INCLUDEDIR})
+find_library(XKBCOMMON_LIBRARY NAMES xkbcommon
+                          PATHS ${PC_XKBCOMMON_LIBDIR})
+
+set(XKBCOMMON_VERSION ${PC_XKBCOMMON_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Xkbcommon
+                                  REQUIRED_VARS XKBCOMMON_LIBRARY XKBCOMMON_INCLUDE_DIR
+                                  VERSION_VAR XKBCOMMON_VERSION)
+
+if(XKBCOMMON_FOUND)
+  set(XKBCOMMON_INCLUDE_DIRS ${XKBCOMMON_INCLUDE_DIR})
+  set(XKBCOMMON_LIBRARIES ${XKBCOMMON_LIBRARY})
+
+  if(NOT TARGET XKBCOMMON::XKBCOMMON)
+    add_library(XKBCOMMON::XKBCOMMON UNKNOWN IMPORTED)
+    set_target_properties(XKBCOMMON::XKBCOMMON PROPERTIES
+                                     IMPORTED_LOCATION "${XKBCOMMON_LIBRARY}"
+                                     INTERFACE_INCLUDE_DIRECTORIES "${XKBCOMMON_INCLUDE_DIR}")
+  endif()
+endif()
+
+mark_as_advanced(XKBCOMMON_INCLUDE_DIR XKBCOMMON_LIBRARY)


### PR DESCRIPTION
## Description

FindXkbcommon includes from wrong path when x-compiling and xkbcommon is installed on host.

## Motivation and Context
OE buildscan  fail because of -Wpoison-host-paths

## How Has This Been Tested?
LG webos Open Edition build

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)
