### PR TITLE
[PVR] Guide window: Prevent concurrent updates.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -192,6 +192,16 @@ void CGUIWindowPVRGuideBase::UpdateButtons(void)
 
 bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
+  if (m_vecItemsUpdating)
+  {
+    // Prevent concurrent updates. Instead, let the timeline items refresh thread pick it up later.
+    CSingleLock lock(m_critSection);
+    m_bRefreshTimelineItems = true;
+    return true;
+  }
+
+  CUpdateGuard guard(m_vecItemsUpdating);
+
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory, updateFilterPath);
 
   if (bReturn && !m_bChannelSelectionRestored)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -64,10 +64,7 @@ void CGUIWindowPVRGuideBase::InitEpgGridControl()
   }
 
   if (epgGridContainer && !epgGridContainer->HasData())
-  {
-    CSingleLock lock(m_critSection);
     m_bSyncRefreshTimelineItems = true; // force data update on first window open
-  }
 
   StartRefreshTimelineItemsThread();
 }
@@ -133,7 +130,6 @@ void CGUIWindowPVRGuideBase::Notify(const Observable &obs, const ObservableMessa
       msg == ObservableMessageChannelGroupReset ||
       msg == ObservableMessageChannelGroup)
   {
-    CSingleLock lock(m_critSection);
     m_bRefreshTimelineItems = true;
     // no base class call => do async refresh
     return;
@@ -143,7 +139,6 @@ void CGUIWindowPVRGuideBase::Notify(const Observable &obs, const ObservableMessa
     if (m_guiState && m_guiState->GetSortMethod().sortBy == SortByLastPlayed)
     {
       // set dirty to force sync refresh
-      CSingleLock lock(m_critSection);
       m_bSyncRefreshTimelineItems = true;
     }
   }
@@ -195,7 +190,6 @@ bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool update
   if (m_vecItemsUpdating)
   {
     // Prevent concurrent updates. Instead, let the timeline items refresh thread pick it up later.
-    CSingleLock lock(m_critSection);
     m_bRefreshTimelineItems = true;
     return true;
   }
@@ -216,8 +210,6 @@ bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool update
 
 bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
-  bool bForceRefreshTimelineItems = false;
-
   {
     CSingleLock lock(m_critSection);
 
@@ -226,12 +218,10 @@ bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFile
       // channel group change and not very first open of this window. force immediate update.
       m_bSyncRefreshTimelineItems = true;
     }
-
-    bForceRefreshTimelineItems = m_bSyncRefreshTimelineItems;
   }
 
   // never call DoRefresh with locked mutex!
-  if (bForceRefreshTimelineItems)
+  if (m_bSyncRefreshTimelineItems)
     m_refreshTimelineItemsThread->DoRefresh();
 
   {
@@ -354,10 +344,7 @@ void CGUIWindowPVRGuideBase::RefreshView(CGUIMessage& message, bool bInitGridCon
   CGUIWindowPVRBase::OnMessage(message);
 
   // force grid data update
-  {
-    CSingleLock lock(m_critSection);
-    m_bSyncRefreshTimelineItems = true;
-  }
+  m_bSyncRefreshTimelineItems = true;
 
   if (bInitGridControl)
     InitEpgGridControl();
@@ -601,17 +588,11 @@ bool CGUIWindowPVRGuideBase::OnContextButton(int itemNumber, CONTEXT_BUTTON butt
 
 bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
 {
-  bool bRefreshTimelineItems;
+  if (m_bRefreshTimelineItems || m_bSyncRefreshTimelineItems)
   {
-    CSingleLock lock(m_critSection);
-
-    bRefreshTimelineItems = m_bRefreshTimelineItems || m_bSyncRefreshTimelineItems;
     m_bRefreshTimelineItems = false;
     m_bSyncRefreshTimelineItems = false;
-  }
 
-  if (bRefreshTimelineItems)
-  {
     CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (epgGridContainer)
     {


### PR DESCRIPTION
Fixes a crash while fast switching channel groups in the guide window.

<pre>
Thread 1 (Thread 0x7f235bc958c0 (LWP 1382)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f235823140c in __GI_abort () at abort.c:79
#2  0x00007f2357f14723 in ?? () from /usr/lib/libstdc++.so.6
#3  0x00007f2357f1a766 in ?? () from /usr/lib/libstdc++.so.6
#4  0x00007f2357f1a7a1 in std::terminate() () from /usr/lib/libstdc++.so.6
#5  0x00007f2357f1a9d3 in __cxa_throw () from /usr/lib/libstdc++.so.6
#6  0x00000000009cac64 in CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) ()
#7  0x0000000000b1993a in PVR::CGUIWindowPVRGuideBase::GetDirectory(std::string const&, CFileItemList&) ()
#8  0x00000000008eb53c in CGUIMediaWindow::Update(std::string const&, bool) ()
#9  0x0000000000b1a38a in PVR::CGUIWindowPVRBase::Update(std::string const&, bool) ()
#10 0x0000000000b1a421 in PVR::CGUIWindowPVRGuideBase::Update(std::string const&, bool) ()
#11 0x00000000008c640b in CGUIMediaWindow::Refresh(bool) ()
#12 0x0000000000b285dc in PVR::CGUIWindowPVRGuideBase::OnMessage(CGUIMessage&) ()
#13 0x00000000009c633d in CGUIWindowManager::SendMessage(CGUIMessage&) ()
#14 0x00000000009cde89 in CGUIWindowManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage*) ()
#15 0x000000000091675d in KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::ThreadMessage*) ()
#16 0x0000000000916803 in KODI::MESSAGING::CApplicationMessenger::ProcessWindowMessages() ()
#17 0x0000000000a74960 in CApplication::Process() ()
#18 0x00000000009ad13e in CGUIWindowManager::ProcessRenderLoop(bool) ()
#19 0x00000000009cacaa in CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) ()
#20 0x0000000000b1993a in PVR::CGUIWindowPVRGuideBase::GetDirectory(std::string const&, CFileItemList&) ()
#21 0x00000000008eb53c in CGUIMediaWindow::Update(std::string const&, bool) ()
#22 0x0000000000b1a38a in PVR::CGUIWindowPVRBase::Update(std::string const&, bool) ()
#23 0x0000000000b1a421 in PVR::CGUIWindowPVRGuideBase::Update(std::string const&, bool) ()
#24 0x0000000000b0ef70 in PVR::CGUIWindowPVRBase::SetChannelGroup(std::shared_ptr<PVR::CPVRChannelGroup>&&, bool) ()
#25 0x0000000000b1a9f6 in PVR::CGUIWindowPVRBase::OnAction(CAction const&) ()
#26 0x00000000009cd1c4 in CGUIWindowManager::HandleAction(CAction const&) const ()
#27 0x00000000009cd230 in CGUIWindowManager::OnAction(CAction const&) const ()
#28 0x0000000000a71865 in CApplication::OnAction(CAction const&) ()
#29 0x0000000000917a18 in CInputManager::HandleKey(CKey const&) ()
#30 0x0000000000918aa1 in CInputManager::ProcessPeripherals(float) ()
#31 0x0000000000918acf in CInputManager::Process(int, float) ()
#32 0x0000000000a73011 in CApplication::FrameMove(bool, bool) ()
#33 0x0000000000aa8669 in CXBApplicationEx::Run(CAppParamParser const&) ()
#34 0x00000000008ff1cf in XBMC_Run ()
#35 0x00000000006bccf2 in main ()
</pre>

@FernetMenta mind taking a look?