### PR TITLE
input: LibInputTouch: Switch to get_seat_slot() to fix single touch device input

### DIFF
--- a/xbmc/platform/linux/input/LibInputTouch.cpp
+++ b/xbmc/platform/linux/input/LibInputTouch.cpp
@@ -55,7 +55,7 @@ void CLibInputTouch::SetPosition(int slot, CPoint point)
 
 void CLibInputTouch::ProcessTouchDown(libinput_event_touch *e)
 {
-  int slot = libinput_event_touch_get_slot(e);
+  int slot = libinput_event_touch_get_seat_slot(e);
 
   SetPosition(slot, GetPos(e));
   SetEvent(slot, TouchInputDown);
@@ -64,7 +64,7 @@ void CLibInputTouch::ProcessTouchDown(libinput_event_touch *e)
 
 void CLibInputTouch::ProcessTouchMotion(libinput_event_touch *e)
 {
-  int slot = libinput_event_touch_get_slot(e);
+  int slot = libinput_event_touch_get_seat_slot(e);
   uint64_t nanotime = libinput_event_touch_get_time_usec(e) * 1000LL;
 
   SetPosition(slot, GetPos(e));
@@ -78,7 +78,7 @@ void CLibInputTouch::ProcessTouchMotion(libinput_event_touch *e)
 
 void CLibInputTouch::ProcessTouchUp(libinput_event_touch *e)
 {
-  int slot = libinput_event_touch_get_slot(e);
+  int slot = libinput_event_touch_get_seat_slot(e);
 
   SetEvent(slot, TouchInputUp);
   CLog::Log(LOGDEBUG, "CLibInputTouch::%s - touch input up", __FUNCTION__);
@@ -86,7 +86,7 @@ void CLibInputTouch::ProcessTouchUp(libinput_event_touch *e)
 
 void CLibInputTouch::ProcessTouchCancel(libinput_event_touch *e)
 {
-  int slot = libinput_event_touch_get_slot(e);
+  int slot = libinput_event_touch_get_seat_slot(e);
   uint64_t nanotime = libinput_event_touch_get_time_usec(e) * 1000LL;
 
   CLog::Log(LOGDEBUG, "CLibInputTouch::%s - touch input cancel", __FUNCTION__);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
When a single touch device is connected, the `libinput_event_touch_get_slot()` call returns -1 as documented in [1]:
```
If the touch event has no assigned slot, for example if it is from a single touch device, this function returns -1.
```
The ` libinput_event_touch_get_seat_slot()` call is designed so return an unique slot number and is valid for single touch devices:
```
Events from single touch devices will be represented as one individual touch point per device.
```

[1] https://wayland.freedesktop.org/libinput/doc/latest/api/group__event__touch.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Kodi crashed when a touch event is returned because the return slot number is -1.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
The Wavestar 7inch HDMI LCD screen is seen as a single touch HID input device, with the fix applied, the touch events are taken in account correctly.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed