### PR TITLE
[Music]Fix forced expansion of .m3u playlists

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -442,7 +442,7 @@ void CDirectory::FilterFileDirectories(CFileItemList &items, const std::string &
   for (int i=0; i< items.Size(); ++i)
   {
     CFileItemPtr pItem=items[i];
-    auto mode = expandImages ? EFILEFOLDER_TYPE_ONBROWSE : EFILEFOLDER_TYPE_ALWAYS;
+    auto mode = expandImages && pItem->IsDiscImage() ? EFILEFOLDER_TYPE_ONBROWSE : EFILEFOLDER_TYPE_ALWAYS;
     if (!pItem->m_bIsFolder && pItem->IsFileFolder(mode))
     {
       std::unique_ptr<IFileDirectory> pDirectory(CFileDirectoryFactory::Create(pItem->GetURL(),pItem.get(),mask));


### PR DESCRIPTION
Fix regression introduced by https://github.com/xbmc/xbmc/pull/12004 where by .m3u playlists in the music window are always treated as folders regardless of playlistasfolders being false.

This restores the effect of having `<playlistasfolders>false</playlistasfolders>` in advancedsettings.xml where .m3u playlists are treated as a item (not a folder), the total size is shown and enter triggers playback rather than display of the playlist contents.

@notspiff if you could check I have not messed up this tiny change 
