### PR TITLE
RetroPlayer: Fix no game input after controller shuts off

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -91,6 +91,9 @@ void CGameClientInput::Start()
 
   // Ensure hardware is open to receive events
   m_hardware.reset(new CGameClientHardware(m_gameClient));
+
+  if (CServiceBroker::IsServiceManagerUp())
+    CServiceBroker::GetPeripherals().RegisterObserver(this);
 }
 
 void CGameClientInput::Deinitialize()
@@ -100,6 +103,9 @@ void CGameClientInput::Deinitialize()
 
 void CGameClientInput::Stop()
 {
+  if (CServiceBroker::IsServiceManagerUp())
+    CServiceBroker::GetPeripherals().UnregisterObserver(this);
+
   m_hardware.reset();
 
   std::vector<std::string> ports;


### PR DESCRIPTION
This fixes input dropping and never resuming in the game when a controller disconnects, such as for low-battery situations.

## Motivation and Context
Reported [here](https://forum.kodi.tv/showthread.php?tid=173361&pid=2759570#pid2759570).

## How Has This Been Tested?
Test builds: https://github.com/garbear/xbmc/releases

Tested by unplugging/replugging controller on OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
