### PR TITLE
[droid] bump the target API to 26 defined in androidmanifest.

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -7,7 +7,7 @@
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="22" />
+        android:targetSdkVersion="26" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
## Description
As of November 2018 every update to playstore must at least target API 26 or you cannot submit updates. We don't know what will break/stop working but we'll just have to deal with the fallout.

## Motivation and Context
We have no option but to just do this and see what happens and if some one will submit a PR to fix it.

## How Has This Been Tested?
Kodi runs but will likely miss access to local storage like USB stick/drives and maybe other things:

- Copy to internal storage works
- Copy to external does not (also broken in current nightlies)
- Read files is no issue
