### PR TITLE
VideoPlayer: fix video rotation

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -94,20 +94,21 @@ protected:
                             float inputFrameRatio, float zoomAmount, float verticalShift);
   void CalculateFrameAspectRatio(unsigned int desired_width, unsigned int desired_height);
   virtual void ManageRenderArea();
-  virtual void ReorderDrawPoints();//might be overwritten (by egl e.x.)
+  virtual void ReorderDrawPoints();
   virtual EShaderFormat GetShaderFormat();
+  void MarkDirty();
+
+  //@todo drop those
   void saveRotatedCoords();//saves the current state of m_rotatedDestCoords
   void syncDestRectToRotatedPoints();//sync any changes of m_destRect to m_rotatedDestCoords
   void restoreRotatedCoords();//restore the current state of m_rotatedDestCoords from saveRotatedCoords
-  void MarkDirty();
 
-  unsigned int m_sourceWidth;
-  unsigned int m_sourceHeight;
-  float m_sourceFrameRatio;
-  float m_fps;
+  unsigned int m_sourceWidth = 720;
+  unsigned int m_sourceHeight = 480;
+  float m_sourceFrameRatio = 1.0f;
+  float m_fps = 0.0f;
 
-  unsigned int m_renderOrientation; // orientation of the video in degrees counter clockwise
-  unsigned int m_oldRenderOrientation; // orientation of the previous frame
+  unsigned int m_renderOrientation = 0; // orientation of the video in degrees counter clockwise
   // for drawing the texture with glVertex4f (holds all 4 corner points of the destination rect
   // with correct orientation based on m_renderOrientation
   // 0 - top left, 1 - top right, 2 - bottom right, 3 - bottom left
@@ -115,12 +116,11 @@ protected:
   CPoint m_savedRotatedDestCoords[4];//saved points from saveRotatedCoords call
 
   CRect m_destRect;
-  CRect m_oldDestRect; // destrect of the previous frame
   CRect m_sourceRect;
   CRect m_viewRect;
 
   // rendering flags
-  unsigned m_iFlags;
+  unsigned m_iFlags = 0;
   AVPixelFormat m_format = AV_PIX_FMT_NONE;
 
   CVideoSettings m_videoSettings;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -557,7 +557,7 @@ void CLinuxRendererGL::DrawBlackBars()
   glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
 
   //top quad
-  if (m_rotatedDestCoords[0].y > 0.0)
+  if (m_destRect.y1 > 0.0)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;
@@ -567,25 +567,25 @@ void CLinuxRendererGL::DrawBlackBars()
     vertices[quad+1].y = 0;
     vertices[quad+1].z = 0;
     vertices[quad+2].x = m_viewRect.Width();
-    vertices[quad+2].y = m_rotatedDestCoords[0].y;
+    vertices[quad+2].y = m_destRect.y1;
     vertices[quad+2].z = 0;
     vertices[quad+3] = vertices[quad+2];
     vertices[quad+4].x = 0;
-    vertices[quad+4].y = m_rotatedDestCoords[0].y;
+    vertices[quad+4].y = m_destRect.y1;
     vertices[quad+4].z = 0;
     vertices[quad+5] = vertices[quad];
     count += 6;
   }
 
   // bottom quad
-  if (m_rotatedDestCoords[2].y < m_viewRect.Height())
+  if (m_destRect.y2 < m_viewRect.Height())
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;
-    vertices[quad].y = m_rotatedDestCoords[2].y;
+    vertices[quad].y = m_destRect.y2;
     vertices[quad].z = 0;
     vertices[quad+1].x = m_viewRect.Width();
-    vertices[quad+1].y = m_rotatedDestCoords[2].y;
+    vertices[quad+1].y = m_destRect.y2;
     vertices[quad+1].z = 0;
     vertices[quad+2].x = m_viewRect.Width();
     vertices[quad+2].y = m_viewRect.Height();
@@ -599,42 +599,42 @@ void CLinuxRendererGL::DrawBlackBars()
   }
 
   // left quad
-  if (m_rotatedDestCoords[0].x > 0.0)
+  if (m_destRect.x1 > 0.0)
   {
     GLubyte quad = count;
     vertices[quad].x = 0.0;
-    vertices[quad].y = m_rotatedDestCoords[0].y;
+    vertices[quad].y = m_destRect.y1;
     vertices[quad].z = 0;
-    vertices[quad+1].x = m_rotatedDestCoords[0].x;
-    vertices[quad+1].y = m_rotatedDestCoords[0].y;
+    vertices[quad+1].x = m_destRect.x1;
+    vertices[quad+1].y = m_destRect.y1;
     vertices[quad+1].z = 0;
-    vertices[quad+2].x = m_rotatedDestCoords[3].x;
-    vertices[quad+2].y = m_rotatedDestCoords[3].y;
+    vertices[quad+2].x = m_destRect.x1;
+    vertices[quad+2].y = m_destRect.y2;
     vertices[quad+2].z = 0;
     vertices[quad+3] = vertices[quad+2];
     vertices[quad+4].x = 0;
-    vertices[quad+4].y = m_rotatedDestCoords[3].y;
+    vertices[quad+4].y = m_destRect.y2;
     vertices[quad+4].z = 0;
     vertices[quad+5] = vertices[quad];
     count += 6;
   }
 
-  //right quad
-  if (m_rotatedDestCoords[2].x < m_viewRect.Width())
+  // right quad
+  if (m_destRect.x2 < m_viewRect.Width())
   {
     GLubyte quad = count;
-    vertices[quad].x = m_rotatedDestCoords[1].x;
-    vertices[quad].y = m_rotatedDestCoords[1].y;
+    vertices[quad].x = m_destRect.x2;
+    vertices[quad].y = m_destRect.y1;
     vertices[quad].z = 0;
     vertices[quad+1].x = m_viewRect.Width();
-    vertices[quad+1].y = m_rotatedDestCoords[1].y;
+    vertices[quad+1].y = m_destRect.y1;
     vertices[quad+1].z = 0;
     vertices[quad+2].x = m_viewRect.Width();
-    vertices[quad+2].y = m_rotatedDestCoords[2].y;
+    vertices[quad+2].y = m_destRect.y2;
     vertices[quad+2].z = 0;
     vertices[quad+3] = vertices[quad+2];
-    vertices[quad+4].x = m_rotatedDestCoords[1].x;
-    vertices[quad+4].y = m_rotatedDestCoords[2].y;
+    vertices[quad+4].x = m_destRect.x2;
+    vertices[quad+4].y = m_destRect.y2;
     vertices[quad+4].z = 0;
     vertices[quad+5] = vertices[quad];
     count += 6;


### PR DESCRIPTION
Rotated video has to be scaled to entire render area.

Before:

![screenshot000](https://user-images.githubusercontent.com/576009/44147109-f15971b2-a092-11e8-8b78-424cae21fe6b.png)

After:

![screenshot001](https://user-images.githubusercontent.com/576009/44147115-f79c5e90-a092-11e8-8cfb-66c05cba30cb.png)
