### PR TITLE
PythonInvoker: fix thread termination check

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -372,8 +372,9 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
       CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): failed to set abortRequested", GetId(), m_sourceFile.c_str());
 
     // make sure all sub threads have finished
-    for (PyThreadState *s = m_threadState->interp->tstate_head, *old = nullptr; s != nullptr && m_threadState != nullptr;)
+    for (PyThreadState *old = nullptr; m_threadState != nullptr;)
     {
+      PyThreadState *s = m_threadState->interp->tstate_head;
       for (; s && s == m_threadState;)
         s = s->next;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

When PythonInvoker() stopps an addon, thread termination is not detected while waiting for it and addon is finally killed.

Variable `PyThreadState *s` is never updated in the loop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

From the [kodi.log](http://ix.io/1lhE):
```
02:17:43.986 T:139745095547008   DEBUG: CServiceAddonManager: stopping service.libreelec.settings.
02:17:43.986 T:139745095547008   DEBUG: CPythonInvoker(0, /storage/.kodi/addons/service.libreelec.settings/service.py): trigger Monitor abort request
02:17:43.986 T:139744637855488   DEBUG: ## LibreELEC Addon ## xdbus::stop_service ## enter_function
02:17:43.986 T:139744637855488   DEBUG: ## LibreELEC Addon ## xdbus::dbusMonitor::stop_service ## enter_function
02:17:43.987 T:139744637855488   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_signal_receivers ## enter_function
02:17:43.989 T:139743757145856    INFO: ## LibreELEC Addon ## xdbus Monitor stopped. ##
02:17:43.989 T:139743757145856   DEBUG: ## LibreELEC Addon ## xdbus::dbusMonitor::run ## exit_function
02:17:43.991 T:139744637855488   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_agent ## enter_function
02:17:44.009 T:139744637855488   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_agent ## exit_function
02:17:44.010 T:139744637855488   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_signal_receivers ## exit_function
02:17:44.010 T:139744637855488   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::remove_signal_receivers ## enter_function
02:17:44.014 T:139744637855488   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::remove_signal_receivers ## exit_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## xdbus::dbusMonitor::stop_service ## exit_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## xdbus::stop_service ## exit_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## system::stop_service ## enter_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## system::updateThread::stop() ## enter_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## system::updateThread::stop() ## exit_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## system::stop_service ## exit_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## bluetooth::stop_service ## enter_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## bluetooth::stop_service ## exit_function
02:17:44.015 T:139744637855488   DEBUG: ## LibreELEC Addon ## connman::stop_service ## enter_function
02:17:44.018 T:139744637855488   DEBUG: ## LibreELEC Addon ## connman::stop_service ## exit_function
02:17:44.018 T:139744637855488   DEBUG: ## LibreELEC Addon ## services::stop_service ## enter_function
02:17:44.018 T:139744637855488   DEBUG: ## LibreELEC Addon ## services::stop_service ## exit_function
02:17:44.018 T:139744637855488   DEBUG: ## LibreELEC Addon ## STOP SERVICE DONE !
02:17:44.018 T:139744637855488   DEBUG: ## LibreELEC Addon ## _service_::stop ## enter_function
02:17:44.018 T:139744637855488   DEBUG: ## LibreELEC Addon ## _service_::stop ## exit_function
02:17:44.019 T:139744637855488    INFO: CPythonInvoker(0, /storage/.kodi/addons/service.libreelec.settings/service.py): script successfully run
02:17:44.019 T:139744637855488    INFO: CPythonInvoker(0, /storage/.kodi/addons/service.libreelec.settings/service.py): waiting on thread 139743748753152
02:17:44.019 T:139743748753152    INFO: ## LibreELEC Addon ## _service_::run ## MESSAGE:'exit'
02:17:44.019 T:139743748753152   DEBUG: ## LibreELEC Addon ## _service_::run ## exit_function
02:17:44.046 T:139743790618368    INFO: ## LibreELEC Addon ## system::updateThread ## Stopped
02:17:44.047 T:139743790618368   DEBUG: ## LibreELEC Addon ## system::updateThread::run ## exit_function
02:17:48.989 T:139745095547008   ERROR: CPythonInvoker(0, /storage/.kodi/addons/service.libreelec.settings/service.py): script didn't stop in 5 seconds - let's kill it
```

Stopping service.libreelec.settings: thread 139743748753152 exits but is still waited for.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Test build succeeds in detection:
```
18:31:15.719 T:140587177392256   DEBUG: CServiceAddonManager: stopping service.libreelec.settings.
18:31:15.719 T:140587177392256   DEBUG: CPythonInvoker(0, /usr/share/kodi/addons/service.libreelec.settings/service.py): trigger Monitor abort request
18:31:15.719 T:140586736666368   DEBUG: ## LibreELEC Addon ## xdbus::stop_service ## enter_function
18:31:15.719 T:140586736666368   DEBUG: ## LibreELEC Addon ## xdbus::dbusMonitor::stop_service ## enter_function
18:31:15.719 T:140586736666368   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_signal_receivers ## enter_function
18:31:15.720 T:140586449479424    INFO: ## LibreELEC Addon ## xdbus Monitor stopped. ##
18:31:15.720 T:140586449479424   DEBUG: ## LibreELEC Addon ## xdbus::dbusMonitor::run ## exit_function
18:31:15.724 T:140586736666368   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_agent ## enter_function
18:31:15.741 T:140586736666368   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_agent ## exit_function
18:31:15.741 T:140586736666368   DEBUG: ## LibreELEC Addon ## connman::monitor::remove_signal_receivers ## exit_function
18:31:15.741 T:140586736666368   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::remove_signal_receivers ## enter_function
18:31:15.748 T:140586736666368   DEBUG: ## LibreELEC Addon ## bluetooth::monitor::remove_signal_receivers ## exit_function
18:31:15.748 T:140586736666368   DEBUG: ## LibreELEC Addon ## xdbus::dbusMonitor::stop_service ## exit_function
18:31:15.748 T:140586736666368   DEBUG: ## LibreELEC Addon ## xdbus::stop_service ## exit_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## system::stop_service ## enter_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## system::updateThread::stop() ## enter_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## system::updateThread::stop() ## exit_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## system::stop_service ## exit_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## bluetooth::stop_service ## enter_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## bluetooth::stop_service ## exit_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## connman::stop_service ## enter_function
18:31:15.749 T:140586736666368   DEBUG: ## LibreELEC Addon ## connman::stop_service ## exit_function
18:31:15.750 T:140586736666368   DEBUG: ## LibreELEC Addon ## services::stop_service ## enter_function
18:31:15.750 T:140586736666368   DEBUG: ## LibreELEC Addon ## services::stop_service ## exit_function
18:31:15.750 T:140586736666368   DEBUG: ## LibreELEC Addon ## STOP SERVICE DONE !
18:31:15.750 T:140586736666368   DEBUG: ## LibreELEC Addon ## _service_::stop ## enter_function
18:31:15.751 T:140586457872128    INFO: ## LibreELEC Addon ## system::updateThread ## Stopped
18:31:15.751 T:140586457872128   DEBUG: ## LibreELEC Addon ## system::updateThread::run ## exit_function
18:31:15.753 T:140586736666368   DEBUG: ## LibreELEC Addon ## _service_::stop ## exit_function
18:31:15.753 T:140586736666368    INFO: CPythonInvoker(0, /usr/share/kodi/addons/service.libreelec.settings/service.py): script successfully run
18:31:15.753 T:140586736666368    INFO: CPythonInvoker(0, /usr/share/kodi/addons/service.libreelec.settings/service.py): waiting on thread 140586441086720
18:31:15.753 T:140586441086720    INFO: ## LibreELEC Addon ## _service_::run ## MESSAGE:'exit'
18:31:15.754 T:140586441086720   DEBUG: ## LibreELEC Addon ## _service_::run ## exit_function
18:31:15.853 T:140586736666368   DEBUG: onExecutionDone(0, /usr/share/kodi/addons/service.libreelec.settings/service.py)
18:31:15.876 T:140586736666368    INFO: Python interpreter interrupted by user
18:31:15.876 T:140587177392256   DEBUG: CPythonInvoker(0, /usr/share/kodi/addons/service.libreelec.settings/service.py): script termination took 156ms
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
