### PR TITLE
GUIWindowVideoNav.cpp: Fix comparison bug

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1040,7 +1040,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_EDIT:
     {
       CONTEXT_BUTTON ret = (CONTEXT_BUTTON)CGUIDialogVideoInfo::ManageVideoItem(item);
-      if (ret >= 0)
+      if (ret != CONTEXT_BUTTON_CANCELLED)
       {
         Refresh(true);
         if (ret == CONTEXT_BUTTON_DELETE)


### PR DESCRIPTION
While tracking down compiler warnings, I came across a tautological compare that is probably a bug.

The warning given was:

```
GUIWindowVideoNav.cpp:1043:15: warning: comparison of unsigned enum expression >= 0 is always true [-Wtautological-unsigned-enum-zero-compare]
      if (ret >= 0)
          ~~~ ^  ~
```

I think the author meant to write it as in this PR.

Introduced in https://github.com/xbmc/xbmc/pull/3017.

## Motivation and Context
Noticed when tracking down compiler warnings for https://github.com/xbmc/xbmc/pull/14309

## How Has This Been Tested?
Untested.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
