### PR TITLE
Fix parent directory ".." not exiting plugins providing multiple types

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -335,15 +335,10 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
   }
   else if (url.IsProtocol("plugin"))
   {
-    if (!url.GetOptions().empty())
-    {
-      url.SetOptions("");
-      strParent = url.Get();
-      return true;
-    }
     if (!url.GetFileName().empty())
     {
       url.SetFileName("");
+      url.SetOptions("");
       strParent = url.Get();
       return true;
     }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -707,7 +707,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
             CURL::GetRedacted(strDirectory).c_str());
   CLog::Log(LOGDEBUG,"  ParentPath = [%s]", CURL::GetRedacted(strParentPath).c_str());
 
-  if (pathToUrl.IsProtocol("plugin"))
+  if (pathToUrl.IsProtocol("plugin") && !pathToUrl.GetHostName().empty())
     CServiceBroker::GetAddonMgr().UpdateLastUsed(pathToUrl.GetHostName());
 
   // see if we can load a previously cached folder


### PR DESCRIPTION
This fixes unable being able to exit plugins by selecting ".." at the plugin's root when the plugin provides multiple types.

When a plugin provides multiple types, it is launched with the context as URL options, e.g. `plugin://addon.id/?content_type=video`.

When the ".." at the plugin root is selected, plugins with a single type updated to `plugin://` and exit. This is the expected behavior.

Plugins with multiple types, however, update with `plugin://addon.id/`, which refreshes the root window and doesn't exit.

To fix this, we make the parent directory of the URL with options but no file equal to `plugin://`, which exits the plugin.

Also includes a small validation check.

## Motivation and Context
Reported here: https://github.com/garbear/xbmc/issues/94

## How Has This Been Tested?
Tested on Windows 10 with IAGL. Selecting ".." correctly exits the plugin.

This may have side effects, but I'm not aware of any.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
