### PR TITLE
[android] bump targetsdk to 26 and handle runtime security

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         applicationId "@APP_PACKAGE@"
         minSdkVersion 21
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode @APP_VERSION_CODE_ANDROID@
         versionName "@APP_VERSION@"
     }

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.Enumeration;
 import java.util.ArrayList;
 
+import android.Manifest;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -49,6 +50,8 @@ import android.content.BroadcastReceiver;
 import android.content.IntentFilter;
 import android.os.Environment;
 
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
 public class Splash extends Activity
 {
 
@@ -61,11 +64,17 @@ public class Splash extends Activity
   private static final int CachingDone = 6;
   private static final int WaitingStorageChecked = 7;
   private static final int StorageChecked = 8;
+  private static final int CheckingPermissions = 9;
+  private static final int CheckingPermissionsDone = 10;
+  private static final int CheckingPermissionsInfo = 11;
+  private static final int CheckExternalStorage = 12;
   private static final int DownloadingObb = 90;
   private static final int DownloadObbDone = 91;
   private static final int StartingXBMC = 99;
 
   private static final String TAG = "@APP_NAME@";
+
+  private static final int PERMISSION_RESULT_CODE = 8947;
 
   private String mCpuinfo = "";
   private ArrayList<String> mMounts = new ArrayList<String>();
@@ -87,6 +96,7 @@ public class Splash extends Activity
   private boolean mExternalStorageChecked = false;
   private boolean mCachingDone = false;
   private boolean mInstallLibs = false;
+  private boolean mPermissionOK = false;
 
   private class StateMachine extends Handler
   {
@@ -108,6 +118,38 @@ public class Splash extends Activity
         case InError:
           showErrorDialog(mSplash, "Error", mErrorMsg);
           break;
+        case CheckingPermissionsInfo:
+          AlertDialog dialog = new AlertDialog.Builder(mSplash).create();
+          dialog.setCancelable(false);
+          dialog.setTitle("Info");
+          dialog.setMessage("@APP_NAME@ requires access to your device media and files to function. Please allow this via the following dialogue box or @APP_NAME@ will exit.");
+          dialog.setButton(DialogInterface.BUTTON_NEUTRAL, "continue", new DialogInterface.OnClickListener()
+          {
+            @Override
+            public void onClick(DialogInterface dialog, int which)
+            {
+              mStateMachine.sendEmptyMessage(CheckingPermissions);
+            }
+          });
+          dialog.show();
+          break;
+        case CheckingPermissions:
+          mSplash.mTextView.setText("Asking for permissions...");
+          mSplash.mProgress.setVisibility(View.INVISIBLE);
+
+          requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    PERMISSION_RESULT_CODE);
+          break;
+        case CheckingPermissionsDone:
+          if (mPermissionOK)
+            sendEmptyMessage(CheckExternalStorage);
+          else
+          {
+            mErrorMsg = "Permission denied!! Exiting...";
+            sendEmptyMessage(InError);
+            break;
+          }
+          break;
         case Checking:
           break;
         case Clearing:
@@ -120,10 +162,26 @@ public class Splash extends Activity
           new FillCache(mSplash).execute();
           break;
         case Caching:
+          if (!mCachingDone)
+            new FillCache(mSplash).execute();
+          else
+            mStateMachine.sendEmptyMessage(CachingDone);
           break;
         case CachingDone:
           mSplash.mCachingDone = true;
           sendEmptyMessage(StartingXBMC);
+          break;
+        case CheckExternalStorage:
+          if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState()))
+          {
+            mExternalStorageChecked = true;
+            sendEmptyMessage(StorageChecked);
+          }
+          else
+          {
+            startWatchingExternalStorage();
+            sendEmptyMessage(WaitingStorageChecked);
+          }
           break;
         case WaitingStorageChecked:
           mSplash.mTextView.setText("Waiting for external storage...");
@@ -138,6 +196,8 @@ public class Splash extends Activity
           else
           {
             SetupEnvironment();
+            MigrateUserData();
+
             if (mState == InError)
             {
               sendEmptyMessage(InError);
@@ -700,6 +760,40 @@ public class Splash extends Activity
     return m.find();
   }
 
+  private boolean CheckPermissions()
+  {
+    boolean retVal = false;
+    if (android.os.Build.VERSION.SDK_INT > 22)
+    {
+      int permissionCheck;
+      permissionCheck = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+      if (permissionCheck == PERMISSION_GRANTED)
+        retVal = true;
+    }
+    else
+      retVal=  true;
+
+    return retVal;
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults)
+  {
+    switch (requestCode)
+    {
+      case PERMISSION_RESULT_CODE:
+      {
+        // If request is cancelled, the result arrays are empty.
+        if (grantResults.length > 0
+                && grantResults[0] == PERMISSION_GRANTED)
+        {
+          mPermissionOK = true;
+        }
+      }
+    }
+    mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+  }
+
   void updateExternalStorageState()
   {
     String state = Environment.getExternalStorageState();
@@ -847,21 +941,29 @@ public class Splash extends Activity
     if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState()))
       mExternalStorageChecked = true;
 
-    if (mState != InError && mExternalStorageChecked)
+    mPermissionOK = CheckPermissions();
+    if (!mPermissionOK)
     {
-      mState = ChecksDone;
-
-      SetupEnvironment();
-      MigrateUserData();
-
-      if ((mState != DownloadingObb && mState != InError) && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified() && !mInstallLibs)
+      mState = CheckingPermissionsInfo;
+    }
+    else
+    {
+      if (mState != InError && mExternalStorageChecked)
       {
-        mState = CachingDone;
-        mCachingDone = true;
+        mState = ChecksDone;
+
+        SetupEnvironment();
+        MigrateUserData();
+
+        if ((mState != DownloadingObb && mState != InError) && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified() && !mInstallLibs)
+        {
+          mState = CachingDone;
+          mCachingDone = true;
+        }
       }
     }
 
-    if ((mState != DownloadingObb && mState != InError) && mCachingDone && mExternalStorageChecked)
+    if ((mState != DownloadingObb && mState != InError) && mCachingDone && mExternalStorageChecked && mPermissionOK)
     {
       startXBMC();
       return;
@@ -871,7 +973,7 @@ public class Splash extends Activity
     mProgress = (ProgressBar) findViewById(R.id.progressBar1);
     mTextView = (TextView) findViewById(R.id.textView1);
 
-    if (mState == DownloadingObb || mState == InError)
+    if (mState == DownloadingObb || mState == InError || mState == CheckingPermissionsInfo)
     {
       mStateMachine.sendEmptyMessage(mState);
       return;


### PR DESCRIPTION
## Description
Bump android targetsdk to 26 and check `WRITE_EXTERNAL_STORAGE` at runtime (Kodi star)for SDK >= 22.

## Motivation and Context
Google Play will require that app updates target Android 8.0 (API level 26) from November 1, 2018.

## How Has This Been Tested?
- targetsdk 22: still works
- targetsdk 26: permission for writing to storage is asked at first Kodi start

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
