### PR TITLE
Include cleanup

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -10,7 +10,6 @@
 #include "PlayListPlayer.h"
 #include "Application.h"
 #include "PartyModeManager.h"
-#include "ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIComponent.h"
@@ -28,6 +27,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "filesystem/VideoDatabaseFile.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "ServiceBroker.h"
 
 using namespace PLAYLIST;
 using namespace KODI::MESSAGING;
@@ -599,14 +599,14 @@ void CPlayListPlayer::ReShuffle(int iPlaylist, int iPosition)
       (g_application.GetAppPlayer().IsPlayingVideo() && iPlaylist == PLAYLIST_VIDEO)
       )
     {
-      CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
+      GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
     }
   }
   // otherwise, shuffle from the passed position
   // which is the position of the first new item added
   else
   {
-    CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(iPosition);
+    GetPlaylist(iPlaylist).Shuffle(iPosition);
   }
 }
 

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -7,7 +7,6 @@
  */
 #include "Service.h"
 #include "AddonManager.h"
-#include "ServiceBroker.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -10,7 +10,6 @@
 
 #include "addons/AddonStatusHandler.h"
 #include "GUIUserMessages.h"
-#include "ServiceBroker.h"
 #include "addons/settings/AddonSettings.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "events/EventLog.h"

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -9,7 +9,6 @@
 #include "FavouritesService.h"
 #include "filesystem/File.h"
 #include "Util.h"
-#include "profiles/ProfilesManager.h"
 #include "FileItem.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"


### PR DESCRIPTION
This removes some unused/duplicate includes and removes two redundant uses of CServiceBroker.

## Motivation and Context
Split out from https://github.com/xbmc/xbmc/pull/14302.

## How Has This Been Tested?
Only tested as part of #14302.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
