### PR TITLE
[PVR] trac18007: PVRDialogChannelsOSD: Fix crash after accessing m_ve…

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -243,8 +243,10 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
   if (item < 0 || item >= m_vecItems->Size())
     return;
 
+  // Preserve the item before closing self, because this will clear m_vecItems
+  const CFileItemPtr itemptr = m_vecItems->Get(item);
   Close();
-  CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(m_vecItems->Get(item), true /* bCheckResume */);
+  CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(itemptr, true /* bCheckResume */);
 }
 
 void CGUIDialogPVRChannelsOSD::ShowInfo(int item)


### PR DESCRIPTION
...cItems after closing the doalog.

Fixes https://trac.kodi.tv/ticket/18007

Runtime tested on macOS, latest kodi master.

@Jalle19 another one for a quick review/approval.

@debutanker fyi