### PR TITLE
Use Linux Sysfs SoC interface for SystemInfo and CPUInfo

### DIFF
--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -10,6 +10,7 @@
 
 #include "CPUInfo.h"
 #include "utils/log.h"
+#include "utils/SysfsUtils.h"
 #include "utils/Temperature.h"
 #include <string>
 #include <string.h>
@@ -419,6 +420,21 @@ CCPUInfo::CCPUInfo(void)
       }
     }
     fclose(fCPUInfo);
+    // new socs use the sysfs soc interface to describe the hardware
+    if (SysfsUtils::Has("/sys/bus/soc/devices/soc0"))
+    {
+      std::string machine, family, soc_id;
+      if (SysfsUtils::Has("/sys/bus/soc/devices/soc0/machine"))
+        SysfsUtils::GetString("/sys/bus/soc/devices/soc0/machine", machine);
+      if (SysfsUtils::Has("/sys/bus/soc/devices/soc0/family"))
+        SysfsUtils::GetString("/sys/bus/soc/devices/soc0/family", family);
+      if (SysfsUtils::Has("/sys/bus/soc/devices/soc0/soc_id"))
+        SysfsUtils::GetString("/sys/bus/soc/devices/soc0/soc_id", soc_id);
+      if (m_cpuHardware.empty() && !machine.empty())
+        m_cpuHardware = machine;
+      if (!family.empty() && !soc_id.empty())
+        m_cpuSoC = family + " " + soc_id;
+    }
     //  /proc/cpuinfo is not reliable on some Android platforms
     //  At least we should get the correct cpu count for multithreaded decoding
 #if defined(TARGET_ANDROID)

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -54,6 +54,7 @@ struct CoreInfo
   std::string m_strVendor;
   std::string m_strModel;
   std::string m_strBogoMips;
+  std::string m_strSoC;
   std::string m_strHardware;
   std::string m_strRevision;
   std::string m_strSerial;
@@ -72,6 +73,7 @@ public:
   bool getTemperature(CTemperature& temperature);
   std::string& getCPUModel() { return m_cpuModel; }
   std::string& getCPUBogoMips() { return m_cpuBogoMips; }
+  std::string& getCPUSoC() { return m_cpuSoC; }
   std::string& getCPUHardware() { return m_cpuHardware; }
   std::string& getCPURevision() { return m_cpuRevision; }
   std::string& getCPUSerial() { return m_cpuSerial; }
@@ -115,6 +117,7 @@ private:
   XbmcThreads::EndTime m_nextUsedReadTime;
   std::string  m_cpuModel;
   std::string  m_cpuBogoMips;
+  std::string  m_cpuSoC;
   std::string  m_cpuHardware;
   std::string  m_cpuRevision;
   std::string  m_cpuSerial;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -498,6 +498,13 @@ std::string CSysInfo::GetCPUBogoMips()
   return "BogoMips: " + g_cpuInfo.getCPUBogoMips();
 }
 
+std::string CSysInfo::GetCPUSoC()
+{
+  if (!g_cpuInfo.getCPUSoC().empty())
+    return "SoC: " + g_cpuInfo.getCPUSoC();
+  return "";
+}
+
 std::string CSysInfo::GetCPUHardware()
 {
   return "Hardware: " + g_cpuInfo.getCPUHardware();

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -27,6 +27,7 @@
 #include "settings/Settings.h"
 #include "platform/Filesystem.h"
 #include "utils/log.h"
+#include "utils/SysfsUtils.h"
 
 #ifdef TARGET_WINDOWS
 #include "dwmapi.h"
@@ -771,6 +772,20 @@ std::string CSysInfo::GetManufacturerName(void)
     auto eas = EasClientDeviceInformation();
     auto manufacturer = eas.SystemManufacturer();
     g_charsetConverter.wToUTF8(std::wstring(manufacturer.c_str()), manufName);
+#elif defined(TARGET_LINUX)
+    if (SysfsUtils::Has("/sys/bus/soc/devices/soc0/family"))
+    {
+      std::string family;
+      SysfsUtils::GetString("/sys/bus/soc/devices/soc0/family", family);
+      if (SysfsUtils::Has("/sys/bus/soc/devices/soc0/soc_id"))
+      {
+        std::string soc_id;
+        SysfsUtils::GetString("/sys/bus/soc/devices/soc0/soc_id", soc_id);
+        manufName = family + " " + soc_id;
+      }
+      else
+        manufName = family;
+    }
 #elif defined(TARGET_WINDOWS)
     // We just don't care, might be useful on embedded
 #endif
@@ -804,6 +819,9 @@ std::string CSysInfo::GetModelName(void)
     auto eas = EasClientDeviceInformation();
     auto manufacturer = eas.SystemProductName();
     g_charsetConverter.wToUTF8(std::wstring(manufacturer.c_str()), modelName);
+#elif defined(TARGET_LINUX)
+    if (SysfsUtils::Has("/sys/bus/soc/devices/soc0/machine"))
+      SysfsUtils::GetString("/sys/bus/soc/devices/soc0/machine", modelName);
 #elif defined(TARGET_WINDOWS)
     // We just don't care, might be useful on embedded
 #endif

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -122,6 +122,7 @@ public:
   static const std::string& GetKernelCpuFamily(void);
   std::string GetCPUModel();
   std::string GetCPUBogoMips();
+  std::string GetCPUSoC();
   std::string GetCPUHardware();
   std::string GetCPURevision();
   std::string GetCPUSerial();

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -147,6 +147,8 @@ void CGUIWindowSystemInfo::FrameMove()
     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUModel());
 #if defined(__arm__) && defined(TARGET_LINUX)
     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUBogoMips());
+    if (!g_sysinfo.GetCPUSoC().empty())
+      SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUSoC());
     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUHardware());
     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPURevision());
     SET_CONTROL_LABEL(i++, g_sysinfo.GetCPUSerial());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Newer platforms upstreamed uses the newly introduced SoC sysfs interface to give userspace information about the system SoC family, id and revision. It also gives the current board model.

The interface is documented at : https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-soc

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Under Upstream Linux, the SystemInfo and CPUInfo does not gather very usefull information on the underlying hardware except the CPU model.
These changes makes the SystemInfo and CPUInfo make precise about the actual board running Kodi.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
The patch has been tested on multiple Amlogic SoCs running Linux 4.18 running the LibreELEC distribution.

The kodi Log now shows:
```
11:11:51.575 T:4098215136  NOTICE: Running on Amlogic Meson GXL (S905X) Libre Technology CC with LibreELEC (community): devel-20180911132354-c6fa5b5 9.1, kernel: Linux ARM 64-bit version 4.18.6
```

## Screenshots (if appropriate):
![Kodi on Libre Computer CC](https://user-images.githubusercontent.com/492099/45432274-c378c400-b6a9-11e8-95d1-d58b14910863.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed


