### PR TITLE
kodi.sh: add apport support

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -83,6 +83,8 @@ if [ ! -x ${KODI_BINARY} ]; then
     exit 2
 fi
 
+APPORT_CORE="/var/crash/$(echo -n ${KODI_BINARY}|tr / _).$(id -u).crash"
+
 migrate_home()
 {
   [ "$(basename $0)" = "xbmc" ] && echo "WARNING: Running ${bin_name} as "xbmc" is deprecated and will be removed in later versions, please switch to using the ${bin_name} binary"
@@ -143,6 +145,14 @@ print_crash_report()
       systemd-coredumpctl dump -o core $(basename ${KODI_BINARY}) > /dev/null 2>&1
     elif command_exists coredumpctl; then
       coredumpctl dump -o core $(basename ${KODI_BINARY})  > /dev/null 2>&1
+    elif command_exists apport-unpack && test -f "${APPORT_CORE}"; then
+      TMP_DIR="$(mktemp -d -p ${HOME})"
+      if [ -d "${TMP_DIR}" ]; then
+        rm -f "${HOME}/core"
+        apport-unpack "${APPORT_CORE}" "${TMP_DIR}"
+        mv "${TMP_DIR}/CoreDump" "${HOME}/core"
+        rm -rf "${TMP_DIR}"
+      fi
     fi
     single_stacktrace "$PWD" 1
     # Find in plugins directories
@@ -195,6 +205,7 @@ fi
 LOOP=1
 while [ $(( $LOOP )) = "1" ]
 do
+  [ -f "${APPORT_CORE}" ] && rm -f "${APPORT_CORE}"
   LOOP=0
   ${KODI_BINARY} $SAVED_ARGS
   RET=$?


### PR DESCRIPTION
## Description
GDB backtrace is missing in crash logs on default Ubuntu 18.04 installations. Add apport support.

## Motivation and Context / How Has This Been Tested?
Tried to [create a crash log](https://trac.kodi.tv/ticket/18038)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
