### PR TITLE
Fix silently failing to launch game when emulators are disabled

### DIFF
--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -163,7 +163,7 @@ bool CGameUtils::HasGameExtension(const std::string &path)
   // Look for a game client that supports this extension
   VECADDONS gameClients;
   CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
-  addonCache.GetAddons(gameClients, ADDON_GAMEDLL);
+  addonCache.GetInstalledAddons(gameClients, ADDON_GAMEDLL);
   for (auto& gameClient : gameClients)
   {
     GameClientPtr gc(std::static_pointer_cast<CGameClient>(gameClient));


### PR DESCRIPTION
Kodi detects games using extensions from local and remote add-ons. However, if add-ons are installed but disabled, their extensions are missed. Because Kodi doesn't detect the item as a game, it tries to use VP and silently fails.

## Motivation and Context
Discovered while hunting down https://github.com/xbmc/xbmc/pull/14478. Discovered after deleting AddonDB, which disabled all local emulators, and trying to launch a game.

## How Has This Been Tested?
Tested on OSX. With all emulators disabled, Kodi shows the appropriate error message instead of silently failing (see below).

## Screenshots (if appropriate):

![screen shot 2018-09-26 at 10 34 40 am](https://user-images.githubusercontent.com/531482/46072050-0ea2d480-c18a-11e8-9ea8-5ab7673f0c0a.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
