### PR TITLE
Update Cpack Deb packaging names.

### DIFF
--- a/cmake/cpack/CPackConfigDEB.cmake
+++ b/cmake/cpack/CPackConfigDEB.cmake
@@ -182,7 +182,7 @@ install(FILES ${CPACK_PACKAGE_DIRECTORY}/deb/kodi-ps3remote.1.gz
         COMPONENT kodi-eventclients-ps3)
 install(FILES ${CPACK_PACKAGE_DIRECTORY}/deb/kodi-send.1.gz
         DESTINATION share/man/man1
-        COMPONENT kodi-eventclients-xbmc-send)
+        COMPONENT kodi-eventclients-kodi-send)
 install(FILES ${CPACK_PACKAGE_DIRECTORY}/deb/kodi-wiiremote.1.gz
         DESTINATION share/man/man1
         COMPONENT kodi-eventclients-wiiremote)

--- a/cmake/cpack/deb/packages/kodi-eventclients-kodi-send.txt.in
+++ b/cmake/cpack/deb/packages/kodi-eventclients-kodi-send.txt.in
@@ -1,4 +1,4 @@
-# kodi-eventclients-xbmc-send debian package metadata
+# kodi-eventclients-kodi-send debian package metadata
 #
 # Setting PACKAGE_SHLIBDEPS to 'ON' will cause CPack to use dpkg-shlibdeps to
 # automatically generate the package dependency list and append its output to
@@ -10,7 +10,7 @@
 #
 # Remaining settings are (hopefully) self-explanatory.
 
-PACKAGE_NAME @APP_NAME_LC@-eventclients-xbmc-send
+PACKAGE_NAME @APP_NAME_LC@-eventclients-kodi-send
 PACKAGE_ARCHITECTURE all
 PACKAGE_SECTION video
 PACKAGE_PRIORITY optional
@@ -18,8 +18,8 @@ PACKAGE_SHLIBDEPS
 PACKAGE_DEPENDS @APP_NAME_LC@-eventclients-common (= @CPACK_DEBIAN_PACKAGE_VERSION@)
 PACKAGE_RECOMMENDS
 PACKAGE_SUGGESTS
-PACKAGE_BREAKS
-PACKAGE_REPLACES
-PACKAGE_PROVIDES xbmc-eventclients-xbmc-send
+PACKAGE_BREAKS kodi-eventclients-xbmc-send
+PACKAGE_REPLACES kodi-eventclients-xbmc-send
+PACKAGE_PROVIDES kodi-eventclients-kodi-send
 PACKAGE_DESCRIPTION_HEADER @APP_NAME@ Media Center (@APP_NAME@-send event client package)
 PACKAGE_DESCRIPTION_FOOTER This is the Kodi-SEND package for @APP_NAME@'s event client.

--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -264,11 +264,11 @@ if(ENABLE_EVENTCLIENTS)
             COMPONENT kodi-eventclients-wiiremote)
   endif()
 
-  # Install kodi-eventclients-xbmc-send
+  # Install kodi-eventclients-kodi-send
   install(PROGRAMS ${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/KodiSend/kodi-send.py
           RENAME ${APP_NAME_LC}-send
           DESTINATION ${bindir}
-          COMPONENT kodi-eventclients-xbmc-send)
+          COMPONENT kodi-eventclients-kodi-send)
 endif()
 
 # Install XBT skin files


### PR DESCRIPTION
## Description
Update Cpack Deb packaging names, replacing "xbmc" with "kodi". This matches the current package naming in Debian an Ubuntu latest versions.

## Motivation and Context

## How Has This Been Tested?
Compiled and tested in RPI.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
