### PR TITLE
RetroPlayer: Fix out-of-memory error on resolution change

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.cpp
@@ -72,7 +72,7 @@ IRenderBuffer *CBaseRenderBufferPool::GetBuffer(unsigned int width, unsigned int
 
     for (auto it = m_free.begin(); it != m_free.end(); ++it)
     {
-      std::unique_ptr<IRenderBuffer> &buffer = m_free.front();
+      std::unique_ptr<IRenderBuffer> &buffer = *it;
 
       // Only return buffers of the same dimensions
       const unsigned int bufferWidth = buffer->GetWidth();


### PR DESCRIPTION
## Description
This fixes RetroPlayer allocating a new render buffer each frame when the resolution changes. It only checked the dimensions of the first free buffer, so after a resolution change the dimensions were always different and render buffers were continuously allocated.

Problem was introduced in https://github.com/xbmc/xbmc/pull/14208. The offending line wasn't updated for the change there.

## Motivation and Context
Report: https://forum.kodi.tv/showthread.php?tid=173361&pid=2758892#pid2758892

## How Has This Been Tested?
Tested on Windows 10 x64.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
