### PR TITLE
[guiinfo] Fix GUIInfoManager::GetItemImage for non-listitem labels.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6464,8 +6464,8 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
     {
       case STRING_IS_EMPTY:
         // note: Get*Image() falls back to Get*Label(), so this should cover all of them
-        if (item && item->IsFileItem())
-          bReturn = GetItemImage(static_cast<const CFileItem*>(item), contextWindow, info.GetData1()).empty();
+        if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
+          bReturn = GetItemImage(item, contextWindow, info.GetData1()).empty();
         else
           bReturn = GetImage(info.GetData1(), contextWindow).empty();
         break;
@@ -6475,8 +6475,8 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           if (info.GetData2() < 0) // info labels are stored with negative numbers
           {
             int info2 = -info.GetData2();
-            if (item && item->IsFileItem())
-              compare = GetItemImage(static_cast<const CFileItem*>(item), contextWindow, info2);
+            if (item && item->IsFileItem() && IsListItemInfo(info2))
+              compare = GetItemImage(item, contextWindow, info2);
             else
               compare = GetImage(info2, contextWindow);
           }
@@ -6484,8 +6484,8 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           { // conditional string
             compare = info.GetData3();
           }
-          if (item && item->IsFileItem())
-            bReturn = StringUtils::EqualsNoCase(GetItemImage(static_cast<const CFileItem *>(item), contextWindow, info.GetData1()), compare);
+          if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
+            bReturn = StringUtils::EqualsNoCase(GetItemImage(item, contextWindow, info.GetData1()), compare);
           else
             bReturn = StringUtils::EqualsNoCase(GetImage(info.GetData1(), contextWindow), compare);
         }
@@ -6500,8 +6500,8 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           if (!GetInt(integer, info.GetData1(), contextWindow, item))
           {
             std::string value;
-            if (item && item->IsFileItem())
-              value = GetItemImage(static_cast<const CFileItem*>(item), contextWindow, info.GetData1());
+            if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
+              value = GetItemImage(item, contextWindow, info.GetData1());
             else
               value = GetImage(info.GetData1(), contextWindow);
 
@@ -6534,16 +6534,11 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           // our compare string is already in lowercase, so lower case our label as well
           // as std::string::Find() is case sensitive
           std::string label;
-          if (item && item->IsFileItem())
-          {
-            label = GetItemImage(static_cast<const CFileItem*>(item), contextWindow, info.GetData1());
-            StringUtils::ToLower(label);
-          }
+          if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
+            label = GetItemImage(item, contextWindow, info.GetData1());
           else
-          {
             label = GetImage(info.GetData1(), contextWindow);
-            StringUtils::ToLower(label);
-          }
+          StringUtils::ToLower(label);
           if (condition == STRING_STARTS_WITH)
             bReturn = StringUtils::StartsWith(label, compare);
           else if (condition == STRING_ENDS_WITH)
@@ -6643,7 +6638,7 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *
   {
     const CGUIListItemPtr item = GUIINFO::GetCurrentListItem(contextWindow);
     if (item && item->IsFileItem())
-      return GetItemImage(static_cast<CFileItem*>(item.get()), contextWindow, info, fallback);
+      return GetItemImage(item.get(), contextWindow, info, fallback);
   }
 
   return GetLabel(info, contextWindow, fallback);
@@ -6735,6 +6730,15 @@ int CGUIInfoManager::AddMultiInfo(const CGUIInfo &info)
   if (id > MULTI_INFO_END)
     CLog::Log(LOGERROR, "%s - too many multiinfo bool/labels in this skin", __FUNCTION__);
   return id;
+}
+
+bool CGUIInfoManager::IsListItemInfo(int info) const
+{
+  int iResolvedInfo = info;
+  while (iResolvedInfo >= MULTI_INFO_START && iResolvedInfo <= MULTI_INFO_END)
+    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].m_info;
+
+  return (iResolvedInfo >= LISTITEM_START && iResolvedInfo <= LISTITEM_END);
 }
 
 bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int contextWindow, int info) const
@@ -6866,9 +6870,12 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
   return value;
 }
 
-std::string CGUIInfoManager::GetItemImage(const CFileItem *item, int contextWindow, int info, std::string *fallback /*= nullptr*/) const
+std::string CGUIInfoManager::GetItemImage(const CGUIListItem *item, int contextWindow, int info, std::string *fallback /*= nullptr*/) const
 {
-  return GetMultiInfoItemImage(item, contextWindow, CGUIInfo(info), fallback);
+  if (!item || !item->IsFileItem())
+    return std::string();
+
+  return GetMultiInfoItemImage(static_cast<const CFileItem*>(item), contextWindow, CGUIInfo(info), fallback);
 }
 
 std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback /*= nullptr*/) const

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -98,7 +98,7 @@ public:
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item = nullptr);
 
   std::string GetItemLabel(const CFileItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;
-  std::string GetItemImage(const CFileItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;
+  std::string GetItemImage(const CGUIListItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;
   /*! \brief Get integer value of info.
    \param value int reference to pass value of given info
    \param info id of info
@@ -186,6 +186,8 @@ private:
   std::string GetSkinVariableString(int info, bool preferImage = false, const CGUIListItem *item = nullptr) const;
 
   int AddMultiInfo(const KODI::GUILIB::GUIINFO::CGUIInfo &info);
+
+  bool IsListItemInfo(int info) const;
 
   void SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag &tag);
   void SetCurrentVideoTag(const CVideoInfoTag &tag);

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -75,7 +75,7 @@ const std::string &CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool pr
       {
         std::string infoLabel;
         if (preferImages)
-          infoLabel = infoMgr.GetItemImage(static_cast<const CFileItem*>(item), 0, portion.m_info, fallback);
+          infoLabel = infoMgr.GetItemImage(item, 0, portion.m_info, fallback);
         else
           infoLabel = infoMgr.GetItemLabel(static_cast<const CFileItem *>(item), 0, portion.m_info, fallback);
         needsUpdate |= portion.NeedsUpdate(infoLabel);


### PR DESCRIPTION
Fixes a regression reported in the forum: https://forum.kodi.tv/showthread.php?tid=330696&pid=2754128#pid2754128

@HitcherUK thanks for runtime-testing the fix.

