### PR TITLE
VideoPlayer: demuxClient, wait until video has extradata

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -292,6 +292,15 @@ DemuxPacket* CDVDDemuxClient::Read()
     }
   }
 
+  if (!IsVideoReady())
+  {
+    m_packet.reset();
+    DemuxPacket *pPacket = CDVDDemuxUtils::AllocateDemuxPacket(0);
+    pPacket->demuxerId = m_demuxerId;
+    return pPacket;
+  }
+
+  //! @todo drop this block
   CDVDInputStream::IDisplayTime *inputStream = m_pInput->GetIDisplayTime();
   if (inputStream)
   {
@@ -310,6 +319,7 @@ DemuxPacket* CDVDDemuxClient::Read()
       m_packet->dispTime += DVD_TIME_TO_MSEC(m_packet->dts - m_dtsAtDisplayTime);
     }
   }
+
   return m_packet.release();
 }
 
@@ -552,6 +562,17 @@ std::shared_ptr<CDemuxStream> CDVDDemuxClient::GetStreamInternal(int iStreamId)
 int CDVDDemuxClient::GetNrOfStreams() const
 {
   return m_streams.size();
+}
+
+bool CDVDDemuxClient::IsVideoReady()
+{
+  for (const auto& stream : m_streams)
+  {
+    if (stream.second->type == STREAM_VIDEO &&
+        stream.second->ExtraData == nullptr)
+      return false;
+  }
+  return true;
 }
 
 std::string CDVDDemuxClient::GetFileName()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -47,6 +47,7 @@ protected:
   bool ParsePacket(DemuxPacket* pPacket);
   void DisposeStreams();
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);
+  bool IsVideoReady();
 
   std::shared_ptr<CDVDInputStream> m_pInput;
   std::shared_ptr<CDVDInputStream::IDemux> m_IDemux;


### PR DESCRIPTION
without extradata video can't be started

this avoids viz kicking in, if i.e. tvh starts a channel with SPS not in first packets