### PR TITLE
Kill advanced settings global singleton

### DIFF
--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -10,20 +10,29 @@
 
 #include "FileItem.h"
 
+#include <string>
+
+class CAdvancedSettings;
+
 class CAppParamParser
 {
-  public:
-    CAppParamParser();
-    void Parse(const char* const* argv, int nArgs);
+public:
+  CAppParamParser();
+  void Parse(const char* const* argv, int nArgs);
+  void SetAdvancedSettings(CAdvancedSettings& advancedSettings) const;
 
-    const CFileItemList &Playlist() const { return m_playlist; }
+  const CFileItemList &Playlist() const { return m_playlist; }
 
-  private:
-    bool m_testmode;
-    void ParseArg(const std::string &arg);
-    void DisplayHelp();
-    void DisplayVersion();
-    void EnableDebugMode();
+  int m_logLevel;
+  bool m_startFullScreen = false;
 
-    CFileItemList m_playlist;
+private:
+  void ParseArg(const std::string &arg);
+  void DisplayHelp();
+  void DisplayVersion();
+
+  bool m_testmode = false;
+  bool m_standAlone = false;
+  std::string m_settingsFile;
+  CFileItemList m_playlist;
 };

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -365,7 +365,7 @@ bool CApplication::Create(const CAppParamParser &params)
 
   m_ServiceManager.reset(new CServiceManager());
 
-  if (!m_ServiceManager->InitStageOne())
+  if (!m_ServiceManager->InitStageOne(params))
   {
     return false;
   }
@@ -1846,7 +1846,7 @@ void CApplication::Render()
 
 void CApplication::SetStandAlone(bool value)
 {
-  g_advancedSettings.m_handleMounting = m_bStandalone = value;
+  m_bStandalone = value;
 }
 
 bool CApplication::OnAction(const CAction &action)
@@ -2740,7 +2740,6 @@ bool CApplication::Cleanup()
       m_ServiceManager->DeinitStageTwo();
 
     CServiceBroker::GetSettings()->Uninitialize();
-    g_advancedSettings.Clear();
 
     CSpecialProtocol::UnregisterProfileManager();
     m_ServiceManager->DeinitStageOnePointFive();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -274,7 +274,7 @@ void CApplication::HandlePortEvents()
       case XBMC_VIDEORESIZE:
         if (CServiceBroker::GetGUI()->GetWindowManager().Initialized())
         {
-          if (!g_advancedSettings.m_fullScreen)
+          if (!CServiceBroker::GetAdvancedSettings().m_fullScreen)
           {
             CServiceBroker::GetWinSystem()->GetGfxContext().ApplyWindowResize(newEvent.resize.w, newEvent.resize.h);
             CServiceBroker::GetSettings()->SetInt(CSettings::SETTING_WINDOW_WIDTH, newEvent.resize.w);
@@ -628,7 +628,7 @@ bool CApplication::CreateGUI()
   // update the window resolution
   CServiceBroker::GetWinSystem()->SetWindowResolution(CServiceBroker::GetSettings()->GetInt(CSettings::SETTING_WINDOW_WIDTH), CServiceBroker::GetSettings()->GetInt(CSettings::SETTING_WINDOW_HEIGHT));
 
-  if (g_advancedSettings.m_startFullScreen && CDisplaySettings::GetInstance().GetCurrentResolution() == RES_WINDOW)
+  if (CServiceBroker::GetAdvancedSettings().m_startFullScreen && CDisplaySettings::GetInstance().GetCurrentResolution() == RES_WINDOW)
   {
     // defer saving resolution after window was created
     CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP);
@@ -2671,7 +2671,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
       m_skipGuiRender = true;
 #endif
 
-    if (g_advancedSettings.m_guiSmartRedraw && m_guiRefreshTimer.IsTimePast())
+    if (CServiceBroker::GetAdvancedSettings().m_guiSmartRedraw && m_guiRefreshTimer.IsTimePast())
     {
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_REFRESH_TIMER, 0, 0);
       m_guiRefreshTimer.Set(500);
@@ -3177,21 +3177,21 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (item.IsVideo() && playlist == PLAYLIST_VIDEO && CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
-    options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() && g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+    options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() && CServiceBroker::GetAdvancedSettings().m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
   }
   else if(m_stackHelper.IsPlayingRegularStack())
   {
     //! @todo - this will fail if user seeks back to first file in stack
     if(m_stackHelper.GetCurrentPartNumber() == 0 || m_stackHelper.GetRegisteredStack(item)->m_lStartOffset != 0)
-      options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+      options.fullscreen = CServiceBroker::GetAdvancedSettings().m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
     else
       options.fullscreen = false;
   }
   else
-    options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+    options.fullscreen = CServiceBroker::GetAdvancedSettings().m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
 
   // stereo streams may have lower quality, i.e. 32bit vs 16 bit
-  options.preferStereo = g_advancedSettings.m_videoPreferStereoStream &&
+  options.preferStereo = CServiceBroker::GetAdvancedSettings().m_videoPreferStereoStream &&
                          CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
 
   // reset VideoStartWindowed as it's a temp setting
@@ -3354,21 +3354,23 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
 
   percent = bookmark.timeInSeconds / bookmark.totalTimeInSeconds * 100;
 
-  if ((fileItem.IsAudio() && g_advancedSettings.m_audioPlayCountMinimumPercent > 0 &&
-       percent >= g_advancedSettings.m_audioPlayCountMinimumPercent) ||
-      (fileItem.IsVideo() && g_advancedSettings.m_videoPlayCountMinimumPercent > 0 &&
-       percent >= g_advancedSettings.m_videoPlayCountMinimumPercent))
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+
+  if ((fileItem.IsAudio() && advancedSettings.m_audioPlayCountMinimumPercent > 0 &&
+       percent >= advancedSettings.m_audioPlayCountMinimumPercent) ||
+      (fileItem.IsVideo() && advancedSettings.m_videoPlayCountMinimumPercent > 0 &&
+       percent >= advancedSettings.m_videoPlayCountMinimumPercent))
   {
     playCountUpdate = true;
   }
 
-  if (g_advancedSettings.m_videoIgnorePercentAtEnd > 0 &&
+  if (advancedSettings.m_videoIgnorePercentAtEnd > 0 &&
       bookmark.totalTimeInSeconds - bookmark.timeInSeconds <
-        0.01f * g_advancedSettings.m_videoIgnorePercentAtEnd * bookmark.totalTimeInSeconds)
+        0.01f * advancedSettings.m_videoIgnorePercentAtEnd * bookmark.totalTimeInSeconds)
   {
     resumeBookmark.timeInSeconds = -1.0f;
   }
-  else if (bookmark.timeInSeconds > g_advancedSettings.m_videoIgnoreSecondsAtStart)
+  else if (bookmark.timeInSeconds > advancedSettings.m_videoIgnoreSecondsAtStart)
   {
     resumeBookmark = bookmark;
     if (m_stackHelper.GetRegisteredStack(file) != nullptr)
@@ -4334,7 +4336,7 @@ void CApplication::ProcessSlow()
 
   // Check if we need to shutdown (if enabled).
 #if defined(TARGET_DARWIN)
-  if (CServiceBroker::GetSettings()->GetInt(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNTIME) && g_advancedSettings.m_fullScreen)
+  if (CServiceBroker::GetSettings()->GetInt(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNTIME) && CServiceBroker::GetAdvancedSettings().m_fullScreen)
 #else
   if (CServiceBroker::GetSettings()->GetInt(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNTIME))
 #endif
@@ -4591,13 +4593,13 @@ void CApplication::VolumeChanged()
 int CApplication::GetSubtitleDelay()
 {
   // converts subtitle delay to a percentage
-  return int(((m_appPlayer.GetVideoSettings().m_SubtitleDelay + g_advancedSettings.m_videoSubsDelayRange)) / (2 * g_advancedSettings.m_videoSubsDelayRange)*100.0f + 0.5f);
+  return int(((m_appPlayer.GetVideoSettings().m_SubtitleDelay + CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange)) / (2 * CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange)*100.0f + 0.5f);
 }
 
 int CApplication::GetAudioDelay()
 {
   // converts audio delay to a percentage
-  return int(((m_appPlayer.GetVideoSettings().m_AudioDelay + g_advancedSettings.m_videoAudioDelayRange)) / (2 * g_advancedSettings.m_videoAudioDelayRange)*100.0f + 0.5f);
+  return int(((m_appPlayer.GetVideoSettings().m_AudioDelay + CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange)) / (2 * CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange)*100.0f + 0.5f);
 }
 
 // Returns the total time in seconds of the current media.  Fractional

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -43,6 +43,7 @@
 #include <cstdlib>
 
 #include "CueDocument.h"
+#include "ServiceBroker.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -172,10 +173,11 @@ bool CCueDocument::ParseTag(const std::string &strContent)
 //////////////////////////////////////////////////////////////////////////////////
 void CCueDocument::GetSongs(VECSONGS &songs)
 {
-  for (size_t i = 0; i < m_tracks.size(); ++i)
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+
+  for (const auto& track : m_tracks)
   {
     CSong aSong;
-    const CCueTrack& track = m_tracks[i];
     //Pass artist to MusicInfoTag object by setting artist description string only.
     //Artist credits not used during loading from cue sheet.
     if (track.strArtist.empty() && !m_strArtist.empty())
@@ -183,9 +185,9 @@ void CCueDocument::GetSongs(VECSONGS &songs)
     else
       aSong.strArtistDesc = track.strArtist;
     //Pass album artist to MusicInfoTag object by setting album artist vector.
-    aSong.SetAlbumArtist(StringUtils::Split(m_strArtist, g_advancedSettings.m_musicItemSeparator));
+    aSong.SetAlbumArtist(StringUtils::Split(m_strArtist, advancedSettings.m_musicItemSeparator));
     aSong.strAlbum = m_strAlbum;
-    aSong.genre = StringUtils::Split(m_strGenre, g_advancedSettings.m_musicItemSeparator);
+    aSong.genre = StringUtils::Split(m_strGenre, advancedSettings.m_musicItemSeparator);
     aSong.iYear = m_iYear;
     aSong.iTrack = track.iTrackNumber;
     if (m_iDiscNumber > 0)

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -16,6 +16,7 @@
 #include "pvr/PVRDatabase.h"
 #include "pvr/epg/EpgDatabase.h"
 #include "settings/AdvancedSettings.h"
+#include "ServiceBroker.h"
 
 using namespace PVR;
 
@@ -37,15 +38,17 @@ void CDatabaseManager::Initialize()
 
   CLog::Log(LOGDEBUG, "%s, updating databases...", __FUNCTION__);
 
+  CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+
   // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
   //       before CVideoDatabase.
   { CAddonDatabase db; UpdateDatabase(db); }
   { CViewDatabase db; UpdateDatabase(db); }
   { CTextureDatabase db; UpdateDatabase(db); }
-  { CMusicDatabase db; UpdateDatabase(db, &g_advancedSettings.m_databaseMusic); }
-  { CVideoDatabase db; UpdateDatabase(db, &g_advancedSettings.m_databaseVideo); }
-  { CPVRDatabase db; UpdateDatabase(db, &g_advancedSettings.m_databaseTV); }
-  { CPVREpgDatabase db; UpdateDatabase(db, &g_advancedSettings.m_databaseEpg); }
+  { CMusicDatabase db; UpdateDatabase(db, &advancedSettings.m_databaseMusic); }
+  { CVideoDatabase db; UpdateDatabase(db, &advancedSettings.m_databaseVideo); }
+  { CPVRDatabase db; UpdateDatabase(db, &advancedSettings.m_databaseTV); }
+  { CPVREpgDatabase db; UpdateDatabase(db, &advancedSettings.m_databaseEpg); }
 
   CLog::Log(LOGDEBUG, "%s, updating databases... DONE", __FUNCTION__);
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1010,7 +1010,7 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
   if(types & always_type)
   {
     if(IsSmartPlayList()
-    || (IsPlayList() && g_advancedSettings.m_playlistAsFolders)
+    || (IsPlayList() && CServiceBroker::GetAdvancedSettings().m_playlistAsFolders)
     || IsAPK()
     || IsZIP()
     || IsRAR()
@@ -1030,7 +1030,7 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
 
   if(types & EFILEFOLDER_TYPE_ONBROWSE)
   {
-    if((IsPlayList() && !g_advancedSettings.m_playlistAsFolders)
+    if((IsPlayList() && !CServiceBroker::GetAdvancedSettings().m_playlistAsFolders)
     || IsDiscImage())
       return true;
   }
@@ -2602,7 +2602,7 @@ void CFileItemList::StackFolders()
   // Precompile our REs
   VECCREGEXP folderRegExps;
   CRegExp folderRegExp(true, CRegExp::autoUtf8);
-  const std::vector<std::string>& strFolderRegExps = g_advancedSettings.m_folderStackRegExps;
+  const std::vector<std::string>& strFolderRegExps = CServiceBroker::GetAdvancedSettings().m_folderStackRegExps;
 
   std::vector<std::string>::const_iterator strExpression = strFolderRegExps.begin();
   while (strExpression != strFolderRegExps.end())
@@ -2701,7 +2701,7 @@ void CFileItemList::StackFiles()
   // Precompile our REs
   VECCREGEXP stackRegExps;
   CRegExp tmpRegExp(true, CRegExp::autoUtf8);
-  const std::vector<std::string>& strStackRegExps = g_advancedSettings.m_videoStackRegExps;
+  const std::vector<std::string>& strStackRegExps = CServiceBroker::GetAdvancedSettings().m_videoStackRegExps;
   std::vector<std::string>::const_iterator strRegExp = strStackRegExps.begin();
   while (strRegExp != strStackRegExps.end())
   {
@@ -2978,7 +2978,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
    || m_bIsShareOrDrive
    || IsInternetStream()
    || URIUtils::IsUPnP(m_strPath)
-   || (URIUtils::IsFTP(m_strPath) && !g_advancedSettings.m_bFTPThumbs)
+   || (URIUtils::IsFTP(m_strPath) && !CServiceBroker::GetAdvancedSettings().m_bFTPThumbs)
    || IsPlugin()
    || IsAddonsPath()
    || IsLibraryFolder()
@@ -3001,7 +3001,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
   // if a folder, check for folder.jpg
   if (m_bIsFolder && !IsFileFolder() && (!IsRemote() || alwaysCheckRemote || CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_MUSICFILES_FINDREMOTETHUMBS)))
   {
-    std::vector<std::string> thumbs = StringUtils::Split(g_advancedSettings.m_musicThumbs, "|");
+    std::vector<std::string> thumbs = StringUtils::Split(CServiceBroker::GetAdvancedSettings().m_musicThumbs, "|");
     for (std::vector<std::string>::const_iterator i = thumbs.begin(); i != thumbs.end(); ++i)
     {
       std::string folderThumb(GetFolderThumb(*i));
@@ -3070,7 +3070,7 @@ bool CFileItem::SkipLocalArt() const
        || m_bIsShareOrDrive
        || IsInternetStream()
        || URIUtils::IsUPnP(m_strPath)
-       || (URIUtils::IsFTP(m_strPath) && !g_advancedSettings.m_bFTPThumbs)
+       || (URIUtils::IsFTP(m_strPath) && !CServiceBroker::GetAdvancedSettings().m_bFTPThumbs)
        || IsPlugin()
        || IsAddonsPath()
        || IsLibraryFolder()
@@ -3270,7 +3270,7 @@ std::string CFileItem::GetLocalFanart() const
    || IsPlugin()
    || IsAddonsPath()
    || IsDVD()
-   || (URIUtils::IsFTP(strFile) && !g_advancedSettings.m_bFTPThumbs)
+   || (URIUtils::IsFTP(strFile) && !CServiceBroker::GetAdvancedSettings().m_bFTPThumbs)
    || m_strPath.empty())
     return "";
 
@@ -3288,7 +3288,7 @@ std::string CFileItem::GetLocalFanart() const
     items.Append(moreItems);
   }
 
-  std::vector<std::string> fanarts = StringUtils::Split(g_advancedSettings.m_fanartImages, "|");
+  std::vector<std::string> fanarts = StringUtils::Split(CServiceBroker::GetAdvancedSettings().m_fanartImages, "|");
 
   strFile = URIUtils::ReplaceExtension(strFile, "-fanart");
   fanarts.insert(m_bIsFolder ? fanarts.end() : fanarts.begin(), URIUtils::GetFileName(strFile));
@@ -3377,9 +3377,9 @@ bool CFileItem::LoadMusicTag()
   {
     std::string fileName = URIUtils::GetFileName(m_strPath);
     URIUtils::RemoveExtension(fileName);
-    for (unsigned int i = 0; i < g_advancedSettings.m_musicTagsFromFileFilters.size(); i++)
+    for (const std::string& fileFilter : CServiceBroker::GetAdvancedSettings().m_musicTagsFromFileFilters)
     {
-      CLabelFormatter formatter(g_advancedSettings.m_musicTagsFromFileFilters[i], "");
+      CLabelFormatter formatter(fileFilter, "");
       if (formatter.FillMusicTag(fileName, GetMusicInfoTag()))
       {
         GetMusicInfoTag()->SetLoaded(true);
@@ -3554,7 +3554,7 @@ std::string CFileItem::FindTrailer() const
   // Precompile our REs
   VECCREGEXP matchRegExps;
   CRegExp tmpRegExp(true, CRegExp::autoUtf8);
-  const std::vector<std::string>& strMatchRegExps = g_advancedSettings.m_trailerMatchRegExps;
+  const std::vector<std::string>& strMatchRegExps = CServiceBroker::GetAdvancedSettings().m_trailerMatchRegExps;
 
   std::vector<std::string>::const_iterator strRegExp = strMatchRegExps.begin();
   while (strRegExp != strMatchRegExps.end())

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1040,7 +1040,7 @@ const std::string& CLangInfo::GetSpeedUnitString(CSpeed::Unit speedUnit)
 std::set<std::string> CLangInfo::GetSortTokens() const
 {
   std::set<std::string> sortTokens = m_sortTokens;
-  sortTokens.insert(g_advancedSettings.m_vecTokens.begin(), g_advancedSettings.m_vecTokens.end());
+  sortTokens.insert(CServiceBroker::GetAdvancedSettings().m_vecTokens.begin(), CServiceBroker::GetAdvancedSettings().m_vecTokens.end());
 
   return sortTokens;
 }

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -314,8 +314,9 @@ bool CPlayListPlayer::Play(int iSong, std::string player, bool bAutoPlay /* = fa
     if (!m_iFailedSongs)
       m_failedSongsStart = playAttempt;
     m_iFailedSongs++;
-    if ((m_iFailedSongs >= g_advancedSettings.m_playlistRetries && g_advancedSettings.m_playlistRetries >= 0)
-        || ((XbmcThreads::SystemClockMillis() - m_failedSongsStart  >= (unsigned int)g_advancedSettings.m_playlistTimeout * 1000) && g_advancedSettings.m_playlistTimeout))
+    const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+    if ((m_iFailedSongs >= advancedSettings.m_playlistRetries && advancedSettings.m_playlistRetries >= 0)
+        || ((XbmcThreads::SystemClockMillis() - m_failedSongsStart  >= static_cast<unsigned int>(advancedSettings.m_playlistTimeout) * 1000) && CServiceBroker::GetAdvancedSettings().m_playlistTimeout))
     {
       CLog::Log(LOGDEBUG,"Playlist Player: one or more items failed to play... aborting playback");
 

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -223,18 +223,18 @@ void CSeekHandler::FrameMove()
   }
 }
 
-void CSeekHandler::SettingOptionsSeekStepsFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+void CSeekHandler::SettingOptionsSeekStepsFiller(SettingConstPtr setting, std::vector<std::pair<std::string, int>> &list, int &current, void *data)
 {
   std::string label;
-  for (std::vector<int>::iterator it = g_advancedSettings.m_seekSteps.begin(); it != g_advancedSettings.m_seekSteps.end(); ++it) {
-    int seconds = *it;
+  for (int seconds : CServiceBroker::GetAdvancedSettings().m_seekSteps)
+  {
     if (seconds > 60)
       label = StringUtils::Format(g_localizeStrings.Get(14044).c_str(), seconds / 60);
     else
       label = StringUtils::Format(g_localizeStrings.Get(14045).c_str(), seconds);
 
-    list.insert(list.begin(), make_pair("-" + label, seconds*-1));
-    list.push_back(make_pair(label, seconds));
+    list.insert(list.begin(), std::make_pair("-" + label, seconds * -1));
+    list.push_back(std::make_pair(label, seconds));
   }
 }
 

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -27,6 +27,11 @@ void CServiceBroker::UnregisterAnnouncementManager()
   m_pAnnouncementManager.reset();
 }
 
+CAdvancedSettings &CServiceBroker::GetAdvancedSettings()
+{
+  return g_application.m_ServiceManager->GetAdvancedSettings();
+}
+
 ADDON::CAddonMgr &CServiceBroker::GetAddonMgr()
 {
   return g_application.m_ServiceManager->GetAddonMgr();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -34,6 +34,7 @@ namespace PLAYLIST
   class CPlayListPlayer;
 }
 
+class CAdvancedSettings;
 class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
@@ -80,6 +81,8 @@ public:
   static std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> GetAnnouncementManager();
   static void RegisterAnnouncementManager(std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> announcementManager);
   static void UnregisterAnnouncementManager();
+
+  static CAdvancedSettings &GetAdvancedSettings();
 
   static ADDON::CAddonMgr &GetAddonMgr();
   static ADDON::CBinaryAddonManager &GetBinaryAddonManager();
@@ -137,5 +140,4 @@ private:
   static IAE* m_pActiveAE;
   static std::shared_ptr<CAppInboundProtocol> m_pAppPort;
   static std::shared_ptr<CSettings> m_pSettings;
-
 };

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -13,18 +13,19 @@
 
 class CAppParamParser;
 
-namespace ADDON {
-class CAddonMgr;
-class CBinaryAddonManager;
-class CBinaryAddonCache;
-class CVFSAddonCache;
-class CServiceAddonManager;
-class CRepositoryUpdater;
+namespace ADDON
+{
+  class CAddonMgr;
+  class CBinaryAddonManager;
+  class CBinaryAddonCache;
+  class CVFSAddonCache;
+  class CServiceAddonManager;
+  class CRepositoryUpdater;
 }
 
 namespace PVR
 {
-class CPVRManager;
+  class CPVRManager;
 }
 
 namespace PLAYLIST
@@ -32,6 +33,7 @@ namespace PLAYLIST
   class CPlayListPlayer;
 }
 
+class CAdvancedSettings;
 class CContextMenuManager;
 #ifdef HAS_PYTHON
 class XBPython;
@@ -76,7 +78,7 @@ public:
   ~CServiceManager();
 
   bool InitForTesting();
-  bool InitStageOne();
+  bool InitStageOne(const CAppParamParser &params);
   bool InitStageOnePointFive(); // Services that need our DllLoaders emu env
   bool InitStageTwo(const CAppParamParser &params);
   bool InitStageThree();
@@ -85,6 +87,9 @@ public:
   void DeinitStageTwo();
   void DeinitStageOnePointFive();
   void DeinitStageOne();
+
+  CAdvancedSettings& GetAdvancedSettings();
+
   ADDON::CAddonMgr& GetAddonMgr();
   ADDON::CBinaryAddonManager& GetBinaryAddonManager();
   ADDON::CBinaryAddonCache& GetBinaryAddonCache();
@@ -141,6 +146,7 @@ protected:
     void operator()(CFavouritesService *p) const;
   };
 
+  std::unique_ptr<CAdvancedSettings> m_advancedSettings;
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
   std::unique_ptr<ADDON::CBinaryAddonManager> m_binaryAddonManager;
   std::unique_ptr<ADDON::CBinaryAddonCache> m_binaryAddonCache;

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "TextureCacheJob.h"
+#include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "guilib/Texture.h"
 #include "settings/AdvancedSettings.h"
@@ -167,7 +168,7 @@ std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned in
       additional_info = "flipped";
 
     if (thumbURL.GetOption("size") == "thumb")
-      width = height = g_advancedSettings.m_imageRes;
+      width = height = CServiceBroker::GetAdvancedSettings().m_imageRes;
     else
     {
       if (thumbURL.HasOption("width") && StringUtils::IsInteger(thumbURL.GetOption("width")))

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -388,14 +388,15 @@ void CUtil::CleanString(const std::string& strFileName,
   if (strFileName == "..")
    return;
 
-  const std::vector<std::string> &regexps = g_advancedSettings.m_videoCleanStringRegExps;
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+  const std::vector<std::string> &regexps = advancedSettings.m_videoCleanStringRegExps;
 
   CRegExp reTags(true, CRegExp::autoUtf8);
   CRegExp reYear(false, CRegExp::autoUtf8);
 
-  if (!reYear.RegComp(g_advancedSettings.m_videoCleanDateTimeRegExp))
+  if (!reYear.RegComp(advancedSettings.m_videoCleanDateTimeRegExp))
   {
-    CLog::Log(LOGERROR, "%s: Invalid datetime clean RegExp:'%s'", __FUNCTION__, g_advancedSettings.m_videoCleanDateTimeRegExp.c_str());
+    CLog::Log(LOGERROR, "%s: Invalid datetime clean RegExp:'%s'", __FUNCTION__, advancedSettings.m_videoCleanDateTimeRegExp.c_str());
   }
   else
   {

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -361,7 +361,7 @@ void CAddonInstaller::PrunePackageCache()
 {
   std::map<std::string,CFileItemList*> packs;
   int64_t size = EnumeratePackageFolder(packs);
-  int64_t limit = (int64_t)g_advancedSettings.m_addonPackageFolderSize * 1024 * 1024;
+  int64_t limit = static_cast<int64_t>(CServiceBroker::GetAdvancedSettings().m_addonPackageFolderSize) * 1024 * 1024;
   if (size < limit)
     return;
 

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -264,7 +264,7 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording &xbmcRecording, PV
   xbmcRecording.RecordingTimeAsUTC().GetAsTime(recTime);
 
   addonRecording = {{0}};
-  addonRecording.recordingTime       = recTime - g_advancedSettings.m_iPVRTimeCorrection;
+  addonRecording.recordingTime       = recTime - CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection;
   strncpy(addonRecording.strRecordingId, xbmcRecording.m_strRecordingId.c_str(), sizeof(addonRecording.strRecordingId) - 1);
   strncpy(addonRecording.strTitle, xbmcRecording.m_strTitle.c_str(), sizeof(addonRecording.strTitle) - 1);
   strncpy(addonRecording.strPlotOutline, xbmcRecording.m_strPlotOutline.c_str(), sizeof(addonRecording.strPlotOutline) - 1);
@@ -295,6 +295,8 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
   xbmcTimer.FirstDayAsUTC().GetAsTime(firstDay);
   CPVREpgInfoTagPtr epgTag = xbmcTimer.GetEpgInfoTag();
 
+  int iPVRTimeCorrection = CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection;
+
   addonTimer = {0};
   addonTimer.iClientIndex              = xbmcTimer.m_iClientIndex;
   addonTimer.iParentClientIndex        = xbmcTimer.m_iParentClientIndex;
@@ -311,11 +313,11 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
   addonTimer.iPreventDuplicateEpisodes = xbmcTimer.m_iPreventDupEpisodes;
   addonTimer.iRecordingGroup           = xbmcTimer.m_iRecordingGroup;
   addonTimer.iWeekdays                 = xbmcTimer.m_iWeekdays;
-  addonTimer.startTime                 = start - g_advancedSettings.m_iPVRTimeCorrection;
-  addonTimer.endTime                   = end - g_advancedSettings.m_iPVRTimeCorrection;
+  addonTimer.startTime                 = start - iPVRTimeCorrection;
+  addonTimer.endTime                   = end - iPVRTimeCorrection;
   addonTimer.bStartAnyTime             = xbmcTimer.m_bStartAnyTime;
   addonTimer.bEndAnyTime               = xbmcTimer.m_bEndAnyTime;
-  addonTimer.firstDay                  = firstDay - g_advancedSettings.m_iPVRTimeCorrection;
+  addonTimer.firstDay                  = firstDay - iPVRTimeCorrection;
   addonTimer.iEpgUid                   = epgTag ? epgTag->UniqueBroadcastID() : PVR_TIMER_NO_EPG_UID;
   strncpy(addonTimer.strSummary, xbmcTimer.m_strSummary.c_str(), sizeof(addonTimer.strSummary) - 1);
   addonTimer.iMarginStart              = xbmcTimer.m_iMarginStart;
@@ -642,10 +644,12 @@ PVR_ERROR CPVRClient::GetEPGForChannel(const CPVRChannelPtr &channel, CPVREpg *e
     handle.dataAddress    = epg;
     handle.dataIdentifier = bSaveInDb ? 1 : 0; // used by the callback method CPVRClient::cb_transfer_epg_entry()
 
+    int iPVRTimeCorrection = CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection;
+
     return addon->GetEPGForChannel(&handle,
                                    addonChannel,
-                                   start ? start - g_advancedSettings.m_iPVRTimeCorrection : 0,
-                                   end ? end - g_advancedSettings.m_iPVRTimeCorrection : 0);
+                                   start ? start - iPVRTimeCorrection : 0,
+                                   end ? end - iPVRTimeCorrection : 0);
   }, m_clientCapabilities.SupportsEPG());
 }
 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -208,7 +208,7 @@ std::string CScraper::GetPathSettings()
 
 void CScraper::ClearCache()
 {
-  std::string strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath, "scrapers");
+  std::string strCachePath = URIUtils::AddFileToFolder(CServiceBroker::GetAdvancedSettings().m_cachePath, "scrapers");
 
   // create scraper cache dir if needed
   if (!CDirectory::Exists(strCachePath))
@@ -644,7 +644,7 @@ CMusicArtistInfo FromFileItem<CMusicArtistInfo>(const CFileItem &item)
   info = CMusicArtistInfo(sTitle, url);
   if (item.HasProperty("artist.genre"))
     info.GetArtist().genre = StringUtils::Split(item.GetProperty("artist.genre").asString(),
-                                                g_advancedSettings.m_musicItemSeparator);
+                                                CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   if (item.HasProperty("artist.born"))
     info.GetArtist().strBorn = item.GetProperty("artist.born").asString();
 
@@ -679,8 +679,8 @@ static std::string FromString(const CFileItem &item, const std::string &key)
 static std::vector<std::string> FromArray(const CFileItem &item, const std::string &key, int sep)
 {
   return StringUtils::Split(item.GetProperty(key).asString(),
-                            sep ? g_advancedSettings.m_videoItemSeparator
-                                : g_advancedSettings.m_musicItemSeparator);
+                            sep ? CServiceBroker::GetAdvancedSettings().m_videoItemSeparator
+                                : CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
 }
 
 static void ParseThumbs(CScraperUrl &scurl,
@@ -1148,7 +1148,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::
         XMLUtils::GetString(pxeArtist, "genre", genre);
         if (!genre.empty())
           ari.GetArtist().genre =
-              StringUtils::Split(genre, g_advancedSettings.m_musicItemSeparator);
+              StringUtils::Split(genre, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
         XMLUtils::GetString(pxeArtist, "year", ari.GetArtist().strBorn);
 
         vcari.push_back(ari);

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -191,17 +191,16 @@ CEncoder* CCDDARipJob::SetupEncoder(CFile& reader)
     return NULL;
 
   // we have to set the tags before we init the Encoder
-  std::string strTrack = StringUtils::Format("%li", strtol(m_input.substr(13, m_input.size() - 13 - 5).c_str(),NULL,10));
+  const std::string strTrack = StringUtils::Format("%li", strtol(m_input.substr(13, m_input.size() - 13 - 5).c_str(), nullptr, 10));
+
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
 
   encoder->SetComment(std::string("Ripped with ") + CSysInfo::GetAppName());
-  encoder->SetArtist(StringUtils::Join(m_tag.GetArtist(),
-                                      g_advancedSettings.m_musicItemSeparator));
+  encoder->SetArtist(StringUtils::Join(m_tag.GetArtist(), itemSeparator));
   encoder->SetTitle(m_tag.GetTitle());
   encoder->SetAlbum(m_tag.GetAlbum());
-  encoder->SetAlbumArtist(StringUtils::Join(m_tag.GetAlbumArtist(),
-                                      g_advancedSettings.m_musicItemSeparator));
-  encoder->SetGenre(StringUtils::Join(m_tag.GetGenre(),
-                                      g_advancedSettings.m_musicItemSeparator));
+  encoder->SetAlbumArtist(StringUtils::Join(m_tag.GetAlbumArtist(), itemSeparator));
+  encoder->SetGenre(StringUtils::Join(m_tag.GetGenre(), itemSeparator));
   encoder->SetTrack(strTrack);
   encoder->SetTrackLength(static_cast<int>(reader.GetLength()));
   encoder->SetYear(m_tag.GetYearString());

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -226,7 +226,7 @@ std::string CCDDARipper::GetAlbumDirName(const MUSIC_INFO::CMusicInfoTag& infoTa
   // replace %G with genre
   if (strAlbumDir.find("%G") != std::string::npos)
   {
-    std::string strGenre = StringUtils::Join(infoTag.GetGenre(), g_advancedSettings.m_musicItemSeparator);
+    std::string strGenre = StringUtils::Join(infoTag.GetGenre(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
     if (strGenre.empty())
       strGenre = "Unknown Genre";
     else

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 
 #include "AESinkALSA.h"
+#include "ServiceBroker.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/AudioEngine/Utils/AEELDParser.h"
@@ -447,7 +448,7 @@ snd_pcm_chmap_t* CAESinkALSA::SelectALSAChannelMap(const CAEChannelInfo& info)
       chmap = CopyALSAchmap(&supportedMaps[best]->map);
   }
 
-  if (chmap && g_advancedSettings.CanLogComponent(LOGAUDIO))
+  if (chmap && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGAUDIO))
     CLog::Log(LOGDEBUG, "CAESinkALSA::SelectALSAChannelMap - Selected ALSA map \"%s\"", ALSAchmapToString(chmap).c_str());
 
   snd_pcm_free_chmaps(supportedMaps);
@@ -1594,7 +1595,7 @@ bool CAESinkALSA::GetELD(snd_hctl_t *hctl, int device, CAEDeviceInfo& info, bool
 
 void CAESinkALSA::sndLibErrorHandler(const char *file, int line, const char *function, int err, const char *fmt, ...)
 {
-  if(!g_advancedSettings.CanLogComponent(LOGAUDIO))
+  if(!CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGAUDIO))
     return;
 
   va_list arg;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "AESinkXAudio.h"
+#include "ServiceBroker.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
@@ -655,7 +656,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
   if (format.m_dataFormat == AE_FMT_RAW) //No sense in trying other formats for passthrough.
     return false;
 
-  if (g_advancedSettings.CanLogComponent(LOGAUDIO))
+  if (CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGAUDIO))
     CLog::Log(LOGDEBUG, __FUNCTION__": CreateSourceVoice failed (%s) - trying to find a compatible format", WASAPIErrToStr(hr));
 
   int closestMatch;

--- a/xbmc/cores/AudioEngine/Utils/AELimiter.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AELimiter.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "AELimiter.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/MathUtils.h"
 #include <algorithm>
@@ -43,8 +44,8 @@ float CAELimiter::Run(float* frame[AE_CH_MAX], int channels, int offset /*= 0*/,
   if (sample * m_attenuation > 1.0f)
   {
     m_attenuation = 1.0f / sample;
-    m_holdcounter = MathUtils::round_int(m_samplerate * g_advancedSettings.m_limiterHold);
-    m_increase = powf(std::min(sample, 10000.0f), 1.0f / (g_advancedSettings.m_limiterRelease * m_samplerate));
+    m_holdcounter = MathUtils::round_int(m_samplerate * CServiceBroker::GetAdvancedSettings().m_limiterHold);
+    m_increase = powf(std::min(sample, 10000.0f), 1.0f / (CServiceBroker::GetAdvancedSettings().m_limiterRelease * m_samplerate));
   }
 
   float attenuation = m_attenuation;

--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "cores/FFmpeg.h"
+#include "ServiceBroker.h"
 #include "utils/log.h"
 #include "threads/CriticalSection.h"
 #include "utils/StringUtils.h"
@@ -70,9 +71,9 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
     maxLevel = AV_LOG_INFO;
 
   if (level > maxLevel &&
-     !g_advancedSettings.CanLogComponent(LOGFFMPEG))
+     !CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGFFMPEG))
     return;
-  else if (g_advancedSettings.m_logLevel <= LOG_LEVEL_NORMAL)
+  else if (CServiceBroker::GetAdvancedSettings().m_logLevel <= LOG_LEVEL_NORMAL)
     return;
 
   int type;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -591,7 +591,7 @@ void CDVDAudioCodecAndroidMediaCodec::GetData(DVDAudioFrame &frame)
     frame.duration = ((double)frame.nb_frames * DVD_TIME_BASE) / frame.format.m_sampleRate;
   else
     frame.duration = 0.0;
-  if (frame.nb_frames > 0 && g_advancedSettings.CanLogComponent(LOGAUDIO))
+  if (frame.nb_frames > 0 && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGAUDIO))
     CLog::Log(LOGDEBUG, "MediaCodecAudio::GetData: frames:%d pts: %0.4f", frame.nb_frames, frame.pts);
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "DVDAudioCodecFFmpeg.h"
+#include "ServiceBroker.h"
 #include "../../DVDStreamInfo.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
@@ -94,8 +95,9 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
     }
   }
 
-  if (g_advancedSettings.m_audioApplyDrc >= 0.0)
-    av_opt_set_double(m_pCodecContext, "drc_scale", g_advancedSettings.m_audioApplyDrc, AV_OPT_SEARCH_CHILDREN);
+  float applyDrc = CServiceBroker::GetAdvancedSettings().m_audioApplyDrc;
+  if (applyDrc >= 0.0)
+    av_opt_set_double(m_pCodecContext, "drc_scale", applyDrc, AV_OPT_SEARCH_CHILDREN);
 
   if (avcodec_open2(m_pCodecContext, pCodec, NULL) < 0)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -190,7 +190,7 @@ void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTim
     if (m_frameready)
       m_frameready->Reset();
 
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     int64_t diff = displayTime ? displayTime - CurrentHostCounter() : 0;
     CLog::Log(LOGDEBUG, "CMediaCodecVideoBuffer::ReleaseOutputBuffer index(%d), render(%d), time:%lld, offset:%lld", m_bufferId, render, displayTime, diff);
@@ -795,7 +795,7 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
 
   double pts(packet.pts), dts(packet.dts);
 
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::AddData dts:%0.2lf pts:%0.2lf sz:%d indexBuffer:%d current state (%d)", dts, pts, packet.iSize, m_indexInputBuffer, m_state);
   else if (m_state != MEDIACODEC_STATE_RUNNING)
     CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::AddData current state (%d)", m_state);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -391,9 +391,10 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
   // advanced setting override for skip loop filter (see avcodec.h for valid options)
   //! @todo allow per video setting?
-  if (g_advancedSettings.m_iSkipLoopFilter != 0)
+  int iSkipLoopFilter = CServiceBroker::GetAdvancedSettings().m_iSkipLoopFilter;
+  if (iSkipLoopFilter != 0)
   {
-    m_pCodecContext->skip_loop_filter = (AVDiscard)g_advancedSettings.m_iSkipLoopFilter;
+    m_pCodecContext->skip_loop_filter = static_cast<AVDiscard>(iSkipLoopFilter);
   }
 
   // set any special options
@@ -862,7 +863,7 @@ bool CDVDVideoCodecFFmpeg::SetPictureParams(VideoPicture* pVideoPicture)
 
   if (m_processInfo.GetVideoSettings().m_PostProcess)
   {
-    m_postProc.SetType(g_advancedSettings.m_videoPPFFmpegPostProc, false);
+    m_postProc.SetType(CServiceBroker::GetAdvancedSettings().m_videoPPFFmpegPostProc, false);
     m_postProc.Process(pVideoPicture);
   }
 
@@ -1148,7 +1149,7 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const std::string& filters, bool scale)
     return result;
   }
 
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     char* graphDump = avfilter_graph_dump(m_pFilterGraph, nullptr);
     if (graphDump)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -990,10 +990,10 @@ static bool CheckCompatibility(AVCodecContext *avctx)
   // The advanced setting lets the user override the autodetection (in case of false positive or negative)
 
   bool checkcompat;
-  if (!g_advancedSettings.m_DXVACheckCompatibilityPresent)
+  if (!CServiceBroker::GetAdvancedSettings().m_DXVACheckCompatibilityPresent)
     checkcompat = IsL41LimitedATI();  // ATI UVD and UVD+ cards can only do L4.1 - corresponds roughly to series 3xxx
   else
-    checkcompat = g_advancedSettings.m_DXVACheckCompatibility;
+    checkcompat = CServiceBroker::GetAdvancedSettings().m_DXVACheckCompatibility;
 
   if (checkcompat && !CheckH264L41(avctx))
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -214,7 +214,7 @@ void CMMALVideo::dec_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
       // we don't keep up when running at 60fps in the background so switch to half rate
       if (m_fps > 40.0f && !CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo() && !(m_num_decoded & 1))
         wanted = false;
-      if (g_advancedSettings.m_omxDecodeStartWithValidFrame && (buffer->flags & MMAL_BUFFER_HEADER_FLAG_CORRUPTED))
+      if (CServiceBroker::GetAdvancedSettings().m_omxDecodeStartWithValidFrame && (buffer->flags & MMAL_BUFFER_HEADER_FLAG_CORRUPTED))
         wanted = false;
       m_num_decoded++;
       CLog::Log(LOGDEBUG, LOGVIDEO,
@@ -586,7 +586,7 @@ bool CMMALVideo::AddData(const DemuxPacket &packet)
   uint8_t* pData = packet.pData;
   int iSize = packet.iSize;
   CSingleLock lock(m_sharedSection);
-  //if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+  //if (CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   //  CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d dts:%.3f pts:%.3f ready_queue(%d)",
   //    CLASSNAME, __func__, pData, iSize, dts == DVD_NOPTS_VALUE ? 0.0 : packet.dts*1e-6, packet.pts == DVD_NOPTS_VALUE ? 0.0 : packet.pts*1e-6, m_output_ready.size());
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -670,7 +670,7 @@ long CDecoder::ReleasePicReference()
 
 void CDecoder::SetWidthHeight(int width, int height)
 {
-  m_vdpauConfig.upscale = g_advancedSettings.m_videoVDPAUScaling;
+  m_vdpauConfig.upscale = CServiceBroker::GetAdvancedSettings().m_videoVDPAUScaling;
 
   //pick the smallest dimensions, so we downscale with vdpau and upscale with opengl when appropriate
   //this requires the least amount of gpu memory bandwidth
@@ -2172,7 +2172,7 @@ void CMixer::SetDeinterlacing()
     ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF)
     {
       VdpBool enabled[] = {1,0,0};
-      if (g_advancedSettings.m_videoVDPAUtelecine)
+      if (CServiceBroker::GetAdvancedSettings().m_videoVDPAUtelecine)
         enabled[2] = 1;
       vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     }
@@ -2180,7 +2180,7 @@ void CMixer::SetDeinterlacing()
          ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF)
     {
       VdpBool enabled[] = {1,1,0};
-      if (g_advancedSettings.m_videoVDPAUtelecine)
+      if (CServiceBroker::GetAdvancedSettings().m_videoVDPAUtelecine)
         enabled[2] = 1;
       vdp_st = m_config.context->GetProcs().vdp_video_mixer_set_feature_enables(m_videoMixer, ARSIZE(feature), feature, enabled);
     }
@@ -2207,7 +2207,7 @@ void CMixer::SetDeintSkipChroma()
   VdpStatus vdp_st;
 
   uint8_t val;
-  if (g_advancedSettings.m_videoVDPAUdeintSkipChromaHD && m_config.outHeight >= 720)
+  if (CServiceBroker::GetAdvancedSettings().m_videoVDPAUdeintSkipChromaHD && m_config.outHeight >= 720)
     val = 1;
   else
     val = 0;
@@ -2390,7 +2390,7 @@ void CMixer::Init()
   m_PostProc = false;
   m_vdpError = false;
 
-  m_config.upscale = g_advancedSettings.m_videoVDPAUScaling;
+  m_config.upscale = CServiceBroker::GetAdvancedSettings().m_videoVDPAUScaling;
   m_config.useInteropYuv = !CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_VIDEOPLAYER_USEVDPAUMIXER);
 
   CreateVdpauMixer();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -333,7 +333,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
         // the advancedsetting is for allowing the user to force outputting the
         // 44.1 kHz DTS wav file as PCM, so that an A/V receiver can decode
         // it (this is temporary until we handle 44.1 kHz passthrough properly)
-        if (trySPDIFonly || (iformat && strcmp(iformat->name, "wav") == 0 && !g_advancedSettings.m_VideoPlayerIgnoreDTSinWAV))
+        if (trySPDIFonly || (iformat && strcmp(iformat->name, "wav") == 0 && !CServiceBroker::GetAdvancedSettings().m_VideoPlayerIgnoreDTSinWAV))
         {
           // check for spdif and dts
           // This is used with wav files and audio CDs that may contain
@@ -427,7 +427,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   }
 
   // Avoid detecting framerate if advancedsettings.xml says so
-  if (g_advancedSettings.m_videoFpsDetect == 0)
+  if (CServiceBroker::GetAdvancedSettings().m_videoFpsDetect == 0)
       m_pFormatContext->fps_probe_size = 0;
 
   // analyse very short to speed up mjpeg playback start
@@ -754,7 +754,7 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
     if (!hasUserAgent)
     {
       // set default xbmc user-agent.
-      av_dict_set(&options, "user_agent", g_advancedSettings.m_userAgent.c_str(), 0);
+      av_dict_set(&options, "user_agent", CServiceBroker::GetAdvancedSettings().m_userAgent.c_str(), 0);
     }
 
     if (!headers.empty())

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "DVDFileInfo.h"
+#include "ServiceBroker.h"
 #include "threads/SystemClock.h"
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
@@ -244,7 +245,7 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
         if (iDecoderState == CDVDVideoCodec::VC_PICTURE && !(picture.iFlags & DVP_FLAG_DROPPED))
         {
           {
-            unsigned int nWidth = std::min(picture.iDisplayWidth, g_advancedSettings.m_imageRes);
+            unsigned int nWidth = std::min(picture.iDisplayWidth, CServiceBroker::GetAdvancedSettings().m_imageRes);
             double aspect = (double)picture.iDisplayWidth / (double)picture.iDisplayHeight;
             if(hint.forced_aspect && hint.aspect != 0)
               aspect = hint.aspect;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "DVDInputStreamFile.h"
+#include "ServiceBroker.h"
 #include "filesystem/File.h"
 #include "filesystem/IFile.h"
 #include "settings/AdvancedSettings.h"
@@ -57,10 +58,11 @@ bool CDVDInputStreamFile::Open()
    */
   if (!URIUtils::IsOnDVD(m_item.GetDynPath()) && !URIUtils::IsBluray(m_item.GetDynPath())) // Never cache these
   {
-    if ((g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_INTERNET && URIUtils::IsInternetStream(m_item.GetDynPath(), true))
-     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET && URIUtils::IsInternetStream(m_item.GetDynPath(), false))
-     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_REMOTE && URIUtils::IsRemote(m_item.GetDynPath()))
-     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
+    unsigned int iCacheBufferMode = CServiceBroker::GetAdvancedSettings().m_cacheBufferMode;
+    if ((iCacheBufferMode == CACHE_BUFFER_MODE_INTERNET && URIUtils::IsInternetStream(m_item.GetDynPath(), true))
+     || (iCacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET && URIUtils::IsInternetStream(m_item.GetDynPath(), false))
+     || (iCacheBufferMode == CACHE_BUFFER_MODE_REMOTE && URIUtils::IsRemote(m_item.GetDynPath()))
+     || (iCacheBufferMode == CACHE_BUFFER_MODE_ALL))
     {
       flags |= READ_CACHED;
     }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -682,8 +682,8 @@ bool CEdl::AddCut(Cut& cut)
      * the start (autowait) and automatically rewind by a bit (autowind) at the end of the commercial
      * break.
      */
-    int autowait = g_advancedSettings.m_iEdlCommBreakAutowait * 1000; // seconds -> ms
-    int autowind = g_advancedSettings.m_iEdlCommBreakAutowind * 1000; // seconds -> ms
+    int autowait = CServiceBroker::GetAdvancedSettings().m_iEdlCommBreakAutowait * 1000; // seconds -> ms
+    int autowind = CServiceBroker::GetAdvancedSettings().m_iEdlCommBreakAutowind * 1000; // seconds -> ms
 
     if (cut.start > 0) // Only autowait if not at the start.
      cut.start += autowait;
@@ -968,13 +968,14 @@ void CEdl::MergeShortCommBreaks()
     m_vecCuts.erase(m_vecCuts.begin());
   }
 
-  if (g_advancedSettings.m_bEdlMergeShortCommBreaks)
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+  if (advancedSettings.m_bEdlMergeShortCommBreaks)
   {
-    for (int i = 0; i < (int)m_vecCuts.size() - 1; i++)
+    for (int i = 0; i < static_cast<int>(m_vecCuts.size()) - 1; i++)
     {
       if ((m_vecCuts[i].action == COMM_BREAK && m_vecCuts[i + 1].action == COMM_BREAK)
-      &&  (m_vecCuts[i + 1].end - m_vecCuts[i].start < g_advancedSettings.m_iEdlMaxCommBreakLength * 1000) // s to ms
-      &&  (m_vecCuts[i + 1].start - m_vecCuts[i].end < g_advancedSettings.m_iEdlMaxCommBreakGap * 1000)) // s to ms
+          &&  (m_vecCuts[i + 1].end - m_vecCuts[i].start < advancedSettings.m_iEdlMaxCommBreakLength * 1000) // s to ms
+          &&  (m_vecCuts[i + 1].start - m_vecCuts[i].end < advancedSettings.m_iEdlMaxCommBreakGap * 1000)) // s to ms
       {
         Cut commBreak;
         commBreak.action = COMM_BREAK;
@@ -1003,8 +1004,8 @@ void CEdl::MergeShortCommBreaks()
      * the maximum commercial break length being triggered.
      */
     if (!m_vecCuts.empty()
-    &&  m_vecCuts[0].action == COMM_BREAK
-    &&  m_vecCuts[0].start < g_advancedSettings.m_iEdlMaxStartGap * 1000)
+        &&  m_vecCuts[0].action == COMM_BREAK
+        &&  m_vecCuts[0].start < advancedSettings.m_iEdlMaxStartGap * 1000)
     {
       CLog::Log(LOGDEBUG, "%s - Expanding first commercial break back to start [%s - %s].", __FUNCTION__,
                 MillisecondsToTimeString(m_vecCuts[0].start).c_str(), MillisecondsToTimeString(m_vecCuts[0].end).c_str());
@@ -1014,15 +1015,15 @@ void CEdl::MergeShortCommBreaks()
     /*
      * Remove any commercial breaks shorter than the minimum (unless at the start)
      */
-    for (int i = 0; i < (int)m_vecCuts.size(); i++)
+    for (int i = 0; i < static_cast<int>(m_vecCuts.size()); i++)
     {
       if (m_vecCuts[i].action == COMM_BREAK
-      &&  m_vecCuts[i].start > 0
-      && (m_vecCuts[i].end - m_vecCuts[i].start) < g_advancedSettings.m_iEdlMinCommBreakLength * 1000)
+          &&  m_vecCuts[i].start > 0
+          && (m_vecCuts[i].end - m_vecCuts[i].start) < advancedSettings.m_iEdlMinCommBreakLength * 1000)
       {
         CLog::Log(LOGDEBUG, "%s - Removing short commercial break [%s - %s]. Minimum length: %i seconds", __FUNCTION__,
                   MillisecondsToTimeString(m_vecCuts[i].start).c_str(), MillisecondsToTimeString(m_vecCuts[i].end).c_str(),
-                  g_advancedSettings.m_iEdlMinCommBreakLength);
+                  advancedSettings.m_iEdlMinCommBreakLength);
         m_vecCuts.erase(m_vecCuts.begin() + i);
 
         i--;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ProcessInfo.h"
+#include "ServiceBroker.h"
 #include "cores/DataCacheCore.h"
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
@@ -577,7 +578,7 @@ float CProcessInfo::MaxTempoPlatform()
 bool CProcessInfo::IsTempoAllowed(float tempo)
 {
   if (tempo > MinTempoPlatform() &&
-      (tempo < MaxTempoPlatform() || tempo < g_advancedSettings.m_maxTempo))
+      (tempo < MaxTempoPlatform() || tempo < CServiceBroker::GetAdvancedSettings().m_maxTempo))
     return true;
 
   return false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3177,14 +3177,15 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   }
 
   int64_t seekTarget;
-  if (g_advancedSettings.m_videoUseTimeSeeking && m_processInfo->GetMaxTime() > 2000*g_advancedSettings.m_videoTimeSeekForwardBig)
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+  if (advancedSettings.m_videoUseTimeSeeking && m_processInfo->GetMaxTime() > 2000 * advancedSettings.m_videoTimeSeekForwardBig)
   {
     if (bLargeStep)
-      seekTarget = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig :
-                           g_advancedSettings.m_videoTimeSeekBackwardBig;
+      seekTarget = bPlus ? advancedSettings.m_videoTimeSeekForwardBig :
+                           advancedSettings.m_videoTimeSeekBackwardBig;
     else
-      seekTarget = bPlus ? g_advancedSettings.m_videoTimeSeekForward :
-                           g_advancedSettings.m_videoTimeSeekBackward;
+      seekTarget = bPlus ? advancedSettings.m_videoTimeSeekForward :
+                           advancedSettings.m_videoTimeSeekBackward;
     seekTarget *= 1000;
     seekTarget += GetTime();
   }
@@ -3192,10 +3193,10 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   {
     int percent;
     if (bLargeStep)
-      percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
+      percent = bPlus ? advancedSettings.m_videoPercentSeekForwardBig : advancedSettings.m_videoPercentSeekBackwardBig;
     else
-      percent = bPlus ? g_advancedSettings.m_videoPercentSeekForward : g_advancedSettings.m_videoPercentSeekBackward;
-    seekTarget = (int64_t)(m_processInfo->GetMaxTime()*(GetPercentage()+percent)/100);
+      percent = bPlus ? advancedSettings.m_videoPercentSeekForward : advancedSettings.m_videoPercentSeekBackward;
+    seekTarget = static_cast<int64_t>(m_processInfo->GetMaxTime() * (GetPercentage() + percent) / 100);
   }
 
   bool restore = true;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -951,7 +951,7 @@ void CVideoPlayerVideo::ResetFrameRateCalc()
   m_iFrameRateCount = 0;
   m_iFrameRateLength = 1;
   m_iFrameRateErr = 0;
-  m_bAllowDrop = g_advancedSettings.m_videoFpsDetect == 0;
+  m_bAllowDrop = CServiceBroker::GetAdvancedSettings().m_videoFpsDetect == 0;
 }
 
 double CVideoPlayerVideo::GetCurrentPts()
@@ -980,7 +980,7 @@ double CVideoPlayerVideo::GetCurrentPts()
 
 void CVideoPlayerVideo::CalcFrameRate()
 {
-  if (m_iFrameRateLength >= 128 || g_advancedSettings.m_videoFpsDetect == 0)
+  if (m_iFrameRateLength >= 128 || CServiceBroker::GetAdvancedSettings().m_videoFpsDetect == 0)
     return; //don't calculate the fps
 
   if (!m_ptsTracker.HasFullBuffer())
@@ -993,7 +993,7 @@ void CVideoPlayerVideo::CalcFrameRate()
     frameduration = m_ptsTracker.GetMinFrameDuration();
 
   if ((frameduration==DVD_NOPTS_VALUE) ||
-      ((g_advancedSettings.m_videoFpsDetect == 1) && ((m_ptsTracker.GetPatternLength() > 1) && !m_ptsTracker.VFRDetection())))
+      ((CServiceBroker::GetAdvancedSettings().m_videoFpsDetect == 1) && ((m_ptsTracker.GetPatternLength() > 1) && !m_ptsTracker.VFRDetection())))
   {
     //reset the stored framerates if no good framerate was detected
     m_fStableFrameRate = 0.0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -41,13 +41,13 @@ using namespace MMAL;
 
 CMMALBuffer::CMMALBuffer(int id) : CVideoBuffer(id)
 {
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, static_cast<void*>(this));
 }
 
 CMMALBuffer::~CMMALBuffer()
 {
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s %p", CLASSNAME, __func__, static_cast<void*>(this));
 }
 
@@ -363,7 +363,7 @@ CMMALBuffer *CMMALPool::GetBuffer(uint32_t timeout)
                 __FUNCTION__, static_cast<void*>(m_mmal_pool), static_cast<void*>(omvb),
                 static_cast<void*>(buffer), timeout);
     }
-  else if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  else if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     CLog::Log(LOGDEBUG,
               "%s::%s pool:%p omvb:%p mmal:%p gmem:%p new:%d id:%d to:%d %dx%d (%dx%d) size:%d "
@@ -388,7 +388,7 @@ void CMMALPool::Prime()
     return;
   while (omvb = GetBuffer(0), omvb)
   {
-    if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+    if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     {
       CLog::Log(
           LOGDEBUG, "%s::%s Send omvb:%p mmal:%p from pool %p to %s len:%d cmd:%x flags:%x pool:%p",
@@ -440,7 +440,7 @@ CRenderInfo CMMALRenderer::GetRenderInfo()
 
 void CMMALRenderer::vout_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
 {
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p dts:%.3f pts:%.3f len:%d cmd:%x flags:%x",
               CLASSNAME, __func__, static_cast<void*>(buffer->user_data),
@@ -707,7 +707,7 @@ void CMMALRenderer::Run()
     bool kept = false;
 
     CMMALBuffer *omvb = (CMMALBuffer *)buffer->user_data;
-    if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+    if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     {
       CLog::Log(LOGDEBUG,
                 "%s::%s %s omvb:%p mmal:%p dts:%.3f pts:%.3f len:%d cmd:%x flags:%x enc:%.4s",
@@ -830,7 +830,7 @@ void CMMALRenderer::Run()
         if (m_queue_render)
         {
           mmal_queue_put(m_queue_render, buffer);
-          if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+          if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
             CLog::Log(LOGDEBUG, "%s::%s send %p to m_queue_render", CLASSNAME, __func__, static_cast<void*>(omvb));
           kept = true;
         }
@@ -839,7 +839,7 @@ void CMMALRenderer::Run()
           CheckConfigurationVout(omvb->Width(), omvb->Height(), omvb->AlignedWidth(), omvb->AlignedHeight(), omvb->Encoding());
           if (m_vout_input)
           {
-            if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+            if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
               CLog::Log(LOGDEBUG, "%s::%s send %p to m_vout_input", CLASSNAME, __func__, static_cast<void*>(omvb));
             MMAL_STATUS_T status = mmal_port_send_buffer(m_vout_input, buffer);
             if (status != MMAL_SUCCESS)
@@ -859,7 +859,7 @@ void CMMALRenderer::Run()
     }
     if (!kept)
     {
-      if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+      if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
       {
         CLog::Log(
             LOGDEBUG,
@@ -897,7 +897,7 @@ void CMMALRenderer::UpdateFramerateStats(double pts)
   }
   if (pts != DVD_NOPTS_VALUE)
     m_lastPts = pts;
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s pts:%.3f diff:%.3f m_frameInterval:%.6f m_frameIntervalDiff:%.6f", CLASSNAME, __func__, pts*1e-6, diff * 1e-6 , m_frameInterval * 1e-6, m_frameIntervalDiff *1e-6);
 }
 
@@ -905,7 +905,7 @@ void CMMALRenderer::AddVideoPicture(const VideoPicture& pic, int id)
 {
   CMMALBuffer *buffer = dynamic_cast<CMMALBuffer*>(pic.videoBuffer);
   assert(buffer);
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     CLog::Log(LOGDEBUG, "%s::%s MMAL - %p (%p) %i", CLASSNAME, __func__, static_cast<void*>(buffer),
               static_cast<void*>(buffer->mmal_buffer), id);
@@ -957,7 +957,7 @@ void CMMALRenderer::ReleaseBuffer(int id)
 {
   CSingleLock lock(m_sharedSection);
   CMMALBuffer *omvb = m_buffers[id];
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     CLog::Log(LOGDEBUG, "%s::%s - MMAL: source:%d omvb:%p mmal:%p", CLASSNAME, __func__, id,
               static_cast<void*>(omvb), omvb ? static_cast<void*>(omvb->mmal_buffer) : nullptr);
@@ -1020,7 +1020,7 @@ void CMMALRenderer::RenderUpdate(int index, int index2, bool clear, unsigned int
   if (omvb && omvb->m_state == MMALStateBypass)
   {
     // dummy buffer from omxplayer
-    if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+    if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     {
       CLog::Log(LOGDEBUG, "%s::%s - OMX: clear:%d flags:%x alpha:%d source:%d omvb:%p", CLASSNAME,
                 __func__, clear, flags, alpha, index, static_cast<void*>(omvb));
@@ -1069,7 +1069,7 @@ exit:
 
 void CMMALRenderer::ReleaseBuffers()
 {
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
     CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
   for (int i=0; i<NUM_BUFFERS; i++)
     ReleaseBuffer(i);
@@ -1303,7 +1303,7 @@ void CMMALRenderer::SetVideoRect(const CRect& InSrcRect, const CRect& InDestRect
 
 void CMMALRenderer::deint_input_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
 {
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p dts:%.3f pts:%.3f len:%d cmd:%x flags:%x",
               CLASSNAME, __func__, static_cast<void*>(buffer->user_data),
@@ -1321,7 +1321,7 @@ static void deint_input_port_cb_static(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *
 
 void CMMALRenderer::deint_output_port_cb(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
 {
-  if (VERBOSE && g_advancedSettings.CanLogComponent(LOGVIDEO))
+  if (VERBOSE && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGVIDEO))
   {
     CLog::Log(LOGDEBUG, "%s::%s omvb:%p mmal:%p dts:%.3f pts:%.3f len:%d cmd:%x flags:%x",
               CLASSNAME, __func__, static_cast<void*>(buffer->user_data),

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
@@ -169,7 +169,7 @@ bool CRendererVDPAU::Supports(ESCALINGMETHOD method)
         && method != VS_SCALINGMETHOD_LANCZOS3)
       return true;
     else
-      return g_advancedSettings.m_videoEnableHighQualityHwScalers;
+      return CServiceBroker::GetAdvancedSettings().m_videoEnableHighQualityHwScalers;
   }
 
   return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -751,7 +751,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
   {
     bool scaleSD = m_sourceHeight < 720 && m_sourceWidth < 1280;
     bool scaleUp = (int)m_sourceHeight < m_viewRect.Height() && (int)m_sourceWidth < m_viewRect.Width();
-    bool scaleFps = m_fps < g_advancedSettings.m_videoAutoScaleMaxFps + 0.01f;
+    bool scaleFps = m_fps < CServiceBroker::GetAdvancedSettings().m_videoAutoScaleMaxFps + 0.01f;
 
     if (Supports(VS_SCALINGMETHOD_LANCZOS3_FAST) && scaleSD && scaleUp && scaleFps)
       m_scalingMethod = VS_SCALINGMETHOD_LANCZOS3_FAST;
@@ -1094,7 +1094,7 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
   if (g_application.GetAppPlayer().IsInMenu())
     m_pYUVShader->SetNonLinStretch(1.0);
   else
-    m_pYUVShader->SetNonLinStretch(pow(CDisplaySettings::GetInstance().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
+    m_pYUVShader->SetNonLinStretch(pow(CDisplaySettings::GetInstance().GetPixelRatio(), CServiceBroker::GetAdvancedSettings().m_videoNonLinStretchRatio));
 
   if (field == FIELD_TOP)
     m_pYUVShader->SetField(1);
@@ -1460,7 +1460,7 @@ void CLinuxRendererGL::RenderFromFBO()
   if (g_application.GetAppPlayer().IsInMenu())
     m_pVideoFilterShader->SetNonLinStretch(1.0);
   else
-    m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::GetInstance().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
+    m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::GetInstance().GetPixelRatio(), CServiceBroker::GetAdvancedSettings().m_videoNonLinStretchRatio));
 
   m_pVideoFilterShader->SetMatrices(glMatrixProject.Get(), glMatrixModview.Get());
   m_pVideoFilterShader->Enable();
@@ -1602,7 +1602,7 @@ void CLinuxRendererGL::RenderRGB(int index, int field)
   if (g_application.GetAppPlayer().IsInMenu())
     m_pVideoFilterShader->SetNonLinStretch(1.0);
   else
-    m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::GetInstance().GetPixelRatio(), g_advancedSettings.m_videoNonLinStretchRatio));
+    m_pVideoFilterShader->SetNonLinStretch(pow(CDisplaySettings::GetInstance().GetPixelRatio(), CServiceBroker::GetAdvancedSettings().m_videoNonLinStretchRatio));
 
   m_pVideoFilterShader->SetMatrices(glMatrixProject.Get(), glMatrixModview.Get());
   m_pVideoFilterShader->Enable();
@@ -2622,7 +2622,7 @@ bool CLinuxRendererGL::Supports(ESCALINGMETHOD method)
       && method != VS_SCALINGMETHOD_LANCZOS3)
         return true;
       else
-        return g_advancedSettings.m_videoEnableHighQualityHwScalers;
+        return CServiceBroker::GetAdvancedSettings().m_videoEnableHighQualityHwScalers;
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1510,7 +1510,7 @@ bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method)
       && method != VS_SCALINGMETHOD_LANCZOS3)
         return true;
       else
-        return g_advancedSettings.m_videoEnableHighQualityHwScalers;
+        return CServiceBroker::GetAdvancedSettings().m_videoEnableHighQualityHwScalers;
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -345,7 +345,7 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
   int subalign = CServiceBroker::GetSettings()->GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
   if(subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE
   || subalign == SUBTITLE_ALIGN_TOP_OUTSIDE
-  ||(subalign == SUBTITLE_ALIGN_MANUAL && g_advancedSettings.m_videoAssFixedWorks))
+  ||(subalign == SUBTITLE_ALIGN_MANUAL && CServiceBroker::GetAdvancedSettings().m_videoAssFixedWorks))
     useMargin = 1;
   else
     useMargin = 0;
@@ -355,7 +355,7 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
   if(subalign == SUBTITLE_ALIGN_TOP_INSIDE
   || subalign == SUBTITLE_ALIGN_TOP_OUTSIDE)
     position = 100.0;
-  else if (subalign == SUBTITLE_ALIGN_MANUAL && g_advancedSettings.m_videoAssFixedWorks)
+  else if (subalign == SUBTITLE_ALIGN_MANUAL && CServiceBroker::GetAdvancedSettings().m_videoAssFixedWorks)
   {
     RESOLUTION_INFO res;
     res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
@@ -41,7 +41,7 @@ bool CRenderCaptureBase::UseOcclusionQuery()
 {
   if (m_flags & CAPTUREFLAG_IMMEDIATELY)
     return false;
-  else if (g_advancedSettings.m_videoCaptureUseOcclusionQuery == 0)
+  else if (CServiceBroker::GetAdvancedSettings().m_videoCaptureUseOcclusionQuery == 0)
     return false;
   else
     return true;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -854,7 +854,7 @@ void CRenderManager::UpdateLatencyTweak()
   float refresh = fps;
   if (CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution() == RES_WINDOW)
     refresh = 0; // No idea about refresh rate when windowed, just get the default latency
-  m_latencyTweak = g_advancedSettings.GetLatencyTweak(refresh);
+  m_latencyTweak = CServiceBroker::GetAdvancedSettings().GetLatencyTweak(refresh);
 }
 
 void CRenderManager::UpdateResolution()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -12,6 +12,7 @@
 #include "YUVMatrix.h"
 #include "ConversionMatrix.h"
 #include "ConvolutionKernels.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
@@ -50,7 +51,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect, EShaderFormat format, bo
   else
     m_defines += "#define XBMC_texture_rectangle 0\n";
 
-  if (g_advancedSettings.m_GLRectangleHack)
+  if (CServiceBroker::GetAdvancedSettings().m_GLRectangleHack)
     m_defines += "#define XBMC_texture_rectangle_hack 1\n";
   else
     m_defines += "#define XBMC_texture_rectangle_hack 0\n";

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -526,7 +526,7 @@ void CWinRenderer::SelectPSVideoFilter()
     bool scaleSD = m_sourceHeight < 720 && m_sourceWidth < 1280;
     bool scaleUp = static_cast<int>(m_sourceHeight) < CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()
                 && static_cast<int>(m_sourceWidth) < CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth();
-    bool scaleFps = m_fps < (g_advancedSettings.m_videoAutoScaleMaxFps + 0.01f);
+    bool scaleFps = m_fps < (CServiceBroker::GetAdvancedSettings().m_videoAutoScaleMaxFps + 0.01f);
 
     if (m_renderMethod == RENDER_DXVA)
     {
@@ -1039,7 +1039,7 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
       if (method == VS_SCALINGMETHOD_DXVA_HARDWARE
        || method == VS_SCALINGMETHOD_AUTO)
         return true;
-      if (!g_advancedSettings.m_DXVAAllowHqScaling || m_renderOrientation)
+      if (!CServiceBroker::GetAdvancedSettings().m_DXVAAllowHqScaling || m_renderOrientation)
         return false;
     }
 

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -1017,7 +1017,7 @@ bool COMXAudio::ApplyVolume(void)
   fVolume = CAEUtil::GainToScale(CAEUtil::PercentToGain(fVolume));
 
   // the analogue volume is too quiet for some. Allow use of an advancedsetting to boost this (at risk of distortion) (deprecated)
-  double gain = pow(10, (g_advancedSettings.m_ac3Gain - 12.0f) / 20.0);
+  double gain = pow(10, (CServiceBroker::GetAdvancedSettings().m_ac3Gain - 12.0f) / 20.0);
 
   const float* coeff = m_downmix_matrix;
 
@@ -1243,8 +1243,8 @@ void COMXAudio::UpdateAttenuation()
   {
     float alpha_h = -1.0f/(0.025f*log10f(0.999f));
     float alpha_r = -1.0f/(0.100f*log10f(0.900f));
-    float decay  = powf(10.0f, -1.0f / (alpha_h * g_advancedSettings.m_limiterHold));
-    float attack = powf(10.0f, -1.0f / (alpha_r * g_advancedSettings.m_limiterRelease));
+    float decay  = powf(10.0f, -1.0f / (alpha_h * CServiceBroker::GetAdvancedSettings().m_limiterHold));
+    float attack = powf(10.0f, -1.0f / (alpha_r * CServiceBroker::GetAdvancedSettings().m_limiterRelease));
     // if we are going to clip imminently then deal with it now
     if (imminent_maxlevel > m_maxLevel)
       m_maxLevel = imminent_maxlevel;

--- a/xbmc/cores/omxplayer/OMXImage.cpp
+++ b/xbmc/cores/omxplayer/OMXImage.cpp
@@ -149,13 +149,15 @@ bool COMXImage::ClampLimits(unsigned int &width, unsigned int &height, unsigned 
 
   if (max_width == 0 || max_height == 0)
   {
-    max_height = g_advancedSettings.m_imageRes;
+    const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
 
-    if (g_advancedSettings.m_fanartRes > g_advancedSettings.m_imageRes)
+    max_height = advancedSettings.m_imageRes;
+
+    if (advancedSettings.m_fanartRes > advancedSettings.m_imageRes)
     { // 16x9 images larger than the fanart res use that rather than the image res
-      if (fabsf(aspect / (16.0f/9.0f) - 1.0f) <= 0.01f && m_height >= g_advancedSettings.m_fanartRes)
+      if (fabsf(aspect / (16.0f/9.0f) - 1.0f) <= 0.01f && m_height >= advancedSettings.m_fanartRes)
       {
-        max_height = g_advancedSettings.m_fanartRes;
+        max_height = advancedSettings.m_fanartRes;
       }
     }
     max_width = max_height * 16/9;

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -587,7 +587,7 @@ bool COMXVideo::Open(CDVDStreamInfo &hints, OMXClock *clock, bool hdmi_clock_syn
   }
   OMX_PARAM_BRCMVIDEODECODEERRORCONCEALMENTTYPE concanParam;
   OMX_INIT_STRUCTURE(concanParam);
-  if(g_advancedSettings.m_omxDecodeStartWithValidFrame)
+  if(CServiceBroker::GetAdvancedSettings().m_omxDecodeStartWithValidFrame)
     concanParam.bStartWithValidFrame = OMX_TRUE;
   else
     concanParam.bStartWithValidFrame = OMX_FALSE;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -1023,12 +1023,13 @@ void PAPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   if (!CanSeek()) return;
 
   long long seek;
-  if (g_advancedSettings.m_musicUseTimeSeeking && m_playerGUIData.m_totalTime > 2 * g_advancedSettings.m_musicTimeSeekForwardBig)
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+  if (advancedSettings.m_musicUseTimeSeeking && m_playerGUIData.m_totalTime > 2 * advancedSettings.m_musicTimeSeekForwardBig)
   {
     if (bLargeStep)
-      seek = bPlus ? g_advancedSettings.m_musicTimeSeekForwardBig : g_advancedSettings.m_musicTimeSeekBackwardBig;
+      seek = bPlus ? advancedSettings.m_musicTimeSeekForwardBig : advancedSettings.m_musicTimeSeekBackwardBig;
     else
-      seek = bPlus ? g_advancedSettings.m_musicTimeSeekForward : g_advancedSettings.m_musicTimeSeekBackward;
+      seek = bPlus ? advancedSettings.m_musicTimeSeekForward : advancedSettings.m_musicTimeSeekBackward;
     seek *= 1000;
     seek += m_playerGUIData.m_time;
   }
@@ -1036,9 +1037,9 @@ void PAPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   {
     float percent;
     if (bLargeStep)
-      percent = bPlus ? (float)g_advancedSettings.m_musicPercentSeekForwardBig : (float)g_advancedSettings.m_musicPercentSeekBackwardBig;
+      percent = bPlus ? static_cast<float>(advancedSettings.m_musicPercentSeekForwardBig) : static_cast<float>(advancedSettings.m_musicPercentSeekBackwardBig);
     else
-      percent = bPlus ? (float)g_advancedSettings.m_musicPercentSeekForward : (float)g_advancedSettings.m_musicPercentSeekBackward;
+      percent = bPlus ? static_cast<float>(advancedSettings.m_musicPercentSeekForward) : static_cast<float>(advancedSettings.m_musicPercentSeekBackward);
     seek = static_cast<long long>(GetTotalTime64() * (GetPercentage() + percent) / 100);
   }
 

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -158,9 +158,9 @@ int CPlayerCoreFactory::GetPlayerIndex(const std::string& strCoreName) const
     // Dereference "*default*player" aliases
     std::string strRealCoreName;
     if (StringUtils::EqualsNoCase(strCoreName, "audiodefaultplayer"))
-      strRealCoreName = g_advancedSettings.m_audioDefaultPlayer;
+      strRealCoreName = CServiceBroker::GetAdvancedSettings().m_audioDefaultPlayer;
     else if (StringUtils::EqualsNoCase(strCoreName, "videodefaultplayer"))
-      strRealCoreName = g_advancedSettings.m_videoDefaultPlayer;
+      strRealCoreName = CServiceBroker::GetAdvancedSettings().m_videoDefaultPlayer;
     else
       strRealCoreName = strCoreName;
 

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "FavouritesService.h"
+#include "ServiceBroker.h"
 #include "filesystem/File.h"
 #include "Util.h"
 #include "FileItem.h"
@@ -182,7 +183,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
     const CURL url(item.GetPath());
     execute = CURL::Decode(url.GetHostName());
   }
-  else if (item.m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
+  else if (item.m_bIsFolder && (CServiceBroker::GetAdvancedSettings().m_playlistAsFolders ||
                                 !(item.IsSmartPlayList() || item.IsPlayList())))
   {
     if (!contextWindow.empty())

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -60,7 +60,7 @@ extern "C" int debug_callback(CURL_HANDLE *handle, curl_infotype info, char *out
   if (info == CURLINFO_DATA_IN || info == CURLINFO_DATA_OUT)
     return 0;
 
-  if (!g_advancedSettings.CanLogComponent(LOGCURL))
+  if (!CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGCURL))
     return 0;
 
   std::string strLine;
@@ -460,7 +460,7 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
 
   g_curlInterface.easy_setopt(h, CURLOPT_DEBUGFUNCTION, debug_callback);
 
-  if( g_advancedSettings.m_logLevel >= LOG_LEVEL_DEBUG )
+  if( CServiceBroker::GetAdvancedSettings().m_logLevel >= LOG_LEVEL_DEBUG )
     g_curlInterface.easy_setopt(h, CURLOPT_VERBOSE, CURL_ON);
   else
     g_curlInterface.easy_setopt(h, CURLOPT_VERBOSE, CURL_OFF);
@@ -588,9 +588,9 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   if (m_userAgent.length() > 0)
     g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, m_userAgent.c_str());
   else /* set some default agent as shoutcast doesn't return proper stuff otherwise */
-    g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, g_advancedSettings.m_userAgent.c_str());
+    g_curlInterface.easy_setopt(h, CURLOPT_USERAGENT, CServiceBroker::GetAdvancedSettings().m_userAgent.c_str());
 
-  if (g_advancedSettings.m_curlDisableIPV6)
+  if (CServiceBroker::GetAdvancedSettings().m_curlDisableIPV6)
     g_curlInterface.easy_setopt(h, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 
   if (!m_proxyhost.empty())
@@ -610,7 +610,7 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
     g_curlInterface.easy_setopt(h, CURLOPT_CUSTOMREQUEST, m_customrequest.c_str());
 
   if (m_connecttimeout == 0)
-    m_connecttimeout = g_advancedSettings.m_curlconnecttimeout;
+    m_connecttimeout = CServiceBroker::GetAdvancedSettings().m_curlconnecttimeout;
 
   // set our timeouts, we abort connection after m_timeout, and reads after no data for m_timeout seconds
   g_curlInterface.easy_setopt(h, CURLOPT_CONNECTTIMEOUT, m_connecttimeout);
@@ -619,7 +619,7 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   g_curlInterface.easy_setopt(h, CURLOPT_LOW_SPEED_LIMIT, 1);
 
   if (m_lowspeedtime == 0)
-    m_lowspeedtime = g_advancedSettings.m_curllowspeedtime;
+    m_lowspeedtime = CServiceBroker::GetAdvancedSettings().m_curllowspeedtime;
 
   // Set the lowspeed time very low as it seems Curl takes much longer to detect a lowspeed condition
   g_curlInterface.easy_setopt(h, CURLOPT_LOW_SPEED_TIME, m_lowspeedtime);
@@ -1003,7 +1003,7 @@ bool CCurlFile::Open(const CURL& url)
                                 &m_state->m_multiHandle);
 
   // setup common curl options
-  SetCommonOptions(m_state, m_failOnError && !g_advancedSettings.CanLogComponent(LOGCURL));
+  SetCommonOptions(m_state, m_failOnError && !CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGCURL));
   SetRequestHeaders(m_state);
   m_state->m_sendRange = m_seekable;
   m_state->m_bRetry = m_allowRetry;
@@ -1013,7 +1013,7 @@ bool CCurlFile::Open(const CURL& url)
   if (m_httpresponse <= 0 || (m_failOnError && m_httpresponse >= 400))
   {
     std::string error;
-    if (m_httpresponse >= 400 && g_advancedSettings.CanLogComponent(LOGCURL))
+    if (m_httpresponse >= 400 && CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGCURL))
     {
       error.resize(256);
       ReadString(&error[0], 255);
@@ -1388,7 +1388,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
 
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
-  g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_TIMEOUT, g_advancedSettings.m_curlconnecttimeout);
+  g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_TIMEOUT, CServiceBroker::GetAdvancedSettings().m_curlconnecttimeout);
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_NOBODY, 1);
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FILETIME , 1);
 
@@ -1419,7 +1419,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
     /* somehow curl doesn't reset CURLOPT_NOBODY properly so reset everything */
     SetCommonOptions(m_state);
     SetRequestHeaders(m_state);
-    g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_TIMEOUT, g_advancedSettings.m_curlconnecttimeout);
+    g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_TIMEOUT, CServiceBroker::GetAdvancedSettings().m_curlconnecttimeout);
     g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FILETIME, 1);
 #if LIBCURL_VERSION_NUM >= 0x072000 // 0.7.32
     g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_XFERINFOFUNCTION, transfer_abort_callback);
@@ -1636,7 +1636,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
         m_bLastError = true; // Flag error for the next run
 
         // Retry immediately or leave it up to the caller?
-        if ((m_bRetry && retry < g_advancedSettings.m_curlretries) || (bRetryNow && retry == 0))
+        if ((m_bRetry && retry < CServiceBroker::GetAdvancedSettings().m_curlretries) || (bRetryNow && retry == 0))
         {
           retry++;
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -11,6 +11,7 @@
 #include "threads/Thread.h"
 #include "File.h"
 #include "URL.h"
+#include "ServiceBroker.h"
 
 #include "CircularCache.h"
 #include "threads/SingleLock.h"
@@ -167,7 +168,7 @@ bool CFileCache::Open(const CURL& url)
 
   if (!m_pCache)
   {
-    if (g_advancedSettings.m_cacheMemSize == 0)
+    if (CServiceBroker::GetAdvancedSettings().m_cacheMemSize == 0)
     {
       // Use cache on disk
       m_pCache = new CSimpleFileCache();
@@ -176,14 +177,14 @@ bool CFileCache::Open(const CURL& url)
     else
     {
       size_t cacheSize;
-      if (m_fileSize > 0 && m_fileSize < g_advancedSettings.m_cacheMemSize && !(m_flags & READ_AUDIO_VIDEO))
+      if (m_fileSize > 0 && m_fileSize < CServiceBroker::GetAdvancedSettings().m_cacheMemSize && !(m_flags & READ_AUDIO_VIDEO))
       {
         // NOTE: We don't need to take into account READ_MULTI_STREAM here as it's only used for audio/video
         cacheSize = m_fileSize;
       }
       else
       {
-        cacheSize = g_advancedSettings.m_cacheMemSize;
+        cacheSize = CServiceBroker::GetAdvancedSettings().m_cacheMemSize;
       }
 
       size_t back = cacheSize / 4;
@@ -284,13 +285,13 @@ void CFileCache::Process()
 
     while (m_writeRate)
     {
-      if (m_writePos - m_readPos < m_writeRate * g_advancedSettings.m_cacheReadFactor)
+      if (m_writePos - m_readPos < m_writeRate * CServiceBroker::GetAdvancedSettings().m_cacheReadFactor)
       {
         limiter.Reset(m_writePos);
         break;
       }
 
-      if (limiter.Rate(m_writePos) < m_writeRate * g_advancedSettings.m_cacheReadFactor)
+      if (limiter.Rate(m_writePos) < m_writeRate * CServiceBroker::GetAdvancedSettings().m_cacheReadFactor)
         break;
 
       if (m_seekEvent.WaitMSec(100))

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "HTTPDirectory.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "CurlFile.h"
 #include "FileItem.h"
@@ -214,7 +215,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             pItem->m_dwSize = (int64_t)Size;
           }
           else
-          if (g_advancedSettings.m_bHTTPDirectoryStatFilesize) // As a fallback get the size by stat-ing the file (slow)
+          if (CServiceBroker::GetAdvancedSettings().m_bHTTPDirectoryStatFilesize) // As a fallback get the size by stat-ing the file (slow)
           {
             CCurlFile file;
             file.Open(url);

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -180,7 +180,7 @@ static void ParseItemMRSS(CFileItem* item, SResources& resources, TiXmlElement* 
     else if(scheme == "urn:boxee:source")
       item->SetProperty("boxee:provider_source", text);
     else
-      vtag->m_genre = StringUtils::Split(text, g_advancedSettings.m_videoItemSeparator);
+      vtag->m_genre = StringUtils::Split(text, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
   }
   else if(name == "rating")
   {
@@ -206,7 +206,7 @@ static void ParseItemMRSS(CFileItem* item, SResources& resources, TiXmlElement* 
     }
   }
   else if(name == "copyright")
-    vtag->m_studio = StringUtils::Split(text, g_advancedSettings.m_videoItemSeparator);
+    vtag->m_studio = StringUtils::Split(text, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
   else if(name == "keywords")
     item->SetProperty("keywords", text);
 

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -14,6 +14,7 @@
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "URL.h"
+#include "ServiceBroker.h"
 
 namespace XFILE
 {
@@ -44,7 +45,7 @@ namespace XFILE
     // Load up our REs
     VECCREGEXP  RegExps;
     CRegExp     tempRE(true, CRegExp::autoUtf8);
-    const std::vector<std::string>& strRegExps = g_advancedSettings.m_videoStackRegExps;
+    const std::vector<std::string>& strRegExps = CServiceBroker::GetAdvancedSettings().m_videoStackRegExps;
     std::vector<std::string>::const_iterator itRegExp = strRegExps.begin();
     while (itRegExp != strRegExps.end())
     {

--- a/xbmc/filesystem/test/TestFileFactory.cpp
+++ b/xbmc/filesystem/test/TestFileFactory.cpp
@@ -31,7 +31,7 @@ protected:
         CServiceBroker::GetSettings()->Load(it);
 
       for (const auto& it : advancedsettings)
-        g_advancedSettings.ParseSettingsFile(it);
+        CServiceBroker::GetAdvancedSettings().ParseSettingsFile(it);
 
       CServiceBroker::GetSettings()->SetLoaded();
     }
@@ -39,7 +39,7 @@ protected:
 
   ~TestFileFactory() override
   {
-    g_advancedSettings.Clear();
+    CServiceBroker::GetAdvancedSettings().Clear();
     CServiceBroker::GetSettings()->Unload();
     CServiceBroker::GetSettings()->Uninitialize();
   }

--- a/xbmc/guilib/DirtyRegionTracker.cpp
+++ b/xbmc/guilib/DirtyRegionTracker.cpp
@@ -11,6 +11,7 @@
 #include "utils/log.h"
 #include <stdio.h>
 #include "DirtyRegionSolvers.h"
+#include "ServiceBroker.h"
 
 CDirtyRegionTracker::CDirtyRegionTracker(int buffering)
 {
@@ -27,7 +28,7 @@ void CDirtyRegionTracker::SelectAlgorithm()
 {
   delete m_solver;
 
-  switch (g_advancedSettings.m_guiAlgorithmDirtyRegions)
+  switch (CServiceBroker::GetAdvancedSettings().m_guiAlgorithmDirtyRegions)
   {
     case DIRTYREGION_SOLVER_FILL_VIEWPORT_ON_CHANGE:
       CLog::Log(LOGDEBUG, "guilib: Fill viewport on change for solving rendering passes");
@@ -72,7 +73,7 @@ CDirtyRegionList CDirtyRegionTracker::GetDirtyRegions()
 
 void CDirtyRegionTracker::CleanMarkedRegions()
 {
-  int buffering = g_advancedSettings.m_guiVisualizeDirtyRegions ? 20 : m_buffering;
+  int buffering = CServiceBroker::GetAdvancedSettings().m_guiVisualizeDirtyRegions ? 20 : m_buffering;
   int i = m_markedRegions.size() - 1;
   while (i >= 0)
 	{

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -302,7 +302,7 @@ void CGUIVisualisationControl::UpdateTrack()
 
   std::string artist(tag->GetArtistString());
   std::string albumArtist(tag->GetAlbumArtistString());
-  std::string genre(StringUtils::Join(tag->GetGenre(), g_advancedSettings.m_musicItemSeparator));
+  std::string genre(StringUtils::Join(tag->GetGenre(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 
   VisTrack track = {0};
   track.title       = tag->GetTitle().c_str();

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -324,7 +324,7 @@ void CGUIWindow::CenterWindow()
 
 void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  if (!IsControlDirty() && g_advancedSettings.m_guiSmartRedraw)
+  if (!IsControlDirty() && CServiceBroker::GetAdvancedSettings().m_guiSmartRedraw)
     return;
 
   CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(m_coordsRes, m_needsScaling);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1186,12 +1186,12 @@ bool CGUIWindowManager::Render()
 
   bool hasRendered = false;
   // If we visualize the regions we will always render the entire viewport
-  if (g_advancedSettings.m_guiVisualizeDirtyRegions || g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_FILL_VIEWPORT_ALWAYS)
+  if (CServiceBroker::GetAdvancedSettings().m_guiVisualizeDirtyRegions || CServiceBroker::GetAdvancedSettings().m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_FILL_VIEWPORT_ALWAYS)
   {
     RenderPass();
     hasRendered = true;
   }
-  else if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_FILL_VIEWPORT_ON_CHANGE)
+  else if (CServiceBroker::GetAdvancedSettings().m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_FILL_VIEWPORT_ON_CHANGE)
   {
     if (!dirtyRegions.empty())
     {
@@ -1213,7 +1213,7 @@ bool CGUIWindowManager::Render()
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetScissors();
   }
 
-  if (g_advancedSettings.m_guiVisualizeDirtyRegions)
+  if (CServiceBroker::GetAdvancedSettings().m_guiVisualizeDirtyRegions)
   {
     CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(), false);
     const CDirtyRegionList &markedRegions  = m_tracker.GetMarkedRegions();

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -164,18 +164,18 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
   std::string searchString(needle);
   CRegExp re(true);
 
-  if (!re.RegComp(g_advancedSettings.m_stereoscopicregex_3d.c_str()))
+  if (!re.RegComp(CServiceBroker::GetAdvancedSettings().m_stereoscopicregex_3d.c_str()))
   {
-    CLog::Log(LOGERROR, "%s: Invalid RegExp for matching 3d content:'%s'", __FUNCTION__, g_advancedSettings.m_stereoscopicregex_3d.c_str());
+    CLog::Log(LOGERROR, "%s: Invalid RegExp for matching 3d content:'%s'", __FUNCTION__, CServiceBroker::GetAdvancedSettings().m_stereoscopicregex_3d.c_str());
     return stereoMode;
   }
 
   if (re.RegFind(searchString) == -1)
     return stereoMode;    // no match found for 3d content, assume mono mode
 
-  if (!re.RegComp(g_advancedSettings.m_stereoscopicregex_sbs.c_str()))
+  if (!re.RegComp(CServiceBroker::GetAdvancedSettings().m_stereoscopicregex_sbs.c_str()))
   {
-    CLog::Log(LOGERROR, "%s: Invalid RegExp for matching 3d SBS content:'%s'", __FUNCTION__, g_advancedSettings.m_stereoscopicregex_sbs.c_str());
+    CLog::Log(LOGERROR, "%s: Invalid RegExp for matching 3d SBS content:'%s'", __FUNCTION__, CServiceBroker::GetAdvancedSettings().m_stereoscopicregex_sbs.c_str());
     return stereoMode;
   }
 
@@ -185,9 +185,9 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
     return stereoMode;
   }
 
-  if (!re.RegComp(g_advancedSettings.m_stereoscopicregex_tab.c_str()))
+  if (!re.RegComp(CServiceBroker::GetAdvancedSettings().m_stereoscopicregex_tab.c_str()))
   {
-    CLog::Log(LOGERROR, "%s: Invalid RegExp for matching 3d TAB content:'%s'", __FUNCTION__, g_advancedSettings.m_stereoscopicregex_tab.c_str());
+    CLog::Log(LOGERROR, "%s: Invalid RegExp for matching 3d TAB content:'%s'", __FUNCTION__, CServiceBroker::GetAdvancedSettings().m_stereoscopicregex_tab.c_str());
     return stereoMode;
   }
 

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -170,7 +170,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case MUSICPLAYER_GENRE:
       case LISTITEM_GENRE:
-        value =  StringUtils::Join(tag->GetGenre(), g_advancedSettings.m_musicItemSeparator);
+        value =  StringUtils::Join(tag->GetGenre(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
         return true;
       case MUSICPLAYER_LYRICS:
         value = tag->GetLyrics();

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -93,7 +93,7 @@ CTemperature CSystemGUIInfo::GetGPUTemperature() const
 #elif defined(TARGET_WINDOWS_STORE)
   return CTemperature::CreateFromCelsius(0);
 #else
-  std::string cmd = g_advancedSettings.m_gpuTempCmd;
+  std::string cmd = CServiceBroker::GetAdvancedSettings().m_gpuTempCmd;
   int ret = 0;
   FILE* p = NULL;
 
@@ -553,7 +553,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = !(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_LOGIN_SCREEN);
       return true;
     case SYSTEM_SHOW_EXIT_BUTTON:
-      value = g_advancedSettings.m_showExitButton;
+      value = CServiceBroker::GetAdvancedSettings().m_showExitButton;
       return true;
     case SYSTEM_HAS_LOGINSCREEN:
       value = CServiceBroker::GetProfileManager().UsingLoginScreen();

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -114,11 +114,11 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case VIDEOPLAYER_GENRE:
       case LISTITEM_GENRE:
-        value = StringUtils::Join(tag->m_genre, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_genre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case VIDEOPLAYER_DIRECTOR:
       case LISTITEM_DIRECTOR:
-        value = StringUtils::Join(tag->m_director, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_director, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case VIDEOPLAYER_IMDBNUMBER:
       case LISTITEM_IMDBNUMBER:
@@ -240,11 +240,11 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case VIDEOPLAYER_STUDIO:
       case LISTITEM_STUDIO:
-        value = StringUtils::Join(tag->m_studio, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_studio, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case VIDEOPLAYER_COUNTRY:
       case LISTITEM_COUNTRY:
-        value = StringUtils::Join(tag->m_country, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_country, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case VIDEOPLAYER_MPAA:
       case LISTITEM_MPAA:
@@ -268,7 +268,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case VIDEOPLAYER_ARTIST:
       case LISTITEM_ARTIST:
-        value = StringUtils::Join(tag->m_artist, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case VIDEOPLAYER_ALBUM:
       case LISTITEM_ALBUM:
@@ -276,7 +276,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case VIDEOPLAYER_WRITER:
       case LISTITEM_WRITER:
-        value = StringUtils::Join(tag->m_writingCredits, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_writingCredits, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case VIDEOPLAYER_TAGLINE:
       case LISTITEM_TAGLINE:
@@ -339,7 +339,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         value = tag->m_strStatus;
         return true;
       case LISTITEM_TAG:
-        value = StringUtils::Join(tag->m_tags, g_advancedSettings.m_videoItemSeparator);
+        value = StringUtils::Join(tag->m_tags, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         return true;
       case LISTITEM_SET:
         value = tag->m_set.title;

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -114,7 +114,7 @@ static int ToggleDebug(const std::vector<std::string>& params)
 {
   bool debug = CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_DEBUG_SHOWLOGINFO);
   CServiceBroker::GetSettings()->SetBool(CSettings::SETTING_DEBUG_SHOWLOGINFO, !debug);
-  g_advancedSettings.SetDebugMode(!debug);
+  CServiceBroker::GetAdvancedSettings().SetDebugMode(!debug);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -371,7 +371,7 @@ static int SetStereoMode(const std::vector<std::string>& params)
  */
 static int ToggleDirty(const std::vector<std::string>&)
 {
-  g_advancedSettings.ToggleDirtyRegionVisualization();
+  CServiceBroker::GetAdvancedSettings().ToggleDirtyRegionVisualization();
 
   return 0;
 }

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -742,7 +742,7 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const std::string &method, ITransp
       CopyStringArray(parameterObject["musicbrainzalbumartistid"], mbids);
     // When display artist is not provided and yet artists is changing make by concatenation
     if (!ParameterNotNull(parameterObject, "displayartist"))
-      album.strArtistDesc = StringUtils::Join(artists, g_advancedSettings.m_musicItemSeparator);
+      album.strArtistDesc = StringUtils::Join(artists, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
     album.SetArtistCredits(artists, std::vector<std::string>(), mbids);
     // On updatealbum artists will be changed
     album.bArtistSongMerge = true;
@@ -841,7 +841,7 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
       CopyStringArray(parameterObject["musicbrainzartistid"], mbids);
     // When display artist is not provided and yet artists is changing make by concatenation
     if (!ParameterNotNull(parameterObject, "displayartist"))
-      song.strArtistDesc = StringUtils::Join(artists, g_advancedSettings.m_musicItemSeparator);
+      song.strArtistDesc = StringUtils::Join(artists, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
     song.SetArtistCredits(artists, std::vector<std::string>(), mbids);
   }
 

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -79,17 +79,17 @@ JSONRPC_STATUS CFileOperations::GetDirectory(const std::string &method, ITranspo
   std::string extensions;
   if (media == "video")
   {
-    regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
+    regexps = CServiceBroker::GetAdvancedSettings().m_videoExcludeFromListingRegExps;
     extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
   }
   else if (media == "music")
   {
-    regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
+    regexps = CServiceBroker::GetAdvancedSettings().m_audioExcludeFromListingRegExps;
     extensions = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
   }
   else if (media == "pictures")
   {
-    regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
+    regexps = CServiceBroker::GetAdvancedSettings().m_pictureExcludeFromListingRegExps;
     extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
   }
 
@@ -341,17 +341,17 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
 
       if (media == "video")
       {
-        regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
+        regexps = CServiceBroker::GetAdvancedSettings().m_videoExcludeFromListingRegExps;
         extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
       }
       else if (media == "music")
       {
-        regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
+        regexps = CServiceBroker::GetAdvancedSettings().m_audioExcludeFromListingRegExps;
         extensions = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
       }
       else if (media == "pictures")
       {
-        regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
+        regexps = CServiceBroker::GetAdvancedSettings().m_pictureExcludeFromListingRegExps;
         extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
       }
 

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -264,7 +264,7 @@ std::string CJSONRPC::MethodCall(const std::string &inputString, ITransportLayer
 
   std::string str;
   if (hasResponse)
-    CJSONVariantWriter::Write(outputroot, str, g_advancedSettings.m_jsonOutputCompact);
+    CJSONVariantWriter::Write(outputroot, str, CServiceBroker::GetAdvancedSettings().m_jsonOutputCompact);
 
   return str;
 }

--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "InfoTagMusic.h"
+#include "ServiceBroker.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 
@@ -67,7 +68,7 @@ namespace XBMCAddon
 
     String InfoTagMusic::getGenre()
     {
-      return StringUtils::Join(infoTag->GetGenre(), g_advancedSettings.m_musicItemSeparator);
+      return StringUtils::Join(infoTag->GetGenre(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
     }
 
     int InfoTagMusic::getDuration()

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "InfoTagVideo.h"
+#include "ServiceBroker.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 
@@ -37,17 +38,17 @@ namespace XBMCAddon
 
     String InfoTagVideo::getDirector()
     {
-      return StringUtils::Join(infoTag->m_director, g_advancedSettings.m_videoItemSeparator);
+      return StringUtils::Join(infoTag->m_director, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     }
 
     String InfoTagVideo::getWritingCredits()
     {
-      return StringUtils::Join(infoTag->m_writingCredits, g_advancedSettings.m_videoItemSeparator);
+      return StringUtils::Join(infoTag->m_writingCredits, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     }
 
     String InfoTagVideo::getGenre()
     {
-      return StringUtils::Join(infoTag->m_genre, g_advancedSettings.m_videoItemSeparator);
+      return StringUtils::Join(infoTag->m_genre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     }
 
     String InfoTagVideo::getTagLine()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -22,6 +22,7 @@
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "Util.h"
+#include "ServiceBroker.h"
 
 namespace XBMCAddon
 {
@@ -582,11 +583,11 @@ namespace XBMCAddon
           else if (key == "musicbrainztrackid")
             musictag.SetMusicBrainzTrackID(value);
           else if (key == "musicbrainzartistid")
-            musictag.SetMusicBrainzArtistID(StringUtils::Split(value, g_advancedSettings.m_musicItemSeparator));
+            musictag.SetMusicBrainzArtistID(StringUtils::Split(value, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
           else if (key == "musicbrainzalbumid")
             musictag.SetMusicBrainzAlbumID(value);
           else if (key == "musicbrainzalbumartistid")
-            musictag.SetMusicBrainzAlbumArtistID(StringUtils::Split(value, g_advancedSettings.m_musicItemSeparator));
+            musictag.SetMusicBrainzAlbumArtistID(StringUtils::Split(value, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
           else if (key == "comment")
             musictag.SetComment(value);
           else if (key == "date")
@@ -856,7 +857,7 @@ namespace XBMCAddon
       {
         if (value.empty())
           value = alt.former();
-        return StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
+        return StringUtils::Split(value, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
       }
 
       std::vector<std::string> els;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -102,7 +102,7 @@ void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender,
   }
 
   std::string jsonData;
-  if (CJSONVariantWriter::Write(data, jsonData, g_advancedSettings.m_jsonOutputCompact))
+  if (CJSONVariantWriter::Write(data, jsonData, CServiceBroker::GetAdvancedSettings().m_jsonOutputCompact))
     OnNotification(sender, std::string(ANNOUNCEMENT::AnnouncementFlagToString(flag)) + "." + std::string(message), jsonData);
 }
 

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -14,6 +14,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/MathUtils.h"
 #include "FileItem.h"
+#include "ServiceBroker.h"
 
 #include <algorithm>
 
@@ -63,7 +64,7 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
 {
   std::vector<std::string> albumartistHints = hints;
   //Split the artist sort string to try and get sort names for individual artists
-  auto artistSort = StringUtils::Split(strArtistSort, g_advancedSettings.m_musicItemSeparator);
+  auto artistSort = StringUtils::Split(strArtistSort, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   artistCredits.clear();
 
   if (!mbids.empty())
@@ -186,7 +187,7 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
       albumArtists = albumartistHints;
     else
       // Split album artist names further using multiple possible delimiters, over single separator applied in Tag loader
-      albumArtists = StringUtils::SplitMulti(albumArtists, g_advancedSettings.m_musicArtistSeparators);
+      albumArtists = StringUtils::SplitMulti(albumArtists, CServiceBroker::GetAdvancedSettings().m_musicArtistSeparators);
 
     if (artistSort.size() != albumArtists.size())
       // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
@@ -331,7 +332,7 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
 
 std::string CAlbum::GetGenreString() const
 {
-  return StringUtils::Join(genre, g_advancedSettings.m_musicItemSeparator);
+  return StringUtils::Join(genre, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
 }
 
 const std::vector<std::string> CAlbum::GetAlbumArtist() const
@@ -367,7 +368,7 @@ const std::string CAlbum::GetAlbumArtistString() const
     artistvector.emplace_back(i->GetArtist());
   std::string artistString;
   if (!artistvector.empty())
-    artistString = StringUtils::Join(artistvector, g_advancedSettings.m_musicItemSeparator);
+    artistString = StringUtils::Join(artistvector, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   return artistString;
 }
 
@@ -463,17 +464,19 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
   if (!append)
     Reset();
 
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   XMLUtils::GetString(album,              "title", strAlbum);
   XMLUtils::GetString(album, "musicbrainzalbumid", strMusicBrainzAlbumID);
   XMLUtils::GetString(album, "musicbrainzreleasegroupid", strReleaseGroupMBID);
   XMLUtils::GetBoolean(album, "scrapedmbid", bScrapedMBID);
   XMLUtils::GetString(album, "artistdesc", strArtistDesc);
   std::vector<std::string> artist; // Support old style <artist></artist> for backwards compatibility
-  XMLUtils::GetStringArray(album, "artist", artist, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(album, "genre", genre, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(album, "style", styles, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(album, "mood", moods, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(album, "theme", themes, prioritise, g_advancedSettings.m_musicItemSeparator);
+  XMLUtils::GetStringArray(album, "artist", artist, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(album, "genre", genre, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(album, "style", styles, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(album, "mood", moods, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(album, "theme", themes, prioritise, itemSeparator);
   XMLUtils::GetBoolean(album, "compilation", bCompilation);
 
   XMLUtils::GetString(album,"review",strReview);

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -8,6 +8,7 @@
 
 #include "Artist.h"
 #include "utils/XMLUtils.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 
 #include <algorithm>
@@ -68,17 +69,19 @@ bool CArtist::Load(const TiXmlElement *artist, bool append, bool prioritise)
   if (!append)
     Reset();
 
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   XMLUtils::GetString(artist,                "name", strArtist);
   XMLUtils::GetString(artist, "musicBrainzArtistID", strMusicBrainzArtistID);
   XMLUtils::GetString(artist,            "sortname", strSortName);
   XMLUtils::GetString(artist, "type", strType);
   XMLUtils::GetString(artist, "gender", strGender);
   XMLUtils::GetString(artist, "disambiguation", strDisambiguation);
-  XMLUtils::GetStringArray(artist,       "genre", genre, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(artist,       "style", styles, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(artist,        "mood", moods, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(artist, "yearsactive", yearsActive, prioritise, g_advancedSettings.m_musicItemSeparator);
-  XMLUtils::GetStringArray(artist, "instruments", instruments, prioritise, g_advancedSettings.m_musicItemSeparator);
+  XMLUtils::GetStringArray(artist,       "genre", genre, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(artist,       "style", styles, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(artist,        "mood", moods, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(artist, "yearsactive", yearsActive, prioritise, itemSeparator);
+  XMLUtils::GetStringArray(artist, "instruments", instruments, prioritise, itemSeparator);
 
   XMLUtils::GetString(artist,      "born", strBorn);
   XMLUtils::GetString(artist,    "formed", strFormed);

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -83,7 +83,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   std::string strTrack=CServiceBroker::GetSettings()->GetString(CSettings::SETTING_MUSICFILES_LIBRARYTRACKFORMAT);
   if (strTrack.empty())
     strTrack = CServiceBroker::GetSettings()->GetString(CSettings::SETTING_MUSICFILES_TRACKFORMAT);
-  std::string strAlbum = g_advancedSettings.m_strMusicLibraryAlbumFormat;
+  std::string strAlbum = CServiceBroker::GetAdvancedSettings().m_strMusicLibraryAlbumFormat;
   if (strAlbum.empty())
     strAlbum = "%B"; // album
   CLog::Log(LOGDEBUG,"Custom album format = [%s]", strAlbum.c_str());
@@ -356,7 +356,7 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
   }
   else if (items.GetContent() == "albums")
   {
-    std::string strAlbum = g_advancedSettings.m_strMusicLibraryAlbumFormat;
+    std::string strAlbum = CServiceBroker::GetAdvancedSettings().m_strMusicLibraryAlbumFormat;
     if (strAlbum.empty())
       strAlbum = "%B"; // album
     // album
@@ -513,7 +513,7 @@ void CGUIViewStateWindowMusicNav::SaveViewState()
 
 void CGUIViewStateWindowMusicNav::AddOnlineShares()
 {
-  if (!g_advancedSettings.m_bVirtualShares)
+  if (!CServiceBroker::GetAdvancedSettings().m_bVirtualShares)
     return;
 
   VECSOURCES *musicSources = CMediaSourceSettings::GetInstance().GetSources("music");

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -107,7 +107,7 @@ CMusicDatabase::~CMusicDatabase(void)
 
 bool CMusicDatabase::Open()
 {
-  return CDatabase::Open(g_advancedSettings.m_databaseMusic);
+  return CDatabase::Open(CServiceBroker::GetAdvancedSettings().m_databaseMusic);
 }
 
 void CMusicDatabase::CreateTables()
@@ -493,14 +493,16 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
   BeginTransaction();
   SetLibraryLastUpdated();
 
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   UpdateAlbum(album.idAlbum,
               album.strAlbum, album.strMusicBrainzAlbumID,
               album.strReleaseGroupMBID,
               album.GetAlbumArtistString(), album.GetAlbumArtistSort(),
               album.GetGenreString(),
-              StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator).c_str(),
-              StringUtils::Join(album.styles, g_advancedSettings.m_musicItemSeparator).c_str(),
-              StringUtils::Join(album.themes, g_advancedSettings.m_musicItemSeparator).c_str(),
+              StringUtils::Join(album.moods, itemSeparator),
+              StringUtils::Join(album.styles, itemSeparator),
+              StringUtils::Join(album.themes, itemSeparator),
               album.strReview,
               album.thumbURL.m_xml.c_str(),
               album.strLabel, album.strType,
@@ -769,7 +771,7 @@ int CMusicDatabase::UpdateSong(int idSong,
       " strTitle = '%s', iTrack = %i, iDuration = %i, iYear = %i, strFileName = '%s'",
       idPath,
       artistDisp.c_str(),
-      StringUtils::Join(genres, g_advancedSettings.m_musicItemSeparator).c_str(),
+      StringUtils::Join(genres, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator).c_str(),
       strTitle.c_str(),
       iTrack, iDuration, iYear,
       strFileName.c_str());
@@ -1116,18 +1118,20 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
 {
   SetLibraryLastUpdated();
 
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   UpdateArtist(artist.idArtist,
                artist.strArtist, artist.strSortName,
                artist.strMusicBrainzArtistID, artist.bScrapedMBID,
                artist.strType, artist.strGender, artist.strDisambiguation,
                artist.strBorn, artist.strFormed,
-               StringUtils::Join(artist.genre, g_advancedSettings.m_musicItemSeparator),
-               StringUtils::Join(artist.moods, g_advancedSettings.m_musicItemSeparator),
-               StringUtils::Join(artist.styles, g_advancedSettings.m_musicItemSeparator),
-               StringUtils::Join(artist.instruments, g_advancedSettings.m_musicItemSeparator),
+               StringUtils::Join(artist.genre, itemSeparator),
+               StringUtils::Join(artist.moods, itemSeparator),
+               StringUtils::Join(artist.styles, itemSeparator),
+               StringUtils::Join(artist.instruments, itemSeparator),
                artist.strBiography, artist.strDied,
                artist.strDisbanded,
-               StringUtils::Join(artist.yearsActive, g_advancedSettings.m_musicItemSeparator).c_str(),
+               StringUtils::Join(artist.yearsActive, itemSeparator).c_str(),
                artist.thumbURL.m_xml.c_str(),
                artist.fanart.m_xml.c_str());
 
@@ -1621,7 +1625,7 @@ void CMusicDatabase::AddSongContributors(int idSong, const VECMUSICROLES& contri
   size_t countComposer = 0;
   if (!strSort.empty())
   {
-    composerSort = StringUtils::Split(strSort, g_advancedSettings.m_musicItemSeparator);
+    composerSort = StringUtils::Split(strSort, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   }
 
   for (const auto &credit : contributors)
@@ -1744,7 +1748,7 @@ bool CMusicDatabase::AddSongGenres(int idSong, const std::vector<std::string>& g
         return false;
     }
     // Update concatenated genre string from the standardised genre values
-    std::string strGenres = StringUtils::Join(modgenres, g_advancedSettings.m_musicItemSeparator);
+    std::string strGenres = StringUtils::Join(modgenres, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
     strSQL = PrepareSQL("UPDATE song SET strGenres = '%s' WHERE idSong = %i", strGenres.c_str(), idSong);
     if (!ExecuteQuery(strSQL))
       return false;
@@ -2099,7 +2103,7 @@ CSong CMusicDatabase::GetSongFromDataset(const dbiplus::sql_record* const record
   song.strArtistDesc = record->at(offset + song_strArtists).get_asString();
   song.strArtistSort = record->at(offset + song_strArtistSort).get_asString();
   // Get the full genre string
-  song.genre = StringUtils::Split(record->at(offset + song_strGenres).get_asString(), g_advancedSettings.m_musicItemSeparator);
+  song.genre = StringUtils::Split(record->at(offset + song_strGenres).get_asString(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   // and the rest...
   song.strAlbum = record->at(offset + song_strAlbum).get_asString();
   song.idAlbum = record->at(offset + song_idAlbum).get_asInt();
@@ -2225,6 +2229,8 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(dbiplus::Dataset* pDS, int offset /* 
 
 CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */, bool imageURL /* = false*/)
 {
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   CAlbum album;
   album.idAlbum = record->at(offset + album_idAlbum).get_asInt();
   album.strAlbum = record->at(offset + album_strAlbum).get_asString();
@@ -2234,7 +2240,7 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
   album.strReleaseGroupMBID = record->at(offset + album_strReleaseGroupMBID).get_asString();
   album.strArtistDesc = record->at(offset + album_strArtists).get_asString();
   album.strArtistSort = record->at(offset + album_strArtistSort).get_asString();
-  album.genre = StringUtils::Split(record->at(offset + album_strGenres).get_asString(), g_advancedSettings.m_musicItemSeparator);
+  album.genre = StringUtils::Split(record->at(offset + album_strGenres).get_asString(), itemSeparator);
   album.iYear = record->at(offset + album_iYear).get_asInt();
   if (imageURL)
     album.thumbURL.ParseString(record->at(offset + album_strThumbURL).get_asString());
@@ -2243,9 +2249,9 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
   album.iVotes = record->at(offset + album_iVotes).get_asInt();
   album.iYear = record->at(offset + album_iYear).get_asInt();
   album.strReview = record->at(offset + album_strReview).get_asString();
-  album.styles = StringUtils::Split(record->at(offset + album_strStyles).get_asString(), g_advancedSettings.m_musicItemSeparator);
-  album.moods = StringUtils::Split(record->at(offset + album_strMoods).get_asString(), g_advancedSettings.m_musicItemSeparator);
-  album.themes = StringUtils::Split(record->at(offset + album_strThemes).get_asString(), g_advancedSettings.m_musicItemSeparator);
+  album.styles = StringUtils::Split(record->at(offset + album_strStyles).get_asString(), itemSeparator);
+  album.moods = StringUtils::Split(record->at(offset + album_strMoods).get_asString(), itemSeparator);
+  album.themes = StringUtils::Split(record->at(offset + album_strThemes).get_asString(), itemSeparator);
   album.strLabel = record->at(offset + album_strLabel).get_asString();
   album.strType = record->at(offset + album_strType).get_asString();
   album.bCompilation = record->at(offset + album_bCompilation).get_asInt() == 1;
@@ -2288,6 +2294,8 @@ CArtist CMusicDatabase::GetArtistFromDataset(dbiplus::Dataset* pDS, int offset /
 
 CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const record, int offset /* = 0 */, bool needThumb /* = true */)
 {
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   CArtist artist;
   artist.idArtist = record->at(offset + artist_idArtist).get_asInt();
   if (artist.idArtist == BLANKARTIST_ID && m_translateBlankArtist)
@@ -2299,16 +2307,16 @@ CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const re
   artist.strType = record->at(offset + artist_strType).get_asString();
   artist.strGender = record->at(offset + artist_strGender).get_asString();
   artist.strDisambiguation = record->at(offset + artist_strDisambiguation).get_asString();
-  artist.genre = StringUtils::Split(record->at(offset + artist_strGenres).get_asString(), g_advancedSettings.m_musicItemSeparator);
+  artist.genre = StringUtils::Split(record->at(offset + artist_strGenres).get_asString(), itemSeparator);
   artist.strBiography = record->at(offset + artist_strBiography).get_asString();
-  artist.styles = StringUtils::Split(record->at(offset + artist_strStyles).get_asString(), g_advancedSettings.m_musicItemSeparator);
-  artist.moods = StringUtils::Split(record->at(offset + artist_strMoods).get_asString(), g_advancedSettings.m_musicItemSeparator);
+  artist.styles = StringUtils::Split(record->at(offset + artist_strStyles).get_asString(), itemSeparator);
+  artist.moods = StringUtils::Split(record->at(offset + artist_strMoods).get_asString(), itemSeparator);
   artist.strBorn = record->at(offset + artist_strBorn).get_asString();
   artist.strFormed = record->at(offset + artist_strFormed).get_asString();
   artist.strDied = record->at(offset + artist_strDied).get_asString();
   artist.strDisbanded = record->at(offset + artist_strDisbanded).get_asString();
-  artist.yearsActive = StringUtils::Split(record->at(offset + artist_strYearsActive).get_asString(), g_advancedSettings.m_musicItemSeparator);
-  artist.instruments = StringUtils::Split(record->at(offset + artist_strInstruments).get_asString(), g_advancedSettings.m_musicItemSeparator);
+  artist.yearsActive = StringUtils::Split(record->at(offset + artist_strYearsActive).get_asString(), itemSeparator);
+  artist.instruments = StringUtils::Split(record->at(offset + artist_strInstruments).get_asString(), itemSeparator);
   artist.bScrapedMBID = record->at(offset + artist_bScrapedMBID).get_asInt() == 1;
   artist.strLastScraped = record->at(offset + artist_lastScraped).get_asString();
   artist.SetDateAdded(record->at(offset + artist_dtDateAdded).get_asString());
@@ -2672,7 +2680,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, 
       "JOIN songview ON songview.idAlbum = playedalbums.idAlbum "
       "JOIN songartistview ON songview.idSong = songartistview.idSong "
       "ORDER BY playedalbums.lastplayed DESC,songartistview.idsong, songartistview.idRole, songartistview.iOrder",
-      g_advancedSettings.m_iMusicLibraryRecentlyAddedItems);
+      CServiceBroker::GetAdvancedSettings().m_iMusicLibraryRecentlyAddedItems);
     CLog::Log(LOGDEBUG,"GetRecentlyPlayedAlbumSongs() query: %s", strSQL.c_str());
     if (!m_pDS->query(strSQL)) return false;
 
@@ -2749,7 +2757,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
       "JOIN albumview ON albumview.idAlbum = recentalbums.idAlbum "
       "JOIN albumartistview ON albumview.idAlbum = albumartistview.idAlbum "
       "ORDER BY albumview.idAlbum desc, albumartistview.iOrder ",
-       limit ? limit : g_advancedSettings.m_iMusicLibraryRecentlyAddedItems);
+       limit ? limit : CServiceBroker::GetAdvancedSettings().m_iMusicLibraryRecentlyAddedItems);
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     if (!m_pDS->query(strSQL)) return false;
@@ -2807,7 +2815,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, C
         "JOIN songview ON songview.idAlbum = recentalbums.idAlbum "
         "JOIN songartistview ON songview.idSong = songartistview.idSong "
         "ORDER BY songview.idAlbum DESC, songview.idSong, songartistview.idRole, songartistview.iOrder ",
-        limit ? limit : g_advancedSettings.m_iMusicLibraryRecentlyAddedItems);
+        limit ? limit : CServiceBroker::GetAdvancedSettings().m_iMusicLibraryRecentlyAddedItems);
     CLog::Log(LOGDEBUG,"GetRecentlyAddedAlbumSongs() query: %s", strSQL.c_str());
     if (!m_pDS->query(strSQL)) return false;
 
@@ -5265,7 +5273,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
               artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asFloat();
             else if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "array")
               artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] =
-              StringUtils::Split(record->at(1 + i).get_asString(), g_advancedSettings.m_musicItemSeparator);
+              StringUtils::Split(record->at(1 + i).get_asString(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
             else if (JSONtoDBArtist[dbfieldindex[i]].formatJSON == "boolean")
               artistObj[JSONtoDBArtist[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asBool();
             else
@@ -5845,7 +5853,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
               albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = std::max(record->at(1 + i).get_asFloat(), 0.f);
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "array")
               albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = StringUtils::Split(record->at(1 + i).get_asString(),
-                g_advancedSettings.m_musicItemSeparator);
+                CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "boolean")
               albumObj[JSONtoDBAlbum[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asBool();
             else if (JSONtoDBAlbum[dbfieldindex[i]].formatJSON == "image")
@@ -6451,7 +6459,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
                 field != songObj[displayXXX].end_array(); field++)
                 names.emplace_back(field->asString());
 
-              std::string role = StringUtils::Join(names, g_advancedSettings.m_musicItemSeparator);
+              std::string role = StringUtils::Join(names, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
               songObj[displayXXX] = role;
             }
             else
@@ -6492,7 +6500,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "float")
               songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = std::max(record->at(1 + i).get_asFloat(), 0.f);
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "array")
-              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = StringUtils::Split(record->at(1 + i).get_asString(), g_advancedSettings.m_musicItemSeparator);
+              songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = StringUtils::Split(record->at(1 + i).get_asString(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
             else if (JSONtoDBSong[dbfieldindex[i]].formatJSON == "boolean")
               songObj[JSONtoDBSong[dbfieldindex[i]].fieldJSON] = record->at(1 + i).get_asBool();
             else
@@ -8567,7 +8575,7 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
 
 int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::vector<std::string>& artist)
 {
-  return GetAlbumByName(strAlbum, StringUtils::Join(artist, g_advancedSettings.m_musicItemSeparator));
+  return GetAlbumByName(strAlbum, StringUtils::Join(artist, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 int CMusicDatabase::GetAlbumByMatch(const CAlbum &album)
@@ -8625,7 +8633,7 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
   // Propagate artist sort names into concatenated artist sort name string for songs and albums
   std::string strSQL;
   // MySQL syntax for GROUP_CONCAT with order is different from that in SQLite (not handled by PrepareSQL)
-  bool bisMySQL = StringUtils::EqualsNoCase(g_advancedSettings.m_databaseMusic.type, "mysql");
+  bool bisMySQL = StringUtils::EqualsNoCase(CServiceBroker::GetAdvancedSettings().m_databaseMusic.type, "mysql");
 
   BeginMultipleExecute();
   if (bisMySQL)
@@ -9915,41 +9923,45 @@ void CMusicDatabase::ImportFromXML(const std::string &xmlFile)
 
 void CMusicDatabase::SetPropertiesFromArtist(CFileItem& item, const CArtist& artist)
 {
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   item.SetProperty("artist_sortname", artist.strSortName);
   item.SetProperty("artist_type", artist.strType);
   item.SetProperty("artist_gender", artist.strGender);
   item.SetProperty("artist_disambiguation", artist.strDisambiguation);
-  item.SetProperty("artist_instrument", StringUtils::Join(artist.instruments, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("artist_instrument", StringUtils::Join(artist.instruments, itemSeparator));
   item.SetProperty("artist_instrument_array", artist.instruments);
-  item.SetProperty("artist_style", StringUtils::Join(artist.styles, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("artist_style", StringUtils::Join(artist.styles, itemSeparator));
   item.SetProperty("artist_style_array", artist.styles);
-  item.SetProperty("artist_mood", StringUtils::Join(artist.moods, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("artist_mood", StringUtils::Join(artist.moods, itemSeparator));
   item.SetProperty("artist_mood_array", artist.moods);
   item.SetProperty("artist_born", artist.strBorn);
   item.SetProperty("artist_formed", artist.strFormed);
   item.SetProperty("artist_description", artist.strBiography);
-  item.SetProperty("artist_genre", StringUtils::Join(artist.genre, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("artist_genre", StringUtils::Join(artist.genre, itemSeparator));
   item.SetProperty("artist_genre_array", artist.genre);
   item.SetProperty("artist_died", artist.strDied);
   item.SetProperty("artist_disbanded", artist.strDisbanded);
-  item.SetProperty("artist_yearsactive", StringUtils::Join(artist.yearsActive, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("artist_yearsactive", StringUtils::Join(artist.yearsActive, itemSeparator));
   item.SetProperty("artist_yearsactive_array", artist.yearsActive);
 }
 
 void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album)
 {
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_musicItemSeparator;
+
   item.SetProperty("album_description", album.strReview);
-  item.SetProperty("album_theme", StringUtils::Join(album.themes, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("album_theme", StringUtils::Join(album.themes, itemSeparator));
   item.SetProperty("album_theme_array", album.themes);
-  item.SetProperty("album_mood", StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("album_mood", StringUtils::Join(album.moods, itemSeparator));
   item.SetProperty("album_mood_array", album.moods);
-  item.SetProperty("album_style", StringUtils::Join(album.styles, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("album_style", StringUtils::Join(album.styles, itemSeparator));
   item.SetProperty("album_style_array", album.styles);
   item.SetProperty("album_type", album.strType);
   item.SetProperty("album_label", album.strLabel);
   item.SetProperty("album_artist", album.GetAlbumArtistString());
   item.SetProperty("album_artist_array", album.GetAlbumArtist());
-  item.SetProperty("album_genre", StringUtils::Join(album.genre, g_advancedSettings.m_musicItemSeparator));
+  item.SetProperty("album_genre", StringUtils::Join(album.genre, itemSeparator));
   item.SetProperty("album_genre_array", album.genre);
   item.SetProperty("album_title", album.strAlbum);
   if (album.fRating > 0)
@@ -10670,10 +10682,10 @@ void CMusicDatabase::UpdateFileDateAdded(int songId, const std::string& strFileN
     if (NULL == m_pDS.get()) return;
 
     // 1 preferring to use the files mtime(if it's valid) and only using the file's ctime if the mtime isn't valid
-    if (g_advancedSettings.m_iMusicLibraryDateAdded == 1)
+    if (CServiceBroker::GetAdvancedSettings().m_iMusicLibraryDateAdded == 1)
       dateAdded = CFileUtils::GetModificationDate(strFileNameAndPath, false);
     //2 using the newer datetime of the file's mtime and ctime
-    else if (g_advancedSettings.m_iMusicLibraryDateAdded == 2)
+    else if (CServiceBroker::GetAdvancedSettings().m_iMusicLibraryDateAdded == 2)
       dateAdded = CFileUtils::GetModificationDate(strFileNameAndPath, true);
     //0 using the current datetime if non of the above matches or one returns an invalid datetime
     if (!dateAdded.IsValid())

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -12,6 +12,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 
 using namespace MUSIC_INFO;
@@ -40,7 +41,7 @@ CSong::CSong(CFileItem& item)
     m_albumArtist = tag.GetMusicBrainzAlbumArtistHints();
   else
     // Split album artist names further using multiple possible delimiters, over single separator applied in Tag loader
-    m_albumArtist = StringUtils::SplitMulti(m_albumArtist, g_advancedSettings.m_musicArtistSeparators);
+    m_albumArtist = StringUtils::SplitMulti(m_albumArtist, CServiceBroker::GetAdvancedSettings().m_musicArtistSeparators);
   for (auto artistname : m_albumArtist)
     StringUtils::Trim(artistname);
   m_strAlbumArtistSort = tag.GetAlbumArtistSort();
@@ -82,7 +83,7 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
   artistCredits.clear();
   std::vector<std::string> artistHints = hints;
   //Split the artist sort string to try and get sort names for individual artists
-  std::vector<std::string> artistSort = StringUtils::Split(strArtistSort, g_advancedSettings.m_musicItemSeparator);
+  std::vector<std::string> artistSort = StringUtils::Split(strArtistSort, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
 
   if (!mbids.empty())
   { // Have musicbrainz artist info, so use it
@@ -174,7 +175,7 @@ void CSong::SetArtistCredits(const std::vector<std::string>& names, const std::v
       artists = artistHints;
     else
       // Split artist names further using multiple possible delimiters, over single separator applied in Tag loader
-      artists = StringUtils::SplitMulti(artists, g_advancedSettings.m_musicArtistSeparators);
+      artists = StringUtils::SplitMulti(artists, CServiceBroker::GetAdvancedSettings().m_musicArtistSeparators);
 
     if (artistSort.size() != artists.size())
       // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
@@ -274,7 +275,7 @@ const std::vector<std::string> CSong::GetArtist() const
   //This is a temporary fix, in the longer term other areas should query the song_artist table and populate
   //artist credits. Note that splitting the string may not give the same artists as held in the song_artist table
   if (songartists.empty() && !strArtistDesc.empty())
-    songartists = StringUtils::Split(strArtistDesc, g_advancedSettings.m_musicItemSeparator);
+    songartists = StringUtils::Split(strArtistDesc, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   return songartists;
 }
 
@@ -316,7 +317,7 @@ const std::string CSong::GetArtistString() const
     artistvector.push_back(i->GetArtist());
   std::string artistString;
   if (!artistvector.empty())
-    artistString = StringUtils::Join(artistvector, g_advancedSettings.m_musicItemSeparator);
+    artistString = StringUtils::Join(artistvector, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   return artistString;
 }
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -252,7 +252,7 @@ void CMusicInfoScanner::Process()
       }
     }
     //propagate artist sort names to albums and songs
-    if (g_advancedSettings.m_bMusicLibraryArtistSortOnUpdate)
+    if (CServiceBroker::GetAdvancedSettings().m_bMusicLibraryArtistSortOnUpdate)
       m_musicDatabase.UpdateArtistSortNames();
   }
   catch (...)
@@ -301,7 +301,7 @@ void CMusicInfoScanner::Start(const std::string& strDirectory, int flags)
   }
   m_musicDatabase.Close();
 
-  m_bClean = g_advancedSettings.m_bMusicLibraryCleanOnUpdate;
+  m_bClean = CServiceBroker::GetAdvancedSettings().m_bMusicLibraryCleanOnUpdate;
 
   m_scanType = 0;
   m_bRunning = true;
@@ -467,7 +467,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   m_seenPaths.insert(strDirectory);
 
   // Discard all excluded files defined by m_musicExcludeRegExps
-  const std::vector<std::string> &regexps = g_advancedSettings.m_audioExcludeFromScanRegExps;
+  const std::vector<std::string> &regexps = CServiceBroker::GetAdvancedSettings().m_audioExcludeFromScanRegExps;
 
   if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
     return true;
@@ -549,7 +549,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 CInfoScanner::INFO_RET CMusicInfoScanner::ScanTags(const CFileItemList& items,
                                                    CFileItemList& scannedItems)
 {
-  std::vector<std::string> regexps = g_advancedSettings.m_audioExcludeFromScanRegExps;
+  std::vector<std::string> regexps = CServiceBroker::GetAdvancedSettings().m_audioExcludeFromScanRegExps;
 
   for (int i = 0; i < items.Size(); ++i)
   {
@@ -786,7 +786,7 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
       album.strAlbum = songsByAlbumName->first;
 
       //Split the albumartist sort string to try and get sort names for individual artists
-      std::vector<std::string> sortnames = StringUtils::Split(albumartistsort, g_advancedSettings.m_musicItemSeparator);
+      std::vector<std::string> sortnames = StringUtils::Split(albumartistsort, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
       if (sortnames.size() != common.size())
           // Split artist sort names further using multiple possible delimiters, over single separator applied in Tag loader
         sortnames = StringUtils::SplitMulti(sortnames, { ";", ":", "|", "#" });
@@ -1798,7 +1798,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
               strTemp += " ("+scraper.GetArtist(i).GetArtist().strBorn+")";
             if (!scraper.GetArtist(i).GetArtist().genre.empty())
             {
-              std::string genres = StringUtils::Join(scraper.GetArtist(i).GetArtist().genre, g_advancedSettings.m_musicItemSeparator);
+              std::string genres = StringUtils::Join(scraper.GetArtist(i).GetArtist().genre, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
               if (!genres.empty())
                 strTemp = StringUtils::Format("[%s] %s", genres.c_str(), strTemp.c_str());
             }
@@ -1912,14 +1912,14 @@ std::vector<std::string> CMusicInfoScanner::GetArtTypesToScan(const MediaType& m
   if (mediaType == MediaTypeArtist)
   {
     arttypes = { "thumb", "fanart" };
-    arttypes.insert(arttypes.end(), g_advancedSettings.m_musicArtistExtraArt.begin(),
-      g_advancedSettings.m_musicArtistExtraArt.end());
+    arttypes.insert(arttypes.end(), CServiceBroker::GetAdvancedSettings().m_musicArtistExtraArt.begin(),
+      CServiceBroker::GetAdvancedSettings().m_musicArtistExtraArt.end());
   }
   else if (mediaType == MediaTypeAlbum)
   {
     arttypes = { "thumb" };
-    arttypes.insert(arttypes.end(), g_advancedSettings.m_musicAlbumExtraArt.begin(),
-      g_advancedSettings.m_musicAlbumExtraArt.end());
+    arttypes.insert(arttypes.end(), CServiceBroker::GetAdvancedSettings().m_musicAlbumExtraArt.begin(),
+      CServiceBroker::GetAdvancedSettings().m_musicAlbumExtraArt.end());
   }
 
   return arttypes;
@@ -2135,7 +2135,7 @@ void CMusicInfoScanner::SetDiscSetArtwork(CAlbum& album, const std::vector<std::
   arttypes = GetArtTypesToScan(MediaTypeAlbum);
 
   // Check that there are art types other than thumb to process
-  bool extratype = !g_advancedSettings.m_musicAlbumExtraArt.empty();
+  bool extratype = !CServiceBroker::GetAdvancedSettings().m_musicAlbumExtraArt.empty();
 
   std::string firstDiscThumb;
   int iDiscThumb = 10000;

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -10,6 +10,7 @@
 #include "music/Artist.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Variant.h"
 #include "utils/Archive.h"
@@ -78,7 +79,7 @@ const std::string CMusicInfoTag::GetArtistString() const
   if (!m_strArtistDesc.empty())
     return m_strArtistDesc;
   else if (!m_artist.empty())
-    return StringUtils::Join(m_artist, g_advancedSettings.m_musicItemSeparator);
+    return StringUtils::Join(m_artist, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   else
     return StringUtils::Empty;
 }
@@ -113,7 +114,7 @@ const std::string CMusicInfoTag::GetAlbumArtistString() const
   if (!m_strAlbumArtistDesc.empty())
     return m_strAlbumArtistDesc;
   if (!m_albumArtist.empty())
-    return StringUtils::Join(m_albumArtist, g_advancedSettings.m_musicItemSeparator);
+    return StringUtils::Join(m_albumArtist, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   else
     return StringUtils::Empty;
 }
@@ -248,7 +249,7 @@ void CMusicInfoTag::SetArtist(const std::string& strArtist)
   if (!strArtist.empty())
   {
     SetArtistDesc(strArtist);
-    SetArtist(StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator));
+    SetArtist(StringUtils::Split(strArtist, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   }
   else
   {
@@ -262,7 +263,7 @@ void CMusicInfoTag::SetArtist(const std::vector<std::string>& artists, bool Fill
   m_artist = artists;
   if (m_strArtistDesc.empty() || FillDesc)
   {
-    SetArtistDesc(StringUtils::Join(artists, g_advancedSettings.m_musicItemSeparator));
+    SetArtistDesc(StringUtils::Join(artists, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   }
 }
 
@@ -296,7 +297,7 @@ void CMusicInfoTag::SetAlbumArtist(const std::string& strAlbumArtist)
   if (!strAlbumArtist.empty())
   {
     SetAlbumArtistDesc(strAlbumArtist);
-    SetAlbumArtist(StringUtils::Split(strAlbumArtist, g_advancedSettings.m_musicItemSeparator));
+    SetAlbumArtist(StringUtils::Split(strAlbumArtist, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   }
   else
   {
@@ -309,7 +310,7 @@ void CMusicInfoTag::SetAlbumArtist(const std::vector<std::string>& albumArtists,
 {
   m_albumArtist = albumArtists;
   if (m_strAlbumArtistDesc.empty() || FillDesc)
-    SetAlbumArtistDesc(StringUtils::Join(albumArtists, g_advancedSettings.m_musicItemSeparator));
+    SetAlbumArtistDesc(StringUtils::Join(albumArtists, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 void CMusicInfoTag::SetAlbumArtistDesc(const std::string& strAlbumArtistDesc)
@@ -325,7 +326,7 @@ void CMusicInfoTag::SetAlbumArtistSort(const std::string& strAlbumArtistSort)
 void CMusicInfoTag::SetGenre(const std::string& strGenre, bool bTrim /* = false*/)
 {
   if (!strGenre.empty())
-    SetGenre(StringUtils::Split(strGenre, g_advancedSettings.m_musicItemSeparator), bTrim);
+    SetGenre(StringUtils::Split(strGenre, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator), bTrim);
   else
     m_genre.clear();
 }
@@ -577,7 +578,7 @@ void CMusicInfoTag::SetArtist(const CArtist& artist)
   SetMusicBrainzArtistID({ artist.strMusicBrainzArtistID });
   SetMusicBrainzAlbumArtistID({ artist.strMusicBrainzArtistID });
   SetGenre(artist.genre);
-  SetMood(StringUtils::Join(artist.moods, g_advancedSettings.m_musicItemSeparator));
+  SetMood(StringUtils::Join(artist.moods, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   SetDateAdded(artist.dateAdded);
   SetDatabaseId(artist.idArtist, MediaTypeArtist);
 
@@ -603,7 +604,7 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetMusicBrainzReleaseGroupID(album.strReleaseGroupMBID);
   SetMusicBrainzReleaseType(album.strType);
   SetGenre(album.genre);
-  SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
+  SetMood(StringUtils::Join(album.moods, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   SetRecordLabel(album.strLabel);
   SetRating(album.fRating);
   SetUserrating(album.iUserrating);
@@ -688,7 +689,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   // A longer term solution would be to ensure that when individual artists are to be returned then the song_artist and artist tables
   // are queried.
   if (m_artist.empty())
-    value["artist"] = StringUtils::Split(GetArtistString(), g_advancedSettings.m_musicItemSeparator);
+    value["artist"] = StringUtils::Split(GetArtistString(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
 
   value["displayartist"] = GetArtistString();
   value["displayalbumartist"] = GetAlbumArtistString();
@@ -722,7 +723,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["displayconductor"] = GetArtistStringForRole("conductor"); //TPE3
   value["displayorchestra"] = GetArtistStringForRole("orchestra");
   value["displaylyricist"] = GetArtistStringForRole("lyricist");   //TEXT
-  value["mood"] = StringUtils::Split(m_strMood, g_advancedSettings.m_musicItemSeparator);
+  value["mood"] = StringUtils::Split(m_strMood, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
   value["recordlabel"] = m_strRecordLabel;
   value["rating"] = m_Rating;
   value["userrating"] = m_Userrating;
@@ -961,7 +962,7 @@ void CMusicInfoTag::AppendGenre(const std::string &genre)
 void CMusicInfoTag::AddArtistRole(const std::string& Role, const std::string& strArtist)
 {
   if (!strArtist.empty() && !Role.empty())
-    AddArtistRole(Role, StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator));
+    AddArtistRole(Role, StringUtils::Split(strArtist, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 void CMusicInfoTag::AddArtistRole(const std::string& Role, const std::vector<std::string>& artists)
@@ -990,7 +991,7 @@ const std::string CMusicInfoTag::GetArtistStringForRole(const std::string& strRo
     if (StringUtils::EqualsNoCase(credit->GetRoleDesc(), strRole))
       artistvector.push_back(credit->GetArtist());
   }
-  return StringUtils::Join(artistvector, g_advancedSettings.m_musicItemSeparator);
+  return StringUtils::Join(artistvector, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
 }
 
 const std::string CMusicInfoTag::GetContributorsText() const

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -56,6 +56,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Base64.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 
 using namespace TagLib;
@@ -211,7 +212,7 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
       if (art)
         art->Set(reinterpret_cast<const uint8_t *>(pic.picture().data()), pic.picture().size(), pic.mimeType().toCString());
     }
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+    else if (CServiceBroker::GetAdvancedSettings().m_logLevel == LOG_LEVEL_MAX)
       CLog::Log(LOGDEBUG, "unrecognized ASF tag name: %s", it->first.toCString(true));
   }
   // artist may be specified in the ContentDescription block rather than using the 'Author' attribute.
@@ -365,7 +366,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
           SetComposerSort(tag, StringListToVectorString(stringList));
         else if (desc == "MOOD")
           tag.SetMood(stringList.front().to8Bit(true));
-        else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+        else if (CServiceBroker::GetAdvancedSettings().m_logLevel == LOG_LEVEL_MAX)
           CLog::Log(LOGDEBUG, "unrecognized user text tag detected: TXXX:%s", frame->description().toCString(true));
       }
     else if (it->first == "TIPL")
@@ -435,7 +436,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
           tag.SetUserrating(POPMtoXBMC(popFrame->rating()));
         }
       }
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+    else if (CServiceBroker::GetAdvancedSettings().m_logLevel == LOG_LEVEL_MAX)
       CLog::Log(LOGDEBUG, "unrecognized ID3 frame detected: %c%c%c%c", it->first[0], it->first[1], it->first[2], it->first[3]);
   } // for
 
@@ -560,7 +561,7 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
       tag.SetMusicBrainzTrackID(it->second.toString().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_ALBUMTYPE")
       SetReleaseType(tag, StringListToVectorString(it->second.toStringList()));
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+    else if (CServiceBroker::GetAdvancedSettings().m_logLevel == LOG_LEVEL_MAX)
       CLog::Log(LOGDEBUG, "unrecognized APE tag: %s", it->first.toCString(true));
   }
 
@@ -712,7 +713,7 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
       pictures[2].setMimeType(it->second.front());
     }
 #endif
-    else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
+    else if (CServiceBroker::GetAdvancedSettings().m_logLevel == LOG_LEVEL_MAX)
       CLog::Log(LOGDEBUG, "unrecognized XipComment name: %s", it->first.toCString(true));
   }
 
@@ -927,13 +928,13 @@ void CTagLoaderTagLib::SetArtistSort(CMusicInfoTag &tag, const std::vector<std::
   if (values.size() == 1)
     tag.SetArtistSort(values[0]);
   else
-    tag.SetArtistSort(StringUtils::Join(values, g_advancedSettings.m_musicItemSeparator));
+    tag.SetArtistSort(StringUtils::Join(values, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 void CTagLoaderTagLib::SetArtistHints(CMusicInfoTag &tag, const std::vector<std::string> &values)
 {
   if (values.size() == 1)
-    tag.SetMusicBrainzArtistHints(StringUtils::Split(values[0], g_advancedSettings.m_musicItemSeparator));
+    tag.SetMusicBrainzArtistHints(StringUtils::Split(values[0], CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   else
     tag.SetMusicBrainzArtistHints(values);
 }
@@ -974,13 +975,13 @@ void CTagLoaderTagLib::SetAlbumArtistSort(CMusicInfoTag &tag, const std::vector<
   if (values.size() == 1)
     tag.SetAlbumArtistSort(values[0]);
   else
-    tag.SetAlbumArtistSort(StringUtils::Join(values, g_advancedSettings.m_musicItemSeparator));
+    tag.SetAlbumArtistSort(StringUtils::Join(values, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 void CTagLoaderTagLib::SetAlbumArtistHints(CMusicInfoTag &tag, const std::vector<std::string> &values)
 {
   if (values.size() == 1)
-    tag.SetMusicBrainzAlbumArtistHints(StringUtils::Split(values[0], g_advancedSettings.m_musicItemSeparator));
+    tag.SetMusicBrainzAlbumArtistHints(StringUtils::Split(values[0], CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
   else
     tag.SetMusicBrainzAlbumArtistHints(values);
 }
@@ -991,7 +992,7 @@ void CTagLoaderTagLib::SetComposerSort(CMusicInfoTag &tag, const std::vector<std
   if (values.size() == 1)
     tag.SetComposerSort(values[0]);
   else
-    tag.SetComposerSort(StringUtils::Join(values, g_advancedSettings.m_musicItemSeparator));
+    tag.SetComposerSort(StringUtils::Join(values, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 void CTagLoaderTagLib::SetGenre(CMusicInfoTag &tag, const std::vector<std::string> &values)
@@ -1023,7 +1024,7 @@ void CTagLoaderTagLib::SetReleaseType(CMusicInfoTag &tag, const std::vector<std:
   if (values.size() == 1)
     tag.SetMusicBrainzReleaseType(values[0]);
   else
-    tag.SetMusicBrainzReleaseType(StringUtils::Join(values, g_advancedSettings.m_musicItemSeparator));
+    tag.SetMusicBrainzReleaseType(StringUtils::Join(values, CServiceBroker::GetAdvancedSettings().m_musicItemSeparator));
 }
 
 void CTagLoaderTagLib::AddArtistRole(CMusicInfoTag &tag, const std::string& strRole, const std::vector<std::string> &values)
@@ -1258,7 +1259,7 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
     ParseTag(mp4, art, tag);
   if (xiph) // xiph tags override id3v2 tags in badly tagged FLACs
     ParseTag(xiph, art, tag);
-  if (ape && (!id3v2 || g_advancedSettings.m_prioritiseAPEv2tags)) // ape tags override id3v2 if we're prioritising them
+  if (ape && (!id3v2 || CServiceBroker::GetAdvancedSettings().m_prioritiseAPEv2tags)) // ape tags override id3v2 if we're prioritising them
     ParseTag(ape, art, tag);
 
   // art for flac files is outside the tag

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -524,7 +524,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
         // allow a folder to be ad-hoc queued and played by the default player
         if (item->m_bIsFolder || (item->IsPlayList() &&
-           !g_advancedSettings.m_playlistAsFolders))
+           !CServiceBroker::GetAdvancedSettings().m_playlistAsFolders))
         {
           buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208); // Play
         }

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -214,7 +214,7 @@ void CGUIWindowVisualisation::FrameMove()
     m_initTimer.StartZero();
     infoMgr.GetInfoProviders().GetPlayerInfoProvider().SetShowInfo(true);
   }
-  if (m_initTimer.IsRunning() && m_initTimer.GetElapsedSeconds() > (float)g_advancedSettings.m_songInfoDuration)
+  if (m_initTimer.IsRunning() && m_initTimer.GetElapsedSeconds() > (float)CServiceBroker::GetAdvancedSettings().m_songInfoDuration)
   {
     m_initTimer.Stop();
     if (!CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_MYMUSIC_SONGTHUMBINVIS))

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -84,10 +84,10 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   if (pItem)
   {
     pItem->m_bIsFolder = true;
-    pItem->SetSpecialSort(g_advancedSettings.m_bMusicLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
+    pItem->SetSpecialSort(CServiceBroker::GetAdvancedSettings().m_bMusicLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
     pItem->SetCanQueue(false);
     pItem->SetLabelPreformatted(true);
-    if (g_advancedSettings.m_bMusicLibraryAllItemsOnBottom)
+    if (CServiceBroker::GetAdvancedSettings().m_bMusicLibraryAllItemsOnBottom)
       items.Add(pItem);
     else
       items.AddFront(pItem, (items.Size() > 0 && items[0]->IsParentFolder()) ? 1 : 0);

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -499,7 +499,7 @@ void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *sess
 void shairplay_log(void *cls, int level, const char *msg)
 {
   int xbmcLevel = LOGINFO;
-  if(!g_advancedSettings.CanLogComponent(LOGAIRTUNES))
+  if(!CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGAIRTUNES))
     return;
 
   switch(level)
@@ -687,7 +687,7 @@ bool CAirTunesServer::Initialize(const std::string &password)
       unsigned short port = (unsigned short)m_port;
 
       m_pLibShairplay->raop_set_log_level(m_pRaop, RAOP_LOG_WARNING);
-      if(g_advancedSettings.CanLogComponent(LOGAIRTUNES))
+      if(CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGAIRTUNES))
       {
         m_pLibShairplay->raop_set_log_level(m_pRaop, RAOP_LOG_DEBUG);
       }

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -592,7 +592,7 @@ bool CNetworkServices::StartAirPlayServer()
   if (IsAirPlayServerRunning())
     return true;
 
-  if (!CAirPlayServer::StartServer(g_advancedSettings.m_airPlayPort, true))
+  if (!CAirPlayServer::StartServer(CServiceBroker::GetAdvancedSettings().m_airPlayPort, true))
     return false;
 
   if (!CAirPlayServer::SetCredentials(m_settings->GetBool(CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD),
@@ -612,7 +612,7 @@ bool CNetworkServices::StartAirPlayServer()
   // we have implemented it anyways).
   txt.push_back(std::make_pair("features", "0x20F7"));
 
-  CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", CSysInfo::GetDeviceName(), g_advancedSettings.m_airPlayPort, txt);
+  CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", CSysInfo::GetDeviceName(), CServiceBroker::GetAdvancedSettings().m_airPlayPort, txt);
 #endif // HAS_ZEROCONF
 
   return true;
@@ -654,7 +654,7 @@ bool CNetworkServices::StartAirTunesServer()
   if (IsAirTunesServerRunning())
     return true;
 
-  if (!CAirTunesServer::StartServer(g_advancedSettings.m_airTunesPort, true,
+  if (!CAirTunesServer::StartServer(CServiceBroker::GetAdvancedSettings().m_airTunesPort, true,
                                     m_settings->GetBool(CSettings::SETTING_SERVICES_USEAIRPLAYPASSWORD),
                                     m_settings->GetString(CSettings::SETTING_SERVICES_AIRPLAYPASSWORD)))
   {
@@ -695,7 +695,7 @@ bool CNetworkServices::StartJSONRPCServer()
   if (IsJSONRPCServerRunning())
     return true;
 
-  if (!CTCPServer::StartServer(g_advancedSettings.m_jsonTcpPort, m_settings->GetBool(CSettings::SETTING_SERVICES_ESALLINTERFACES)))
+  if (!CTCPServer::StartServer(CServiceBroker::GetAdvancedSettings().m_jsonTcpPort, m_settings->GetBool(CSettings::SETTING_SERVICES_ESALLINTERFACES)))
     return false;
 
 #ifdef HAS_ZEROCONF
@@ -703,7 +703,7 @@ bool CNetworkServices::StartJSONRPCServer()
   txt.push_back(std::make_pair("txtvers", "1"));
   txt.push_back(std::make_pair("uuid", CServiceBroker::GetSettings()->GetString(CSettings::SETTING_SERVICES_DEVICEUUID)));
 
-  CZeroconf::GetInstance()->PublishService("servers.jsonrpc-tpc", "_xbmc-jsonrpc._tcp", CSysInfo::GetDeviceName(), g_advancedSettings.m_jsonTcpPort, txt);
+  CZeroconf::GetInstance()->PublishService("servers.jsonrpc-tpc", "_xbmc-jsonrpc._tcp", CSysInfo::GetDeviceName(), CServiceBroker::GetAdvancedSettings().m_jsonTcpPort, txt);
 #endif // HAS_ZEROCONF
 
   return true;

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -235,7 +235,7 @@ int CTCPServer::GetCapabilities()
 
 void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
 {
-  std::string str = IJSONRPCAnnouncer::AnnouncementToJSONRPC(flag, sender, message, data, g_advancedSettings.m_jsonOutputCompact);
+  std::string str = IJSONRPCAnnouncer::AnnouncementToJSONRPC(flag, sender, message, data, CServiceBroker::GetAdvancedSettings().m_jsonOutputCompact);
 
   for (unsigned int i = 0; i < m_connections.size(); i++)
   {

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -684,22 +684,23 @@ void CWakeOnAccess::QueueMACDiscoveryForAllRemotes()
   AddHostsFromVecSource(ms.GetSources("pictures"), hosts);
   AddHostsFromVecSource(ms.GetSources("programs"), hosts);
 
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+
   // add mysql servers
-  AddHostFromDatabase(g_advancedSettings.m_databaseVideo, hosts);
-  AddHostFromDatabase(g_advancedSettings.m_databaseMusic, hosts);
-  AddHostFromDatabase(g_advancedSettings.m_databaseEpg, hosts);
-  AddHostFromDatabase(g_advancedSettings.m_databaseTV, hosts);
+  AddHostFromDatabase(advancedSettings.m_databaseVideo, hosts);
+  AddHostFromDatabase(advancedSettings.m_databaseMusic, hosts);
+  AddHostFromDatabase(advancedSettings.m_databaseEpg, hosts);
+  AddHostFromDatabase(advancedSettings.m_databaseTV, hosts);
 
   // add from path substitutions ..
-  for (CAdvancedSettings::StringMapping::iterator i = g_advancedSettings.m_pathSubstitutions.begin(); i != g_advancedSettings.m_pathSubstitutions.end(); ++i)
+  for (const auto& pathPair : advancedSettings.m_pathSubstitutions)
   {
-    CURL url(i->second);
-
+    CURL url(pathPair.second);
     AddHost (url.GetHostName(), hosts);
   }
 
-  for (std::vector<std::string>::const_iterator it = hosts.begin(); it != hosts.end(); ++it)
-    QueueMACDiscoveryForHost(*it);
+  for (const std::string& host : hosts)
+    QueueMACDiscoveryForHost(host);
 }
 
 void CWakeOnAccess::SaveMACDiscoveryResult(const std::string& host, const std::string& mac)

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1253,7 +1253,7 @@ void CWebServer::UnregisterRequestHandler(IHTTPRequestHandler *handler)
 
 void CWebServer::LogRequest(const HTTPRequest& request) const
 {
-  if (!g_advancedSettings.CanLogComponent(LOGWEBSERVER))
+  if (!CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGWEBSERVER))
     return;
 
   std::multimap<std::string, std::string> headerValues;
@@ -1278,7 +1278,7 @@ void CWebServer::LogRequest(const HTTPRequest& request) const
 
 void CWebServer::LogResponse(const HTTPRequest& request, int responseStatus) const
 {
-  if (!g_advancedSettings.CanLogComponent(LOGWEBSERVER))
+  if (!CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGWEBSERVER))
     return;
 
   std::multimap<std::string, std::string> headerValues;

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -10,6 +10,7 @@
 #include "cddb.h"
 #include "CompileInfo.h"
 #include "network/DNSNameCache.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -33,7 +34,7 @@ Xcddb::Xcddb()
 #else
     : m_cddb_socket(close, -1)
 #endif
-    , m_cddb_ip_address(g_advancedSettings.m_cddbAddress)
+    , m_cddb_ip_address(CServiceBroker::GetAdvancedSettings().m_cddbAddress)
 {
   m_lastError = 0;
 }

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -264,7 +264,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     if (tag.m_iDbId != -1 ) {
         if (tag.m_type == MediaTypeMusicVideo) {
           object.m_ObjectClass.type = "object.item.videoItem.musicVideoClip";
-          object.m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator).c_str();
+          object.m_Creator = StringUtils::Join(tag.m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator).c_str();
           for (std::vector<std::string>::const_iterator itArtist = tag.m_artist.begin(); itArtist != tag.m_artist.end(); ++itArtist)
               object.m_People.artists.Add(itArtist->c_str());
           object.m_Affiliation.album = tag.m_strAlbum.c_str();
@@ -508,7 +508,7 @@ BuildObject(CFileItem&                    item,
                   break;
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_ACTOR:
                   container->m_ObjectClass.type += ".person.videoArtist";
-                  container->m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator).c_str();
+                  container->m_Creator = StringUtils::Join(tag.m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator).c_str();
                   container->m_Title   = tag.m_strTitle.c_str();
                   break;
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_SEASONS:

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -10,6 +10,7 @@
 
 #include "Picture.h"
 #include "URL.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
@@ -200,20 +201,23 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
   uint32_t &dest_width, uint32_t &dest_height, const std::string &dest,
   CPictureScalingAlgorithm::Algorithm scalingAlgorithm /* = CPictureScalingAlgorithm::NoAlgorithm */)
 {
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
+
   // if no max width or height is specified, don't resize
   if (dest_width == 0)
     dest_width = width;
   if (dest_height == 0)
     dest_height = height;
   if (scalingAlgorithm == CPictureScalingAlgorithm::NoAlgorithm)
-    scalingAlgorithm = g_advancedSettings.m_imageScalingAlgorithm;
+    scalingAlgorithm = advancedSettings.m_imageScalingAlgorithm;
 
-  uint32_t max_height = g_advancedSettings.m_imageRes;
-  if (g_advancedSettings.m_fanartRes > g_advancedSettings.m_imageRes)
+  uint32_t max_height = advancedSettings.m_imageRes;
+  if (advancedSettings.m_fanartRes > advancedSettings.m_imageRes)
   { // 16x9 images larger than the fanart res use that rather than the image res
-    if (fabsf((float)width / (float)height / (16.0f/9.0f) - 1.0f) <= 0.01f && height >= g_advancedSettings.m_fanartRes)
+    if (fabsf(static_cast<float>(width) / static_cast<float>(height) / (16.0f / 9.0f) - 1.0f) <= 0.01f &&
+        height >= advancedSettings.m_fanartRes)
     {
-      max_height = g_advancedSettings.m_fanartRes;
+      max_height = advancedSettings.m_fanartRes;
     }
   }
   uint32_t max_width = max_height * 16/9;
@@ -263,13 +267,15 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
   unsigned int num_across = (unsigned int)ceil(sqrt((float)files.size()));
   unsigned int num_down = (files.size() + num_across - 1) / num_across;
 
-  unsigned int tile_width = g_advancedSettings.m_imageRes / num_across;
-  unsigned int tile_height = g_advancedSettings.m_imageRes / num_down;
+  unsigned int imageRes = CServiceBroker::GetAdvancedSettings().m_imageRes;
+
+  unsigned int tile_width = imageRes / num_across;
+  unsigned int tile_height = imageRes / num_down;
   unsigned int tile_gap = 1;
   bool success = false;
 
   // create a buffer for the resulting thumb
-  uint32_t *buffer = (uint32_t *)calloc(g_advancedSettings.m_imageRes * g_advancedSettings.m_imageRes, 4);
+  uint32_t *buffer = static_cast<uint32_t *>(calloc(imageRes * imageRes, 4));
   if (!buffer)
     return false;
   for (unsigned int i = 0; i < files.size(); ++i)
@@ -294,12 +300,12 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
           // drop into the texture
           unsigned int posX = x*tile_width + (tile_width - width)/2;
           unsigned int posY = y*tile_height + (tile_height - height)/2;
-          uint32_t *dest = buffer + posX + posY*g_advancedSettings.m_imageRes;
+          uint32_t *dest = buffer + posX + posY * imageRes;
           uint32_t *src = scaled;
           for (unsigned int y = 0; y < height; ++y)
           {
             memcpy(dest, src, width*4);
-            dest += g_advancedSettings.m_imageRes;
+            dest += imageRes;
             src += width;
           }
         }
@@ -310,8 +316,7 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
   }
   // now save to a file
   if (success)
-    success = CreateThumbnailFromSurface((uint8_t *)buffer, g_advancedSettings.m_imageRes, g_advancedSettings.m_imageRes,
-                                      g_advancedSettings.m_imageRes * 4, thumb);
+    success = CreateThumbnailFromSurface((uint8_t *)buffer, imageRes, imageRes, imageRes * 4, thumb);
 
   free(buffer);
   return success;

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -232,8 +232,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         {
           CTextureDetails details;
           details.file = relativeCacheFile;
-          details.width = g_advancedSettings.m_imageRes;
-          details.height = g_advancedSettings.m_imageRes;
+          details.width = CServiceBroker::GetAdvancedSettings().m_imageRes;
+          details.height = CServiceBroker::GetAdvancedSettings().m_imageRes;
           CTextureCache::GetInstance().AddCachedTexture(thumb, details);
           db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
           pItem->SetArt("thumb", CTextureCache::GetCachedPath(relativeCacheFile));

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -204,15 +204,15 @@ void CSlideShowPic::SetTexture_Internal(int iSlideNumber, CBaseTexture* pTexture
       // Calculate start and end positions
       // choose a random direction
       float angle = (rand() % 1000) / 1000.0f * 2 * (float)M_PI;
-      m_fPosX = cos(angle) * g_advancedSettings.m_slideshowPanAmount * m_iTotalFrames * 0.00005f;
-      m_fPosY = sin(angle) * g_advancedSettings.m_slideshowPanAmount * m_iTotalFrames * 0.00005f;
+      m_fPosX = cos(angle) * CServiceBroker::GetAdvancedSettings().m_slideshowPanAmount * m_iTotalFrames * 0.00005f;
+      m_fPosY = sin(angle) * CServiceBroker::GetAdvancedSettings().m_slideshowPanAmount * m_iTotalFrames * 0.00005f;
       m_fVelocityX = -m_fPosX * 2.0f / m_iTotalFrames;
       m_fVelocityY = -m_fPosY * 2.0f / m_iTotalFrames;
     }
     else if (m_displayEffect == EFFECT_ZOOM)
     {
       m_fPosZ = 1.0f;
-      m_fVelocityZ = 0.0001f * g_advancedSettings.m_slideshowZoomAmount;
+      m_fVelocityZ = 0.0001f * CServiceBroker::GetAdvancedSettings().m_slideshowZoomAmount;
     }
   }
 
@@ -352,7 +352,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
     {
       m_fPosX += m_fVelocityX;
       m_fPosY += m_fVelocityY;
-      float fMoveAmount = g_advancedSettings.m_slideshowPanAmount * m_iTotalFrames * 0.0001f;
+      float fMoveAmount = CServiceBroker::GetAdvancedSettings().m_slideshowPanAmount * m_iTotalFrames * 0.0001f;
       if (m_fPosX > fMoveAmount)
       {
         m_fPosX = fMoveAmount;
@@ -462,7 +462,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
   float fScaleInv = fScreenWidth / m_fHeight;
 
   bool bFillScreen = false;
-  float fComp = 1.0f + 0.01f * g_advancedSettings.m_slideshowBlackBarCompensation;
+  float fComp = 1.0f + 0.01f * CServiceBroker::GetAdvancedSettings().m_slideshowBlackBarCompensation;
   float fScreenRatio = fScreenWidth / fScreenHeight * fPixelRatio;
   // work out if we should be compensating the zoom to minimize blackbars
   // we should compute this based on the % of black bars on screen perhaps??
@@ -487,7 +487,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
       fScale *= m_fHeight / fScreenHeight * fScreenWidth / m_fWidth;
   }
   if (m_displayEffect == EFFECT_FLOAT)
-    fScale *= (1.0f + g_advancedSettings.m_slideshowPanAmount * m_iTotalFrames * 0.0001f);
+    fScale *= (1.0f + CServiceBroker::GetAdvancedSettings().m_slideshowPanAmount * m_iTotalFrames * 0.0001f);
   if (m_displayEffect == EFFECT_ZOOM)
     fScale *= m_fPosZ;
   // zoom image

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -367,12 +367,11 @@ using namespace KODI::MESSAGING;
   NSConditionLock* myLock = arg;
   [myLock lock];
 
+  CAppParamParser appParamParser;
   #ifdef _DEBUG
-    g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
-    g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
+    appParamParser.m_logLevel = LOG_LEVEL_DEBUG;
   #else
-    g_advancedSettings.m_logLevel     = LOG_LEVEL_NORMAL;
-    g_advancedSettings.m_logLevelHint = LOG_LEVEL_NORMAL;
+    appParamParser.m_logLevel = LOG_LEVEL_NORMAL;
   #endif
 
   // Prevent child processes from becoming zombies on exit if not waited upon. See also Util::Command
@@ -385,7 +384,7 @@ using namespace KODI::MESSAGING;
   setlocale(LC_NUMERIC, "C");
 
   g_application.Preflight();
-  if (!g_application.Create(CAppParamParser()))
+  if (!g_application.Create(appParamParser))
   {
     readyToRun = false;
     ELOG(@"%sUnable to create application", __PRETTY_FUNCTION__);
@@ -407,8 +406,8 @@ using namespace KODI::MESSAGING;
 
   if (readyToRun)
   {
-    g_advancedSettings.m_startFullScreen = true;
-    g_advancedSettings.m_canWindowed = false;
+    CServiceBroker::GetAdvancedSettings().m_startFullScreen = true;
+    CServiceBroker::GetAdvancedSettings().m_canWindowed = false;
     xbmcAlive = TRUE;
     try
     {

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -138,7 +138,7 @@ void CLirc::ProcessCode(char *buf)
       appPort->OnEvent(newEvent);
     return;
   }
-  else if (repeat > g_advancedSettings.m_remoteDelay)
+  else if (repeat > CServiceBroker::GetAdvancedSettings().m_remoteDelay)
   {
     XBMC_Event newEvent;
     newEvent.type = XBMC_BUTTON;

--- a/xbmc/platform/linux/storage/UDisks2Provider.cpp
+++ b/xbmc/platform/linux/storage/UDisks2Provider.cpp
@@ -10,6 +10,7 @@
 
 #include "PosixMountProvider.h"
 #include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -398,7 +399,7 @@ void CUDisks2Provider::FilesystemAdded(Filesystem *fs, bool isNew)
     m_filesystems[fs->m_object] = fs;
   }
 
-  if (fs->IsReady() && !fs->m_isMounted && g_advancedSettings.m_handleMounting)
+  if (fs->IsReady() && !fs->m_isMounted && CServiceBroker::GetAdvancedSettings().m_handleMounting)
   {
     fs->Mount();
   }

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 #include "UDisksProvider.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
@@ -269,7 +270,7 @@ void CUDisksProvider::DeviceAdded(const char *object, IStorageEventsCallback *ca
     device = new CUDiskDevice(object);
   m_AvailableDevices[object] = device;
 
-  if (g_advancedSettings.m_handleMounting)
+  if (CServiceBroker::GetAdvancedSettings().m_handleMounting)
     device->Mount();
 
   CLog::Log(LOGDEBUG, LOGDBUS, "UDisks: DeviceAdded - %s", device->toString().c_str());
@@ -312,7 +313,7 @@ void CUDisksProvider::DeviceChanged(const char *object, IStorageEventsCallback *
     bool mounted = device->m_isMounted;
     /* make sure to not silently remount ejected usb thumb drives
        that user wants to eject, but make sure to mount blurays */
-    if (!mounted && g_advancedSettings.m_handleMounting && device->m_isOptical)
+    if (!mounted && CServiceBroker::GetAdvancedSettings().m_handleMounting && device->m_isOptical)
       device->Mount();
 
     device->Update();

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -21,6 +21,7 @@
 #include "Util.h"
 #include "guilib/LocalizeStrings.h"
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -121,7 +122,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         bIsDir = (aDir.type == SMBC_DIR);
 
         struct stat info = {0};
-        if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && g_advancedSettings.m_sambastatfiles)
+        if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && CServiceBroker::GetAdvancedSettings().m_sambastatfiles)
         {
           // make sure we use the authenticated path wich contains any default username
           const std::string strFullName = strAuth + smb.URLEncode(strFile);

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -142,8 +142,8 @@ void CSMB::Init()
 
         // use user-configured charset. if no charset is specified,
         // samba tries to use charset 850 but falls back to ASCII in case it is not available
-        if (g_advancedSettings.m_sambadoscodepage.length() > 0)
-          fprintf(f, "\tdos charset = %s\n", g_advancedSettings.m_sambadoscodepage.c_str());
+        if (CServiceBroker::GetAdvancedSettings().m_sambadoscodepage.length() > 0)
+          fprintf(f, "\tdos charset = %s\n", CServiceBroker::GetAdvancedSettings().m_sambadoscodepage.c_str());
 
         // include users configuration if available
         fprintf(f, "\tinclude = %s/.smb/user.conf\n", home.c_str());
@@ -169,13 +169,13 @@ void CSMB::Init()
     setenv("HOME", truehome.c_str(), 1);
 
 #ifdef DEPRECATED_SMBC_INTERFACE
-    smbc_setDebug(m_context, g_advancedSettings.CanLogComponent(LOGSAMBA) ? 10 : 0);
+    smbc_setDebug(m_context, CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGSAMBA) ? 10 : 0);
     smbc_setFunctionAuthData(m_context, xb_smbc_auth);
     orig_cache = smbc_getFunctionGetCachedServer(m_context);
     smbc_setFunctionGetCachedServer(m_context, xb_smbc_cache);
     smbc_setOptionOneSharePerServer(m_context, false);
     smbc_setOptionBrowseMaxLmbCount(m_context, 0);
-    smbc_setTimeout(m_context, g_advancedSettings.m_sambaclienttimeout * 1000);
+    smbc_setTimeout(m_context, CServiceBroker::GetAdvancedSettings().m_sambaclienttimeout * 1000);
     // we do not need to strdup these, smbc_setXXX below will make their own copies
     if (CServiceBroker::GetSettings()->GetString(CSettings::SETTING_SMB_WORKGROUP).length() > 0)
       //! @bug libsmbclient < 4.9 isn't const correct
@@ -184,13 +184,13 @@ void CSMB::Init()
     //! @bug libsmbclient < 4.8 isn't const correct
     smbc_setUser(m_context, const_cast<char*>(guest.c_str()));
 #else
-    m_context->debug = (g_advancedSettings.CanLogComponent(LOGSAMBA) ? 10 : 0);
+    m_context->debug = (CServiceBroker::GetAdvancedSettings().CanLogComponent(LOGSAMBA) ? 10 : 0);
     m_context->callbacks.auth_fn = xb_smbc_auth;
     orig_cache = m_context->callbacks.get_cached_srv_fn;
     m_context->callbacks.get_cached_srv_fn = xb_smbc_cache;
     m_context->options.one_share_per_server = false;
     m_context->options.browse_max_lmb_count = 0;
-    m_context->timeout = g_advancedSettings.m_sambaclienttimeout * 1000;
+    m_context->timeout = CServiceBroker::GetAdvancedSettings().m_sambaclienttimeout * 1000;
     // we need to strdup these, they will get free'd on smbc_free_context
     if (CServiceBroker::GetSettings()->GetString(CSettings::SETTING_SMB_WORKGROUP).length() > 0)
       m_context->workgroup = strdup(CServiceBroker::GetSettings()->GetString(CSettings::SETTING_SMB_WORKGROUP).c_str());

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -25,7 +25,6 @@
 #include "PlayListPlayer.h"
 #include "platform/MessagePrinter.h"
 #include "platform/xbmc.h"
-#include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 
 #ifdef HAS_LIRC
@@ -88,8 +87,6 @@ int main(int argc, char* argv[])
 
   setlocale(LC_NUMERIC, "C");
 
-  // Initialize before CAppParamParser so it can set the log level
-  g_advancedSettings.Initialize();
   CAppParamParser appParamParser;
   appParamParser.Parse(argv, argc);
 

--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -15,7 +15,6 @@
 #include "platform/xbmc.h"
 #include "platform/win32/CharsetConverter.h"
 #include "rendering/dx/RenderContext.h"
-#include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/SystemInfo.h"
 #include "windowing/win10/WinEventsWin10.h"
@@ -78,16 +77,14 @@ void App::Load(const winrt::hstring&)
 void App::Run()
 {
   {
-    // Initialize before CAppParamParser so it can set the log level
-    g_advancedSettings.Initialize();
     // fix the case then window opened in FS, but current setting is RES_WINDOW
     // the proper way is make window params related to setting, but in this setting isn't loaded yet
     // perhaps we should observe setting changes and change window's Preffered props
     bool fullscreen = ApplicationView::GetForCurrentView().IsFullScreenMode();
-    g_advancedSettings.m_startFullScreen = fullscreen;
 
     CAppParamParser appParamParser;
     appParamParser.Parse(m_argv.data(), m_argv.size());
+    appParamParser.m_startFullScreen = fullscreen;
 
     if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Xbox)
       g_application.SetStandAlone(true);

--- a/xbmc/platform/win10/input/RemoteControlXbox.cpp
+++ b/xbmc/platform/win10/input/RemoteControlXbox.cpp
@@ -108,7 +108,7 @@ void CRemoteControlXbox::HandleAcceleratorKey(const CoreDispatcher& sender, cons
     else
     {
       m_repeatCount++;
-      if (m_repeatCount > g_advancedSettings.m_remoteDelay)
+      if (m_repeatCount > CServiceBroker::GetAdvancedSettings().m_remoteDelay)
       {
         newEvent.keybutton.holdtime = XbmcThreads::SystemClockMillis() - m_firstClickTime;
         if (appPort)

--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -12,7 +12,6 @@
 #include "threads/platform/win/Win32Exception.h"
 #include "platform/win32/CharsetConverter.h"
 #include "platform/xbmc.h"
-#include "settings/AdvancedSettings.h"
 #include "utils/CPUInfo.h"
 #include "platform/Environment.h"
 #include "utils/CharsetConverter.h" // Required to initialize converters before usage
@@ -116,9 +115,6 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
 
   int status;
   {
-    // Initialize before CAppParamParser so it can set the log level
-    g_advancedSettings.Initialize();
-
     CAppParamParser appParamParser;
     appParamParser.Parse(argv, argc);
     // Create and run the app

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "Application.h"
-#include "settings/AdvancedSettings.h"
 
 #ifdef TARGET_RASPBERRY_PI
 #include "platform/linux/RBP.h"
@@ -30,11 +29,6 @@
 extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
 {
   int status = -1;
-
-  if (!g_advancedSettings.Initialized())
-  {
-    g_advancedSettings.Initialize();
-  }
 
   if (!g_application.Create(params))
   {

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstdlib>
 
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
 
@@ -18,7 +19,7 @@ namespace PVR
 {
 
 CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler()
-: CPVRChannelNumberInputHandler(g_advancedSettings.m_iPVRNumericChannelSwitchTimeout, CHANNEL_NUMBER_INPUT_MAX_DIGITS)
+: CPVRChannelNumberInputHandler(CServiceBroker::GetAdvancedSettings().m_iPVRNumericChannelSwitchTimeout, CHANNEL_NUMBER_INPUT_MAX_DIGITS)
 {
 }
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -26,7 +26,7 @@ using namespace PVR;
 bool CPVRDatabase::Open()
 {
   CSingleLock lock(m_critSection);
-  return CDatabase::Open(g_advancedSettings.m_databaseTV);
+  return CDatabase::Open(CServiceBroker::GetAdvancedSettings().m_databaseTV);
 }
 
 void CPVRDatabase::Close()
@@ -415,7 +415,7 @@ bool CPVRDatabase::RemoveStaleChannelsFromGroup(const CPVRChannelGroup &group)
 
     // XXX work around for frodo: fix this up so it uses one query for all db types
     // mysql doesn't support subqueries when deleting and sqlite doesn't support joins when deleting
-    if (StringUtils::EqualsNoCase(g_advancedSettings.m_databaseTV.type, "mysql"))
+    if (StringUtils::EqualsNoCase(CServiceBroker::GetAdvancedSettings().m_databaseTV.type, "mysql"))
     {
       const  std::string strQuery = PrepareSQL("DELETE m FROM map_channelgroups_channels m LEFT JOIN channels c ON (c.idChannel = m.idChannel) WHERE c.idChannel IS NULL");
       bDelete = ExecuteQuery(strQuery);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -127,7 +127,7 @@ void CPVRGUIInfo::Notify(const Observable &obs, const ObservableMessage msg)
 void CPVRGUIInfo::Process(void)
 {
   unsigned int iLoop = 0;
-  int toggleInterval = g_advancedSettings.m_iPVRInfoToggleInterval / 1000;
+  int toggleInterval = CServiceBroker::GetAdvancedSettings().m_iPVRInfoToggleInterval / 1000;
 
   /* updated on request */
   CServiceBroker::GetPVRManager().RegisterObserver(this);

--- a/xbmc/pvr/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/PVRGUITimerInfo.cpp
@@ -55,7 +55,7 @@ bool CPVRGUITimerInfo::TimerInfoToggle()
     return true;
   }
 
-  if ((int) (XbmcThreads::SystemClockMillis() - m_iTimerInfoToggleStart) > g_advancedSettings.m_iPVRInfoToggleInterval)
+  if ((int) (XbmcThreads::SystemClockMillis() - m_iTimerInfoToggleStart) > CServiceBroker::GetAdvancedSettings().m_iPVRInfoToggleInterval)
   {
     unsigned int iPrevious = m_iTimerInfoToggleCurrent;
     unsigned int iBoundary = m_iRecordingTimerAmount > 0 ? m_iRecordingTimerAmount : m_iTimerAmount;

--- a/xbmc/pvr/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/PVRGUITimesInfo.cpp
@@ -399,5 +399,5 @@ int CPVRGUITimesInfo::GetEpgEventProgress(const CPVREpgInfoTagPtr& epgTag) const
 bool CPVRGUITimesInfo::IsTimeshifting() const
 {
   CSingleLock lock(m_critSection);
-  return (m_iTimeshiftOffset > static_cast<unsigned int>(g_advancedSettings.m_iPVRTimeshiftThreshold));
+  return (m_iTimeshiftOffset > static_cast<unsigned int>(CServiceBroker::GetAdvancedSettings().m_iPVRTimeshiftThreshold));
 }

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -239,7 +239,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
         (itItem = fileItemMap.find(strLegalChannelName)) != fileItemMap.end() ||
         (itItem = fileItemMap.find(strChannelUid)) != fileItemMap.end())
     {
-      channel->SetIconPath(itItem->second, g_advancedSettings.m_bPVRAutoScanIconsUserSet);
+      channel->SetIconPath(itItem->second, CServiceBroker::GetAdvancedSettings().m_bPVRAutoScanIconsUserSet);
     }
 
     if (bUpdateDb)

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -294,7 +294,7 @@ bool CPVRChannelGroupInternal::UpdateGroupEntries(const CPVRChannelGroup &channe
   if (CPVRChannelGroup::UpdateGroupEntries(channels))
   {
     /* try to find channel icons */
-    if (g_advancedSettings.m_bPVRChannelIconsAutoScan)
+    if (CServiceBroker::GetAdvancedSettings().m_bPVRChannelIconsAutoScan)
       SearchAndSetChannelIcons();
 
     CServiceBroker::GetPVRManager().Timers()->UpdateChannels();

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -495,7 +495,7 @@ bool CPVREpg::Update(const time_t start, const time_t end, int iUpdateTime, bool
 
   /* enforce advanced settings update interval override for TV Channels with no EPG data */
   if (m_tags.empty() && !bUpdate && ChannelID() > 0 && !Channel()->IsRadio())
-    iUpdateTime = g_advancedSettings.m_iEpgUpdateEmptyTagsInterval;
+    iUpdateTime = CServiceBroker::GetAdvancedSettings().m_iEpgUpdateEmptyTagsInterval;
 
   if (!bForceUpdate)
   {

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -335,7 +335,7 @@ void CPVREpgContainer::Process(void)
       m_bIsInitialising = false;
 
     /* clean up old entries */
-    if (!m_bStop && iNow >= m_iLastEpgCleanup + g_advancedSettings.m_iEpgCleanupInterval)
+    if (!m_bStop && iNow >= m_iLastEpgCleanup + CServiceBroker::GetAdvancedSettings().m_iEpgCleanupInterval)
       RemoveOldEntries();
 
     /* check for pending manual EPG updates */
@@ -621,8 +621,7 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
 {
   bool bInterrupted = false;
   unsigned int iUpdatedTables = 0;
-  bool bShowProgress = false;
-  int pendingUpdates = 0;
+  const CAdvancedSettings& advancedSettings = CServiceBroker::GetAdvancedSettings();
 
   /* set start and end time */
   time_t start;
@@ -630,7 +629,10 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   CDateTime::GetUTCDateTime().GetAsTime(start);
   end = start + GetFutureDaysToDisplay() * 24 * 60 * 60;
   start -= GetPastDaysToDisplay() * 24 * 60 * 60;
-  bShowProgress = g_advancedSettings.m_bEpgDisplayUpdatePopup && (m_bIsInitialising || g_advancedSettings.m_bEpgDisplayIncrementalUpdatePopup);
+
+  bool bShowProgress = (m_bIsInitialising || advancedSettings.m_bEpgDisplayIncrementalUpdatePopup) &&
+                       advancedSettings.m_bEpgDisplayUpdatePopup;
+  int pendingUpdates = 0;
 
   {
     CSingleLock lock(m_critSection);
@@ -698,13 +700,13 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
     /* the update has been interrupted. try again later */
     time_t iNow;
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
-    m_iNextEpgUpdate = iNow + g_advancedSettings.m_iEpgRetryInterruptedUpdateInterval;
+    m_iNextEpgUpdate = iNow + advancedSettings.m_iEpgRetryInterruptedUpdateInterval;
   }
   else
   {
     CSingleLock lock(m_critSection);
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgUpdate);
-    m_iNextEpgUpdate += g_advancedSettings.m_iEpgUpdateCheckInterval;
+    m_iNextEpgUpdate += advancedSettings.m_iEpgUpdateCheckInterval;
     if (m_pendingUpdates == pendingUpdates)
       m_pendingUpdates = 0;
   }
@@ -797,7 +799,7 @@ bool CPVREpgContainer::CheckPlayingEvents(void)
       bFoundChanges = epgEntry.second->CheckPlayingEvent() || bFoundChanges;
 
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNextEpgActiveTagCheck);
-    iNextEpgActiveTagCheck += g_advancedSettings.m_iEpgActiveTagCheckInterval;
+    iNextEpgActiveTagCheck += CServiceBroker::GetAdvancedSettings().m_iEpgActiveTagCheckInterval;
 
     /* pvr tags always start on the full minute */
     if (CServiceBroker::GetPVRManager().IsStarted())

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 
+#include "ServiceBroker.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "dbwrappers/dataset.h"
 #include "settings/AdvancedSettings.h"
@@ -24,7 +25,7 @@ using namespace PVR;
 bool CPVREpgDatabase::Open()
 {
   CSingleLock lock(m_critSection);
-  return CDatabase::Open(g_advancedSettings.m_databaseEpg);
+  return CDatabase::Open(CServiceBroker::GetAdvancedSettings().m_databaseEpg);
 }
 
 void CPVREpgDatabase::Close()

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -48,9 +48,9 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG &data, int iClientId)
   m_iUniqueBroadcastID(data.iUniqueBroadcastId),
   m_iUniqueChannelID(data.iUniqueChannelId),
   m_iYear(data.iYear),
-  m_startTime(data.startTime + g_advancedSettings.m_iPVRTimeCorrection),
-  m_endTime(data.endTime + g_advancedSettings.m_iPVRTimeCorrection),
-  m_firstAired(data.firstAired + g_advancedSettings.m_iPVRTimeCorrection),
+  m_startTime(data.startTime + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection),
+  m_endTime(data.endTime + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection),
+  m_firstAired(data.firstAired + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection),
   m_iFlags(data.iFlags)
 {
   SetGenre(data.iGenreType, data.iGenreSubType, data.strGenreDescription);
@@ -400,17 +400,17 @@ const std::string CPVREpgInfoTag::GetCastLabel() const
 
 const std::string CPVREpgInfoTag::GetDirectorsLabel() const
 {
-  return StringUtils::Join(m_directors, g_advancedSettings.m_videoItemSeparator);
+  return StringUtils::Join(m_directors, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
 }
 
 const std::string CPVREpgInfoTag::GetWritersLabel() const
 {
-  return StringUtils::Join(m_writers, g_advancedSettings.m_videoItemSeparator);
+  return StringUtils::Join(m_writers, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
 }
 
 const std::string CPVREpgInfoTag::GetGenresLabel() const
 {
-  return StringUtils::Join(m_genre, g_advancedSettings.m_videoItemSeparator);
+  return StringUtils::Join(m_genre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
 }
 
 int CPVREpgInfoTag::Year(void) const
@@ -438,7 +438,7 @@ void CPVREpgInfoTag::SetGenre(int iGenreType, int iGenreSubType, const char* str
     else
     {
       /* Determine the genre description from the type and subtype IDs */
-      m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType), g_advancedSettings.m_videoItemSeparator);
+      m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     }
   }
 }
@@ -642,7 +642,7 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /
       else
       {
         /* Determine genre description by type/subtype */
-        m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType), g_advancedSettings.m_videoItemSeparator);
+        m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
       }
       m_firstAired         = tag.m_firstAired;
       m_iParentalRating    = tag.m_iParentalRating;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -76,7 +76,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   if (recording.iYear > 0)
     SetYear(recording.iYear);
   m_iClientId                      = iClientId;
-  m_recordingTime                  = recording.recordingTime + g_advancedSettings.m_iPVRTimeCorrection;
+  m_recordingTime                  = recording.recordingTime + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection;
   m_iPriority                      = recording.iPriority;
   m_iLifetime                      = recording.iLifetime;
   // Deleted recording is placed at the root of the deleted view
@@ -477,11 +477,11 @@ void CPVRRecording::SetGenre(int iGenreType, int iGenreSubType, const std::strin
   if ((iGenreType == EPG_GENRE_USE_STRING) && !strGenre.empty())
   {
     /* Type and sub type are not given. Use the provided genre description if available. */
-    m_genre = StringUtils::Split(strGenre, g_advancedSettings.m_videoItemSeparator);
+    m_genre = StringUtils::Split(strGenre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
   }
   else
   {
     /* Determine the genre description from the type and subtype IDs */
-    m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType), g_advancedSettings.m_videoItemSeparator);
+    m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
   }
 }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -92,9 +92,9 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr 
   m_bIsRadio(channel && channel->IsRadio()),
   m_iMarginStart(timer.iMarginStart),
   m_iMarginEnd(timer.iMarginEnd),
-  m_StartTime(timer.startTime + g_advancedSettings.m_iPVRTimeCorrection),
-  m_StopTime(timer.endTime + g_advancedSettings.m_iPVRTimeCorrection),
-  m_FirstDay(timer.firstDay + g_advancedSettings.m_iPVRTimeCorrection),
+  m_StartTime(timer.startTime + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection),
+  m_StopTime(timer.endTime + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection),
+  m_FirstDay(timer.firstDay + CServiceBroker::GetAdvancedSettings().m_iPVRTimeCorrection),
   m_strSeriesLink(timer.strSeriesLink),
   m_iEpgUid(timer.iEpgUid),
   m_channel(channel)

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -55,7 +55,7 @@ bool CRenderSystemBase::SupportsStereo(RENDER_STEREO_MODE mode) const
 
 void CRenderSystemBase::ShowSplash(const std::string& message)
 {
-  if (!g_advancedSettings.m_splashImage && !(m_splashImage || !message.empty()))
+  if (!CServiceBroker::GetAdvancedSettings().m_splashImage && !(m_splashImage || !message.empty()))
     return;
 
   if (!m_splashImage)

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -580,7 +580,7 @@ void DX::DeviceResources::ResizeBuffers()
     ComPtr<IDXGISwapChain1> swapChain;
     if ( m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_11_0
       && !bHWStereoEnabled
-      && g_advancedSettings.m_bTry10bitOutput)
+      && CServiceBroker::GetAdvancedSettings().m_bTry10bitOutput)
     {
       swapChainDesc.Format = DXGI_FORMAT_R10G10B10A2_UNORM;
       hr = CreateSwapChain(swapChainDesc, scFSDesc, &swapChain);
@@ -1018,7 +1018,7 @@ bool DX::DeviceResources::DoesTextureSharingWork()
     return false;
 
   // @todo proper check in run-time
-  return g_advancedSettings.m_allowUseSeparateDeviceForDecoding;
+  return CServiceBroker::GetAdvancedSettings().m_allowUseSeparateDeviceForDecoding;
 }
 
 #if defined(TARGET_WINDOWS_DESKTOP)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "AppParamParser.h"
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
@@ -90,6 +91,12 @@ void CAdvancedSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting
     m_extraLogEnabled = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
   else if (settingId == CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL)
     setExtraLogLevel(CSettingUtils::GetList(std::static_pointer_cast<const CSettingList>(setting)));
+}
+
+void CAdvancedSettings::Initialize(const CAppParamParser &params)
+{
+  Initialize();
+  params.SetAdvancedSettings(*this);
 }
 
 void CAdvancedSettings::Initialize()
@@ -858,8 +865,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       if (setting != NULL)
         setting->SetVisible(false);
     }
-    g_advancedSettings.m_logLevel = std::max(g_advancedSettings.m_logLevel, g_advancedSettings.m_logLevelHint);
-    CLog::SetLogLevel(g_advancedSettings.m_logLevel);
+    m_logLevel = std::max(m_logLevel, m_logLevelHint);
+    CLog::SetLogLevel(m_logLevel);
   }
 
   XMLUtils::GetString(pRootElement, "cddbaddress", m_cddbAddress);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -381,7 +381,3 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
   private:
     void setExtraLogLevel(const std::vector<CVariant> &components);
 };
-
-// TODO: Remove this; change code to use CServiceBroker::GetAdvancedSettings() directly
-#include "ServiceBroker.h"
-#define g_advancedSettings CServiceBroker::GetAdvancedSettings()

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -24,6 +24,7 @@
 #define CACHE_BUFFER_MODE_NONE          3
 #define CACHE_BUFFER_MODE_REMOTE        4
 
+class CAppParamParser;
 class CProfilesManager;
 class CVariant;
 
@@ -112,6 +113,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
 
     void Initialize();
+    void Initialize(const CAppParamParser &params);
     bool Initialized() { return m_initialized; };
     void AddSettingsFile(const std::string &filename);
     bool Load(const CProfilesManager &profileManager);
@@ -380,5 +382,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void setExtraLogLevel(const std::vector<CVariant> &components);
 };
 
-XBMC_GLOBAL_REF(CAdvancedSettings,g_advancedSettings);
-#define g_advancedSettings XBMC_GLOBAL_USE(CAdvancedSettings)
+// TODO: Remove this; change code to use CServiceBroker::GetAdvancedSettings() directly
+#include "ServiceBroker.h"
+#define g_advancedSettings CServiceBroker::GetAdvancedSettings()

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -757,7 +757,7 @@ void CDisplaySettings::SettingOptionsDispModeFiller(SettingConstPtr setting, std
   // setting. When the user sets canwindowed to true but the windowing system
   // does not support windowed modes, we would just shoot ourselves in the foot
   // by offering the option.
-  if (g_advancedSettings.m_canWindowed && CServiceBroker::GetWinSystem()->CanDoWindowed())
+  if (CServiceBroker::GetAdvancedSettings().m_canWindowed && CServiceBroker::GetWinSystem()->CanDoWindowed())
     list.push_back(std::make_pair(g_localizeStrings.Get(242), DM_WINDOWED));
 
   list.push_back(std::make_pair(g_localizeStrings.Get(244), DM_FULLSCREEN));

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -45,6 +45,7 @@
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRSettings.h"
 #include "pvr/windows/GUIWindowPVRGuide.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -777,7 +778,7 @@ void CSettings::InitializeISettingsHandlers()
 {
   // register ISettingsHandler implementations
   // The order of these matters! Handlers are processed in the order they were registered.
-  GetSettingsManager()->RegisterSettingsHandler(&g_advancedSettings);
+  GetSettingsManager()->RegisterSettingsHandler(&CServiceBroker::GetAdvancedSettings());
   GetSettingsManager()->RegisterSettingsHandler(&CMediaSourceSettings::GetInstance());
 #ifdef HAS_UPNP
   GetSettingsManager()->RegisterSettingsHandler(&CUPnPSettings::GetInstance());
@@ -795,7 +796,7 @@ void CSettings::InitializeISettingsHandlers()
 void CSettings::UninitializeISettingsHandlers()
 {
   // unregister ISettingCallback implementations
-  GetSettingsManager()->UnregisterCallback(&g_advancedSettings);
+  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetAdvancedSettings());
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application.GetAppPlayer().GetSeekHandler());
@@ -842,7 +843,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_DEBUG_SHOWLOGINFO);
   settingSet.insert(CSettings::SETTING_DEBUG_EXTRALOGGING);
   settingSet.insert(CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL);
-  GetSettingsManager()->RegisterCallback(&g_advancedSettings, settingSet);
+  GetSettingsManager()->RegisterCallback(&CServiceBroker::GetAdvancedSettings(), settingSet);
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_MUSICLIBRARY_CLEANUP);
@@ -961,7 +962,7 @@ void CSettings::InitializeISettingCallbacks()
 
 void CSettings::UninitializeISettingCallbacks()
 {
-  GetSettingsManager()->UnregisterCallback(&g_advancedSettings);
+  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetAdvancedSettings());
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application.GetAppPlayer().GetSeekHandler());

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -241,7 +241,7 @@ void CDetectDVDMedia::DetectMediaType()
 
   if (m_pCdInfo->IsISOUDF(1))
   {
-    if (!g_advancedSettings.m_detectAsUdf)
+    if (!CServiceBroker::GetAdvancedSettings().m_detectAsUdf)
     {
       strNewUrl = "iso9660://";
       m_isoReader.Scan();

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -30,6 +30,19 @@
 
 namespace fs = KODI::PLATFORM::FILESYSTEM;
 
+namespace
+{
+  class TestServiceManager : public CServiceManager
+  {
+  public:
+    TestServiceManager()
+    {
+      m_advancedSettings.reset(new CAdvancedSettings());
+      m_advancedSettings->Initialize();
+    }
+  };
+} // unnamed namespace
+
 void TestBasicEnvironment::SetUp()
 {
   m_pSettings.reset(new CSettings());
@@ -37,12 +50,7 @@ void TestBasicEnvironment::SetUp()
 
   XFILE::CFile *f;
 
-  /* NOTE: The below is done to fix memleak warning about uninitialized variable
-   * in xbmcutil::GlobalsSingleton<CAdvancedSettings>::getInstance().
-   */
-  g_advancedSettings.Initialize();
-
-  g_application.m_ServiceManager.reset(new CServiceManager());
+  g_application.m_ServiceManager.reset(new TestServiceManager());
 
   if (!CXBMCTestUtils::Instance().SetReferenceFileBasePath())
     SetUpError();

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -8,6 +8,7 @@
 
 #include "FileItem.h"
 #include "URL.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 
 #include "gtest/gtest.h"
@@ -32,8 +33,8 @@ public:
 AdvancedSettingsResetBase::AdvancedSettingsResetBase()
 {
   // Force all settings to be reset to defaults
-  g_advancedSettings.OnSettingsUnloaded();
-  g_advancedSettings.Initialize();
+  CServiceBroker::GetAdvancedSettings().OnSettingsUnloaded();
+  CServiceBroker::GetAdvancedSettings().Initialize();
 }
 
 class TestFileItemSpecifiedArtJpg : public AdvancedSettingsResetBase,

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -93,6 +93,7 @@
 #endif
 
 #ifdef TARGET_POSIX
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #endif
 
@@ -629,7 +630,7 @@ bool CCPUInfo::getTemperature(CTemperature& temperature)
 #else
   int         ret   = 0;
   FILE        *p    = NULL;
-  std::string  cmd   = g_advancedSettings.m_cpuTempCmd;
+  std::string  cmd   = CServiceBroker::GetAdvancedSettings().m_cpuTempCmd;
 
   temperature.SetValid(false);
 

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -11,6 +11,7 @@
 
 #include "StringUtils.h"
 #include "guilib/IDirtyRegionSolver.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 
 #include <EGL/eglext.h>
@@ -146,8 +147,9 @@ bool CEGLContextUtils::InitializeDisplay(EGLint renderableType, EGLint rendering
 
   EGLint surfaceType = EGL_WINDOW_BIT;
   // for the non-trivial dirty region modes, we need the EGL buffer to be preserved across updates
-  if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
-      g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
+  int guiAlgorithmDirtyRegions = CServiceBroker::GetAdvancedSettings().m_guiAlgorithmDirtyRegions;
+  if (guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
+      guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
     surfaceType |= EGL_SWAP_BEHAVIOR_PRESERVED_BIT;
 
   EGLint attribs[] =
@@ -228,8 +230,9 @@ void CEGLContextUtils::SurfaceAttrib()
   }
 
   // for the non-trivial dirty region modes, we need the EGL buffer to be preserved across updates
-  if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
-      g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
+  int guiAlgorithmDirtyRegions = CServiceBroker::GetAdvancedSettings().m_guiAlgorithmDirtyRegions;
+  if (guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
+      guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
   {
     if (eglSurfaceAttrib(m_eglDisplay, m_eglSurface, EGL_SWAP_BEHAVIOR, EGL_BUFFER_PRESERVED) != EGL_TRUE)
     {

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -22,13 +22,13 @@ const std::vector<TYPE> ADDON_TYPES = {
   ADDON_AUDIODECODER
 };
 
-CFileExtensionProvider::CFileExtensionProvider(ADDON::CAddonMgr &addonManager,
+CFileExtensionProvider::CFileExtensionProvider(CAdvancedSettings &advancedSettings,
+                                               ADDON::CAddonMgr &addonManager,
                                                ADDON::CBinaryAddonManager &binaryAddonManager) :
+  m_advancedSettings(advancedSettings),
   m_addonManager(addonManager),
   m_binaryAddonManager(binaryAddonManager)
 {
-  m_advancedSettings = g_advancedSettingsRef;
-
   SetAddonExtensions();
 
   m_addonManager.Events().Subscribe(this, &CFileExtensionProvider::OnAddonEvent);
@@ -38,18 +38,17 @@ CFileExtensionProvider::~CFileExtensionProvider()
 {
   m_addonManager.Events().Unsubscribe(this);
 
-  m_advancedSettings.reset();
   m_addonExtensions.clear();
 }
 
 std::string CFileExtensionProvider::GetDiscStubExtensions() const
 {
-  return m_advancedSettings->m_discStubExtensions;
+  return m_advancedSettings.m_discStubExtensions;
 }
 
 std::string CFileExtensionProvider::GetMusicExtensions() const
 {
-  std::string extensions(m_advancedSettings->m_musicExtensions);
+  std::string extensions(m_advancedSettings.m_musicExtensions);
   extensions += '|' + GetAddonExtensions(ADDON_VFS);
   extensions += '|' + GetAddonExtensions(ADDON_AUDIODECODER);
 
@@ -58,7 +57,7 @@ std::string CFileExtensionProvider::GetMusicExtensions() const
 
 std::string CFileExtensionProvider::GetPictureExtensions() const
 {
-  std::string extensions(m_advancedSettings->m_pictureExtensions);
+  std::string extensions(m_advancedSettings.m_pictureExtensions);
   extensions += '|' + GetAddonExtensions(ADDON_VFS);
   extensions += '|' + GetAddonExtensions(ADDON_IMAGEDECODER);
 
@@ -67,7 +66,7 @@ std::string CFileExtensionProvider::GetPictureExtensions() const
 
 std::string CFileExtensionProvider::GetSubtitleExtensions() const
 {
-  std::string extensions(m_advancedSettings->m_subtitlesExtensions);
+  std::string extensions(m_advancedSettings.m_subtitlesExtensions);
   extensions += '|' + GetAddonExtensions(ADDON_VFS);
 
   return extensions;
@@ -75,7 +74,7 @@ std::string CFileExtensionProvider::GetSubtitleExtensions() const
 
 std::string CFileExtensionProvider::GetVideoExtensions() const
 {
-  std::string extensions(m_advancedSettings->m_videoExtensions);
+  std::string extensions(m_advancedSettings.m_videoExtensions);
   if (!extensions.empty())
     extensions += '|';
   extensions += GetAddonExtensions(ADDON_VFS);

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -12,6 +12,8 @@
 #include "addons/AddonEvents.h"
 #include "settings/AdvancedSettings.h"
 
+class CAdvancedSettings;
+
 namespace ADDON
 {
   class CAddonMgr;
@@ -21,7 +23,8 @@ namespace ADDON
 class CFileExtensionProvider
 {
 public:
-  CFileExtensionProvider(ADDON::CAddonMgr &addonManager,
+  CFileExtensionProvider(CAdvancedSettings &advancedSettings,
+                         ADDON::CAddonMgr &addonManager,
                          ADDON::CBinaryAddonManager &binaryAddonManager);
   ~CFileExtensionProvider();
 
@@ -64,11 +67,11 @@ private:
   void OnAddonEvent(const ADDON::AddonEvent& event);
 
   // Construction properties
+  CAdvancedSettings &m_advancedSettings;
   ADDON::CAddonMgr &m_addonManager;
   ADDON::CBinaryAddonManager &m_binaryAddonManager;
 
   // File extension properties
   std::map<ADDON::TYPE, std::string> m_addonExtensions;
-  std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   std::map<ADDON::TYPE, std::string> m_addonFileFolderExtensions;
 };

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -23,7 +23,7 @@ void _VerifyGLState(const char* szfile, const char* szfunction, int lineno){
                   matrix[ixx*4+3]);                                     \
       }                                                                 \
   }
-  if (g_advancedSettings.m_logLevel < LOG_LEVEL_DEBUG_FREEMEM)
+  if (CServiceBroker::GetAdvancedSettings().m_logLevel < LOG_LEVEL_DEBUG_FREEMEM)
     return;
   GLenum err = glGetError();
   if (err==GL_NO_ERROR)

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -167,7 +167,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     if (music && music->GetArtistString().size())
       value = music->GetArtistString();
     if (movie && movie->m_artist.size())
-      value = StringUtils::Join(movie->m_artist, g_advancedSettings.m_videoItemSeparator);
+      value = StringUtils::Join(movie->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     break;
   case 'T':
     if (music && music->GetTitle().size())
@@ -187,9 +187,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
   case 'G':
     if (music && music->GetGenre().size())
-      value = StringUtils::Join(music->GetGenre(), g_advancedSettings.m_musicItemSeparator);
+      value = StringUtils::Join(music->GetGenre(), CServiceBroker::GetAdvancedSettings().m_musicItemSeparator);
     if (movie && movie->m_genre.size())
-      value = StringUtils::Join(movie->m_genre, g_advancedSettings.m_videoItemSeparator);
+      value = StringUtils::Join(movie->m_genre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     break;
   case 'Y':
     if (music)
@@ -290,7 +290,7 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 'U':
     if (movie && !movie->m_studio.empty())
     {// Studios
-      value = StringUtils::Join(movie ->m_studio, g_advancedSettings.m_videoItemSeparator);
+      value = StringUtils::Join(movie ->m_studio, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
     }
     break;
   case 'V': // Playcount

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -153,7 +153,7 @@ bool CRecentlyAddedJob::UpdateVideo()
       home->SetProperty("LatestMusicVideo." + value + ".Plot"        , item->GetVideoInfoTag()->m_strPlot);
       home->SetProperty("LatestMusicVideo." + value + ".RunningTime" , item->GetVideoInfoTag()->GetDuration() / 60);
       home->SetProperty("LatestMusicVideo." + value + ".Path"        , item->GetVideoInfoTag()->m_strFileNameAndPath);
-      home->SetProperty("LatestMusicVideo." + value + ".Artist"      , StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator));
+      home->SetProperty("LatestMusicVideo." + value + ".Artist"      , StringUtils::Join(item->GetVideoInfoTag()->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator));
 
       if (!item->HasArt("thumb"))
         loader.LoadItem(item.get());

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -122,7 +122,7 @@ void CRssReader::Process()
     m_strColors[iFeed].clear();
 
     CCurlFile http;
-    http.SetUserAgent(g_advancedSettings.m_userAgent);
+    http.SetUserAgent(CServiceBroker::GetAdvancedSettings().m_userAgent);
     http.SetTimeout(2);
     std::string strXML;
     std::string strUrl = m_vecUrls[iFeed];

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -8,6 +8,7 @@
 
 #include "XMLUtils.h"
 #include "ScraperUrl.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "CharsetConverter.h"
 #include "utils/CharsetDetection.h"
@@ -187,7 +188,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
 
   if (!scrURL.m_cache.empty())
   {
-    strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
+    strCachePath = URIUtils::AddFileToFolder(CServiceBroker::GetAdvancedSettings().m_cachePath,
                               "scrapers", cacheContext, scrURL.m_cache);
     if (XFILE::CFile::Exists(strCachePath))
     {
@@ -287,7 +288,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
 
   if (!scrURL.m_cache.empty())
   {
-    std::string strCachePath = URIUtils::AddFileToFolder(g_advancedSettings.m_cachePath,
+    std::string strCachePath = URIUtils::AddFileToFolder(CServiceBroker::GetAdvancedSettings().m_cachePath,
                               "scrapers", cacheContext, scrURL.m_cache);
     XFILE::CFile file;
     if (!file.OpenForWrite(strCachePath, true) || file.Write(strHTML.data(), strHTML.size()) != static_cast<ssize_t>(strHTML.size()))

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -486,22 +486,10 @@ CURL URIUtils::SubstitutePath(const CURL& url, bool reverse /* = false */)
 
 std::string URIUtils::SubstitutePath(const std::string& strPath, bool reverse /* = false */)
 {
-  for (CAdvancedSettings::StringMapping::iterator i = g_advancedSettings.m_pathSubstitutions.begin();
-      i != g_advancedSettings.m_pathSubstitutions.end(); ++i)
+  for (const auto& pathPair : CServiceBroker::GetAdvancedSettings().m_pathSubstitutions)
   {
-    std::string fromPath;
-    std::string toPath;
-
-    if (!reverse)
-    {
-      fromPath = i->first;  // Fake path
-      toPath = i->second;   // Real path
-    }
-    else
-    {
-      fromPath = i->second; // Real path
-      toPath = i->first;    // Fake path
-    }
+    const std::string fromPath = reverse ? pathPair.second : pathPair.first;
+    const std::string toPath = reverse ? pathPair.first : pathPair.second;
 
     if (strncmp(strPath.c_str(), fromPath.c_str(), HasSlashAtEnd(fromPath) ? fromPath.size() - 1 : fromPath.size()) == 0)
     {

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -8,6 +8,7 @@
 
 #include "log.h"
 #include "CompileInfo.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "threads/CriticalSection.h"
 #include "threads/SingleLock.h"
@@ -91,7 +92,7 @@ void CLog::LogString(int logLevel, std::string&& logString)
 
 void CLog::LogString(int logLevel, int component, std::string&& logString)
 {
-  if (g_advancedSettings.CanLogComponent(component) && IsLogLevelLogged(logLevel))
+  if (CServiceBroker::GetAdvancedSettings().CanLogComponent(component) && IsLogLevelLogged(logLevel))
     LogString(logLevel, std::move(logString));
 }
 

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -12,6 +12,7 @@
 
 #include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 
 #ifdef TARGET_POSIX
@@ -64,7 +65,7 @@ private:
 #ifndef TARGET_WINDOWS
 TEST(TestCPUInfo, getTemperature)
 {
-  TemporarySetting command(g_advancedSettings.m_cpuTempCmd, "echo '50 c'");
+  TemporarySetting command(CServiceBroker::GetAdvancedSettings().m_cpuTempCmd, "echo '50 c'");
   CTemperature t;
   EXPECT_TRUE(g_cpuInfo.getTemperature(t));
   EXPECT_TRUE(t.IsValid());

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 
 #include "filesystem/MultiPathDirectory.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "URL.h"
 #include "utils/URIUtils.h"
@@ -23,7 +24,7 @@ protected:
   TestURIUtils() = default;
   ~TestURIUtils() override
   {
-    g_advancedSettings.m_pathSubstitutions.clear();
+    CServiceBroker::GetAdvancedSettings().m_pathSubstitutions.clear();
   }
 };
 
@@ -187,15 +188,15 @@ TEST_F(TestURIUtils, SubstitutePath)
 
   from = "C:\\My Videos";
   to = "https://myserver/some%20other%20path";
-  g_advancedSettings.m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetAdvancedSettings().m_pathSubstitutions.push_back(std::make_pair(from, to));
 
   from = "/this/path1";
   to = "/some/other/path2";
-  g_advancedSettings.m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetAdvancedSettings().m_pathSubstitutions.push_back(std::make_pair(from, to));
 
   from = "davs://otherserver/my%20music%20path";
   to = "D:\\Local Music\\MP3 Collection";
-  g_advancedSettings.m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetAdvancedSettings().m_pathSubstitutions.push_back(std::make_pair(from, to));
 
   ref = "https://myserver/some%20other%20path/sub%20dir/movie%20name.avi";
   var = URIUtils::SubstitutePath("C:\\My Videos\\sub dir\\movie name.avi");

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -121,73 +121,73 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_SUBTITLE_DELAY_MIN:
       {
+        float videoSubsDelayRange = CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange;
         CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
         vs.m_SubtitleDelay -= 0.1f;
-        if (vs.m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
-          vs.m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
+        if (vs.m_SubtitleDelay < -videoSubsDelayRange)
+          vs.m_SubtitleDelay = -videoSubsDelayRange;
         g_application.GetAppPlayer().SetSubTitleDelay(vs.m_SubtitleDelay);
 
         ShowSlider(action.GetID(), 22006, g_application.GetAppPlayer().GetVideoSettings().m_SubtitleDelay,
-                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
-                                           g_advancedSettings.m_videoSubsDelayRange);
+                   -videoSubsDelayRange, 0.1f, videoSubsDelayRange);
         return true;
       }
 
       case ACTION_SUBTITLE_DELAY_PLUS:
       {
+        float videoSubsDelayRange = CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange;
         CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
         vs.m_SubtitleDelay += 0.1f;
-        if (vs.m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
-          vs.m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
+        if (vs.m_SubtitleDelay > videoSubsDelayRange)
+          vs.m_SubtitleDelay = videoSubsDelayRange;
         g_application.GetAppPlayer().SetSubTitleDelay(vs.m_SubtitleDelay);
 
         ShowSlider(action.GetID(), 22006, g_application.GetAppPlayer().GetVideoSettings().m_SubtitleDelay,
-                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
-                                           g_advancedSettings.m_videoSubsDelayRange);
+                   -videoSubsDelayRange, 0.1f, videoSubsDelayRange);
         return true;
       }
 
       case ACTION_SUBTITLE_DELAY:
       {
+        float videoSubsDelayRange = CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange;
         ShowSlider(action.GetID(), 22006, g_application.GetAppPlayer().GetVideoSettings().m_SubtitleDelay,
-                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
-                                           g_advancedSettings.m_videoSubsDelayRange, true);
+                   -videoSubsDelayRange, 0.1f, videoSubsDelayRange, true);
         return true;
       }
 
       case ACTION_AUDIO_DELAY:
       {
+        float videoAudioDelayRange = CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange;
         ShowSlider(action.GetID(), 297, g_application.GetAppPlayer().GetVideoSettings().m_AudioDelay,
-                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
-                                         g_advancedSettings.m_videoAudioDelayRange, true);
+                   -videoAudioDelayRange, 0.025f, videoAudioDelayRange, true);
         return true;
       }
 
       case ACTION_AUDIO_DELAY_MIN:
       {
+        float videoAudioDelayRange = CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange;
         CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
         vs.m_AudioDelay -= 0.025f;
-        if (vs.m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
-          vs.m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
+        if (vs.m_AudioDelay < -videoAudioDelayRange)
+          vs.m_AudioDelay = -videoAudioDelayRange;
         g_application.GetAppPlayer().SetAVDelay(vs.m_AudioDelay);
 
         ShowSlider(action.GetID(), 297, g_application.GetAppPlayer().GetVideoSettings().m_AudioDelay,
-                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
-                                         g_advancedSettings.m_videoAudioDelayRange);
+                   -videoAudioDelayRange, 0.025f, videoAudioDelayRange);
         return true;
       }
 
       case ACTION_AUDIO_DELAY_PLUS:
       {
+        float videoAudioDelayRange = CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange;
         CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
         vs.m_AudioDelay += 0.025f;
-        if (vs.m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
-          vs.m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
+        if (vs.m_AudioDelay > videoAudioDelayRange)
+          vs.m_AudioDelay = videoAudioDelayRange;
         g_application.GetAppPlayer().SetAVDelay(vs.m_AudioDelay);
 
         ShowSlider(action.GetID(), 297, g_application.GetAppPlayer().GetVideoSettings().m_AudioDelay,
-                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
-                                         g_advancedSettings.m_videoAudioDelayRange);
+                   -videoAudioDelayRange, 0.025f, videoAudioDelayRange);
         return true;
       }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -77,7 +77,7 @@ CVideoDatabase::~CVideoDatabase(void) = default;
 //********************************************************************************************************************************
 bool CVideoDatabase::Open()
 {
-  return CDatabase::Open(g_advancedSettings.m_databaseVideo);
+  return CDatabase::Open(CServiceBroker::GetAdvancedSettings().m_databaseVideo);
 }
 
 void CVideoDatabase::CreateTables()
@@ -920,10 +920,10 @@ void CVideoDatabase::UpdateFileDateAdded(int idFile, const std::string& strFileN
       if (!URIUtils::IsPlugin(strFileNameAndPath))
       {
         // 1 preferring to use the files mtime(if it's valid) and only using the file's ctime if the mtime isn't valid
-        if (g_advancedSettings.m_iVideoLibraryDateAdded == 1)
+        if (CServiceBroker::GetAdvancedSettings().m_iVideoLibraryDateAdded == 1)
           finalDateAdded = CFileUtils::GetModificationDate(strFileNameAndPath, false);
         //2 using the newer datetime of the file's mtime and ctime
-        else if (g_advancedSettings.m_iVideoLibraryDateAdded == 2)
+        else if (CServiceBroker::GetAdvancedSettings().m_iVideoLibraryDateAdded == 2)
           finalDateAdded = CFileUtils::GetModificationDate(strFileNameAndPath, true);
       }
       //0 using the current datetime if non of the above matches or one returns an invalid datetime
@@ -1304,7 +1304,7 @@ bool CVideoDatabase::AddPathToTvShow(int idShow, const std::string &path, const 
   {
     CDateTime finalDateAdded = dateAdded;
     // Skip looking at the files ctime/mtime if defined by the user through as.xml
-    if (!finalDateAdded.IsValid() && g_advancedSettings.m_iVideoLibraryDateAdded > 0)
+    if (!finalDateAdded.IsValid() && CServiceBroker::GetAdvancedSettings().m_iVideoLibraryDateAdded > 0)
     {
       struct __stat64 buffer;
       if (XFILE::CFile::Stat(path, &buffer) == 0)
@@ -1937,7 +1937,7 @@ void CVideoDatabase::GetMusicVideosByArtist(const std::string& strArtist, CFileI
     {
       CVideoInfoTag tag = GetDetailsForMusicVideo(m_pDS);
       CFileItemPtr pItem(new CFileItem(tag));
-      pItem->SetLabel(StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator));
+      pItem->SetLabel(StringUtils::Join(tag.m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator));
       items.Add(pItem);
       m_pDS->next();
     }
@@ -2243,7 +2243,7 @@ std::string CVideoDatabase::GetValueString(const CVideoInfoTag &details, int min
       break;
     case VIDEODB_TYPE_STRINGARRAY:
       conditions.emplace_back(PrepareSQL("c%02d='%s'", i, StringUtils::Join(*((const std::vector<std::string>*)(((const char*)&details)+offsets[i].offset)),
-                                                                          g_advancedSettings.m_videoItemSeparator).c_str()));
+                                                                          CServiceBroker::GetAdvancedSettings().m_videoItemSeparator).c_str()));
       break;
     case VIDEODB_TYPE_DATE:
       conditions.emplace_back(PrepareSQL("c%02d='%s'", i, ((const CDateTime*)(((const char*)&details)+offsets[i].offset))->GetAsDBDate().c_str()));
@@ -3672,7 +3672,7 @@ void CVideoDatabase::GetDetailsFromDB(const dbiplus::sql_record* const record, i
     {
       std::string value = record->at(i+idxOffset).get_asString();
       if (!value.empty())
-        *(std::vector<std::string>*)(((char*)&details)+offsets[i].offset) = StringUtils::Split(value, g_advancedSettings.m_videoItemSeparator);
+        *(std::vector<std::string>*)(((char*)&details)+offsets[i].offset) = StringUtils::Split(value, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
       break;
     }
     case VIDEODB_TYPE_DATE:
@@ -4070,8 +4070,8 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
   details.m_dateAdded.SetFromDBDateTime(record->at(VIDEODB_DETAILS_EPISODE_DATEADDED).get_asString());
   details.m_strMPAARating = record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_MPAA).get_asString();
   details.m_strShowTitle = record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_NAME).get_asString();
-  details.m_genre = StringUtils::Split(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_GENRE).get_asString(), g_advancedSettings.m_videoItemSeparator);
-  details.m_studio = StringUtils::Split(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_STUDIO).get_asString(), g_advancedSettings.m_videoItemSeparator);
+  details.m_genre = StringUtils::Split(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_GENRE).get_asString(), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
+  details.m_studio = StringUtils::Split(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_STUDIO).get_asString(), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
   details.SetPremieredFromDBDate(record->at(VIDEODB_DETAILS_EPISODE_TVSHOW_AIRED).get_asString());
   
   details.SetResumePoint(record->at(VIDEODB_DETAILS_EPISODE_RESUME_TIME).get_asInt(),
@@ -6681,8 +6681,8 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
           pItem->GetVideoInfoTag()->SetPremiered(pItem->GetVideoInfoTag()->GetPremiered());
         else if (pItem->GetVideoInfoTag()->HasYear())
           pItem->GetVideoInfoTag()->SetYear(pItem->GetVideoInfoTag()->GetYear());
-        pItem->GetVideoInfoTag()->m_genre = StringUtils::Split(m_pDS->fv(VIDEODB_ID_SEASON_TVSHOW_GENRE).get_asString(), g_advancedSettings.m_videoItemSeparator);
-        pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(m_pDS->fv(VIDEODB_ID_SEASON_TVSHOW_STUDIO).get_asString(), g_advancedSettings.m_videoItemSeparator);
+        pItem->GetVideoInfoTag()->m_genre = StringUtils::Split(m_pDS->fv(VIDEODB_ID_SEASON_TVSHOW_GENRE).get_asString(), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
+        pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(m_pDS->fv(VIDEODB_ID_SEASON_TVSHOW_STUDIO).get_asString(), CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
         pItem->GetVideoInfoTag()->m_strMPAARating = m_pDS->fv(VIDEODB_ID_SEASON_TVSHOW_MPAA).get_asString();
         pItem->GetVideoInfoTag()->m_iIdShow = showId;
 
@@ -7230,7 +7230,7 @@ bool CVideoDatabase::GetRecentlyAddedMoviesNav(const std::string& strBaseDir, CF
 {
   Filter filter;
   filter.order = "dateAdded desc, idMovie desc";
-  filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
+  filter.limit = PrepareSQL("%u", limit ? limit : CServiceBroker::GetAdvancedSettings().m_iVideoLibraryRecentlyAddedItems);
   return GetMoviesByWhere(strBaseDir, filter, items, SortDescription(), getDetails);
 }
 
@@ -7238,7 +7238,7 @@ bool CVideoDatabase::GetRecentlyAddedEpisodesNav(const std::string& strBaseDir, 
 {
   Filter filter;
   filter.order = "dateAdded desc, idEpisode desc";
-  filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
+  filter.limit = PrepareSQL("%u", limit ? limit : CServiceBroker::GetAdvancedSettings().m_iVideoLibraryRecentlyAddedItems);
   return GetEpisodesByWhere(strBaseDir, filter, items, false, SortDescription(), getDetails);
 }
 
@@ -7246,7 +7246,7 @@ bool CVideoDatabase::GetRecentlyAddedMusicVideosNav(const std::string& strBaseDi
 {
   Filter filter;
   filter.order = "dateAdded desc, idMVideo desc";
-  filter.limit = PrepareSQL("%u", limit ? limit : g_advancedSettings.m_iVideoLibraryRecentlyAddedItems);
+  filter.limit = PrepareSQL("%u", limit ? limit : CServiceBroker::GetAdvancedSettings().m_iVideoLibraryRecentlyAddedItems);
   return GetMusicVideosByWhere(strBaseDir, filter, items, true, SortDescription(), getDetails);
 }
 
@@ -9280,7 +9280,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       {
         if (singleFile)
         {
-          std::string strFileName(StringUtils::Join(movie.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + movie.m_strTitle);
+          std::string strFileName(StringUtils::Join(movie.m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator) + "." + movie.m_strTitle);
           if (movie.HasYear())
             strFileName += StringUtils::Format("_%i", movie.GetYear());
           item.SetPath(GetSafeFile(musicvideosDir, strFileName) + ".avi");
@@ -9674,7 +9674,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         info.Load(movie);
         CFileItem item(info);
         bool useFolders = info.m_basePath.empty() ? LookupByFolders(item.GetPath()) : false;
-        std::string filename = StringUtils::Join(info.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + info.m_strTitle;
+        std::string filename = StringUtils::Join(info.m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator) + "." + info.m_strTitle;
         if (info.HasYear())
           filename += StringUtils::Format("_%i", info.GetYear());
         CFileItem artItem(item);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -201,7 +201,7 @@ namespace VIDEO
       }
     }
     m_database.Close();
-    m_bClean = g_advancedSettings.m_bVideoLibraryCleanOnUpdate;
+    m_bClean = CServiceBroker::GetAdvancedSettings().m_bVideoLibraryCleanOnUpdate;
 
     m_bRunning = true;
     Process();
@@ -248,8 +248,8 @@ namespace VIDEO
     CONTENT_TYPE content = info ? info->Content() : CONTENT_NONE;
 
     // exclude folders that match our exclude regexps
-    const std::vector<std::string> &regexps = content == CONTENT_TVSHOWS ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
-                                                         : g_advancedSettings.m_moviesExcludeFromScanRegExps;
+    const std::vector<std::string> &regexps = content == CONTENT_TVSHOWS ? CServiceBroker::GetAdvancedSettings().m_tvshowExcludeFromScanRegExps
+                                                         : CServiceBroker::GetAdvancedSettings().m_moviesExcludeFromScanRegExps;
 
     if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
       return true;
@@ -277,7 +277,7 @@ namespace VIDEO
       }
 
       std::string fastHash;
-      if (g_advancedSettings.m_bVideoLibraryUseFastHash && !URIUtils::IsPlugin(strDirectory))
+      if (CServiceBroker::GetAdvancedSettings().m_bVideoLibraryUseFastHash && !URIUtils::IsPlugin(strDirectory))
         fastHash = GetFastHash(strDirectory, regexps);
 
       if (m_database.GetPathHash(strDirectory, dbHash) && !fastHash.empty() && StringUtils::EqualsNoCase(fastHash, dbHash))
@@ -425,8 +425,8 @@ namespace VIDEO
         continue;
 
       // Discard all exclude files defined by regExExclude
-      if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
-                                                                    : g_advancedSettings.m_moviesExcludeFromScanRegExps))
+      if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), (content == CONTENT_TVSHOWS) ? CServiceBroker::GetAdvancedSettings().m_tvshowExcludeFromScanRegExps
+                                                                    : CServiceBroker::GetAdvancedSettings().m_moviesExcludeFromScanRegExps))
         continue;
 
       if (info2->Content() == CONTENT_MOVIES || info2->Content() == CONTENT_MUSICVIDEOS)
@@ -827,7 +827,7 @@ namespace VIDEO
   bool CVideoInfoScanner::EnumerateSeriesFolder(CFileItem* item, EPISODELIST& episodeList)
   {
     CFileItemList items;
-    const std::vector<std::string> &regexps = g_advancedSettings.m_tvshowExcludeFromScanRegExps;
+    const std::vector<std::string> &regexps = CServiceBroker::GetAdvancedSettings().m_tvshowExcludeFromScanRegExps;
 
     bool bSkip = false;
 
@@ -854,7 +854,7 @@ namespace VIDEO
           allowEmptyHash = true;
         }
       }
-      else if (g_advancedSettings.m_bVideoLibraryUseFastHash)
+      else if (CServiceBroker::GetAdvancedSettings().m_bVideoLibraryUseFastHash)
         hash = GetRecursiveFastHash(item->GetPath(), regexps);
 
       if (m_database.GetPathHash(item->GetPath(), dbHash) && (allowEmptyHash || !hash.empty()) && StringUtils::EqualsNoCase(dbHash, hash))
@@ -1087,7 +1087,7 @@ namespace VIDEO
 
   bool CVideoInfoScanner::EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList)
   {
-    SETTINGS_TVSHOWLIST expression = g_advancedSettings.m_tvshowEnumRegExps;
+    SETTINGS_TVSHOWLIST expression = CServiceBroker::GetAdvancedSettings().m_tvshowEnumRegExps;
 
     std::string strLabel;
 
@@ -1176,7 +1176,7 @@ namespace VIDEO
 
       CRegExp reg2(true, CRegExp::autoUtf8);
       // check the remainder of the string for any further episodes.
-      if (!byDate && reg2.RegComp(g_advancedSettings.m_tvshowMultiPartEnumRegExp))
+      if (!byDate && reg2.RegComp(CServiceBroker::GetAdvancedSettings().m_tvshowMultiPartEnumRegExp))
       {
         int offset = 0;
 
@@ -1190,7 +1190,7 @@ namespace VIDEO
 
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new season %u, multipart episode %u [%s]",
                       episode.iSeason, episode.iEpisode,
-                      g_advancedSettings.m_tvshowMultiPartEnumRegExp.c_str());
+                      CServiceBroker::GetAdvancedSettings().m_tvshowMultiPartEnumRegExp.c_str());
 
             episodeList.push_back(episode);
             remainder = reg.GetMatch(3);
@@ -1201,7 +1201,7 @@ namespace VIDEO
           {
             episode.iEpisode = atoi(reg2.GetMatch(1).c_str());
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding multipart episode %u [%s]",
-                      episode.iEpisode, g_advancedSettings.m_tvshowMultiPartEnumRegExp.c_str());
+                      episode.iEpisode, CServiceBroker::GetAdvancedSettings().m_tvshowMultiPartEnumRegExp.c_str());
             episodeList.push_back(episode);
             offset += regexp2pos + reg2.GetFindLen();
           }
@@ -1386,10 +1386,10 @@ namespace VIDEO
 
     if (!pItem->m_bIsFolder)
     {
-      if (g_advancedSettings.m_bVideoLibraryImportWatchedState || libraryImport)
+      if (CServiceBroker::GetAdvancedSettings().m_bVideoLibraryImportWatchedState || libraryImport)
         m_database.SetPlayCount(*pItem, movieDetails.GetPlayCount(), movieDetails.m_lastPlayed);
 
-      if ((g_advancedSettings.m_bVideoLibraryImportResumePoint || libraryImport) &&
+      if ((CServiceBroker::GetAdvancedSettings().m_bVideoLibraryImportResumePoint || libraryImport) &&
           movieDetails.GetResumePoint().IsSet())
         m_database.AddBookMarkToFile(pItem->GetPath(), movieDetails.GetResumePoint(), CBookmark::RESUME);
     }
@@ -1844,7 +1844,7 @@ namespace VIDEO
 
   bool CVideoInfoScanner::CanFastHash(const CFileItemList &items, const std::vector<std::string> &excludes) const
   {
-    if (!g_advancedSettings.m_bVideoLibraryUseFastHash || items.IsPlugin())
+    if (!CServiceBroker::GetAdvancedSettings().m_bVideoLibraryUseFastHash || items.IsPlugin())
       return false;
 
     for (int i = 0; i < items.Size(); ++i)
@@ -2036,7 +2036,7 @@ namespace VIDEO
 
   bool CVideoInfoScanner::DownloadFailed(CGUIDialogProgress* pDialog)
   {
-    if (g_advancedSettings.m_bVideoScannerIgnoreErrors)
+    if (CServiceBroker::GetAdvancedSettings().m_bVideoScannerIgnoreErrors)
       return true;
 
     if (pDialog)

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -9,6 +9,7 @@
 #include "VideoInfoTag.h"
 #include "utils/XMLUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -987,24 +988,26 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     m_strPictureURL.m_xml = xmlAdd;
   }
 
+  const std::string itemSeparator = CServiceBroker::GetAdvancedSettings().m_videoItemSeparator;
+
   std::vector<std::string> genres(m_genre);
-  if (XMLUtils::GetStringArray(movie, "genre", genres, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "genre", genres, prioritise, itemSeparator))
     SetGenre(genres);
 
   std::vector<std::string> country(m_country);
-  if (XMLUtils::GetStringArray(movie, "country", country, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "country", country, prioritise, itemSeparator))
     SetCountry(country);
 
   std::vector<std::string> credits(m_writingCredits);
-  if (XMLUtils::GetStringArray(movie, "credits", credits, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "credits", credits, prioritise, itemSeparator))
     SetWritingCredits(credits);
 
   std::vector<std::string> director(m_director);
-  if (XMLUtils::GetStringArray(movie, "director", director, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "director", director, prioritise, itemSeparator))
     SetDirector(director);
 
   std::vector<std::string> showLink(m_showLink);
-  if (XMLUtils::GetStringArray(movie, "showlink", showLink, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "showlink", showLink, prioritise, itemSeparator))
     SetShowLink(showLink);
 
   const TiXmlElement* namedSeason = movie->FirstChildElement("namedseason");
@@ -1071,11 +1074,11 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   }
 
   std::vector<std::string> tags(m_tags);
-  if (XMLUtils::GetStringArray(movie, "tag", tags, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "tag", tags, prioritise, itemSeparator))
     SetTags(tags);
 
   std::vector<std::string> studio(m_studio);
-  if (XMLUtils::GetStringArray(movie, "studio", studio, prioritise, g_advancedSettings.m_videoItemSeparator))
+  if (XMLUtils::GetStringArray(movie, "studio", studio, prioritise, itemSeparator))
     SetStudio(studio);
 
   // artists
@@ -1096,7 +1099,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       const char* clear=node->Attribute("clear");
       if (clear && stricmp(clear,"true")==0)
         artist.clear();
-      std::vector<std::string> newArtists = StringUtils::Split(pValue, g_advancedSettings.m_videoItemSeparator);
+      std::vector<std::string> newArtists = StringUtils::Split(pValue, itemSeparator);
       artist.insert(artist.end(), newArtists.begin(), newArtists.end());
     }
     node = node->NextSiblingElement("artist");

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -549,7 +549,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
      thumbloader thread accesses the streamed filesystem at the same time as the
      App thread and the latter has to wait for it.
    */
-  if (item.m_bIsFolder && (item.IsInternetStream(true) || g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
+  if (item.m_bIsFolder && (item.IsInternetStream(true) || CServiceBroker::GetAdvancedSettings().m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
   {
     CFileItemList items; // Dummy list
     CDirectory::GetDirectory(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -259,7 +259,7 @@ void CGUIDialogAudioSettings::InitializeSettings()
   // audio delay setting
   if (SupportsAudioFeature(IPC_AUD_OFFSET))
   {
-    std::shared_ptr<CSettingNumber> settingAudioDelay = AddSlider(groupAudio, SETTING_AUDIO_DELAY, 297, SettingLevel::Basic, videoSettings.m_AudioDelay, 0, -g_advancedSettings.m_videoAudioDelayRange, 0.025f, g_advancedSettings.m_videoAudioDelayRange, 297, usePopup);
+    std::shared_ptr<CSettingNumber> settingAudioDelay = AddSlider(groupAudio, SETTING_AUDIO_DELAY, 297, SettingLevel::Basic, videoSettings.m_AudioDelay, 0, -CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange, 0.025f, CServiceBroker::GetAdvancedSettings().m_videoAudioDelayRange, 297, usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingAudioDelay->GetControl())->SetFormatter(SettingFormatterDelay);
   }
 

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -254,7 +254,7 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
   // subtitle delay setting
   if (SupportsSubtitleFeature(IPC_SUBS_OFFSET))
   {
-    std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, SettingLevel::Basic, videoSettings.m_SubtitleDelay, 0, -g_advancedSettings.m_videoSubsDelayRange, 0.1f, g_advancedSettings.m_videoSubsDelayRange, 22006, usePopup);
+    std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, SettingLevel::Basic, videoSettings.m_SubtitleDelay, 0, -CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange, 0.1f, CServiceBroker::GetAdvancedSettings().m_videoSubsDelayRange, 22006, usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingSubtitleDelay->GetControl())->SetFormatter(SettingFormatterDelay);
   }
 

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -38,7 +38,7 @@
 
 using namespace KODI::MESSAGING;
 
-#define BOOKMARK_THUMB_WIDTH g_advancedSettings.m_imageRes
+#define BOOKMARK_THUMB_WIDTH CServiceBroker::GetAdvancedSettings().m_imageRes
 
 #define CONTROL_ADD_BOOKMARK           2
 #define CONTROL_CLEAR_BOOKMARKS        3

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -536,7 +536,7 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
   db.GetMusicVideosByArtist(strSearch, movies);
   for (int i = 0; i < movies.Size(); ++i)
   {
-    std::string label = StringUtils::Join(movies[i]->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator) + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
+    std::string label = StringUtils::Join(movies[i]->GetVideoInfoTag()->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator) + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
     if (movies[i]->GetVideoInfoTag()->HasYear())
       label += StringUtils::Format(" (%i)", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -223,7 +223,7 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
         CFileItemPtr item2 = items[i];
 
         if (item2->IsVideo() && !item2->IsPlayList() &&
-            !CUtil::ExcludeFileOrFolder(item2->GetPath(), g_advancedSettings.m_moviesExcludeFromScanRegExps))
+            !CUtil::ExcludeFileOrFolder(item2->GetPath(), CServiceBroker::GetAdvancedSettings().m_moviesExcludeFromScanRegExps))
         {
           item.SetPath(item2->GetPath());
           item.m_bIsFolder = false;
@@ -828,7 +828,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
 
         // allow a folder to be ad-hoc queued and played by the default player
         if (item->m_bIsFolder || (item->IsPlayList() &&
-           !g_advancedSettings.m_playlistAsFolders))
+           !CServiceBroker::GetAdvancedSettings().m_playlistAsFolders))
         {
           buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208);
         }
@@ -840,7 +840,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
         }
       }
 
-      if (!item->m_bIsFolder && !(item->IsPlayList() && !g_advancedSettings.m_playlistAsFolders))
+      if (!item->m_bIsFolder && !(item->IsPlayList() && !CServiceBroker::GetAdvancedSettings().m_playlistAsFolders))
       {
         const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
 
@@ -1399,7 +1399,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
 
   // set movie info
   movie.m_strTitle = strTitle;
-  movie.m_genre = StringUtils::Split(strGenre, g_advancedSettings.m_videoItemSeparator);
+  movie.m_genre = StringUtils::Split(strGenre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator);
 
   // everything is ok, so add to database
   m_database.Open();
@@ -1410,7 +1410,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
 
   // done...
   HELPERS::ShowOKDialogLines(CVariant{20177}, CVariant{movie.m_strTitle},
-                                CVariant{StringUtils::Join(movie.m_genre, g_advancedSettings.m_videoItemSeparator)},
+                                CVariant{StringUtils::Join(movie.m_genre, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator)},
                                 CVariant{movie.GetUniqueID()});
 
   // library view cache needs to be cleared

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -930,7 +930,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       CMusicDatabase database;
       database.Open();
-      if (database.GetArtistByName(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)) > -1)
+      if (database.GetArtistByName(StringUtils::Join(item->GetVideoInfoTag()->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator)) > -1)
         buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20396);
     }
     if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_strAlbum.empty())
@@ -946,7 +946,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       CMusicDatabase database;
       database.Open();
-      if (database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),
+      if (database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(item->GetVideoInfoTag()->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator),
                                                    item->GetVideoInfoTag()->m_strAlbum,
                                                    item->GetVideoInfoTag()->m_strTitle) > -1)
       {
@@ -1072,7 +1072,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CMusicDatabase database;
       database.Open();
       strPath = StringUtils::Format("musicdb://artists/%i/",
-                                    database.GetArtistByName(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)));
+                                    database.GetArtistByName(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator)));
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_MUSIC_NAV,strPath);
       return true;
     }
@@ -1091,7 +1091,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CMusicDatabase database;
       database.Open();
       CSong song;
-      if (database.GetSong(database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum,
+      if (database.GetSong(database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, CServiceBroker::GetAdvancedSettings().m_videoItemSeparator),m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum,
                                                                         m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strTitle),
                                                                         song))
       {

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -108,7 +108,7 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   if (pItem)
   {
     pItem->m_bIsFolder = true;
-    pItem->SetSpecialSort(g_advancedSettings.m_bVideoLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
+    pItem->SetSpecialSort(CServiceBroker::GetAdvancedSettings().m_bVideoLibraryAllItemsOnBottom ? SortSpecialOnBottom : SortSpecialOnTop);
     pItem->SetCanQueue(false);
     items.Add(pItem);
   }

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -445,7 +445,7 @@ VECSOURCES& CGUIViewState::GetSources()
 
 void CGUIViewState::AddAddonsSource(const std::string &content, const std::string &label, const std::string &thumb)
 {
-  if (!g_advancedSettings.m_bVirtualShares)
+  if (!CServiceBroker::GetAdvancedSettings().m_bVirtualShares)
     return;
 
   CFileItemList items;

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -393,19 +393,19 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
   }
 
   // If we are switching to the same resolution and same window/full-screen, no need to do anything
-  if (!forceUpdate && res == lastRes && m_bFullScreenRoot == g_advancedSettings.m_fullScreen)
+  if (!forceUpdate && res == lastRes && m_bFullScreenRoot == CServiceBroker::GetAdvancedSettings().m_fullScreen)
   {
     return;
   }
 
   if (res >= RES_DESKTOP)
   {
-    g_advancedSettings.m_fullScreen = true;
+    CServiceBroker::GetAdvancedSettings().m_fullScreen = true;
     m_bFullScreenRoot = true;
   }
   else
   {
-    g_advancedSettings.m_fullScreen = false;
+    CServiceBroker::GetAdvancedSettings().m_fullScreen = false;
     m_bFullScreenRoot = false;
   }
 
@@ -425,7 +425,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
   RESOLUTION_INFO info_org  = CDisplaySettings::GetInstance().GetResolutionInfo(res);
 
   bool switched = false;
-  if (g_advancedSettings.m_fullScreen)
+  if (CServiceBroker::GetAdvancedSettings().m_fullScreen)
   {
 #if defined (TARGET_DARWIN) || defined (TARGET_WINDOWS)
     bool blankOtherDisplays = CServiceBroker::GetSettings()->GetBool(CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS);
@@ -485,12 +485,12 @@ void CGraphicContext::ApplyVideoResolution(RESOLUTION res)
 
   if (res >= RES_DESKTOP)
   {
-    g_advancedSettings.m_fullScreen = true;
+    CServiceBroker::GetAdvancedSettings().m_fullScreen = true;
     m_bFullScreenRoot = true;
   }
   else
   {
-    g_advancedSettings.m_fullScreen = false;
+    CServiceBroker::GetAdvancedSettings().m_fullScreen = false;
     m_bFullScreenRoot = false;
   }
 

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -162,9 +162,9 @@ bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
 
   //try to find a refreshrate from the override
-  for (int i = 0; i < (int)g_advancedSettings.m_videoAdjustRefreshOverrides.size(); i++)
+  for (int i = 0; i < (int)CServiceBroker::GetAdvancedSettings().m_videoAdjustRefreshOverrides.size(); i++)
   {
-    RefreshOverride& override = g_advancedSettings.m_videoAdjustRefreshOverrides[i];
+    RefreshOverride& override = CServiceBroker::GetAdvancedSettings().m_videoAdjustRefreshOverrides[i];
 
     if (override.fallback != fallback)
       continue;

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -165,14 +165,14 @@ void CWinEventsWin10::UpdateWindowSize()
 {
   auto size = DX::DeviceResources::Get()->GetOutputSize();
 
-  CLog::Log(LOGDEBUG, __FUNCTION__": window resize event %f x %f (as:%s)", size.Width, size.Height, g_advancedSettings.m_fullScreen ? "true" : "false");
+  CLog::Log(LOGDEBUG, __FUNCTION__": window resize event %f x %f (as:%s)", size.Width, size.Height, CServiceBroker::GetAdvancedSettings().m_fullScreen ? "true" : "false");
 
   auto appView = ApplicationView::GetForCurrentView();
   appView.SetDesiredBoundsMode(ApplicationViewBoundsMode::UseCoreWindow);
 
   // seems app has lost FS mode it may occurs if an user use core window's button
-  if (g_advancedSettings.m_fullScreen && !appView.IsFullScreenMode())
-    g_advancedSettings.m_fullScreen = false;
+  if (CServiceBroker::GetAdvancedSettings().m_fullScreen && !appView.IsFullScreenMode())
+    CServiceBroker::GetAdvancedSettings().m_fullScreen = false;
 
   XBMC_Event newEvent;
   memset(&newEvent, 0, sizeof(newEvent));

--- a/xbmc/windowing/windows/WinKeyMap.h
+++ b/xbmc/windowing/windows/WinKeyMap.h
@@ -10,6 +10,7 @@
 
 #include "input/XBMC_keysym.h"
 #include "input/XBMC_vkeys.h"
+#include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "Util.h"
 
@@ -149,7 +150,7 @@ namespace KODI
 
         // Only include the multimedia keys if they have been enabled in the
         // advanced settings
-        if (g_advancedSettings.m_enableMultimediaKeys)
+        if (CServiceBroker::GetAdvancedSettings().m_enableMultimediaKeys)
         {
           VK_keymap[VK_BROWSER_BACK] = XBMCK_BROWSER_BACK;
           VK_keymap[VK_BROWSER_FORWARD] = XBMCK_BROWSER_FORWARD;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -69,7 +69,7 @@ CWinSystemWin32::CWinSystemWin32()
   CAESinkDirectSound::Register();
   CAESinkWASAPI::Register();
   CWin32PowerSyscall::Register();
-  if (g_advancedSettings.m_bScanIRServer)
+  if (CServiceBroker::GetAdvancedSettings().m_bScanIRServer)
   {
     m_irss.reset(new CIRServerSuite());
     m_irss->Initialize();
@@ -343,7 +343,7 @@ void CWinSystemWin32::AdjustWindow(bool forceResize)
   }
   else // m_state == WINDOW_STATE_WINDOWED
   {
-    windowAfter = g_advancedSettings.m_alwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST;
+    windowAfter = CServiceBroker::GetAdvancedSettings().m_alwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST;
 
     rc.left = m_nLeft;
     rc.right = m_nLeft + m_nWidth;
@@ -971,7 +971,7 @@ bool CWinSystemWin32::Show(bool raise)
     if (m_bFullScreen)
       windowAfter = HWND_TOP;
     else
-      windowAfter = g_advancedSettings.m_alwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST;
+      windowAfter = CServiceBroker::GetAdvancedSettings().m_alwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST;
   }
 
   SetWindowPos(m_hWnd, windowAfter, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -763,11 +763,11 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
 
   //! @todo Do we want to limit the directories we apply the video ones to?
   if (iWindow == WINDOW_VIDEO_NAV)
-    regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
+    regexps = CServiceBroker::GetAdvancedSettings().m_videoExcludeFromListingRegExps;
   if (iWindow == WINDOW_MUSIC_NAV)
-    regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
+    regexps = CServiceBroker::GetAdvancedSettings().m_audioExcludeFromListingRegExps;
   if (iWindow == WINDOW_PICTURES)
-    regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
+    regexps = CServiceBroker::GetAdvancedSettings().m_pictureExcludeFromListingRegExps;
 
   if (regexps.size())
   {
@@ -881,7 +881,7 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);
     pItem->m_bIsFolder = true;
-    pItem->SetSpecialSort(g_advancedSettings.m_addSourceOnTop ?
+    pItem->SetSpecialSort(CServiceBroker::GetAdvancedSettings().m_addSourceOnTop ?
                                              SortSpecialOnTop : SortSpecialOnBottom);
     m_vecItems->Add(pItem);
   }

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -41,7 +41,7 @@ CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void) = default;
 
 void CGUIWindowDebugInfo::UpdateVisibility()
 {
-  if (LOG_LEVEL_DEBUG_FREEMEM <= g_advancedSettings.m_logLevel || g_SkinInfo->IsDebugging())
+  if (LOG_LEVEL_DEBUG_FREEMEM <= CServiceBroker::GetAdvancedSettings().m_logLevel || g_SkinInfo->IsDebugging())
     Open();
   else
     Close();
@@ -87,7 +87,7 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     return;
 
   std::string info;
-  if (LOG_LEVEL_DEBUG_FREEMEM <= g_advancedSettings.m_logLevel)
+  if (LOG_LEVEL_DEBUG_FREEMEM <= CServiceBroker::GetAdvancedSettings().m_logLevel)
   {
     MEMORYSTATUSEX stat;
     stat.dwLength = sizeof(MEMORYSTATUSEX);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -51,8 +51,8 @@ void CGUIWindowHome::OnInitWindow()
 {
   // for shared databases (ie mysql) always force an update on return to home
   // this is a temporary solution until remote announcements can be delivered
-  if (StringUtils::EqualsNoCase(g_advancedSettings.m_databaseVideo.type, "mysql") ||
-      StringUtils::EqualsNoCase(g_advancedSettings.m_databaseMusic.type, "mysql") )
+  if (StringUtils::EqualsNoCase(CServiceBroker::GetAdvancedSettings().m_databaseVideo.type, "mysql") ||
+      StringUtils::EqualsNoCase(CServiceBroker::GetAdvancedSettings().m_databaseMusic.type, "mysql") )
     m_updateRA = (Audio | Video | Totals);
   AddRecentlyAddedJobs( m_updateRA );
 

--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -26,7 +26,7 @@ CGUIWindowSplash::~CGUIWindowSplash(void) = default;
 
 void CGUIWindowSplash::OnInitWindow()
 {
-  if (!g_advancedSettings.m_splashImage)
+  if (!CServiceBroker::GetAdvancedSettings().m_splashImage)
     return;
 
   m_image = std::unique_ptr<CGUIImage>(new CGUIImage(0, 0, 0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(), CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(), CTextureInfo(CUtil::GetSplashPath())));


### PR DESCRIPTION
After updating to macOS 10.14 I experienced crashes in `CAdvancedSettings`dtor while exiting Kodi and thought it would be a good time to eliminate another global singleton: `g_advancedSettings`.

Example error message in console log:

```
[...]
2018-09-26 16:34:26.521365+0200 kodi.bin[26047:1536643] Debug Print: application stopped...
kodi.bin(26047,0x107f075c0) malloc: tiny_free_list_remove_ptr: Internal invariant broken (prev ptr of next): ptr=0x10959c290, next_prev=0x0
kodi.bin(26047,0x107f075c0) malloc: *** set a breakpoint in malloc_error_break to debug
```

Example crash:

```
(lldb) thread backtrace
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00007fff79b09b86 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x0000000109290884 libsystem_pthread.dylib`pthread_kill + 285
    frame #2: 0x00007fff79a731c9 libsystem_c.dylib`abort + 127
    frame #3: 0x00007fff79b816e2 libsystem_malloc.dylib`malloc_vreport + 545
    frame #4: 0x00007fff79b9586c libsystem_malloc.dylib`malloc_zone_error + 184
    frame #5: 0x00007fff79b7e130 libsystem_malloc.dylib`tiny_free_list_remove_ptr + 589
    frame #6: 0x00007fff79b7baee libsystem_malloc.dylib`tiny_free_no_lock + 933
    frame #7: 0x00007fff79b7b631 libsystem_malloc.dylib`free_tiny + 483
  * frame #8: 0x0000000100121b09 kodi.bin`std::__1::__vector_base<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::~__vector_base() [inlined] std::__1::__libcpp_deallocate(__ptr=0x000000010959c740) at new:236
    frame #9: 0x0000000100121b00 kodi.bin`std::__1::__vector_base<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::~__vector_base() [inlined] std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::deallocate(this=0x000000010a003e88, __p="[\\/].+\\.ite[\\/]", (null)=4) at memory:1796
    frame #10: 0x0000000100121af8 kodi.bin`std::__1::__vector_base<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::~__vector_base() [inlined] std::__1::allocator_traits<std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::deallocate(__a=0x000000010a003e88, __p="[\\/].+\\.ite[\\/]", __n=4) at memory:1555
    frame #11: 0x0000000100121ae0 kodi.bin`std::__1::__vector_base<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::~__vector_base(this=0x000000010a003e78) at vector:442
    frame #12: 0x0000000100121935 kodi.bin`std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::~vector(this=0x000000010a003e78 size=0) at vector:447
    frame #13: 0x00000001001213a5 kodi.bin`std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::~vector(this=0x000000010a003e78 size=0) at vector:447
    frame #14: 0x0000000102183574 kodi.bin`CAdvancedSettings::~CAdvancedSettings(this=0x000000010a003c00) at AdvancedSettings.h:104
    frame #15: 0x00000001021813d5 kodi.bin`CAdvancedSettings::~CAdvancedSettings(this=0x000000010a003c00) at AdvancedSettings.h:104
    frame #16: 0x00000001021813f9 kodi.bin`CAdvancedSettings::~CAdvancedSettings(this=0x000000010a003c00) at AdvancedSettings.h:104
    frame #17: 0x000000010000b935 kodi.bin`std::__1::__shared_ptr_pointer<CAdvancedSettings*, std::__1::default_delete<CAdvancedSettings>, std::__1::allocator<CAdvancedSettings> >::__on_zero_shared() [inlined] std::__1::default_delete<CAdvancedSettings>::operator(this=0x0000000109405d08, __ptr=0x000000010a003c00)(CAdvancedSettings*) const at memory:2285
    frame #18: 0x000000010000b90c kodi.bin`std::__1::__shared_ptr_pointer<CAdvancedSettings*, std::__1::default_delete<CAdvancedSettings>, std::__1::allocator<CAdvancedSettings> >::__on_zero_shared(this=0x0000000109405cf0) at memory:3586
    frame #19: 0x000000010000bb91 kodi.bin`std::__1::shared_ptr<CAdvancedSettings>::~shared_ptr() [inlined] std::__1::__shared_count::__release_shared(this=0x0000000109405cf0) at memory:3490
    frame #20: 0x000000010000bb47 kodi.bin`std::__1::shared_ptr<CAdvancedSettings>::~shared_ptr() [inlined] std::__1::__shared_weak_count::__release_shared(this=0x0000000109405cf0) at memory:3532
    frame #21: 0x000000010000bb47 kodi.bin`std::__1::shared_ptr<CAdvancedSettings>::~shared_ptr(this=0x000000010940e260) at memory:4468
    frame #22: 0x000000010000aae5 kodi.bin`std::__1::shared_ptr<CAdvancedSettings>::~shared_ptr(this=0x000000010940e260) at memory:4466
    frame #23: 0x000000010000bafc kodi.bin`xbmcutil::GlobalsSingleton<CAdvancedSettings>::Deleter<std::__1::shared_ptr<CAdvancedSettings> >::~Deleter(this=0x00000001050f1ff0) at GlobalsHandling.h:117
    frame #24: 0x000000010000af85 kodi.bin`xbmcutil::GlobalsSingleton<CAdvancedSettings>::Deleter<std::__1::shared_ptr<CAdvancedSettings> >::~Deleter(this=0x00000001050f1ff0) at GlobalsHandling.h:117
    frame #25: 0x00007fff79a73ef2 libsystem_c.dylib`__cxa_finalize_ranges + 351
    frame #26: 0x00007fff79a741de libsystem_c.dylib`exit + 55
    frame #27: 0x00007fff799cb08c libdyld.dylib`start + 8
(lldb) 
```
For me, this actually (and as expected) fixes the crashes.

I've put the changes into two commits. First commit contains the changes needed to get rid of the global singleton, and just redefines g_advancedSettings. Second commit contains all the changes needed to actually eliminate all occurrences of g_advancedSettings from the source code.

Changes are runtime-tested on macOS, latest Kodi master and Jenkins is happy as well.

Although this is a larger code change, I suggest to include it for v18.

@MilhouseVH could you include this PR into your next testbuilds, please?