### PR TITLE
Fix stuck progress dialog opening "My add-ons" without network

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -587,6 +587,9 @@ bool URIUtils::IsRemote(const std::string& strFile)
   if(HasParentInHostname(url))
     return IsRemote(url.GetHostName());
 
+  if (IsAddonsPath(strFile))
+    return false;
+
   if (!url.IsLocal())
     return true;
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -590,6 +590,9 @@ bool URIUtils::IsRemote(const std::string& strFile)
   if (IsAddonsPath(strFile))
     return false;
 
+  if (IsSourcesPath(strFile))
+    return false;
+
   if (!url.IsLocal())
     return true;
 

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -376,6 +376,7 @@ TEST_F(TestURIUtils, IsRemote)
 {
   EXPECT_TRUE(URIUtils::IsRemote("http://path/to/file"));
   EXPECT_TRUE(URIUtils::IsRemote("https://path/to/file"));
+  EXPECT_FALSE(URIUtils::IsRemote("addons://user/"));
 }
 
 TEST_F(TestURIUtils, IsSmb)

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -377,6 +377,7 @@ TEST_F(TestURIUtils, IsRemote)
   EXPECT_TRUE(URIUtils::IsRemote("http://path/to/file"));
   EXPECT_TRUE(URIUtils::IsRemote("https://path/to/file"));
   EXPECT_FALSE(URIUtils::IsRemote("addons://user/"));
+  EXPECT_FALSE(URIUtils::IsRemote("sources://video/"));
 }
 
 TEST_F(TestURIUtils, IsSmb)


### PR DESCRIPTION
When "My add-ons" is opened from the home screen, Kodi thinks it's a remote path and waits for network. This is because `addons://user/` is detected as a remote path. If the network never comes up, the progress dialog doesn't go away. However, even when the user manually dismisses it, the add-on manager launches at the root `addons://` instead of `addons://user/`, which is clearly incorrect.

## Motivation and Context
Encountered when at a coffee shop in Sofia with broken WiFi.

## How Has This Been Tested?
Tested on OSX with network disabled. After patch, progress dialog is not shown.

TODO: Need test cases.

## Screenshots (if appropriate):
Kodi shows this dialog and never closes without network:

![screen shot 2018-09-26 at 9 56 30 am](https://user-images.githubusercontent.com/531482/46071306-650f1380-c188-11e8-9e47-abf6e4e86b5a.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
