### PR TITLE
[CURL] Update to version 7.61.1

### DIFF
--- a/tools/depends/target/curl/01-pkg-config-openssl.patch
+++ b/tools/depends/target/curl/01-pkg-config-openssl.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1517,7 +1517,7 @@
+@@ -1623,7 +1623,7 @@
  
      if test "$PKGCONFIG" != "no" ; then
        SSL_LIBS=`CURL_EXPORT_PCDIR([$OPENSSL_PCDIR]) dnl

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile 01-pkg-config-openssl.patch
 
 # lib name, version
 LIBNAME=curl
-VERSION=7.56.1
+VERSION=7.61.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 # configuration settings

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1975,7 +1975,18 @@ const std::vector<std::string> CCurlFile::GetPropertyValues(XFILE::FileProperty 
 
 double CCurlFile::GetDownloadSpeed()
 {
-  double res = 0.0f;
-  g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_SPEED_DOWNLOAD, &res);
-  return res;
+#if LIBCURL_VERSION_NUM >= 0x073a00 // 0.7.58.0
+  double speed = 0.0;
+  if (g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_SPEED_DOWNLOAD, &speed) == CURLE_OK)
+    return speed;
+#else
+  double time = 0.0, size = 0.0;
+  if (g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_TOTAL_TIME, &time) == CURLE_OK
+    && g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_SIZE_DOWNLOAD, &size) == CURLE_OK
+    && time > 0.0)
+  {
+    return size / time;
+  }
+#endif
+  return 0.0;
 }


### PR DESCRIPTION
## Description
Update to version 7.61.1

## Motivation and Context
CURLINFO_SPEED_DOWNLOAD does return wrong values especially if download takes shor timet.
For example loading 500kb in 0.1sec, CURLINFO_SPEED_DOWNLOAD reports 500kb/sec.

## How Has This Been Tested?
Demo MPD stream
- start with manual stream selection, choose low bitrate stream.
- switch back to Auto stream selection and grep for 'speed' in log

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
