### PR TITLE
AEBitstreamPacker: Differentiate between DTS-HD-MA and DTS-HD-HR

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2666,6 +2666,8 @@ bool CActiveAE::SupportsRaw(AEAudioFormat &format)
     return false;
   if (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD && !m_settings.dtshdpassthrough)
     return false;
+  if (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD_MA && !m_settings.dtshdpassthrough)
+    return false;
 
   if (!m_sink.SupportsFormat(CServiceBroker::GetSettings()->GetString(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE), format))
     return false;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -142,6 +142,7 @@ bool CActiveAESink::SupportsFormat(const std::string &device, AEAudioFormat &for
                 break;
 
               case CAEStreamInfo::STREAM_TYPE_DTSHD:
+              case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
                 samplerate = 192000;
                 break;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -110,7 +110,7 @@ inline CAEChannelInfo CAESinkALSA::GetChannelLayoutRaw(const AEAudioFormat& form
 
   switch (format.m_streamInfo.m_type)
   {
-    case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
       count = 8;
       break;
@@ -120,6 +120,7 @@ inline CAEChannelInfo CAESinkALSA::GetChannelLayoutRaw(const AEAudioFormat& form
     case CAEStreamInfo::STREAM_TYPE_DTS_2048:
     case CAEStreamInfo::STREAM_TYPE_AC3:
     case CAEStreamInfo::STREAM_TYPE_EAC3:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD:
       count = 2;
       break;
     default:
@@ -1521,6 +1522,7 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
     // we don't trust ELD information and push back our supported formats explicitly
     info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
     info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+    info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
     info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
     info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
     info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -350,7 +350,7 @@ inline CAEChannelInfo CAESinkOSS::GetChannelLayout(const AEAudioFormat& format)
   {
     switch (format.m_streamInfo.m_type)
     {
-    case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
       count = 8;
       break;
@@ -360,6 +360,7 @@ inline CAEChannelInfo CAESinkOSS::GetChannelLayout(const AEAudioFormat& format)
     case CAEStreamInfo::STREAM_TYPE_DTS_2048:
     case CAEStreamInfo::STREAM_TYPE_AC3:
     case CAEStreamInfo::STREAM_TYPE_EAC3:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD:
       count = 2;
       break;
     default:
@@ -494,6 +495,7 @@ void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
       info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
       info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+      info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
       info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
       info.m_dataFormats.push_back(AE_FMT_RAW);
     }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -421,6 +421,39 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = pDevice->Activate(pClient.GetAddressOf());
     if (SUCCEEDED(hr))
     {
+      /* Test format DTS-HD-HR */
+      wfxex.Format.cbSize               = sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX);
+      wfxex.Format.nSamplesPerSec       = 192000;
+      wfxex.dwChannelMask               = KSAUDIO_SPEAKER_5POINT1;
+      wfxex.Format.wFormatTag           = WAVE_FORMAT_EXTENSIBLE;
+      wfxex.SubFormat                   = KSDATAFORMAT_SUBTYPE_IEC61937_DTS_HD;
+      wfxex.Format.wBitsPerSample       = 16;
+      wfxex.Samples.wValidBitsPerSample = 16;
+      wfxex.Format.nChannels            = 2;
+      wfxex.Format.nBlockAlign          = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
+      wfxex.Format.nAvgBytesPerSec      = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
+      hr = pClient->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, &wfxex.Format, NULL);
+      if (hr == AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED)
+      {
+        CLog::LogF(LOGNOTICE,
+                   "Exclusive mode is not allowed on device \"%s\", check device settings.",
+                   details.strDescription);
+        SafeRelease(&pDevice);
+        continue;
+      }
+      if (SUCCEEDED(hr) || details.eDeviceType == AE_DEVTYPE_HDMI)
+      {
+        if(FAILED(hr))
+        {
+          CLog::LogF(LOGNOTICE, "stream type \"%s\" on device \"%s\" seems to be not supported.",
+                     CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD),
+                     details.strDescription);
+        }
+
+        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+        add192 = true;
+      }
+
       /* Test format DTS-HD */
       wfxex.Format.cbSize               = sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX);
       wfxex.Format.nSamplesPerSec       = 192000;
@@ -446,11 +479,11 @@ void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
         if(FAILED(hr))
         {
           CLog::LogF(LOGNOTICE, "stream type \"%s\" on device \"%s\" seems to be not supported.",
-                     CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD),
+                     CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD_MA),
                      details.strDescription);
         }
 
-        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+        deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
         add192 = true;
       }
 

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.cpp
@@ -107,8 +107,8 @@ const char *WASAPIErrToStr(HRESULT err)
     {
       wfxex.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
       if (format.m_dataFormat == AE_FMT_RAW &&
-        ((format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_AC3) ||
-        (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3) ||
+         ((format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_AC3) ||
+          (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3) ||
           (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD_CORE) ||
           (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTS_2048) ||
           (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTS_1024) ||
@@ -127,8 +127,9 @@ const char *WASAPIErrToStr(HRESULT err)
           CLog::Log(LOGERROR, "Invalid sample rate supplied for RAW format");
       }
       else if (format.m_dataFormat == AE_FMT_RAW &&
-        ((format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD) ||
-        (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)))
+        ((format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD_MA) ||
+        (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD) ||
+        (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD)))
       {
         // IEC 61937 transmissions over HDMI
         wfxex.Format.nSamplesPerSec = 192000L;
@@ -143,10 +144,15 @@ const char *WASAPIErrToStr(HRESULT err)
           wfxex.Format.nChannels = 8; // Four IEC 60958 Lines.
           wfxex.dwChannelMask = KSAUDIO_SPEAKER_7POINT1_SURROUND;
           break;
-        case CAEStreamInfo::STREAM_TYPE_DTSHD:
+        case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
           wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DTS_HD;
           wfxex.Format.nChannels = 8; // Four IEC 60958 Lines.
           wfxex.dwChannelMask = KSAUDIO_SPEAKER_7POINT1_SURROUND;
+          break;
+        case CAEStreamInfo::STREAM_TYPE_DTSHD:
+          wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DTS_HD;
+          wfxex.Format.nChannels = 2; // One IEC 60958 Lines.
+          wfxex.dwChannelMask = KSAUDIO_SPEAKER_5POINT1;
           break;
         }
 

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -45,6 +45,7 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
       break;
 
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
       PackDTSHD (info, data, size);
       break;
 
@@ -90,6 +91,7 @@ bool CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, boo
 
     case CAEStreamInfo::STREAM_TYPE_AC3:
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
     case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
     case CAEStreamInfo::STREAM_TYPE_DTS_512:
     case CAEStreamInfo::STREAM_TYPE_DTS_1024:
@@ -258,6 +260,7 @@ unsigned int CAEBitstreamPacker::GetOutputRate(CAEStreamInfo &info)
       rate = info.m_sampleRate;
       break;
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
       rate = 192000;
       break;
     default:
@@ -278,11 +281,12 @@ CAEChannelInfo CAEBitstreamPacker::GetOutputChannelMap(CAEStreamInfo &info)
     case CAEStreamInfo::STREAM_TYPE_DTS_1024:
     case CAEStreamInfo::STREAM_TYPE_DTS_2048:
     case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD:
       channels = 2;
       break;
 
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
-    case CAEStreamInfo::STREAM_TYPE_DTSHD:
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
       channels = 8;
       break;
 

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -36,7 +36,8 @@ public:
     STREAM_TYPE_DTSHD_CORE,
     STREAM_TYPE_EAC3,
     STREAM_TYPE_MLP,
-    STREAM_TYPE_TRUEHD
+    STREAM_TYPE_TRUEHD,
+    STREAM_TYPE_DTSHD_MA
   };
   DataType m_type = STREAM_TYPE_NULL;
   unsigned int m_sampleRate;

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -154,6 +154,8 @@ const char* CAEUtil::StreamTypeToStr(const enum CAEStreamInfo::DataType dataType
       return "STREAM_TYPE_AC3";
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
       return "STREAM_TYPE_DTSHD";
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
+      return "STREAM_TYPE_DTSHD_MA";
     case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
       return "STREAM_TYPE_DTSHD_CORE";
     case CAEStreamInfo::STREAM_TYPE_DTS_1024:


### PR DESCRIPTION
Recent AVRs produce crackling and noise when DTS-HD-HR is sent via 8 channels / 192 khz. A solution investigated and found by the colleagues of lavfilters is to transmit this content via 192 khz / 2 channels.

The core part of this solution was implemented by the OSMC team. I adapted it and tried to keep ownership as the original commit was only in patchform.

Succesfully tested on:
- ALSA
- Audiotrack (Nvidia Shield)
- AudioTrack (AMLogic)
- Windows 64 with WASAPI