### PR TITLE
[Estuary] show chinese input labels in proper position

### DIFF
--- a/addons/skin.estuary/xml/DialogKeyboard.xml
+++ b/addons/skin.estuary/xml/DialogKeyboard.xml
@@ -632,8 +632,8 @@
 				<content>$VAR[AutoCompletionContentVar]</content>
 			</control>
 			<control type="label" id="313">
-				<left>60</left>
-				<top>690</top>
+				<centerleft>50%</centerleft>
+				<top>290</top>
 				<width>1480</width>
 				<height>90</height>
 				<font>font37</font>
@@ -643,22 +643,22 @@
 			<control type="group">
 				<visible>Control.IsVisible(313)</visible>
 				<control type="image">
-					<left>20</left>
-					<top>690</top>
+					<centerleft>50%</centerleft>
+					<top>290</top>
 					<width>1560</width>
 					<height>90</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="image">
-					<left>20</left>
-					<top>770</top>
+					<centerleft>50%</centerleft>
+					<top>370</top>
 					<width>1560</width>
 					<height>90</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="label" id="314">
-					<left>60</left>
-					<top>770</top>
+					<centerleft>50%</centerleft>
+					<top>370</top>
 					<width>1480</width>
 					<height>90</height>
 					<font>font37</font>


### PR DESCRIPTION
## Description
For now, Chinese input labels overlap with the visual keyboard.  This PR fixed the issue. 

## How Has This Been Tested?
Tested on Windows 10

## Screenshots:
Screenshot before fixed:
![screenshot001](https://user-images.githubusercontent.com/102434/45260323-0f600a80-b417-11e8-8bfb-4614c275a22b.png)

Screenshot after fixed:
![screenshot000](https://user-images.githubusercontent.com/102434/45260328-3f0f1280-b417-11e8-8296-8cee9dc1495e.png)

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
