### PR TITLE
[PVR] Store epg database on exit + epg code cleanup

### DIFF
--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -391,7 +391,7 @@ namespace PVR
     void OnPlaybackStarted(const CFileItemPtr &item);
 
     /*!
-     * @brief Inform GUI actions manager that playback of an item was stopped due to user interaction.
+     * @brief Inform GUI actions that playback of an item was stopped due to user interaction.
      * @param item The item that stopped to play.
      */
     void OnPlaybackStopped(const CFileItemPtr &item);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -767,6 +767,7 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
   }
 
   m_guiActions->OnPlaybackStarted(item);
+  m_epgContainer.OnPlaybackStarted(item);
 }
 
 void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
@@ -797,6 +798,7 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
   }
 
   m_guiActions->OnPlaybackStopped(item);
+  m_epgContainer.OnPlaybackStopped(item);
 }
 
 void CPVRManager::OnPlaybackEnded(const CFileItemPtr item)

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -133,7 +133,7 @@ bool CPVRChannel::Delete(void)
   {
     CPVRChannelPtr empty;
     epg->SetChannel(empty);
-    CServiceBroker::GetPVRManager().EpgContainer().DeleteEpg(*epg, true);
+    CServiceBroker::GetPVRManager().EpgContainer().DeleteEpg(epg, true);
     CSingleLock lock(m_critSection);
     m_bEPGCreated = false;
   }

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -945,9 +945,8 @@ int CPVRChannelGroup::GetEPGAll(CFileItemList &results, bool bIncludeChannelsWit
       if (bIncludeChannelsWithoutEPG && iAdded == 0)
       {
         // Add dummy EPG tag associated with this channel
-        epgTag = CPVREpgInfoTag::CreateDefaultTag();
-        epgTag->SetChannel(channel);
-        results.Add(CFileItemPtr(new CFileItem(epgTag)));
+        epgTag = std::make_shared<CPVREpgInfoTag>(channel);
+        results.Add(std::make_shared<CFileItem>(epgTag));
       }
     }
   }

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -17,7 +17,6 @@
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 
@@ -293,7 +292,7 @@ CPVREpgInfoTagPtr CPVREpg::GetTagBetween(const CDateTime &beginTime, const CDate
     if (tag)
     {
       m_tags.insert(make_pair(tag->StartAsUTC(), tag));
-      UpdateEntry(tag, !CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT));
+      UpdateEntry(tag, !CServiceBroker::GetPVRManager().EpgContainer().IgnoreDB());
     }
   }
 
@@ -402,7 +401,7 @@ bool CPVREpg::UpdateEntries(const CPVREpg &epg, bool bStoreInDb /* = true */)
 
 CDateTime CPVREpg::GetLastScanTime(void)
 {
-  bool bIgnore = CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT);
+  bool bIgnore = CServiceBroker::GetPVRManager().EpgContainer().IgnoreDB();
   CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
 
   CDateTime lastScanTime;
@@ -603,7 +602,7 @@ int CPVREpg::Get(CFileItemList &results, const CPVREpgSearchFilter &filter) cons
 
 bool CPVREpg::Persist(void)
 {
-  if (CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT) || !NeedsSave())
+  if (CServiceBroker::GetPVRManager().EpgContainer().IgnoreDB() || !NeedsSave())
     return true;
 
   CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
@@ -831,13 +830,13 @@ bool CPVREpg::LoadFromClients(time_t start, time_t end, bool bForceUpdate)
   {
     CPVREpg tmpEpg(channel);
     if (tmpEpg.UpdateFromScraper(start, end, bForceUpdate))
-      bReturn = UpdateEntries(tmpEpg, !CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT));
+      bReturn = UpdateEntries(tmpEpg, !CServiceBroker::GetPVRManager().EpgContainer().IgnoreDB());
   }
   else
   {
     CPVREpg tmpEpg(m_iEpgID, m_strName, m_strScraperName);
     if (tmpEpg.UpdateFromScraper(start, end, bForceUpdate))
-      bReturn = UpdateEntries(tmpEpg, !CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT));
+      bReturn = UpdateEntries(tmpEpg, !CServiceBroker::GetPVRManager().EpgContainer().IgnoreDB());
   }
 
   return bReturn;

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -283,7 +283,7 @@ void CPVREpg::AddEntry(const CPVREpgInfoTag &tag)
       newTag = it->second;
     else
     {
-      newTag.reset(new CPVREpgInfoTag(this, m_pvrChannel, m_strName, m_pvrChannel ? m_pvrChannel->IconPath() : ""));
+      newTag = std::make_shared<CPVREpgInfoTag>(m_pvrChannel, this, m_strName);
       m_tags.insert(std::make_pair(tag.StartAsUTC(), newTag));
     }
 
@@ -399,7 +399,7 @@ bool CPVREpg::UpdateEntry(const CPVREpgInfoTagPtr &tag, bool bUpdateDatabase)
     }
     else
     {
-      infoTag.reset(new CPVREpgInfoTag(this, m_pvrChannel, m_strName, m_pvrChannel ? m_pvrChannel->IconPath() : ""));
+      infoTag = std::make_shared<CPVREpgInfoTag>(m_pvrChannel, this, m_strName);
       infoTag->SetUniqueBroadcastID(tag->UniqueBroadcastID());
       m_tags.insert(std::make_pair(tag->StartAsUTC(), infoTag));
       bNewTag = true;

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -36,21 +36,18 @@ namespace PVR
      * @param strScraperName The name of the scraper to use.
      * @param bLoadedFromDb True if this table was loaded from the database, false otherwise.
      */
-    CPVREpg(int iEpgID, const std::string &strName = "", const std::string &strScraperName = "", bool bLoadedFromDb = false);
+    CPVREpg(int iEpgID, const std::string &strName, const std::string &strScraperName, bool bLoadedFromDb);
 
     /*!
      * @brief Create a new EPG instance for a channel.
      * @param channel The channel to create the EPG for.
-     * @param bLoadedFromDb True if this table was loaded from the database, false otherwise.
      */
-    CPVREpg(const PVR::CPVRChannelPtr &channel, bool bLoadedFromDb = false);
+    CPVREpg(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Destroy this EPG instance.
      */
     ~CPVREpg(void) override;
-
-    CPVREpg &operator =(const CPVREpg &right);
 
     /*!
      * @brief Load all entries for this table from the database.
@@ -62,36 +59,34 @@ namespace PVR
      * @brief The channel this EPG belongs to.
      * @return The channel this EPG belongs to
      */
-    PVR::CPVRChannelPtr Channel(void) const;
+    CPVRChannelPtr Channel(void) const;
 
+    /*!
+     * @brief The id of the channel this EPG belongs to.
+     * @return The channel id or -1 if no channel
+     */
     int ChannelID(void) const;
 
     /*!
      * @brief Channel the channel tag linked to this EPG table.
      * @param channel The new channel tag.
      */
-    void SetChannel(const PVR::CPVRChannelPtr &channel);
+    void SetChannel(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Get the name of the scraper to use for this table.
      * @return The name of the scraper to use for this table.
      */
-    const std::string &ScraperName(void) const { return m_strScraperName; }
-
-    /*!
-     * @brief Specify if EPG should be manually updated on the next cycle
-     * @param bUpdatePending True if EPG should be manually updated
-     */
-    void SetUpdatePending(bool bUpdatePending = true);
+    const std::string &ScraperName(void) const;
 
     /*!
      * @brief Returns if there is a manual update pending for this EPG
-     * @returns True if there are is a manual update pending, false otherwise
+     * @return True if there is a manual update pending, false otherwise
      */
     bool UpdatePending(void) const;
 
     /*!
-     * @brief Clear the current tag and schedule manual update
+     * @brief Clear the current tags and schedule manual update
      */
     void ForceUpdate(void);
 
@@ -99,19 +94,13 @@ namespace PVR
      * @brief Get the name of this table.
      * @return The name of this table.
      */
-    const std::string &Name(void) const { return m_strName; }
-
-    /*!
-     * @brief Changed the name of this table.
-     * @param strName The new name.
-     */
-    void SetName(const std::string &strName);
+    const std::string &Name(void) const;
 
     /*!
      * @brief Get the database ID of this table.
      * @return The database ID of this table.
      */
-    int EpgID(void) const { return m_iEpgID; }
+    int EpgID(void) const;
 
     /*!
      * @brief Check whether this EPG contains valid entries.
@@ -122,9 +111,9 @@ namespace PVR
     /*!
      * @brief Remove all entries from this EPG that finished before the given time
      *        and that have no timers set.
-     * @param Time Delete entries with an end time before this time in UTC.
+     * @param time Delete entries with an end time before this time in UTC.
      */
-    void Cleanup(const CDateTime &Time);
+    void Cleanup(const CDateTime &time);
 
     /*!
      * @brief Remove all entries from this EPG that finished before the given time
@@ -156,7 +145,7 @@ namespace PVR
     CPVREpgInfoTagPtr GetTagPrevious() const;
 
     /*!
-     * Get the event that occurs between the given begin and end time.
+     * @brief Get the event that occurs between the given begin and end time.
      * @param beginTime Minimum start time in UTC of the event.
      * @param endTime Maximum end time in UTC of the event.
      * @param bUpdateFromClient if true, try to fetch the event from the client if not found locally.
@@ -165,7 +154,7 @@ namespace PVR
     CPVREpgInfoTagPtr GetTagBetween(const CDateTime &beginTime, const CDateTime &endTime, bool bUpdateFromClient = false);
 
     /*!
-     * Get all events occurring between the given begin and end time.
+     * @brief Get all events occurring between the given begin and end time.
      * @param beginTime Minimum start time in UTC of the event.
      * @param endTime Maximum end time in UTC of the event.
      * @return The tags found or an empty vector if none was found.
@@ -249,12 +238,14 @@ namespace PVR
     CDateTime GetLastDate(void) const;
 
     /*!
+     * @brief Get the time the EPG data were last updated.
      * @return The last time this table was scanned.
      */
     CDateTime GetLastScanTime(void);
 
     /*!
      * @brief Notify observers when the currently active tag changed.
+     * @return True if the playing tag has changed, false otherwise.
      */
     bool CheckPlayingEvent(void);
 
@@ -264,19 +255,24 @@ namespace PVR
      * @param iSubID The genre sub ID.
      * @return A human readable name.
      */
-    static const std::string &ConvertGenreIdToString(int iID, int iSubID);
+    static const std::string& ConvertGenreIdToString(int iID, int iSubID);
 
-    size_t Size(void) const;
-
+    /*!
+     * @brief Check whether this EPG has unsaved data.
+     * @return True if this EPG contains unsaved data, false otherwise.
+     */
     bool NeedsSave(void) const;
 
     /*!
-     * @return True when this EPG is valid and can be updated, false otherwise.
+     * @brief Check whether this EPG is valid.
+     * @return True if this EPG is valid and can be updated, false otherwise.
      */
     bool IsValid(void) const;
 
   private:
-    CPVREpg(void) = default;
+    CPVREpg(void) = delete;
+    CPVREpg(const CPVREpg&) = delete;
+    CPVREpg& operator =(const CPVREpg&) = delete;
 
     /*!
      * @brief Update the EPG from a scraper set in the channel tag.
@@ -332,7 +328,7 @@ namespace PVR
 
     CDateTime                           m_lastScanTime;    /*!< the last time the EPG has been updated */
 
-    PVR::CPVRChannelPtr                 m_pvrChannel;      /*!< the channel this EPG belongs to */
+    CPVRChannelPtr                      m_pvrChannel;      /*!< the channel this EPG belongs to */
 
     mutable CCriticalSection            m_critSection;     /*!< critical section for changes in this table */
     bool                                m_bUpdateLastScanTime = false;

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -24,8 +24,6 @@
 /** EPG container for CPVREpgInfoTag instances */
 namespace PVR
 {
-  typedef std::map<unsigned int, CPVREpgPtr> EPGMAP;
-
   class CPVREpg : public Observable
   {
     friend class CPVREpgDatabase;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -528,7 +528,7 @@ CPVREpgPtr CPVREpgContainer::CreateChannelEpg(const CPVRChannelPtr &channel)
     if (channel->EpgID() <= 0)
       channel->SetEpgID(NextEpgId());
 
-    epg.reset(new CPVREpg(channel, false));
+    epg.reset(new CPVREpg(channel));
 
     CSingleLock lock(m_critSection);
     m_epgs.insert(std::make_pair(static_cast<unsigned int>(epg->EpgID()), epg));

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -333,7 +333,7 @@ bool CPVREpgContainer::PersistAll(void)
   auto copy = m_epgs;
   m_critSection.unlock();
 
-  for (EPGMAP::const_iterator it = copy.begin(); it != copy.end() && !m_bStop; ++it)
+  for (EPGMAP::const_iterator it = copy.begin(); it != copy.end(); ++it)
   {
     CPVREpgPtr epg = it->second;
     if (epg && epg->NeedsSave())
@@ -455,6 +455,9 @@ void CPVREpgContainer::Process(void)
 
     Sleep(1000);
   }
+
+  // store data on exit
+  PersistAll();
 }
 
 CPVREpgPtr CPVREpgContainer::GetById(int iEpgId) const

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -54,25 +54,13 @@ namespace PVR
 
     /*!
      * @brief Stop the EPG update thread.
-     * @return
      */
-    bool Stop(void);
+    void Stop(void);
 
     /*!
      * @brief Clear all EPG entries.
-     * @param bClearDb Clear the database too if true.
      */
-    void Clear(bool bClearDb = false);
-
-    /*!
-     * @brief Stop the update thread and unload all data.
-     */
-    void Unload(void);
-
-    /*!
-     * @brief Clear the EPG and all it's database entries.
-     */
-    void Reset(void) { Clear(true); }
+    void Clear();
 
     /*!
      * @brief Check whether the EpgContainer has fully started.
@@ -84,9 +72,9 @@ namespace PVR
      * @brief Delete an EPG table from this container.
      * @param epg The table to delete.
      * @param bDeleteFromDatabase Delete this table from the database too if true.
-     * @return
+     * @return True on success, false otherwise.
      */
-    bool DeleteEpg(const CPVREpg &epg, bool bDeleteFromDatabase = false);
+    bool DeleteEpg(const CPVREpgPtr &epg, bool bDeleteFromDatabase = false);
 
     /*!
      * @brief Process a notification from an observable.
@@ -95,7 +83,12 @@ namespace PVR
      */
     void Notify(const Observable &obs, const ObservableMessage msg) override;
 
-    CPVREpgPtr CreateChannelEpg(const PVR::CPVRChannelPtr &channel);
+    /*!
+     * @brief Create the EPg for a given channel.
+     * @param channel The channel.
+     * @return the created EPG
+     */
+    CPVREpgPtr CreateChannelEpg(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Get all EPG tables and apply a filter.
@@ -112,9 +105,9 @@ namespace PVR
     const CDateTime GetFirstEPGDate(void);
 
     /*!
-      * @brief Get the end time of the last entry.
-      * @return The end time.
-      */
+     * @brief Get the end time of the last entry.
+     * @return The end time.
+     */
     const CDateTime GetLastEPGDate(void);
 
     /*!
@@ -130,55 +123,26 @@ namespace PVR
      * @param iBroadcastId The event id to get
      * @return The requested event, or an empty tag when not found
      */
-    CPVREpgInfoTagPtr GetTagById(const PVR::CPVRChannelPtr &channel, unsigned int iBroadcastId) const;
+    CPVREpgInfoTagPtr GetTagById(const CPVRChannelPtr &channel, unsigned int iBroadcastId) const;
 
     /*!
      * @brief Get the EPG events matching the given timer
      * @param timer The timer to get the matching events for.
      * @return The matching events, or an empty vector when no matching tag was found
      */
-    std::vector<CPVREpgInfoTagPtr> GetEpgTagsForTimer(const PVR::CPVRTimerInfoTagPtr &timer) const;
+    std::vector<CPVREpgInfoTagPtr> GetEpgTagsForTimer(const CPVRTimerInfoTagPtr &timer) const;
 
     /*!
-     * @brief Notify EPG table observers when the currently active tag changed.
-     * @return True if the check was done, false if it was not the right time to check
-     */
-    bool CheckPlayingEvents(void);
-
-    /*!
-     * @brief The next EPG ID to be given to a table when the db isn't being used.
-     * @return The next ID.
-     */
-    unsigned int NextEpgId(void);
-
-    /*!
-     * @return True to not to store EPG entries in the database.
+     * @brief Check whether data should be persisted to the EPG database.
+     * @return True if data should not be persisted to the EPG database, false otherwise.
      */
     bool IgnoreDB() const;
-
-    /*!
-     * @brief Wait for an EPG update to finish.
-     * @param bInterrupt True to interrupt a running update.
-     */
-    void WaitForUpdateFinish(bool bInterrupt = true);
-
-    /*!
-     * @brief Set to true to prevent updates.
-     * @param bSetTo The new value.
-     */
-    void PreventUpdates(bool bSetTo = true) { m_bPreventUpdates = bSetTo;  }
 
     /*!
      * @brief Notify EPG container that there are pending manual EPG updates
      * @param bHasPendingUpdates The new value
      */
     void SetHasPendingUpdates(bool bHasPendingUpdates = true);
-
-    /*!
-     * @brief Call Persist() on each table
-     * @return True when they all were persisted, false otherwise.
-     */
-    bool PersistAll(void);
 
     /*!
      * @brief A client triggered an epg update request for a channel
@@ -208,10 +172,27 @@ namespace PVR
 
   private:
     /*!
-     * @brief Load the EPG settings.
-     * @return True if the settings were loaded successfully, false otherwise.
+     * @brief Notify EPG table observers when the currently active tag changed.
+     * @return True if the check was done, false if it was not the right time to check
      */
-    bool LoadSettings(void);
+    bool CheckPlayingEvents(void);
+
+    /*!
+     * @brief The next EPG ID to be given to a table when the db isn't being used.
+     * @return The next ID.
+     */
+    unsigned int NextEpgId(void);
+
+    /*!
+     * @brief Wait for an EPG update to finish.
+     */
+    void WaitForUpdateFinish();
+
+    /*!
+     * @brief Call Persist() on each table
+     * @return True when they all were persisted, false otherwise.
+     */
+    bool PersistAll(void);
 
     /*!
      * @brief Remove old EPG entries.
@@ -227,6 +208,7 @@ namespace PVR
     bool UpdateEPG(bool bOnlyPending = false);
 
     /*!
+     * @brief Check whether a running update should be interrupted.
      * @return True if a running update should be interrupted, false otherwise.
      */
     bool InterruptUpdate(void) const;
@@ -241,27 +223,28 @@ namespace PVR
      */
     void LoadFromDB(void);
 
-    void InsertFromDatabase(const CPVREpgPtr &newEpg);
+    /*!
+     * @brief Insert data from database
+     * @param newEpg the EPG containing the updated data.
+     */
+    void InsertFromDB(const CPVREpgPtr &newEpg);
 
     CPVREpgDatabasePtr m_database; /*!< the EPG database */
 
-    /** @name Class state properties */
-    //@{
-    bool         m_bIsUpdating;            /*!< true while an update is running */
-    bool         m_bIsInitialising;        /*!< true while the epg manager hasn't loaded all tables */
-    bool         m_bStarted;               /*!< true if EpgContainer has fully started */
-    bool         m_bLoaded;                /*!< true after epg data is initially loaded from the database */
-    bool         m_bPreventUpdates;        /*!< true to prevent EPG updates */
-    int          m_pendingUpdates;         /*!< count of pending manual updates */
-    time_t       m_iLastEpgCleanup;        /*!< the time the EPG was cleaned up */
-    time_t       m_iNextEpgUpdate;         /*!< the time the EPG will be updated */
-    time_t       m_iNextEpgActiveTagCheck; /*!< the time the EPG will be checked for active tag updates */
-    unsigned int m_iNextEpgId;             /*!< the next epg ID that will be given to a new table when the db isn't being used */
-    EPGMAP       m_epgs;                   /*!< the EPGs in this container */
-    //@}
+    bool m_bIsUpdating = false;                /*!< true while an update is running */
+    bool m_bIsInitialising = true;             /*!< true while the epg manager hasn't loaded all tables */
+    bool m_bStarted = false;                   /*!< true if EpgContainer has fully started */
+    bool m_bLoaded = false;                    /*!< true after epg data is initially loaded from the database */
+    bool m_bPreventUpdates = false;            /*!< true to prevent EPG updates */
+    int m_pendingUpdates = 0;                  /*!< count of pending manual updates */
+    time_t m_iLastEpgCleanup = 0;              /*!< the time the EPG was cleaned up */
+    time_t m_iNextEpgUpdate = 0;               /*!< the time the EPG will be updated */
+    time_t m_iNextEpgActiveTagCheck = 0;       /*!< the time the EPG will be checked for active tag updates */
+    unsigned int m_iNextEpgId = 0;             /*!< the next epg ID that will be given to a new table when the db isn't being used */
+    std::map<unsigned int, CPVREpgPtr> m_epgs; /*!< the EPGs in this container */
 
-    mutable CCriticalSection       m_critSection;    /*!< a critical section for changes to this container */
-    CEvent                         m_updateEvent;    /*!< trigger when an update finishes */
+    mutable CCriticalSection m_critSection;    /*!< a critical section for changes to this container */
+    CEvent m_updateEvent;                      /*!< trigger when an update finishes */
 
     std::list<CEpgUpdateRequest> m_updateRequests; /*!< list of update requests triggered by addon */
     CCriticalSection m_updateRequestsLock;         /*!< protect update requests */

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -170,6 +170,19 @@ namespace PVR
      */
     int GetFutureDaysToDisplay() const;
 
+    /*!
+     * @brief Inform the epg container that playback of an item just started.
+     * @param item The item that started to play.
+     */
+    void OnPlaybackStarted(const CFileItemPtr &item);
+
+    /*!
+     * @brief Inform the epg container that playback of an item was stopped due to user interaction.
+     * @param item The item that stopped to play.
+     */
+    void OnPlaybackStopped(const CFileItemPtr &item);
+
+
   private:
     /*!
      * @brief Notify EPG table observers when the currently active tag changed.
@@ -236,6 +249,7 @@ namespace PVR
     bool m_bStarted = false;                   /*!< true if EpgContainer has fully started */
     bool m_bLoaded = false;                    /*!< true after epg data is initially loaded from the database */
     bool m_bPreventUpdates = false;            /*!< true to prevent EPG updates */
+    bool m_bPlaying = false;                   /*!< true if Kodi is currently playing something */
     int m_pendingUpdates = 0;                  /*!< count of pending manual updates */
     time_t m_iLastEpgCleanup = 0;              /*!< the time the EPG was cleaned up */
     time_t m_iNextEpgUpdate = 0;               /*!< the time the EPG will be updated */

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -185,13 +185,13 @@ bool CPVREpgDatabase::DeleteEpgEntries(const CDateTime &maxEndTime)
 bool CPVREpgDatabase::Delete(const CPVREpgInfoTag &tag)
 {
   /* tag without a database ID was not persisted */
-  if (tag.BroadcastId() <= 0)
+  if (tag.DatabaseID() <= 0)
     return false;
 
   Filter filter;
 
   CSingleLock lock(m_critSection);
-  filter.AppendWhere(PrepareSQL("idBroadcast = %u", tag.BroadcastId()));
+  filter.AppendWhere(PrepareSQL("idBroadcast = %u", tag.DatabaseID()));
   return DeleteValues("epgtags", filter);
 }
 
@@ -256,7 +256,7 @@ std::vector<CPVREpgInfoTagPtr> CPVREpgDatabase::Get(const CPVREpg &epg)
         // Compat: null value for broadcast uid changed from numerical -1 to 0 with PVR Addon API v4.0.0
         newTag->m_iUniqueBroadcastID = iBroadcastUID == -1 ? EPG_TAG_INVALID_UID : iBroadcastUID;
 
-        newTag->m_iBroadcastId       = m_pDS->fv("idBroadcast").get_asInt();
+        newTag->m_iDatabaseID        = m_pDS->fv("idBroadcast").get_asInt();
         newTag->m_strTitle           = m_pDS->fv("sTitle").get_asString().c_str();
         newTag->m_strPlotOutline     = m_pDS->fv("sPlotOutline").get_asString().c_str();
         newTag->m_strPlot            = m_pDS->fv("sPlot").get_asString().c_str();
@@ -366,7 +366,7 @@ int CPVREpgDatabase::Persist(const CPVREpgInfoTag &tag, bool bSingleUpdate /* = 
   tag.EndAsUTC().GetAsTime(iEndTime);
   tag.FirstAiredAsUTC().GetAsTime(iFirstAired);
 
-  int iBroadcastId = tag.BroadcastId();
+  int iBroadcastId = tag.DatabaseID();
   std::string strQuery;
 
   /* Only store the genre string when needed */

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -35,34 +35,24 @@ namespace PVR
 
   public:
     /*!
-     * @brief Create a new empty event .
-     */
-    static CPVREpgInfoTagPtr CreateDefaultTag();
-
-    /*!
-     * @brief Create a new EPG infotag with 'data' as content.
-     * @param data The tag's content.
+     * @brief Create a new EPG infotag.
+     * @param data The tag's data.
+     * @param iClientId The client id.
      */
     CPVREpgInfoTag(const EPG_TAG &data, int iClientId);
 
-  private:
     /*!
-     * @brief Create a new empty event.
+     * @brief Create a new EPG infotag.
+     * @param channel The channel.
+     * @param epg The epg data.
+     * @param strTabelName The name of the epg database table.
      */
-    CPVREpgInfoTag(void);
+    CPVREpgInfoTag(const CPVRChannelPtr &channel, CPVREpg *epg = nullptr, const std::string &strTableName = "");
 
-    /*!
-     * @brief Create a new empty event without a unique ID.
-     */
-    CPVREpgInfoTag(CPVREpg *epg, const PVR::CPVRChannelPtr &channel, const std::string &strTableName = "", const std::string &strIconPath = "");
-
-    CPVREpgInfoTag(const CPVREpgInfoTag &tag) = delete;
-    CPVREpgInfoTag &operator =(const CPVREpgInfoTag &other) = delete;
-
-  public:
     bool operator ==(const CPVREpgInfoTag& right) const;
     bool operator !=(const CPVREpgInfoTag& right) const;
 
+    // ISerializable implementation
     void Serialize(CVariant &value) const override;
 
     // ISortable implementation
@@ -81,36 +71,38 @@ namespace PVR
     bool IsActive(void) const;
 
     /*!
+     * @brief Check if this event is in the past.
      * @return True when this event has already passed, false otherwise.
      */
     bool WasActive(void) const;
 
     /*!
+     * @brief Check if this event is in the future.
      * @return True when this event is an upcoming event, false otherwise.
      */
     bool IsUpcoming(void) const;
 
     /*!
+     * @brief Get the progress of this tag in percent.
      * @return The current progress of this tag.
      */
     float ProgressPercentage(void) const;
 
     /*!
+     * @brief Get the progress of this tag in seconds.
      * @return The current progress of this tag in seconds.
      */
     int Progress(void) const;
 
     /*!
-     * @brief The table this event belongs to
-     * @return The table this event belongs to
+     * @brief Get EPG ID of this tag.
+     * @return The epg ID.
      */
-    const CPVREpg *GetTable() const;
-
     int EpgID(void) const;
 
     /*!
-     * @brief Sets the epg reference of this event
-     * @param epg The epg item
+     * @brief Sets the EPG for this event.
+     * @param epg The epg.
      */
     void SetEpg(CPVREpg *epg);
 
@@ -130,26 +122,36 @@ namespace PVR
      * @brief Get the event's database ID.
      * @return The database ID.
      */
-    int BroadcastId(void) const;
+    int DatabaseID(void) const;
 
     /*!
-     * @brief Get the unique ID of the channel this event belongs to.
+     * @brief Get the unique ID of the channel associated with this event.
      * @return The unique channel ID.
      */
     unsigned int UniqueChannelID(void) const;
 
     /*!
      * @brief Get the event's start time.
-     * @return The new start time.
+     * @return The start time in UTC.
      */
     CDateTime StartAsUTC(void) const;
+
+    /*!
+     * @brief Get the event's start time.
+     * @return The start time as local time.
+     */
     CDateTime StartAsLocalTime(void) const;
 
     /*!
      * @brief Get the event's end time.
-     * @return The new start time.
+     * @return The end time in UTC.
      */
     CDateTime EndAsUTC(void) const;
+
+    /*!
+     * @brief Get the event's end time.
+     * @return The end time as local time.
+     */
     CDateTime EndAsLocalTime(void) const;
 
     /*!
@@ -160,15 +162,9 @@ namespace PVR
 
     /*!
      * @brief Get the duration of this event in seconds.
-     * @return The duration in seconds.
+     * @return The duration.
      */
     int GetDuration(void) const;
-
-    /*!
-     * @brief Check whether this event is parental locked.
-     * @return True if whether this event is parental locked, false otherwise.
-     */
-    bool IsParentalLocked() const;
 
     /*!
      * @brief Get the title of this event.
@@ -272,9 +268,14 @@ namespace PVR
 
     /*!
      * @brief Get the first air date of this event.
-     * @return The first air date.
+     * @return The first air date in UTC.
      */
     CDateTime FirstAiredAsUTC(void) const;
+
+    /*!
+     * @brief Get the first air date of this event.
+     * @return The first air date as local time.
+     */
     CDateTime FirstAiredAsLocalTime(void) const;
 
     /*!
@@ -342,7 +343,7 @@ namespace PVR
      * @brief Set a timer for this event.
      * @param timer The timer.
      */
-    void SetTimer(const PVR::CPVRTimerInfoTagPtr &timer);
+    void SetTimer(const CPVRTimerInfoTagPtr &timer);
 
     /*!
      * @brief Clear the timer for this event.
@@ -350,28 +351,28 @@ namespace PVR
     void ClearTimer(void);
 
     /*!
-     * @brief Check whether this event has an active timer tag.
-     * @return True if it has an active timer tag, false if not.
+     * @brief Check whether this event has a timer tag.
+     * @return True if it has a timer tag, false if not.
      */
     bool HasTimer(void) const;
 
     /*!
-     * @brief Check whether this event has an active timer rule.
-     * @return True if it has an active timer rule, false if not.
+     * @brief Check whether this event has a timer rule.
+     * @return True if it has a timer rule, false if not.
      */
     bool HasTimerRule(void) const;
 
     /*!
-     * @brief Get a pointer to the timer for event or NULL if there is none.
-     * @return A pointer to the timer for event or NULL if there is none.
+     * @brief Get the timer for this event, if any.
+     * @return The timer or nullptr if there is none.
      */
-    PVR::CPVRTimerInfoTagPtr Timer(void) const;
+    CPVRTimerInfoTagPtr Timer(void) const;
 
     /*!
-     * @brief Set a recording for this event or NULL to clear it.
-     * @param recording The recording value.
+     * @brief Set a recording for this event.
+     * @param recording The recording.
      */
-    void SetRecording(const PVR::CPVRRecordingPtr &recording);
+    void SetRecording(const CPVRRecordingPtr &recording);
 
     /*!
      * @brief Clear a recording for this event.
@@ -379,16 +380,16 @@ namespace PVR
     void ClearRecording(void);
 
     /*!
-     * @brief Check whether this event has a recording tag.
-     * @return True if it has a recording tag, false if not.
+     * @brief Check whether this event has a recording.
+     * @return True if it has a recording, false if not.
      */
     bool HasRecording(void) const;
 
     /*!
-     * @brief Get a pointer to the recording for event or NULL if there is none.
-     * @return A pointer to the recording for event or NULL if there is none.
+     * @brief Get the recording for this event, if any.
+     * @return The pointer or nullptr if there is none.
      */
-    PVR::CPVRRecordingPtr Recording(void) const;
+    CPVRRecordingPtr Recording(void) const;
 
     /*!
      * @brief Check if this event can be recorded.
@@ -403,21 +404,22 @@ namespace PVR
     bool IsPlayable(void) const;
 
     /*!
-     * @brief Change the channel tag of this epg tag
-     * @param channel The new channel
+     * @brief Set the channel of this epg tag
+     * @param channel The channel
      */
-    void SetChannel(const PVR::CPVRChannelPtr &channel);
+    void SetChannel(const CPVRChannelPtr &channel);
 
     /*!
-     * @return True if this tag has a PVR channel set.
+     * @brief Check whether this event has a channel.
+     * @return True if it has a channel, false if not.
      */
     bool HasChannel(void) const;
 
     /*!
-     * @brief Get the channel that plays this event.
-     * @return a pointer to the channel.
+     * @brief Get the channel for this event.
+     * @return The channel.
      */
-    const PVR::CPVRChannelPtr Channel(void) const;
+    const CPVRChannelPtr Channel(void) const;
 
     /*!
      * @brief Persist this tag in the database.
@@ -441,6 +443,7 @@ namespace PVR
     std::vector<PVR_EDL_ENTRY> GetEdl() const;
 
     /*!
+     * @brief Check whether this tag has any series attributes.
      * @return True if this tag has any series attributes, false otherwise
      */
     bool IsSeries() const;
@@ -456,16 +459,27 @@ namespace PVR
      * @param str The string to tokenize.
      * @return the tokens.
      */
-    const std::vector<std::string> Tokenize(const std::string &str) const;
+    static const std::vector<std::string> Tokenize(const std::string &str);
 
     /*!
      * @brief Combine the given strings to a single string. Inserts EPG_STRING_TOKEN_SEPARATOR as separator.
      * @param tokens The tokens.
      * @return the combined string.
      */
-    const std::string DeTokenize(const std::vector<std::string> &tokens) const;
+    static const std::string DeTokenize(const std::vector<std::string> &tokens);
 
   private:
+    CPVREpgInfoTag() = default;
+
+    CPVREpgInfoTag(const CPVREpgInfoTag &tag) = delete;
+    CPVREpgInfoTag &operator =(const CPVREpgInfoTag &other) = delete;
+
+    /*!
+     * @brief Check whether this event is parental locked.
+     * @return True if whether this event is parental locked, false otherwise.
+     */
+    bool IsParentalLocked() const;
+
     /*!
      * @brief Change the genre of this event.
      * @param iGenreType The genre type ID.
@@ -474,53 +488,51 @@ namespace PVR
     void SetGenre(int iGenreType, int iGenreSubType, const char* strGenre);
 
     /*!
-     * @brief Hook that is called when the start date changed.
+     * @brief Update the path of this tag.
      */
     void UpdatePath(void);
 
     /*!
      * @brief Get current time, taking timeshifting into account.
+     * @return The playing time.
      */
     CDateTime GetCurrentPlayingTime(void) const;
 
-    bool                     m_bNotify = false;            /*!< notify on start */
-    int                      m_iClientId = -1;          /*!< client id */
-    int                      m_iBroadcastId = -1;       /*!< database ID */
-    int                      m_iGenreType = 0;         /*!< genre type */
-    int                      m_iGenreSubType = 0;      /*!< genre subtype */
-    int                      m_iParentalRating = 0;    /*!< parental rating */
-    int                      m_iStarRating = 0;        /*!< star rating */
-    int                      m_iSeriesNumber = 0;      /*!< series number */
-    int                      m_iEpisodeNumber = 0;     /*!< episode number */
-    int                      m_iEpisodePart = 0;       /*!< episode part number */
-    unsigned int             m_iUniqueBroadcastID; /*!< unique broadcast ID */
-    unsigned int             m_iUniqueChannelID;   /*!< unique channel ID */
-    std::string              m_strTitle;           /*!< title */
-    std::string              m_strPlotOutline;     /*!< plot outline */
-    std::string              m_strPlot;            /*!< plot */
-    std::string              m_strOriginalTitle;   /*!< original title */
-    std::vector<std::string> m_cast;               /*!< cast */
-    std::vector<std::string> m_directors;          /*!< director(s) */
-    std::vector<std::string> m_writers;            /*!< writer(s) */
-    int                      m_iYear = 0;              /*!< year */
-    std::string              m_strIMDBNumber;      /*!< imdb number */
-    std::vector<std::string> m_genre;              /*!< genre */
-    std::string              m_strEpisodeName;     /*!< episode name */
-    std::string              m_strIconPath;        /*!< the path to the icon */
-    std::string              m_strFileNameAndPath; /*!< the filename and path */
-    CDateTime                m_startTime;          /*!< event start time */
-    CDateTime                m_endTime;            /*!< event end time */
-    CDateTime                m_firstAired;         /*!< first airdate */
-
-    PVR::CPVRTimerInfoTagPtr m_timer;
-
-    CPVREpg *                m_epg = nullptr;                /*!< the schedule that this event belongs to */
-
-    unsigned int             m_iFlags;             /*!< the flags applicable to this EPG entry */
-    std::string              m_strSeriesLink;      /*!< series link */
+    bool                     m_bNotify = false;     /*!< notify on start */
+    int                      m_iClientId = -1;      /*!< client id */
+    int                      m_iDatabaseID = -1;    /*!< database ID */
+    int                      m_iGenreType = 0;      /*!< genre type */
+    int                      m_iGenreSubType = 0;   /*!< genre subtype */
+    int                      m_iParentalRating = 0; /*!< parental rating */
+    int                      m_iStarRating = 0;     /*!< star rating */
+    int                      m_iSeriesNumber = 0;   /*!< series number */
+    int                      m_iEpisodeNumber = 0;  /*!< episode number */
+    int                      m_iEpisodePart = 0;    /*!< episode part number */
+    unsigned int m_iUniqueBroadcastID = EPG_TAG_INVALID_UID;   /*!< unique broadcast ID */
+    unsigned int m_iUniqueChannelID = PVR_CHANNEL_INVALID_UID; /*!< unique channel ID */
+    std::string              m_strTitle;            /*!< title */
+    std::string              m_strPlotOutline;      /*!< plot outline */
+    std::string              m_strPlot;             /*!< plot */
+    std::string              m_strOriginalTitle;    /*!< original title */
+    std::vector<std::string> m_cast;                /*!< cast */
+    std::vector<std::string> m_directors;           /*!< director(s) */
+    std::vector<std::string> m_writers;             /*!< writer(s) */
+    int                      m_iYear = 0;           /*!< year */
+    std::string              m_strIMDBNumber;       /*!< imdb number */
+    std::vector<std::string> m_genre;               /*!< genre */
+    std::string              m_strEpisodeName;      /*!< episode name */
+    std::string              m_strIconPath;         /*!< the path to the icon */
+    std::string              m_strFileNameAndPath;  /*!< the filename and path */
+    CDateTime                m_startTime;           /*!< event start time */
+    CDateTime                m_endTime;             /*!< event end time */
+    CDateTime                m_firstAired;          /*!< first airdate */
+    unsigned int m_iFlags = EPG_TAG_FLAG_UNDEFINED; /*!< the flags applicable to this EPG entry */
+    std::string              m_strSeriesLink;       /*!< series link */
 
     mutable CCriticalSection m_critSection;
-    PVR::CPVRChannelPtr      m_channel;
-    PVR::CPVRRecordingPtr    m_recording;
+    CPVREpg *m_epg = nullptr;
+    CPVRChannelPtr m_channel;
+    CPVRTimerInfoTagPtr m_timer;
+    CPVRRecordingPtr m_recording;
   };
 }

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
@@ -204,9 +204,8 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList> 
         }
         else
         {
-          CPVREpgInfoTagPtr gapTag(CPVREpgInfoTag::CreateDefaultTag());
-          gapTag->SetChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
-          CFileItemPtr gapItem(new CFileItem(gapTag));
+          const CPVREpgInfoTagPtr gapTag(new CPVREpgInfoTag(m_channelItems[channel]->GetPVRChannelInfoTag()));
+          const CFileItemPtr gapItem(new CFileItem(gapTag));
           for (int i = block + blockDelta; i >= block - itemSize + sizeDelta; --i)
           {
             m_gridIndex[channel][i].item = gapItem;
@@ -229,9 +228,8 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList> 
           }
           else
           {
-            CPVREpgInfoTagPtr gapTag(CPVREpgInfoTag::CreateDefaultTag());
-            gapTag->SetChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
-            CFileItemPtr gapItem(new CFileItem(gapTag));
+            const CPVREpgInfoTagPtr gapTag(new CPVREpgInfoTag(m_channelItems[channel]->GetPVRChannelInfoTag()));
+            const CFileItemPtr gapItem(new CFileItem(gapTag));
             m_gridIndex[channel][block].item = gapItem;
           }
 


### PR DESCRIPTION
First commit fixes: EPG database changes are saved with a fixed interval of 60 secs. On exit, any pending changes were not written to db.

Second+ commits: Code cleanup along the way.

Runtime-tested on macOS, latest Kodi master.

@Jalle19 do you have some spare time for a code review?