### PR TITLE
Game OSD: Extend help dialog to explain lack of remote support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17472,7 +17472,13 @@ msgctxt "#35235"
 msgid "Press {0:s} to open the in-game menu."
 msgstr ""
 
-#empty strings from id 35236 to 35249
+#. Additional help text shown when the user first plays a game. This will be removed in the future.
+#: addons/skin.estuary/xml/GameOSD.xml
+msgctxt "#35236"
+msgid "In this release, only controllers can be used to play games."
+msgstr ""
+
+#empty strings from id 35237 to 35249
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#35250"

--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -10,13 +10,13 @@
 				<visible>System.GetBool(gamesgeneral.showosdhelp)</visible>
 				<defaultcontrol always="true">1103</defaultcontrol>
 				<centerleft>50%</centerleft>
-				<height>910</height>
+				<height>1040</height>
 				<centertop>50%</centertop>
 				<width>700</width>
 				<animation effect="fade" time="200">VisibleChange</animation>
 				<include content="DialogBackgroundCommons">
 					<param name="width" value="700" />
-					<param name="height" value="910" />
+					<param name="height" value="1040" />
 					<param name="header_label" value="$LOCALIZE[35221]" />
 					<param name="header_id" value="2" />
 				</include>
@@ -36,6 +36,15 @@
 							<left>30</left>
 							<width>640</width>
 							<height>640</height>
+						</control>
+						<control type="textbox">
+							<description>Additional help text. This will be removed in future versions.</description>
+							<bottom>30</bottom>
+							<left>30</left>
+							<right>30</right>
+							<height>130</height>
+							<font>font13</font>
+							<label>$LOCALIZE[35236]</label>
 						</control>
 						<control type="button">
 							<description>Button to close the dialog</description>


### PR DESCRIPTION
This adds a second message to the game OSD help dialog (shown on first run) that explains that only controllers are supported. The message will be removed when gameplay supports remote input.

@da-anda what do you think?

## Motivation and Context
Watched @Razzeee start 2048 with a remote control, and was confused when the directions did not make the tiles move.

## How Has This Been Tested?
Tested on OSX.

## Screenshots (if appropriate):
![screen shot 2018-09-30 at 5 21 24 pm](https://user-images.githubusercontent.com/531482/46258565-b7786900-c4d5-11e8-84cd-90ee5a319361.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
