### PR TITLE
[videoplayer] Always report "not caching" while browsing disc menus.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4553,7 +4553,7 @@ void CVideoPlayer::AddSubtitle(const std::string& strSubPath)
 bool CVideoPlayer::IsCaching() const
 {
   CSingleLock lock(m_StateSection);
-  return m_State.caching;
+  return !m_State.isInMenu && m_State.caching;
 }
 
 int CVideoPlayer::GetCacheLevel() const


### PR DESCRIPTION
With this PR those caching progress icons (0% for a few ms) are not shown while browsing disc menus.