### PR TITLE
Controller dialog: Make it more awesome

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16866,7 +16866,13 @@ msgctxt "#35021"
 msgid "Get all"
 msgstr ""
 
-#empty strings from id 35022 to 35046
+#. Message shown in the controller dialog when there is nothing to map, for example hubs (multitaps) have no buttons
+#: xbmc/games/controllers/windows/GUIFeatureList.cpp
+msgctxt "#35022"
+msgid "Nothing to map"
+msgstr ""
+
+#empty strings from id 35023 to 35046
 
 #. Name of setting to configure peripheral add-ons
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -817,10 +817,11 @@ msgctxt "#185"
 msgid "Searching album"
 msgstr ""
 
+#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 #: xbmc/dialogs/GUIDialogSelect.cpp
-#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
+#: xbmc/games/controllers/windows/GUIControllerWindow.cpp
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#186"
 msgid "OK"
@@ -13891,12 +13892,13 @@ msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
-#: addons/skin.estuary/xml/MyPrograms.xml
+#: addons/skin.estuary/xml/DialogGameControllers.xml
 #: addons/skin.estuary/xml/Includes.xml
-#: addons/skin.estuary/xml/MyVideoNav.xml
-#: addons/skin.estuary/xml/MyPics.xml
-#: addons/skin.estuary/xml/MyMusicNav.xml
 #: addons/skin.estuary/xml/MyGames.xml
+#: addons/skin.estuary/xml/MyMusicNav.xml
+#: addons/skin.estuary/xml/MyPics.xml
+#: addons/skin.estuary/xml/MyPrograms.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
 msgctxt "#21452"
 msgid "Get more..."
 msgstr ""
@@ -14928,6 +14930,7 @@ msgstr ""
 
 #. Used as a title in the progress dialog when installing an add-on
 #: xbmc/addons/AddonInstaller.cpp
+#: xbmc/games/controllers/windows/ControllerInstaller.cpp
 msgctxt "#24057"
 msgid "Installing {0:s}..."
 msgstr ""
@@ -15075,6 +15078,7 @@ msgstr ""
 
 #. Used as a text in the progress dialog when installing an add-on
 #: xbmc/addons/AddonInstaller.cpp
+#: xbmc/games/controllers/windows/ControllerInstaller.cpp
 msgctxt "#24086"
 msgid "Installing add-on..."
 msgstr ""
@@ -16856,7 +16860,13 @@ msgctxt "#35020"
 msgid "Press all analog buttons now to detect them:[CR][CR]{0:s}"
 msgstr ""
 
-#empty strings from id 35021 to 35046
+#. Button in the controller configuration dialog to install all controller profiles
+#: addons/skin.estuary/xml/DialogGameControllers.xml
+msgctxt "#35021"
+msgid "Get all"
+msgstr ""
+
+#empty strings from id 35022 to 35046
 
 #. Name of setting to configure peripheral add-ons
 #: system/settings/settings.xml
@@ -16880,6 +16890,7 @@ msgstr ""
 #. Name of controller add-ons
 #: addons/skin.estuary/xml/DialogGameControllers.xml
 #: xbmc/addons/Addon.cpp
+#: xbmc/games/controllers/windows/ControllerInstaller.cpp
 #: xbmc/games/controllers/windows/GUIControllerWindow.cpp
 msgctxt "#35050"
 msgid "Controller profiles"
@@ -16942,6 +16953,7 @@ msgid "Would you like to reset this controller profile for all attached devices?
 msgstr ""
 
 #. Notice that all controller profiles are installed
+#: xbmc/games/controllers/windows/ControllerInstaller.cpp
 #: xbmc/games/controllers/windows/GUIControllerWindow.cpp
 msgctxt "#35062"
 msgid "All available controller profiles are installed."
@@ -17503,6 +17515,7 @@ msgstr ""
 
 #. Error message when a game client fails to install when a game is being launched
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+#: xbmc/games/controllers/windows/ControllerInstaller.cpp
 msgctxt "#35256"
 msgid "Failed to install add-on."
 msgstr ""
@@ -21393,6 +21406,7 @@ msgid "installed"
 msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
+#: xbmc/games/controllers/windows/ControllerInstaller.cpp
 msgctxt "#39020"
 msgid "The following additional add-ons will be installed"
 msgstr ""

--- a/addons/skin.estuary/xml/DialogGameControllers.xml
+++ b/addons/skin.estuary/xml/DialogGameControllers.xml
@@ -7,68 +7,87 @@
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
 			<width>1820</width>
-			<height>690</height>
+			<height>870</height>
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1820" />
-				<param name="height" value="690" />
+				<param name="height" value="870" />
 				<param name="header_label" value="$LOCALIZE[35058]" />
 				<param name="header_id" value="2" />
 			</include>
-			<control type="label">
-				<description>Controller profiles grouplist heading</description>
+			<control type="group">
+				<description>Controller list</description>
 				<top>90</top>
-				<left>15</left>
-				<width>330</width>
-				<height>25</height>
-				<font>font12</font>
-				<label>$LOCALIZE[35050]</label>
-				<align>center</align>
-				<aligny>center</aligny>
-				<textcolor>button_focus</textcolor>
-			</control>
-			<control type="image">
-				<left>-5</left>
-				<top>110</top>
-				<width>370</width>
-				<height>582</height>
-				<texture border="40">buttons/dialogbutton-nofo.png</texture>
-			</control>
-			<control type="grouplist" id="3">
-				<description>Controller profiles grouplist</description>
-				<left>15</left>
-				<top>130</top>
-				<width>330</width>
-				<height>540</height>
-				<onleft>9001</onleft>
-				<onright>5</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
-			</control>
-			<control type="button" id="10">
-				<description>Default controller button</description>
-				<height>60</height>
-				<width>330</width>
-				<align>center</align>
-				<aligny>center</aligny>
-				<font>font25_title</font>
-				<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
-				<texturenofocus />
+				<left>30</left>
+				<width>410</width>
+				<height>580</height>
+				<control type="label">
+					<description>Controller profiles grouplist heading</description>
+					<height>25</height>
+					<right>20</right>
+					<font>font12</font>
+					<label>$LOCALIZE[35050]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<textcolor>button_focus</textcolor>
+				</control>
+				<control type="image">
+					<description>Controller profiles grouplist background</description>
+					<top>20</top>
+					<bottom>-20</bottom>
+					<left>-20</left>
+					<right>0</right>
+					<texture border="40">buttons/dialogbutton-nofo.png</texture>
+				</control>
+				<control type="grouplist" id="3">
+					<description>Controller profiles grouplist</description>
+					<top>40</top>
+					<right>20</right>
+					<onleft>9001</onleft>
+					<onright>5</onright>
+					<onup>3</onup>
+					<ondown>3</ondown>
+					<pagecontrol>62</pagecontrol>
+				</control>
+				<control type="scrollbar" id="62">
+					<top>40</top>
+					<right>0</right>
+					<width>12</width>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="button" id="10">
+					<description>Default controller button</description>
+					<width>390</width>
+					<height>60</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font25_title</font>
+					<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+					<texturenofocus />
+				</control>
 			</control>
 			<control type="gamecontroller" id="31">
-				<left>400</left>
-				<top>108</top>
-				<width>547</width>
-				<height>547</height>
+				<top>130</top>
+				<left>470</left>
+				<width>540</width>
+				<height>540</height>
 			</control>
+			<!--
+			<control type="image">
+				<top>110</top>
+				<left>440</left>
+				<width>580</width>
+				<height>580</height>
+				<texture border="40">buttons/dialogbutton-nofo.png</texture>
+			</control>
+			-->
 			<control type="group">
-				<left>1000</left>
-				<width>410</width>
+				<description>Feature list</description>
 				<top>90</top>
-				<height>602</height>
+				<left>1040</left>
+				<width>410</width>
+				<height>580</height>
 				<control type="label">
 					<description>Feature list heading</description>
-					<left>20</left>
-					<right>20</right>
 					<height>25</height>
 					<font>font12</font>
 					<label>$LOCALIZE[35059]</label>
@@ -78,18 +97,17 @@
 				</control>
 				<control type="image">
 					<top>20</top>
-					<bottom>0</bottom>
+					<bottom>-20</bottom>
+					<left>-20</left>
 					<right>0</right>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="grouplist" id="5">
 					<description>Features grouplist</description>
-					<left>20</left>
-					<right>20</right>
 					<top>40</top>
-					<bottom>20</bottom>
+					<right>20</right>
 					<onleft>3</onleft>
-					<onright>61</onright>
+					<onright>9001</onright>
 					<onup>5</onup>
 					<ondown>5</ondown>
 					<pagecontrol>61</pagecontrol>
@@ -98,13 +116,11 @@
 					<right>0</right>
 					<top>40</top>
 					<width>12</width>
-					<bottom>20</bottom>
-					<onleft>5</onleft>
-					<onright>9001</onright>
 					<orientation>vertical</orientation>
 				</control>
 				<control type="button" id="7">
 					<description>Default feature button</description>
+					<width>390</width>
 					<height>60</height>
 					<left>20</left>
 					<right>20</right>
@@ -116,28 +132,26 @@
 				</control>
 				<control type="label" id="8">
 					<description>Feature group title</description>
-					<left>20</left>
-					<right>20</right>
-					<align>center</align>
-					<top>0</top>
+					<width>390</width>
 					<height>40</height>
+					<align>center</align>
 					<aligny>center</aligny>
 					<font>font20_title</font>
 					<textcolor>grey</textcolor>
 					<shadowcolor>black</shadowcolor>
 				</control>
-			</control>
-			<control type="image" id="9">
-				<description>Feature separator image</description>
-				<height>3</height>
-				<texture colordiffuse="AAAAAAAA" border="3">dialogs/separator-grey.png</texture>
+				<control type="image" id="9">
+					<description>Feature separator image</description>
+					<height>3</height>
+					<texture colordiffuse="AAAAAAAA" border="3">dialogs/separator-grey.png</texture>
+				</control>
 			</control>
 			<control type="grouplist" id="9001">
-				<right>20</right>
 				<top>110</top>
+				<right>20</right>
+				<width>340</width>
 				<onleft>5</onleft>
 				<onright>3</onright>
-				<width>350</width>
 				<itemgap>dialogbuttons_itemgap</itemgap>
 				<include content="DefaultDialogButton">
 					<param name="width" value="350" />
@@ -164,6 +178,29 @@
 					<param name="id" value="21" />
 					<param name="label" value="$LOCALIZE[35019]" />
 				</include>
+			</control>
+			<control type="group">
+				<description>Bottom controller description</description>
+				<bottom>30</bottom>
+				<left>30</left>
+				<right>30</right>
+				<height>140</height>
+				<control type="image">
+					<description>Controller description background image</description>
+					<top>-20</top>
+					<bottom>-20</bottom>
+					<left>-20</left>
+					<right>-20</right>
+					<texture border="40">buttons/dialogbutton-nofo.png</texture>
+				</control>
+				<control type="textbox" id="32">
+					<top>5</top>
+					<bottom>5</bottom>
+					<left>10</left>
+					<right>10</right>
+					<description>Controller description</description>
+					<textcolor>grey</textcolor>
+				</control>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.estuary/xml/DialogGameControllers.xml
+++ b/addons/skin.estuary/xml/DialogGameControllers.xml
@@ -170,6 +170,11 @@
 				</include>
 				<include content="DefaultDialogButton">
 					<param name="width" value="350" />
+					<param name="id" value="22" />
+					<param name="label" value="$LOCALIZE[35021]" />
+				</include>
+				<include content="DefaultDialogButton">
+					<param name="width" value="350" />
 					<param name="id" value="17" />
 					<param name="label" value="$LOCALIZE[10043]" />
 				</include>

--- a/xbmc/games/controllers/windows/CMakeLists.txt
+++ b/xbmc/games/controllers/windows/CMakeLists.txt
@@ -1,9 +1,11 @@
-set(SOURCES GUIConfigurationWizard.cpp
+set(SOURCES ControllerInstaller.cpp
+            GUIConfigurationWizard.cpp
             GUIControllerList.cpp
             GUIControllerWindow.cpp
             GUIFeatureList.cpp)
 
-set(HEADERS GUIConfigurationWizard.h
+set(HEADERS ControllerInstaller.h
+            GUIConfigurationWizard.h
             GUIControllerDefines.h
             GUIControllerList.h
             GUIControllerWindow.h

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ControllerInstaller.h"
+#include "addons/Addon.h"
+#include "addons/AddonInstaller.h"
+#include "addons/AddonManager.h"
+#include "dialogs/GUIDialogProgress.h"
+#include "dialogs/GUIDialogSelect.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "guilib/WindowIDs.h"
+#include "messaging/helpers/DialogOKHelper.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "FileItem.h"
+#include "ServiceBroker.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CControllerInstaller::CControllerInstaller() :
+  CThread("ControllerInstaller")
+{
+}
+
+void CControllerInstaller::Process()
+{
+  CGUIComponent *gui = CServiceBroker::GetGUI();
+  if (gui == nullptr)
+    return;
+
+  CGUIWindowManager &windowManager = gui->GetWindowManager();
+
+  auto pSelectDialog = windowManager.GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+  if (pSelectDialog == nullptr)
+    return;
+
+  auto pProgressDialog = windowManager.GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+  if (pProgressDialog == nullptr)
+    return;
+
+  ADDON::VECADDONS installableAddons;
+  CServiceBroker::GetAddonMgr().GetInstallableAddons(installableAddons, ADDON::ADDON_GAME_CONTROLLER);
+  if (installableAddons.empty())
+  {
+    // "Controller profiles"
+    // "All available controller profiles are installed."
+    MESSAGING::HELPERS::ShowOKDialogText(CVariant{ 35050 }, CVariant{ 35062 });
+    return;
+  }
+
+  CLog::Log(LOGDEBUG, "Controller installer: Found %u controller add-ons", installableAddons.size());
+
+  CFileItemList items;
+  for (const auto &addon : installableAddons)
+  {
+    CFileItemPtr item(new CFileItem(addon->Name()));
+    item->SetIconImage(addon->Icon());
+    items.Add(std::move(item));
+  }
+
+  pSelectDialog->Reset();
+  pSelectDialog->SetHeading(39020); // "The following additional add-ons will be installed"
+  pSelectDialog->SetUseDetails(true);
+  pSelectDialog->EnableButton(true, 186); // "OK""
+  for (const auto &it : items)
+    pSelectDialog->Add(*it);
+  pSelectDialog->Open();
+
+  if (!pSelectDialog->IsButtonPressed())
+  {
+    CLog::Log(LOGDEBUG, "Controller installer: User cancelled installation dialog");
+    return;
+  }
+
+  CLog::Log(LOGDEBUG, "Controller installer: Installing %u controller add-ons", installableAddons.size());
+
+  pProgressDialog->SetHeading(CVariant{ 24086 }); // "Installing add-on..."
+  pProgressDialog->SetLine(0, CVariant{ "" });
+  pProgressDialog->SetLine(1, CVariant{ "" });
+  pProgressDialog->SetLine(2, CVariant{ "" });
+
+  pProgressDialog->Open();
+
+  unsigned int installedCount = 0;
+  while (installedCount < installableAddons.size())
+  {
+    const auto &addon = installableAddons[installedCount];
+
+    // Set dialog text
+    const std::string progressTemplate = g_localizeStrings.Get(24057); // "Installing {0:s}..."
+    const std::string progressText = StringUtils::Format(progressTemplate, addon->Name());
+    pProgressDialog->SetLine(0, CVariant{ progressText });
+
+    // Set dialog percentage
+    const unsigned int percentage = 100 * (installedCount + 1) / installableAddons.size();
+    pProgressDialog->SetPercentage(percentage);
+
+    if (!CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), false, false))
+    {
+      CLog::Log(LOGERROR, "Controller installer: Failed to install %s", addon->ID().c_str());
+      // "Error"
+      // "Failed to install add-on."
+      MESSAGING::HELPERS::ShowOKDialogText(257, 35256);
+      break;
+    }
+
+    if (pProgressDialog->IsCanceled())
+    {
+      CLog::Log(LOGDEBUG, "Controller installer: User cancelled add-on installation");
+      break;
+    }
+
+    if (windowManager.GetActiveWindowOrDialog() != WINDOW_DIALOG_PROGRESS)
+    {
+      CLog::Log(LOGDEBUG, "Controller installer: Progress dialog is hidden, cancelling");
+      break;
+    }
+
+    installedCount++;
+  }
+
+  CLog::Log(LOGDEBUG, "Controller window: Installed %u controller add-ons", installedCount);
+  pProgressDialog->Close();
+}

--- a/xbmc/games/controllers/windows/ControllerInstaller.h
+++ b/xbmc/games/controllers/windows/ControllerInstaller.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/Thread.h"
+
+namespace KODI
+{
+namespace GAME
+{
+  class CControllerInstaller : public CThread
+  {
+  public:
+    CControllerInstaller();
+    ~CControllerInstaller() override = default;
+
+  protected:
+    // implementation of CThread
+    void Process() override;
+  };
+}
+}

--- a/xbmc/games/controllers/windows/GUIControllerDefines.h
+++ b/xbmc/games/controllers/windows/GUIControllerDefines.h
@@ -27,6 +27,7 @@
 #define CONTROL_GET_MORE                    20
 #define CONTROL_FIX_SKIPPING                21
 #define CONTROL_GAME_CONTROLLER             31
+#define CONTROL_CONTROLLER_DESCRIPTION      32
 
 #define MAX_CONTROLLER_COUNT  100 // large enough
 #define MAX_FEATURE_COUNT     200 // large enough

--- a/xbmc/games/controllers/windows/GUIControllerDefines.h
+++ b/xbmc/games/controllers/windows/GUIControllerDefines.h
@@ -21,13 +21,16 @@
 #define CONTROL_FEATURE_GROUP_TITLE         8
 #define CONTROL_FEATURE_SEPARATOR           9
 #define CONTROL_CONTROLLER_BUTTON_TEMPLATE  10
+#define CONTROL_GAME_CONTROLLER             31
+#define CONTROL_CONTROLLER_DESCRIPTION      32
+
+// GUI button IDs
 #define CONTROL_HELP_BUTTON                 17
 #define CONTROL_CLOSE_BUTTON                18
 #define CONTROL_RESET_BUTTON                19
 #define CONTROL_GET_MORE                    20
 #define CONTROL_FIX_SKIPPING                21
-#define CONTROL_GAME_CONTROLLER             31
-#define CONTROL_CONTROLLER_DESCRIPTION      32
+#define CONTROL_GET_ALL                     22
 
 #define MAX_CONTROLLER_COUNT  100 // large enough
 #define MAX_FEATURE_COUNT     200 // large enough

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -169,7 +169,7 @@ void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
   {
     using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg);
+    CApplicationMessenger::GetInstance().SendGUIMessage(msg, m_guiWindow->GetID());
   }
 }
 

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -132,6 +132,11 @@ void CGUIControllerList::OnFocus(unsigned int controllerIndex)
     CGUIGameController* pController = dynamic_cast<CGUIGameController*>(m_guiWindow->GetControl(CONTROL_GAME_CONTROLLER));
     if (pController)
       pController->ActivateController(controller);
+
+    // Update controller description
+    CGUIMessage msg(GUI_MSG_LABEL_SET, m_guiWindow->GetID(), CONTROL_CONTROLLER_DESCRIPTION);
+    msg.SetLabel(controller->Description());
+    m_guiWindow->OnMessage(msg);
   }
 }
 

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -179,21 +179,6 @@ bool CGUIControllerList::RefreshControllers(void)
   CGameServices& gameServices = CServiceBroker::GetGameServices();
   ControllerVector newControllers = gameServices.GetControllers();
 
-  // Don't show an empty feature list in the GUI
-  auto HasButtonForFeature = [this](const CControllerFeature &feature)
-    {
-      return m_featureList->HasButton(feature.Type());
-    };
-
-  auto HasButtonForController = [&](const ControllerPtr &controller)
-    {
-      const auto &features = controller->Features();
-      auto it = std::find_if(features.begin(), features.end(), HasButtonForFeature);
-      return it == features.end();
-    };
-
-  newControllers.erase(std::remove_if(newControllers.begin(), newControllers.end(), HasButtonForController), newControllers.end());
-
   // Filter by current game add-on
   if (m_gameClient)
   {

--- a/xbmc/games/controllers/windows/GUIControllerWindow.h
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.h
@@ -12,10 +12,13 @@
 #include "games/GameTypes.h"
 #include "guilib/GUIDialog.h"
 
+#include <memory>
+
 namespace KODI
 {
 namespace GAME
 {
+  class CControllerInstaller;
   class IControllerList;
   class IFeatureList;
 
@@ -44,6 +47,7 @@ namespace GAME
 
     // Action for the available button
     void GetMoreControllers(void);
+    void GetAllControllers();
     void ResetController(void);
     void ShowHelp(void);
     void ShowButtonCaptureDialog(void);
@@ -53,6 +57,9 @@ namespace GAME
 
     // Game paremeters
     GameClientPtr m_gameClient;
+
+    // Controller parameters
+    std::unique_ptr<CControllerInstaller> m_installer;
   };
 }
 }

--- a/xbmc/games/controllers/windows/GUIFeatureList.cpp
+++ b/xbmc/games/controllers/windows/GUIFeatureList.cpp
@@ -109,32 +109,29 @@ void CGUIFeatureList::Load(const ControllerPtr& controller)
       buttons = GetButtons(itGroup->features, m_buttonCount);
     }
 
-    if (!buttons.empty())
+    // Just in case
+    if (m_buttonCount + buttons.size() >= MAX_FEATURE_COUNT)
+      break;
+
+    // Add a separator if the group list isn't empty
+    if (m_guiFeatureSeparator && m_guiList->GetTotalSize() > 0)
     {
-      // Just in case
-      if (m_buttonCount + buttons.size() >= MAX_FEATURE_COUNT)
-        break;
-
-      // Add a separator if the group list isn't empty
-      if (m_guiFeatureSeparator && m_guiList->GetTotalSize() > 0)
-      {
-        CGUIFeatureSeparator* pSeparator = new CGUIFeatureSeparator(*m_guiFeatureSeparator, m_buttonCount);
-        m_guiList->AddControl(pSeparator);
-      }
-
-      // Add the group title
-      if (m_guiGroupTitle && !groupName.empty())
-      {
-        CGUIFeatureGroupTitle* pGroupTitle = new CGUIFeatureGroupTitle(*m_guiGroupTitle, groupName, m_buttonCount);
-        m_guiList->AddControl(pGroupTitle);
-      }
-
-      // Add the buttons
-      for (CGUIButtonControl* pButton : buttons)
-        m_guiList->AddControl(pButton);
-
-      m_buttonCount += buttons.size();
+      CGUIFeatureSeparator* pSeparator = new CGUIFeatureSeparator(*m_guiFeatureSeparator, m_buttonCount);
+      m_guiList->AddControl(pSeparator);
     }
+
+    // Add the group title
+    if (m_guiGroupTitle && !groupName.empty())
+    {
+      CGUIFeatureGroupTitle* pGroupTitle = new CGUIFeatureGroupTitle(*m_guiGroupTitle, groupName, m_buttonCount);
+      m_guiList->AddControl(pGroupTitle);
+    }
+
+    // Add the buttons
+    for (CGUIButtonControl* pButton : buttons)
+      m_guiList->AddControl(pButton);
+
+    m_buttonCount += buttons.size();
   }
 }
 
@@ -228,6 +225,14 @@ std::vector<CGUIFeatureList::FeatureGroup> CGUIFeatureList::GetFeatureGroups(con
       group.features.emplace_back(feature);
       groups.emplace_back(std::move(group));
     }
+  }
+
+  // If there are no features, add an empty group
+  if (groups.empty())
+  {
+    FeatureGroup group;
+    group.groupName = g_localizeStrings.Get(35022); // "Nothing to map"
+    groups.emplace_back(std::move(group));
   }
 
   return groups;


### PR DESCRIPTION
This improves the controller dialog in several ways:

First, @da-anda and @pkerling removed all logos from controllers in https://github.com/kodi-game/controller-topology-project/pull/30. Just to be safe.

Next, I've exposed the controller descriptions I wrote as part of the Controller Topology Project. Even though logos are gone, we could still be targeted by &lt;insert litigious game company>. Showing descriptions strengthens our argument for fair use because it becomes informative and historical.

Next, because it's so awesome to read descriptions about all controllers, I added "Get all" button below the "Get more..." button to install the entire controller topology project. I've never observed anyone actually using the "Get more..." button, but *I* wanted a way to install everything in one click.

Next, I removed some code that hides controllers with no mappable features, such as hubs and unfinished controllers. Even though they can't be mapped, with descriptions, it's still fun to read about them.

Finally, I fixed a bug that didn't refresh controller profiles when new ones are installed.

TODO: When the list refreshes with a new controller, it should be made active.

## Motivation and Context
Adding ideas that came to me during my DevCon presentation in Sofia.

## How Has This Been Tested?
It probably hard-crashes on startup.

But seriously, test builds are here: https://github.com/garbear/xbmc/releases/tag/retroplayer-18beta3-20181001

## Screenshots (if appropriate):
Controller descriptions:

![screen shot 2018-09-30 at 1 30 06 pm](https://user-images.githubusercontent.com/531482/46256572-21cce180-c4b5-11e8-8a48-bc4428af024d.png)

"Get all" dialog:

![screen shot 2018-09-30 at 1 30 17 pm](https://user-images.githubusercontent.com/531482/46256594-71aba880-c4b5-11e8-8001-1897ce80ab8e.png)

Progress dialog while installing controller add-ons:

![screen shot 2018-09-30 at 1 31 02 pm](https://user-images.githubusercontent.com/531482/46256599-7cfed400-c4b5-11e8-852e-5e03e966cd76.png)

Controller profile with nothing to map:
![screen shot 2018-09-30 at 1 33 10 pm](https://user-images.githubusercontent.com/531482/46256612-acaddc00-c4b5-11e8-8e06-299c5b3e36cb.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
