### PR TITLE
Circular dependencies: Clean up services

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -10,7 +10,6 @@
 #include "PlayListPlayer.h"
 #include "Application.h"
 #include "PartyModeManager.h"
-#include "ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIComponent.h"
@@ -28,6 +27,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "filesystem/VideoDatabaseFile.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "ServiceBroker.h"
 
 using namespace PLAYLIST;
 using namespace KODI::MESSAGING;
@@ -599,14 +599,14 @@ void CPlayListPlayer::ReShuffle(int iPlaylist, int iPosition)
       (g_application.GetAppPlayer().IsPlayingVideo() && iPlaylist == PLAYLIST_VIDEO)
       )
     {
-      CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
+      GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
     }
   }
   // otherwise, shuffle from the passed position
   // which is the position of the first new item added
   else
   {
-    CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(iPosition);
+    GetPlaylist(iPlaylist).Shuffle(iPosition);
   }
 }
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -181,7 +181,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_powerManager->Initialize();
   m_powerManager->SetDefaults();
 
-  m_weatherManager.reset(new CWeatherManager());
+  m_weatherManager.reset(new CWeatherManager(*m_settings,
+                                             *m_addonMgr));
 
   init_level = 2;
   return true;

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -175,7 +175,9 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_fileExtensionProvider.reset(new CFileExtensionProvider(*m_addonMgr,
                                                            *m_binaryAddonManager));
 
-  m_powerManager.reset(new CPowerManager(*m_settings));
+  m_powerManager.reset(new CPowerManager(*m_settings,
+                                         *m_network,
+                                         *m_PVRManager));
   m_powerManager->Initialize();
   m_powerManager->SetDefaults();
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -62,7 +62,6 @@ bool CServiceManager::InitForTesting()
 
   m_databaseManager.reset(new CDatabaseManager);
 
-  m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager());
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
@@ -70,6 +69,7 @@ bool CServiceManager::InitForTesting()
     return false;
   }
 
+  m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager(*m_addonMgr));
   if (!m_binaryAddonManager->Init())
   {
     CLog::Log(LOGFATAL, "CServiceManager::%s: Unable to initialize CBinaryAddonManager", __FUNCTION__);
@@ -128,7 +128,6 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_Platform.reset(CPlatform::CreateInstance());
   m_Platform->Init();
 
-  m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager()); /* Need to constructed before, GetRunningInstance() of binary CAddonDll need to call them */
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
@@ -136,6 +135,7 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
     return false;
   }
 
+  m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager(*m_addonMgr));
   if (!m_binaryAddonManager->Init())
   {
     CLog::Log(LOGFATAL, "CServiceManager::%s: Unable to initialize CBinaryAddonManager", __FUNCTION__);

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -144,7 +144,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
 
   m_repositoryUpdater.reset(new ADDON::CRepositoryUpdater(*m_addonMgr));
 
-  m_vfsAddonCache.reset(new ADDON::CVFSAddonCache());
+  m_vfsAddonCache.reset(new ADDON::CVFSAddonCache(*m_addonMgr,
+                                                  *m_binaryAddonManager));
   m_vfsAddonCache->Init();
 
   m_PVRManager.reset(new PVR::CPVRManager());

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -148,12 +148,14 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
                                                   *m_binaryAddonManager));
   m_vfsAddonCache->Init();
 
-  m_PVRManager.reset(new PVR::CPVRManager());
+  m_binaryAddonCache.reset(new ADDON::CBinaryAddonCache());
+  m_binaryAddonCache->Init();
+
+  m_PVRManager.reset(new PVR::CPVRManager(*m_addonMgr,
+                                          *m_binaryAddonCache,
+                                          *m_network));
 
   m_dataCacheCore.reset(new CDataCacheCore());
-
-  m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
-  m_binaryAddonCache->Init();
 
   m_favouritesService.reset(new CFavouritesService(m_profileManager->GetProfileUserDataFolder()));
 
@@ -230,9 +232,9 @@ void CServiceManager::DeinitStageTwo()
   m_contextMenuManager.reset();
   m_serviceAddons.reset();
   m_favouritesService.reset();
-  m_binaryAddonCache.reset();
   m_dataCacheCore.reset();
   m_PVRManager.reset();
+  m_binaryAddonCache.reset();
   m_vfsAddonCache.reset();
   m_repositoryUpdater.reset();
   m_binaryAddonManager.reset();

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -7,7 +7,6 @@
  */
 #include "Service.h"
 #include "AddonManager.h"
-#include "ServiceBroker.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -9,13 +9,19 @@
 #include "URL.h"
 #include "addons/binary-addons/BinaryAddonBase.h"
 #include "addons/binary-addons/BinaryAddonManager.h"
-#include "ServiceBroker.h"
 #include "network/ZeroconfBrowser.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 
 namespace ADDON
 {
+
+CVFSAddonCache::CVFSAddonCache(ADDON::CAddonMgr &addonManager,
+                               ADDON::CBinaryAddonManager &binaryAddonManager) :
+  m_addonManager(addonManager),
+  m_binaryAddonManager(binaryAddonManager)
+{
+}
 
 CVFSAddonCache::~CVFSAddonCache()
 {
@@ -24,13 +30,13 @@ CVFSAddonCache::~CVFSAddonCache()
 
 void CVFSAddonCache::Init()
 {
-  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CVFSAddonCache::OnEvent);
+  m_addonManager.Events().Subscribe(this, &CVFSAddonCache::OnEvent);
   Update();
 }
 
 void CVFSAddonCache::Deinit()
 {
-  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
+  m_addonManager.Events().Unsubscribe(this);
 }
 
 const std::vector<VFSEntryPtr> CVFSAddonCache::GetAddonInstances()
@@ -72,7 +78,7 @@ void CVFSAddonCache::OnEvent(const AddonEvent& event)
       typeid(event) == typeid(AddonEvents::Disabled) ||
       typeid(event) == typeid(AddonEvents::ReInstalled))
   {
-    if (CServiceBroker::GetAddonMgr().HasType(event.id, ADDON_VFS))
+    if (m_addonManager.HasType(event.id, ADDON_VFS))
       Update();
   }
   else if (typeid(event) == typeid(AddonEvents::UnInstalled))
@@ -86,7 +92,7 @@ void CVFSAddonCache::Update()
   std::vector<VFSEntryPtr> addonmap;
 
   BinaryAddonBaseList addonInfos;
-  CServiceBroker::GetBinaryAddonManager().GetAddonInfos(addonInfos, true, ADDON_VFS);
+  m_binaryAddonManager.GetAddonInfos(addonInfos, true, ADDON_VFS);
   for (const auto& addonInfo : addonInfos)
   {
     VFSEntryPtr vfs = std::make_shared<CVFSEntry>(addonInfo);

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -16,6 +16,8 @@
 
 namespace ADDON
 {
+  class CAddonMgr;
+  class CBinaryAddonManager;
 
   class CVFSEntry;
   typedef std::shared_ptr<CVFSEntry> VFSEntryPtr;
@@ -23,6 +25,8 @@ namespace ADDON
   class CVFSAddonCache
   {
   public:
+    CVFSAddonCache(CAddonMgr &addonManager,
+                   CBinaryAddonManager &binaryAddonManager);
     virtual ~CVFSAddonCache();
     void Init();
     void Deinit();
@@ -35,6 +39,11 @@ namespace ADDON
 
     CCriticalSection m_critSection;
     std::vector<VFSEntryPtr> m_addonsInstances;
+
+  private:
+    // Construction parameters
+    ADDON::CAddonMgr &m_addonManager;
+    ADDON::CBinaryAddonManager &m_binaryAddonManager;
   };
 
   //! \brief A virtual filesystem entry add-on.

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -10,7 +10,6 @@
 
 #include "addons/AddonStatusHandler.h"
 #include "GUIUserMessages.h"
-#include "ServiceBroker.h"
 #include "addons/settings/AddonSettings.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "events/EventLog.h"

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -9,7 +9,6 @@
 #include "BinaryAddonManager.h"
 #include "BinaryAddonBase.h"
 
-#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/Directory.h"
@@ -18,8 +17,9 @@
 
 using namespace ADDON;
 
-CBinaryAddonManager::CBinaryAddonManager()
-  : m_tempAddonBasePath("special://temp/binary-addons")
+CBinaryAddonManager::CBinaryAddonManager(CAddonMgr &addonManager)
+  : m_addonManager(addonManager),
+    m_tempAddonBasePath("special://temp/binary-addons")
 {
 }
 
@@ -30,10 +30,10 @@ CBinaryAddonManager::~CBinaryAddonManager()
 
 bool CBinaryAddonManager::Init()
 {
-  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CBinaryAddonManager::OnEvent);
+  m_addonManager.Events().Subscribe(this, &CBinaryAddonManager::OnEvent);
 
   BINARY_ADDON_LIST binaryAddonList;
-  if (!CServiceBroker::GetAddonMgr().GetInstalledBinaryAddons(binaryAddonList))
+  if (!m_addonManager.GetInstalledBinaryAddons(binaryAddonList))
   {
     CLog::Log(LOGNOTICE, "CBinaryAddonManager::%s: No binary addons present and related manager, init not necessary", __FUNCTION__);
     return true;
@@ -53,7 +53,7 @@ void CBinaryAddonManager::DeInit()
   if (XFILE::CDirectory::Exists(m_tempAddonBasePath))
     XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(m_tempAddonBasePath));
 
-  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
+  m_addonManager.Events().Unsubscribe(this);
 }
 
 bool CBinaryAddonManager::HasInstalledAddons(const TYPE &type) const
@@ -211,7 +211,7 @@ void CBinaryAddonManager::DisableEvent(const std::string& addonId)
 void CBinaryAddonManager::InstalledChangeEvent()
 {
   BINARY_ADDON_LIST binaryAddonList;
-  CServiceBroker::GetAddonMgr().GetInstalledBinaryAddons(binaryAddonList);
+  m_addonManager.GetInstalledBinaryAddons(binaryAddonList);
 
   CSingleLock lock(m_critSection);
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -10,7 +10,6 @@
 #include "BinaryAddonBase.h"
 
 #include "addons/AddonManager.h"
-#include "filesystem/SpecialProtocol.h"
 #include "filesystem/Directory.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
@@ -51,7 +50,7 @@ void CBinaryAddonManager::DeInit()
 {
   /* If temporary directory was used from addon delete them */
   if (XFILE::CDirectory::Exists(m_tempAddonBasePath))
-    XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(m_tempAddonBasePath));
+    XFILE::CDirectory::RemoveRecursive(m_tempAddonBasePath);
 
   m_addonManager.Events().Unsubscribe(this);
 }

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -15,7 +15,7 @@
 
 namespace ADDON
 {
-
+  class CAddonMgr;
   class IAddonInstanceHandler;
 
   class CAddonDll;
@@ -28,7 +28,7 @@ namespace ADDON
   class CBinaryAddonManager
   {
   public:
-    CBinaryAddonManager();
+    CBinaryAddonManager(CAddonMgr &addonManager);
     CBinaryAddonManager(const CBinaryAddonManager&) = delete;
     ~CBinaryAddonManager();
 
@@ -136,6 +136,9 @@ namespace ADDON
     void EnableEvent(const std::string& addonId);
     void DisableEvent(const std::string& addonId);
     void InstalledChangeEvent();
+
+    // Construction parameters
+    CAddonMgr &m_addonManager;
 
     mutable CCriticalSection m_critSection;
 

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -9,7 +9,6 @@
 #include "FavouritesService.h"
 #include "filesystem/File.h"
 #include "Util.h"
-#include "profiles/ProfilesManager.h"
 #include "FileItem.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -35,6 +35,7 @@ set(HEADERS hardware/IHardwareInput.h
             CustomControllerTranslator.h
             GamepadTranslator.h
             IButtonMapper.h
+            IInputEventSource.h
             IKeymap.h
             IKeymapEnvironment.h
             InertialScrollingHandler.h

--- a/xbmc/input/IInputEventSource.h
+++ b/xbmc/input/IInputEventSource.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CKey;
+
+/// \addtogroup input
+/// \{
+
+class IInputEventSource
+{
+public:
+  virtual ~IInputEventSource() = default;
+
+  /*!
+   * \brief Try to get a keypress from an external source
+   * \param frameTime The current frametime
+   * \param key The fetched key
+   * \return True when a keypress was fetched, false otherwise
+   */
+  virtual bool GetNextKeypress(float frameTime, CKey &key) { return false; }
+};
+
+/// \}

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -30,6 +30,7 @@ class CJoystickMapper;
 class CKey;
 class CProfilesManager;
 class CTouchTranslator;
+class IInputEventSource;
 class IKeymapEnvironment;
 class IWindowKeymap;
 
@@ -85,12 +86,12 @@ public:
    */
   bool ProcessEventServer(int windowId, float frameTime);
 
-  /*! \brief decode an event from peripherals.
+  /*! \brief decode an event from an external source
    *
    * \param frameTime Time in seconds since last call
    * \return true if event is handled, false otherwise
    */
-  bool ProcessPeripherals(float frameTime);
+  bool ProcessExternalEvent(float frameTime);
 
   /*! \brief Process all inputs
    *
@@ -223,6 +224,9 @@ public:
   virtual void RegisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler);
   virtual void UnregisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler);
 
+  void RegisterExternalEvents(IInputEventSource *events);
+  void UnregisterExternalEvents(IInputEventSource *events);
+
 private:
 
   /*! \brief Process keyboard event and translate into an action
@@ -289,6 +293,8 @@ private:
   std::vector<KODI::MOUSE::IMouseDriverHandler*> m_mouseHandlers;
 
   std::unique_ptr<KODI::KEYBOARD::IKeyboardDriverHandler> m_keyboardEasterEgg;
+
+  std::vector<IInputEventSource*> m_externalEvents;
 };
 
 /// \}

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -12,7 +12,6 @@
 #include <arpa/inet.h>
 
 #include "Network.h"
-#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/NetworkServices.h"
 #include "settings/Settings.h"
@@ -126,7 +125,8 @@ int NetworkAccessPoint::FreqToChannel(float frequency)
 }
 
 CNetworkBase::CNetworkBase(CSettings &settings) :
-  m_services(new CNetworkServices(settings))
+  m_settings(settings),
+  m_services(new CNetworkServices(*this, settings))
 {
   CApplicationMessenger::GetInstance().PostMsg(TMSG_NETWORKMESSAGE, SERVICES_UP, 0);
 }
@@ -513,7 +513,7 @@ std::vector<SOCKET> CreateTCPServerSocket(const int port, const bool bindLocal, 
 
 void CNetworkBase::WaitForNet()
 {
-  const int timeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_POWERMANAGEMENT_WAITFORNETWORK);
+  const int timeout = m_settings.GetInt(CSettings::SETTING_POWERMANAGEMENT_WAITFORNETWORK);
   if (timeout <= 0)
     return; // wait for network is disabled
 

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -147,6 +147,11 @@ public:
 
    // Waits for the first network interface to become available
    void WaitForNet();
+
+private:
+  // Construction parameters
+  CSettings &m_settings;
+
   std::unique_ptr<CNetworkServices> m_services;
 };
 

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -10,6 +10,7 @@
 
 #include "settings/lib/ISettingCallback.h"
 
+class CNetworkBase;
 class CSettings;
 #ifdef HAS_WEB_SERVER
 class CWebServer;
@@ -29,7 +30,7 @@ class CHTTPWebinterfaceAddonsHandler;
 class CNetworkServices : public ISettingCallback
 {
 public:
-  CNetworkServices(CSettings &settings);
+  CNetworkServices(CNetworkBase &network, CSettings &settings);
   ~CNetworkServices() override;
 
   bool OnSettingChanging(std::shared_ptr<const CSetting> setting) override;
@@ -89,6 +90,7 @@ private:
   bool ValidatePort(int port);
 
   // Construction parameters
+  CNetworkBase &m_network;
   CSettings &m_settings;
 
   // Network services

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -36,15 +36,16 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "FileItem.h"
 #include "bus/virtual/PeripheralBusApplication.h"
-#include "input/joysticks/interfaces/IButtonMapper.h"
-#include "interfaces/AnnouncementManager.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "GUIUserMessages.h"
+#include "input/joysticks/interfaces/IButtonMapper.h"
+#include "input/InputManager.h"
 #include "input/Key.h"
+#include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
 #include "peripherals/dialogs/GUIDialogPeripherals.h"
@@ -82,10 +83,14 @@ CPeripherals::CPeripherals(CInputManager &inputManager,
   settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
   settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
   CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
+
+  m_inputManager.RegisterExternalEvents(this);
 }
 
 CPeripherals::~CPeripherals()
 {
+  m_inputManager.UnregisterExternalEvents(this);
+
   // Unregister settings
   CServiceBroker::GetSettings().UnregisterCallback(this);
 

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -14,6 +14,7 @@
 #include "IEventScannerCallback.h"
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
+#include "input/IInputEventSource.h"
 #include "interfaces/IAnnouncer.h"
 #include "messaging/IMessageTarget.h"
 #include "settings/lib/ISettingCallback.h"
@@ -50,7 +51,8 @@ namespace PERIPHERALS
                         public Observable,
                         public KODI::MESSAGING::IMessageTarget,
                         public IEventScannerCallback,
-                        public ANNOUNCEMENT::IAnnouncer
+                        public ANNOUNCEMENT::IAnnouncer,
+                        public IInputEventSource
   {
   public:
     explicit CPeripherals(CInputManager &inputManager,
@@ -210,14 +212,6 @@ namespace PERIPHERALS
     bool UnMute() { return ToggleMute(); } //! @todo CEC only supports toggling the mute status at this time
 
     /*!
-     * @brief Try to get a keypress from a peripheral.
-     * @param frameTime The current frametime.
-     * @param key The fetched key.
-     * @return True when a keypress was fetched, false otherwise.
-     */
-    bool GetNextKeypress(float frameTime, CKey &key);
-
-    /*!
      * @brief Register with the event scanner to control scan timing
      * @return A handle that unregisters itself when expired
      */
@@ -311,6 +305,9 @@ namespace PERIPHERALS
 
     // implementation of IAnnouncer
     void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+
+    // Implementation of IInputEventSource
+    bool GetNextKeypress(float frameTime, CKey &key) override;
 
     /*!
      * \brief Access the input manager passed to the constructor

--- a/xbmc/platform/win10/powermanagement/Win10PowerSyscall.h
+++ b/xbmc/platform/win10/powermanagement/Win10PowerSyscall.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "powermanagement/IPowerSyscall.h"
-#include "powermanagement/PowerManager.h"
 
 class CPowerSyscall : public CAbstractPowerSyscall
 {

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -13,7 +13,6 @@
 
 #include "PowerTypes.h"
 #include "Application.h"
-#include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogKaiToast.h"
@@ -36,8 +35,12 @@
 extern HWND g_hWnd;
 #endif
 
-CPowerManager::CPowerManager(CSettings &settings) :
-  m_settings(settings)
+CPowerManager::CPowerManager(CSettings &settings,
+                             CNetworkBase &network,
+                             PVR::CPVRManager &pvr) :
+  m_settings(settings),
+  m_network(network),
+  m_pvr(pvr)
 {
   m_settings.GetSettingsManager()->RegisterSettingOptionsFiller("shutdownstates", SettingOptionsShutdownStatesFiller);
 }
@@ -62,30 +65,30 @@ void CPowerManager::SetDefaults()
         defaultShutdown = POWERSTATE_SHUTDOWN;
     break;
     case POWERSTATE_HIBERNATE:
-      if (!CServiceBroker::GetPowerManager().CanHibernate())
+      if (!CanHibernate())
       {
-        if (CServiceBroker::GetPowerManager().CanSuspend())
+        if (CanSuspend())
           defaultShutdown = POWERSTATE_SUSPEND;
         else
-          defaultShutdown = CServiceBroker::GetPowerManager().CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
+          defaultShutdown = CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
       }
     break;
     case POWERSTATE_SUSPEND:
-      if (!CServiceBroker::GetPowerManager().CanSuspend())
+      if (!CanSuspend())
       {
-        if (CServiceBroker::GetPowerManager().CanHibernate())
+        if (CanHibernate())
           defaultShutdown = POWERSTATE_HIBERNATE;
         else
-          defaultShutdown = CServiceBroker::GetPowerManager().CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
+          defaultShutdown = CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
       }
     break;
     case POWERSTATE_SHUTDOWN:
-      if (!CServiceBroker::GetPowerManager().CanPowerdown())
+      if (!CanPowerdown())
       {
-        if (CServiceBroker::GetPowerManager().CanSuspend())
+        if (CanSuspend())
           defaultShutdown = POWERSTATE_SUSPEND;
         else
-          defaultShutdown = CServiceBroker::GetPowerManager().CanHibernate() ? POWERSTATE_HIBERNATE : POWERSTATE_QUIT;
+          defaultShutdown = CanHibernate() ? POWERSTATE_HIBERNATE : POWERSTATE_QUIT;
       }
     break;
   }
@@ -176,7 +179,7 @@ void CPowerManager::OnSleep()
 
   CLog::Log(LOGNOTICE, "%s: Running sleep jobs", __FUNCTION__);
 
-  CServiceBroker::GetPVRManager().OnSleep();
+  m_pvr.OnSleep();
   StorePlayerState();
   g_application.StopPlaying();
   g_application.StopShutdownTimer();
@@ -189,7 +192,7 @@ void CPowerManager::OnWake()
 {
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
 
-  CServiceBroker::GetNetwork().WaitForNet();
+  m_network.WaitForNet();
 
   // reset out timers
   g_application.ResetShutdownTimers();

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -16,15 +16,23 @@
 #include "IPowerSyscall.h"
 
 class CFileItem;
+class CNetworkBase;
 class CSetting;
 class CSettings;
+
+namespace PVR
+{
+  class CPVRManager;
+}
 
 // This class will wrap and handle PowerSyscalls.
 // It will handle and decide if syscalls are needed.
 class CPowerManager : public IPowerEventsCallback
 {
 public:
-  CPowerManager(CSettings &settings);
+  CPowerManager(CSettings &settings,
+                CNetworkBase &network,
+                PVR::CPVRManager &pvr);
   ~CPowerManager() override;
 
   void Initialize();
@@ -55,6 +63,8 @@ private:
 
   // Construction parameters
   CSettings &m_settings;
+  CNetworkBase &m_network;
+  PVR::CPVRManager &m_pvr;
 
   std::unique_ptr<IPowerSyscall> m_instance;
   std::unique_ptr<CFileItem> m_lastPlayedFileItem;

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -146,8 +146,9 @@ namespace PVR
     }
   };
 
-  CPVRGUIActions::CPVRGUIActions()
-  : m_settings({
+  CPVRGUIActions::CPVRGUIActions(CNetworkBase &network)
+  : m_network(network),
+    m_settings({
       CSettings::SETTING_LOOKANDFEEL_STARTUPACTION,
       CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL,
       CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME,
@@ -1781,7 +1782,7 @@ namespace PVR
       if (client)
       {
         const std::string hostname = client->GetBackendHostname();
-        if (!hostname.empty() && CServiceBroker::GetNetwork().IsLocalHost(hostname))
+        if (!hostname.empty() && m_network.IsLocalHost(hostname))
           return true;
       }
     }

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -23,6 +23,7 @@ class CFileItem;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
 
 class CGUIWindow;
+class CNetworkBase;
 
 namespace PVR
 {
@@ -64,7 +65,7 @@ namespace PVR
   class CPVRGUIActions
   {
   public:
-    CPVRGUIActions();
+    CPVRGUIActions(CNetworkBase &network);
     virtual ~CPVRGUIActions() = default;
 
     /*!
@@ -481,6 +482,11 @@ namespace PVR
     bool AllLocalBackendsIdle(CPVRTimerInfoTagPtr& causingEvent) const;
     bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
     bool IsNextEventWithinBackendIdleTime(void) const;
+
+    /** @name Construction parameters */
+    //@{
+    CNetworkBase &m_network;
+    //@}
 
     mutable CCriticalSection m_critSection;
     CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -116,14 +116,16 @@ bool CPVRManagerJobQueue::WaitForJobs(unsigned int milliSeconds)
   return m_triggerEvent.WaitMSec(milliSeconds);
 }
 
-CPVRManager::CPVRManager(void) :
+CPVRManager::CPVRManager(ADDON::CAddonMgr &addonManager,
+                         ADDON::CBinaryAddonCache &addonCache,
+                         CNetworkBase &network) :
     CThread("PVRManager"),
     m_channelGroups(new CPVRChannelGroupsContainer),
     m_recordings(new CPVRRecordings),
     m_timers(new CPVRTimers),
-    m_addons(new CPVRClients),
+    m_addons(new CPVRClients(*this, addonManager, addonCache)),
     m_guiInfo(new CPVRGUIInfo),
-    m_guiActions(new CPVRGUIActions),
+    m_guiActions(new CPVRGUIActions(network)),
     m_database(new CPVRDatabase),
     m_parentalTimer(new CStopWatch),
     m_settings({

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -29,8 +29,15 @@
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/recordings/PVRRecording.h"
 
+class CNetworkBase;
 class CStopWatch;
 class CVariant;
+
+namespace ADDON
+{
+  class CAddonMgr;
+  class CBinaryAddonCache;
+}
 
 namespace PVR
 {
@@ -64,7 +71,9 @@ namespace PVR
     /*!
      * @brief Create a new CPVRManager instance, which handles all PVR related operations in XBMC.
      */
-    CPVRManager(void);
+    CPVRManager(ADDON::CAddonMgr &addonManager,
+                ADDON::CBinaryAddonCache &addonCache,
+                CNetworkBase &network);
 
     /*!
      * @brief Stop the PVRManager and destroy all objects it created.

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -21,6 +21,8 @@
 namespace ADDON
 {
   struct AddonEvent;
+  class CAddonMgr;
+  class CBinaryAddonCache;
 }
 
 namespace PVR
@@ -29,6 +31,7 @@ namespace PVR
   class CPVRChannelGroup;
   class CPVRChannelGroups;
   class CPVREpg;
+  class CPVRManager;
   class CPVRRecordings;
   class CPVRTimersContainer;
 
@@ -53,7 +56,9 @@ namespace PVR
   class CPVRClients : public ADDON::IAddonMgrCallback
   {
   public:
-    CPVRClients(void);
+    CPVRClients(CPVRManager &manager,
+                ADDON::CAddonMgr &addonManager,
+                ADDON::CBinaryAddonCache &addonCache);
     ~CPVRClients(void) override;
 
     /*!
@@ -354,6 +359,11 @@ namespace PVR
      * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
      */
     PVR_ERROR ForCreatedClients(const char* strFunctionName, PVRClientFunction function, std::vector<int> &failedClients) const;
+
+    // Construction parameters
+    CPVRManager &m_manager;
+    ADDON::CAddonMgr &m_addonManager;
+    ADDON::CBinaryAddonCache &m_addonCache;
 
     mutable CCriticalSection m_critSection;
     CPVRClientMap m_clientMap;

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -26,9 +26,13 @@
 
 using namespace ADDON;
 
-CWeatherManager::CWeatherManager(void) : CInfoLoader(30 * 60 * 1000) // 30 minutes
+CWeatherManager::CWeatherManager(CSettings &settings,
+                                 ADDON::CAddonMgr &addonManager) :
+  CInfoLoader(30 * 60 * 1000), // 30 minutes
+  m_settings(settings),
+  m_addonManager(addonManager)
 {
-  CServiceBroker::GetSettings().GetSettingsManager()->RegisterCallback(this, {
+  m_settings.GetSettingsManager()->RegisterCallback(this, {
     CSettings::SETTING_WEATHER_ADDON,
     CSettings::SETTING_WEATHER_ADDONSETTINGS
   });
@@ -38,7 +42,7 @@ CWeatherManager::CWeatherManager(void) : CInfoLoader(30 * 60 * 1000) // 30 minut
 
 CWeatherManager::~CWeatherManager(void)
 {
-  CServiceBroker::GetSettings().GetSettingsManager()->UnregisterCallback(this);
+  m_settings.GetSettingsManager()->UnregisterCallback(this);
 }
 
 std::string CWeatherManager::BusyInfo(int info) const
@@ -115,8 +119,8 @@ const ForecastDay &CWeatherManager::GetForecast(int day) const
  */
 void CWeatherManager::SetArea(int iLocation)
 {
-  CServiceBroker::GetSettings().SetInt(CSettings::SETTING_WEATHER_CURRENTLOCATION, iLocation);
-  CServiceBroker::GetSettings().Save();
+  m_settings.SetInt(CSettings::SETTING_WEATHER_CURRENTLOCATION, iLocation);
+  m_settings.Save();
 }
 
 /*!
@@ -125,7 +129,7 @@ void CWeatherManager::SetArea(int iLocation)
  */
 int CWeatherManager::GetArea() const
 {
-  return CServiceBroker::GetSettings().GetInt(CSettings::SETTING_WEATHER_CURRENTLOCATION);
+  return m_settings.GetInt(CSettings::SETTING_WEATHER_CURRENTLOCATION);
 }
 
 CJob *CWeatherManager::GetJob() const
@@ -164,7 +168,7 @@ void CWeatherManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
   if (settingId == CSettings::SETTING_WEATHER_ADDONSETTINGS)
   {
     AddonPtr addon;
-    if (CServiceBroker::GetAddonMgr().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_WEATHER_ADDON), addon, ADDON_SCRIPT_WEATHER) && addon != NULL)
+    if (m_addonManager.GetAddon(m_settings.GetString(CSettings::SETTING_WEATHER_ADDON), addon, ADDON_SCRIPT_WEATHER) && addon != NULL)
     { //! @todo maybe have ShowAndGetInput return a bool if settings changed, then only reset weather if true.
       CGUIDialogAddonSettings::ShowForAddon(addon);
       Refresh();

--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -23,6 +23,13 @@
 #define WEATHER_LABEL_CURRENT_DEWP 27
 #define WEATHER_LABEL_CURRENT_HUMI 28
 
+class CSettings;
+
+namespace ADDON
+{
+  class CAddonMgr;
+}
+
 static const std::string ICON_ADDON_PATH = "resource://resource.images.weathericons.default";
 
 struct ForecastDay
@@ -81,7 +88,8 @@ class CWeatherManager
 : public CInfoLoader, public ISettingCallback
 {
 public:
-  CWeatherManager(void);
+  CWeatherManager(CSettings &settings,
+                  ADDON::CAddonMgr &addonManager);
   ~CWeatherManager(void) override;
   static bool GetSearchResults(const std::string &strSearch, std::string &strResult);
 
@@ -103,6 +111,9 @@ protected:
   void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
 private:
+  // Construction parameters
+  CSettings &m_settings;
+  ADDON::CAddonMgr &m_addonManager;
 
   CWeatherInfo m_info;
 };


### PR DESCRIPTION
This breaks two circular dependencies:

* Settings and PowerManager
* Input and Peripherals

It also cleans up a bunch of dependencies on CServiceBroker, itself a cause of circular dependency.

## Motivation and Context
Initial step in breaking circular dependencies for the login screen. That project is too big to tackle, so I'm chipping away at the edges by reducing some circular dependencies among services.

## How Has This Been Tested?
Untested - Kodi compiles and starts on OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
