### PR TITLE
[guiinfo] Fix VideoPlayer.Title and MusicPlayer.Title

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -95,9 +95,15 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         value = GUIINFO::GetFileInfoLabelValueFromPath(info.m_info, value);
         return true;
       case PLAYER_TITLE:
-      case MUSICPLAYER_TITLE:
         value = tag->GetTitle();
         return !value.empty();
+      case MUSICPLAYER_TITLE:
+        value = tag->GetTitle();
+        if (value.empty())
+          value = item->GetLabel();
+        if (value.empty())
+          value = CUtil::GetTitleFromPath(item->GetPath());
+        return true;
       case LISTITEM_TITLE:
         value = tag->GetTitle();
         return true;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -102,9 +102,15 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         value = GUIINFO::GetFileInfoLabelValueFromPath(info.m_info, value);
         return true;
       case PLAYER_TITLE:
-      case VIDEOPLAYER_TITLE:
         value = tag->m_strTitle;
         return !value.empty();
+      case VIDEOPLAYER_TITLE:
+        value = tag->m_strTitle;
+        if (value.empty())
+          value = item->GetLabel();
+        if (value.empty())
+          value = CUtil::GetTitleFromPath(item->GetPath());
+        return true;
       case LISTITEM_TITLE:
         value = tag->m_strTitle;
         return true;


### PR DESCRIPTION
Fixes a regression introduced with https://github.com/xbmc/xbmc/pull/14439, reported here: https://forum.kodi.tv/showthread.php?tid=298461&pid=2778006#pid2778006

Runtime-tested on macOS, latest kodi master.