### PR TITLE
[videoplayer] Reduce the number of GetSubtitle() calls a bit.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5124,7 +5124,10 @@ void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo &info)
     index = m_content.m_subtitleIndex;
 
   if (index < 0 || index > GetSubtitleCount() - 1)
+  {
+    info.valid = false;
     return;
+  }
 
   SelectionStream& s = m_content.m_selectionStreams.Get(STREAM_SUBTITLE, index);
   if(s.name.length() > 0)

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -453,7 +453,7 @@ namespace XBMCAddon
       if (g_application.GetAppPlayer().HasPlayer())
       {
         SubtitleStreamInfo info;
-        g_application.GetAppPlayer().GetSubtitleStreamInfo(g_application.GetAppPlayer().GetSubtitle(), info);
+        g_application.GetAppPlayer().GetSubtitleStreamInfo(CURRENT_STREAM, info);
 
         if (info.language.length() > 0)
           return info.language;

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -52,11 +52,12 @@ bool CPlayerController::OnAction(const CAction &action)
 
         bool subsOn = !g_application.GetAppPlayer().GetSubtitleVisible();
         g_application.GetAppPlayer().SetSubtitleVisible(subsOn);
-        std::string sub, lang;
+        std::string sub;
         if (subsOn)
         {
+          std::string lang;
           SubtitleStreamInfo info;
-          g_application.GetAppPlayer().GetSubtitleStreamInfo(g_application.GetAppPlayer().GetSubtitle(), info);
+          g_application.GetAppPlayer().GetSubtitleStreamInfo(CURRENT_STREAM, info);
           if (!g_LangCodeExpander.Lookup(info.language, lang))
             lang = g_localizeStrings.Get(13205); // Unknown
 


### PR DESCRIPTION
Nothing spectacular. Funny fact is that we don't check for the invalid flag in any "frontend" class.