### PR TITLE
[PVR] Guide window: Fix deadlock.

### DIFF
--- a/xbmc/pvr/windows/GUIEPGGridContainer.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.h
@@ -225,7 +225,6 @@ namespace PVR
     mutable CCriticalSection m_critSection;
     std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
     std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
-    std::unique_ptr<CGUIEPGGridContainerModel> m_outdatedGridModel;
 
     GridItem *m_item;
   };

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
@@ -14,6 +14,7 @@
 #include "ServiceBroker.h"
 #include "settings/Settings.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
@@ -36,28 +37,13 @@ void CGUIEPGGridContainerModel::SetInvalid()
     ruler->SetInvalid();
 }
 
-void CGUIEPGGridContainerModel::Reset()
+void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize)
 {
-  for (auto &channel : m_gridIndex)
+  if (!m_channelItems.empty())
   {
-    for (const auto &block : channel)
-    {
-      if (block.item)
-        block.item->ClearProperties();
-    }
-    channel.clear();
+    CLog::LogF(LOGERROR, "Already initialized!");
+    return;
   }
-  m_gridIndex.clear();
-
-  m_channelItems.clear();
-  m_programmeItems.clear();
-  m_rulerItems.clear();
-  m_epgItemsPtr.clear();
-}
-
-void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize)
-{
-  Reset();
 
   ////////////////////////////////////////////////////////////////////////
   // Create programme & channel items

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.h
@@ -36,9 +36,10 @@ namespace PVR
     static const int MINSPERBLOCK = 5; // minutes
     static const int MAXBLOCKS = 33 * 24 * 60 / MINSPERBLOCK; //! 33 days of 5 minute blocks (31 days for upcoming data + 1 day for past data + 1 day for fillers)
 
-    virtual ~CGUIEPGGridContainerModel() { Reset(); }
+    CGUIEPGGridContainerModel() = default;
+    virtual ~CGUIEPGGridContainerModel() = default;
 
-    void Refresh(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
+    void Initialize(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
     void SetInvalid();
 
     static const int INVALID_INDEX = -1;
@@ -83,7 +84,6 @@ namespace PVR
 
   private:
     void FreeItemsMemory();
-    void Reset();
 
     struct ItemsPtr
     {


### PR DESCRIPTION
This fixes a deadlock I recently encountered.

<pre>
Thread 64 (Thread 0x7f207890b700 (LWP 18600)):
#0  __pthread_mutex_lock_full (mutex=0x2708c28) at ../nptl/pthread_mutex_lock.c:416
==> wants global gfx mutex
#1  0x0000000000d1ea5b in ?? ()
#2  0x0000000000a66809 in CGUITextureManager::ReleaseTexture(std::string const&, bool) ()
#3  0x0000000000a66933 in CGUITextureBase::FreeResources(bool) ()
#4  0x0000000000a88876 in CGUIImage::FreeTextures(bool) ()
#5  0x0000000000a7e1c3 in CGUIImage::FreeResources(bool) ()
#6  0x0000000000a7e202 in CGUIControlGroup::FreeResources(bool) ()
#7  0x0000000000a7cf37 in CGUIListItem::FreeMemory(bool) ()
#8  0x0000000000a9cc3c in CGUIListItem::~CGUIListItem() ()
#9  0x000000000099460b in CFileItem::~CFileItem() ()
#10 0x0000000000d21887 in ?? ()
#11 0x0000000000776a99 in ?? ()
#12 0x00000000007354c9 in ?? ()
#13 0x000000000090e011 in PVR::CGUIEPGGridContainerModel::Reset() ()
#14 0x000000000090f580 in ?? ()
#15 0x000000000090f5d5 in ?? ()
#16 0x000000000090f523 in PVR::CGUIEPGGridContainer::SetTimelineItems(std::unique_ptr<CFileItemList, std::default_delete<CFileItemList> > const&, CDateTime const&, CDateTime const&) ()
#17 0x0000000000916c2e in PVR::CGUIWindowPVRGuideBase::RefreshTimelineItems() ()
#18 0x0000000000916d57 in PVR::CPVRRefreshTimelineItemsThread::Process() ()
#19 0x0000000000ae417d in CThread::Action() ()
#20 0x0000000000b04301 in CThread::staticThread(void*) ()
#21 0x00007f20f9667fa0 in start_thread (arg=<optimized out>) at pthread_create.c:486
#22 0x00007f20f5194d5f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95


Thread 1 (Thread 0x7f20f89158c0 (LWP 769)):
#0  futex_abstimed_wait_cancelable (private=0, abstime=0x7ffef54191f0, expected=0, futex_word=0x4c31058) at ../sysdeps/unix/sysv/linux/futex-internal.h:205
#1  __pthread_cond_wait_common (abstime=<optimized out>, mutex=0x94e4db0, cond=0x4c31030) at pthread_cond_wait.c:539
#2  __pthread_cond_timedwait (cond=0x4c31030, mutex=0x94e4db0, abstime=0x7ffef54191f0) at pthread_cond_wait.c:667
#3  0x0000000000d21bf2 in ?? ()
#4  0x0000000000d2775b in ?? ()
#5  0x0000000000ae4564 in CThread::StopThread(bool) ()
===> waits for thread to leave its worker function which never will happen, because this thread owns the global gfx mutex while waiting an the thread to end
#6  0x00000000008eadbd in PVR::CPVRRefreshTimelineItemsThread::~CPVRRefreshTimelineItemsThread() ()
#7  0x00000000008eade7 in PVR::CPVRRefreshTimelineItemsThread::~CPVRRefreshTimelineItemsThread() ()
#8  0x0000000000903ae5 in PVR::CGUIWindowPVRGuideBase::StartRefreshTimelineItemsThread() ()
#9  0x0000000000903ba2 in PVR::CGUIWindowPVRGuideBase::InitEpgGridControl() ()
#10 0x0000000000912bbc in PVR::CGUIWindowPVRGuideBase::OnMessage(CGUIMessage&) ()
#11 0x0000000000a6d43d in CGUIWindowManager::SendMessage(CGUIMessage&) ()
===> has global gfx mutex
#12 0x0000000000a70c39 in CGUIWindowManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage*) ()
#13 0x0000000000ad516f in KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::ThreadMessage*) ()
#14 0x0000000000ad5215 in KODI::MESSAGING::CApplicationMessenger::ProcessWindowMessages() ()
#15 0x00000000009a9cce in CApplication::Process() ()
#16 0x000000000096efdb in CXBApplicationEx::Run(CAppParamParser const&) ()
#17 0x0000000000ac2496 in XBMC_Run ()
#18 0x00000000006f10d4 in main ()
</pre>

I once thought, for performance reasons it would be a good idea to not destroy the large `CFileItemList`s the epg grid is using in the main thread and thus I delegated the destruction to a thread. But it now turned out that this can lead to the deadlock described above.

This PR reverts that unfortunate performance optimization and ensures that those `CFileItemList` instances never will be destructed outside the main thread.

If you think about this deadlock a bit longer this leads to the conclusion, that no worker function must destruct CFileItem instances as those are GUIListItems and the latter can lock global gfx mutex on destruvtion. I don't know how many threads we have can run into the same problem...

I runtime-tested this for some weeks and thus I'm very sure it does not have any bad side effects. On my systems I did not even realized any performance dip while working with the PVR Guide window.