### PR TITLE
Controller dialog: Fix keyboard and mouse ignored in sub-dialogs

### DIFF
--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -49,6 +49,19 @@ bool CGUIDialogAxisDetection::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonM
   return true;
 }
 
+bool CGUIDialogAxisDetection::AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) const
+{
+  switch (type)
+  {
+  case JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS:
+    return true;
+  default:
+    break;
+  }
+
+  return false;
+}
+
 void CGUIDialogAxisDetection::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap, unsigned int axisIndex)
 {
   AddAxis(buttonMap->DeviceName(), axisIndex);

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
@@ -26,6 +26,7 @@ namespace GAME
     virtual ~CGUIDialogAxisDetection() = default;
 
     // specialization of IButtonMapper via CGUIDialogButtonCapture
+    bool AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) const override;
     void OnLateAxis(const JOYSTICK::IButtonMap* buttonMap, unsigned int axisIndex) override;
 
   protected:

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -20,6 +20,20 @@
 using namespace KODI;
 using namespace GAME;
 
+bool CGUIDialogIgnoreInput::AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) const
+{
+  switch (type)
+  {
+  case JOYSTICK::PRIMITIVE_TYPE::BUTTON:
+  case JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS:
+    return true;
+  default:
+    break;
+  }
+
+  return false;
+}
+
 std::string CGUIDialogIgnoreInput::GetDialogText()
 {
   // "Some controllers have buttons and axes that interfere with mapping. Press

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
@@ -25,6 +25,9 @@ namespace GAME
 
     virtual ~CGUIDialogIgnoreInput() = default;
 
+    // specialization of IButtonMapper via CGUIDialogButtonCapture
+    bool AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) const override;
+
   protected:
     // implementation of CGUIDialogButtonCapture
     virtual std::string GetDialogText() override;

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -55,6 +55,7 @@ namespace GAME
     // implementation of IButtonMapper
     virtual std::string ControllerID(void) const override { return m_strControllerId; }
     virtual bool NeedsCooldown(void) const override { return true; }
+    virtual bool AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) const override { return true; }
     virtual bool MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
                               IKeymap* keymap,
                               const JOYSTICK::CDriverPrimitive& primitive) override;

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -364,16 +364,25 @@ CButtonMapping::CButtonMapping(IButtonMapper* buttonMapper, IButtonMap* buttonMa
 
 bool CButtonMapping::OnButtonMotion(unsigned int buttonIndex, bool bPressed)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::BUTTON))
+    return false;
+
   return GetButton(buttonIndex).OnMotion(bPressed);
 }
 
 bool CButtonMapping::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::HAT))
+    return false;
+
   return GetHat(hatIndex).OnMotion(state);
 }
 
 bool CButtonMapping::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::SEMIAXIS))
+    return false;
+
   return GetAxis(axisIndex, position).OnMotion(position);
 }
 
@@ -389,21 +398,33 @@ void CButtonMapping::ProcessAxisMotions(void)
 
 bool CButtonMapping::OnKeyPress(const CKey& key)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::KEY))
+    return false;
+
   return GetKey(static_cast<XBMCKey>(key.GetKeycode())).OnMotion(true);
 }
 
 bool CButtonMapping::OnPosition(int x, int y)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::RELATIVE_POINTER))
+    return false;
+
   return GetPointer().OnMotion(x, y);
 }
 
 bool CButtonMapping::OnButtonPress(MOUSE::BUTTON_ID button)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::MOUSE_BUTTON))
+    return false;
+
   return GetMouseButton(button).OnMotion(true);
 }
 
 void CButtonMapping::OnButtonRelease(MOUSE::BUTTON_ID button)
 {
+  if (!m_buttonMapper->AcceptsPrimitive(PRIMITIVE_TYPE::MOUSE_BUTTON))
+    return;
+
   GetMouseButton(button).OnMotion(false);
 }
 

--- a/xbmc/input/joysticks/interfaces/IButtonMapper.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMapper.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "input/joysticks/JoystickTypes.h"
+
 #include <map>
 #include <string>
 
@@ -50,6 +52,15 @@ namespace JOYSTICK
      *         timeout from the previous command.
      */
     virtual bool NeedsCooldown(void) const = 0;
+
+    /*!
+     * \brief Return true if the button mapper accepts primitives of the given type
+     *
+     * \param type The primitive type
+     *
+     * \return True if the button mapper can map the primitive type, false otherwise
+     */
+    virtual bool AcceptsPrimitive(PRIMITIVE_TYPE type) const = 0;
 
     /*!
      * \brief Handle button/hat press or axis threshold

--- a/xbmc/input/joysticks/interfaces/IButtonMapper.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMapper.h
@@ -43,12 +43,12 @@ namespace JOYSTICK
     virtual std::string ControllerID(void) const = 0;
 
     /*!
-    * \brief Return true if the button mapper wants a cooldown between button
-    *        mapping commands
-    *
-    * \return True to only send button mapping commands that occur after a small
-    *         timeout from the previous command.
-    */
+     * \brief Return true if the button mapper wants a cooldown between button
+     *        mapping commands
+     *
+     * \return True to only send button mapping commands that occur after a small
+     *         timeout from the previous command.
+     */
     virtual bool NeedsCooldown(void) const = 0;
 
     /*!


### PR DESCRIPTION
Currently, the controller dialog has two sub-dialogs for specifying input to ignore and detecting axes. However, when one is opened, it can't be dismissed with the keyboard or mouse (only controller) because all input is captured. This PR changes the sub-dialogs to only capture controller buttons and axes.

## Motivation and Context
Needed something to do on my flight home from Sofia.

## How Has This Been Tested?
Tested on OSX. Mouse and keyboard are no longer captured and successfully dismiss the dialog.

## Screenshots (if appropriate):
Sub-dialog for specifying buttons/axes to ignore:

![screen shot 2018-10-01 at 12 20 32 pm](https://user-images.githubusercontent.com/531482/46283348-74b99e00-c574-11e8-86aa-52829fb88c36.png)

After this change, mouse and keyboard can dismiss the dialog.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
