### PR TITLE
[videoplayer] [bluray] Fix playback of disc with truehd tracks in menu mode. 

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1394,7 +1394,7 @@ void CDVDDemuxFFmpeg::DisposeStreams()
 CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
 {
   AVStream* pStream = m_pFormatContext->streams[streamIdx];
-  if (pStream)
+  if (pStream && pStream->discard != AVDISCARD_ALL)
   {
     // Video (mp4) from GoPro cameras can have a 'meta' track used for a file repair containing
     // 'fdsc' data, this is also called the SOS track.


### PR DESCRIPTION
The problem is that ffmpeg finds a truehd core ac3 stream on some Blu-rays with the same pid as the truehd stream, but libbluray does not. Therefore our videoplayer (rapidly) opens each of the two streams in turns. This leads to a stall.

The following output is from ffmpeg, stream 0:2 and 0:3 have the same pid:
```
Debug Print: ffmpeg[4370]:     Stream #0:0[0x1011]: Video: vc1 (Advanced) (VC-1 / 0x312D4356), yuv420p(progressive), 1920x1080 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 90k tbn, 47.95 tbc
Debug Print: ffmpeg[4370]:     Stream #0:1[0x1100]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), fltp, 640 kb/s
Debug Print: ffmpeg[4370]:     Stream #0:2[0x1101]: Audio: truehd (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), s32 (24 bit)
Debug Print: ffmpeg[4370]:     Stream #0:3[0x1101]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), fltp, 640 kb/s
Debug Print: ffmpeg[4370]:     Stream #0:4[0x1102]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, stereo, fltp, 192 kb/s
Debug Print: ffmpeg[4370]:     Stream #0:5[0x1103]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), fltp, 640 kb/s
Debug Print: ffmpeg[4370]:     Stream #0:6[0x1104]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), fltp, 640 kb/s
Debug Print: ffmpeg[4370]:     Stream #0:7[0x1105]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), fltp, 640 kb/s
Debug Print: ffmpeg[4370]:     Stream #0:8[0x1106]: Audio: ac3 (AC-3 / 0x332D4341), 48000 Hz, 5.1(side), fltp, 640 kb/s
```
But, according to libbluray, the current clip has the following audio streams:
```
Debug Print: audio stream idx: 0 pid: 1100, type: 129, lang: eng
Debug Print: audio stream idx: 1 pid: 1101, type: 131, lang: eng
Debug Print: audio stream idx: 2 pid: 1102, type: 129, lang: eng
Debug Print: audio stream idx: 3 pid: 1103, type: 129, lang: fra
Debug Print: audio stream idx: 4 pid: 1105, type: 129, lang: deu
Debug Print: audio stream idx: 5 pid: 1104, type: 129, lang: ita
Debug Print: audio stream idx: 6 pid: 1106, type: 129, lang: spa
```
I'm not sure about the second commit, but without it the function gets called quite often at the start of the playback.
