### PR TITLE
input: libinput: add setting to allow changing keymap layout

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19735,7 +19735,13 @@ msgctxt "#36435"
 msgid "Use VideoPlayer for decoding of video files with MMAL acceleration."
 msgstr ""
 
-#empty strings from id 36436 to 36441
+#. Description for setting #310: "Keyboard layouts"
+#: system/settings/settings.xml
+msgctxt "#36436"
+msgid "Select OS keyboard layout."
+msgstr ""
+
+#empty strings from id 36437 to 36441
 
 #. Description of setting "System -> Audio output -> Volume control steps" with label #1302
 #: system/settings/settings.xml

--- a/system/settings/aml-linux.xml
+++ b/system/settings/aml-linux.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings version="1">
+  <section id="system">
+    <category id="input">
+      <group id="4" label="35150">
+        <setting id="input.libinputkeyboardlayout" type="string" label="310" help="36436">
+          <level>0</level>
+          <default>us</default>
+          <visible>true</visible>
+          <constraints>
+            <options>libinputkeyboardlayout</options>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>false</multiselect>
+          </control>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -48,5 +48,20 @@
         </setting>
       </group>
     </category>
+    <category id="input">
+      <group id="4" label="35150">
+        <setting id="input.libinputkeyboardlayout" type="string" label="310" help="36436">
+          <level>0</level>
+          <default>us</default>
+          <visible>true</visible>
+          <constraints>
+            <options>libinputkeyboardlayout</options>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>false</multiselect>
+          </control>
+        </setting>
+      </group>
+    </category>
   </section>
 </settings>

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -104,5 +104,20 @@
         </setting>
       </group>
     </category>
+    <category id="input">
+      <group id="4" label="35150">
+        <setting id="input.libinputkeyboardlayout" type="string" label="310" help="36436">
+          <level>0</level>
+          <default>us</default>
+          <visible>true</visible>
+          <constraints>
+            <options>libinputkeyboardlayout</options>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>false</multiselect>
+          </control>
+        </setting>
+      </group>
+    </category>
   </section>
 </settings>

--- a/xbmc/platform/linux/input/CMakeLists.txt
+++ b/xbmc/platform/linux/input/CMakeLists.txt
@@ -11,11 +11,13 @@ if(CORE_PLATFORM_NAME_LC STREQUAL rbpi OR CORE_PLATFORM_NAME_LC STREQUAL gbm OR 
     list(APPEND SOURCES LibInputHandler.cpp
                         LibInputKeyboard.cpp
                         LibInputPointer.cpp
+                        LibInputSettings.cpp
                         LibInputTouch.cpp)
 
     list(APPEND HEADERS LibInputHandler.h
                         LibInputKeyboard.h
                         LibInputPointer.h
+                        LibInputSettings.h
                         LibInputTouch.h)
   endif()
 endif()

--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -9,6 +9,7 @@
 #include "LibInputHandler.h"
 #include "LibInputKeyboard.h"
 #include "LibInputPointer.h"
+#include "LibInputSettings.h"
 #include "LibInputTouch.h"
 
 #include "utils/log.h"
@@ -90,6 +91,7 @@ CLibInputHandler::CLibInputHandler() : CThread("libinput")
   m_keyboard.reset(new CLibInputKeyboard());
   m_pointer.reset(new CLibInputPointer());
   m_touch.reset(new CLibInputTouch());
+  m_settings.reset(new CLibInputSettings(this));
 }
 
 CLibInputHandler::~CLibInputHandler()
@@ -98,6 +100,11 @@ CLibInputHandler::~CLibInputHandler()
 
   libinput_unref(m_li);
   udev_unref(m_udev);
+}
+
+bool CLibInputHandler::SetKeymap(const std::string& layout)
+{
+  return m_keyboard->SetKeymap(layout);
 }
 
 void CLibInputHandler::Start()

--- a/xbmc/platform/linux/input/LibInputHandler.h
+++ b/xbmc/platform/linux/input/LibInputHandler.h
@@ -17,6 +17,7 @@
 
 class CLibInputKeyboard;
 class CLibInputPointer;
+class CLibInputSettings;
 class CLibInputTouch;
 
 class CLibInputHandler : CThread
@@ -26,6 +27,8 @@ public:
   ~CLibInputHandler();
 
   void Start();
+
+  bool SetKeymap(const std::string& layout);
 
 private:
   void Process() override;
@@ -39,6 +42,7 @@ private:
 
   std::unique_ptr<CLibInputKeyboard> m_keyboard;
   std::unique_ptr<CLibInputPointer> m_pointer;
+  std::unique_ptr<CLibInputSettings> m_settings;
   std::unique_ptr<CLibInputTouch> m_touch;
   std::vector<libinput_device*> m_devices;
 };

--- a/xbmc/platform/linux/input/LibInputKeyboard.h
+++ b/xbmc/platform/linux/input/LibInputKeyboard.h
@@ -26,6 +26,8 @@ public:
   void UpdateLeds(libinput_device *dev);
   void GetRepeat(libinput_device *dev);
 
+  bool SetKeymap(const std::string& layout);
+
 private:
   XBMCKey XBMCKeyForKeysym(xkb_keysym_t sym, uint32_t scancode);
   void KeyRepeatTimeout();

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "LibInputSettings.h"
+
+#include "LibInputHandler.h"
+#include "ServiceBroker.h"
+#include "settings/lib/Setting.h"
+#include "settings/lib/SettingsManager.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <algorithm>
+
+const std::string CLibInputSettings::SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT = "input.libinputkeyboardlayout";
+static std::vector<std::pair<std::string, std::string>> layouts;
+
+CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
+  m_libInputHandler(handler)
+{
+  std::set<std::string> settingSet;
+  settingSet.insert(SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT);
+  CServiceBroker::GetSettings()->GetSettingsManager()->RegisterCallback(this, settingSet);
+
+  CServiceBroker::GetSettings()->GetSettingsManager()->RegisterSettingOptionsFiller("libinputkeyboardlayout", SettingOptionsKeyboardLayoutsFiller);
+
+  /* load the keyboard layouts from xkeyboard-config */
+  std::string xkbFile("/usr/share/X11/xkb/rules/base.xml");
+
+  CXBMCTinyXML xmlDoc;
+  if (!xmlDoc.LoadFile(xkbFile))
+  {
+    CLog::Log(LOGWARNING, "CLibInputSettings: unable to open: %s", xkbFile.c_str());
+    return;
+  }
+
+  const TiXmlElement* rootElement = xmlDoc.RootElement();
+  if (!rootElement)
+  {
+    CLog::Log(LOGWARNING, "CLibInputSettings: missing or invalid XML root element in: %s", xkbFile.c_str());
+    return;
+  }
+
+  if (rootElement->ValueStr() != "xkbConfigRegistry")
+  {
+    CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML root element %s in: %s", rootElement->Value(), xkbFile.c_str());
+    return;
+  }
+
+  const TiXmlElement* layoutListElement = rootElement->FirstChildElement("layoutList");
+  if (!layoutListElement)
+  {
+    CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element %s in: %s", layoutListElement->Value(), xkbFile.c_str());
+    return;
+  }
+
+  const TiXmlElement* layoutElement = layoutListElement->FirstChildElement("layout");
+  while (layoutElement)
+  {
+    const TiXmlElement* configElement = layoutElement->FirstChildElement("configItem");
+    if (!configElement)
+    {
+      CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element %s in: %s", layoutListElement->Value(), xkbFile.c_str());
+      return;
+    }
+
+    const TiXmlElement* nameElement = configElement->FirstChildElement("name");
+    if (!nameElement)
+    {
+      CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element %s in: %s", configElement->Value(), xkbFile.c_str());
+      return;
+    }
+
+    const TiXmlElement* descriptionElement = configElement->FirstChildElement("description");
+    if (!descriptionElement)
+    {
+      CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element %s in: %s", configElement->Value(), xkbFile.c_str());
+      return;
+    }
+
+    std::string layout = nameElement->GetText();
+    std::string layoutDescription = descriptionElement->GetText();
+
+    if (!layout.empty() && !layoutDescription.empty())
+      layouts.emplace_back(std::make_pair(layoutDescription, layout));
+
+    layoutElement = layoutElement->NextSiblingElement();
+  }
+
+  std::sort(layouts.begin(), layouts.end());
+}
+
+CLibInputSettings::~CLibInputSettings()
+{
+  std::shared_ptr<CSettings> settings = CServiceBroker::GetSettings();
+  if (settings)
+  {
+    settings->GetSettingsManager()->UnregisterSettingOptionsFiller("libinputkeyboardlayout");
+    settings->GetSettingsManager()->UnregisterCallback(this);
+  }
+}
+
+void CLibInputSettings::SettingOptionsKeyboardLayoutsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+{
+  list = layouts;
+}
+
+void CLibInputSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
+{
+  if (setting == nullptr)
+    return;
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT)
+  {
+    std::string layout = std::dynamic_pointer_cast<const CSettingString>(setting)->GetValue();
+    m_libInputHandler->SetKeymap(layout);
+  }
+}

--- a/xbmc/platform/linux/input/LibInputSettings.h
+++ b/xbmc/platform/linux/input/LibInputSettings.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "settings/lib/ISettingCallback.h"
+#include "settings/lib/ISettingsHandler.h"
+#include "settings/Settings.h"
+
+#include <memory>
+#include <vector>
+
+class CLibInputHandler;
+
+class CLibInputSettings : public ISettingCallback, public ISettingsHandler
+{
+public:
+  static const std::string SETTING_INPUT_LIBINPUTKEYBOARDLAYOUT;
+
+  void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
+  static void SettingOptionsKeyboardLayoutsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+
+  CLibInputSettings(CLibInputHandler *handler);
+  ~CLibInputSettings();
+
+private:
+  CLibInputHandler *m_libInputHandler{nullptr};
+};


### PR DESCRIPTION
This is a bit of a hack but it's needed in order for us to allow
using a different keyboard layout. The idea in the future is to
move libinput to a peripheral add-on but that won't be until
V19. So this is needed in the meantime.

I can also add more options in the future related to mice and keyboards
but I have only heard about keyboard layouts so far.

~~Even if we don't merge this because it's a bit invasive I'm ok with that and we can carry the patch for V18 in LibreELEC.~~