### PR TITLE
[messaging] CID 1439117:  Uninitialized members  (UNINIT_CTOR)

### DIFF
--- a/xbmc/messaging/ThreadMessage.h
+++ b/xbmc/messaging/ThreadMessage.h
@@ -53,6 +53,7 @@ public:
     : dwMessage{ messageId }
     , param1{ p1 }
     , param2{ p2 }
+    , param3{ 0 }
     , lpVoid{ payload }
     , strParam( param )
     , params( vecParams )


### PR DESCRIPTION
Fixes:

<pre>
*** CID 1439117:  Uninitialized members  (UNINIT_CTOR)
/xbmc/messaging/ThreadMessage.h: 60 in KODI::MESSAGING::ThreadMessage::ThreadMessage(unsigned int, int, int, void *, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>)()
54         , param1{ p1 }
55         , param2{ p2 }
56         , lpVoid{ payload }
57         , strParam( param )
58         , params( vecParams )
59       {
>>>     CID 1439117:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "param3" is not initialized in this constructor nor in any functions that it calls.
60       }
61     
62       ThreadMessage(const ThreadMessage& other)
63         : dwMessage(other.dwMessage),
64         param1(other.param1),
65         param2(other.param2),
</pre>