### PR TITLE
 CDRMPRIMEEGL: specify EGL colorspace and colorrange

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -8,6 +8,8 @@
 
 #include "DRMPRIMEEGL.h"
 
+#include "utils/log.h"
+
 void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
 {
   m_eglImage.reset(new CEGLImage(eglDisplay));
@@ -40,6 +42,8 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME *buffer)
     attribs.width = m_texWidth;
     attribs.height = m_texHeight;
     attribs.format = layer->format;
+    attribs.colorSpace = GetColorSpace(buffer->GetColorEncoding());
+    attribs.colorRange = GetColorRange(buffer->GetColorRange());
     attribs.planes = planes;
 
     if (!m_eglImage->CreateImage(attribs))
@@ -72,4 +76,38 @@ void CDRMPRIMETexture::Unmap()
 
   m_primebuffer->Release();
   m_primebuffer = nullptr;
+}
+
+int CDRMPRIMETexture::GetColorSpace(int colorSpace)
+{
+  switch(colorSpace)
+  {
+    case DRM_COLOR_YCBCR_BT2020:
+      return EGL_ITU_REC2020_EXT;
+    case DRM_COLOR_YCBCR_BT601:
+      return EGL_ITU_REC601_EXT;
+    case DRM_COLOR_YCBCR_BT709:
+      return EGL_ITU_REC709_EXT;
+    default:
+      CLog::Log(LOGERROR, "CEGLImage::%s - failed to get colorspace for: %d", __FUNCTION__, colorSpace);
+      break;
+  }
+
+  return -1;
+}
+
+int CDRMPRIMETexture::GetColorRange(int colorRange)
+{
+  switch(colorRange)
+  {
+    case DRM_COLOR_YCBCR_FULL_RANGE:
+      return EGL_YUV_FULL_RANGE_EXT;
+    case DRM_COLOR_YCBCR_LIMITED_RANGE:
+      return EGL_YUV_NARROW_RANGE_EXT;
+    default:
+      CLog::Log(LOGERROR, "CEGLImage::%s - failed to get colorrange for: %d", __FUNCTION__, colorRange);
+      break;
+  }
+
+  return -1;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -31,4 +31,9 @@ protected:
   GLuint m_texture{0};
   int m_texWidth{0};
   int m_texHeight{0};
+
+private:
+  static int GetColorSpace(int colorSpace);
+  static int GetColorRange(int colorRange);
+
 };

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -7,10 +7,9 @@
  */
 
 #include "EGLImage.h"
+
 #include "EGLUtils.h"
 #include "log.h"
-
-/* --- CEGLImage -------------------------------------------*/
 
 namespace
 {
@@ -67,11 +66,13 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
                {EGL_HEIGHT, imageAttrs.height},
                {EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(imageAttrs.format)}});
 
-  /* this should be configurable at a later point */
-  attribs.Add({{EGL_YUV_COLOR_SPACE_HINT_EXT, EGL_ITU_REC709_EXT},
-               {EGL_SAMPLE_RANGE_HINT_EXT, EGL_YUV_NARROW_RANGE_EXT},
-               {EGL_YUV_CHROMA_VERTICAL_SITING_HINT_EXT, EGL_YUV_CHROMA_SITING_0_EXT},
-               {EGL_YUV_CHROMA_HORIZONTAL_SITING_HINT_EXT, EGL_YUV_CHROMA_SITING_0_EXT}});
+  if (imageAttrs.colorSpace != 0 && imageAttrs.colorRange != 0)
+  {
+    attribs.Add({{EGL_YUV_COLOR_SPACE_HINT_EXT, imageAttrs.colorSpace},
+                 {EGL_SAMPLE_RANGE_HINT_EXT, imageAttrs.colorRange},
+                 {EGL_YUV_CHROMA_VERTICAL_SITING_HINT_EXT, EGL_YUV_CHROMA_SITING_0_EXT},
+                 {EGL_YUV_CHROMA_HORIZONTAL_SITING_HINT_EXT, EGL_YUV_CHROMA_SITING_0_EXT}});
+  }
 
   for (int i = 0; i < MAX_NUM_PLANES; i++)
   {

--- a/xbmc/utils/EGLImage.h
+++ b/xbmc/utils/EGLImage.h
@@ -34,6 +34,8 @@ public:
     int width{0};
     int height{0};
     uint32_t format{0};
+    int colorSpace{0};
+    int colorRange{0};
     std::array<EglPlane, MAX_NUM_PLANES> planes;
   };
 


### PR DESCRIPTION
This converts the colorange and colorspace like so:
~~AVColorSpace -> EGL_YUV_COLOR_SPACE_HINT_EXT
AVColorRange -> EGL_SAMPLE_RANGE_HINT_EXT~~

Needs some testing to make sure I don't break Retroplayer GBM Renderer.


@Kwiboo for review 😸 