### PR TITLE
[fix] Fix a stack overflow in LangCodeExpander

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -331,7 +331,13 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
     }
 
     if (tmp.length() == 3)
+    {
+      // there's only an iso639-2 code that is identical to the language name, e.g. Yao
+      if (StringUtils::EqualsNoCase(tmp, lang))
+        return false;
+
       return ConvertToISO6391(tmp, code);
+    }
   }
 
   return false;


### PR DESCRIPTION
 If there's no iso639-1 code and the iso639-2 code is identical to the language name the stack overflows.
This happens for 'Yao' for example.