### PR TITLE
[Estuary] Music OSD: Remove 'Previous' button for non-seekable stream…

### DIFF
--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -44,7 +44,7 @@
 						<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 					</include>
 					<onclick>PlayerControl(Previous)</onclick>
-					<visible>!MusicPlayer.Content(livetv)</visible>
+					<visible>[MusicPlayer.HasPrevious | Player.SeekEnabled] + !MusicPlayer.Content(livetv)</visible>
 				</control>
 				<control type="radiobutton" id="602">
 					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/play.png</textureradioonfocus>


### PR DESCRIPTION
Music OSD: Remove 'Previous' button for non-seekable streams and if player has no previous item.

"Previous" button in music OSD has two functions. First, go to the previous track in playlist, or go back to the beginning of the playing track. If both it not possible, because the stream is either the first in playlist and/or not seekable (live audio stream), the "Previous" button should be removed from the OSd. This PR implements exactly this change.

Runtime-tested on macOS, latest Kodi master.

@DaveTBlake fyi
@ronie for review of the skin change?