### PR TITLE
Add fourcc, colorspace and colorrange to inputstream API

### DIFF
--- a/xbmc/addons/binary-addons/AddonInstanceHandler.h
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.h
@@ -36,8 +36,8 @@ namespace ADDON
 
     ADDON_STATUS CreateInstance(KODI_HANDLE instance);
     void DestroyInstance();
-    const AddonDllPtr& Addon() { return m_addon; }
-    BinaryAddonBasePtr GetAddonBase() { return m_addonBase; };
+    const AddonDllPtr& Addon() const { return m_addon; }
+    BinaryAddonBasePtr GetAddonBase() const { return m_addonBase; };
 
   private:
     ADDON_TYPE m_type;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -120,6 +120,31 @@ extern "C" {
       FLAG_HEARING_IMPAIRED = 0x0080,
       FLAG_VISUAL_IMPAIRED = 0x0100
     };
+
+    enum INPUTSTREAM_COLORSPACE
+    {
+      COLORSPACE_UNKNOWN,
+      COLORSPACE_BT709,
+      COLORSPACE_BT470M,
+      COLORSPACE_BT470BG,
+      COLORSPACE_SMPTE170M,
+      COLORSPACE_SMPTE240M,
+      COLORSPACE_FILM,
+      COLORSPACE_BT2020,
+      COLORSPACE_SMPTE428,
+      COLORSPACE_SMPTEST428_1,
+      COLORSPACE_SMPTE431,
+      COLORSPACE_SMPTE432,
+      COLORSPACE_JEDEC_P22
+    };
+
+    enum INPUTSTREAM_COLORRANGE
+    {
+      COLORRANGE_UNKNOWN,
+      COLORRANGE_LIMITED,
+      COLORRANGE_FULLRANGE
+    };
+
     uint32_t m_flags;
 
     char m_name[256];                    /*!< @brief (optinal) name of the stream, \0 for default handling */
@@ -139,6 +164,7 @@ extern "C" {
     unsigned int m_Width;                /*!< @brief width of the stream reported by the demuxer */
     float m_Aspect;                      /*!< @brief display aspect of stream */
 
+
     unsigned int m_Channels;             /*!< @brief (required) amount of channels */
     unsigned int m_SampleRate;           /*!< @brief (required) sample rate */
     unsigned int m_BitRate;              /*!< @brief (required) bit rate */
@@ -146,6 +172,11 @@ extern "C" {
     unsigned int m_BlockAlign;
 
     CRYPTO_INFO m_cryptoInfo;
+
+    // new in API version 2.0.8
+    unsigned int m_codecFourCC;          /*!< @brief Codec If available, the fourcc code codec */
+    INPUTSTREAM_COLORSPACE m_colorSpace; /*!< @brief definition of colorspace */
+    INPUTSTREAM_COLORRANGE m_colorRange; /*!< @brief color range if available */
   };
 
   struct INPUTSTREAM_TIMES

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -87,7 +87,7 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.7"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.8"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.7"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -373,6 +373,11 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   demuxStream->flags = static_cast<StreamFlags>(stream.m_flags);
   demuxStream->language = stream.m_language;
 
+  if (GetAddonBase()->Version() >= AddonVersion("2.0.8"))
+  {
+    demuxStream->codec_fourcc = stream.m_codecFourCC;
+  }
+
   if (stream.m_ExtraData && stream.m_ExtraSize)
   {
     demuxStream->ExtraData = new uint8_t[stream.m_ExtraSize];


### PR DESCRIPTION
## Description
Add fourcc, colorspace and colorrange to inputstream API

## Motivation and Context
Support dvhe (HEVC + Dolby Vision) for HDR streams

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
