### PR TITLE
Games: Fix error calculating savestate size

### DIFF
--- a/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/LinearMemoryStream.cpp
@@ -12,7 +12,7 @@ using namespace KODI;
 using namespace RETRO;
 
 // Pad forward to nearest boundary of bytes
-#define PAD_TO_CEIL(x, bytes)  (((x) + (bytes) - 1) / (bytes))
+#define PAD_TO_CEIL(x, bytes)  ((((x) + (bytes) - 1) / (bytes)) * (bytes))
 
 CLinearMemoryStream::CLinearMemoryStream()
 {


### PR DESCRIPTION
Discovered when playing Dig Dug on Stella. Savestate size was too small, and Stella fails to validate size and happily clobbers memory.

## Motivation and Context
Reported here: https://github.com/kodi-game/game.libretro.stella/issues/6

## How Has This Been Tested?
Tested by playing Dig Dug on OSX; crash go bye bye.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
