### PR TITLE
RetroPlayer: Unpause game in volume menu

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -171,7 +171,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   {
     CreatePlayback(m_gameServices.GameSettings().AutosaveEnabled());
     RegisterWindowCallbacks();
-    SetSpeedInternal(1.0);
+    SetSpeedInternal(1.0, true);
     m_callback.OnPlayBackStarted(fileCopy);
     m_callback.OnAVStarted(fileCopy);
     if (!bStandalone)
@@ -329,7 +329,7 @@ void CRetroPlayer::SeekTime(int64_t iTime /* = 0 */)
     return;
 
   m_playback->SeekTimeMs(static_cast<unsigned int>(iTime));
-  OnSpeedChange(m_playback->GetSpeed());
+  OnSpeedChange(m_playback->GetSpeed(), false);
 }
 
 bool CRetroPlayer::SeekTimeRelative(int64_t iTime)
@@ -362,7 +362,7 @@ void CRetroPlayer::SetSpeed(float speed)
       m_callback.OnPlayBackPaused();
   }
 
-  SetSpeedInternal(static_cast<double>(speed));
+  SetSpeedInternal(static_cast<double>(speed), speed != 0.0f);
 }
 
 bool CRetroPlayer::OnAction(const CAction &action)
@@ -392,7 +392,7 @@ bool CRetroPlayer::OnAction(const CAction &action)
   }
   case ACTION_SHOW_OSD:
   {
-    if (m_gameClient && m_playback->GetSpeed() == 0.0)
+    if (m_gameClient && m_state != State::FULLSCREEN)
     {
       CLog::Log(LOGDEBUG, "RetroPlayer[PLAYER]: Closing OSD via ACTION_SHOW_OSD");
       CloseOSD();
@@ -439,6 +439,7 @@ void CRetroPlayer::FrameMove()
 
     const int activeId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog();
     const bool bInMenu = (activeId != WINDOW_FULLSCREEN_GAME);
+    const bool bPlayInBackground = (activeId == WINDOW_DIALOG_GAME_VOLUME);
 
     switch (m_state)
     {
@@ -452,26 +453,31 @@ void CRetroPlayer::FrameMove()
     {
       if (bInMenu)
       {
-        m_priorSpeed = m_playback->GetSpeed();
-
-        if (m_priorSpeed != 0.0)
+        if (bPlayInBackground)
+          m_state = State::BACKGROUND_PLAY;
+        else
         {
-          IPlayerCallback *callback = &m_callback;
-          CJobManager::GetInstance().Submit([callback]()
-            {
-              callback->OnPlayBackPaused();
-            }, CJob::PRIORITY_NORMAL);
+          m_priorSpeed = m_playback->GetSpeed();
+
+          if (m_priorSpeed != 0.0)
+          {
+            IPlayerCallback *callback = &m_callback;
+            CJobManager::GetInstance().Submit([callback]()
+              {
+                callback->OnPlayBackPaused();
+              }, CJob::PRIORITY_NORMAL);
+          }
+
+          SetSpeedInternal(0.0, false);
+
+          m_state = State::IN_MENU;
         }
-
-        SetSpeedInternal(0.0);
-
-        m_state = State::BACKGROUND;
       }
       break;
     }
-    case State::BACKGROUND:
+    case State::IN_MENU:
     {
-      if (!bInMenu)
+      if (bPlayInBackground || !bInMenu)
       {
         if (m_playback->GetSpeed() == 0.0 && m_priorSpeed != 0.0)
         {
@@ -481,13 +487,44 @@ void CRetroPlayer::FrameMove()
               callback->OnPlayBackResumed();
             }, CJob::PRIORITY_NORMAL);
 
-          SetSpeedInternal(m_priorSpeed);
+          SetSpeedInternal(m_priorSpeed, false);
         }
 
-        m_state = State::FULLSCREEN;
+        if (bPlayInBackground)
+          m_state = State::BACKGROUND_PLAY;
+        else
+          m_state = State::FULLSCREEN;
       }
       break;
     }
+    case State::BACKGROUND_PLAY:
+    {
+      if (!bPlayInBackground)
+      {
+        if (!bInMenu)
+          m_state = State::FULLSCREEN;
+        else
+        {
+          m_priorSpeed = m_playback->GetSpeed();
+
+          if (m_priorSpeed != 0.0)
+          {
+            IPlayerCallback *callback = &m_callback;
+            CJobManager::GetInstance().Submit([callback]()
+                                              {
+                                                callback->OnPlayBackPaused();
+                                              }, CJob::PRIORITY_NORMAL);
+          }
+
+          SetSpeedInternal(0.0, false);
+
+          m_state = State::IN_MENU;
+        }
+      }
+      break;
+    }
+    default:
+      break;
     }
 
     m_processInfo->SetPlayTimes(0, GetTime(), 0, GetTotalTime());
@@ -522,9 +559,9 @@ std::string CRetroPlayer::CreateSavestate()
   return m_playback->CreateSavestate();
 }
 
-void CRetroPlayer::SetSpeedInternal(double speed)
+void CRetroPlayer::SetSpeedInternal(double speed, bool bCloseOSD)
 {
-  OnSpeedChange(speed);
+  OnSpeedChange(speed, bCloseOSD);
 
   if (speed == 0.0)
     m_playback->PauseAsync();
@@ -532,13 +569,14 @@ void CRetroPlayer::SetSpeedInternal(double speed)
     m_playback->SetSpeed(speed);
 }
 
-void CRetroPlayer::OnSpeedChange(double newSpeed)
+void CRetroPlayer::OnSpeedChange(double newSpeed, bool bCloseOSD)
 {
   m_streamManager->EnableAudio(newSpeed == 1.0);
   m_input->SetSpeed(newSpeed);
   m_renderManager->SetSpeed(newSpeed);
   m_processInfo->SetSpeed(static_cast<float>(newSpeed));
-  if (newSpeed != 0.0)
+
+  if (bCloseOSD)
   {
     CLog::Log(LOGDEBUG, "RetroPlayer[PLAYER]: Closing OSD via speed change (%f)", newSpeed);
     CloseOSD();

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -434,8 +434,11 @@ void CRetroPlayer::FrameMove()
 
   if (m_gameClient)
   {
+    const int windowId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
+    const bool bFullscreen = (windowId == WINDOW_FULLSCREEN_GAME);
+
     const int activeId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog();
-    const bool bFullscreen = (activeId == WINDOW_FULLSCREEN_GAME);
+    const bool bInMenu = (activeId != WINDOW_FULLSCREEN_GAME);
 
     switch (m_state)
     {
@@ -447,7 +450,7 @@ void CRetroPlayer::FrameMove()
     }
     case State::FULLSCREEN:
     {
-      if (!bFullscreen)
+      if (bInMenu)
       {
         m_priorSpeed = m_playback->GetSpeed();
 
@@ -468,7 +471,7 @@ void CRetroPlayer::FrameMove()
     }
     case State::BACKGROUND:
     {
-      if (bFullscreen)
+      if (!bInMenu)
       {
         if (m_playback->GetSpeed() == 0.0 && m_priorSpeed != 0.0)
         {

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -73,13 +73,14 @@ namespace RETRO
     std::string CreateSavestate() override;
 
   private:
-    void SetSpeedInternal(double speed);
+    void SetSpeedInternal(double speed, bool bCloseOSD);
 
     /*!
      * \brief Called when the speed changes
      * \param newSpeed The new speed, possibly equal to the previous speed
+     * \param bCloseOSD If true, the OSD will be closed
      */
-    void OnSpeedChange(double newSpeed);
+    void OnSpeedChange(double newSpeed, bool bCloseOSD);
 
     // Playback functions
     void CreatePlayback(bool bRestoreState);
@@ -108,7 +109,8 @@ namespace RETRO
     {
       STARTING,
       FULLSCREEN,
-      BACKGROUND,
+      IN_MENU,
+      BACKGROUND_PLAY,
     };
 
     State                              m_state = State::STARTING;


### PR DESCRIPTION
This unpauses the game in the volume menu of the OSD settings.

Unpausing allows the game to play at normal speed so the user can get audible feedback of the current volume level.

When the volume menu is exited, the game is paused again. If the volume menu is closed with ACTION_OSD (such as by pressing Select + X) then the OSD closes and the game resumes, similar to the rest of the OSD.

Requires the fix in #14425.

## Motivation and Context
Something I've meant to do since #12765.

## How Has This Been Tested?
Test builds: https://github.com/garbear/xbmc/releases

Tested on OSX. I'm still not 100% happy with this but it's a definite improvement. I'll try to work on this more before release.

## Screenshots (if appropriate):

![screenshot004](https://user-images.githubusercontent.com/531482/29999292-81e63880-8ff7-11e7-8005-8cdcaa333cce.png)
(pretend there's music and video in the background of the dialog)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
