### PR TITLE
Fix log format string in PeripheralJoystick

### DIFF
--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -73,7 +73,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
       // Ensure an add-on is present to translate input
       if (!m_manager.GetAddonWithButtonMap(this))
       {
-        CLog::Log(LOGERROR, "CPeripheralJoystick: No button mapping add-on for %", m_strLocation.c_str());
+        CLog::Log(LOGERROR, "CPeripheralJoystick: No button mapping add-on for %s", m_strLocation.c_str());
       }
       else
       {


### PR DESCRIPTION
## Description
see title

## Motivation and Context
can lead to segfaults during startup / wrong log output

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
