### PR TITLE
Fix game getting stuck in rewind/fast-forward

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -155,10 +155,8 @@
       <x hotkey="back">OSD</x>
       <y hotkey="back">OSD</y>
       <start hotkey="back">Stop</start>
-      <!--
-      <rightbumper hotkey="back">Save</rightbumper>
-      <leftbumper hotkey="back">Load</leftbumper>
-      -->
+      <rightbumper hotkey="back">AnalogFastForward</rightbumper>
+      <leftbumper hotkey="back">AnalogRewind</leftbumper>
       <righttrigger hotkey="back">AnalogFastForward</righttrigger>
       <lefttrigger hotkey="back">AnalogRewind</lefttrigger>
       <!--

--- a/xbmc/input/Action.cpp
+++ b/xbmc/input/Action.cpp
@@ -11,13 +11,16 @@
 #include "ActionTranslator.h"
 #include "Key.h"
 
+CAction::CAction() :
+  m_id(ACTION_NONE)
+{
+}
+
 CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.0f */, const std::string &name /* = "" */, unsigned int holdTime /*= 0*/)
 {
   m_id = actionID;
   m_amount[0] = amount1;
   m_amount[1] = amount2;
-  for (unsigned int i = 2; i < max_amounts; i++)
-    m_amount[i] = 0;
   m_name = name;
   m_repeat = 0;
   m_buttonCode = 0;
@@ -35,8 +38,6 @@ CAction::CAction(int actionID, unsigned int state, float posX, float posY, float
   m_amount[3] = offsetY;
   m_amount[4] = velocityX;
   m_amount[5] = velocityY;
-  for (unsigned int i = 6; i < max_amounts; i++)
-    m_amount[i] = 0;
   m_repeat = 0;
   m_buttonCode = 0;
   m_unicode = 0;
@@ -46,8 +47,6 @@ CAction::CAction(int actionID, unsigned int state, float posX, float posY, float
 CAction::CAction(int actionID, wchar_t unicode)
 {
   m_id = actionID;
-  for (float& amount : m_amount)
-    amount = 0;
   m_repeat = 0;
   m_buttonCode = 0;
   m_unicode = unicode;
@@ -59,8 +58,6 @@ CAction::CAction(int actionID, const std::string &name, const CKey &key):
 {
   m_id = actionID;
   m_amount[0] = 1; // digital button (could change this for repeat acceleration)
-  for (unsigned int i = 1; i < max_amounts; i++)
-    m_amount[i] = 0;
   m_repeat = key.GetRepeat();
   m_buttonCode = key.GetButtonCode();
   m_unicode = key.GetUnicode();
@@ -102,8 +99,6 @@ CAction::CAction(int actionID, const std::string &name):
   m_name(name)
 {
   m_id = actionID;
-  for (float& amount : m_amount)
-    amount = 0;
   m_repeat = 0;
   m_buttonCode = 0;
   m_unicode = 0;
@@ -125,6 +120,12 @@ CAction& CAction::operator=(const CAction& rhs)
     m_text = rhs.m_text;
   }
   return *this;
+}
+
+void CAction::ClearAmount()
+{
+  for (float& amount : m_amount)
+    amount = 0;
 }
 
 bool CAction::IsMouse() const

--- a/xbmc/input/Action.h
+++ b/xbmc/input/Action.h
@@ -21,6 +21,7 @@ class CKey;
 class CAction
 {
 public:
+  CAction();
   CAction(int actionID, float amount1 = 1.0f, float amount2 = 0.0f, const std::string &name = "", unsigned int holdTime = 0);
   CAction(int actionID, wchar_t unicode);
   CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY, float velocityX = 0.0f, float velocityY = 0.0f, const std::string &name = "");
@@ -63,6 +64,10 @@ public:
    */
   float GetAmount(unsigned int index = 0) const { return (index < max_amounts) ? m_amount[index] : 0; };
 
+  /*! \brief Reset all amount values to zero
+   */
+  void ClearAmount();
+
   /*! \brief Unicode value associated with this action
    \return unicode value associated with this action, for keyboard input.
    */
@@ -90,12 +95,12 @@ private:
   std::string   m_name;
 
   static const unsigned int max_amounts = 6; // Must be at least 6
-  float        m_amount[max_amounts];
+  float        m_amount[max_amounts] = {};
 
-  float        m_repeat;
-  unsigned int m_holdTime;
-  unsigned int m_buttonCode;
-  wchar_t      m_unicode;
+  float        m_repeat = 0.0f;
+  unsigned int m_holdTime = 0;
+  unsigned int m_buttonCode = 0;
+  wchar_t      m_unicode = 0;
   std::string  m_text;
 };
 

--- a/xbmc/input/joysticks/keymaps/KeyHandler.h
+++ b/xbmc/input/joysticks/keymaps/KeyHandler.h
@@ -10,6 +10,7 @@
 
 #include "input/joysticks/interfaces/IKeyHandler.h"
 #include "input/joysticks/JoystickTypes.h"
+#include "input/Action.h"
 
 #include <map>
 #include <string>
@@ -44,10 +45,39 @@ namespace JOYSTICK
   private:
     void Reset();
 
-    bool HandleActions(std::vector<const KeymapAction*> actions, int windowId, float magnitude, unsigned int holdTimeMs);
-    bool HandleRelease(std::vector<const KeymapAction*> actions, int windowId);
+    /*!
+     * \brief Process actions to see if an action should be dispatched
+     *
+     * \param actions All actions from the keymap defined for the current window
+     * \param windowId The current window ID
+     * \param magnitude The magnitude or distance of the feature being handled
+     * \param holdTimeMs The time which the feature has been past the hold threshold
+     *
+     * \return The action to dispatch, or action with ID ACTION_NONE if no action should be dispatched
+     */
+    CAction ProcessActions(std::vector<const KeymapAction*> actions, int windowId, float magnitude, unsigned int holdTimeMs);
 
-    bool HandleAction(const KeymapAction& action, int windowId, float magnitude, unsigned int holdTimeMs);
+    /*!
+     * \brief Process actions after release event to see if an action should be dispatched
+     *
+     * \param actions All actions from the keymap defined for the current window
+     * \param windowId The current window ID
+     *
+     * \return The action to dispatch, or action with ID ACTION_NONE if no action should be dispatched
+     */
+    CAction ProcessRelease(std::vector<const KeymapAction*> actions, int windowId);
+
+    /*!
+     * \brief Process an action to see if it should be dispatched
+     *
+     * \param action The action chosen to be dispatched
+     * \param windowId The current window ID
+     * \param magnitude The magnitude or distance of the feature being handled
+     * \param holdTimeMs The time which the feature has been past the hold threshold
+     *
+     * \return The action to dispatch, or action with ID ACTION_NONE if no action should be dispatched
+     */
+    CAction ProcessAction(const KeymapAction& action, int windowId, float magnitude, unsigned int holdTimeMs);
 
     // Check criteria for sending a repeat action
     bool SendRepeatAction(unsigned int holdTimeMs);
@@ -69,6 +99,7 @@ namespace JOYSTICK
     bool m_bActionSent;
     unsigned int m_lastActionMs;
     int m_activeWindowId = -1; // Window that activated the key
+    CAction m_lastAction;
   };
 }
 }


### PR DESCRIPTION
Rewind and fast-forward are fully supported in RetroPlayer, even though they're not in the main menu. For now these are "hidden features". RW is activated by Select + Left Trigger (or shoulder), FF is activated by Select + Right Trigger (or shoulder).

However, due to the design of Kodi, analog triggers send an action with an "amount" each frame. The game resumes normal play when an amount of zero is sent (triggers are released). If the action with a zero amount isn't sent, the game gets stuck in RW/FF.

This bug manifests when the user rewinds, then unplugs their controller or simply releases the Select hotkey while holding the trigger.

To fix this, we add the last action to the controller state. We can use this to compare subsequent actions to the previous one. When any button press occurs that results in a different (or no) action, we inject an extra action with a zero amount, which successfully resumes gameplay.

Also, I mapped the shoulder buttons to FF/RW like the triggers so that controllers without triggers (e.g. SNES) can rewind.

## Motivation and Context
Observed users getting stuck while button mashing.

## How Has This Been Tested?
Tested while waiting for Keith to get off the phone so we can hit the pubs in Sofia, Bulgaria.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
