### PR TITLE
[CUtil] HAS_IRSERVERSUITE is never defined

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -64,8 +64,6 @@
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
-#ifdef HAS_IRSERVERSUITE
-#endif
 #include "guilib/LocalizeStrings.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"


### PR DESCRIPTION
## Description
Remove the last `HAS_IRSERVERSUITE` ifdef present in the code.

## Motivation and Context
Clean up

## How Has This Been Tested?
Not tested.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)