### PR TITLE
Enable games by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2015,7 +2015,7 @@
         <setting id="gamesgeneral.enable" type="boolean">
           <visible>false</visible>
           <level>0</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="gamesgeneral.enableautosave" type="boolean" label="35253" help="35254">

--- a/system/settings/win10.xml
+++ b/system/settings/win10.xml
@@ -39,4 +39,13 @@
         </setting>
     </category>
   </section>
+  <section id="games">
+    <category id="gamesgeneral">
+      <group id="1">
+        <setting id="gamesgeneral.enable">
+          <default>false</default>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>


### PR DESCRIPTION
I think we should enable games by default in nightlies, but still hidden in betas and RCs. Just to cause a nice splash in our final release blog post.

But that's just my opinion. Release manager @MartijnKaijser should weigh in.

### Issues I don't plan to fix before release

* RetroPlayer issues: https://github.com/garbear/xbmc/issues/80
* Input issues: https://github.com/garbear/xbmc/issues/79

I plan to do no more work until release, but I might devote a week or two once we hit RC. Also any contributors will get my full attention.

### Issues I want to fix

1. How do we inform the user of the Select + X hotkey to bring up the OSD?

2. What should we do about extensions? Currently in my test builds I do:

```xml
<advancedsettings>
  <videoextensions>
    <remove>.bin|.img|.iso|.zip</remove>
  </videoextensions>
  <musicextensions>
    <remove>.cue|.zip</remove>
  </musicextensions>
  <pictureextensions>
    <remove>.zip</remove>
  </pictureextensions>
</advancedsettings>
```