### PR TITLE
VideoPlayer/Amlogic: fix for VC1 seek

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1187,8 +1187,17 @@ int pre_header_feeding(am_private_t *para, am_packet_t *pkt)
         } else if ((CODEC_TAG_WVC1 == para->video_codec_tag)
                 || (CODEC_TAG_VC_1 == para->video_codec_tag)
                 || (CODEC_TAG_WMVA == para->video_codec_tag)) {
-            CLog::Log(LOGDEBUG, "CODEC_TAG_WVC1 == para->video_codec_tag");
-            ret = wvc1_write_header(para, pkt);
+            if (para->extrasize > 4 && !*para->extradata && !*(para->extradata + 1) &&
+                *(para->extradata + 2) == 0x01 && *(para->extradata + 3) == 0x0f && ((*(para->extradata + 4) & 0x03) == 0x03))
+            {
+                CLog::Log(LOGDEBUG, "CODEC_TAG_WVC1 == para->video_codec_tag, using wmv3_write_header");
+                ret = wmv3_write_header(para, pkt);
+            }
+            else
+            {
+                CLog::Log(LOGDEBUG, "CODEC_TAG_WVC1 == para->video_codec_tag");
+                ret = wvc1_write_header(para, pkt);
+            }
             if (ret != PLAYER_SUCCESS) {
                 return ret;
             }


### PR DESCRIPTION
## Description
This PR is fix for VC1 seek issue by HW Amlogic decoding.
 
## Motivation and Context
Any attempt to seek new  position broke VC1 playback.  For every seek operation is reset decoder. The issue is in pre-header-feeding called in codec reset function.  Changing pre-header-feeding for VC1 fixed the seeking issue.

## How Has This Been Tested?

This fix was successfully tested in CoreELEC 8.90 builds.
 
## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
