### PR TITLE
VideoPlayer: fix player states regarding time

### DIFF
--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -340,6 +340,15 @@ void CDataCacheCore::SetPlayTimes(time_t start, int64_t current, int64_t min, in
   m_timeInfo.m_timeMax = max;
 }
 
+void CDataCacheCore::GetPlayTimes(time_t &start, int64_t &current, int64_t &min, int64_t &max)
+{
+  CSingleLock lock(m_stateSection);
+  start = m_timeInfo.m_startTime;
+  current = m_timeInfo.m_time;
+  min = m_timeInfo.m_timeMin;
+  max = m_timeInfo.m_timeMax;
+}
+
 time_t CDataCacheCore::GetStartTime()
 {
   CSingleLock lock(m_stateSection);

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -68,6 +68,7 @@ public:
   void SetVideoRender(bool video);
   bool GetVideoRender();
   void SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max);
+  void GetPlayTimes(time_t &start, int64_t &current, int64_t &min, int64_t &max);
 
   /*!
    * \brief Get the start time

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4751,9 +4751,6 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     state.timeMax = (double) m_Edl.RemoveCutTime(llrint(state.timeMax));
   }
 
-  if (state.timeMax <= 0)
-    state.canseek = false;
-
   if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)
     state.caching = true;
   else
@@ -4784,6 +4781,18 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     state.cache_bytes = 0;
 
   state.timestamp = m_clock.GetAbsoluteClock();
+
+  if (state.timeMax <= 0)
+  {
+    state.timeMax = state.time;
+    state.timeMin = state.time;
+  }
+  if (state.timeMin == state.timeMax)
+  {
+    state.canseek = false;
+    state.canpause = false;
+    state.cantempo = false;
+  }
 
   m_processInfo->SetPlayTimes(state.startTime, state.time, state.timeMin, state.timeMax);
 


### PR DESCRIPTION
VideoPlayer exposes three times: min, max, current

If content is seekable, current can be set between min and max:
min <= current <= max

If content is not seekable
min == current == max

In order to avoid inconsistencies due to task switches, all times can be queries with a single method from DataCacheCore.