### PR TITLE
Keep the order of the add-on context menu items as defined in the addon.xml file

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -186,7 +186,7 @@ ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem, co
         result.emplace_back(new CContextMenuItem(menu));
   }
 
-  if (&root == &MAIN || &root == &MANAGE)
+  if (&root == &MANAGE)
   {
     std::sort(result.begin(), result.end(),
         [&](const ContextMenuView::value_type& lhs, const ContextMenuView::value_type& rhs)


### PR DESCRIPTION
Kodi add-ons can define context menu items via the `<extension point="kodi.context.item">` extension point. However, the order of these menu items are not respected and sorting is done by label. 

## Description
I removed the sorting by label to find out that Kodi first reads the sub-menus and then the menu items. So instead of first doing the sub-menus and then the items, I now iterate over all the child-items in order and either treat them as a menu or an item.

## Motivation and Context
It allows an add-on dev to order their context menus in a better way.

## How Has This Been Tested?
Tested it locally on Windows x64. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
