### PR TITLE
[videoplayer] DVDDemux::GetStreamType(): Add Opus codec string.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -53,6 +53,9 @@ std::string CDemuxStreamAudio::GetStreamType()
   case AV_CODEC_ID_FLAC:
     strInfo = "FLAC ";
     break;
+  case AV_CODEC_ID_OPUS:
+    strInfo = "Opus ";
+    break;
   case AV_CODEC_ID_VORBIS:
     strInfo = "Vorbis ";
     break;


### PR DESCRIPTION
## Description
Adds "Opus" string to codec information in DVDDemux.cpp.

## Motivation and Context
Follow on to #13965 which missed out adding Opus when its popularity in (stereo and surround) encodes is increasing. Opus is a capitalised name and inserted alphabetically in listed codecs.

## How Has This Been Tested?
Compiled.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed