### PR TITLE
InputManager: Remove circular dependency on Peripherals

### DIFF
--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -35,6 +35,7 @@ set(HEADERS hardware/IHardwareInput.h
             CustomControllerTranslator.h
             GamepadTranslator.h
             IButtonMapper.h
+            IInputEventSource.h
             IKeymap.h
             IKeymapEnvironment.h
             InertialScrollingHandler.h

--- a/xbmc/input/IInputEventSource.h
+++ b/xbmc/input/IInputEventSource.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CKey;
+
+/// \addtogroup input
+/// \{
+
+class IInputEventSource
+{
+public:
+  virtual ~IInputEventSource() = default;
+
+  /*!
+   * \brief Try to get a keypress from an external source
+   * \param frameTime The current frametime
+   * \param key The fetched key
+   * \return True when a keypress was fetched, false otherwise
+   */
+  virtual bool GetNextKeypress(float frameTime, CKey &key) { return false; }
+};
+
+/// \}

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -30,6 +30,7 @@ class CJoystickMapper;
 class CKey;
 class CProfilesManager;
 class CTouchTranslator;
+class IInputEventSource;
 class IKeymapEnvironment;
 class IWindowKeymap;
 
@@ -85,12 +86,12 @@ public:
    */
   bool ProcessEventServer(int windowId, float frameTime);
 
-  /*! \brief decode an event from peripherals.
+  /*! \brief decode an event from an external source
    *
    * \param frameTime Time in seconds since last call
    * \return true if event is handled, false otherwise
    */
-  bool ProcessPeripherals(float frameTime);
+  bool ProcessExternalEvent(float frameTime);
 
   /*! \brief Process all inputs
    *
@@ -223,6 +224,9 @@ public:
   virtual void RegisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler);
   virtual void UnregisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler);
 
+  void RegisterExternalEvents(IInputEventSource *events);
+  void UnregisterExternalEvents(IInputEventSource *events);
+
 private:
 
   /*! \brief Process keyboard event and translate into an action
@@ -289,6 +293,8 @@ private:
   std::vector<KODI::MOUSE::IMouseDriverHandler*> m_mouseHandlers;
 
   std::unique_ptr<KODI::KEYBOARD::IKeyboardDriverHandler> m_keyboardEasterEgg;
+
+  std::vector<IInputEventSource*> m_externalEvents;
 };
 
 /// \}

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -36,15 +36,16 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "FileItem.h"
 #include "bus/virtual/PeripheralBusApplication.h"
-#include "input/joysticks/interfaces/IButtonMapper.h"
-#include "interfaces/AnnouncementManager.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "GUIUserMessages.h"
+#include "input/joysticks/interfaces/IButtonMapper.h"
+#include "input/InputManager.h"
 #include "input/Key.h"
+#include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
 #include "peripherals/dialogs/GUIDialogPeripherals.h"
@@ -84,10 +85,14 @@ CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements,
   settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
   settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
   CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
+
+  m_inputManager.RegisterExternalEvents(this);
 }
 
 CPeripherals::~CPeripherals()
 {
+  m_inputManager.UnregisterExternalEvents(this);
+
   // Unregister settings
   CServiceBroker::GetSettings().UnregisterCallback(this);
 

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -14,6 +14,7 @@
 #include "IEventScannerCallback.h"
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
+#include "input/IInputEventSource.h"
 #include "interfaces/IAnnouncer.h"
 #include "messaging/IMessageTarget.h"
 #include "settings/lib/ISettingCallback.h"
@@ -55,7 +56,8 @@ namespace PERIPHERALS
                         public Observable,
                         public KODI::MESSAGING::IMessageTarget,
                         public IEventScannerCallback,
-                        public ANNOUNCEMENT::IAnnouncer
+                        public ANNOUNCEMENT::IAnnouncer,
+                        public IInputEventSource
   {
   public:
     explicit CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements,
@@ -216,14 +218,6 @@ namespace PERIPHERALS
     bool UnMute() { return ToggleMute(); } //! @todo CEC only supports toggling the mute status at this time
 
     /*!
-     * @brief Try to get a keypress from a peripheral.
-     * @param frameTime The current frametime.
-     * @param key The fetched key.
-     * @return True when a keypress was fetched, false otherwise.
-     */
-    bool GetNextKeypress(float frameTime, CKey &key);
-
-    /*!
      * @brief Register with the event scanner to control scan timing
      * @return A handle that unregisters itself when expired
      */
@@ -317,6 +311,9 @@ namespace PERIPHERALS
 
     // implementation of IAnnouncer
     void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+
+    // Implementation of IInputEventSource
+    bool GetNextKeypress(float frameTime, CKey &key) override;
 
     /*!
      * \brief Access the input manager passed to the constructor


### PR DESCRIPTION
This breaks a circular dependency between input and peripherals. Peripherals uses InputManager a lot, but only shows up in InputManager once, so I swapped InputManager's use of peripherals for a minimal interface based on the functionality. Peripherals now registers itself with input in its constructor, putting itself behind an interface and breaking the circular dependency.

## Motivation and Context
Split out from #14302.

## How Has This Been Tested?
Compiles and starts on OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
