### PR TITLE
Retroplayer: black screen fix for ARGB1555 and some other small changes

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.cpp
@@ -16,11 +16,9 @@ using namespace KODI;
 using namespace RETRO;
 
 CRenderBufferGBM::CRenderBufferGBM(CRenderContext &context,
-                                   int fourcc,
-                                   int bpp) :
+                                   int fourcc) :
   m_context(context),
   m_fourcc(fourcc),
-  m_bpp(bpp),
   m_egl(new CEGLImage(static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetEGLDisplay())),
   m_bo(new CGBMBufferObject(fourcc))
 {

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.h
@@ -27,8 +27,7 @@ namespace RETRO
   {
   public:
     CRenderBufferGBM(CRenderContext &context,
-                     int fourcc,
-                     int bpp);
+                     int fourcc);
     ~CRenderBufferGBM() override;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
@@ -46,7 +45,6 @@ namespace RETRO
     // Construction parameters
     CRenderContext &m_context;
     const int m_fourcc = 0;
-    const int m_bpp;
 
     const GLenum m_textureTarget = GL_TEXTURE_EXTERNAL_OES;
     GLuint m_textureId = 0;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.cpp
@@ -47,11 +47,6 @@ bool CRenderBufferPoolGBM::ConfigureInternal()
       return true;
     }
     case AV_PIX_FMT_RGB555:
-    {
-      m_fourcc = DRM_FORMAT_RGBA5551;
-      m_bpp = sizeof(uint16_t);
-      return true;
-    }
     case AV_PIX_FMT_RGB565:
     {
       m_fourcc = DRM_FORMAT_RGB565;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.cpp
@@ -32,8 +32,7 @@ bool CRenderBufferPoolGBM::IsCompatible(const CRenderVideoSettings &renderSettin
 IRenderBuffer *CRenderBufferPoolGBM::CreateRenderBuffer(void *header /* = nullptr */)
 {
   return new CRenderBufferGBM(m_context,
-                              m_fourcc,
-                              m_bpp);
+                              m_fourcc);
 }
 
 bool CRenderBufferPoolGBM::ConfigureInternal()
@@ -43,14 +42,12 @@ bool CRenderBufferPoolGBM::ConfigureInternal()
     case AV_PIX_FMT_0RGB32:
     {
       m_fourcc = DRM_FORMAT_ARGB8888;
-      m_bpp = sizeof(uint32_t);
       return true;
     }
     case AV_PIX_FMT_RGB555:
     case AV_PIX_FMT_RGB565:
     {
       m_fourcc = DRM_FORMAT_RGB565;
-      m_bpp = sizeof(uint16_t);
       return true;
     }
     default:

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.h
@@ -35,7 +35,6 @@ namespace RETRO
 
     // Configuration parameters
     int m_fourcc = 0;
-    int m_bpp = 0;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
@@ -67,13 +67,6 @@ bool CRenderBufferPoolOpenGLES::ConfigureInternal()
     return true;
   }
   case AV_PIX_FMT_RGB555:
-  {
-    m_pixeltype = GL_UNSIGNED_SHORT_5_5_5_1;
-    m_internalformat = GL_RGB;
-    m_pixelformat = GL_RGB;
-    m_bpp = sizeof(uint16_t);
-    return true;
-  }
   case AV_PIX_FMT_RGB565:
   {
     m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
@@ -70,7 +70,7 @@ bool CRenderBufferPoolOpenGLES::ConfigureInternal()
   case AV_PIX_FMT_RGB565:
   {
     m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
-    m_internalformat = GL_RGB;
+    m_internalformat = GL_RGB565;
     m_pixelformat = GL_RGB;
     m_bpp = sizeof(uint16_t);
     return true;


### PR DESCRIPTION
The first two commits get rid of a black screen when the emulator/core uses ARGB1555 format. I'm not sure why exactly it's not working but this at least allows us to show something (with the colors not quite right).

The 3rd commit allows us to use a sized internal format for the RGB565 format

the 4th commit gets rid of the notion of bpp for the retroplayer gbm renderer as it isn't need anywhere.