### PR TITLE
Fix for (external)player from playercorefactory.xml gets the default

### DIFF
--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -438,7 +438,7 @@ bool CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
     CloseHandle(m_processInfo.hProcess);
     m_processInfo.hProcess = 0;
   }
-  return (ret == 0);
+  return (ret == TRUE);
 }
 #endif
 


### PR DESCRIPTION

## Description
When you define an playercorefactory.xml file with an rule the behaviour should be:

- if the filename has "4K" in it, kodi should launch the external player

- if the filename has NOT "4K" in it, kodi should play it with the default player

But the behaviour is:

- After Kodi start: if the filename has NOT "4K" in it, kodi playes it with internal video player. When you play more files with no 4K in filename, no issue. Default internal videoplayer is used.

- If play a single file with "4K" in the filename, kodi launches the external player.

- After you played one file with the external player, KODI IS PLAYING ALL FILES WITH THE EXTERNAL PLAYER. It doesnt care about the filename.

## Motivation and Context
Because its an bug.
Here is the trac ticket: https://trac.kodi.tv/ticket/17983#ticket
And the forum thread post: https://forum.kodi.tv/showthread.php?tid=43511&pid=2757968#pid2757968

## How Has This Been Tested?
Test on my local dev PC and on my main HTPC.
All tests was positive that the bug is fixed.

## Screenshots (if appropriate):

## Types of change
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
