### PR TITLE
gbm: fix surface creation when no modifiers are present

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -428,6 +428,8 @@ bool CDRMUtils::FindPlanes()
   if (!FindModifiersForPlane(m_overlay_plane))
   {
     CLog::Log(LOGDEBUG, "CDRMUtils::%s - no drm modifiers present for the overlay plane", __FUNCTION__);
+    m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_ARGB8888, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
+    m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_XRGB8888, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
   }
 
   return true;

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -48,13 +48,15 @@ bool CGBMUtils::CreateSurface(int width, int height, const uint64_t *modifiers, 
                                                 GBM_FORMAT_ARGB8888,
                                                 modifiers,
                                                 modifiers_count);
-#else
-  m_surface = gbm_surface_create(m_device,
-                                 width,
-                                 height,
-                                 GBM_FORMAT_ARGB8888,
-                                 GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
 #endif
+  if (!m_surface)
+  {
+    m_surface = gbm_surface_create(m_device,
+                                   width,
+                                   height,
+                                   GBM_FORMAT_ARGB8888,
+                                   GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+  }
 
   if (!m_surface)
   {


### PR DESCRIPTION
`DRM_FORMAT_MOD_LINEAR` should always be present so the modifier count should always be > 0. Before the surface would get created but was corrupted. It seems like odd behaviour but this now matches what kmscube is doing for surface creation.

for reference: https://cgit.freedesktop.org/mesa/kmscube/commit/?id=063ce5c732598b3855775e59b59d9ddffe4ddb24