### PR TITLE
Use DBus to delay the triggered system poweroff so that Kodi can shut…

### DIFF
--- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
+++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
@@ -38,10 +38,15 @@ private:
   bool m_hasUPower;
   bool m_lowBattery;
   int m_batteryLevel;
-  int m_delayLockFd; // file descriptor for the logind sleep delay lock
+  int m_delayLockSleepFd = -1; // file descriptor for the logind sleep delay lock
+  int m_delayLockShutdownFd = -1; // file descriptor for the logind powerdown delay lock
   void UpdateBatteryLevel();
-  void InhibitDelayLock();
-  void ReleaseDelayLock();
+  void InhibitDelayLockSleep();
+  void InhibitDelayLockShutdown();  
+  int InhibitDelayLock(const char *what);
+  void ReleaseDelayLockSleep();
+  void ReleaseDelayLockShutdown();
+  void ReleaseDelayLock(int lockFd, const char *what);
   static bool LogindSetPowerState(const char *state);
   static bool LogindCheckCapability(const char *capability);
 };


### PR DESCRIPTION
…down completely.

## Description
Fixes  #17837: PVR wakeup command is not called on System Shutdown/Reboot.
Added DBus delay lock for Linux system shutdown.

## Motivation and Context
https://trac.kodi.tv/ticket/17837
Without a delay lock the PVR Manager is never stopped/unloaded on a system shutdown from the Kodi power menu, so the wakeup command is never called in this case.

## How Has This Been Tested?
This change was tested in my current setup for multiple weeks.
Test system: Ubuntu 18.04
The wakeup time was successfully set every day for the test period. So it looks like the delay lock is working as expected.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
