### PR TITLE
[XBMCHelper] - fixed up/down buttons on macOS 10.13.6

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -219,6 +219,8 @@ bool CInputManager::ProcessEventServer(int windowId, float frameTime)
 
           m_Mouse.SetActive(false);
 
+          CLog::Log(LOGDEBUG, "EventServer: key %d translated to action %s", wKeyID, actionName);
+
           return ExecuteInputAction(CAction(actionID, fAmount, 0.0f, actionName));
         }
         else

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -26,6 +26,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "ServiceBroker.h"
+#include "utils/log.h"
 
 using namespace EVENTCLIENT;
 using namespace EVENTPACKET;
@@ -388,6 +389,8 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
 
   float famount = 0;
   bool active = (flags & PTB_DOWN) ? true : false;
+  
+  CLog::Log(LOGDEBUG, "EventClient: button code %d %s", bcode, active ? "pressed" : "released");
 
   if(flags & PTB_USE_AMOUNT)
   {

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -437,15 +437,22 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
 
         /* if last event had an amount, we must resend without amount */
         if(it2->m_bUseAmount && it2->m_fAmount != 0.0)
+        {
           m_buttonQueue.push_back(state);
+        }
 
         /* if the last event was waiting for a repeat interval, it has executed already.*/
         if(it2->m_bRepeat)
         {
           if(it2->m_iNextRepeat > 0)
+          {
             m_buttonQueue.erase(it2);
+          }
           else
+          {
             it2->m_bRepeat = false;
+            it2->m_bActive = false;
+          }
         }
 
       }


### PR DESCRIPTION
## Description
This addresses 2 issues related to IR remotes on macOS and event server.

1. Since macOS 10.13.6 there seems to be a change of behaviour for button up and down.
    Those buttons were always special but now they are even more. When pressing those          
     Buttons there is an extra press/release event pair with really short duration (<5ms) prior    
     the real events which actually result from the user pressing those buttons.

To fix this I have added some sort of debouncing in XBMCHelper (which is the eventclient for IR remotes on macos). It discards press/release events which have a lower duration then 10ms (which a human can not easlily generate over IR).

This revealed another bug in EventServer in kodi.

2. The changed behaviour of macOS results in release event following a press event in the same millisecond. This resulted in the fact that event server did remove the “repeat” flag on the held button. All those events get queued in the button queue before the app thread calls “getbuttoncode” for removing the event from the app queue. As long as the event is in the queue - any further events related to the same button are altered in the queue. The bug was that the release event did clear the repeat flag of the button but did not mark the button as “inactive” ( meaning “not pressed”) in the queue. That resulted in non repeating button codes for up and down keys.


## Motivation and Context

Fix non repeating up / down button with ir remotes on macOS as of 10.13.6

## How Has This Been Tested?

Tested by the reporter here 
https://forum.kodi.tv/showthread.php?tid=334909

And in simulation by me

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
