### PR TITLE
[fix][win32] rebuild libcec to also ship cec.lib

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win32.list
@@ -20,7 +20,7 @@ libaacs-0.9.0-win32-vc140.7z
 libass-d18a5f1-win32-vc140.7z
 libbluray-1.0.2-win32-vc140.7z
 libcdio-0.9.3-win32-vc140.7z
-libcec-4.0.1-win32-vc140-2.7z
+libcec-4.0.2-Win32-v141.7z
 libfribidi-0.19.2-win32.7z
 libiconv-1.14-win32-vc140-v2.7z
 libjpeg-turbo-1.4.90-win32-vc140.7z


### PR DESCRIPTION
## Description
After removing the dynamic loading of libcec (#13926) windows also needs the lib in the cmake find module.

## Motivation and Context
fixes https://trac.kodi.tv/ticket/17941

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
