### PR TITLE
Fix compiler warnings

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
@@ -254,6 +254,11 @@
 		case kHIDRemoteButtonCodeMenuHold:
 			return (@"Menu (hold)");
       break;
+        case kHIDRemoteButtonCodePlay:
+            return (@"Play");
+      break;
+        default:
+      break;
 	}
 	return ([NSString stringWithFormat:@"Button %x", (int)buttonCode]);
 }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -179,7 +179,7 @@ static CSpeed::Unit StringToSpeedUnit(const std::string& speedUnit)
 
 struct SortLanguage
 {
-  bool operator()(const std::pair<std::string, std::string> &left, const std::pair<std::string, std::string> &right)
+  bool operator()(const std::pair<std::string, std::string> &left, const std::pair<std::string, std::string> &right) const
   {
     std::string strLeft = left.first;
     std::string strRight = right.first;

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -79,7 +79,7 @@ private:
 };
 
 /// \brief DateTime class, which uses FILETIME as it's base.
-class CDateTime : public IArchivable
+class CDateTime final : public IArchivable
 {
 public:
   CDateTime();

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -251,17 +251,17 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
     CGUIDialogKaiToast::eMessageType usedType;
     switch (qtype)
     {
-    case QUEUE_WARNING:
+    case QueueMsg::QUEUE_WARNING:
       usedType = CGUIDialogKaiToast::Warning;
       withSound = true;
       CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Warning Message: '%s'", __FUNCTION__, addon->Name().c_str(), message);
       break;
-    case QUEUE_ERROR:
+    case QueueMsg::QUEUE_ERROR:
       usedType = CGUIDialogKaiToast::Error;
       withSound = true;
       CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Error Message : '%s'", __FUNCTION__, addon->Name().c_str(), message);
       break;
-    case QUEUE_INFO:
+    case QueueMsg::QUEUE_INFO:
     default:
       usedType = CGUIDialogKaiToast::Info;
       withSound = false;

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -68,7 +68,7 @@ bool CCDDARipJob::DoWork()
 
   // init ripper
   CFile reader;
-  CEncoder* encoder;
+  CEncoder* encoder = nullptr;
   if (!reader.Open(m_input,READ_CACHED) || !(encoder=SetupEncoder(reader)))
   {
     CLog::Log(LOGERROR, "Error: CCDDARipper::Init failed");

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -230,7 +230,7 @@ int CAESinkAUDIOTRACK::AudioTrackWrite(char* audioData, int offsetInBytes, int s
   }
   else
   {
-    if (m_charbuf.size() != (sizeInBytes - offsetInBytes))
+    if (static_cast<int>(m_charbuf.size()) != (sizeInBytes - offsetInBytes))
       m_charbuf.resize(sizeInBytes - offsetInBytes);
     memcpy(m_charbuf.data(), audioData + offsetInBytes, sizeInBytes - offsetInBytes);
     if (CJNIBase::GetSDKVersion() >= 23)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagMicroDVD.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagMicroDVD.cpp
@@ -28,9 +28,11 @@ void CDVDSubtitleTagMicroDVD::ConvertLine(CDVDOverlayText* pOverlay, const char*
     {
       if (strUTF8[pos] == '{')
       {
-        size_t pos2, pos3;
-        if (((pos2 = strUTF8.find(':', pos)) != std::string::npos) &&
-            ((pos3 = strUTF8.find('}', pos2)) != std::string::npos))
+        size_t pos2 = strUTF8.find(':', pos);
+        size_t pos3 = strUTF8.find('}', pos2);
+
+        if ((pos2 != std::string::npos) &&
+            (pos3 != std::string::npos))
         {
           std::string tagName = strUTF8.substr(pos + 1, pos2 - pos - 1);
           std::string tagValue = strUTF8.substr(pos2 + 1, pos3 - pos2 - 1);

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -86,7 +86,8 @@ const CControllerFeature& CController::GetFeature(const std::string &name) const
 unsigned int CController::FeatureCount(FEATURE_TYPE type /* = FEATURE_TYPE::UNKNOWN */,
                                        JOYSTICK::INPUT_TYPE inputType /* = JOYSTICK::INPUT_TYPE::UNKNOWN */) const
 {
-  return std::count_if(m_features.begin(), m_features.end(), FeatureTypeEqual(type, inputType));
+  auto featureCount = std::count_if(m_features.begin(), m_features.end(), FeatureTypeEqual(type, inputType));
+  return static_cast<unsigned int>(featureCount);
 }
 
 void CController::GetFeatures(std::vector<std::string>& features,

--- a/xbmc/games/controllers/types/ControllerGrid.cpp
+++ b/xbmc/games/controllers/types/ControllerGrid.cpp
@@ -100,7 +100,7 @@ unsigned int CControllerGrid::AddPorts(const ControllerPortVec &ports, Controlle
       if (port.PortType() == PORT_TYPE::CONTROLLER)
       {
         // Add controller
-        height = std::max(height, AddController(port, column.vertices.size(), column.vertices, grid));
+        height = std::max(height, AddController(port, static_cast<unsigned int>(column.vertices.size()), column.vertices, grid));
 
         if (bFirstPlayer == true)
         {
@@ -108,9 +108,9 @@ unsigned int CControllerGrid::AddPorts(const ControllerPortVec &ports, Controlle
 
           // Keyboard and mouse are added below the first controller
           if (itKeyboard != ports.end())
-            height = std::max(height, AddController(*itKeyboard, column.vertices.size(), column.vertices, grid));
+            height = std::max(height, AddController(*itKeyboard, static_cast<unsigned int>(column.vertices.size()), column.vertices, grid));
           if (itMouse != ports.end())
-            height = std::max(height, AddController(*itMouse, column.vertices.size(), column.vertices, grid));
+            height = std::max(height, AddController(*itMouse, static_cast<unsigned int>(column.vertices.size()), column.vertices, grid));
         }
       }
 
@@ -124,9 +124,9 @@ unsigned int CControllerGrid::AddPorts(const ControllerPortVec &ports, Controlle
     ControllerColumn column;
 
     if (itKeyboard != ports.end())
-      height = std::max(height, AddController(*itKeyboard, column.vertices.size(), column.vertices, grid));
+      height = std::max(height, AddController(*itKeyboard, static_cast<unsigned int>(column.vertices.size()), column.vertices, grid));
     if (itMouse != ports.end())
-      height = std::max(height, AddController(*itMouse, column.vertices.size(), column.vertices, grid));
+      height = std::max(height, AddController(*itMouse, static_cast<unsigned int>(column.vertices.size()), column.vertices, grid));
 
     if (!column.vertices.empty())
       grid.emplace_back(std::move(column));
@@ -222,7 +222,7 @@ void CControllerGrid::SetHeight(unsigned int height, ControllerGrid &grid)
 {
   for (auto &column : grid)
   {
-    while (column.vertices.size() < height)
+    while (static_cast<unsigned int>(column.vertices.size()) < height)
       AddInvisible(column.vertices);
   }
 }

--- a/xbmc/games/controllers/types/ControllerGrid.h
+++ b/xbmc/games/controllers/types/ControllerGrid.h
@@ -62,7 +62,7 @@ namespace GAME
     /*!
      * \brief Get the width of the controller grid
      */
-    unsigned int Width() const { return m_grid.size(); }
+    unsigned int Width() const { return static_cast<unsigned int>(m_grid.size()); }
 
     /*!
      * \brief Get the height (deepest controller) of the controller grid

--- a/xbmc/guilib/DDSImage.cpp
+++ b/xbmc/guilib/DDSImage.cpp
@@ -96,7 +96,7 @@ bool CDDSImage::ReadFile(const std::string &inputFile)
     return false;
 
   // and read it in
-  if (file.Read(m_data, m_desc.linearSize) != m_desc.linearSize)
+  if (file.Read(m_data, m_desc.linearSize) != static_cast<ssize_t>(m_desc.linearSize))
     return false;
 
   file.Close();

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -630,12 +630,13 @@ bool CPeripheralAddon::SetIgnoredPrimitives(const CPeripheral* device, const Pri
 
   JOYSTICK_DRIVER_PRIMITIVE* addonPrimitives = nullptr;
   kodi::addon::DriverPrimitives::ToStructs(primitives, &addonPrimitives);
+  const unsigned int primitiveCount = static_cast<unsigned int>(primitives.size());
 
   LogError(retVal = m_struct.toAddon.set_ignored_primitives(&m_struct, &joystickStruct,
-        primitives.size(), addonPrimitives), "SetIgnoredPrimitives()");
+    primitiveCount, addonPrimitives), "SetIgnoredPrimitives()");
 
   kodi::addon::Joystick::FreeStruct(joystickStruct);
-  kodi::addon::DriverPrimitives::FreeStructs(primitives.size(), addonPrimitives);
+  kodi::addon::DriverPrimitives::FreeStructs(primitiveCount, addonPrimitives);
 
   return retVal == PERIPHERAL_NO_ERROR;
 }

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -76,7 +76,9 @@ bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width
   }
 
   XFILE::CFile file;
-  const bool ret = file.OpenForWrite(thumbFile, true) && file.Write(thumb, thumbsize) == thumbsize;
+  const bool ret = file.OpenForWrite(thumbFile, true) &&
+                   file.Write(thumb, thumbsize) == static_cast<ssize_t>(thumbsize);
+
   pImage->ReleaseThumbnailBuffer();
   delete pImage;
 

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.h
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.h
@@ -27,9 +27,9 @@ namespace PERIPHERALS
 
     int GetDeviceId() const { return m_deviceId; }
 
-    unsigned int GetButtonCount() const { return m_buttons.size(); }
-    unsigned int GetHatCount() const { return m_hats.size(); }
-    unsigned int GetAxisCount() const { return m_axes.size(); }
+    unsigned int GetButtonCount() const { return static_cast<unsigned int>(m_buttons.size()); }
+    unsigned int GetHatCount() const { return static_cast<unsigned int>(m_hats.size()); }
+    unsigned int GetAxisCount() const { return static_cast<unsigned int>(m_axes.size()); }
 
     /*!
      * Initialize the joystick object. Joystick will be initialized before the

--- a/xbmc/powermanagement/DPMSSupport.cpp
+++ b/xbmc/powermanagement/DPMSSupport.cpp
@@ -22,7 +22,7 @@ static const char* const MODE_NAMES[DPMSSupport::NUM_MODES] =
 
 bool DPMSSupport::CheckValidMode(PowerSavingMode mode)
 {
-  if (mode < 0 || mode > NUM_MODES)
+  if (mode > NUM_MODES)
   {
     CLog::Log(LOGERROR, "Invalid power-saving mode %d", mode);
     return false;

--- a/xbmc/utils/EmbeddedArt.h
+++ b/xbmc/utils/EmbeddedArt.h
@@ -19,6 +19,7 @@ class EmbeddedArtInfo : public IArchivable
 public:
   EmbeddedArtInfo() = default;
   EmbeddedArtInfo(size_t size, const std::string &mime, const std::string& type = "");
+  virtual ~EmbeddedArtInfo() = default;
 
   // implementation of IArchivable
   void Archive(CArchive& ar) override;

--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -17,7 +17,7 @@
 #include "utils/StringUtils.h"
 #include "filesystem/CurlFile.h"
 
-std::map<std::string, std::string> fillMimeTypes()
+static std::map<std::string, std::string> fillMimeTypes()
 {
   std::map<std::string, std::string> mimeTypes;
 


### PR DESCRIPTION
This PR contains all the compiler warning fixes I've stashed away since last release.

I measured the warning count decrease on Windows. We went from 1,030 warnings to 978. Improvement!

## How Has This Been Tested?
Compile-tested on Windows 7 x64 and OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
