### PR TITLE
[Android] call OnResetDisplay() on HDMI_AUDIO_PLUG event

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -82,6 +82,7 @@ set(package_files strings.xml
                   src/interfaces/XBMCNsdManagerRegistrationListener.java
                   src/interfaces/XBMCNsdManagerDiscoveryListener.java
                   src/interfaces/XBMCMediaDrmOnEventListener.java
+                  src/interfaces/XBMCDisplayManagerDisplayListener.java
                   src/model/TVEpisode.java
                   src/model/Movie.java
                   src/model/TVShow.java

--- a/tools/android/packaging/xbmc/src/interfaces/XBMCDisplayManagerDisplayListener.java.in
+++ b/tools/android/packaging/xbmc/src/interfaces/XBMCDisplayManagerDisplayListener.java.in
@@ -1,0 +1,28 @@
+package @APP_PACKAGE@.interfaces;
+
+import android.hardware.display.DisplayManager;
+
+public class XBMCDisplayManagerDisplayListener implements DisplayManager.DisplayListener
+{
+  native void _onDisplayAdded(int displayId);
+  native void _onDisplayChanged(int displayId);
+  native void _onDisplayRemoved(int displayId);
+
+  @Override
+  public void onDisplayAdded(int displayId)
+  {
+    _onDisplayAdded(displayId);
+  }
+
+  @Override
+  public void onDisplayChanged(int displayId)
+  {
+    _onDisplayChanged(displayId);
+  }
+
+  @Override
+  public void onDisplayRemoved(int displayId)
+  {
+    _onDisplayRemoved(displayId);
+  }
+}

--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=6f753a823b587c192d2b41575f4b71f7c3dd69cc
+VERSION=fe51b38eedf2b0219d45ae62e763fbe4e45dfb76
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/platform/android/activity/CMakeLists.txt
+++ b/xbmc/platform/android/activity/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES android_main.cpp
             JNIXBMCNsdManagerResolveListener.cpp
             JNIXBMCJsonHandler.cpp
             JNIXBMCFile.cpp
+            JNIXBMCDisplayManagerDisplayListener.cpp
             ${NDKROOT}/sources/android/native_app_glue/android_native_app_glue.c
             ${NDKROOT}/sources/android/cpufeatures/cpu-features.c)
 
@@ -41,6 +42,7 @@ set(HEADERS AndroidExtra.h
             JNIXBMCNsdManagerResolveListener.h
             JNIXBMCJsonHandler.h
             JNIXBMCFile.h
+            JNIXBMCDisplayManagerDisplayListener.h
             XBMCApp.h)
 
 core_add_library(platform_android_activity)

--- a/xbmc/platform/android/activity/JNIMainActivity.h
+++ b/xbmc/platform/android/activity/JNIMainActivity.h
@@ -45,4 +45,8 @@ protected:
   virtual void onVolumeChanged(int volume)=0;
   virtual void doFrame(int64_t frameTimeNanos)=0;
   virtual void onVisibleBehindCanceled() = 0;
+
+  virtual void onDisplayAdded(int displayId)=0;
+  virtual void onDisplayChanged(int displayId)=0;
+  virtual void onDisplayRemoved(int displayId)=0;
 };

--- a/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016 Christian Browet
+ *  Copyright (C) 2018 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
@@ -32,9 +32,9 @@ void CJNIXBMCDisplayManagerDisplayListener::RegisterNatives(JNIEnv* env)
   {
     JNINativeMethod methods[] =
     {
-      {"_onDisplayAdded", "(I)V", (void*)&CJNIXBMCDisplayManagerDisplayListener::_onDisplayAdded},
-      {"_onDisplayChanged", "(I)V", (void*)&CJNIXBMCDisplayManagerDisplayListener::_onDisplayChanged},
-      {"_onDisplayRemoved", "(I)V", (void*)&CJNIXBMCDisplayManagerDisplayListener::_onDisplayRemoved},
+      {"_onDisplayAdded", "(I)V", reinterpret_cast<void*>(&CJNIXBMCDisplayManagerDisplayListener::_onDisplayAdded)},
+      {"_onDisplayChanged", "(I)V", reinterpret_cast<void*>(&CJNIXBMCDisplayManagerDisplayListener::_onDisplayChanged)},
+      {"_onDisplayRemoved", "(I)V", reinterpret_cast<void*>(&CJNIXBMCDisplayManagerDisplayListener::_onDisplayRemoved)},
     };
 
     env->RegisterNatives(cClass, methods, sizeof(methods)/sizeof(methods[0]));

--- a/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2016 Christian Browet
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIXBMCDisplayManagerDisplayListener.h"
+#include <androidjni/jutils-details.hpp>
+
+#include <androidjni/Context.h>
+#include "CompileInfo.h"
+
+#include "XBMCApp.h"
+
+using namespace jni;
+
+static std::string s_className = std::string(CCompileInfo::GetClass()) + "/interfaces/XBMCDisplayManagerDisplayListener";
+
+CJNIXBMCDisplayManagerDisplayListener::CJNIXBMCDisplayManagerDisplayListener()
+  : CJNIBase(s_className)
+{
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName(s_className)));
+  m_object.setGlobal();
+}
+
+void CJNIXBMCDisplayManagerDisplayListener::RegisterNatives(JNIEnv* env)
+{
+  jclass cClass = env->FindClass(s_className.c_str());
+  if(cClass)
+  {
+    JNINativeMethod methods[] =
+    {
+      {"_onDisplayAdded", "(I)V", (void*)&CJNIXBMCDisplayManagerDisplayListener::_onDisplayAdded},
+      {"_onDisplayChanged", "(I)V", (void*)&CJNIXBMCDisplayManagerDisplayListener::_onDisplayChanged},
+      {"_onDisplayRemoved", "(I)V", (void*)&CJNIXBMCDisplayManagerDisplayListener::_onDisplayRemoved},
+    };
+
+    env->RegisterNatives(cClass, methods, sizeof(methods)/sizeof(methods[0]));
+  }
+}
+
+void CJNIXBMCDisplayManagerDisplayListener::_onDisplayAdded(JNIEnv *env, jobject context, jint displayId)
+{
+  static_cast<void>(env);
+  static_cast<void>(context);
+
+  CXBMCApp::get()->onDisplayAdded(displayId);
+}
+
+void CJNIXBMCDisplayManagerDisplayListener::_onDisplayChanged(JNIEnv *env, jobject context, jint displayId)
+{
+  static_cast<void>(env);
+  static_cast<void>(context);
+
+  CXBMCApp::get()->onDisplayChanged(displayId);
+}
+
+void CJNIXBMCDisplayManagerDisplayListener::_onDisplayRemoved(JNIEnv *env, jobject context, jint displayId)
+{
+  static_cast<void>(env);
+  static_cast<void>(context);
+
+  CXBMCApp::get()->onDisplayRemoved(displayId);
+}

--- a/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.h
+++ b/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2016 Christian Browet
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <androidjni/JNIBase.h>
+
+class CJNIXBMCDisplayManagerDisplayListener : public CJNIBase
+{
+public:
+  CJNIXBMCDisplayManagerDisplayListener();
+  CJNIXBMCDisplayManagerDisplayListener(const jni::jhobject &object) : CJNIBase(object) {}
+
+  static void RegisterNatives(JNIEnv* env);
+
+protected:
+  static void _onDisplayAdded(JNIEnv* env, jobject thiz, int displayId);
+  static void _onDisplayChanged(JNIEnv* env, jobject thiz, int displayId);
+  static void _onDisplayRemoved(JNIEnv* env, jobject thiz, int displayId);
+};

--- a/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.h
+++ b/xbmc/platform/android/activity/JNIXBMCDisplayManagerDisplayListener.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016 Christian Browet
+ *  Copyright (C) 2018 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -31,6 +31,7 @@
 #include <androidjni/Context.h>
 #include <androidjni/Cursor.h>
 #include <androidjni/Display.h>
+#include <androidjni/DisplayManager.h>
 #include <androidjni/Environment.h>
 #include <androidjni/File.h>
 #include <androidjni/Intent.h>
@@ -84,7 +85,7 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "windowing/android/VideoSyncAndroid.h"
-#include "windowing/WinSystem.h"
+#include "windowing/android/WinSystemAndroid.h"
 #include "windowing/WinEvents.h"
 #include "platform/xbmc.h"
 
@@ -118,6 +119,7 @@ int CXBMCApp::m_batteryLevel = 0;
 bool CXBMCApp::m_hasFocus = false;
 bool CXBMCApp::m_headsetPlugged = false;
 bool CXBMCApp::m_hdmiPlugged = true;
+bool CXBMCApp::m_hdmiReportedState = true;
 IInputDeviceCallbacks* CXBMCApp::m_inputDeviceCallbacks = nullptr;
 IInputDeviceEventHandler* CXBMCApp::m_inputDeviceEventHandler = nullptr;
 bool CXBMCApp::m_hasReqVisible = false;
@@ -336,9 +338,20 @@ void CXBMCApp::onLostFocus()
   m_hasFocus = false;
 }
 
+void CXBMCApp::RegisterDisplayListener(CVariant* variant)
+{
+  CJNIDisplayManager displayManager(getSystemService("display"));
+  if (displayManager)
+  {
+    android_printf("CXBMCApp: installing DisplayManager::DisplayListener");
+    displayManager.registerDisplayListener(CXBMCApp::get()->getDisplayListener());
+  }
+}
+
 void CXBMCApp::Initialize()
 {
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(CXBMCApp::get());
+  runNativeOnUiThread(RegisterDisplayListener, nullptr);
 }
 
 void CXBMCApp::Deinitialize()
@@ -522,6 +535,11 @@ void CXBMCApp::SetDisplayModeCallback(CVariant* variant)
     CJNIWindowManagerLayoutParams params = window.getAttributes();
     if (params.getpreferredDisplayModeId() != mode)
     {
+      if (g_application.GetAppPlayer().IsPlaying())
+      {
+        dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(false);
+        m_hdmiReportedState = false;
+      }
       params.setpreferredDisplayModeId(mode);
       params.setpreferredRefreshRate(rate);
       window.setAttributes(params);
@@ -963,7 +981,12 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     {
       CLog::Log(LOGDEBUG, "-- HDMI state: %s",  newstate ? "on" : "off");
       m_hdmiPlugged = newstate;
-      CServiceBroker::GetActiveAE()->DeviceChange();
+      //CServiceBroker::GetActiveAE()->DeviceChange();
+      if (m_hdmiPlugged != m_hdmiReportedState)
+      {
+        dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(m_hdmiPlugged);
+        m_hdmiReportedState = m_hdmiPlugged;
+      }
     }
   }
   else if (action == "android.intent.action.SCREEN_OFF")
@@ -1314,12 +1337,29 @@ bool CXBMCApp::onInputDeviceEvent(const AInputEvent* event)
 }
 
 
+void CXBMCApp::onDisplayAdded(int displayId)
+{
+  android_printf("%s: ", __PRETTY_FUNCTION__);
+}
+
+void CXBMCApp::onDisplayChanged(int displayId)
+{
+  android_printf("%s: ", __PRETTY_FUNCTION__);
+}
+
+void CXBMCApp::onDisplayRemoved(int displayId)
+{
+  android_printf("%s: ", __PRETTY_FUNCTION__);
+}
+
 void CXBMCApp::surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height)
 {
+  android_printf("%s: ", __PRETTY_FUNCTION__);
 }
 
 void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
 {
+  android_printf("%s: ", __PRETTY_FUNCTION__);
   m_window = ANativeWindow_fromSurface(xbmc_jnienv(), holder.getSurface().get_raw());
   if (m_window == NULL)
   {
@@ -1334,6 +1374,7 @@ void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
 
 void CXBMCApp::surfaceDestroyed(CJNISurfaceHolder holder)
 {
+  android_printf("%s: ", __PRETTY_FUNCTION__);
   // If we have exited XBMC, it no longer exists.
   if (!m_exiting)
   {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -981,7 +981,6 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     {
       CLog::Log(LOGDEBUG, "-- HDMI state: %s",  newstate ? "on" : "off");
       m_hdmiPlugged = newstate;
-      //CServiceBroker::GetActiveAE()->DeviceChange();
       if (m_hdmiPlugged != m_hdmiReportedState)
       {
         dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(m_hdmiPlugged);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -516,6 +516,11 @@ void CXBMCApp::SetRefreshRateCallback(CVariant* rateVariant)
     CJNIWindowManagerLayoutParams params = window.getAttributes();
     if (params.getpreferredRefreshRate() != rate)
     {
+      if (g_application.GetAppPlayer().IsPlaying())
+      {
+        dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(false, 1000);
+        m_hdmiReportedState = false;
+      }
       params.setpreferredRefreshRate(rate);
       if (params.getpreferredRefreshRate() > 0.0)
         window.setAttributes(params);

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -30,6 +30,7 @@
 #include "IInputHandler.h"
 #include "JNIMainActivity.h"
 #include "JNIXBMCAudioManagerOnAudioFocusChangeListener.h"
+#include "JNIXBMCDisplayManagerDisplayListener.h"
 #include "JNIXBMCMainView.h"
 #include "JNIXBMCMediaSession.h"
 #include "platform/xbmc.h"
@@ -103,6 +104,12 @@ public:
   void onInputDeviceAdded(int deviceId) override;
   void onInputDeviceChanged(int deviceId) override;
   void onInputDeviceRemoved(int deviceId) override;
+
+  // implementation of DisplayManager::DisplayListener
+  void onDisplayAdded(int displayId) override;
+  void onDisplayChanged(int displayId) override;
+  void onDisplayRemoved(int displayId) override;
+  jni::jhobject getDisplayListener() { return m_displayListener.get_raw(); }
 
   bool isValid() { return m_activity != NULL; }
   const ANativeActivity *getActivity() const { return m_activity; }
@@ -201,21 +208,26 @@ protected:
 private:
   static CXBMCApp* m_xbmcappinstance;
   CJNIXBMCAudioManagerOnAudioFocusChangeListener m_audioFocusListener;
+  CJNIXBMCDisplayManagerDisplayListener m_displayListener;
   static std::unique_ptr<CJNIXBMCMainView> m_mainView;
   std::unique_ptr<jni::CJNIXBMCMediaSession> m_mediaSession;
   static bool HasLaunchIntent(const std::string &package);
   std::string GetFilenameFromIntent(const CJNIIntent &intent);
+
   void run();
   void stop();
   void SetupEnv();
   static void SetRefreshRateCallback(CVariant *rate);
   static void SetDisplayModeCallback(CVariant *mode);
+  static void RegisterDisplayListener(CVariant*);
+
   static ANativeActivity *m_activity;
   static CJNIWakeLock *m_wakeLock;
   static int m_batteryLevel;
   static bool m_hasFocus;
   static bool m_headsetPlugged;
   static bool m_hdmiPlugged;
+  static bool m_hdmiReportedState;
   static IInputDeviceCallbacks* m_inputDeviceCallbacks;
   static IInputDeviceEventHandler* m_inputDeviceEventHandler;
   static bool m_hasReqVisible;

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -26,6 +26,7 @@
 #include "platform/android/activity/JNIXBMCNsdManagerResolveListener.h"
 #include "platform/android/activity/JNIXBMCJsonHandler.h"
 #include "platform/android/activity/JNIXBMCFile.h"
+#include "platform/android/activity/JNIXBMCDisplayManagerDisplayListener.h"
 #include "utils/StringUtils.h"
 #include "XBMCApp.h"
 
@@ -132,15 +133,17 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
   std::string pkgRoot = CCompileInfo::GetClass();
 
-  std::string mainClass = pkgRoot + "/Main";
-  std::string bcReceiver = pkgRoot + "/XBMCBroadcastReceiver";
-  std::string settingsObserver = pkgRoot + "/XBMCSettingsContentObserver";
-  std::string inputDeviceListener = pkgRoot + "/XBMCInputDeviceListener";
+  const std::string mainClass = pkgRoot + "/Main";
+  const std::string bcReceiver = pkgRoot + "/XBMCBroadcastReceiver";
+  const std::string settingsObserver = pkgRoot + "/XBMCSettingsContentObserver";
+  const std::string inputDeviceListener = pkgRoot + "/XBMCInputDeviceListener";
 
   CJNIXBMCAudioManagerOnAudioFocusChangeListener::RegisterNatives(env);
   CJNIXBMCSurfaceTextureOnFrameAvailableListener::RegisterNatives(env);
   CJNIXBMCMainView::RegisterNatives(env);
   CJNIXBMCVideoView::RegisterNatives(env);
+  CJNIXBMCDisplayManagerDisplayListener::RegisterNatives(env);
+
   jni::CJNIXBMCNsdManagerDiscoveryListener::RegisterNatives(env);
   jni::CJNIXBMCNsdManagerRegistrationListener::RegisterNatives(env);
   jni::CJNIXBMCNsdManagerResolveListener::RegisterNatives(env);

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -199,7 +199,7 @@ void CWinSystemAndroid::OnTimeout()
   SetHDMIState(true);
 }
 
-void CWinSystemAndroid::SetHDMIState(bool connected)
+void CWinSystemAndroid::SetHDMIState(bool connected, uint32_t timeoutMs)
 {
   CSingleLock lock(m_resourceSection);
   if (connected && m_dispResetState == RESET_WAITEVENT)
@@ -209,12 +209,16 @@ void CWinSystemAndroid::SetHDMIState(bool connected)
   }
   else if (!connected)
   {
-    int delay = CServiceBroker::GetSettings()->GetInt("videoscreen.delayrefreshchange");
+    int delay = CServiceBroker::GetSettings()->GetInt("videoscreen.delayrefreshchange") * 100;
+
+    if (timeoutMs > delay)
+      delay = timeoutMs;
+
     if (delay > 0)
     {
        m_dispResetState = RESET_WAITTIMER;
        m_dispResetTimer->Stop();
-       m_dispResetTimer->Start(delay * 100);
+       m_dispResetTimer->Start(delay);
     }
     else
       m_dispResetState = RESET_WAITEVENT;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -34,6 +34,8 @@ public:
   bool DestroyWindow() override;
   void UpdateResolutions() override;
 
+  void SetHDMIState(bool connected);
+
   bool HasCursor() override { return false; };
 
   bool Hide() override;
@@ -58,9 +60,6 @@ protected:
   int m_displayHeight;
 
   RENDER_STEREO_MODE m_stereo_mode;
-
-  bool m_delayDispReset;
-  XbmcThreads::EndTime m_dispResetTimer;
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -13,12 +13,12 @@
 #include "rendering/gles/RenderSystemGLES.h"
 #include "threads/CriticalSection.h"
 #include "windowing/WinSystem.h"
-#include "threads/SystemClock.h"
+#include "threads/Timer.h"
 #include "EGL/egl.h"
 
 class IDispResource;
 
-class CWinSystemAndroid : public CWinSystemBase
+class CWinSystemAndroid : public CWinSystemBase, public ITimerCallback
 {
 public:
   CWinSystemAndroid();
@@ -50,6 +50,7 @@ public:
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
+  void OnTimeout() override;
 
   CAndroidUtils *m_android;
 
@@ -60,6 +61,16 @@ protected:
   int m_displayHeight;
 
   RENDER_STEREO_MODE m_stereo_mode;
+
+  enum RESETSTATE
+  {
+    RESET_NOTWAITING,
+    RESET_WAITTIMER,
+    RESET_WAITEVENT
+  };
+
+  RESETSTATE m_dispResetState;
+  CTimer *m_dispResetTimer;
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -34,7 +34,7 @@ public:
   bool DestroyWindow() override;
   void UpdateResolutions() override;
 
-  void SetHDMIState(bool connected);
+  void SetHDMIState(bool connected, uint32_t timeoutMs = 0);
 
   bool HasCursor() override { return false; };
 

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -66,14 +66,6 @@ bool CWinSystemAndroidGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_delayDispReset)
-  {
-    CSingleLock lock(m_resourceSection);
-    // tell any shared resources
-    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
-      (*i)->OnResetDisplay();
-  }
-
   return true;
 }
 
@@ -98,14 +90,6 @@ void CWinSystemAndroidGLESContext::SetVSyncImpl(bool enable)
 
 void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
 {
-  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
-  {
-    m_delayDispReset = false;
-    CSingleLock lock(m_resourceSection);
-    // tell any shared resources
-    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
-      (*i)->OnResetDisplay();
-  }
   // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
   // we can't actually do anything about it
   if (rendered && !m_pGLContext.TrySwapBuffers() && eglGetError() != EGL_BAD_SURFACE)


### PR DESCRIPTION
## Description
Call OnResetDisplay on HDMI_ADIO_PLUG event, it seems so far the only intent which notifies kodi when the Display / TV is available after a resolution / refreshrate switch.

## Motivation and Context
SetDisplayMode (refresh rate switch) can take some time on Android devices because android terminates / restarts all apps to make sure changes are reflected.

Currently we call onResetDisplay directly after onLostDisplay what lead to lost of the stream begin and can lead to issues during surfaceCreation / HDCP initialization.

This PR notifies Player to continue at the shortest possible time,

## How Has This Been Tested?
NVIDIA shield / AFTV4 / Wetek HUB, force a Displaymode change.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
