### PR TITLE
[videoplayer] Fix dvd stream indices for (direct) selection

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2839,6 +2839,7 @@ void CVideoPlayer::HandleMessages()
           if(pStream->SetActiveSubtitleStream(st.id))
           {
             m_dvd.iSelectedSPUStream = -1;
+            m_dvd.iSelectedLogicalSPUStream = -1;
             CloseStream(m_CurrentSubtitle, false);
           }
         }
@@ -4115,9 +4116,15 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
         SetSubtitleVisibleInternal(visible);
 
         if (iStream >= 0)
+        {
           m_dvd.iSelectedSPUStream = (iStream & ~0x80);
+          m_dvd.iSelectedLogicalSPUStream = (event->logical & ~0x80);
+        }
         else
+        {
           m_dvd.iSelectedSPUStream = -1;
+          m_dvd.iSelectedLogicalSPUStream = -1;
+        }
 
         m_CurrentSubtitle.stream = NULL;
       }
@@ -5023,7 +5030,7 @@ void CVideoPlayer::UpdateContentState()
     m_content.m_audioIndex = m_SelectionStreams.IndexOf(STREAM_AUDIO, STREAM_SOURCE_NAV,
       m_CurrentAudio.demuxerId, m_dvd.iSelectedAudioStream);
     m_content.m_subtitleIndex = m_SelectionStreams.IndexOf(STREAM_SUBTITLE, STREAM_SOURCE_NAV,
-      m_CurrentSubtitle.demuxerId, m_dvd.iSelectedSPUStream);
+      m_CurrentSubtitle.demuxerId, m_dvd.iSelectedLogicalSPUStream);
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -553,7 +553,7 @@ protected:
       state                =  DVDSTATE_NORMAL;
       iSelectedSPUStream   = -1;
       iSelectedAudioStream = -1;
-      iSelectedVideoStream = -1;
+      iSelectedVideoStream =  0;
       iDVDStillTime        =  0;
       iDVDStillStartTime   =  0;
       syncClock = false;
@@ -565,7 +565,7 @@ protected:
     unsigned int iDVDStillStartTime; // time in ticks when we started the still
     int iSelectedSPUStream;   // mpeg stream id, or -1 if disabled
     int iSelectedAudioStream; // mpeg stream id, or -1 if disabled
-    int iSelectedVideoStream; // mpeg stream id or angle, -1 if disabled
+    int iSelectedVideoStream = 0; // angle
   } m_dvd;
 
   SPlayerState m_State;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -552,6 +552,7 @@ protected:
     {
       state                =  DVDSTATE_NORMAL;
       iSelectedSPUStream   = -1;
+      iSelectedLogicalSPUStream = -1;
       iSelectedAudioStream = -1;
       iSelectedVideoStream =  0;
       iDVDStillTime        =  0;
@@ -563,7 +564,8 @@ protected:
     bool syncClock;
     unsigned int iDVDStillTime;      // total time in ticks we should display the still before continuing
     unsigned int iDVDStillStartTime; // time in ticks when we started the still
-    int iSelectedSPUStream;   // mpeg stream id, or -1 if disabled
+    int iSelectedSPUStream;   //  widescreen SPU display mpeg stream id, or -1 if disabled
+    int iSelectedLogicalSPUStream = -1; //logical mpeg stream id, or -1 if disabled
     int iSelectedAudioStream; // mpeg stream id, or -1 if disabled
     int iSelectedVideoStream = 0; // angle
   } m_dvd;


### PR DESCRIPTION
Till now no (valid) info for the current a/v/s streams can presented to the gui.
With this change the info can be queried/presented when the demuxer is ready.
I think I have another solution if the info is really needed before the demuxer is ready.

This pr also fixes angle selection via our gui/playercontroller. 
@FernetMenta our multi angle sample seeks to nirvana on angle change. ```GetUpdatedTime()``` returns a value that is to large.

The second commit is necessary if the various possible spu numbers differ (cf. https://github.com/xbmc/xbmc/blob/eb161cdb7c4c97e9f054192c9ea9e8d00839c305/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/dvdnav_events.h#L64-L82).

My LOTR dvd shows this behaviour. But for that dvd dvdnav also reports 5 subs, whereas the menu and ffmpeg only reports 3. Therefore ```ACTION_NEXT_SUBTITLE``` and ```ACTION_CYCLE_SUBTITLE``` doesn't work properly.

Another more intrusive approach would be to merge demuxer's info with dvdnav's info in ```CSelectionStreams::Update(...)``` . 
But @FernetMenta  wanted to overhaul that part anyway, right?