### PR TITLE
Do not show busy dialog if progress dialog is active while calling a plugin

### DIFF
--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -182,6 +182,19 @@ bool CGUIDialogProgress::Wait(int progresstime /*= 10*/)
   return !m_bCanceled;
 }
 
+bool CGUIDialogProgress::WaitOnEvent(CEvent& event)
+{
+  while (!event.WaitMSec(1))
+  {
+    if (m_bCanceled)
+      return false;
+
+    Progress();
+  }
+
+  return !m_bCanceled;
+}
+
 void CGUIDialogProgress::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (m_bInvalidated)

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -49,6 +49,13 @@ public:
    */
   bool Wait(int progresstime = 10);
 
+  /*! \brief Wait on an event or for the progress dialog to be canceled, while
+  regularly rendering to allow for pointer movement or progress to be shown.
+  \param event the CEvent to wait on.
+  \return true if the event completed, false if cancelled.
+  */
+  bool WaitOnEvent(CEvent& event);
+
   // Implements IProgressCallback
   void SetProgressMax(int iMax) override;
   void SetProgressAdvance(int nSteps=1) override;


### PR DESCRIPTION
## Description
Applies only for calling plugins from the main thread. If execution of a plugin takes some time then CGUIDialogBusy automatically opens. But if we already have topmost modal CGUIDialogProgress then additional busy dialog is no longer needed - we can use progress dialog's render loop and handle "cancel" action. Especially in case of sequentially plugin calling.

## Motivation and Context
There is no need to show two status dialogs simultaneously.

## How Has This Been Tested?
Build and functionality tested on Windows and Android.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
