### PR TITLE
[win10] allow stat for directory in windows library.

### DIFF
--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.h
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.h
@@ -32,5 +32,6 @@ namespace XFILE
     friend CWinLibraryFile;
     static winrt::Windows::Storage::StorageFolder GetRootFolder(const CURL& url);
     static winrt::Windows::Storage::StorageFolder GetFolder(const CURL &url);
+    static int StatDirectory(const CURL& url, struct __stat64* statData);
   };
 }


### PR DESCRIPTION
this allows speed-up re-scanning sources from windows library.