### PR TITLE
[docs] Documentation fixes for built-in functions

### DIFF
--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -332,7 +332,7 @@ static int UpdateLocals(const std::vector<std::string>& params)
 
 // Note: For new Texts with comma add a "\" before!!! Is used for table text.
 //
-/// \page page_List_of_built_in_functions List of build in functions
+/// \page page_List_of_built_in_functions List of built-in functions
 /// \section built_in_functions_1 Add-on built-in's
 ///
 /// -----------------------------------------------------------------------------
@@ -366,6 +366,11 @@ static int UpdateLocals(const std::vector<std::string>& params)
 ///     ,
 ///     Install the specified plugin/script
 ///     @param[in] id                    The add-on id
+///   }
+///   \table_row2_l{
+///     <b>`InstallFromZip`</b>
+///     ,
+///     Opens the "Install from zip" dialog if "Unknown sources" is enabled. Prompts the warning message if not.
 ///   }
 ///   \table_row2_l{
 ///     <b>`RunAddon(id[\,opt])`</b>

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -181,9 +181,9 @@ static int WakeOnLAN(const std::vector<std::string>& params)
 ///     @param[in] showvolumebar         Add "showVolumeBar" to show volume bar (optional).
 ///   }
 ///   \table_row2_l{
-///     <b>`Skin.ToggleDebug`</b>
+///     <b>`ToggleDebug`</b>
 ///     ,
-///     Toggles skin debug info on/off
+///     Toggles debug mode on/off
 ///   }
 ///   \table_row2_l{
 ///     <b>`ToggleDPMS`</b>

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -298,7 +298,7 @@ static int SearchVideoLibrary(const std::vector<std::string>& params)
 ///     <b>`cleanlibrary(type)`</b>
 ///     ,
 ///      Clean the video/music library
-///     @param[in] type                  "video", "movies", "tvshows", "musicvideos" or "music".
+///     @param[in] type                  "video"\, "movies"\, "tvshows"\, "musicvideos" or "music".
 ///   }
 ///   \table_row2_l{
 ///     <b>`exportlibrary(type [\, exportSingeFile\, exportThumbs\, overwrite\, exportActorThumbs])`</b>
@@ -316,9 +316,9 @@ static int SearchVideoLibrary(const std::vector<std::string>& params)
 ///     ,
 ///     Export the video/music library with extended parameters
 ///     @param[in] library               "video" or "music".
-///     @param[in] exportFiletype        "singlefile", "separate" or "library"
-///     @param[in] path                  Path to destination folder
-///     @param[in] unscraped             Add "unscraped" to include unscraped items
+///     @param[in] exportFiletype        "singlefile"\, "separate" or "library".
+///     @param[in] path                  Path to destination folder.
+///     @param[in] unscraped             Add "unscraped" to include unscraped items.
 ///     @param[in] overwrite             Add "overwrite" to overwrite exitsing files.
 ///     @param[in] artwork               Add "artwork" to include images such as thumbs and fanart.
 ///     @param[in] skipnfo               Add "skipnfo" to not include nfo files(just art).

--- a/xbmc/interfaces/builtins/PVRBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PVRBuiltins.cpp
@@ -50,7 +50,7 @@ static int ToggleRecordPlayingChannel(const std::vector<std::string>& params)
 ///   \table_row2_l{
 ///     <b>`PVR.ToggleRecordPlayingChannel`</b>
 ///     ,
-///     Will toggle recording on playing channel, if any
+///     Will toggle recording on playing channel\, if any
 ///   }
 /// \table_end
 ///

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -517,22 +517,45 @@ static int Seek(const std::vector<std::string>& params)
 ///     @param[in] param                 "restart" to restart from resume point (optional)
 ///   }
 ///   \table_row2_l{
-///     <b>`PlayerControl(command[\,param])`</b>
+///     <b>`PlayerControl(control[\,param])`</b>
 ///     ,
-///     Allows control of music and videos. The command may be one of Play\, Stop\,
-///     Forward\, Rewind\, Next\, Previous\, BigSkipForward\, BigSkipBackward\,
-///     SmallSkipForward\, SmallSkipBackward\, Random\, RandomOn\, RandomOff\,
-///     Repeat\, RepeatOne\, RepeatAll\, RepeatOff\, Partymode(music) or
-///     Partymode(video) or Partymode(path to .xsp file)\, and Record. Play will
-///     either pause\, resume\, or stop ffwding or rewinding. Random toggles random
-///     playback and Repeat cycles through the repeat modes (these both take an
-///     optional second parameter\, Notify\, that notifies the user of the new
-///     state). Partymode(music/video) toggles the appropriate partymode\,
-///     defaults to music if no parameter is given\, besides the default music or
-///     video partymode you can also pass a path to a custom smartplaylist (.xsp)
-///     as parameter.
+///     Allows control of music and videos. <br>
+///     <br>
+///     | Control                 | Video playback behaviour               | Audio playback behaviour    | Added in    |
+///     |:------------------------|:---------------------------------------|:----------------------------|:------------|
+///     | Play                    | Play/Pause                             | Play/Pause                  |             | 
+///     | Stop                    | Stop                                   | Stop                        |             |
+///     | Forward                 | Fast Forward                           | Fast Forward                |             |
+///     | Rewind                  | Rewind                                 | Rewind                      |             |
+///     | Next                    | Next chapter or movie in playlists     | Next track                  |             |
+///     | Previous                | Previous chapter or movie in playlists | Previous track              |             |
+///     | TempoUp                 | Increases playback speed               | none                        | Kodi v18    |
+///     | TempoDown               | Decreases playback speed               | none                        | Kodi v18    |
+///     | BigSkipForward          | Big Skip Forward                       | Big Skip Forward            | Kodi v15    |
+///     | BigSkipBackward         | Big Skip Backward                      | Big Skip Backward           | Kodi v15    |
+///     | SmallSkipForward        | Small Skip Forward                     | Small Skip Forward          | Kodi v15    |
+///     | SmallSkipBackward       | Small Skip Backward                    | Small Skip Backward         | Kodi v15    |
+///     | SeekPercentage(n)       | Seeks to given percentage              | Seeks to given percentage   |             |
+///     | Random *                | Toggle Random Playback                 | Toggle Random Playback      |             |
+///     | RandomOn                | Sets 'Random' to 'on'                  | Sets 'Random' to 'on'       |             |
+///     | RandomOff               | Sets 'Random' to 'off'                 | Sets 'Random' to 'off'      |             |
+///     | Repeat *                | Cycles through repeat modes            | Cycles through repeat modes |             |
+///     | RepeatOne               | Repeats a single video                 | Repeats a single track      |             |
+///     | RepeatAll               | Repeat all videos in a list            | Repeats all tracks in a list|             |
+///     | RepeatOff               | Sets 'Repeat' to 'off'                 | Sets 'Repeat' to 'off'      |             |
+///     | Partymode(music) **     | none                                   | Toggles music partymode     |             |
+///     | Partymode(video) **     | Toggles video partymode                | none                        |             |
+///     | Partymode(path to .xsp) | Partymode for *.xsp-file               | Partymode for *.xsp-file    |             |
+///     | ShowVideoMenu           | Shows the DVD/BR menu if available     | none                        |             |
+///     <br>
+///     '*' = For these controls, the PlayerControl built-in function can make use of the 'notify'-parameter. For example: PlayerControl(random\, notify)
+///     '**' = If no argument is given for 'partymode'\, the control  will default to music.
+///     <br>
 ///     @param[in] control               Control to execute.
 ///     @param[in] param                 "notify" to notify user (optional\, certain controls).
+///
+///     @note 'TempoUp' or 'TempoDown' only works if "Sync playback to display" is enabled.
+///     @note 'Next' will behave differently while using video playlists. In those\, chapters will be ignored and the next movie will be played.
 ///   }
 ///   \table_row2_l{
 ///     <b>`Playlist.Clear`</b>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR fixes some layout problems in the  docs as some commas haven't been escaped. 

I also changed `Skin.ToggleDebug` to `ToggleDebug` for the docs at `ApplicationBuitins.cpp` because the specific code doesn't toggle the Skin-debugmode but toggles the debuglog. Also `Skin.ToggleDebug` is specified at `SkinBuitlins.cpp`.

`InstallFromZip` wasn't documented at all, as well es tthe PlayerControl option for `TempoUp` or `TempoDown`

 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Keeping the documentation up to date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I compiled the doxygen HTML files to check the changes and also checked if the specific built-in functions are working as expected via `kodi-send -a "<some_built_in>"`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
