### PR TITLE
[Android] check profile when selecting h/w decoder

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=fe51b38eedf2b0219d45ae62e763fbe4e45dfb76
+VERSION=482232cc05102021e955e9d907b0047801fa47b4
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc


### PR DESCRIPTION
## Description
Check profile when selecting h/w decoder

## Motivation and Context
Android provides decoder capabilities which let kodi know early if h/w decoder can be used or not.
For example VP9 profile 2 is not implemented on shield, but profile 1 is.

We currently fail to play such profile 2 videos, this PR let kodi fall back to ffmpeg if a profile is not supported.

## How Has This Been Tested?
NVidia shield / play VP9 p1 and p2

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
