### PR TITLE
RendererDRMPRIME: reference count video buffers presented on screen

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -16,9 +16,6 @@
 #include "utils/log.h"
 #include "windowing/gbm/WinSystemGbm.h"
 
-#include <xf86drm.h>
-#include <xf86drmMode.h>
-
 extern "C" {
 #include "libavcodec/avcodec.h"
 #include "libavutil/pixdesc.h"
@@ -47,22 +44,6 @@ void CVideoBufferDRMPRIME::SetRef(AVFrame* frame)
 
 void CVideoBufferDRMPRIME::Unref()
 {
-  if (m_fb_id)
-  {
-    drmModeRmFB(m_drm_fd, m_fb_id);
-    m_fb_id = 0;
-  }
-
-  for (int i = 0; i < AV_DRM_MAX_PLANES; i++)
-  {
-    if (m_handles[i])
-    {
-      struct drm_gem_close gem_close = { .handle = m_handles[i] };
-      drmIoctl(m_drm_fd, DRM_IOCTL_GEM_CLOSE, &gem_close);
-      m_handles[i] = 0;
-    }
-  }
-
   av_frame_unref(m_pFrame);
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -54,7 +54,7 @@ public:
   void Reset() override;
   CDVDVideoCodec::VCReturn GetPicture(VideoPicture* pVideoPicture) override;
   const char* GetName() override { return m_name.c_str(); };
-  unsigned GetAllowedReferences() override { return 4; };
+  unsigned GetAllowedReferences() override { return 5; };
   void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
 
 protected:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -29,7 +29,6 @@ public:
   void SetRef(AVFrame* frame);
   void Unref();
 
-  uint32_t m_drm_fd = -1;
   uint32_t m_fb_id = 0;
   uint32_t m_handles[AV_DRM_MAX_PLANES] = {0};
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -23,7 +23,7 @@ const std::string SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimere
 
 CRendererDRMPRIME::~CRendererDRMPRIME()
 {
-  Reset();
+  Flush(false);
 }
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
@@ -69,7 +69,7 @@ bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsign
   SetViewMode(m_videoSettings.m_ViewMode);
   ManageRenderArea();
 
-  Reset();
+  Flush(false);
 
   m_bConfigured = true;
   return true;
@@ -92,26 +92,20 @@ void CRendererDRMPRIME::ManageRenderArea()
 void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, double currentClock)
 {
   BUFFER& buf = m_buffers[index];
-
-  // delay Release of videoBuffer after a Flush call to prevent drmModeRmFB of a videoBuffer tied to a drm plane
-  // TODO: move Release to Flush once current videoBuffer tied to a drm plane is reference counted
   if (buf.videoBuffer)
+  {
+    CLog::LogF(LOGERROR, "unreleased video buffer");
     buf.videoBuffer->Release();
-
+  }
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
 }
 
-void CRendererDRMPRIME::Reset()
+bool CRendererDRMPRIME::Flush(bool saveBuffers)
 {
   for (int i = 0; i < NUM_BUFFERS; i++)
     ReleaseBuffer(i);
 
-  m_iLastRenderBuffer = -1;
-}
-
-bool CRendererDRMPRIME::Flush(bool saveBuffers)
-{
   m_iLastRenderBuffer = -1;
   return false;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -253,7 +253,7 @@ void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
 bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
 {
   AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
-  uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0};
+  uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0}, flags = 0;
   uint64_t modifier[4] = {0};
   int ret;
 
@@ -284,8 +284,12 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
     }
   }
 
+  if (modifier[0] && modifier[0] != DRM_FORMAT_MOD_INVALID)
+    flags = DRM_MODE_FB_MODIFIERS;
+
   // add the video frame FB
-  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(), buffer->GetHeight(), layer->format, handles, pitches, offsets, modifier, &buffer->m_fb_id, 0);
+  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(), buffer->GetHeight(), layer->format,
+                                   handles, pitches, offsets, modifier, &buffer->m_fb_id, flags);
   if (ret < 0)
   {
     CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to add fb %d, ret = %d", __FUNCTION__, buffer->m_fb_id, ret);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -103,11 +103,12 @@ void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, 
 
 bool CRendererDRMPRIME::Flush(bool saveBuffers)
 {
-  for (int i = 0; i < NUM_BUFFERS; i++)
-    ReleaseBuffer(i);
+  if (!saveBuffers)
+    for (int i = 0; i < NUM_BUFFERS; i++)
+      ReleaseBuffer(i);
 
   m_iLastRenderBuffer = -1;
-  return false;
+  return saveBuffers;
 }
 
 void CRendererDRMPRIME::ReleaseBuffer(int index)
@@ -252,6 +253,9 @@ void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
 
 bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
 {
+  if (buffer->m_fb_id)
+    return true;
+
   AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
   uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0}, flags = 0;
   uint64_t modifier[4] = {0};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -71,8 +71,6 @@ protected:
   void ManageRenderArea() override;
 
 private:
-  void Reset();
-
   bool m_bConfigured = false;
   int m_iLastRenderBuffer = -1;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -12,11 +12,33 @@
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "windowing/gbm/WinSystemGbmEGLContext.h"
 
+class CVideoLayerBridgeDRMPRIME
+  : public CVideoLayerBridge
+{
+public:
+  CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm);
+  ~CVideoLayerBridgeDRMPRIME();
+  void Disable() override;
+
+  virtual void Configure(CVideoBufferDRMPRIME* buffer);
+  virtual void SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect);
+
+protected:
+  std::shared_ptr<CDRMUtils> m_DRM;
+
+private:
+  void Acquire(CVideoBufferDRMPRIME* buffer);
+  void Release(CVideoBufferDRMPRIME* buffer);
+
+  CVideoBufferDRMPRIME* m_buffer = nullptr;
+  CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
+};
+
 class CRendererDRMPRIME
   : public CBaseRenderer
 {
 public:
-  CRendererDRMPRIME(std::shared_ptr<CDRMUtils> drm);
+  CRendererDRMPRIME() = default;
   ~CRendererDRMPRIME();
 
   // Registration
@@ -48,12 +70,11 @@ protected:
 
 private:
   void Reset();
-  void SetVideoPlane(CVideoBufferDRMPRIME* buffer);
 
   bool m_bConfigured = false;
   int m_iLastRenderBuffer = -1;
 
-  std::shared_ptr<CDRMUtils> m_DRM;
+  std::shared_ptr<CVideoLayerBridgeDRMPRIME> m_videoLayerBridge;
 
   struct BUFFER
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -29,6 +29,8 @@ protected:
 private:
   void Acquire(CVideoBufferDRMPRIME* buffer);
   void Release(CVideoBufferDRMPRIME* buffer);
+  bool Map(CVideoBufferDRMPRIME* buffer);
+  void Unmap(CVideoBufferDRMPRIME* buffer);
 
   CVideoBufferDRMPRIME* m_buffer = nullptr;
   CVideoBufferDRMPRIME* m_prev_buffer = nullptr;

--- a/xbmc/windowing/gbm/VideoLayerBridge.h
+++ b/xbmc/windowing/gbm/VideoLayerBridge.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CVideoLayerBridge
+{
+public:
+  virtual ~CVideoLayerBridge() = default;
+  virtual void Disable() {};
+};

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -235,11 +235,23 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
 void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 {
+  if (m_videoLayerBridge && !videoLayer)
+  {
+    // disable video plane when video layer no longer is active
+    m_videoLayerBridge->Disable();
+  }
+
   struct gbm_bo *bo = m_GBM->LockFrontBuffer();
 
   m_DRM->FlipPage(bo, rendered, videoLayer);
 
   m_GBM->ReleaseBuffer();
+
+  if (m_videoLayerBridge && !videoLayer)
+  {
+    // delete video layer bridge when video layer no longer is active
+    m_videoLayerBridge.reset();
+  }
 }
 
 void CWinSystemGbm::WaitVBlank()

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -16,6 +16,7 @@
 #include "threads/CriticalSection.h"
 #include "windowing/WinSystem.h"
 #include "DRMUtils.h"
+#include "VideoLayerBridge.h"
 
 class IDispResource;
 
@@ -50,6 +51,9 @@ public:
   virtual void Register(IDispResource *resource);
   virtual void Unregister(IDispResource *resource);
 
+  std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; };
+  void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge) { m_videoLayerBridge = bridge; };
+
   std::string GetModule() const { return m_DRM->GetModule(); }
   std::string GetDevicePath() const { return m_DRM->GetDevicePath(); }
   struct gbm_device *GetGBMDevice() const { return m_GBM->GetDevice(); }
@@ -60,6 +64,7 @@ protected:
 
   std::shared_ptr<CDRMUtils> m_DRM;
   std::unique_ptr<CGBMUtils> m_GBM;
+  std::shared_ptr<CVideoLayerBridge> m_videoLayerBridge;
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*>  m_resources;


### PR DESCRIPTION
## Description
This PR adds a video layer "bridge" between the drm prime renderer and gbm windowing to handle reference count and map/unmap of video frames that is presented on screen.

**CDVDVideoCodecDRMPRIME**
Interacts with FFmpeg and creates `CVideoBufferDRMPRIME` objects wrapping decoded `AVFrame` / `AVDRMFrameDescriptor`.

**CRendererDRMPRIME**
Keeps track of video buffers that should be presented on screen same as any other renderer. Pushes the `CVideoBufferDRMPRIME` that is to be presented on screen to `CVideoLayerBridgeDRMPRIME`.

**CVideoLayerBridgeDRMPRIME**
Maps video buffers and adds the frame buffer to the next atomic drm commit, unmap/releases the video buffer once it no longer is presented on screen. Disables the video plane when video playback is stopped before the last video buffer is unmap/released.

`CVideoLayerBridgeDRMPRIME` can also configure HDR and HDMI properties when the video layer is activated, an example for Rockchip BSP kernel can be found at https://github.com/Kwiboo/plex-home-theater/compare/drmprime-bridge...Kwiboo:drmprime-bridge-rockchip (mainline kernel do no yet support such properties).

## Motivation and Context
This fixes a "black-on-stop" issue that can be observed on Rockchip when there is no resolution change at end of video playback, the display pipeline could end up disabled and the TV would show a no-signal message.

## How Has This Been Tested?
Tested on my Tinker Board S and Rock64
An earlier version of this patchset has been part of my test images at http://kwiboo.libreelec.tv/test/

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic change (non-breaking change that doesn't touch code)
- [ ] None of the above (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
