### PR TITLE
RFC: windowing/gbm: set HDMI and color drm properties

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7297,7 +7297,61 @@ msgctxt "#13465"
 msgid "EGL"
 msgstr ""
 
-#empty strings from id 13466 to 13504
+#. Option for setting HDMI Content Type
+#: system/settings/gbm.xml
+msgctxt "#13466"
+msgid "HDMI Content Type"
+msgstr ""
+
+#. Description of videoscreen setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13467"
+msgid "This option sets content type to use in HDMI infoframes."
+msgstr ""
+
+#. Description of videoplayer setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13468"
+msgid "This option sets content type to use in HDMI infoframes when video is playing using the Direct To Plane render method."
+msgstr ""
+
+#. String for options 1 of setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13469"
+msgid "Default"
+msgstr ""
+
+#. String for options 2 of setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13470"
+msgid "No Data"
+msgstr ""
+
+#. String for options 3 of setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13471"
+msgid "Graphics"
+msgstr ""
+
+#. String for options 4 of setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13472"
+msgid "Photo"
+msgstr ""
+
+#. String for options 5 of setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13473"
+msgid "Cinema"
+msgstr ""
+
+#. String for options 6 of setting with label #13466 "HDMI Content Type"
+#: system/settings/gbm.xml
+msgctxt "#13474"
+msgid "Game"
+msgstr ""
+
+#empty strings from id 13475 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7351,7 +7351,49 @@ msgctxt "#13474"
 msgid "Game"
 msgstr ""
 
-#empty strings from id 13475 to 13504
+#. Option for setting HDMI Output Format
+#: system/settings/gbm.xml
+msgctxt "#13475"
+msgid "HDMI Output Format"
+msgstr ""
+
+#. Description of videoscreen setting with label #13475 "HDMI Output Format"
+#: system/settings/gbm.xml
+msgctxt "#13476"
+msgid "This option sets HDMI output format to use."
+msgstr ""
+
+#. Description of videoplayer setting with label #13475 "HDMI Output Format"
+#: system/settings/gbm.xml
+msgctxt "#13477"
+msgid "This option sets HDMI output format to use when video is playing."
+msgstr ""
+
+#. String for options 1 of setting with label #13475 "HDMI Output Format"
+#: system/settings/gbm.xml
+msgctxt "#13478"
+msgid "Default"
+msgstr ""
+
+#. String for options 2 of setting with label #13475 "HDMI Output Format"
+#: system/settings/gbm.xml
+msgctxt "#13479"
+msgid "RGB"
+msgstr ""
+
+#. String for options 3 of setting with label #13475 "HDMI Output Format"
+#: system/settings/gbm.xml
+msgctxt "#13480"
+msgid "YCbCr 4:2:2"
+msgstr ""
+
+#. String for options 3 of setting with label #13475 "HDMI Output Format"
+#: system/settings/gbm.xml
+msgctxt "#13481"
+msgid "YCbCr 4:4:4"
+msgstr ""
+
+#empty strings from id 13482 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7393,7 +7393,37 @@ msgctxt "#13481"
 msgid "YCbCr 4:4:4"
 msgstr ""
 
-#empty strings from id 13482 to 13504
+#. Option for setting HDMI Output Format
+#: system/settings/gbm.xml
+msgctxt "#13482"
+msgid "HDMI Quantization Range"
+msgstr ""
+
+#. Description of videoscreen setting with label #13482 "HDMI Quantization Range"
+#: system/settings/gbm.xml
+msgctxt "#13483"
+msgid "This option sets HDMI quantization range to use."
+msgstr ""
+
+#. String for options 1 of setting with label #13482 "HDMI Quantization Range"
+#: system/settings/gbm.xml
+msgctxt "#13484"
+msgid "Default"
+msgstr ""
+
+#. String for options 2 of setting with label #13482 "HDMI Quantization Range"
+#: system/settings/gbm.xml
+msgctxt "#13485"
+msgid "Full"
+msgstr ""
+
+#. String for options 3 of setting with label #13482 "HDMI Quantization Range"
+#: system/settings/gbm.xml
+msgctxt "#13486"
+msgid "Limited"
+msgstr ""
+
+#empty strings from id 13487 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -32,6 +32,26 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="videoplayer.hdmioutputformat" type="integer" label="13475" help="13477">
+          <visible>false</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useprimedecoder" operator="is">true</condition>
+              <condition setting="videoplayer.useprimerenderer" operator="is">0</condition>
+            </dependency>
+          </dependencies>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13478">0</option> <!-- Default -->
+              <option label="13479">1</option> <!-- RGB -->
+              <option label="13480">2</option> <!-- YCbCr 4:2:2 -->
+              <option label="13481">3</option> <!-- YCbCr 4:4:4 -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videoplayer.hdmicontenttype" type="integer" label="13466" help="13468">
           <visible>false</visible>
           <dependencies>
@@ -66,6 +86,19 @@
           <level>3</level>
           <default>false</default>
           <control type="toggle" />
+        </setting>
+        <setting id="videoscreen.hdmioutputformat" type="integer" label="13475" help="13476">
+          <visible>false</visible>
+          <level>3</level>
+          <default>1</default>
+          <constraints>
+            <options>
+              <option label="13479">1</option> <!-- RGB -->
+              <option label="13480">2</option> <!-- YCbCr 4:2:2 -->
+              <option label="13481">3</option> <!-- YCbCr 4:4:4 -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
         </setting>
         <setting id="videoscreen.hdmicontenttype" type="integer" label="13466" help="13467">
           <visible>false</visible>

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -100,6 +100,19 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="videoscreen.hdmiquantizationrange" type="integer" label="13482" help="13483">
+          <visible>false</visible>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13484">0</option> <!-- Default -->
+              <option label="13485">1</option> <!-- Full -->
+              <option label="13486">2</option> <!-- Limited -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videoscreen.hdmicontenttype" type="integer" label="13466" help="13467">
           <visible>false</visible>
           <level>3</level>

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -32,6 +32,27 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="videoplayer.hdmicontenttype" type="integer" label="13466" help="13468">
+          <visible>false</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useprimedecoder" operator="is">true</condition>
+              <condition setting="videoplayer.useprimerenderer" operator="is">0</condition>
+            </dependency>
+          </dependencies>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13469">0</option> <!-- Default -->
+              <option label="13470">1</option> <!-- Graphics -->
+              <option label="13472">2</option> <!-- Photo -->
+              <option label="13473">3</option> <!-- Cinema -->
+              <option label="13474">4</option> <!-- Game -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
       </group>
     </category>
   </section>
@@ -45,6 +66,21 @@
           <level>3</level>
           <default>false</default>
           <control type="toggle" />
+        </setting>
+        <setting id="videoscreen.hdmicontenttype" type="integer" label="13466" help="13467">
+          <visible>false</visible>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13469">0</option> <!-- No Data -->
+              <option label="13471">1</option> <!-- Graphics -->
+              <option label="13472">2</option> <!-- Photo -->
+              <option label="13473">3</option> <!-- Cinema -->
+              <option label="13474">4</option> <!-- Game -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
         </setting>
       </group>
     </category>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -49,12 +49,19 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 void CRendererDRMPRIME::Register()
 {
   CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-  if (winSystem && winSystem->GetDrm()->GetVideoPlane()->plane &&
-      std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
-  {
-    CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)->SetVisible(true);
-    VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
+  if (!winSystem)
     return;
+
+  std::shared_ptr<CDRMAtomic> drm = std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm());
+  if (drm && drm->GetVideoPlane()->plane)
+  {
+    const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+    settings->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)->SetVisible(true);
+    VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
+
+    if (drm->SupportsProperty(drm->GetConnector(), "content type"))
+      settings->GetSetting(CDRMUtils::SETTING_VIDEOPLAYER_HDMICONTENTTYPE)->SetVisible(true);
   }
 }
 

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -51,6 +51,12 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       return;
     }
 
+    // Broadcast RGB is an Intel specific drm property
+    if (SupportsProperty(m_connector, "Broadcast RGB"))
+    {
+      AddProperty(m_connector, "Broadcast RGB", GetHdmiQuantizationRange());
+    }
+
     if (SupportsProperty(m_connector, "content type"))
     {
       AddProperty(m_connector, "content type", GetHdmiContentType(videoLayer));
@@ -159,6 +165,13 @@ bool CDRMAtomic::InitDrm()
 
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   std::set<std::string> settingSet;
+
+  // Broadcast RGB is an Intel specific drm property
+  if (SupportsProperty(m_connector, "Broadcast RGB"))
+  {
+    settings->GetSetting(SETTING_VIDEOSCREEN_HDMIQUANTIZATIONRANGE)->SetVisible(true);
+    settingSet.insert(SETTING_VIDEOSCREEN_HDMIQUANTIZATIONRANGE);
+  }
 
   if (SupportsProperty(m_connector, "content type"))
   {

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "DRMUtils.h"
+#include "settings/lib/ISettingCallback.h"
 
 namespace KODI
 {
@@ -17,7 +18,7 @@ namespace WINDOWING
 namespace GBM
 {
 
-class CDRMAtomic : public CDRMUtils
+class CDRMAtomic : public CDRMUtils, public ISettingCallback
 {
 public:
   CDRMAtomic() = default;
@@ -28,6 +29,8 @@ public:
   virtual bool InitDrm() override;
   virtual void DestroyDrm() override;
   virtual bool AddProperty(struct drm_object *object, const char *name, uint64_t value) override;
+
+  void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
 
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -17,6 +17,8 @@
 #include <unistd.h>
 
 #include "platform/linux/XTimeUtils.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "windowing/GraphicContext.h"
@@ -24,6 +26,9 @@
 #include "DRMUtils.h"
 
 using namespace KODI::WINDOWING::GBM;
+
+const std::string CDRMUtils::SETTING_VIDEOSCREEN_HDMICONTENTTYPE = "videoscreen.hdmicontenttype";
+const std::string CDRMUtils::SETTING_VIDEOPLAYER_HDMICONTENTTYPE = "videoplayer.hdmicontenttype";
 
 CDRMUtils::CDRMUtils()
   : m_connector(new connector)
@@ -820,4 +825,14 @@ bool CDRMUtils::CheckConnector(int connector_id)
   drmModeFreeConnector(connectorcheck.connector);
 
   return finalConnectionState == DRM_MODE_CONNECTED;
+}
+
+int CDRMUtils::GetHdmiContentType(bool videoLayer)
+{
+  int contentType = 0;
+  if (videoLayer)
+    contentType = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOPLAYER_HDMICONTENTTYPE);
+  if (contentType == 0)
+    contentType = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOSCREEN_HDMICONTENTTYPE);
+  return contentType;
 }

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -29,6 +29,7 @@ using namespace KODI::WINDOWING::GBM;
 
 const std::string CDRMUtils::SETTING_VIDEOSCREEN_HDMIOUTPUTFORMAT = "videoscreen.hdmioutputformat";
 const std::string CDRMUtils::SETTING_VIDEOPLAYER_HDMIOUTPUTFORMAT = "videoplayer.hdmioutputformat";
+const std::string CDRMUtils::SETTING_VIDEOSCREEN_HDMIQUANTIZATIONRANGE = "videoscreen.hdmiquantizationrange";
 const std::string CDRMUtils::SETTING_VIDEOSCREEN_HDMICONTENTTYPE = "videoscreen.hdmicontenttype";
 const std::string CDRMUtils::SETTING_VIDEOPLAYER_HDMICONTENTTYPE = "videoplayer.hdmicontenttype";
 
@@ -837,6 +838,11 @@ int CDRMUtils::GetHdmiOutputFormat(bool videoLayer)
   if (outputFormat == 0)
     outputFormat = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOSCREEN_HDMIOUTPUTFORMAT);
   return outputFormat;
+}
+
+int CDRMUtils::GetHdmiQuantizationRange()
+{
+  return CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOSCREEN_HDMIQUANTIZATIONRANGE);
 }
 
 int CDRMUtils::GetHdmiContentType(bool videoLayer)

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -27,6 +27,8 @@
 
 using namespace KODI::WINDOWING::GBM;
 
+const std::string CDRMUtils::SETTING_VIDEOSCREEN_HDMIOUTPUTFORMAT = "videoscreen.hdmioutputformat";
+const std::string CDRMUtils::SETTING_VIDEOPLAYER_HDMIOUTPUTFORMAT = "videoplayer.hdmioutputformat";
 const std::string CDRMUtils::SETTING_VIDEOSCREEN_HDMICONTENTTYPE = "videoscreen.hdmicontenttype";
 const std::string CDRMUtils::SETTING_VIDEOPLAYER_HDMICONTENTTYPE = "videoplayer.hdmicontenttype";
 
@@ -825,6 +827,16 @@ bool CDRMUtils::CheckConnector(int connector_id)
   drmModeFreeConnector(connectorcheck.connector);
 
   return finalConnectionState == DRM_MODE_CONNECTED;
+}
+
+int CDRMUtils::GetHdmiOutputFormat(bool videoLayer)
+{
+  int outputFormat = 0;
+  if (videoLayer)
+    outputFormat = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOPLAYER_HDMIOUTPUTFORMAT);
+  if (outputFormat == 0)
+    outputFormat = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOSCREEN_HDMIOUTPUTFORMAT);
+  return outputFormat;
 }
 
 int CDRMUtils::GetHdmiContentType(bool videoLayer)

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -124,10 +124,12 @@ public:
 
   static const std::string SETTING_VIDEOSCREEN_HDMIOUTPUTFORMAT;
   static const std::string SETTING_VIDEOPLAYER_HDMIOUTPUTFORMAT;
+  static const std::string SETTING_VIDEOSCREEN_HDMIQUANTIZATIONRANGE;
   static const std::string SETTING_VIDEOSCREEN_HDMICONTENTTYPE;
   static const std::string SETTING_VIDEOPLAYER_HDMICONTENTTYPE;
 
   int GetHdmiOutputFormat(bool videoLayer);
+  int GetHdmiQuantizationRange();
   int GetHdmiContentType(bool videoLayer);
 
 protected:

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -122,9 +122,12 @@ public:
   static uint32_t FourCCWithAlpha(uint32_t fourcc);
   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
 
+  static const std::string SETTING_VIDEOSCREEN_HDMIOUTPUTFORMAT;
+  static const std::string SETTING_VIDEOPLAYER_HDMIOUTPUTFORMAT;
   static const std::string SETTING_VIDEOSCREEN_HDMICONTENTTYPE;
   static const std::string SETTING_VIDEOPLAYER_HDMICONTENTTYPE;
 
+  int GetHdmiOutputFormat(bool videoLayer);
   int GetHdmiContentType(bool videoLayer);
 
 protected:

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -109,6 +109,7 @@ public:
   std::vector<uint64_t> *GetVideoPlaneModifiersForFormat(uint32_t format) { return &m_video_plane->modifiers_map[format]; }
   std::vector<uint64_t> *GetGuiPlaneModifiersForFormat(uint32_t format) { return &m_gui_plane->modifiers_map[format]; }
   struct crtc* GetCrtc() const { return m_crtc; }
+  struct connector* GetConnector() const { return m_connector; }
 
   virtual RESOLUTION_INFO GetCurrentMode();
   virtual std::vector<RESOLUTION_INFO> GetModes();

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -122,6 +122,11 @@ public:
   static uint32_t FourCCWithAlpha(uint32_t fourcc);
   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
 
+  static const std::string SETTING_VIDEOSCREEN_HDMICONTENTTYPE;
+  static const std::string SETTING_VIDEOPLAYER_HDMICONTENTTYPE;
+
+  int GetHdmiContentType(bool videoLayer);
+
 protected:
   bool OpenDrm(bool needConnector);
   uint32_t GetPropertyId(struct drm_object *object, const char *name);


### PR DESCRIPTION
## Description
This is a request-for-comment on changes to make use of new drm properties.

This adds work-in-progress code to set the following new properties:
- `content type`: allows userspace to control what content type to use in HDMI infoframes (currently only implemented by Intel driver in v4.19)
- ~~`COLOR_ENCODING` and `COLOR_RANGE`: allows userspace to signal what color encoding is used on a YUV plane (currently only intel and malidp is using this property, v4.18/4.19)~~ #14452

This also adds settings for HDMI output format for use with future drm properties (currently only bsp kernels support YCbCr output signal)

Settings has been duplicated, one for general use and another for when direct-to-plane video is activated.

Please get back with feedback on the code and the added settings.
- Should I use the render flags methods to determin color encoding?
- Should I merge the two different videoscreen and videoplayer settings?

ping @lrusak @FernetMenta @fritsch

## Motivation and Context
Mainline linux is starting to add drm properties that makes it possible to control HDMI signal, add code and settings to control the output signal.

## How Has This Been Tested?
This has not been tested.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
