### PR TITLE
[fix] iterate over reference and only copy the variable if needed

### DIFF
--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -391,10 +391,12 @@ void CGUIDialogMediaFilter::InitializeSettings()
     return;
   }
 
-  for (Filter filter : filterList)
+  for (const Filter& f : filterList)
   {
-    if (filter.mediaType != m_mediaType)
+    if (f.mediaType != m_mediaType)
       continue;
+
+    Filter filter = f;
 
     // check the smartplaylist if it contains a matching rule
     for (CDatabaseQueryRules::iterator rule = m_filter->m_ruleCombination.m_rules.begin(); rule != m_filter->m_ruleCombination.m_rules.end(); rule++)


### PR DESCRIPTION
## Description
This reduces the amount of copies after f34a6f7 (#14426), which causes slow directory listings.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
