### PR TITLE
[depends] Fix standalone build of flatbuffers with GCC 8.1

### DIFF
--- a/tools/depends/target/flatbuffers/Makefile
+++ b/tools/depends/target/flatbuffers/Makefile
@@ -49,6 +49,7 @@ ifeq ($(PREFIX),)
 endif
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 < ../../../native/flatbuffers-native/0001-Fix-compiler-warning.patch
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
 


### PR DESCRIPTION
Patch was only applied for native depends build, which builds flatc, but the doxy specifies target, which also builds flatc when building standalone:

```
sudo make -C tools/depends/target/flatbuffers PREFIX=/usr/local
```

This imports the native patch so building standalone on GCC 8.1 doesn't fail.

## Motivation and Context
Reported here: https://forum.kodi.tv/showthread.php?tid=334800

## How Has This Been Tested?
Test compiled with GCC 5.4, no errors.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
