### PR TITLE
[PVR] Guide window: Only sort events item list when actually necessary.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -239,6 +239,16 @@ bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFile
   return true;
 }
 
+void CGUIWindowPVRGuideBase::FormatAndSort(CFileItemList &items)
+{
+  if (&items == m_vecItems)
+  {
+    // Speedup: Nothing to do here as sorting was already done in CGUIWindowPVRGuideBase::RefreshTimelineItems
+    return;
+  }
+  CGUIWindowPVRBase::FormatAndSort(items);
+}
+
 bool CGUIWindowPVRGuideBase::ShouldNavigateToGridContainer(int iAction)
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -49,6 +49,7 @@ namespace PVR
     void UpdateSelectedItemPath() override;
     std::string GetDirectoryPath(void) override { return ""; }
     bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
+    void FormatAndSort(CFileItemList &items) override;
 
     void ClearData() override;
 


### PR DESCRIPTION
Speeds up opening the PVR Guide window. 

Sorting of the epg events - which can consume significant amount of time - is now always done async outside the main thread and only if really necessary, not on every (re-)open of the window.

Runtime-tested with latest kodi master on macOS and Linux.