### PR TITLE
[PVR] Fetch EPG tags for timers if timer start not in configured EPG window.

### DIFF
--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -56,37 +56,37 @@ namespace PVR
 
     /*!
      * @brief Check whether this add-on supports TV channels.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsTV() const { return m_addonCapabilities && m_addonCapabilities->bSupportsTV; }
 
     /*!
      * @brief Check whether this add-on supports radio channels.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsRadio() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRadio; }
 
     /*!
      * @brief Check whether this add-on supports channel groups.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsChannelGroups() const { return m_addonCapabilities && m_addonCapabilities->bSupportsChannelGroups; }
 
     /*!
      * @brief Check whether this add-on supports scanning for new channels on the backend.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsChannelScan() const { return m_addonCapabilities && m_addonCapabilities->bSupportsChannelScan; }
 
     /*!
      * @brief Check whether this add-on supports the following functions: DeleteChannel, RenameChannel, DialogChannelSettings and DialogAddChannel.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsChannelSettings() const { return m_addonCapabilities && m_addonCapabilities->bSupportsChannelSettings; }
 
     /*!
      * @brief Check whether this add-on supports descramble information for playing channels.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsDescrambleInfo() const { return m_addonCapabilities && m_addonCapabilities->bSupportsDescrambleInfo; }
 
@@ -98,9 +98,15 @@ namespace PVR
 
     /*!
      * @brief Check whether this add-on provides EPG information.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsEPG() const { return m_addonCapabilities && m_addonCapabilities->bSupportsEPG; }
+
+    /*!
+     * @brief Check whether this add-on supports asynchronous transfer of epg events.
+     * @return True if supported, false otherwise.
+     */
+    bool SupportsAsyncEPGTransfer() const { return m_addonCapabilities && m_addonCapabilities->bSupportsAsyncEPGTransfer; }
 
     /////////////////////////////////////////////////////////////////////////////////
     //
@@ -110,7 +116,7 @@ namespace PVR
 
     /*!
      * @brief Check whether this add-on supports the creation and editing of timers.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsTimers() const { return m_addonCapabilities && m_addonCapabilities->bSupportsTimers; }
 
@@ -122,7 +128,7 @@ namespace PVR
 
     /*!
      * @brief Check whether this add-on supports recordings.
-     * @return True if recordings are supported, false otherwise.
+     * @return True if supported, false otherwise.
      */
     bool SupportsRecordings() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings; }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -98,7 +98,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.10.1"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.10.2"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "5.10.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -309,6 +309,7 @@ extern "C" {
     bool bSupportsRecordingsRename;     /*!< @brief true if the backend supports renaming recordings. */
     bool bSupportsRecordingsLifetimeChange; /*!< @brief true if the backend supports changing lifetime for recordings. */
     bool bSupportsDescrambleInfo;       /*!< @brief true if the backend supports descramble information for playing channels. */
+    bool bSupportsAsyncEPGTransfer;     /*!< @brief true if this addon-on supports asynchronous transfer of epg events to Kodi using the callback function EpgEventStateChange. */
 
     unsigned int iRecordingsLifetimesSize; /*!< @brief (required) Count of possible values for PVR_RECORDING.iLifetime. 0 means lifetime is not supported for recordings or no own value definition wanted, but to use Kodi defaults of 1..365. */
     PVR_ATTRIBUTE_INT_VALUE recordingsLifetimeValues[PVR_ADDON_ATTRIBUTE_VALUES_ARRAY_SIZE]; /*!< @brief (optional) Array containing the possible values for PVR_RECORDING.iLifetime. Must be filled if iLifetimesSize > 0 */

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -161,9 +161,10 @@ namespace PVR
      * Get the event that occurs between the given begin and end time.
      * @param beginTime Minimum start time in UTC of the event.
      * @param endTime Maximum end time in UTC of the event.
+     * @param bUpdateFromClient if true, try to fetch the event from the client if not found locally.
      * @return The found tag or NULL if it wasn't found.
      */
-    CPVREpgInfoTagPtr GetTagBetween(const CDateTime &beginTime, const CDateTime &endTime) const;
+    CPVREpgInfoTagPtr GetTagBetween(const CDateTime &beginTime, const CDateTime &endTime, bool bUpdateFromClient = false);
 
     /*!
      * Get all events occurring between the given begin and end time.
@@ -286,9 +287,10 @@ namespace PVR
      * @todo not implemented yet for non-pvr EPGs
      * @param start Get entries with a start date after this time.
      * @param end Get entries with an end date before this time.
+     * @param bForceUpdate Force update from client even if it's not the time to
      * @return True if the update was successful, false otherwise.
      */
-    bool UpdateFromScraper(time_t start, time_t end);
+    bool UpdateFromScraper(time_t start, time_t end, bool bForceUpdate);
 
     /*!
      * @brief Fix overlapping events from the tables.
@@ -307,9 +309,10 @@ namespace PVR
      * @brief Load all EPG entries from clients into a temporary table and update this table with the contents of that temporary table.
      * @param start Only get entries after this start time. Use 0 to get all entries before "end".
      * @param end Only get entries before this end time. Use 0 to get all entries after "begin". If both "begin" and "end" are 0, all entries will be updated.
+     * @param bForceUpdate Force update from client even if it's not the time to
      * @return True if the update was successful, false otherwise.
      */
-    bool LoadFromClients(time_t start, time_t end);
+    bool LoadFromClients(time_t start, time_t end, bool bForceUpdate);
 
     /*!
      * @brief Update the contents of this table with the contents provided in "epg"

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -615,11 +615,19 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       if (!endDate.IsValid() || endDate < startDate)
         endDate = startDate;
 
-      // limit start to linger time
-      int iPastDays = CServiceBroker::GetPVRManager().EpgContainer().GetPastDaysToDisplay();
+      CPVREpgContainer& epgContainer = CServiceBroker::GetPVRManager().EpgContainer();
+
+      // limit start to past days to display
+      int iPastDays = epgContainer.GetPastDaysToDisplay();
       const CDateTime maxPastDate(currentDate - CDateTimeSpan(iPastDays, 0, 0, 0));
       if (startDate < maxPastDate)
         startDate = maxPastDate;
+
+      // limit end to future days to display
+      int iFutureDays = epgContainer.GetFutureDaysToDisplay();
+      const CDateTime maxFutureDate(currentDate + CDateTimeSpan(iFutureDays, 0, 0, 0));
+      if (endDate > maxFutureDate)
+        endDate = maxFutureDate;
 
       if (m_guiState.get())
         timeline->Sort(m_guiState->GetSortMethod());


### PR DESCRIPTION
This fixes an issue / implements a feature recently reported for pvr.hts in a general way. => https://github.com/kodi-pvr/pvr.hts/issues/375

> I have async epg, guide data set to the default of three days, default theme, Kodi 18Beta3.
> 
> Although the guide data is 3 days, the timers view in Kodi shows all of my timers that are scheduled for the next couple of weeks. It took me a little while to realize that EPG=3days is the reason the timers for today/tomorrow have full programme information in the right hand panel, whereas timers further in the future have no information in that panel and just say "No information available." (Mainly because I have few timers set and I didn't pay attention to the dates). I didn't associate "timer" with "epg" that way and so tried a few times to bounce tvh/kodi to "fix" the missing data, even though it's obvious in hindsight.
> 
> So, to be clear, the left panel has channel, title, time for all timers on tvheadend, but only timers within the guide data timeframe window are the ones with guide data have full description in the right panel.
> 
> I actually quite like seeing all of the future timers that are set, so it would be a shame to limit timers to the same number of days as the guide data. I could increase guide limit (is it just in DB not all in memory?), but it might not work for other people with small boxes."

Please note that this PR contains a PVR Addon API change to allow the "on demand epg event fetching" also for addons using asnc epg event transfer (namely pvr.hts, pvr.zattoo and pvr.teleboy). This API change is a micro change that does not require addon changes, not even a recompile of the the addons (ADDON_INSTANCE_VERSION_PVR_MIN not bumped). Thus, it is okay to merge this PR even in beta phase.

Runtime-tested on macOS, latest Kodi master plus adapted pvr.hts and other (not recompiled) addons).