### PR TITLE
RetroPlayer: Improve error message when game.libretro is missing

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15162,7 +15162,8 @@ msgctxt "#24103"
 msgid "Skin is missing some files"
 msgstr ""
 
-#: xbmc/addons/Repository.cpp
+#. Error message shown when a game add-on can't be loaded due to missing dependencies
+#: xbmc/games/addons/GameClientProperties.cpp
 msgctxt "#24104"
 msgid "Add-on is incompatible due to unmet dependencies."
 msgstr ""
@@ -17311,6 +17312,7 @@ msgstr ""
 
 #. Dialog title when gameplay fails
 #: xbmc/games/addons/GameClient.cpp
+#: xbmc/games/addons/GameClientProperties.cpp
 #: xbmc/games/GameManager.cpp
 msgctxt "#35210"
 msgid "Failed to play game"
@@ -17388,7 +17390,11 @@ msgctxt "#35222"
 msgid "Exit"
 msgstr ""
 
-#empty string with id 35223
+#. Help text shown when playaing a game with missing add-on dependencies. {0:s} - list of add-ons that are missing
+#: xbmc/games/addons/GameClientProperties.cpp
+msgctxt "#35223"
+msgid "Missing: {0:s}"
+msgstr ""
 
 #. Label of button in the in-game menu for pausing and resuming playback
 #: addons/skin.estuary/xml/GameOSD.xml

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -187,7 +187,8 @@ bool CGameClient::Initialize(void)
   if (!CDirectory::Exists(savestatesDir))
     CDirectory::Create(savestatesDir);
 
-  AddonProperties().InitializeProperties();
+  if (!AddonProperties().InitializeProperties())
+    return false;
 
   m_struct.toKodi.kodiInstance = this;
   m_struct.toKodi.CloseGame = cb_close_game;

--- a/xbmc/games/addons/GameClientProperties.h
+++ b/xbmc/games/addons/GameClientProperties.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "addons/Addon.h"
 #include "games/GameTypes.h"
 
 #include <string>
@@ -35,7 +36,7 @@ public:
   CGameClientProperties(const CGameClient& parent, AddonProps_Game& props);
   ~CGameClientProperties(void) { ReleaseResources(); }
 
-  void InitializeProperties(void);
+  bool InitializeProperties(void);
 
 private:
   // Release mutable resources
@@ -45,7 +46,7 @@ private:
   const char* GetLibraryPath(void);
 
   // List of proxy DLLs needed to load the game client
-  const char** GetProxyDllPaths(void);
+  const char** GetProxyDllPaths(const ADDON::VECADDONS &addons);
 
   // Number of proxy DLLs needed to load the game client
   unsigned int GetProxyDllCount(void) const;
@@ -66,6 +67,7 @@ private:
   unsigned int GetExtensionCount(void) const;
 
   // Helper functions
+  bool GetProxyAddons(ADDON::VECADDONS &addons);
   void AddProxyDll(const GameClientPtr& gameClient);
   bool HasProxyDll(const std::string& strLibPath) const;
 


### PR DESCRIPTION
This improves the error message when game.libretro is missing.

## How Has This Been Tested?
Test builds: https://github.com/garbear/xbmc/releases

Tested on OSX. Tested with no add-ons, and the new error was shown. Tested with add-ons, and libretro cores load successfully.

## Screenshots (if appropriate):

Before:

![screen shot 2018-09-12 at 3 12 56 pm](https://user-images.githubusercontent.com/531482/45456188-b2768580-b69e-11e8-9319-39f0daadaa11.png)

After:

![screen shot 2018-09-12 at 3 30 09 pm](https://user-images.githubusercontent.com/531482/45456749-c8854580-b6a0-11e8-89cd-d9852cedd5bf.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
