### PR TITLE
VideoPlayer: bluray - read chunked from file

### DIFF
--- a/xbmc/filesystem/BlurayCallback.cpp
+++ b/xbmc/filesystem/BlurayCallback.cpp
@@ -123,7 +123,7 @@ BD_FILE_H * CBlurayCallback::file_open(void *handle, const char *rel_path)
   file->eof = file_eof;
 
   CFile* fp = new CFile();
-  if (fp->Open(strFilename))
+  if (fp->Open(strFilename, READ_TRUNCATED | READ_BITRATE | READ_CHUNKED))
   {
     file->internal = (void*)fp;
     return file;


### PR DESCRIPTION
Disable internal streaming buffer for blurays. Makes no sense because br reports chunk size of 6144 to ffmpeg for reading.

Another good example why default parameters are crap. Clients should explicitly set parameters, in this case flags.