### PR TITLE
Improve wrapper.def generation

### DIFF
--- a/xbmc/cores/DllLoader/exports/CMakeLists.txt
+++ b/xbmc/cores/DllLoader/exports/CMakeLists.txt
@@ -16,7 +16,7 @@ elseif(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL w
   add_options(C ALL_BUILDS "-fPIC")
   add_library(wrapper OBJECT wrapper.c)
 
-  add_custom_target(wrapper.def ALL nm ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/wrapper.dir/wrapper.c.o | grep __wrap | awk '{ printf(\"%s \", \$\$3) }' | sed \"s/___wrap_/__wrap_/g\" | sed \"s/__wrap_/-Wl,-wrap,/g\" > wrapper.def)
+  add_custom_target(wrapper.def ALL ${CMAKE_NM} ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/wrapper.dir/wrapper.c.o | grep __wrap | awk '{ printf(\"%s \", \$\$3) }' | sed \"s/___wrap_/__wrap_/g\" | sed \"s/__wrap_/-Wl,-wrap,/g\" > wrapper.def && test -s wrapper.def)
 
   if(CORE_SYSTEM_NAME STREQUAL android)
     add_custom_command(TARGET wrapper.def COMMAND echo \"-L${DEPENDS_PATH}/lib/dummy-lib${APP_NAME_LC} -l${APP_NAME_LC}\" >> wrapper.def)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
Stop build process if an empty wrapper.def is generated. Configure used nm binary if needed. 
<!--- Describe your change in detail here -->
- Add `&& test -s wrapper.def` to the CMake custom target command to fail on empty file.
- Use the variable CMAKE_NM to be able to define nm binary, 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
 When building LibreELEC 9 alpha on a Ubuntu 16.04 build host, playing DVDs from VIDEO_TS folders with Kodi [fails](https://forum.libreelec.tv/thread/12960-libreelec-leia-v8-90-003-alpha/?postID=97063#post97063).

The cause is an empty wrapper.def file generated during build and libdvdnav-x86_64-linux.so not linked correctly.

When executing the wrapper.def custom target nm fails with 
```
[17/1519] cd /home/m/tools/libreelec/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-f08d8686e96edcfbe065d4e5094ab6221da057b9/.x86_64-libreelec-linux-gnu/build/cores/dll-loader/exports && nm /home/m/tools/libreelec/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-f08d8686e96edcfbe065d4e5094ab6221da057b9/.x86_64-libreelec-linux-gnu/build/cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o | grep __wrap | awk '{ printf ( "%s ", $3 ) }' | sed "s/___wrap_/__wrap_/g" | sed "s/__wrap_/-Wl,-wrap,/g" > wrapper.def
nm: /home/m/tools/libreelec/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-f08d8686e96edcfbe065d4e5094ab6221da057b9/.x86_64-libreelec-linux-gnu/build/cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o: plugin needed to handle lto object
```
, an empty wrapper.def is created, but the build continues because the nm error code is ignored in the pipe.

When replacing build hosts /usr/bin/nm with the lto capable nm-gcc from the LibreELEC tool chain the DVDs can be played again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Have built LibreELEC with this PR and tested resulting image.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
