### PR TITLE
[GUI]Fix window onload  control move for music item lists

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -97,7 +97,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_WINDOW_INIT:
     {
-/* We don't want to show Autosourced items (ie removable pendrives, memorycards) in Library mode */
+      /* We don't want to show Autosourced items (ie removable pendrives, memorycards) in Library mode */
       m_rootDir.AllowNonLocalSources(false);
 
       // is this the first time the window is opened?
@@ -115,6 +115,11 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
         for (; i < m_vecItems->Size(); i++)
         {
           CFileItemPtr pItem = m_vecItems->Get(i);
+
+          // skip ".."
+          if (pItem->IsParentFolder())
+            continue;
+
           if (URIUtils::PathEquals(pItem->GetPath(), message.GetStringParam(0), true, true))
           {
             m_viewControl.SetSelectedItem(i);


### PR DESCRIPTION
A regression in nav screen behaviour was added by https://github.com/xbmc/xbmc/pull/11901 when allowing item selection via ActivateWindow.  Using `Control.Move`  in the window OnLoad event to move to a specific list offset  no longer works.

This was quickly spotted and fixed for the MyVideoNav screen by https://github.com/xbmc/xbmc/pull/11989, but the same issue in MyMusicNav was overlooked.  This remedies that omission. 

@HitcherUK can you confirm this allows your  fTV skin to work as expected.
