### PR TITLE
 [PVR] Fix CPVRItem::GetNextEpgInfoTag to use the more flexible metho…

### DIFF
--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -46,7 +46,9 @@ namespace PVR
   {
     if (m_item->IsEPG())
     {
-      return m_item->GetEPGInfoTag()->GetNextEvent();
+      const CPVRChannelPtr channel = m_item->GetEPGInfoTag()->Channel();
+      if (channel)
+        return channel->GetEPGNext();
     }
     else if (m_item->IsPVRChannel())
     {
@@ -54,9 +56,9 @@ namespace PVR
     }
     else if (m_item->IsPVRTimer())
     {
-      const CPVREpgInfoTagPtr current = m_item->GetPVRTimerInfoTag()->GetEpgInfoTag();
-      if (current)
-        return current->GetNextEvent();
+      const CPVRChannelPtr channel =m_item->GetPVRTimerInfoTag()->Channel();
+      if (channel)
+        return channel->GetEPGNext();
     }
     else
     {

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -843,17 +843,6 @@ bool CPVREpg::LoadFromClients(time_t start, time_t end, bool bForceUpdate)
   return bReturn;
 }
 
-CPVREpgInfoTagPtr CPVREpg::GetNextEvent(const CPVREpgInfoTag& tag) const
-{
-  CSingleLock lock(m_critSection);
-  std::map<CDateTime, CPVREpgInfoTagPtr>::const_iterator it = m_tags.find(tag.StartAsUTC());
-  if (it != m_tags.end() && ++it != m_tags.end())
-    return it->second;
-
-  CPVREpgInfoTagPtr retVal;
-  return retVal;
-}
-
 CPVRChannelPtr CPVREpg::Channel(void) const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -268,8 +268,6 @@ namespace PVR
      */
     static const std::string &ConvertGenreIdToString(int iID, int iSubID);
 
-    CPVREpgInfoTagPtr GetNextEvent(const CPVREpgInfoTag& tag) const;
-
     size_t Size(void) const;
 
     bool NeedsSave(void) const;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -272,11 +272,6 @@ int CPVREpgInfoTag::Progress(void) const
   return iDuration;
 }
 
-CPVREpgInfoTagPtr CPVREpgInfoTag::GetNextEvent(void) const
-{
-  return GetTable()->GetNextEvent(*this);
-}
-
 void CPVREpgInfoTag::SetUniqueBroadcastID(unsigned int iUniqueBroadcastID)
 {
   m_iUniqueBroadcastID = iUniqueBroadcastID;

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -101,12 +101,6 @@ namespace PVR
     int Progress(void) const;
 
     /*!
-     * @brief Get a pointer to the next event.
-     * @return A pointer to the next event or NULL if it's not set.
-     */
-    CPVREpgInfoTagPtr GetNextEvent(void) const;
-
-    /*!
      * @brief The table this event belongs to
      * @return The table this event belongs to
      */


### PR DESCRIPTION
…d, which handles epg gaps correctly.

Fixes a small glitch, where info for next epg event is not displayed in OSD if there is no current epg event (EPG has a "gap").

Runtime-tested on macOS, latest Kodi master.

@Jalle19 mind taking a look.