### PR TITLE
gbm/windowing: fix compile when using older EGL headers + assert mess…

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -51,7 +51,10 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_eglContext.CreatePlatformSurface(m_GBM->GetSurface(), m_GBM->GetSurface()))
+  // This check + the reinterpret cast is for security reason, if the user has outdated platform header files which often is the case
+  static_assert(sizeof(EGLNativeWindowType) == sizeof(gbm_surface*), "Declaration specifier differs in size");
+
+  if (!m_eglContext.CreatePlatformSurface(m_GBM->GetSurface(), reinterpret_cast<EGLNativeWindowType>(m_GBM->GetSurface())))
   {
     return false;
   }


### PR DESCRIPTION
…age on size difference

## Description
duplicate of #14228 -> sorry !

cast to EGLNativeWindowType to fix possible compile error

``/home/odroid/hdd/xbmc/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp:122:83: error: no matching function for call to ‘CEGLContextUtils::CreatePlatformSurface(gbm_surface*, gbm_surface*)``

only newer eglplaform.h header files distinguish between GBM, fbdev or i.e X11 when defining EGLNativeWindowType so the user could have wrong type define

**This happens only if the user has outdated platform header files which often is the case** 

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
