### PR TITLE
Armv7 build neon

### DIFF
--- a/xbmc/rendering/MatrixGL.cpp
+++ b/xbmc/rendering/MatrixGL.cpp
@@ -9,8 +9,9 @@
 #include "MatrixGL.h"
 #include "utils/TransformMatrix.h"
 
-#if defined(HAS_NEON)
+#if defined(HAS_NEON) && !defined(__LP64__)
 #include "utils/CPUInfo.h"
+void Matrix4Mul(float* src_mat_1, const float* src_mat_2);
 #endif
 
 #include <cmath>
@@ -128,47 +129,6 @@ void CMatrixGL::Rotatef(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
   MultMatrixf(matrix);
 }
 
-#if defined(HAS_NEON) && !defined(__LP64__)
-
-static inline void Matrix4Mul(float* src_mat_1, const float* src_mat_2)
-{
-  asm volatile (
-    // Store A & B leaving room at top of registers for result (q0-q3)
-    "vldmia %0, { q4-q7 }  \n\t"
-    "vldmia %1, { q8-q11 } \n\t"
-
-    // result = first column of B x first row of A
-    "vmul.f32 q0, q8, d8[0]\n\t"
-    "vmul.f32 q1, q8, d10[0]\n\t"
-    "vmul.f32 q2, q8, d12[0]\n\t"
-    "vmul.f32 q3, q8, d14[0]\n\t"
-
-    // result += second column of B x second row of A
-    "vmla.f32 q0, q9, d8[1]\n\t"
-    "vmla.f32 q1, q9, d10[1]\n\t"
-    "vmla.f32 q2, q9, d12[1]\n\t"
-    "vmla.f32 q3, q9, d14[1]\n\t"
-
-    // result += third column of B x third row of A
-    "vmla.f32 q0, q10, d9[0]\n\t"
-    "vmla.f32 q1, q10, d11[0]\n\t"
-    "vmla.f32 q2, q10, d13[0]\n\t"
-    "vmla.f32 q3, q10, d15[0]\n\t"
-
-    // result += last column of B x last row of A
-    "vmla.f32 q0, q11, d9[1]\n\t"
-    "vmla.f32 q1, q11, d11[1]\n\t"
-    "vmla.f32 q2, q11, d13[1]\n\t"
-    "vmla.f32 q3, q11, d15[1]\n\t"
-
-    // output = result registers
-    "vstmia %1, { q0-q3 }"
-    : //no output
-    : "r" (src_mat_2), "r" (src_mat_1)       // input - note *value* of pointer doesn't change
-    : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11" //clobber
-    );
-}
-#endif
 void CMatrixGL::MultMatrixf(const CMatrixGL &matrix) noexcept
 {
 #if defined(HAS_NEON) && !defined(__LP64__)

--- a/xbmc/rendering/MatrixGL.neon.cpp
+++ b/xbmc/rendering/MatrixGL.neon.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+
+void Matrix4Mul(float* src_mat_1, const float* src_mat_2)
+{
+  asm volatile (
+    // Store A & B leaving room at top of registers for result (q0-q3)
+    "vldmia %0, { q4-q7 }  \n\t"
+    "vldmia %1, { q8-q11 } \n\t"
+
+    // result = first column of B x first row of A
+    "vmul.f32 q0, q8, d8[0]\n\t"
+    "vmul.f32 q1, q8, d10[0]\n\t"
+    "vmul.f32 q2, q8, d12[0]\n\t"
+    "vmul.f32 q3, q8, d14[0]\n\t"
+
+    // result += second column of B x second row of A
+    "vmla.f32 q0, q9, d8[1]\n\t"
+    "vmla.f32 q1, q9, d10[1]\n\t"
+    "vmla.f32 q2, q9, d12[1]\n\t"
+    "vmla.f32 q3, q9, d14[1]\n\t"
+
+    // result += third column of B x third row of A
+    "vmla.f32 q0, q10, d9[0]\n\t"
+    "vmla.f32 q1, q10, d11[0]\n\t"
+    "vmla.f32 q2, q10, d13[0]\n\t"
+    "vmla.f32 q3, q10, d15[0]\n\t"
+
+    // result += last column of B x last row of A
+    "vmla.f32 q0, q11, d9[1]\n\t"
+    "vmla.f32 q1, q11, d11[1]\n\t"
+    "vmla.f32 q2, q11, d13[1]\n\t"
+    "vmla.f32 q3, q11, d15[1]\n\t"
+
+    // output = result registers
+    "vstmia %1, { q0-q3 }"
+    : //no output
+    : "r" (src_mat_2), "r" (src_mat_1)       // input - note *value* of pointer doesn't change
+    : "memory", "q0", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11" //clobber
+    );
+}

--- a/xbmc/rendering/gl/CMakeLists.txt
+++ b/xbmc/rendering/gl/CMakeLists.txt
@@ -8,4 +8,11 @@ set(HEADERS GUIWindowTestPatternGL.h
             ../MatrixGL.h
             GLShader.h)
 
+if(ARCH MATCHES arm AND ENABLE_NEON)
+  list(APPEND SOURCES ../MatrixGL.neon.cpp)
+  if(NOT DEFINED NEON_FLAGS)
+    set_source_files_properties(../MatrixGL.neon.cpp PROPERTIES COMPILE_OPTIONS -mfpu=neon)
+  endif()
+endif()
+
 core_add_library(rendering_gl)

--- a/xbmc/rendering/gles/CMakeLists.txt
+++ b/xbmc/rendering/gles/CMakeLists.txt
@@ -7,5 +7,12 @@ if(OPENGLES_FOUND)
               ../MatrixGL.h
               GLESShader.h)
 
+  if(ARCH MATCHES arm AND ENABLE_NEON)
+    list(APPEND SOURCES ../MatrixGL.neon.cpp)
+    if(NOT DEFINED NEON_FLAGS)
+      set_source_files_properties(../MatrixGL.neon.cpp PROPERTIES COMPILE_OPTIONS -mfpu=neon)
+    endif()
+  endif()
+
   core_add_library(rendering_gles)
 endif()


### PR DESCRIPTION
## Description
Building on arm fails when the builder lacks neon and/or neon isn't enforced with the kodi build.

## Motivation and Context
When building for armv7-a, neon fpu is optional. Altought it can be easier to enable it everywhere, there are several hardware that lack neon support, but still would be relevant for kodi usage.
One case among others is tegra20 (such as Trimslice) where the grate-driver project allow to use the tegra_vde ip block to provide video acceleration using the vdpau API.

## How Has This Been Tested?
Tested at build time with gcc using native compilation on the distro build infra.
Runtime tests are under progress using hw with/without neon support.

## Screenshots (if appropriate):
Build.log from the RPM Fusion infra for fedora 28.
https://koji.fedoraproject.org/koji/taskinfo?taskID=28720079

## Types of change
- [] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
