### PR TITLE
[PVR] Simple timeshift OSD (optional).

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10913,7 +10913,13 @@ msgctxt "#19302"
 msgid "Do you want to record the selected programme or to switch to the current programme?"
 msgstr ""
 
-#empty strings from id 19303 to 19498
+#. pvr setting "Use simple timeshift OSD" value
+#: system/settings/settings.xml
+msgctxt "#19303"
+msgid "Use simple timeshift OSD"
+msgstr ""
+
+#empty strings from id 19304 to 19498
 
 #. label for epg genre value
 #: xbmc/epg/Epg.cpp
@@ -18568,7 +18574,13 @@ msgctxt "#36234"
 msgid "Duration of instant recordings when pressing the record button. This value will be taken into account if \"Instant recording action\" is set to \"Record for a fixed period of time\""
 msgstr ""
 
-#empty strings from id 36235 to 36236
+#. help text for pvr setting "Use simple timeshift OSD"
+#: system/settings/settings.xml
+msgctxt "#36235"
+msgid "Normal timeshift OSD always shows the complete timeshift buffer along with with the currently playing show, whereas the simple timeshift OSD only shows the currently playing show with no visual feedback how far in the timeshift buffer you can jump from the currently playing position."
+msgstr ""
+
+#empty string with id 36236
 
 #: system/settings/settings.xml
 msgctxt "#36237"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1265,7 +1265,14 @@
       </group>
     </category>
     <category id="pvrmenu" label="19181" help="36211">
-      <group id="1" label="14301">
+      <group id="1" label="128">
+        <setting id="pvrmenu.usesimpletimeshiftosd" type="boolean" label="19303" help="36235">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="2" label="14301">
         <setting id="pvrmenu.displaychannelinfo" type="integer" label="19178" help="36212">
           <level>2</level>
           <default>5</default>
@@ -1279,7 +1286,7 @@
           </control>
         </setting>
       </group>
-      <group id="2" label="14302">
+      <group id="3" label="14302">
         <setting id="pvrmenu.iconpath" type="path" label="19018" help="36216">
           <level>2</level>
           <default></default>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -206,6 +206,7 @@ const std::string CSettings::SETTING_PVRMANAGER_GROUPMANAGER = "pvrmanager.group
 const std::string CSettings::SETTING_PVRMANAGER_CHANNELSCAN = "pvrmanager.channelscan";
 const std::string CSettings::SETTING_PVRMANAGER_RESETDB = "pvrmanager.resetdb";
 const std::string CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO = "pvrmenu.displaychannelinfo";
+const std::string CSettings::SETTING_PVRMENU_USESIMPLETIMESHIFTOSD = "pvrmenu.usesimpletimeshiftosd";
 const std::string CSettings::SETTING_PVRMENU_ICONPATH = "pvrmenu.iconpath";
 const std::string CSettings::SETTING_PVRMENU_SEARCHICONS = "pvrmenu.searchicons";
 const std::string CSettings::SETTING_EPG_PAST_DAYSTODISPLAY = "epg.pastdaystodisplay";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -161,6 +161,7 @@ public:
   static const std::string SETTING_PVRMANAGER_CHANNELSCAN;
   static const std::string SETTING_PVRMANAGER_RESETDB;
   static const std::string SETTING_PVRMENU_DISPLAYCHANNELINFO;
+  static const std::string SETTING_PVRMENU_USESIMPLETIMESHIFTOSD;
   static const std::string SETTING_PVRMENU_ICONPATH;
   static const std::string SETTING_PVRMENU_SEARCHICONS;
   static const std::string SETTING_EPG_PAST_DAYSTODISPLAY;


### PR DESCRIPTION
Followup to #14316 

Users reported that they would like to have a timeshift OSD where the playing epg event always spans the whole width of the screen. Having the whole timeshift buffer displayed, thus being able to see how far one can seek, was considered less important.

Thus, I decided to introduce a setting to activate a 'simple timeshift OSD' fulfilling abovenmentioned requirements.

![screenshot007](https://user-images.githubusercontent.com/3226626/44959015-96c5ef00-aee8-11e8-991b-ccb24ae05a12.png)

(The new setting is activated by default.)

Here is, how the simple timeshift OSD looks/works:

![screenshot004](https://user-images.githubusercontent.com/3226626/44959024-b78e4480-aee8-11e8-8c93-23e89a8401d6.png)
![screenshot003](https://user-images.githubusercontent.com/3226626/44959027-b9f09e80-aee8-11e8-84da-121697dbe028.png)
![screenshot000](https://user-images.githubusercontent.com/3226626/44959030-bd842580-aee8-11e8-822b-fcd7d6a9f7bb.png)

The code changes to implement this are trivial as I designed stuff very flexible in the first place. :-)

Runtime tested on macOS, latest Kodi master.

@da-anda fyi