### PR TITLE
[windowing/osx] - fix double release of nsstring when no displayname can be determined

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -386,7 +386,7 @@ NSString* screenNameForDisplay(CGDirectDisplayID displayID)
 
   if (screenName == nil)
   {
-    screenName = [NSString stringWithFormat:@"%i", displayID];
+    screenName = [[NSString alloc] initWithFormat:@"%i", displayID];
   }
   return [screenName autorelease];
 }


### PR DESCRIPTION
Fixes double free of nsstring when display is turned off.