### PR TITLE
[PVR] PVRChannelGroup::ResetChannelnumberCache - fixes trac#18009

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -66,7 +66,6 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
   m_bUsingBackendChannelNumbers = group.m_bUsingBackendChannelNumbers;
   m_iLastWatched                = group.m_iLastWatched;
   m_bHidden                     = group.m_bHidden;
-  m_bSelectedGroup              = group.m_bSelectedGroup;
   m_bPreventSortAndRenumber     = group.m_bPreventSortAndRenumber;
   m_members                     = group.m_members;
   m_sortedMembers               = group.m_sortedMembers;
@@ -290,7 +289,6 @@ bool CPVRChannelGroup::SortAndRenumber(void)
     SortByChannelNumber();
 
   bool bReturn = Renumber();
-  ResetChannelNumberCache();
   return bReturn;
 }
 
@@ -846,23 +844,12 @@ bool CPVRChannelGroup::Renumber(void)
       m_bChanged = true;
       (*it).channelNumber = currentChannelNumber;
     }
+
+    (*it).channel->SetChannelNumber((*it).channelNumber);
   }
 
   SortByChannelNumber();
-  ResetChannelNumberCache();
-
   return bReturn;
-}
-
-void CPVRChannelGroup::ResetChannelNumberCache(void)
-{
-  CSingleLock lock(m_critSection);
-
-  /* set all channel numbers on members of this group */
-  for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::iterator it = m_sortedMembers.begin(); it != m_sortedMembers.end(); ++it)
-  {
-    (*it).channel->SetChannelNumber((*it).channelNumber);
-  }
 }
 
 bool CPVRChannelGroup::HasChangedChannels(void) const
@@ -1151,12 +1138,6 @@ bool CPVRChannelGroup::HasChannels() const
 {
   CSingleLock lock(m_critSection);
   return !m_members.empty();
-}
-
-void CPVRChannelGroup::SetSelectedGroup(bool bSetTo)
-{
-  CSingleLock lock(m_critSection);
-  m_bSelectedGroup = bSetTo;
 }
 
 bool CPVRChannelGroup::CreateChannelEpgs(bool bForce /* = false */)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -857,8 +857,6 @@ bool CPVRChannelGroup::Renumber(void)
 void CPVRChannelGroup::ResetChannelNumberCache(void)
 {
   CSingleLock lock(m_critSection);
-  if (!m_bSelectedGroup)
-    return;
 
   /* set all channel numbers on members of this group */
   for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::iterator it = m_sortedMembers.begin(); it != m_sortedMembers.end(); ++it)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -373,11 +373,6 @@ namespace PVR
     bool HasChanges(void) const;
 
     /*!
-     * @brief Reset the channel number cache if this is the selected group in the UI.
-     */
-    void ResetChannelNumberCache(void);
-
-    /*!
      * @brief Create an EPG table for each channel.
      * @brief bForce Create the tables, even if they already have been created before.
      * @return True if all tables were created successfully, false otherwise.
@@ -435,8 +430,6 @@ namespace PVR
      */
     PVRChannelGroupMember& GetByUniqueID(const std::pair<int, int>& id);
     const PVRChannelGroupMember& GetByUniqueID(const std::pair<int, int>& id) const;
-
-    void SetSelectedGroup(bool bSetTo);
 
     void SetHidden(bool bHidden);
     bool IsHidden(void) const;
@@ -531,7 +524,6 @@ namespace PVR
     bool             m_bChanged = false;                    /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
     bool             m_bUsingBackendChannelOrder = false;   /*!< true to use the channel order from backends, false otherwise */
     bool             m_bUsingBackendChannelNumbers = false; /*!< true to use the channel numbers from 1 backend, false otherwise */
-    bool             m_bSelectedGroup = false;              /*!< true when this is the selected group, false otherwise */
     bool             m_bPreventSortAndRenumber = false;     /*!< true when sorting and renumbering should not be done after adding/updating channels to the group */
     time_t           m_iLastWatched = 0;                /*!< last time group has been watched */
     bool             m_bHidden = false;                     /*!< true if this group is hidden, false otherwise */

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -463,17 +463,8 @@ CPVRChannelGroupPtr CPVRChannelGroups::GetSelectedGroup(void) const
 
 void CPVRChannelGroups::SetSelectedGroup(const CPVRChannelGroupPtr &group)
 {
-  // update the selected group
-  {
-    CSingleLock lock(m_critSection);
-    if (m_selectedGroup)
-      m_selectedGroup->SetSelectedGroup(false);
-    m_selectedGroup = group;
-    group->SetSelectedGroup(true);
-  }
-
-  // update the channel number cache
-  group->Renumber();
+  CSingleLock lock(m_critSection);
+  m_selectedGroup = group;
 }
 
 bool CPVRChannelGroups::AddGroup(const std::string &strName)


### PR DESCRIPTION
Fixes trac#18009: https://trac.kodi.tv/ticket/18009 + a small code cleanup.

Runtime tested on macOS, latest Kodi master.

@Jalle19 for a quick code review, please?

@sualfred fyi