### PR TITLE
Update README.md to list BSD as its own operating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   Welcome to Kodi Home Theater Software!
 </h1>
 
-Kodi is an award-winning **free and open source** software media player and entertainment hub for digital media. Available as a native application for **Android, Linux, macOS, iOS and Windows operating systems**, Kodi runs on most common processor architectures.
+Kodi is an award-winning **free and open source** software media player and entertainment hub for digital media. Available as a native application for **Android, Linux, BSD, macOS, iOS, and Windows operating systems**, Kodi runs on most common processor architectures.
 
 Created in 2003 by a group of like minded programmers, Kodi is a non-profit project run by the XBMC Foundation and developed by volunteers located around the world. More than 500 software developers have contributed to Kodi to date, and 100-plus translators have worked to expand its reach, making it available in more than 70 languages.
 


### PR DESCRIPTION
BSD (Berkeley Software Distribution) based operating systems like example FreeBSD are not just another Linux distribution so "BSD" should reasonably be listed as its own operating system. There are a lot of similarities and OS compatibility layers with Linux, but those does not change the fact that BSD is not Linux. 

Grammatically I also believe that there should be a comma after "and" in  "...iOS and Windows operating systems" so it instead reads "...iOS, and Windows operating systems" because it is a list. See https://lifehacker.com/always-put-a-comma-before-and-in-a-list-no-matter-wh-1793376109 (this is known to grammar nerds as an Oxford comma https://www.grammarbook.com/punctuation/commas.asp ). 