### PR TITLE
Fix getting stuck using VideoPlayer and breaking game launching

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3271,6 +3271,7 @@ void CApplication::PlaybackCleanup()
   if (!m_appPlayer.IsPlaying())
   {
     m_stackHelper.Clear();
+    m_appPlayer.ResetPlayer();
   }
 
   if (IsEnableTestMode())

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -37,10 +37,15 @@ void CApplicationPlayer::ClosePlayer()
   if (player)
   {
     CloseFile();
-    // we need to do this directly on the member
-    CSingleLock lock(m_playerLock);
-    m_pPlayer.reset();
+    ResetPlayer();
   }
+}
+
+void CApplicationPlayer::ResetPlayer()
+{
+  // we need to do this directly on the member
+  CSingleLock lock(m_playerLock);
+  m_pPlayer.reset();
 }
 
 void CApplicationPlayer::CloseFile(bool reopen)

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -35,6 +35,7 @@ public:
 
   // player management
   void ClosePlayer();
+  void ResetPlayer();
   std::string GetCurrentPlayer();
   float GetPlaySpeed();
   float GetPlayTempo();


### PR DESCRIPTION
When a game fails to launch, Kodi gets "stuck" using VideoPlayer. After enabling emulators, Kodi should choose RetroPlayer, but continues to use VideoPlayer, which continues to silently fail.

## Description

When I launched a game with no emulators enabled, VideoPlayer tried to play the ROM and failed. However, the player core in app player was never reset, so after enabling emulators, Kodi continues trying to use the existing player to play games, which breaks all game launching.

To solve this, we reset the app player core, which allows Kodi to successfully create a new RetroPlayer core.

## Motivation and Context
Discovered after deleting AddonDB and having all emulators disabled.

## How Has This Been Tested?
Log when launching a game with emulators disabled. Kodi chooses VideoPlayer (fixed by https://github.com/xbmc/xbmc/pull/14480). VideoPlayer tries to open the game and silently fails:
```
Debug Print: CPlayerCoreFactory::GetPlayers: adding videodefaultplayer (VideoPlayer)
Debug Print: VideoPlayer::OpenFile: /Users/garrett/Library/Application Support/Kodi/userdata/addon_data/plugin.program.iagl/temp_iagl/Super Metroid (Japan, USA) (En,Ja).sfc
Debug Print: Open - error probing input format, /Users/garrett/Library/Application Support/Kodi/userdata/addon_data/plugin.program.iagl/temp_iagl/Super Metroid (Japan, USA) (En,Ja).sfc
Debug Print: OpenDemuxStream - Error creating demuxer
Debug Print: CVideoPlayer::OnExit()
Debug Print: Thread VideoPlayer 123145463148544 terminating
Debug Print: OnPlayBackStopped: CApplication::OnPlayBackStopped
```

Next, log when enabling emulators and launching a game without this patch. Kodi chooses RetroPlayer, however the existing VideoPlayer tries to open the game and silently fails:
```
Debug Print: CPlayerCoreFactory::GetPlayers: adding retroplayer
Debug Print: CPlayerCoreFactory::GetPlayers: added 1 players
Debug Print: VideoPlayer::OpenFile: /Users/garrett/Library/Application Support/Kodi/userdata/addon_data/plugin.program.iagl/temp_iagl/Super Metroid (Japan, USA) (En,Ja).sfc
Debug Print: Open - error probing input format, /Users/garrett/Library/Application Support/Kodi/userdata/addon_data/plugin.program.iagl/temp_iagl/Super Metroid (Japan, USA) (En,Ja).sfc
Debug Print: OpenDemuxStream - Error creating demuxer
Debug Print: CVideoPlayer::OnExit()
Debug Print: Thread VideoPlayer 123145463685120 terminating
Debug Print: OnPlayBackStopped: CApplication::OnPlayBackStopped
```

Next, log and screenshot when enabling emulators and launching a game with this patch. RetroPlayer successfully opens the game:
```
Debug Print: CPlayerCoreFactory::GetPlayers: adding retroplayer
Debug Print: CPlayerCoreFactory::GetPlayers: added 1 players
Debug Print: Select game client dialog: Found 3 candidates
Debug Print: Adding game.libretro.snes9x2002 as a candidate
Debug Print: Adding game.libretro.snes9x2010 as a candidate
Debug Print: Adding game.libretro.snes9x as a candidate
```

![screen shot 2018-09-26 at 12 07 27 pm](https://user-images.githubusercontent.com/531482/46070412-6c352200-c186-11e8-8121-18b207c8d5fe.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
