### PR TITLE
windowing/gbm: replace WaitVBlank with Sleep

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -31,14 +31,6 @@ CDRMUtils::CDRMUtils()
 {
 }
 
-void CDRMUtils::WaitVBlank()
-{
-  drmVBlank vbl;
-  vbl.request.type = DRM_VBLANK_RELATIVE;
-  vbl.request.sequence = 1;
-  drmWaitVBlank(m_fd, &vbl);
-}
-
 bool CDRMUtils::SetMode(const RESOLUTION_INFO& res)
 {
   m_mode = &m_connector->connector->modes[atoi(res.strId.c_str())];

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -84,7 +84,6 @@ public:
   virtual RESOLUTION_INFO GetCurrentMode();
   virtual std::vector<RESOLUTION_INFO> GetModes();
   virtual bool SetMode(const RESOLUTION_INFO& res);
-  virtual void WaitVBlank();
 
   virtual bool AddProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
   virtual bool SetProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }

--- a/xbmc/windowing/gbm/OffScreenModeSetting.h
+++ b/xbmc/windowing/gbm/OffScreenModeSetting.h
@@ -10,10 +10,6 @@
 
 #include "DRMUtils.h"
 
-#ifdef TARGET_POSIX
-#include "platform/linux/XTimeUtils.h"
-#endif
-
 class COffScreenModeSetting : public CDRMUtils
 {
 public:
@@ -28,7 +24,6 @@ public:
   RESOLUTION_INFO GetCurrentMode() override;
   std::vector<RESOLUTION_INFO> GetModes() override;
   bool SetMode(const RESOLUTION_INFO& res) override { return true; }
-  void WaitVBlank() override { Sleep(20); }
 
 private:
   const int DISPLAY_WIDTH = 1280;

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -242,11 +242,6 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
   m_GBM->ReleaseBuffer();
 }
 
-void CWinSystemGbm::WaitVBlank()
-{
-  m_DRM->WaitVBlank();
-}
-
 bool CWinSystemGbm::UseLimitedColor()
 {
   return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -38,7 +38,6 @@ public:
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   void FlipPage(bool rendered, bool videoLayer);
-  void WaitVBlank();
 
   bool CanDoWindowed() override { return false; }
   void UpdateResolutions() override;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -16,6 +16,7 @@
 #include "EGL/eglext.h"
 #include "WinSystemGbmGLContext.h"
 #include "OptionalsReg.h"
+#include "platform/linux/XTimeUtils.h"
 #include "utils/log.h"
 
 using namespace KODI;
@@ -92,7 +93,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
   }
   else
   {
-    CWinSystemGbm::WaitVBlank();
+    Sleep(10);
   }
 
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -18,6 +18,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 
 #include "OptionalsReg.h"
+#include "platform/linux/XTimeUtils.h"
 #include "utils/log.h"
 #include "WinSystemGbmGLESContext.h"
 
@@ -104,7 +105,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   }
   else
   {
-    CWinSystemGbm::WaitVBlank();
+    Sleep(10);
   }
 
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())


### PR DESCRIPTION
## Description
This PR drops the use of `drmWaitVBlank` and changes to use regular `Sleep` when nothing was rendered, similar to what `CRenderSystemGL/GLES` does.

## Motivation and Context
This fixes a 100% cpu usage issue seen on some embedded platforms where `drmWaitVBlank` returns immediately.

## How Has This Been Tested?
Tested on my Tinker Board S, cpu usage while idle on Kodi home screen went from ~100% down to ~10%.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
