### PR TITLE
fixed: add missing dependency for retroplayer messages

### DIFF
--- a/xbmc/cores/RetroPlayer/messages/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/messages/CMakeLists.txt
@@ -17,3 +17,7 @@ add_custom_target(retroplayer_messages DEPENDS ${FLATC_OUTPUTS})
 set_target_properties(retroplayer_messages PROPERTIES FOLDER "Generated Messages"
                                                       INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR}
                                                       SOURCES ${FLATC_OUTPUTS})
+
+if(TARGET flatbuffers)
+  add_dependencies(retroplayer_messages flatbuffers)
+endif()


### PR DESCRIPTION
with internal flatbuffers we need to depend or flatc is not yet available.