### PR TITLE
[ios] - use libdvdcss

### DIFF
--- a/cmake/scripts/ios/ArchSetup.cmake
+++ b/cmake/scripts/ios/ArchSetup.cmake
@@ -36,7 +36,6 @@ list(APPEND DEPLIBS "-framework CoreFoundation" "-framework CoreVideo"
                     "-framework CoreMedia" "-framework AVFoundation"
                     "-framework VideoToolbox")
 
-set(ENABLE_DVDCSS OFF CACHE BOOL "" FORCE)
 set(ENABLE_OPTICAL OFF CACHE BOOL "" FORCE)
 
 set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "9.0")

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -27,13 +27,11 @@ else
 endif
 
 ifeq ($(OS),ios)
-  EXCLUDED_DEPENDS = libcec libusb libdvdcss
+  EXCLUDED_DEPENDS = libcec libusb
   ifeq ($(TARGET_PLATFORM),appletvos)
     DEPENDS += boblight
   endif
   DEPENDS += iosentitlements
-else
-  DVDREAD_DEPS = libdvdcss
 endif
 
 ifeq ($(OS),osx)
@@ -115,7 +113,7 @@ platform: p8-platform
 libcec: p8-platform
 crossguid: $(CROSSGUID_DEPS)
 libdvdnav: libdvdread
-libdvdread: $(DVDREAD_DEPS)
+libdvdread: libdvdcss
 wayland: expat libffi
 waylandpp: wayland $(WAYLANDPP_DEPS)
 dbus: expat

--- a/tools/depends/target/libdvdcss/DVDCSS-VERSION
+++ b/tools/depends/target/libdvdcss/DVDCSS-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=libdvdcss
 BASE_URL=https://github.com/xbmc/libdvdcss
-VERSION=1.4.1-Leia-Alpha-3
+VERSION=1.4.1-Leia-Beta-3
 

--- a/tools/depends/target/libdvdread/Makefile
+++ b/tools/depends/target/libdvdread/Makefile
@@ -3,8 +3,8 @@ include DVDREAD-VERSION
 DEPS = DVDREAD-VERSION Makefile
 
 # configuration settings
-config = --prefix=$(PREFIX) --disable-shared --enable-static --with-pic
-EXTRA_CFLAGS = -D_XBMC
+config = --prefix=$(PREFIX) --disable-shared --enable-static --with-pic --with-libdvdcss
+EXTRA_CFLAGS = -D_XBMC -DHAVE_DVDCSS_DVDCSS_H
 
 ifeq ($(CROSS_COMPILING), yes)
   DEPS += ../../Makefile.include
@@ -21,15 +21,11 @@ else
   endif
 endif
 
-ifneq ($(OS),ios)
-  config += --with-libdvdcss
-  EXTRA_CFLAGS += -DHAVE_DVDCSS_DVDCSS_H
-endif
 ifeq ($(OS),osx)
   EXTRA_CFLAGS +=  -D__DARWIN__
 endif
 ifeq ($(OS),ios)
-  EXTRA_CFLAGS +=  -D__DARWIN__ -UHAVE_DVDCSS_DVDCSS_H
+  EXTRA_CFLAGS +=  -D__DARWIN__
 endif
 
 RETRIEVE_TOOL := curl -Ls --create-dirs --retry 10 --retry-delay 3


### PR DESCRIPTION
## Description
I had this PR open a long time ago already - but now let’s do it ;)
iOS is the only platform that does not support encrypted dvd images.
This PR changes it. Pretty straight forward - fix out ioctl stuff from libdvdcss (no dvd drive support on iOS) - and enable dvdcss in libdvdread.

## Motivation and Context
Finally a user asked for this. :)

## How Has This Been Tested?
Tested on iPhone with iOS 11.xx

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
