### PR TITLE
[addons] Update XSD schemas

### DIFF
--- a/addons/kodi.binary.instance.game/controller.xsd
+++ b/addons/kodi.binary.instance.game/controller.xsd
@@ -15,7 +15,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="kodi\.game\.controller"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/kodi.binary.instance.game/controller.xsd
+++ b/addons/kodi.binary.instance.game/controller.xsd
@@ -8,7 +8,7 @@
           <xs:attribute name="point" type="xs:string" use="required"/>
           <xs:attribute name="id" type="simpleIdentifier"/>
           <xs:attribute name="name" type="xs:string"/>
-          <xs:attribute name="library" type="xs:string"/>
+          <xs:attribute name="library" type="xs:string" use="required"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/addons/kodi.binary.instance.game/controller.xsd
+++ b/addons/kodi.binary.instance.game/controller.xsd
@@ -3,14 +3,10 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="gamecontroller">
-          <xs:attribute name="point" type="xs:string" use="required"/>
-          <xs:attribute name="id" type="simpleIdentifier"/>
-          <xs:attribute name="name" type="xs:string"/>
-          <xs:attribute name="library" type="xs:string" use="required"/>
-        </xs:extension>
-      </xs:complexContent>
+      <xs:attribute name="point" type="xs:string" use="required"/>
+      <xs:attribute name="id" type="simpleIdentifier"/>
+      <xs:attribute name="name" type="xs:string"/>
+      <xs:attribute name="library" type="xs:string" use="required"/>
     </xs:complexType>
   </xs:element>
   <xs:simpleType name="simpleIdentifier">

--- a/addons/kodi.resource/images.xsd
+++ b/addons/kodi.resource/images.xsd
@@ -3,9 +3,14 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:attribute name="point" type="xs:string" use="required"/>
+      <xs:attribute name="point" type="simpleIdentifier" use="required"/>
       <xs:attribute name="compile" type="xs:boolean"/>
       <xs:attribute name="type" type="xs:string"/>
     </xs:complexType>
   </xs:element>
+  <xs:simpleType name="simpleIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="kodi\.resource\.images"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/addons/kodi.resource/images.xsd
+++ b/addons/kodi.resource/images.xsd
@@ -4,6 +4,7 @@
   <xs:element name="extension">
     <xs:complexType>
       <xs:attribute name="point" type="xs:string" use="required"/>
+      <xs:attribute name="compile" type="xs:boolean"/>
       <xs:attribute name="type" type="xs:string"/>
     </xs:complexType>
   </xs:element>

--- a/addons/kodi.resource/language.xsd
+++ b/addons/kodi.resource/language.xsd
@@ -55,7 +55,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="kodi\.resource\.language"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/kodi.resource/language.xsd
+++ b/addons/kodi.resource/language.xsd
@@ -3,10 +3,10 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:sequence>
+      <xs:all>
         <xs:element name="charsets">
           <xs:complexType>
-            <xs:sequence>
+            <xs:all>
               <xs:element name="gui">
                 <xs:complexType>
                   <xs:simpleContent>
@@ -17,7 +17,7 @@
                 </xs:complexType>
               </xs:element>
               <xs:element name="subtitle" type="xs:string"/>
-            </xs:sequence>
+            </xs:all>
           </xs:complexType>
         </xs:element>
         <xs:element name="sorttokens" minOccurs="0">
@@ -37,14 +37,14 @@
         </xs:element>
         <xs:element name="dvd" minOccurs="0">
           <xs:complexType>
-            <xs:sequence>
+            <xs:all>
               <xs:element name="menu" type="xs:string" minOccurs="0"/>
               <xs:element name="audio" type="xs:string" minOccurs="0"/>
               <xs:element name="subtitle" type="xs:string" minOccurs="0"/>
-            </xs:sequence>
+            </xs:all>
           </xs:complexType>
         </xs:element>
-      </xs:sequence>
+      </xs:all>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>

--- a/addons/kodi.resource/language.xsd
+++ b/addons/kodi.resource/language.xsd
@@ -48,7 +48,7 @@
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
-      <xs:attribute name="locale" type="xs:string"/>
+      <xs:attribute name="locale" type="langIdentifier"/>
       <xs:attribute name="language" type="xs:string"/>
       <xs:attribute name="region" type="xs:string"/>
     </xs:complexType>
@@ -56,6 +56,11 @@
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
       <xs:pattern value="kodi\.resource\.language"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="langIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z]{2,3}(_[A-Z]{2}(@\S+)?)?"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/kodi.resource/uisounds.xsd
+++ b/addons/kodi.resource/uisounds.xsd
@@ -10,7 +10,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="kodi\.resource\.uisounds"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.addon/metadata.xsd
+++ b/addons/xbmc.addon/metadata.xsd
@@ -26,7 +26,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="(kodi|xbmc)\.addon\.metadata"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="translatedString">
@@ -53,7 +53,7 @@
   </xs:simpleType>
   <xs:simpleType name="langIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[a-z]{2}(_[A-Z]{2}(@\S+)?)?"/>
+      <xs:pattern value="[a-z]{2,3}(_[A-Z]{2}(@\S+)?)?"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="assetsList">

--- a/addons/xbmc.addon/metadata.xsd
+++ b/addons/xbmc.addon/metadata.xsd
@@ -3,20 +3,22 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:sequence>
+      <xs:choice maxOccurs="unbounded">
         <xs:element name="summary" type="translatedString" minOccurs="1" maxOccurs="unbounded"/>
         <xs:element name="description" type="translatedString" minOccurs="0" maxOccurs="unbounded"/>
-        <xs:element name="disclaimer" type="translatedString" minOccurs="0"/>
+        <xs:element name="disclaimer" type="translatedString" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element name="platform" type="platformList" minOccurs="0"/>
-        <xs:element name="supportedcontent" type="contentList" minOccurs="0"/>
-        <xs:element name="language" type="xs:string"  minOccurs="0"/>
-        <xs:element name="license" type="xs:string"  minOccurs="0"/>
-        <xs:element name="forum" type="xs:string" minOccurs="0"/>
-        <xs:element name="website" type="xs:string" minOccurs="0"/>
-        <xs:element name="source" type="xs:string" minOccurs="0"/>
-        <xs:element name="email" type="xs:string" minOccurs="0"/>
-        <xs:element name="broken" type="xs:string" minOccurs="0"/>
-      </xs:sequence>
+        <xs:element name="language" type="xs:string"  minOccurs="0" maxOccurs="1"/>
+        <xs:element name="license" type="xs:string"  minOccurs="0" maxOccurs="1" />
+        <xs:element name="forum" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="website" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="source" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="broken" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="news" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="reuselanguageinvoker" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="assets" type="assetsList" minOccurs="0" maxOccurs="1"/>
+      </xs:choice>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
@@ -30,7 +32,7 @@
   <xs:complexType name="translatedString">
     <xs:simpleContent>
       <xs:extension base="xs:string">
-        <xs:attribute name="lang" type="xs:string"/>
+        <xs:attribute name="lang" type="langIdentifier" use="required"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -42,22 +44,28 @@
       <xs:enumeration value="osx32"/>
       <xs:enumeration value="ios"/>
       <xs:enumeration value="windx"/>
+      <xs:enumeration value="windows"/>
+      <xs:enumeration value="windowsstore"/>
       <xs:enumeration value="android"/>
+      <xs:enumeration value="freebsd"/>
+      <xs:enumeration value="all"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="langIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z]{2}(_[A-Z]{2}(@\S+)?)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="assetsList">
+    <xs:choice maxOccurs="unbounded">
+        <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="fanart" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="screenshot" type="xs:string" minOccurs="0"/>
+        <xs:element name="clearlogo" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="banner" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:choice>
+  </xs:complexType>
   <xs:simpleType name="platformList">
     <xs:list itemType="platformType"/>
-  </xs:simpleType>
-  <xs:simpleType name="contentType">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="albums"/>
-      <xs:enumeration value="artists"/>
-      <xs:enumeration value="movies"/>
-      <xs:enumeration value="tvshows"/>
-      <xs:enumeration value="musicvideos"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="contentList">
-    <xs:list itemType="contentType"/>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.addon/repository.xsd
+++ b/addons/xbmc.addon/repository.xsd
@@ -38,7 +38,7 @@
   </xs:complexType>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.addon\.repository"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.addon/repository.xsd
+++ b/addons/xbmc.addon/repository.xsd
@@ -3,21 +3,17 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="repositorydirectory">
-          <xs:sequence>
-            <xs:element name="dir" type="repositorydirectory" minOccurs="1" maxOccurs="unbounded"/>
-          </xs:sequence>
-          <xs:attribute name="point" type="xs:string" use="required"/>
-          <xs:attribute name="id" type="simpleIdentifier"/>
-          <xs:attribute name="name" type="xs:string"/>
-        </xs:extension>
-      </xs:complexContent>
+      <xs:sequence>
+        <xs:element name="dir" type="dirItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="point" type="xs:string" use="required"/>
+      <xs:attribute name="id" type="simpleIdentifier"/>
+      <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
   </xs:element>
-  <xs:complexType name="repositorydirectory">
-    <xs:sequence>
-      <xs:element name="info">
+  <xs:complexType name="dirItem">
+    <xs:all>
+      <xs:element name="info" minOccurs="1">
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -26,8 +22,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="checksum" type="xs:string"/>
-      <xs:element name="datadir">
+      <xs:element name="checksum" type="xs:string" minOccurs="1"/>
+      <xs:element name="datadir" minOccurs="1">
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -37,7 +33,7 @@
         </xs:complexType>
       </xs:element>
       <xs:element name="hashes" type="xs:boolean"/>
-    </xs:sequence>
+    </xs:all>
     <xs:attribute name="minversion" type="xs:string"/>
   </xs:complexType>
   <xs:simpleType name="simpleIdentifier">

--- a/addons/xbmc.addon/repository.xsd
+++ b/addons/xbmc.addon/repository.xsd
@@ -3,38 +3,38 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element name="dir" type="dirItem" minOccurs="1" maxOccurs="unbounded"/>
-      </xs:sequence>
+      <xs:all>
+        <xs:element name="info" type="infoItem" minOccurs="1"/>
+        <xs:element name="checksum" type="checksumItem" minOccurs="1"/>
+        <xs:element name="datadir" type="datadirItem" minOccurs="1"/>
+        <xs:element name="artdir" type="xs:string"/>
+        <xs:element name="hashes" type="xs:string"/>
+      </xs:all>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
   </xs:element>
-  <xs:complexType name="dirItem">
-    <xs:all>
-      <xs:element name="info" minOccurs="1">
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="xs:string">
-              <xs:attribute name="compressed" type="xs:boolean"/>
-            </xs:extension>
-          </xs:simpleContent>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="checksum" type="xs:string" minOccurs="1"/>
-      <xs:element name="datadir" minOccurs="1">
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="xs:string">
-              <xs:attribute name="zip" type="xs:boolean"/>
-            </xs:extension>
-          </xs:simpleContent>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="hashes" type="xs:boolean"/>
-    </xs:all>
-    <xs:attribute name="minversion" type="xs:string"/>
+  <xs:complexType name="checksumItem">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="verify" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="infoItem">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="compressed" type="xs:boolean"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="datadirItem">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+          <xs:attribute name="zip" type="xs:boolean"/>
+      </xs:extension>
+    </xs:simpleContent>
   </xs:complexType>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">

--- a/addons/xbmc.gui/skin.xsd
+++ b/addons/xbmc.gui/skin.xsd
@@ -21,6 +21,7 @@
       <xs:attribute name="defaultwideresolution" type="xs:string"/>
       <xs:attribute name="effectslowdown" type="xs:float"/>
       <xs:attribute name="debugging" type="xs:boolean"/>
+      <xs:attribute name="defaultthemename" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:simpleType name="simpleIdentifier">

--- a/addons/xbmc.gui/skin.xsd
+++ b/addons/xbmc.gui/skin.xsd
@@ -26,7 +26,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.gui\.skin"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.metadata/scraper.xsd
+++ b/addons/xbmc.metadata/scraper.xsd
@@ -3,8 +3,8 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:attribute name="point" type="xs:string" use="required"/>
-      <xs:attribute name="id" type="simpleIdentifier"/>
+      <xs:attribute name="point" type="simpleIdentifier" use="required"/>
+      <xs:attribute name="id" type="xs:string"/>
       <xs:attribute name="name" type="xs:string"/>
       <xs:attribute name="library" type="xs:string" use="required"/>
       <xs:attribute name="language" type="xs:string"/>
@@ -14,7 +14,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.metadata\.scraper\.(albums|artists|library|movies|musicvideos|tvshows)"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.metadata/scraper.xsd
+++ b/addons/xbmc.metadata/scraper.xsd
@@ -6,7 +6,7 @@
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
-      <xs:attribute name="library" type="xs:string"/>
+      <xs:attribute name="library" type="xs:string" use="required"/>
       <xs:attribute name="language" type="xs:string"/>
       <xs:attribute name="requiressetting" type="xs:boolean"/>
       <xs:attribute name="cachepersistence" type="xs:string"/>

--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -9,6 +9,7 @@
   <extension-point id="lyrics" schema="script.xsd"/>
   <extension-point id="weather" schema="script.xsd"/>
   <extension-point id="library" schema="script.xsd"/>
+  <extension-point id="screensaver" schema="script.xsd"/>
   <extension-point id="plugin" schema="pluginsource.xsd"/>
   <extension-point id="context.item" schema="contextitem.xsd"/>
 </addon>

--- a/addons/xbmc.python/contextitem.xsd
+++ b/addons/xbmc.python/contextitem.xsd
@@ -11,18 +11,18 @@
     </xs:complexType>
   </xs:element>
   <xs:complexType name="itemType">
-    <xs:sequence>
-      <xs:element name="label" type="xs:string"/>
-      <xs:element name="visible" type="xs:string"/>
-    </xs:sequence>
+    <xs:all>
+      <xs:element name="label" type="xs:string" minOccurs="1"/>
+      <xs:element name="visible" type="xs:string" minOccurs="1"/>
+    </xs:all>
     <xs:attribute name="library" type="xs:string" use="required"/>
   </xs:complexType>
   <xs:complexType name="menuType">
-    <xs:sequence>
+    <xs:choice maxOccurs="unbounded">
       <xs:element name="label" type="xs:string" minOccurs="0"/>
       <xs:element name="item" type="itemType" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="menu" type="menuType" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="id" type="xs:string"/>
   </xs:complexType>
   <xs:simpleType name="simpleIdentifier">

--- a/addons/xbmc.python/contextitem.xsd
+++ b/addons/xbmc.python/contextitem.xsd
@@ -6,8 +6,8 @@
       <xs:sequence>
         <xs:element name="menu" type="menuType" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
-      <xs:attribute name="point" type="xs:string" use="required"/>
-      <xs:attribute name="id" type="simpleIdentifier"/>
+      <xs:attribute name="point" type="pointIdentifier" use="required"/>
+      <xs:attribute name="id" type="menuIdentifier"/>
     </xs:complexType>
   </xs:element>
   <xs:complexType name="itemType">
@@ -25,9 +25,14 @@
     </xs:choice>
     <xs:attribute name="id" type="xs:string"/>
   </xs:complexType>
-  <xs:simpleType name="simpleIdentifier">
+  <xs:simpleType name="pointIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="kodi.context.item"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="menuIdentifier">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="kodi.core.main|kodi.core.manage"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.python/contextitem.xsd
+++ b/addons/xbmc.python/contextitem.xsd
@@ -27,12 +27,12 @@
   </xs:complexType>
   <xs:simpleType name="pointIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="kodi.context.item"/>
+      <xs:pattern value="kodi\.context\.item"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="menuIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="kodi.core.main|kodi.core.manage"/>
+      <xs:pattern value="kodi\.core\.(manage|main)"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -15,7 +15,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.python\.pluginsource"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="providesType">

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -4,7 +4,7 @@
   <xs:element name="extension">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="provides" type="providesList"/>
+        <xs:element name="provides" type="providesList" minOccurs="0" maxOccurs="1"/>
         <xs:element name="medialibraryscanpath" type="pathType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
@@ -46,4 +46,3 @@
     </xs:simpleContent>
   </xs:complexType>
 </xs:schema>
-

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -22,7 +22,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="audio"/>
       <xs:enumeration value="image"/>
-      <xs:enumeration value="executeable"/>
+      <xs:enumeration value="executable"/>
       <xs:enumeration value="video"/>
     </xs:restriction>
   </xs:simpleType>

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -3,10 +3,10 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
-      <xs:sequence>
+      <xs:choice maxOccurs="unbounded">
         <xs:element name="provides" type="providesList" minOccurs="0" maxOccurs="1"/>
         <xs:element name="medialibraryscanpath" type="pathType" minOccurs="0" maxOccurs="unbounded"/>
-      </xs:sequence>
+      </xs:choice>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>

--- a/addons/xbmc.python/pluginsource.xsd
+++ b/addons/xbmc.python/pluginsource.xsd
@@ -21,8 +21,9 @@
   <xs:simpleType name="providesType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="audio"/>
-      <xs:enumeration value="image"/>
       <xs:enumeration value="executable"/>
+      <xs:enumeration value="game"/>
+      <xs:enumeration value="image"/>
       <xs:enumeration value="video"/>
     </xs:restriction>
   </xs:simpleType>
@@ -34,8 +35,8 @@
       <xs:enumeration value="albums"/>
       <xs:enumeration value="artists"/>
       <xs:enumeration value="movies"/>
-      <xs:enumeration value="tvshows"/>
       <xs:enumeration value="musicvideos"/>
+      <xs:enumeration value="tvshows"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="pathType">

--- a/addons/xbmc.python/script.xsd
+++ b/addons/xbmc.python/script.xsd
@@ -3,6 +3,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="extension">
     <xs:complexType>
+      <xs:sequence>
+        <xs:element name="provides" type="providesList" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
@@ -12,6 +15,18 @@
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
       <xs:pattern value="[^.]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="providesList">
+    <xs:list itemType="providesType"/>
+  </xs:simpleType>
+  <xs:simpleType name="providesType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="audio"/>
+      <xs:enumeration value="executable"/>
+      <xs:enumeration value="game"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="video"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.python/script.xsd
+++ b/addons/xbmc.python/script.xsd
@@ -14,7 +14,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.(python\.(library|lyrics|module|script|weather)|ui\.screensaver|subtitle\.module)"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="providesList">

--- a/addons/xbmc.python/service.xsd
+++ b/addons/xbmc.python/service.xsd
@@ -12,7 +12,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.service"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/addons/xbmc.webinterface/webinterface.xsd
+++ b/addons/xbmc.webinterface/webinterface.xsd
@@ -7,6 +7,7 @@
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
       <xs:attribute name="type" type="webinterfaceType"/>
+      <xs:attribute name="library" type="xs:string"/>
       <xs:attribute name="entry" type="xs:string"/>
     </xs:complexType>
   </xs:element>

--- a/addons/xbmc.webinterface/webinterface.xsd
+++ b/addons/xbmc.webinterface/webinterface.xsd
@@ -13,7 +13,7 @@
   </xs:element>
   <xs:simpleType name="simpleIdentifier">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[^.]+"/>
+      <xs:pattern value="xbmc\.webinterface"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="webinterfaceType">


### PR DESCRIPTION
## Description
Kodi has evolved and new elements such as `<reuselanguageinvoker>`, `<news>` and `<assets>` are now available for addon authors to use. However, XSD schemas have not followed the new additions and are sort of incomplete. This PR attempts to add those missing elements and attributes and tries to restrict values whenever possible.

## Motivation and Context
As part of GSOC addon-check project (https://github.com/xbmc/addon-check/pull/35) we plan to use those schemas to validate addon.xml files for addons submitted to the repository. It would be awesome if those schemas could also be maintained when things change. 

## How Has This Been Tested?
Compiled (just for the sake of it). Validated a few addons in our repo using the addon-check tool.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

@Rechi, @tamland, @Razzeee for review
@garbear: can you confirm the controller.xsd change?
@ronie: can you take a look at the resource.images addon changes?