### PR TITLE
[estuary] Video OSD: Hide 'Previous' button for non-seekable streams.

### DIFF
--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -49,7 +49,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 						</include>
 						<onclick>PlayerControl(Previous)</onclick>
-						<visible>!VideoPlayer.Content(livetv)</visible>
+						<visible>!VideoPlayer.Content(livetv) + [Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | Player.SeekEnabled]</visible>
 					</control>
 					<control type="radiobutton" id="602">
 						<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/play.png</textureradioonfocus>


### PR DESCRIPTION
![screenshot000](https://user-images.githubusercontent.com/3226626/44615889-bf911900-a844-11e8-963a-8ca0329e23c7.png)

@ronie mind taking a look.