### PR TITLE
[guiinfo] Fix String.IsEqual if second parameter is a listitem in a given container

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6608,7 +6608,22 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           if (info.GetData2() < 0) // info labels are stored with negative numbers
           {
             int info2 = -info.GetData2();
-            if (item && item->IsFileItem() && IsListItemInfo(info2))
+            CGUIListItemPtr item2;
+
+            if (IsListItemInfo(info2))
+            {
+              int iResolvedInfo2 = ResolveMultiInfo(info2);
+              if (iResolvedInfo2 != 0)
+              {
+                const GUIINFO::CGUIInfo& resolvedInfo2 = m_multiInfo[iResolvedInfo2 - MULTI_INFO_START];
+                if (resolvedInfo2.GetInfoFlag() & INFOFLAG_LISTITEM_CONTAINER)
+                  item2 = GUIINFO::GetCurrentListItem(contextWindow, resolvedInfo2.GetData1()); // data1 contains the container id
+              }
+            }
+
+            if (item2 && item2->IsFileItem())
+              compare = GetItemImage(item2.get(), contextWindow, info2);
+            else if (item && item->IsFileItem())
               compare = GetItemImage(item, contextWindow, info2);
             else
               compare = GetImage(info2, contextWindow);
@@ -6865,6 +6880,20 @@ int CGUIInfoManager::AddMultiInfo(const CGUIInfo &info)
   if (id > MULTI_INFO_END)
     CLog::Log(LOGERROR, "%s - too many multiinfo bool/labels in this skin", __FUNCTION__);
   return id;
+}
+
+int CGUIInfoManager::ResolveMultiInfo(int info) const
+{
+  int iLastInfo = 0;
+
+  int iResolvedInfo = info;
+  while (iResolvedInfo >= MULTI_INFO_START && iResolvedInfo <= MULTI_INFO_END)
+  {
+    iLastInfo = iResolvedInfo;
+    iResolvedInfo = m_multiInfo[iResolvedInfo - MULTI_INFO_START].m_info;
+  }
+
+  return iLastInfo;
 }
 
 bool CGUIInfoManager::IsListItemInfo(int info) const

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -187,6 +187,7 @@ private:
 
   int AddMultiInfo(const KODI::GUILIB::GUIINFO::CGUIInfo &info);
 
+  int ResolveMultiInfo(int info) const;
   bool IsListItemInfo(int info) const;
 
   void SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag &tag);


### PR DESCRIPTION
Fixes a regression reported in the forum: https://forum.kodi.tv/showthread.php?tid=330696&pid=2762714#pid2762714

Runtime tested by me and the issue reporter (@sualfred) on macOS and Windows, latest Kodi master.