### PR TITLE
posix: smb - set chunk size to 64k, fixes ECONNABORT

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -77,7 +77,7 @@ public:
   bool OpenForWrite(const CURL& url, bool bOverWrite = false) override;
   bool Delete(const CURL& url) override;
   bool Rename(const CURL& url, const CURL& urlnew) override;
-  int GetChunkSize() override { return 2048*1024; }
+  int GetChunkSize() override { return 64*1024; }
   int IoControl(EIoControl request, void* param) override;
 
 protected:


### PR DESCRIPTION
see title