### PR TITLE
AESinkAudioTrack: Support multi channel float

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -75,6 +75,7 @@ private:
   static CAEDeviceInfo m_info;
   static std::set<unsigned int>       m_sink_sampleRates;
   static bool m_sinkSupportsFloat;
+  static bool m_sinkSupportsMultiChannelFloat;
 
   AEAudioFormat      m_format;
   double             m_volume;


### PR DESCRIPTION
Seems recent firmwares have improved and we can now succesfully open multi channel with float (32 bit support). See: http://paste.kodi.tv/ejozegitur

Needs some testing, e.g.:
- Playback a 24 bit flac file multichannel and see if it works.