### PR TITLE
Revert "Retroplayer: RenderBufferPoolOpenGLES: use internal format GL…

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
@@ -70,7 +70,7 @@ bool CRenderBufferPoolOpenGLES::ConfigureInternal()
   case AV_PIX_FMT_RGB565:
   {
     m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
-    m_internalformat = GL_RGB565;
+    m_internalformat = GL_RGB;
     m_pixelformat = GL_RGB;
     m_bpp = sizeof(uint16_t);
     return true;


### PR DESCRIPTION
thanks @cdu13a for reporting this issue.

my bad for not reading the docs,

https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glTexImage2D.xml

