### PR TITLE
[PVR] Fix recording thumbnail/channel logo not displayed in video OSD.

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -245,7 +245,7 @@
 				<width>200</width>
 				<height>200</height>
 				<aspectratio aligny="center">keep</aspectratio>
-				<texture>$INFO[Player.Art(thumb)]</texture>
+				<texture>$INFO[Player.Icon]</texture>
 			</control>
 			<control type="textbox">
 				<left>260</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -51,8 +51,8 @@
 	<variable name="NowPlayingPosterVar">
 		<value condition="!String.IsEmpty(Player.Art(poster))">$INFO[Player.Art(poster)]</value>
 		<value condition="!String.IsEmpty(Player.Art(tvshow.poster))">$INFO[Player.Art(tvshow.poster)]</value>
-		<value condition="String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(livetv)">DefaultTVShows.png</value>
-		<value>$INFO[Player.Art(thumb)]</value>
+		<value condition="String.IsEmpty(Player.Icon) + VideoPlayer.Content(livetv)">DefaultTVShows.png</value>
+		<value>$INFO[Player.Icon]</value>
 	</variable>
 	<variable name="ShiftThumbVar">
 		<value condition="ListItem.IsParentFolder">DefaultFolderBackSquare.png</value>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -194,7 +194,22 @@ CFileItem::CFileItem(const CPVRRecordingPtr& record)
   m_pvrRecordingInfoTag = record;
   m_strPath = record->m_strFileNameAndPath;
   SetLabel(record->m_strTitle);
-  m_strLabel2 = record->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false);
+  m_dateTime = record->RecordingTimeAsLocalTime();
+  m_strLabel2 = m_dateTime.GetAsLocalizedDateTime(true, false);
+
+  // Set art
+  if (!record->m_strIconPath.empty())
+  {
+    SetIconImage(record->m_strIconPath);
+    SetArt("icon", record->m_strIconPath);
+  }
+
+  if (!record->m_strThumbnailPath.empty())
+    SetArt("thumb", record->m_strThumbnailPath);
+
+  if (!record->m_strFanartPath.empty())
+    SetArt("fanart", record->m_strFanartPath);
+
   FillInMimeType(false);
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -375,9 +375,15 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     Returns true if player is in frame advance mode. Skins should hide seek bar
 ///     in this mode)
 ///   }
+///   \table_row3{   <b>`Player.Icon`</b>,
+///                  \anchor Player_Icon
+///                  _string_,
+///     Returns the thumbnail of the currently playing item. If no thumbnail image exists\,
+///     the icon will be returned\, if available.
+///   }
 /// \table_end
 /// @}
-const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },           // bools from here
+const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },
                                   { "hasaudio",         PLAYER_HAS_AUDIO },
                                   { "hasvideo",         PLAYER_HAS_VIDEO },
                                   { "hasgame",          PLAYER_HAS_GAME },
@@ -405,7 +411,7 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "muted",            PLAYER_MUTED },
                                   { "hasduration",      PLAYER_HASDURATION },
                                   { "passthrough",      PLAYER_PASSTHROUGH },
-                                  { "cachelevel",       PLAYER_CACHELEVEL },          // labels from here
+                                  { "cachelevel",       PLAYER_CACHELEVEL },
                                   { "title",            PLAYER_TITLE },
                                   { "progress",         PLAYER_PROGRESS },
                                   { "progresscache",    PLAYER_PROGRESS_CACHE },
@@ -421,13 +427,14 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "isinternetstream", PLAYER_ISINTERNETSTREAM },
                                   { "pauseenabled",     PLAYER_CAN_PAUSE },
                                   { "seekenabled",      PLAYER_CAN_SEEK },
-                                  { "channelpreviewactive", PLAYER_IS_CHANNEL_PREVIEW_ACTIVE},
-                                  { "tempoenabled", PLAYER_SUPPORTS_TEMPO},
-                                  { "istempo", PLAYER_IS_TEMPO},
-                                  { "playspeed", PLAYER_PLAYSPEED},
-                                  { "hasprograms", PLAYER_HAS_PROGRAMS},
-                                  { "hasresolutions", PLAYER_HAS_RESOLUTIONS},
-                                  { "frameadvance", PLAYER_FRAMEADVANCE}};
+                                  { "channelpreviewactive", PLAYER_IS_CHANNEL_PREVIEW_ACTIVE },
+                                  { "tempoenabled",     PLAYER_SUPPORTS_TEMPO },
+                                  { "istempo",          PLAYER_IS_TEMPO },
+                                  { "playspeed",        PLAYER_PLAYSPEED },
+                                  { "hasprograms",      PLAYER_HAS_PROGRAMS },
+                                  { "hasresolutions",   PLAYER_HAS_RESOLUTIONS },
+                                  { "frameadvance",     PLAYER_FRAMEADVANCE },
+                                  { "icon",             PLAYER_ICON }};
 
 /// \page modules__General__List_of_gui_access
 /// @{

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -70,6 +70,7 @@
 #define PLAYER_HAS_PROGRAMS          63
 #define PLAYER_HAS_RESOLUTIONS       64
 #define PLAYER_FRAMEADVANCE          65
+#define PLAYER_ICON                  66
 
 #define WEATHER_CONDITIONS_TEXT     100
 #define WEATHER_TEMPERATURE         101

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -285,6 +285,13 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case PLAYER_ITEM_ART:
       value = item->GetArt(info.GetData3());
       return true;
+    case PLAYER_ICON:
+      value = item->GetArt("thumb");
+      if (value.empty())
+        value = item->GetIconImage();
+      if (fallback)
+        *fallback = item->GetIconImage();
+      return true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // PLAYER_PROCESS_*

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -109,7 +109,7 @@ void CPVRRecordings::GetSubDirectories(const CPVRRecordingsPath &recParentPath, 
     else
     {
       pFileItem = results->Get(strFilePath);
-      if (pFileItem->m_dateTime<current->RecordingTimeAsLocalTime())
+      if (pFileItem->m_dateTime < current->RecordingTimeAsLocalTime())
         pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
     }
 
@@ -287,7 +287,7 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
     // get all files of the current directory or recursively all files starting at the current directory if in flatten mode
     for (const auto recording : m_recordings)
     {
-      CPVRRecordingPtr current = recording.second;
+      const CPVRRecordingPtr current = recording.second;
 
       // Omit recordings not matching criteria
       if (!IsDirectoryMember(strDirectory, current->m_strDirectory, bGrouped) ||
@@ -297,28 +297,9 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
 
       current->UpdateMetadata(GetVideoDatabase());
 
-      CFileItemPtr pFileItem(new CFileItem(current));
-      pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
-
-      // Set art
-      if (!current->m_strIconPath.empty())
-      {
-        pFileItem->SetIconImage(current->m_strIconPath);
-        pFileItem->SetArt("icon", current->m_strIconPath);
-      }
-
-      if (!current->m_strThumbnailPath.empty())
-        pFileItem->SetArt("thumb", current->m_strThumbnailPath);
-
-      if (!current->m_strFanartPath.empty())
-        pFileItem->SetArt("fanart", current->m_strFanartPath);
-
-      // Use the channel icon as a fallback when a thumbnail is not available
-      pFileItem->SetArtFallback("thumb", "icon");
-
-      pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pFileItem->GetPVRRecordingInfoTag()->GetPlayCount() > 0);
-
-      items.Add(pFileItem);
+      const CFileItemPtr item = std::make_shared<CFileItem>(current);
+      item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, current->GetPlayCount() > 0);
+      items.Add(item);
     }
   }
 
@@ -330,17 +311,15 @@ void CPVRRecordings::GetAll(CFileItemList &items, bool bDeleted)
   CSingleLock lock(m_critSection);
   for (const auto recording : m_recordings)
   {
-    CPVRRecordingPtr current = recording.second;
+    const CPVRRecordingPtr current = recording.second;
     if (current->IsDeleted() != bDeleted)
       continue;
 
     current->UpdateMetadata(GetVideoDatabase());
 
-    CFileItemPtr pFileItem(new CFileItem(current));
-    pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
-    pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pFileItem->GetPVRRecordingInfoTag()->GetPlayCount() > 0);
-
-    items.Add(pFileItem);
+    const CFileItemPtr item = std::make_shared<CFileItem>(current);
+    item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, current->GetPlayCount() > 0);
+    items.Add(item);
   }
 }
 


### PR DESCRIPTION
Before (no matter there was a thumbnail avail):

![screenshot002](https://user-images.githubusercontent.com/3226626/45381788-9fb07200-b606-11e8-9a9a-83a9600b656e.png)

After (if thumbnail avail):

![screenshot001](https://user-images.githubusercontent.com/3226626/45381809-ab9c3400-b606-11e8-8068-2a3931cadbc9.png)

Second commit fixes video OSD channel logo not displayed as fallback if not thumbnail is available.

Runtime-tested on macOS, latest kodi master
@azlm8t fyi

@ronie this introduces a new guiinfo label `Player.Icon` with the same functionality as the existing `Listitem.Icon`.
