### PR TITLE
Fix show info dialog for music videos on current musicplaylist

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -58,6 +58,7 @@
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "CueDocument.h"
 #include "Autorun.h"
+#include "video/dialogs/GUIDialogVideoInfo.h"
 
 #ifdef TARGET_POSIX
 #include "platform/linux/XTimeUtils.h"
@@ -274,9 +275,9 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
 
   CFileItemPtr item = m_vecItems->Get(iItem);
 
-  if (item->IsVideoDb())
+  if (item->IsVideo())
   { // Music video on a mixed current playlist
-    OnContextButton(iItem, CONTEXT_BUTTON_INFO);
+    CGUIDialogVideoInfo::ShowFor(*item);
     return;
   }
 
@@ -316,7 +317,7 @@ void CGUIWindowMusicBase::RetrieveMusicInfo()
   for (int i = 0; i < m_vecItems->Size(); ++i)
   {
     CFileItemPtr pItem = (*m_vecItems)[i];
-    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || pItem->IsLyrics())
+    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || pItem->IsLyrics() || pItem->IsVideo())
       continue;
 
     CMusicInfoTag& tag = *pItem->GetMusicInfoTag();


### PR DESCRIPTION
Fix issues with showing the video info dialog for music videos from the music current playlist window.
- Make "information" context menu and `<i>` shortcut key action behave consistently and not hang.
- Enable dialog to display the full information (data was missing compared to that shown when dialog called from the music video node).

I seems that these mixed items on current playlist  bugs have been lurking for maybe 9 years! Thanks @scott967 for mentioning it.

To test add songs to the (music) current playlist, then queue a music video which is also added to the music current playlist. Go to the current playlist and check both "information" context menu and `<i>` shortcut key action on the music video item.
