### PR TITLE
VideoPlayer: blurays - do not read chunked in open_stream path

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -24,6 +24,7 @@
 #include "URL.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
+#include "filesystem/IFileTypes.h"
 #include "utils/URIUtils.h"
 #include "ServiceBroker.h"
 #include "addons/binary-addons/BinaryAddonManager.h"
@@ -152,7 +153,10 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
   }
 
   // our file interface handles all these types of streams
-  return std::shared_ptr<CDVDInputStreamFile>(new CDVDInputStreamFile(finalFileitem));
+  return std::shared_ptr<CDVDInputStreamFile>(new CDVDInputStreamFile(finalFileitem,
+                                                                      XFILE::READ_TRUNCATED |
+                                                                      XFILE::READ_BITRATE |
+                                                                      XFILE::READ_CHUNKED));
 }
 
 std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer, const CFileItem &fileitem, const std::vector<std::string>& filenames)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1145,7 +1145,7 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
 
 bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
 {
-  m_pstream.reset(new CDVDInputStreamFile(item));
+  m_pstream.reset(new CDVDInputStreamFile(item, 0));
 
   if (!m_pstream->Open())
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -15,7 +15,8 @@
 
 using namespace XFILE;
 
-CDVDInputStreamFile::CDVDInputStreamFile(const CFileItem& fileitem) : CDVDInputStream(DVDSTREAM_TYPE_FILE, fileitem)
+CDVDInputStreamFile::CDVDInputStreamFile(const CFileItem& fileitem, unsigned int flags)
+  : CDVDInputStream(DVDSTREAM_TYPE_FILE, fileitem), m_flags(flags)
 {
   m_pFile = NULL;
   m_eof = true;
@@ -40,7 +41,7 @@ bool CDVDInputStreamFile::Open()
   if (!m_pFile)
     return false;
 
-  unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+  unsigned int flags = m_flags;
 
   // If this file is audio and/or video (= not a subtitle) flag to caller
   if (!m_item.IsSubtitle())

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -13,7 +13,7 @@
 class CDVDInputStreamFile : public CDVDInputStream
 {
 public:
-  explicit CDVDInputStreamFile(const CFileItem& fileitem);
+  explicit CDVDInputStreamFile(const CFileItem& fileitem, unsigned int flags);
   ~CDVDInputStreamFile() override;
   bool Open() override;
   void Close() override;
@@ -28,6 +28,7 @@ public:
   bool GetCacheStatus(XFILE::SCacheStatus *status) override;
 
 protected:
-  XFILE::CFile* m_pFile;
-  bool m_eof;
+  XFILE::CFile* m_pFile = nullptr;
+  bool m_eof = false;
+  unsigned int m_flags = 0;
 };

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "DVDInputStreamNavigator.h"
+#include "filesystem/IFileTypes.h"
 #include "utils/LangCodeExpander.h"
 #include "../DVDDemuxSPU.h"
 #include "DVDStateSerializer.h"
@@ -107,7 +108,7 @@ bool CDVDInputStreamNavigator::Open()
   if (m_item.IsDiscImage())
   {
     // if dvd image file (ISO or alike) open using libdvdnav stream callback functions
-    m_pstream.reset(new CDVDInputStreamFile(m_item));
+    m_pstream.reset(new CDVDInputStreamFile(m_item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_CHUNKED));
     if (!m_pstream->Open() || m_dll.dvdnav_open_stream(&m_dvdnav, m_pstream.get(), &m_dvdnav_stream_cb) != DVDNAV_STATUS_OK)
     {
       CLog::Log(LOGERROR, "Error opening image file or Error on dvdnav_open_stream\n");


### PR DESCRIPTION
internally libbluray reads in chunks of 6144. we don't want to pass this through the implementation of IFile. when reading from SMB we need much bigger chunks.