### PR TITLE
[Android] Use VSYNC time from Choreographer

### DIFF
--- a/xbmc/windowing/android/VideoSyncAndroid.cpp
+++ b/xbmc/windowing/android/VideoSyncAndroid.cpp
@@ -62,15 +62,14 @@ void CVideoSyncAndroid::FrameCallback(int64_t frameTimeNanos)
 {
   int           NrVBlanks;
   double        VBlankTime;
-  int64_t       nowtime = CurrentHostCounter();
 
   //calculate how many vblanks happened
-  VBlankTime = (double)(nowtime - m_LastVBlankTime) / (double)CurrentHostFrequency();
+  VBlankTime = (double)(frameTimeNanos - m_LastVBlankTime) / (double)CurrentHostFrequency();
   NrVBlanks = MathUtils::round_int(VBlankTime * m_fps);
 
   //save the timestamp of this vblank so we can calculate how many happened next time
-  m_LastVBlankTime = nowtime;
+  m_LastVBlankTime = frameTimeNanos;
 
   //update the vblank timestamp, update the clock and send a signal that we got a vblank
-  UpdateClock(NrVBlanks, nowtime, m_refClock);
+  UpdateClock(NrVBlanks, frameTimeNanos, m_refClock);
 }


### PR DESCRIPTION
## Description
Android Choreographer provides the exact VSYNC timestamp.
The callback timestamp we currently use could be too late

## Motivation and Context
Ensure proper sync to display

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
