### PR TITLE
[PVR] Guide window: Only refresh grid data synchronously when actually necessary.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -48,6 +48,7 @@ CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::s
   m_bChannelSelectionRestored(false)
 {
   m_bRefreshTimelineItems = false;
+  m_bSyncRefreshTimelineItems = false;
   CServiceBroker::GetPVRManager().EpgContainer().RegisterObserver(this);
 }
 
@@ -56,6 +57,7 @@ CGUIWindowPVRGuideBase::~CGUIWindowPVRGuideBase()
   CServiceBroker::GetPVRManager().EpgContainer().UnregisterObserver(this);
 
   m_bRefreshTimelineItems = false;
+  m_bSyncRefreshTimelineItems = false;
   StopRefreshTimelineItemsThread();
 }
 
@@ -76,7 +78,7 @@ void CGUIWindowPVRGuideBase::InitEpgGridControl()
   if (epgGridContainer && !epgGridContainer->HasData())
   {
     CSingleLock lock(m_critSection);
-    m_bRefreshTimelineItems = true; // force data update on first window open
+    m_bSyncRefreshTimelineItems = true; // force data update on first window open
   }
 
   StartRefreshTimelineItemsThread();
@@ -154,7 +156,7 @@ void CGUIWindowPVRGuideBase::Notify(const Observable &obs, const ObservableMessa
     {
       // set dirty to force sync refresh
       CSingleLock lock(m_critSection);
-      m_bRefreshTimelineItems = true;
+      m_bSyncRefreshTimelineItems = true;
     }
   }
 
@@ -216,7 +218,7 @@ bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool update
 
 bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
-  bool bRefreshTimelineItems = false;
+  bool bForceRefreshTimelineItems = false;
 
   {
     CSingleLock lock(m_critSection);
@@ -224,14 +226,14 @@ bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFile
     if (m_cachedChannelGroup && *m_cachedChannelGroup != *GetChannelGroup())
     {
       // channel group change and not very first open of this window. force immediate update.
-      m_bRefreshTimelineItems = true;
+      m_bSyncRefreshTimelineItems = true;
     }
 
-    bRefreshTimelineItems = m_bRefreshTimelineItems;
+    bForceRefreshTimelineItems = m_bSyncRefreshTimelineItems;
   }
 
   // never call DoRefresh with locked mutex!
-  if (bRefreshTimelineItems)
+  if (bForceRefreshTimelineItems)
     m_refreshTimelineItemsThread->DoRefresh();
 
   {
@@ -346,7 +348,7 @@ void CGUIWindowPVRGuideBase::RefreshView(CGUIMessage& message, bool bInitGridCon
   // force grid data update
   {
     CSingleLock lock(m_critSection);
-    m_bRefreshTimelineItems = true;
+    m_bSyncRefreshTimelineItems = true;
   }
 
   if (bInitGridControl)
@@ -595,8 +597,9 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
   {
     CSingleLock lock(m_critSection);
 
-    bRefreshTimelineItems = m_bRefreshTimelineItems;
+    bRefreshTimelineItems = m_bRefreshTimelineItems || m_bSyncRefreshTimelineItems;
     m_bRefreshTimelineItems = false;
+    m_bSyncRefreshTimelineItems = false;
   }
 
   if (bRefreshTimelineItems)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -82,6 +82,7 @@ namespace PVR
 
     std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
     std::atomic_bool m_bRefreshTimelineItems;
+    std::atomic_bool m_bSyncRefreshTimelineItems;
 
     CPVRChannelGroupPtr m_cachedChannelGroup;
     std::unique_ptr<CFileItemList> m_newTimeline;


### PR DESCRIPTION
Fixes a performance dip introduced with #14231