### PR TITLE
[Variables.xml] fix Missing text when sorting from inside addon

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -80,6 +80,8 @@
 		<value condition="String.IsEmpty(Container.PluginName) + Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[556])">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
 		<value condition="String.IsEqual(Container.SortMethod,$LOCALIZE[556])">$INFO[ListItem.Year]</value>
 		<value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
+		<value condition="Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[562])">$INFO[ListItem.Year]</value>
+		<value condition="Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[563])">$INFO[ListItem.Rating]</value>
 		<value>$INFO[ListItem.Label2]</value>
 	</variable>
 	<variable name="ShiftLeftTextBoxVar">


### PR DESCRIPTION
## Description
Fix for missing variables for year/rating sorting inside addon that have setContent(tvshows);

Currently this is omitted for addons, and show incorrect data: for rating showing year, and for year showing nothing.
Label2 is dynamic after Kodi17 and addon creator is unable to set it to correct data from inside addon; Im talking about label2 because that is what should be shown when non condition is meant. 

## Motivation and Context
When addon creator set ListItem as `isFolder=True` and `setContent(tvshows)` the default skin don't populate Label2 dynamic content resulting in wrong data displaying: 
- when folders are sorted by rating they show label2 as year
- when folders are sorted by year they show label2 as empty
- This does work correct for `isFolder=False` resulting in bad end-user experience with more advanced addons.

## How Has This Been Tested?
I created an addon that server TvShows information as folder, with episode inside folders. When I wanted to sort shows by rating I only saw years. I tried all suggestion on forum with few Team-Kodi members involved. With old forum post on kodi site I found our that this rule work differently for `isFolder` being `True` and `False`. With limitation as being only able to `play` any non folder type of item in list I started digging into skins. All other skins from official repo acted as intended - only the default one was broken. I started to looking thru xmls and found out that the missing data is what `Label2` is, then put Label2 as separate object on top of skin so I could see what value it has. I end up finding `Variable` that include text in place that I was missing data. From what I saw this was a valid approach before Kodi17 when Label2 was controlled by addon creator, but as for now (kodi17) Label2 is not controlled so I cannot put year/rating there when I detect given sorting. I then started to look how others skin support this and find out few of those lines, then I came up the code so its the universal as it can go. Tested it with and without Library to see if something got broken (it shouldn't and it didn't). 

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed