### PR TITLE
Fixed: text was not scrolling in the default text dialog

### DIFF
--- a/addons/skin.estuary/xml/Custom_1102_TextViewer.xml
+++ b/addons/skin.estuary/xml/Custom_1102_TextViewer.xml
@@ -22,6 +22,7 @@
 				<pagecontrol>3000</pagecontrol>
 				<font>font37</font>
 				<label>$INFO[Window(home).Property(TextViewer_Text)]</label>
+				<autoscroll delay="4000" repeat="7500" time="4000">true</autoscroll>
 			</control>
 			<control type="scrollbar" id="3000">
 				<include>HiddenObject</include>


### PR DESCRIPTION
## Description
I added a scroll effect to the default text dialog. 

## Motivation and Context
I noticed that my add-on's _news_ was not displayed completely because the text was not scrolling.

## How Has This Been Tested?
Using the _news_ dialog in the add-on info dialog.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
