### PR TITLE
[PVR] Guide window: Add 'sorty by' and 'sort order' for epg grid channels

### DIFF
--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -148,14 +148,12 @@
 					<label>$LOCALIZE[31022]</label>
 					<label2>[B]$INFO[Container.SortMethod][/B]</label2>
 					<onclick>SendClick(3)</onclick>
-					<visible>!Window.IsActive(MyPVRGuide.xml)</visible>
 				</control>
 				<control type="button" id="6055">
 					<include>MediaMenuItemsCommon</include>
 					<label>$LOCALIZE[31032]</label>
 					<label2>[B]$INFO[Container.SortOrder][/B]</label2>
 					<onclick>Container.SetSortDirection</onclick>
-					<visible>!Window.IsActive(MyPVRGuide.xml)</visible>
 				</control>
 				<control type="button" id="10">
 					<description>Watched Toggle</description>
@@ -167,7 +165,7 @@
 				<control type="label" id="300">
 					<label>$LOCALIZE[31021]</label>
 					<include>MediaMenuLabelCommon</include>
-					<visible>Control.IsVisible(31) |Control.IsVisible(5) |Control.IsVisible(6) |Control.IsVisible(7) |Control.IsVisible(8)</visible>
+					<visible>Control.IsVisible(31) | Control.IsVisible(5) | Control.IsVisible(6) | Control.IsVisible(7) | Control.IsVisible(8)</visible>
 				</control>
 				<control type="radiobutton" id="31">
 					<include>MediaMenuItemsCommon</include>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -714,6 +714,9 @@ void CFileItem::ToSortable(SortItem &sortable, Field field) const
   if (HasPVRChannelInfoTag())
     GetPVRChannelInfoTag()->ToSortable(sortable, field);
 
+  if (HasEPGInfoTag())
+    GetEPGInfoTag()->ToSortable(sortable, field);
+
   if (HasAddonInfo())
   {
     switch (field)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -808,6 +808,9 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
   if (item->HasPVRChannelInfoTag() && item->GetPVRChannelInfoTag() == m_playingChannel)
   {
     UpdateLastWatched(item->GetPVRChannelInfoTag());
+    SetChanged();
+    NotifyObservers(ObservableMessageChannelPlaybackStopped);
+
     m_playingChannel.reset();
     m_playingClientId = -1;
     m_strPlayingClientName.clear();

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -287,6 +287,7 @@ namespace PVR
      */
     std::string Path(void) const;
 
+    // ISortable implementation
     void ToSortable(SortItem& sortable, Field field) const override;
 
     /*!

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -194,6 +194,30 @@ void CPVREpgInfoTag::Serialize(CVariant &value) const
   value["serieslink"] = m_strSeriesLink;
 }
 
+void CPVREpgInfoTag::ToSortable(SortItem& sortable, Field field) const
+{
+  if (!m_channel)
+    return;
+
+  switch (field)
+  {
+    case FieldChannelName:
+      sortable[FieldChannelName] = m_channel->ChannelName();
+      break;
+    case FieldChannelNumber:
+      sortable[FieldChannelNumber] = m_channel->ChannelNumber().FormattedChannelNumber();
+      break;
+    case FieldLastPlayed:
+    {
+      const CDateTime lastWatched(m_channel->LastWatched());
+      sortable[FieldLastPlayed] = lastWatched.IsValid() ? lastWatched.GetAsDBDateTime() : StringUtils::Empty;
+      break;
+    }
+    default:
+      break;
+  }
+}
+
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
 {
   if (CServiceBroker::GetPVRManager().GetPlayingChannel() == Channel() &&

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -27,6 +27,7 @@
 #include "XBDateTime.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "utils/ISerializable.h"
+#include "utils/ISortable.h"
 
 #include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRChannel.h"
@@ -39,7 +40,7 @@ namespace PVR
 {
   class CPVREpg;
 
-  class CPVREpgInfoTag final : public ISerializable, public std::enable_shared_from_this<CPVREpgInfoTag>
+  class CPVREpgInfoTag final : public ISerializable, public ISortable, public std::enable_shared_from_this<CPVREpgInfoTag>
   {
     friend class CPVREpg;
     friend class CPVREpgDatabase;
@@ -75,6 +76,9 @@ namespace PVR
     bool operator !=(const CPVREpgInfoTag& right) const;
 
     void Serialize(CVariant &value) const override;
+
+    // ISortable implementation
+    void ToSortable(SortItem& sortable, Field field) const override;
 
     /*!
      * @brief Get the identifier of the client that serves this event.

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -33,8 +33,8 @@ using namespace PVR;
 CGUIViewStateWindowPVRChannels::CGUIViewStateWindowPVRChannels(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
   AddSortMethod(SortByChannelNumber, 549, LABEL_MASKS("%L", "", "%L", ""));      // "Number"      : Filename, empty | Foldername, empty
-  AddSortMethod(SortByLabel,         551, LABEL_MASKS("%L", "", "%L", ""));      // "Name"        : Filename, empty | Foldername, empty
-  AddSortMethod(SortByLastPlayed,    568, LABEL_MASKS( "%L", "%p", "%L", "%p")); // "Last played" : Filename, LastPlayed | Foldername, LastPlayed
+  AddSortMethod(SortByChannel,       551, LABEL_MASKS("%L", "", "%L", ""));      // "Name"        : Filename, empty | Foldername, empty
+  AddSortMethod(SortByLastPlayed,    568, LABEL_MASKS("%L", "%p", "%L", "%p"));  // "Last played" : Filename, LastPlayed | Foldername, LastPlayed
 
   // Default sorting
   SetSortMethod(SortByChannelNumber);
@@ -75,6 +75,13 @@ bool CGUIViewStateWindowPVRRecordings::HideParentDirItems(void)
 
 CGUIViewStateWindowPVRGuide::CGUIViewStateWindowPVRGuide(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
+  AddSortMethod(SortByChannelNumber,                           549, LABEL_MASKS("%L", "", "%L", ""));     // "Number"      : Filename, empty | Foldername, empty
+  AddSortMethod(SortByChannel,                                 551, LABEL_MASKS("%L", "", "%L", ""));     // "Name"        : Filename, empty | Foldername, empty
+  AddSortMethod(SortByLastPlayed,    SortAttributeIgnoreLabel, 568, LABEL_MASKS("%L", "%p", "%L", "%p")); // "Last played" : Filename, LastPlayed | Foldername, LastPlayed
+
+  // Default sorting
+  SetSortMethod(SortByChannelNumber);
+
   LoadViewState("pvr://guide/", m_windowId);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -145,11 +145,21 @@ void CGUIWindowPVRGuideBase::Notify(const Observable &obs, const ObservableMessa
   {
     CSingleLock lock(m_critSection);
     m_bRefreshTimelineItems = true;
+    // no base class call => do async refresh
+    return;
   }
-  else
+  else if (msg == ObservableMessageChannelPlaybackStopped)
   {
-    CGUIWindowPVRBase::Notify(obs, msg);
+    if (m_guiState && m_guiState->GetSortMethod().sortBy == SortByLastPlayed)
+    {
+      // set dirty to force sync refresh
+      CSingleLock lock(m_critSection);
+      m_bRefreshTimelineItems = true;
+    }
   }
+
+  // do sync refresh if dirty
+  CGUIWindowPVRBase::Notify(obs, msg);
 }
 
 void CGUIWindowPVRGuideBase::SetInvalid()
@@ -215,8 +225,9 @@ bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFile
     {
       // channel group change and not very first open of this window. force immediate update.
       m_bRefreshTimelineItems = true;
-      bRefreshTimelineItems = true;
     }
+
+    bRefreshTimelineItems = m_bRefreshTimelineItems;
   }
 
   // never call DoRefresh with locked mutex!
@@ -326,6 +337,22 @@ bool CGUIWindowPVRGuideBase::OnAction(const CAction &action)
   }
 
   return CGUIWindowPVRBase::OnAction(action);
+}
+
+void CGUIWindowPVRGuideBase::RefreshView(CGUIMessage& message, bool bInitGridControl)
+{
+  CGUIWindowPVRBase::OnMessage(message);
+
+  // force grid data update
+  {
+    CSingleLock lock(m_critSection);
+    m_bRefreshTimelineItems = true;
+  }
+
+  if (bInitGridControl)
+    InitEpgGridControl();
+
+  Refresh(true);
 }
 
 bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
@@ -488,28 +515,19 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
           }
         }
       }
-      else if (message.GetSenderId() == CONTROL_BTNVIEWASICONS)
+      else if (message.GetSenderId() == CONTROL_BTNVIEWASICONS ||
+               message.GetSenderId() == CONTROL_BTNSORTBY)
       {
-        // let's set the view mode first before update
-        CGUIWindowPVRBase::OnMessage(message);
-        Refresh(true);
+        RefreshView(message, false);
         bReturn = true;
       }
       break;
     }
+    case GUI_MSG_CHANGE_SORT_DIRECTION:
+    case GUI_MSG_CHANGE_SORT_METHOD:
     case GUI_MSG_CHANGE_VIEW_MODE:
     {
-      // let's set the view mode first before update
-      CGUIWindowPVRBase::OnMessage(message);
-
-      // force data update for the new view control
-      {
-        CSingleLock lock(m_critSection);
-        m_bRefreshTimelineItems = true;
-      }
-      InitEpgGridControl();
-
-      Refresh(true);
+      RefreshView(message, message.GetMessage() == GUI_MSG_CHANGE_VIEW_MODE);
       bReturn = true;
       break;
     }
@@ -527,6 +545,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
         case ObservableMessageChannelGroup:
         case ObservableMessageEpg:
         case ObservableMessageEpgContainer:
+        case ObservableMessageChannelPlaybackStopped:
         {
           Refresh(true);
           break;
@@ -609,6 +628,9 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       const CDateTime maxPastDate(currentDate - CDateTimeSpan(iPastDays, 0, 0, 0));
       if (startDate < maxPastDate)
         startDate = maxPastDate;
+
+      if (m_guiState.get())
+        timeline->Sort(m_guiState->GetSortMethod());
 
       // can be very expensive. never call with lock acquired.
       epgGridContainer->SetTimelineItems(timeline, startDate, endDate);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -78,6 +78,8 @@ namespace PVR
     void StartRefreshTimelineItemsThread();
     void StopRefreshTimelineItemsThread();
 
+    void RefreshView(CGUIMessage& message, bool bInitGridControl);
+
     std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
     std::atomic_bool m_bRefreshTimelineItems;
 

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -46,6 +46,7 @@ typedef enum
   ObservableMessageManagerStopped,
   ObservableMessageSettingsChanged,
   ObservableMessageButtonMapsChanged,
+  ObservableMessageChannelPlaybackStopped,
 } ObservableMessage;
 
 class Observer

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -78,6 +78,9 @@ std::string ByPath(SortAttribute attributes, const SortItem &values)
 
 std::string ByLastPlayed(SortAttribute attributes, const SortItem &values)
 {
+  if (attributes & SortAttributeIgnoreLabel)
+    return values.at(FieldLastPlayed).asString();
+
   return StringUtils::Format("%s %s", values.at(FieldLastPlayed).asString().c_str(), ByLabel(attributes, values).c_str());
 }
 

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -39,7 +39,8 @@ typedef enum {
   SortAttributeNone           = 0x0,
   SortAttributeIgnoreArticle  = 0x1,
   SortAttributeIgnoreFolders  = 0x2,
-  SortAttributeUseArtistSortName = 0x4
+  SortAttributeUseArtistSortName = 0x4,
+  SortAttributeIgnoreLabel = 0x8
 } SortAttribute;
 
 typedef enum {


### PR DESCRIPTION
Add ability to sort channels in pvr guide window. Requested in the forum: https://forum.kodi.tv/showthread.php?tid=262603&pid=2753500#pid2753500

![screenshot000](https://user-images.githubusercontent.com/3226626/43289673-fe4dabde-912b-11e8-9447-c0493be17fb0.png)
![screenshot001](https://user-images.githubusercontent.com/3226626/43289674-fe6b6caa-912b-11e8-9537-a7b7ed60e333.png)

@Jalle19 mind taking a look?