### PR TITLE
Fix access to music information from menu and shortcut key

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1509,7 +1509,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
         { // Save new title (from album or discography)
           CFileItemPtr pItem(new CFileItem(strAlbum));
           pItem->SetLabel2(m_pDS->fv("iYear").get_asString());
-          pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, "album");
+          pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, MediaTypeAlbum);
 
           items.Add(pItem);
           strLastAlbum = strAlbum;
@@ -1517,7 +1517,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
         }
         else if (idAlbum > 0 && iLastID < 0)
         { // Amend previously saved discography item to set album ID
-          items[items.Size() - 1]->GetMusicInfoTag()->SetDatabaseId(idAlbum, "album");
+          items[items.Size() - 1]->GetMusicInfoTag()->SetDatabaseId(idAlbum, MediaTypeAlbum);
         }
       }
       m_pDS->next();
@@ -3941,6 +3941,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
       SYSTEMTIME stTime;
       stTime.wYear = static_cast<unsigned short>(m_pDS->fv(0).get_asInt());
       pItem->GetMusicInfoTag()->SetReleaseDate(stTime);
+      pItem->GetMusicInfoTag()->SetDatabaseId(-1, "year");
 
       CMusicDbUrl itemUrl = musicUrl;
       std::string strDir = StringUtils::Format("%i/", m_pDS->fv(0).get_asInt());

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -152,10 +152,17 @@ bool CMusicThumbLoader::FillThumb(CFileItem &item, bool folderThumbs /* = true *
 
 bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
 {
+  /* Called for any item with MusicInfoTag and no art. 
+     Items on Genres, Sources and Roles nodes have ID (although items on Years
+     node do not) so check for song/album/artist specifically.
+     Non-library songs (file view) can also have MusicInfoTag but no ID or type
+  */
   bool artfound(false);
   std::vector<ArtForThumbLoader> art;
   CMusicInfoTag &tag = *item.GetMusicInfoTag();
-  if (tag.GetDatabaseId() > -1 && !tag.GetType().empty())
+  if (tag.GetDatabaseId() > -1 && (tag.GetType() == MediaTypeSong || 
+      tag.GetType() == MediaTypeAlbum || 
+      tag.GetType() == MediaTypeArtist))
   {
     // Item in music library, fetch the art
     m_musicDatabase->Open();
@@ -168,53 +175,27 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
 
     m_musicDatabase->Close();
   }
-  else
+  else if (!tag.GetArtist().empty() && 
+    (tag.GetType() == MediaTypeNone || tag.GetType() == MediaTypeSong))
   {
-    // Non-library song (has musictag but no ID, and may have thumb already loaded),
-    // try to fetch both song artist(s) and album artist(s) art by artist name,
-    // e.g. "artist.thumb", "artist.fanart", "artist.clearlogo", "artist.banner",
-    // "artist1.thumb", "artist1.fanart", "artist1.clearlogo", "artist1.banner",
-    // "albumartist.thumb", "albumartist.fanart" etc. Set fanart as fallback.
-    tag.SetType(MediaTypeSong);
-
-    // Song artist art
-    // Split song artist names correctly into artist credits from various tag arrays
+    /* 
+    Could be non-library song - has musictag but no ID or type (may have
+    thumb already). Try to fetch both song artist(s) and album artist(s) art by
+    artist name, e.g. "artist.thumb", "artist.fanart", "artist.clearlogo",
+    "artist.banner", "artist1.thumb", "artist1.fanart", "artist1.clearlogo",
+    "artist1.banner", "albumartist.thumb", "albumartist.fanart" etc. 
+    Set fanart as fallback.
+    */
     CSong song;
+    // Try to split song artist names (various tags) into artist credits
     song.SetArtistCredits(tag.GetArtist(), tag.GetMusicBrainzArtistHints(), tag.GetMusicBrainzArtistID());
-    m_musicDatabase->Open();
-    int iOrder = 0;
-    for (const auto& artistCredit : song.artistCredits)
+    if (!song.artistCredits.empty())
     {
-      int idArtist = m_musicDatabase->GetArtistByName(artistCredit.GetArtist());
-      if (idArtist > 0)
-      {
-        std::vector<ArtForThumbLoader> artistart;
-        if (m_musicDatabase->GetArtForItem(-1, -1, idArtist, true, artistart))
-        {
-          for (auto& artitem : artistart)
-          {
-            if (iOrder > 0)
-              artitem.prefix = StringUtils::Format("artist%i", iOrder);
-            else
-              artitem.prefix = "artist";
-          }
-          art.insert(art.end(), artistart.begin(), artistart.end());
-        }
-      }
-      ++iOrder;
-    }
-
-    // Album artist art
-    if (!tag.GetAlbumArtist().empty() && tag.GetArtistString().compare(tag.GetAlbumArtistString()) != 0)
-    {
-      // Split song artist names correctly into artist credits from various tag
-      // arrays, inc. fallback to song artist names
-      CAlbum album;
-      album.SetArtistCredits(tag.GetAlbumArtist(), tag.GetMusicBrainzAlbumArtistHints(), tag.GetMusicBrainzAlbumArtistID(),
-        tag.GetArtist(), tag.GetMusicBrainzArtistHints(), tag.GetMusicBrainzArtistID());
-
-      iOrder = 0;
-      for (const auto& artistCredit : album.artistCredits)
+      tag.SetType(MediaTypeSong);  // Makes "Information" context menu visible
+      m_musicDatabase->Open();
+      int iOrder = 0;
+      // Song artist art
+      for (const auto& artistCredit : song.artistCredits)
       {
         int idArtist = m_musicDatabase->GetArtistByName(artistCredit.GetArtist());
         if (idArtist > 0)
@@ -225,33 +206,64 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
             for (auto& artitem : artistart)
             {
               if (iOrder > 0)
-                artitem.prefix = StringUtils::Format("albumartist%i", iOrder);
+                artitem.prefix = StringUtils::Format("artist%i", iOrder);
               else
-                artitem.prefix = "albumartist";
+                artitem.prefix = "artist";
             }
             art.insert(art.end(), artistart.begin(), artistart.end());
           }
         }
         ++iOrder;
       }
-    }
-    else
-    {
-      // Replicate the artist art as album artist art
-      std::vector<ArtForThumbLoader> artistart;
-      for (const auto& artitem : art)
+      // Album artist art
+      if (!tag.GetAlbumArtist().empty() && tag.GetArtistString().compare(tag.GetAlbumArtistString()) != 0)
       {
-        ArtForThumbLoader newart;
-        newart.artType = artitem.artType;
-        newart.mediaType = artitem.mediaType;
-        newart.prefix = "album" + artitem.prefix;
-        newart.url = artitem.url;
-        artistart.emplace_back(newart);
+        // Split song artist names correctly into artist credits from various tag
+        // arrays, inc. fallback to song artist names
+        CAlbum album;
+        album.SetArtistCredits(tag.GetAlbumArtist(), tag.GetMusicBrainzAlbumArtistHints(), tag.GetMusicBrainzAlbumArtistID(),
+          tag.GetArtist(), tag.GetMusicBrainzArtistHints(), tag.GetMusicBrainzArtistID());
+
+        iOrder = 0;
+        for (const auto& artistCredit : album.artistCredits)
+        {
+          int idArtist = m_musicDatabase->GetArtistByName(artistCredit.GetArtist());
+          if (idArtist > 0)
+          {
+            std::vector<ArtForThumbLoader> artistart;
+            if (m_musicDatabase->GetArtForItem(-1, -1, idArtist, true, artistart))
+            {
+              for (auto& artitem : artistart)
+              {
+                if (iOrder > 0)
+                  artitem.prefix = StringUtils::Format("albumartist%i", iOrder);
+                else
+                  artitem.prefix = "albumartist";
+              }
+              art.insert(art.end(), artistart.begin(), artistart.end());
+            }
+          }
+          ++iOrder;
+        }
       }
-      art.insert(art.end(), artistart.begin(), artistart.end());
-    }
-    artfound = !art.empty();
-    m_musicDatabase->Close();
+      else
+      {
+        // Replicate the artist art as album artist art
+        std::vector<ArtForThumbLoader> artistart;
+        for (const auto& artitem : art)
+        {
+          ArtForThumbLoader newart;
+          newart.artType = artitem.artType;
+          newart.mediaType = artitem.mediaType;
+          newart.prefix = "album" + artitem.prefix;
+          newart.url = artitem.url;
+          artistart.emplace_back(newart);
+        }
+        art.insert(art.end(), artistart.begin(), artistart.end());
+      }
+      artfound = !art.empty();
+      m_musicDatabase->Close();
+    }    
   }
 
   if (artfound)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -258,7 +258,7 @@ void CGUIDialogSongInfo::Update()
   {
     auto item = std::make_shared<CFileItem>(contributor.GetRoleDesc());
     item->SetLabel2(contributor.GetArtist());
-    item->GetMusicInfoTag()->SetDatabaseId(contributor.GetArtistId(), "artist");
+    item->GetMusicInfoTag()->SetDatabaseId(contributor.GetArtistId(), MediaTypeArtist);
     items.Add(std::move(item));
   }
   CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, &items);

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -286,7 +286,11 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
     return;
   }
 
-  CGUIDialogMusicInfo::ShowFor(item.get());
+  // Match visibility test of CMusicInfo::IsVisible
+  if (item->HasMusicInfoTag() && (item->GetMusicInfoTag()->GetType() == MediaTypeSong ||
+    item->GetMusicInfoTag()->GetType() == MediaTypeAlbum ||
+    item->GetMusicInfoTag()->GetType() == MediaTypeArtist))
+    CGUIDialogMusicInfo::ShowFor(item.get());
 }
 
 void CGUIWindowMusicBase::RefreshContent(const std::string& strContent)


### PR DESCRIPTION
Several minor fixes all related to correct use of item type.
- Remove "Information" context menu visibility on items in Years node
- Avoid hang after `<i>` shortcut key press on library nav screen items that do not have information e.g. a genre listed within the Genres node or year within the Years node etc. 
- Restore "information" context menu visibility for non-library songs in file view (as in v16)
- Avoid thumbloader attempts to lookup art in DB for items that are not artists, albums or songs.

The inconsistent behaviour and hanging was reported here https://forum.kodi.tv/showthread.php?tid=332771

The Git compare makes the change to `CMusicThumbLoader::FillThumb` look a lot more complex than it is - just moved processing within an if statement

Test build for Win64 here http://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20180827-2781b661-PR14364-merge-x64.exe