### PR TITLE
GUIWindowManager: Don't mess with RetroPlayer when activating windows

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -832,15 +832,6 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
     return;
   }
 
-  // pause game when leaving fullscreen or resume game when entering fullscreen
-  if (g_application.GetAppPlayer().IsPlayingGame())
-  {
-    if (GetActiveWindow() == WINDOW_FULLSCREEN_GAME && !g_application.GetAppPlayer().IsPaused())
-      g_application.OnAction(ACTION_PAUSE);
-    else if (iWindowID == WINDOW_FULLSCREEN_GAME && g_application.GetAppPlayer().IsPaused())
-      g_application.OnAction(ACTION_PAUSE);
-  }
-
   CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetGUIControlsInfoProvider().SetNextWindow(iWindowID);
 
   // deactivate any window


### PR DESCRIPTION
This causes a race condition on skin reload when the game OSD is open. When the skin is reloaded, RetroPlayer is unpaused before the OSD is reopened, causing the game to play in the background of the OSD. This is undesired, because the OSD occludes the game and absorbs all keypresses.

## Motivation and Context
Encountered when working with #14425.

Fun fact: I added this code in 2013 without any idea what I was doing.

## How Has This Been Tested?
Test builds: https://github.com/garbear/xbmc/releases

Tested on OSX. Tested by reloading the skin when in the game OSD. Instead of playing in the background, RetroPlayer now correctly pauses when the OSD is reopened.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
