### PR TITLE
Move error handling out of CEGLContextUtils::SwapBuffers

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -335,19 +335,12 @@ bool CEGLContextUtils::SetVSync(bool enable)
   return (eglSwapInterval(m_eglDisplay, enable) == EGL_TRUE);
 }
 
-void CEGLContextUtils::SwapBuffers()
+bool CEGLContextUtils::TrySwapBuffers()
 {
   if (m_eglDisplay == EGL_NO_DISPLAY || m_eglSurface == EGL_NO_SURFACE)
   {
-    return;
+    return false;
   }
 
-  if (eglSwapBuffers(m_eglDisplay, m_eglSurface) != EGL_TRUE)
-  {
-    // For now we just hard fail if this fails
-    // Theoretically, EGL_CONTEXT_LOST could be handled, but it needs to be checked
-    // whether egl implementations actually use it (mesa does not)
-    CEGLUtils::LogError("eglSwapBuffers failed");
-    throw std::runtime_error("eglSwapBuffers failed");
-  }
+  return (eglSwapBuffers(m_eglDisplay, m_eglSurface) == EGL_TRUE);
 }

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -141,7 +141,7 @@ public:
   void DestroySurface();
   void DestroyContext();
   bool SetVSync(bool enable);
-  void SwapBuffers();
+  bool TrySwapBuffers();
   bool IsPlatformSupported() const;
 
   EGLDisplay GetEGLDisplay() const

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
@@ -117,7 +117,9 @@ void CWinSystemAmlogicGLESContext::PresentRenderImpl(bool rendered)
   if (!rendered)
     return;
 
-  m_pGLContext.SwapBuffers();
+  // Ignore errors - eglSwapBuffers() sometimes fails during modeswaps on AML,
+  // there is probably nothing we can do about it
+  m_pGLContext.TrySwapBuffers();
 }
 
 EGLDisplay CWinSystemAmlogicGLESContext::GetEGLDisplay() const

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -112,7 +112,13 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
   if (!rendered)
     return;
 
-  m_pGLContext.SwapBuffers();
+  // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
+  // we can't actually do anything about it
+  if (!m_pGLContext.TrySwapBuffers() && eglGetError() != EGL_BAD_SURFACE)
+  {
+    CEGLUtils::LogError("eglSwapBuffers failed");
+    throw std::runtime_error("eglSwapBuffers failed");
+  }
 }
 
 EGLDisplay CWinSystemAndroidGLESContext::GetEGLDisplay() const

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -66,7 +66,11 @@ bool CWinSystemGbmGLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res
     CreateNewWindow("", fullScreen, res);
   }
 
-  m_eglContext.SwapBuffers();
+  if (!m_eglContext.TrySwapBuffers())
+  {
+    CEGLUtils::LogError("eglSwapBuffers failed");
+    throw std::runtime_error("eglSwapBuffers failed");
+  }
 
   CWinSystemGbm::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight);
@@ -90,7 +94,13 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
   if (rendered || videoLayer)
   {
     if (rendered)
-      m_eglContext.SwapBuffers();
+    {
+      if (!m_eglContext.TrySwapBuffers())
+      {
+        CEGLUtils::LogError("eglSwapBuffers failed");
+        throw std::runtime_error("eglSwapBuffers failed");
+      }
+    }
     CWinSystemGbm::FlipPage(rendered, videoLayer);
   }
   else

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -78,7 +78,11 @@ bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
     CreateNewWindow("", fullScreen, res);
   }
 
-  m_eglContext.SwapBuffers();
+  if (!m_eglContext.TrySwapBuffers())
+  {
+    CEGLUtils::LogError("eglSwapBuffers failed");
+    throw std::runtime_error("eglSwapBuffers failed");
+  }
 
   CWinSystemGbm::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
@@ -102,7 +106,13 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   if (rendered || videoLayer)
   {
     if (rendered)
-      m_eglContext.SwapBuffers();
+    {
+      if (!m_eglContext.TrySwapBuffers())
+      {
+        CEGLUtils::LogError("eglSwapBuffers failed");
+        throw std::runtime_error("eglSwapBuffers failed");
+      }
+    }
     CWinSystemGbm::FlipPage(rendered, videoLayer);
   }
   else

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -144,7 +144,11 @@ void CWinSystemRpiGLESContext::PresentRenderImpl(bool rendered)
   if (!rendered)
     return;
 
-  m_pGLContext.SwapBuffers();
+  if (!m_pGLContext.TrySwapBuffers())
+  {
+    CEGLUtils::LogError("eglSwapBuffers failed");
+    throw std::runtime_error("eglSwapBuffers failed");
+  }
 }
 
 EGLDisplay CWinSystemRpiGLESContext::GetEGLDisplay() const

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -114,7 +114,14 @@ void CWinSystemWaylandEGLContext::PresentFrame(bool rendered)
 
   if (rendered)
   {
-    m_eglContext.SwapBuffers();
+    if (!m_eglContext.TrySwapBuffers())
+    {
+      // For now we just hard fail if this fails
+      // Theoretically, EGL_CONTEXT_LOST could be handled, but it needs to be checked
+      // whether egl implementations actually use it (mesa does not)
+      CEGLUtils::LogError("eglSwapBuffers failed");
+      throw std::runtime_error("eglSwapBuffers failed");
+    }
     // eglSwapBuffers() (hopefully) calls commit on the surface and flushes
     // ... well mesa does anyway
   }


### PR DESCRIPTION
Some platforms seem to not implement the EGL specification properly
and give random errors on eglSwapBuffers that are not allowed and we
cannot handle. Move error handling out of CEGLContextUtils::SwapBuffers
and leave it up to the platform.