### PR TITLE
[videoplayer] Fix dvd and bd stream indices for (direct) stream selection.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1643,7 +1643,22 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     if (m_pInput->IsStreamType(DVDSTREAM_TYPE_BLURAY))
     {
       std::static_pointer_cast<CDVDInputStreamBluray>(m_pInput)->GetStreamInfo(pStream->id, stream->language);
-      stream->dvdNavId = pStream->id;
+
+      switch (stream->type)
+      {
+      case STREAM_AUDIO:
+        stream->dvdNavId = pStream->id - 0x1100;
+        break;
+      case STREAM_VIDEO:
+        stream->dvdNavId = pStream->id - 0x1011;
+        break;
+      case STREAM_SUBTITLE:
+        stream->dvdNavId = pStream->id - 0x1200;
+        break;
+      default:
+        stream->dvdNavId = pStream->id;
+        break;
+      }
     }
 #endif
     if( m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD) )

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -114,6 +114,9 @@ public:
     virtual double GetTimeStampCorrection() { return 0.0; };
     virtual bool GetState(std::string &xmlstate) = 0;
     virtual bool SetState(const std::string &xmlstate) = 0;
+    virtual bool SetAudioStream(int streamId) { return false; };
+    virtual bool SetSubtitleStream(int streamId) { return false; };
+    virtual bool SetVideoStream(int streamId) { return false; };
   };
 
   class IDemux
@@ -184,6 +187,7 @@ public:
   virtual IPosTime* GetIPosTime() { return nullptr; }
   virtual IDisplayTime* GetIDisplayTime() { return nullptr; }
   virtual ITimes* GetITimes() { return nullptr; }
+  virtual IMenus* GetIMenus() { return nullptr; }
 
   const CVariant &GetProperty(const std::string key){ return m_item.GetProperty(key); }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -478,6 +478,7 @@ void CDVDInputStreamBluray::ProcessEvent() {
       pid = m_title->clips[m_clip].audio_streams[m_event.param - 1].pid;
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_AUDIO_STREAM %d %d",
         m_event.param, pid);
+    pid = m_event.param - 1;
     m_player->OnDiscNavResult(static_cast<void*>(&pid), BD_EVENT_AUDIO_STREAM);
     break;
 
@@ -497,6 +498,7 @@ void CDVDInputStreamBluray::ProcessEvent() {
     CLog::Log(LOGDEBUG,
         "CDVDInputStreamBluray - BD_EVENT_PG_TEXTST_STREAM %d, %d",
         m_event.param, pid);
+    pid = m_event.param - 1;
     m_player->OnDiscNavResult(static_cast<void*>(&pid), BD_EVENT_PG_TEXTST_STREAM);
     break;
 
@@ -1143,6 +1145,34 @@ bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
     Close();
     return false;
   }
+
+  return true;
+}
+
+bool CDVDInputStreamBluray::SetAudioStream(int streamId)
+{
+  if (!m_bd || !m_title || m_clip >= m_title->clip_count)
+    return false;
+
+  BLURAY_CLIP_INFO *clip = m_title->clips + m_clip;
+  if (streamId > clip->audio_stream_count)
+    return false;
+
+  bd_select_stream(m_bd, BLURAY_AUDIO_STREAM, (streamId + 1), 1);
+
+  return true;
+}
+
+bool CDVDInputStreamBluray::SetSubtitleStream(int streamId)
+{
+  if (!m_bd || !m_title || m_clip >= m_title->clip_count)
+    return false;
+
+  BLURAY_CLIP_INFO *clip = m_title->clips + m_clip;
+  if (streamId > clip->pg_stream_count)
+    return false;
+
+  bd_select_stream(m_bd, BLURAY_PG_TEXTST_STREAM, (streamId + 1), 1);
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -101,6 +101,10 @@ public:
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
   bool PosTime(int ms) override;
 
+  CDVDInputStream::IMenus* GetIMenus() override { return this; }
+  bool SetAudioStream(int streamId) override;
+  bool SetSubtitleStream(int streamId) override;
+
   void GetStreamInfo(int pid, std::string &language);
 
   void OverlayCallback(const BD_OVERLAY * const);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -78,20 +78,21 @@ public:
   bool IsInMenu() override { return m_bInMenu; }
   double GetTimeStampCorrection() override { return (double)(m_iVobUnitCorrection * 1000) / 90; }
 
+  void EnableSubtitleStream(bool bEnable);
   int GetActiveSubtitleStream();
   int GetSubTitleStreamCount();
   SubtitleStreamInfo GetSubtitleStreamInfo(const int iId);
-
-  bool SetActiveSubtitleStream(int iId);
-  void EnableSubtitleStream(bool bEnable);
   bool IsSubtitleStreamEnabled();
+  bool SetSubtitleStream(int streamId) override;
 
   int GetActiveAudioStream();
   int GetAudioStreamCount();
-  int GetActiveAngle();
-  bool SetAngle(int angle);
-  bool SetActiveAudioStream(int iId);
   AudioStreamInfo GetAudioStreamInfo(const int iId);
+  bool SetAudioStream(int streamId) override;
+
+  int GetActiveAngle();
+  VideoStreamInfo GetVideoStreamInfo();
+  bool SetVideoStream(int streamId) override;
 
   bool GetState(std::string &xmlstate) override;
   bool SetState(const std::string &xmlstate) override;
@@ -116,7 +117,7 @@ public:
 
   void CheckButtons();
 
-  VideoStreamInfo GetVideoStreamInfo();
+  CDVDInputStream::IMenus* GetIMenus() override { return this; }
 
 protected:
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -528,8 +528,12 @@ void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux
       /* make sure stream is marked with right source */
       stream->source = source;
 
+      int selectionSource = source;
+      if (input && input->IsStreamType(DVDSTREAM_TYPE_BLURAY))
+        selectionSource = Source(STREAM_SOURCE_NAV, filename);
+
       SelectionStream s;
-      s.source   = source;
+      s.source   = selectionSource;
       s.type     = stream->type;
       s.id       = stream->uniqueId;
       s.demuxerId = stream->demuxerId;
@@ -4015,6 +4019,7 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
 
     case BD_EVENT_PG_TEXTST_STREAM:
       m_dvd.iSelectedSPUStream = *static_cast<int*>(pData);
+      m_dvd.iSelectedLogicalSPUStream = *static_cast<int*>(pData);
       break;
     case BD_EVENT_PG_TEXTST:
     {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2816,6 +2816,13 @@ void CVideoPlayer::HandleMessages()
             UpdateContentState();
             CServiceBroker::GetDataCacheCore().SignalVideoInfoChange();
           }
+          else if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY))
+          {
+            m_dvd.iSelectedVideoStream = st.type_index;
+            CloseStream(m_CurrentVideo, false);
+            OpenStream(m_CurrentVideo, st.demuxerId, st.id, STREAM_SOURCE_DEMUX);
+            seek = true;
+          }
         }
         else
         {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -245,6 +245,7 @@ public:
   CSelectionStreams() = default;
 
   int IndexOf(StreamType type, int source, int64_t demuxerId, int id) const;
+  int IndexOf(StreamType type, int id) const;
   int Count(StreamType type) const;
   int CountSource(StreamType type, StreamSource source) const;
   SelectionStream& Get(StreamType type, int index);
@@ -552,8 +553,9 @@ protected:
     {
       state                =  DVDSTATE_NORMAL;
       iSelectedSPUStream   = -1;
+      iSelectedLogicalSPUStream = -1;
       iSelectedAudioStream = -1;
-      iSelectedVideoStream = -1;
+      iSelectedVideoStream =  0;
       iDVDStillTime        =  0;
       iDVDStillStartTime   =  0;
       syncClock = false;
@@ -563,9 +565,10 @@ protected:
     bool syncClock;
     unsigned int iDVDStillTime;      // total time in ticks we should display the still before continuing
     unsigned int iDVDStillStartTime; // time in ticks when we started the still
-    int iSelectedSPUStream;   // mpeg stream id, or -1 if disabled
+    int iSelectedSPUStream;   //  widescreen SPU display mpeg stream id, or -1 if disabled
+    int iSelectedLogicalSPUStream = -1; //logical mpeg stream id, or -1 if disabled
     int iSelectedAudioStream; // mpeg stream id, or -1 if disabled
-    int iSelectedVideoStream; // mpeg stream id or angle, -1 if disabled
+    int iSelectedVideoStream = 0; // angle
   } m_dvd;
 
   SPlayerState m_State;


### PR DESCRIPTION
Superseeds #14307 and #13144 

- [x] The only thing I need to test again is a blu-ray with secondary video streams.

With this PR users can select a/v/s streams of dvds and blu-rays via osd or player control (e.g. jsonrpc).
The selections is kept in sync with the menu for bds.