### PR TITLE
VideoPlayer: fixup flush after  cdd5417611ddce737fef6008a6a67ebad84be67a

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -424,7 +424,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
       m_overlays.Flush();
       m_debugRenderer.Flush();
 
-      if (m_pRenderer->Flush(saveBuffers))
+      if (!m_pRenderer->Flush(saveBuffers))
       {
         m_queued.clear();
         m_discard.clear();


### PR DESCRIPTION
see title