### PR TITLE
RendererDRMPRIME: set color drm properties

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -47,6 +47,41 @@ void CVideoBufferDRMPRIME::Unref()
   av_frame_unref(m_pFrame);
 }
 
+int CVideoBufferDRMPRIME::GetColorEncoding() const
+{
+  switch (m_pFrame->colorspace)
+  {
+    case AVCOL_SPC_BT2020_CL:
+    case AVCOL_SPC_BT2020_NCL:
+      return DRM_COLOR_YCBCR_BT2020;
+    case AVCOL_SPC_SMPTE170M:
+    case AVCOL_SPC_BT470BG:
+    case AVCOL_SPC_FCC:
+      return DRM_COLOR_YCBCR_BT601;
+    case AVCOL_SPC_BT709:
+      return DRM_COLOR_YCBCR_BT709;
+    case AVCOL_SPC_RESERVED:
+    case AVCOL_SPC_UNSPECIFIED:
+    default:
+      if (m_pFrame->width > 1024 || m_pFrame->height >= 600)
+        return DRM_COLOR_YCBCR_BT709;
+      else
+        return DRM_COLOR_YCBCR_BT601;
+  }
+}
+
+int CVideoBufferDRMPRIME::GetColorRange() const
+{
+  switch (m_pFrame->color_range)
+  {
+    case AVCOL_RANGE_JPEG:
+      return DRM_COLOR_YCBCR_FULL_RANGE;
+    case AVCOL_RANGE_MPEG:
+    default:
+      return DRM_COLOR_YCBCR_LIMITED_RANGE;
+  }
+}
+
 //------------------------------------------------------------------------------
 
 class CVideoBufferPoolDRMPRIME

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -18,6 +18,17 @@ extern "C" {
 #include "libavutil/hwcontext_drm.h"
 }
 
+// Color enums is copied from linux include/drm/drm_color_mgmt.h (strangely not part of uapi)
+enum drm_color_encoding {
+  DRM_COLOR_YCBCR_BT601,
+  DRM_COLOR_YCBCR_BT709,
+  DRM_COLOR_YCBCR_BT2020,
+};
+enum drm_color_range {
+  DRM_COLOR_YCBCR_LIMITED_RANGE,
+  DRM_COLOR_YCBCR_FULL_RANGE,
+};
+
 class CVideoBufferPoolDRMPRIME;
 
 class CVideoBufferDRMPRIME
@@ -35,6 +46,8 @@ public:
   AVDRMFrameDescriptor* GetDescriptor() const { return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]); }
   uint32_t GetWidth() const { return m_pFrame->width; }
   uint32_t GetHeight() const { return m_pFrame->height; }
+  int GetColorEncoding() const;
+  int GetColorRange() const;
 protected:
   AVFrame* m_pFrame = nullptr;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
@@ -49,13 +49,17 @@ if(CORE_SYSTEM_NAME STREQUAL android)
                       RendererMediaCodecSurface.h)
 endif()
 
-if(CORE_PLATFORM_NAME_LC STREQUAL gbm AND OPENGLES_FOUND)
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
   list(APPEND SOURCES RendererDRMPRIME.cpp
-                      RendererDRMPRIMEGLES.cpp
-                      DRMPRIMEEGL.cpp)
+                      VideoLayerBridgeDRMPRIME.cpp)
   list(APPEND HEADERS RendererDRMPRIME.h
-                      RendererDRMPRIMEGLES.h
-                      DRMPRIMEEGL.h)
+                      VideoLayerBridgeDRMPRIME.h)
+  if(OPENGLES_FOUND)
+    list(APPEND SOURCES RendererDRMPRIMEGLES.cpp
+                        DRMPRIMEEGL.cpp)
+    list(APPEND HEADERS RendererDRMPRIMEGLES.h
+                        DRMPRIMEEGL.h)
+  endif()
 endif()
 
 # we might want to build on linux systems

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -8,16 +8,19 @@
 
 #include "RendererDRMPRIME.h"
 
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
-#include "ServiceBroker.h"
-#include "settings/DisplaySettings.h"
 #include "settings/lib/Setting.h"
+#include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "windowing/gbm/DRMAtomic.h"
+#include "windowing/gbm/WinSystemGbm.h"
 #include "windowing/GraphicContext.h"
+#include "ServiceBroker.h"
 
 const std::string SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
 
@@ -31,7 +34,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
   if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer) &&
       CServiceBroker::GetSettings()->GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
-    CWinSystemGbmEGLContext* winSystem = dynamic_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem());
+    CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
     if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane &&
         std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
       return new CRendererDRMPRIME();
@@ -42,7 +45,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 
 void CRendererDRMPRIME::Register()
 {
-  CWinSystemGbmEGLContext* winSystem = dynamic_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem());
+  CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
   if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane &&
       std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
   {
@@ -163,7 +166,7 @@ void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned
 
   if (!m_videoLayerBridge)
   {
-    CWinSystemGbmEGLContext* winSystem = static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem());
+    CWinSystemGbm* winSystem = static_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
     m_videoLayerBridge = std::dynamic_pointer_cast<CVideoLayerBridgeDRMPRIME>(winSystem->GetVideoLayerBridge());
     if (!m_videoLayerBridge)
       m_videoLayerBridge = std::make_shared<CVideoLayerBridgeDRMPRIME>(winSystem->GetDrm());
@@ -206,144 +209,4 @@ bool CRendererDRMPRIME::Supports(ERENDERFEATURE feature)
 bool CRendererDRMPRIME::Supports(ESCALINGMETHOD method)
 {
   return false;
-}
-
-//------------------------------------------------------------------------------
-
-CVideoLayerBridgeDRMPRIME::CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm)
-  : m_DRM(drm)
-{
-}
-
-CVideoLayerBridgeDRMPRIME::~CVideoLayerBridgeDRMPRIME()
-{
-  Release(m_prev_buffer);
-  Release(m_buffer);
-}
-
-void CVideoLayerBridgeDRMPRIME::Disable()
-{
-  // disable video plane
-  struct plane* plane = m_DRM->GetPrimaryPlane();
-  m_DRM->AddProperty(plane, "FB_ID", 0);
-  m_DRM->AddProperty(plane, "CRTC_ID", 0);
-}
-
-void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
-{
-  // release the buffer that is no longer presented on screen
-  Release(m_prev_buffer);
-
-  // release the buffer currently being presented next call
-  m_prev_buffer = m_buffer;
-
-  // reference count the buffer that is going to be presented on screen
-  m_buffer = buffer;
-  m_buffer->Acquire();
-}
-
-void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
-{
-  if (!buffer)
-    return;
-
-  Unmap(buffer);
-  buffer->Release();
-}
-
-bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
-{
-  if (buffer->m_fb_id)
-    return true;
-
-  AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
-  uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0}, flags = 0;
-  uint64_t modifier[4] = {0};
-  int ret;
-
-  // convert Prime FD to GEM handle
-  for (int object = 0; object < descriptor->nb_objects; object++)
-  {
-    ret = drmPrimeFDToHandle(m_DRM->GetFileDescriptor(), descriptor->objects[object].fd, &buffer->m_handles[object]);
-    if (ret < 0)
-    {
-      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to convert prime fd %d to gem handle %u, ret = %d",
-                __FUNCTION__, descriptor->objects[object].fd, buffer->m_handles[object], ret);
-      return false;
-    }
-  }
-
-  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
-
-  for (int plane = 0; plane < layer->nb_planes; plane++)
-  {
-    int object = layer->planes[plane].object_index;
-    uint32_t handle = buffer->m_handles[object];
-    if (handle && layer->planes[plane].pitch)
-    {
-      handles[plane] = handle;
-      pitches[plane] = layer->planes[plane].pitch;
-      offsets[plane] = layer->planes[plane].offset;
-      modifier[plane] = descriptor->objects[object].format_modifier;
-    }
-  }
-
-  if (modifier[0] && modifier[0] != DRM_FORMAT_MOD_INVALID)
-    flags = DRM_MODE_FB_MODIFIERS;
-
-  // add the video frame FB
-  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(), buffer->GetHeight(), layer->format,
-                                   handles, pitches, offsets, modifier, &buffer->m_fb_id, flags);
-  if (ret < 0)
-  {
-    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to add fb %d, ret = %d", __FUNCTION__, buffer->m_fb_id, ret);
-    return false;
-  }
-
-  Acquire(buffer);
-  return true;
-}
-
-void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
-{
-  if (buffer->m_fb_id)
-  {
-    drmModeRmFB(m_DRM->GetFileDescriptor(), buffer->m_fb_id);
-    buffer->m_fb_id = 0;
-  }
-
-  for (int i = 0; i < AV_DRM_MAX_PLANES; i++)
-  {
-    if (buffer->m_handles[i])
-    {
-      struct drm_gem_close gem_close = { .handle = buffer->m_handles[i] };
-      drmIoctl(m_DRM->GetFileDescriptor(), DRM_IOCTL_GEM_CLOSE, &gem_close);
-      buffer->m_handles[i] = 0;
-    }
-  }
-}
-
-void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
-{
-}
-
-void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)
-{
-  if (!Map(buffer))
-  {
-    Unmap(buffer);
-    return;
-  }
-
-  struct plane* plane = m_DRM->GetPrimaryPlane();
-  m_DRM->AddProperty(plane, "FB_ID", buffer->m_fb_id);
-  m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
-  m_DRM->AddProperty(plane, "SRC_X", 0);
-  m_DRM->AddProperty(plane, "SRC_Y", 0);
-  m_DRM->AddProperty(plane, "SRC_W", buffer->GetWidth() << 16);
-  m_DRM->AddProperty(plane, "SRC_H", buffer->GetHeight() << 16);
-  m_DRM->AddProperty(plane, "CRTC_X", static_cast<int32_t>(destRect.x1) & ~1);
-  m_DRM->AddProperty(plane, "CRTC_Y", static_cast<int32_t>(destRect.y1) & ~1);
-  m_DRM->AddProperty(plane, "CRTC_W", (static_cast<uint32_t>(destRect.Width()) + 1) & ~1);
-  m_DRM->AddProperty(plane, "CRTC_H", (static_cast<uint32_t>(destRect.Height()) + 1) & ~1);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -153,8 +153,11 @@ void CRendererDRMPRIME::Update()
 
 void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
-  if (m_iLastRenderBuffer == index)
+  if (m_iLastRenderBuffer == index && m_videoLayerBridge)
+  {
+    m_videoLayerBridge->UpdateVideoPlane();
     return;
+  }
 
   CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
   if (!buffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -8,33 +8,10 @@
 
 #pragma once
 
-#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
-#include "windowing/gbm/WinSystemGbmEGLContext.h"
 
-class CVideoLayerBridgeDRMPRIME
-  : public CVideoLayerBridge
-{
-public:
-  CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm);
-  ~CVideoLayerBridgeDRMPRIME();
-  void Disable() override;
-
-  virtual void Configure(CVideoBufferDRMPRIME* buffer);
-  virtual void SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect);
-
-protected:
-  std::shared_ptr<CDRMUtils> m_DRM;
-
-private:
-  void Acquire(CVideoBufferDRMPRIME* buffer);
-  void Release(CVideoBufferDRMPRIME* buffer);
-  bool Map(CVideoBufferDRMPRIME* buffer);
-  void Unmap(CVideoBufferDRMPRIME* buffer);
-
-  CVideoBufferDRMPRIME* m_buffer = nullptr;
-  CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
-};
+class CVideoBuffer;
+class CVideoLayerBridgeDRMPRIME;
 
 class CRendererDRMPRIME
   : public CBaseRenderer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -149,3 +149,13 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
   m_DRM->AddProperty(plane, "CRTC_W", (static_cast<uint32_t>(destRect.Width()) + 1) & ~1);
   m_DRM->AddProperty(plane, "CRTC_H", (static_cast<uint32_t>(destRect.Height()) + 1) & ~1);
 }
+
+void CVideoLayerBridgeDRMPRIME::UpdateVideoPlane()
+{
+  if (!m_buffer || !m_buffer->m_fb_id)
+    return;
+
+  struct plane* plane = m_DRM->GetPrimaryPlane();
+  m_DRM->AddProperty(plane, "FB_ID", m_buffer->m_fb_id);
+  m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -127,6 +127,13 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
 
 void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
+  struct plane* plane = m_DRM->GetPrimaryPlane();
+  if (m_DRM->SupportsProperty(plane, "COLOR_ENCODING") &&
+      m_DRM->SupportsProperty(plane, "COLOR_RANGE"))
+  {
+    m_DRM->AddProperty(plane, "COLOR_ENCODING", buffer->GetColorEncoding());
+    m_DRM->AddProperty(plane, "COLOR_RANGE", buffer->GetColorRange());
+  }
 }
 
 void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoLayerBridgeDRMPRIME.h"
+
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "utils/log.h"
+#include "windowing/gbm/DRMUtils.h"
+
+CVideoLayerBridgeDRMPRIME::CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm)
+  : m_DRM(drm)
+{
+}
+
+CVideoLayerBridgeDRMPRIME::~CVideoLayerBridgeDRMPRIME()
+{
+  Release(m_prev_buffer);
+  Release(m_buffer);
+}
+
+void CVideoLayerBridgeDRMPRIME::Disable()
+{
+  // disable video plane
+  struct plane* plane = m_DRM->GetPrimaryPlane();
+  m_DRM->AddProperty(plane, "FB_ID", 0);
+  m_DRM->AddProperty(plane, "CRTC_ID", 0);
+}
+
+void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
+{
+  // release the buffer that is no longer presented on screen
+  Release(m_prev_buffer);
+
+  // release the buffer currently being presented next call
+  m_prev_buffer = m_buffer;
+
+  // reference count the buffer that is going to be presented on screen
+  m_buffer = buffer;
+  m_buffer->Acquire();
+}
+
+void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
+{
+  if (!buffer)
+    return;
+
+  Unmap(buffer);
+  buffer->Release();
+}
+
+bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
+{
+  if (buffer->m_fb_id)
+    return true;
+
+  AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
+  uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0}, flags = 0;
+  uint64_t modifier[4] = {0};
+  int ret;
+
+  // convert Prime FD to GEM handle
+  for (int object = 0; object < descriptor->nb_objects; object++)
+  {
+    ret = drmPrimeFDToHandle(m_DRM->GetFileDescriptor(), descriptor->objects[object].fd, &buffer->m_handles[object]);
+    if (ret < 0)
+    {
+      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to convert prime fd %d to gem handle %u, ret = %d",
+                __FUNCTION__, descriptor->objects[object].fd, buffer->m_handles[object], ret);
+      return false;
+    }
+  }
+
+  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
+
+  for (int plane = 0; plane < layer->nb_planes; plane++)
+  {
+    int object = layer->planes[plane].object_index;
+    uint32_t handle = buffer->m_handles[object];
+    if (handle && layer->planes[plane].pitch)
+    {
+      handles[plane] = handle;
+      pitches[plane] = layer->planes[plane].pitch;
+      offsets[plane] = layer->planes[plane].offset;
+      modifier[plane] = descriptor->objects[object].format_modifier;
+    }
+  }
+
+  if (modifier[0] && modifier[0] != DRM_FORMAT_MOD_INVALID)
+    flags = DRM_MODE_FB_MODIFIERS;
+
+  // add the video frame FB
+  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(), buffer->GetHeight(), layer->format,
+                                   handles, pitches, offsets, modifier, &buffer->m_fb_id, flags);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to add fb %d, ret = %d", __FUNCTION__, buffer->m_fb_id, ret);
+    return false;
+  }
+
+  Acquire(buffer);
+  return true;
+}
+
+void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
+{
+  if (buffer->m_fb_id)
+  {
+    drmModeRmFB(m_DRM->GetFileDescriptor(), buffer->m_fb_id);
+    buffer->m_fb_id = 0;
+  }
+
+  for (int i = 0; i < AV_DRM_MAX_PLANES; i++)
+  {
+    if (buffer->m_handles[i])
+    {
+      struct drm_gem_close gem_close = { .handle = buffer->m_handles[i] };
+      drmIoctl(m_DRM->GetFileDescriptor(), DRM_IOCTL_GEM_CLOSE, &gem_close);
+      buffer->m_handles[i] = 0;
+    }
+  }
+}
+
+void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
+{
+}
+
+void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)
+{
+  if (!Map(buffer))
+  {
+    Unmap(buffer);
+    return;
+  }
+
+  struct plane* plane = m_DRM->GetPrimaryPlane();
+  m_DRM->AddProperty(plane, "FB_ID", buffer->m_fb_id);
+  m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
+  m_DRM->AddProperty(plane, "SRC_X", 0);
+  m_DRM->AddProperty(plane, "SRC_Y", 0);
+  m_DRM->AddProperty(plane, "SRC_W", buffer->GetWidth() << 16);
+  m_DRM->AddProperty(plane, "SRC_H", buffer->GetHeight() << 16);
+  m_DRM->AddProperty(plane, "CRTC_X", static_cast<int32_t>(destRect.x1) & ~1);
+  m_DRM->AddProperty(plane, "CRTC_Y", static_cast<int32_t>(destRect.y1) & ~1);
+  m_DRM->AddProperty(plane, "CRTC_W", (static_cast<uint32_t>(destRect.Width()) + 1) & ~1);
+  m_DRM->AddProperty(plane, "CRTC_H", (static_cast<uint32_t>(destRect.Height()) + 1) & ~1);
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -26,6 +26,7 @@ public:
 
   virtual void Configure(CVideoBufferDRMPRIME* buffer);
   virtual void SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect);
+  virtual void UpdateVideoPlane();
 
 protected:
   std::shared_ptr<CDRMUtils> m_DRM;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Interface/StreamInfo.h"
+#include "windowing/gbm/VideoLayerBridge.h"
+
+#include <memory>
+
+class CDRMUtils;
+class CVideoBufferDRMPRIME;
+
+class CVideoLayerBridgeDRMPRIME
+  : public CVideoLayerBridge
+{
+public:
+  CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm);
+  ~CVideoLayerBridgeDRMPRIME();
+  void Disable() override;
+
+  virtual void Configure(CVideoBufferDRMPRIME* buffer);
+  virtual void SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect);
+
+protected:
+  std::shared_ptr<CDRMUtils> m_DRM;
+
+private:
+  void Acquire(CVideoBufferDRMPRIME* buffer);
+  void Release(CVideoBufferDRMPRIME* buffer);
+  bool Map(CVideoBufferDRMPRIME* buffer);
+  void Unmap(CVideoBufferDRMPRIME* buffer);
+
+  CVideoBufferDRMPRIME* m_buffer = nullptr;
+  CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
+};

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -94,14 +94,6 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
 
 void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
 {
-  uint32_t flags = 0;
-
-  if(m_need_modeset)
-  {
-    flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-    m_need_modeset = false;
-  }
-
   struct drm_fb *drm_fb = nullptr;
 
   if (rendered)
@@ -117,6 +109,14 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
       CLog::Log(LOGERROR, "CDRMAtomic::%s - Failed to get a new FBO", __FUNCTION__);
       return;
     }
+  }
+
+  uint32_t flags = 0;
+
+  if (m_need_modeset)
+  {
+    flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+    m_need_modeset = false;
   }
 
   DrmAtomicCommit(!drm_fb ? 0 : drm_fb->fb_id, flags, rendered, videoLayer);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -165,6 +165,15 @@ void CDRMUtils::FreeProperties(struct drm_object *object)
   object->id = 0;
 }
 
+bool CDRMUtils::SupportsProperty(struct drm_object *object, const char *name)
+{
+  for (uint32_t i = 0; i < object->props->count_props; i++)
+    if (!strcmp(object->props_info[i]->name, name))
+      return true;
+
+  return false;
+}
+
 uint32_t CDRMUtils::GetPropertyId(struct drm_object *object, const char *name)
 {
   for (uint32_t i = 0; i < object->props->count_props; i++)

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -85,6 +85,7 @@ public:
   virtual std::vector<RESOLUTION_INFO> GetModes();
   virtual bool SetMode(const RESOLUTION_INFO& res);
 
+  bool SupportsProperty(struct drm_object *object, const char *name);
   virtual bool AddProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
   virtual bool SetProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
 


### PR DESCRIPTION
## Description
This PR includes parts of RFC #14358, an alternative to #14416 and GetColorEncoding/Range methods that can be shared with #14432

@peak3d please check this still fixes your 100% cpu issue
@lrusak hopefully the GetColorEncoding/Range methods can be used with #14432

## How Has This Been Tested?
Runtime tested on Rock64

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
