### PR TITLE
[settings/ios]- ensure that RES_CUSTOM is the default. Fixes the "do …

### DIFF
--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -22,6 +22,9 @@
   <section id="system">
     <category id="display">
       <group id="1">
+        <setting id="videoscreen.resolution">
+          <default>17</default> <!-- RES_CUSTOM -->
+        </setting>
         <setting id="videoscreen.fakefullscreen">
           <visible>false</visible>
         </setting>


### PR DESCRIPTION
…you want to keep the screen settings" dialog that hits clean installations - fixes #17986

fix for http://trac.kodi.tv/ticket/17986
verified in iphone ios 11.x