### PR TITLE
KEY_EPG is wrongly mapped to title instead of guide

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -449,7 +449,7 @@
 		<skipminus>KEY_PREVIOUSSONG</skipminus>
 		<skipminus>KEY_PREVIOUS</skipminus>
 		<title>KEY_TITLE</title>
-		<title>KEY_EPG</title>
+		<guide>KEY_EPG</guide>
 		<subtitle>KEY_SUBTITLE</subtitle>
 		<language>KEY_LANGUAGE</language>
 		<mute>KEY_MUTE</mute>
@@ -564,7 +564,8 @@
 		<pageminus>KEY_CHANNELDOWN</pageminus>
 		<skipplus>KEY_NEXT</skipplus>
 		<skipminus>KEY_PREVIOUS</skipminus>
-		<title>KEY_EPG</title>
+		<guide>KEY_EPG</guide>
+		<title>KEY_TITLE</title>
 		<subtitle>KEY_SUBTITLE</subtitle>
 		<language>KEY_LANGUAGE</language>
 		<info>KEY_INFO</info>
@@ -623,7 +624,8 @@
 		<pageminus>KEY_CHANNELDOWN</pageminus>
 		<skipplus>KEY_NEXT</skipplus>
 		<skipminus>KEY_PREVIOUS</skipminus>
-		<title>KEY_EPG</title>
+		<guide>KEY_EPG</guide>
+		<title>KEY_TITLE</title>
 		<subtitle>KEY_SUBTITLE</subtitle>
 		<language>KEY_LANGUAGE</language>
 		<info>KEY_INFO</info>
@@ -682,7 +684,8 @@
 		<pageminus>KEY_CHANNELDOWN</pageminus>
 		<skipplus>KEY_NEXT</skipplus>
 		<skipminus>KEY_PREVIOUS</skipminus>
-		<title>KEY_EPG</title>
+		<guide>KEY_EPG</guide>
+		<title>KEY_TITLE</title>
 		<subtitle>KEY_SUBTITLE</subtitle>
 		<language>KEY_LANGUAGE</language>
 		<info>KEY_INFO</info>


### PR DESCRIPTION
## Description
It seems that `KEY_EPG` (what is labelled GUIDE on MCE remotes) is wrongly handled as `title`. Looking at the code, this is probably a copy paste error from the past.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
Pushing the Guide button by default opens a context menu. This is because the KEY_EPG is wrongly handled as title.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
