### PR TITLE
[WIN32Utils] Drop strcasestr()

### DIFF
--- a/xbmc/platform/win32/PlatformDefs.h
+++ b/xbmc/platform/win32/PlatformDefs.h
@@ -69,7 +69,6 @@ typedef intptr_t      ssize_t;
 #endif
 
 extern "C" char * strptime(const char *buf, const char *fmt, struct tm *tm);
-extern "C" char * strcasestr(const char* haystack, const char* needle);
 
 #endif // TARGET_WINDOWS
 

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1196,32 +1196,6 @@ void CWIN32Util::CropSource(CRect& src, CRect& dst, CRect target, UINT rotation 
   dst.y2 = ceil(dst.y2);
 }
 
-extern "C"
-{
-  /* case-independent string matching, similar to strstr but
-  * matching */
-  char * strcasestr(const char* haystack, const char* needle)
-  {
-    int i;
-    int nlength = (int) strlen (needle);
-    int hlength = (int) strlen (haystack);
-
-    if (nlength > hlength) return NULL;
-    if (hlength <= 0) return NULL;
-    if (nlength <= 0) return (char *)haystack;
-    /* hlength and nlength > 0, nlength <= hlength */
-    for (i = 0; i <= (hlength - nlength); i++)
-    {
-      if (strncasecmp (haystack + i, needle, nlength) == 0)
-      {
-        return (char *)haystack + i;
-      }
-    }
-    /* substring not found */
-    return NULL;
-  }
-}
-
 // detect if a drive is a usb device
 // code taken from http://banderlogi.blogspot.com/2011/06/enum-drive-letters-attached-for-usb.html
 


### PR DESCRIPTION
## Description
See title.

## Motivation and Context
Can't see `strcasestr()` being used anywhere.

## How Has This Been Tested?
Not tested at all.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [X] None of the above (please explain below)

### Clean up
