### PR TITLE
Windowing: GBM - fix window system initialization

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -17,9 +17,6 @@ using namespace KODI;
 
 bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint apiType)
 {
-  VIDEOPLAYER::CRendererFactory::ClearRenderer();
-  CDVDFactoryCodec::ClearHWAccels();
-
   if (!CWinSystemGbm::InitWindowSystem())
   {
     return false;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -33,6 +33,8 @@ std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
 
 bool CWinSystemGbmGLContext::InitWindowSystem()
 {
+  VIDEOPLAYER::CRendererFactory::ClearRenderer();
+  CDVDFactoryCodec::ClearHWAccels();
   CLinuxRendererGL::Register();
   RETRO::CRPProcessInfoGbm::Register();
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -40,6 +40,8 @@ std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
 
 bool CWinSystemGbmGLESContext::InitWindowSystem()
 {
+  VIDEOPLAYER::CRendererFactory::ClearRenderer();
+  CDVDFactoryCodec::ClearHWAccels();
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfoGbm::Register();
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryGBM);


### PR DESCRIPTION
InitWindowSystemEGL is called from InitWindowSystem
after register calls to various factories
and thus must not clear hwaccels nor the renderer.

## Motivation and Context
Fixes playback of an avi file mentioned in IRC.

## How Has This Been Tested?
Tested playback with GL and GLES on Ubuntu.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
