### PR TITLE
DTS-HD-HR: Fall back to Core as we are incompatible with modern AVRs

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -35,6 +35,12 @@ CDVDAudioCodecPassthrough::~CDVDAudioCodecPassthrough(void)
 bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   m_parser.SetCoreOnly(false);
+
+  // DTS-HD HRA is currently not supported on a wide range of AVRs when transmited
+  // with 8 channels 192 khz - use the core for now
+  if (hints.codec == AV_CODEC_ID_DTS && hints.profile == FF_PROFILE_DTS_HD_HRA)
+    m_parser.SetCoreOnly(true);
+
   switch (m_format.m_streamInfo.m_type)
   {
     case CAEStreamInfo::STREAM_TYPE_AC3:


### PR DESCRIPTION
This falls back to DTS-HD-CORE when we detect DTS-HD-HR. The problem here is that modern AVRs from Denon, Yamaha, Pioneer and others don't expect DTS-HD-HR being sent in 8 channels 192 khz. As a result you end up with DTS-CORE including noise and crackle.

Advantage of this change:
- We are not causing audible problems on any AVR

Disadvantage:
- It's a workaround and real solution would be sending 192 khz / 2 channel encapsulated IEC, which we currently cannot pack for DTS-HD-HR and lack the proper differentiation format DTS-HD-HR in the sinks
- Old AVRs would end up with CORE only while they would support DTS-HD-HR via 8 / 192
- Core is not DTS-HD-HR -> we are loosing quality

Literature:
- Solution: https://github.com/Nevcairiel/LAVFilters/issues/167
- Kodi-Bug: https://trac.kodi.tv/ticket/17886

What would be the best solution:
- Switch to ffmpeg's spdif encoder and add additional DTS-HD-HR format to our sinks

Why I decided for the workaround: I don't have the time to do it properly but also don't want a broken out of the box experience.