### PR TITLE
Fix displaying watched items in plugins and restore functionality after #14409

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -335,10 +335,20 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
   }
   else if (url.IsProtocol("plugin"))
   {
+    if (!url.GetOptions().empty())
+    {
+      //! @todo Make a new python call to get the plugin content type and remove this temporary hack
+      // When a plugin provides multiple types, it has "plugin://addon.id/?content_type=xxx" root URL
+      if (url.GetFileName().empty() && url.HasOption("content_type") && url.GetOptions().find('&') == std::string::npos)
+        url.SetHostName("");
+      //
+      url.SetOptions("");
+      strParent = url.Get();
+      return true;
+    }
     if (!url.GetFileName().empty())
     {
       url.SetFileName("");
-      url.SetOptions("");
       strParent = url.Get();
       return true;
     }


### PR DESCRIPTION
* Fix displaying watched/unwatched/progress items in plugins (closes [#17947](https://trac.kodi.tv/ticket/17947))
* Fix "Reset resume position" in plugin items
* Restore some video database functionality after #14409

## Description
New plugin parenting rules in #14409 breaks some video database functionality e.g. GetScraperForPath() so that we cannot set different content types for plugin nodes (when it is used as a video source), plugin scanning protection in some cases and others. I've restored old functionality, but added a check that makes the parent directory of the URL with content_type option but no file equal to plugin://.
```
// plugin with multiple types (root)
plugin://addon.id/?content_type=movies -> plugin://
// plugin with multiple types (not root)
plugin://addon.id/?content_type=movies&movie_id=123 -> plugin://addon.id/
// plugins with a single type (root)
plugin://addon.id/ -> plugin://
```
## Motivation and Context
[Ticket #17947](https://trac.kodi.tv/ticket/17947)

## How Has This Been Tested?
* Build tested on Windows
* Functionality tested with YouTube 6.1.4 and [test plugin](https://github.com/AkariDN/plugin.video.testlib)

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
