### PR TITLE
"Prefer stereo streams if user has configured 2.0 in AE" as advanced setting

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3177,7 +3177,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   else
     options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
 
-  options.preferStereo = CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
+  // stereo streams may have lower quality, i.e. 32bit vs 16 bit
+  options.preferStereo = g_advancedSettings.m_videoPreferStereoStream &&
+                         CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
 
   // reset VideoStartWindowed as it's a temp setting
   CMediaSettings::GetInstance().SetVideoStartWindowed(false);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -146,6 +146,7 @@ void CAdvancedSettings::Initialize()
   m_DXVAAllowHqScaling = true;
   m_videoFpsDetect = 1;
   m_maxTempo = 1.55f;
+  m_videoPreferStereoStream = false;
 
   m_mediacodecForceSoftwareRendering = false;
 
@@ -677,6 +678,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
     XMLUtils::GetFloat(pElement, "maxtempo", m_maxTempo, 1.5, 2.1);
+    XMLUtils::GetBoolean(pElement, "preferstereostream", m_videoPreferStereoStream);
 
     // Store global display latency settings
     TiXmlElement* pVideoLatency = pElement->FirstChildElement("latency");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -180,6 +180,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int  m_videoFpsDetect;
     bool m_mediacodecForceSoftwareRendering;
     float m_maxTempo;
+    bool m_videoPreferStereoStream = false;
 
     std::string m_videoDefaultPlayer;
     float m_videoPlayCountMinimumPercent;


### PR DESCRIPTION
makes  xbmc/xbmc#13877 configurable as advanced setting

stereo stream may have lower quality. i.e. 32bit vs 16bit

@peak3d as long as this issue is not solved, I disable this per default