### PR TITLE
Fix stream playlists as directory

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -437,38 +437,38 @@ static int PlayMedia(const std::vector<std::string>& params)
 
     if (!items.IsEmpty()) // fall through on non expandable playlist
     {
-    bool containsMusic = false, containsVideo = false;
-    for (int i = 0; i < items.Size(); i++)
-    {
-      bool isVideo = items[i]->IsVideo();
-      containsMusic |= !isVideo;
-      containsVideo |= isVideo;
-
-      if (containsMusic && containsVideo)
-        break;
-    }
-
-    std::unique_ptr<CGUIViewState> state(CGUIViewState::GetViewState(containsVideo ? WINDOW_VIDEO_NAV : WINDOW_MUSIC_NAV, items));
-    if (state.get())
-      items.Sort(state->GetSortMethod());
-    else
-      items.Sort(SortByLabel, SortOrderAscending);
-
-    int playlist = containsVideo? PLAYLIST_VIDEO : PLAYLIST_MUSIC;;
-    if (containsMusic && containsVideo) //mixed content found in the folder
-    {
-      for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
+      bool containsMusic = false, containsVideo = false;
+      for (int i = 0; i < items.Size(); i++)
       {
-        if (!items[i]->IsVideo())
-          items.Remove(i);
-      }
-    }
+        bool isVideo = items[i]->IsVideo();
+        containsMusic |= !isVideo;
+        containsVideo |= isVideo;
 
-    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
-    CServiceBroker::GetPlaylistPlayer().Add(playlist, items);
-    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
-    CServiceBroker::GetPlaylistPlayer().Play(playOffset, "");
-    return 0;
+        if (containsMusic && containsVideo)
+          break;
+      }
+
+      std::unique_ptr<CGUIViewState> state(CGUIViewState::GetViewState(containsVideo ? WINDOW_VIDEO_NAV : WINDOW_MUSIC_NAV, items));
+      if (state.get())
+        items.Sort(state->GetSortMethod());
+      else
+        items.Sort(SortByLabel, SortOrderAscending);
+
+      int playlist = containsVideo? PLAYLIST_VIDEO : PLAYLIST_MUSIC;;
+      if (containsMusic && containsVideo) //mixed content found in the folder
+      {
+        for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
+        {
+          if (!items[i]->IsVideo())
+            items.Remove(i);
+        }
+      }
+
+      CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
+      CServiceBroker::GetPlaylistPlayer().Add(playlist, items);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
+      CServiceBroker::GetPlaylistPlayer().Play(playOffset, "");
+      return 0;
     }
   }
   if (item.IsAudio() || item.IsVideo())

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -435,6 +435,8 @@ static int PlayMedia(const std::vector<std::string>& params)
     std::string extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + "|" + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
     XFILE::CDirectory::GetDirectory(item.GetPath(), items, extensions, XFILE::DIR_FLAG_DEFAULTS);
 
+    if (!items.IsEmpty()) // fall through on non expandable playlist
+    {
     bool containsMusic = false, containsVideo = false;
     for (int i = 0; i < items.Size(); i++)
     {
@@ -466,8 +468,10 @@ static int PlayMedia(const std::vector<std::string>& params)
     CServiceBroker::GetPlaylistPlayer().Add(playlist, items);
     CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
     CServiceBroker::GetPlaylistPlayer().Play(playOffset, "");
+    return 0;
+    }
   }
-  else if (item.IsAudio() || item.IsVideo())
+  if (item.IsAudio() || item.IsVideo())
     CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
   else
     g_application.PlayMedia(item, "", PLAYLIST_NONE);


### PR DESCRIPTION
## Description
Workaround for broken STRM playback from favorites after #14183

## Motivation and Context
Patch #14183 introduced a regression, preventing playlists with streams from being played correctly.
This fixes the problem.,

## How Has This Been Tested?
Ubuntu 18.04, self built master. Tested playback of local playlist and playlist with stream. 

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
