### PR TITLE
[guiinfo] Fix Visualisation.Locked.

### DIFF
--- a/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VisualisationGUIInfo.cpp
@@ -86,6 +86,7 @@ bool CVisualisationGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int 
       {
         CGUIVisualisationControl *pVis = static_cast<CGUIVisualisationControl*>(msg.GetPointer());
         value = pVis->IsLocked();
+        return true;
       }
       break;
     }


### PR DESCRIPTION
Fixes a small guiinfo regression; reported here: https://forum.kodi.tv/showthread.php?tid=336003

Runtime-tested the fix on macOS, latest kodi master.