### PR TITLE
[Android] Fix rounding / type issue when adding VSYNC offset

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1182,9 +1182,9 @@ void CXBMCApp::doFrame(int64_t frameTimeNanos)
     m_syncImpl->FrameCallback(frameTimeNanos);
 
   // Calculate the time, when next surface buffer should be rendered
-  m_frameTimeNanos = CurrentHostCounter();
+  m_frameTimeNanos = frameTimeNanos;
   if (m_refreshRate)
-    m_frameTimeNanos += (1500000000ll / m_refreshRate);
+    m_frameTimeNanos += static_cast<int64_t>(1500000000ll / m_refreshRate);
 
   m_vsyncEvent.Set();
 }


### PR DESCRIPTION
## Description
int64_t += ( (long long) / (float) ) lead to strange results when adding 2 VSYNC offsets.
int64_t += static_cast<int64_t >( (long long) / (float) ) solve the issue

## Motivation and Context
Stutter during video playback

## How Has This Been Tested?
Play "moving bars" samples in different fps on matching / multiple monitor Hz.
WETEK Hub / AFTV Gen 2

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
