### PR TITLE
RetroPlayer: Enable rewind past a reset

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -378,9 +378,7 @@ bool CRetroPlayer::OnAction(const CAction &action)
       m_playback->SetSpeed(0.0);
 
       CLog::Log(LOGDEBUG, "RetroPlayer[PLAYER]: Sending reset command via ACTION_PLAYER_RESET");
-      ResetPlayback();
       m_gameClient->Input().HardwareReset();
-      CreatePlayback(false);
 
       // If rewinding or paused, begin playback
       if (speed <= 0.0f)


### PR DESCRIPTION
This enables rewinding past an accidental reset action.

## Motivation and Context
I discovered this optimization while working to add Rewind and Fast-forward to the OSD menu.

## How Has This Been Tested?
Test builds: On the mirrors soon.

Tested by rewinding (holding Select + Left trigger) past a reset action.

## Screenshots (if appropriate):
No screenshots. Rewind is only accessible by button combo, not the OSD menu, for now. I'm open for ideas of how the rewind dialog should be implemented.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
