### PR TITLE
[cleanup] combine LibInputPointer log lines into a single one

### DIFF
--- a/xbmc/platform/linux/input/LibInputPointer.cpp
+++ b/xbmc/platform/linux/input/LibInputPointer.cpp
@@ -59,10 +59,7 @@ void CLibInputPointer::ProcessButton(libinput_event_pointer *e)
   event.button.x = static_cast<uint16_t>(m_pos.X);
   event.button.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.type: %i", __FUNCTION__, event.type);
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.button.button: %i", __FUNCTION__, event.button.button);
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.button.x: %i", __FUNCTION__, event.button.x);
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.button.y: %i", __FUNCTION__, event.button.y);
+  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.type: %i, event.button.button: %i, event.button.x: %i, event.button.y: %i", __FUNCTION__, event.type, event.button.button, event.button.x, event.button.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
@@ -92,9 +89,7 @@ void CLibInputPointer::ProcessMotion(libinput_event_pointer *e)
   event.motion.x = static_cast<uint16_t>(m_pos.X);
   event.motion.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.type: %i", __FUNCTION__, event.type);
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.motion.x: %i", __FUNCTION__, event.motion.x);
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.motion.y: %i", __FUNCTION__, event.motion.y);
+  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.type: %i, event.motion.x: %i, event.motion.y: %i", __FUNCTION__, event.type, event.motion.x, event.motion.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
@@ -121,9 +116,7 @@ void CLibInputPointer::ProcessAxis(libinput_event_pointer *e)
   event.button.x = static_cast<uint16_t>(m_pos.X);
   event.button.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - scroll: %s", __FUNCTION__, scroll == XBMC_BUTTON_WHEELUP ? "up" : "down");
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.button.x: %i", __FUNCTION__, event.button.x);
-  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.button.y: %i", __FUNCTION__, event.button.y);
+  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - scroll: %s, event.button.x: %i, event.button.y: %i", __FUNCTION__, scroll == XBMC_BUTTON_WHEELUP ? "up" : "down", event.button.x, event.button.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)


### PR DESCRIPTION
## Motivation and Context
Tried to read a debug log, but couldn't see much as it was spammed which those lines.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
