### PR TITLE
[GBM] render frames multiple times if required

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -150,9 +150,6 @@ void CRendererDRMPRIME::Update()
 
 void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
-  if (m_iLastRenderBuffer == index)
-    return;
-
   CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
   if (!buffer)
     return;


### PR DESCRIPTION
## Description
If DRM atomic API has nothing to render, the drmModeAtomicCommit does not block even in blocking mode andthis  leads to high CPU on main thread. Reproducable with 25fps videos on 50hz monitor for example, which leads to 106%CPU usage for 25/50 compared to 6% CPU usage for 50/50 videos.

The PR forces the same frame rendered multiple times if required. The blocking modeSet API now have a frameBuffer for each DisplayVsync and throttles the main thread exactly.

## Motivation and Context
High CPU usage for 25/50 using DRMPRIME renderer / atomic API

## How Has This Been Tested?
- Odroid C2 / 4.18 modified kernel with V4L2-m2m ffmpeg.
- Screen refresh rate 50 hz.
- Video: https://drive.google.com/file/d/0BwxFVkl63-lEWDUzUVUtZEw4cDA/view?usp=sharing

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
