### PR TITLE
[docs] Add missing Player infolabels/boolean conditions

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -237,7 +237,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   }
 ///   \table_row3{   <b>`Player.Title`</b>,
 ///                  \anchor Player_Title
-///                  _boolean_,
+///                  _string_,
 ///     Returns the musicplayer title for audio and the videoplayer title for
 ///     videos.
 ///   }
@@ -402,11 +402,11 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "showtime",         PLAYER_SHOWTIME },
                                   { "showcodec",        PLAYER_SHOWCODEC },
                                   { "showinfo",         PLAYER_SHOWINFO },
-                                  { "title",            PLAYER_TITLE },
                                   { "muted",            PLAYER_MUTED },
                                   { "hasduration",      PLAYER_HASDURATION },
                                   { "passthrough",      PLAYER_PASSTHROUGH },
                                   { "cachelevel",       PLAYER_CACHELEVEL },          // labels from here
+                                  { "title",            PLAYER_TITLE },
                                   { "progress",         PLAYER_PROGRESS },
                                   { "progresscache",    PLAYER_PROGRESS_CACHE },
                                   { "volume",           PLAYER_VOLUME },
@@ -1902,7 +1902,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///   \table_row3{   <b>`VideoPlayer.Premiered`</b>,
 ///                  \anchor VideoPlayer_Premiered
 ///                  _string_,
-///     Release or aired date of the currently playing episode, show, movie or EPG item\, if it's in the database
+///     Release or aired date of the currently playing episode\, show\, movie or EPG item\, if it's in the database
 ///   }
 ///   \table_row3{   <b>`VideoPlayer.Trailer`</b>,
 ///                  \anchor VideoPlayer_Trailer

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -110,6 +110,11 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///                  _boolean_,
 ///     Returns true if the player has an audio file.
 ///   }
+///   \table_row3{   <b>`Player.HasGame`</b>,
+///                  \anchor Player_HasGame
+///                  _boolean_,
+///     Returns true if the player has a game file.
+///   }
 ///   \table_row3{   <b>`Player.HasMedia`</b>,
 ///                  \anchor Player_HasMedia
 ///                  _boolean_,
@@ -331,6 +336,38 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///                  _boolean_,
 ///     Returns true if pvr channel preview is active (used channel tag different
 ///     from played tag)
+///   }
+///   \table_row3{   <b>`Player.TempoEnabled`</b>,
+///                  \anchor Player_TempoEnabled
+///                  _boolean_,
+///     Returns true if player supports tempo (i.e. speed up/down normal playback speed)
+///   }
+///   \table_row3{   <b>`Player.IsTempo`</b>,
+///                  \anchor Player_IsTempo
+///                  _boolean_,
+///     Returns true if player has tempo (i.e. is playing with a playback speed higher or
+///     lower than normal playback speed)
+///   }
+///   \table_row3{   <b>`Player.PlaySpeed`</b>,
+///                  \anchor Player_PlaySpeed
+///                  _string_,
+///     Returns the player playback speed with the format %1.2f (1.00 means normal 
+///     playback speed). For Tempo, the default range is 0.80 - 1.50 (it can be changed 
+///     in advanced settings). If `Player.PlaySpeed` returns a value different from 1.00
+///     and `Player.IsTempo` is false it means the player is in ff/rw mode.
+///   }
+///   \table_row3{   <b>`Player.HasResolutions`</b>,
+///                  \anchor Player_HasResolutions
+///                  _boolean_,
+///     Returns true if the player is allowed to switch resolution and refresh rate 
+///     (i.e. if whitelist modes are configured in Kodi's System/Display settings)
+///   }
+///   \table_row3{   <b>`Player.HasPrograms`</b>,
+///                  \anchor Player_HasPrograms
+///                  _boolean_,
+///     Returns true if the media file being played has programs\, i.e. groups of streams. 
+///     Ex: if a media file has multiple streams (quality\, channels\, etc) a program represents
+///     a particular stream combo.
 ///   }
 ///   \table_row3{   <b>`Player.FrameAdvance`</b>,
 ///                  \anchor Player_FrameAdvance


### PR DESCRIPTION
## Description
Adds missing player infolabels/boolean conditions docs, namely:
- `Player.HasGame`
- `Player.TempoEnabled`
- `Player.IsTempo`
- `Player.PlaySpeed`
- `Player.HasResolutions`
- `Player.HasPrograms`

## Motivation and Context
Have complete docs. Those labels/bools are exposed to python and skins so an effort to clearly state what they do in simple terms is important.
The ultimate goal is to deprecate the respective wiki page as it is tremendously outdated. In follow up PR's I'll continue to track missing doc entries, complement with important info that may be present in the wiki and add information regarding which Kodi version a particular infolabel/bool was introduced.

## How Has This Been Tested?
compiled docs

Pings:
@fernetmenta, @peak3d, @spiff

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
