### PR TITLE
[Addons][GUI] Make realtime streams unresumable

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -990,6 +990,11 @@ bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const
   return URIUtils::IsInternetStream(m_strPath, bStrictCheck);
 }
 
+bool CFileItem::IsRealtime() const
+{
+  return HasProperty("isrealtimestream") && GetProperty("isrealtimestream").asBoolean(false);
+}
+
 bool CFileItem::IsFileFolder(EFileFolderType types) const
 {
   EFileFolderType always_type = EFILEFOLDER_TYPE_ALWAYS;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -187,6 +187,12 @@ public:
 
   bool IsGame() const;
   bool IsCUESheet() const;
+  
+  /*!
+   \brief Check if the item contains a realtime stream
+   \return true if item is a realtime stream, false otherwise.
+   */
+  bool IsRealtime() const;
   bool IsInternetStream(const bool bStrictCheck = false) const;
   bool IsPlayList() const;
   bool IsSmartPlayList() const;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -14,7 +14,7 @@ CDVDInputStream::CDVDInputStream(DVDStreamType streamType, const CFileItem& file
 {
   m_streamType = streamType;
   m_contentLookup = true;
-  m_realtime = fileitem.GetProperty("isrealtimestream").asBoolean(false);
+  m_realtime = fileitem.IsRealtime();
   m_item = fileitem;
 }
 

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -606,7 +606,7 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
       // LISTITEM_*
       /////////////////////////////////////////////////////////////////////////////////////////////
       case LISTITEM_IS_RESUMABLE:
-        value = tag->GetResumePoint().timeInSeconds > 0;
+        value = !item->IsRealtime() && !item->IsDeleted() && tag->GetResumePoint().timeInSeconds > 0;
         return true;
       case LISTITEM_IS_COLLECTION:
         value = tag->m_type == MediaTypeVideoCollection;

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -40,7 +40,7 @@ bool CVideoInfo::Execute(const CFileItemPtr& item) const
 bool CRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
 {
   CFileItem item(itemIn.GetItemToPlay());
-  if (item.IsDeleted()) // e.g. trashed pvr recording
+  if (item.IsDeleted() || item.IsRealtime()) // e.g. trashed pvr recording or realtime stream
     return false;
 
   return CGUIWindowVideoBase::HasResumeItemOffset(&item);
@@ -112,7 +112,7 @@ std::string CResume::GetLabel(const CFileItem& item) const
 bool CResume::IsVisible(const CFileItem& itemIn) const
 {
   CFileItem item(itemIn.GetItemToPlay());
-  if (item.IsDeleted()) // e.g. trashed pvr recording
+  if (item.IsDeleted() || item.IsRealtime()) // e.g. trashed pvr recording or real time stream
     return false;
 
   return CGUIWindowVideoBase::HasResumeItemOffset(&item);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -548,8 +548,8 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
 
 void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int64_t& startoffset, int& partNumber)
 {
-  // do not resume Live TV and 'deleted' items (e.g. trashed pvr recordings)
-  if (item->IsLiveTV() || item->IsDeleted())
+  // do not resume Live TV, realtime stream or 'deleted' items (e.g. trashed pvr recordings)
+  if (item->IsLiveTV() || item->IsRealtime() || item->IsDeleted())
     return;
 
   startoffset = 0;


### PR DESCRIPTION
## Description
Streams flagged as realtime (i.e. with the property `isrealtimestream` set) should not be resumable.

## Motivation and Context
Addon developers need more control over the context menu items and resumable marks that are shown in the GUI. If we are playing a livestream, resume points will be automatically set by Kodi and the ability to resume the stream from the last played position will be available after the stream is stopped. Attempting to resume a realtime stream can cause all sort of issues. Currently, some addon developers are using `xbmc.Player().play()` in plugins instead of `setResolvedUrl` (a hack) just as a means to avoid the default contextmenu items/ resume points. 
Ref: https://forum.kodi.tv/showthread.php?tid=270648&pid=2759631#pid2759631

Pinging @ksooo apart from Fernet as I don't know if this has any implications in PVR.

## How Has This Been Tested?
Compiled and runtime tested. Addon with playable listitems with `isrealtimestream` property set did not show the resume context menu items nor the IsResumable icon as expected.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
