### PR TITLE
Add PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE flag

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -98,7 +98,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.10.2"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.10.3"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "5.10.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -153,6 +153,7 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE     = 0x00800000; /*!< @brief this type should not appear on any create menus unless associated with an EPG tag with 'series' attributes (EPG_TAG.iFlags & EPG_TAG_FLAG_IS_SERIES || EPG_TAG.iSeriesNumber > 0 || EPG_TAG.iEpisodeNumber > 0 || EPG_TAG.iEpisodePartNumber > 0). Implies PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL              = 0x01000000; /*!< @brief this type supports 'any channel', for example when defining a timer rule that should match any channel instaed of a particular channel */
   const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE = 0x02000000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag with a series link */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE          = 0x04000000; /*!< @brief this type allows deletion of an otherwise read-only timer */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -497,7 +497,7 @@ namespace PVR
       if (timer && (!item.GetEPGInfoTag() || !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER)) && !timer->IsRecording())
       {
         const CPVRTimerTypePtr timerType(timer->GetTimerType());
-        return  timerType && !timerType->IsReadOnly();
+        return  timerType && timerType->AllowsDelete();
       }
 
       return false;

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -781,7 +781,7 @@ namespace PVR
         return false;
       }
     }
-    else if (timer->HasTimerType() && timer->GetTimerType()->IsReadOnly())
+    else if (timer->HasTimerType() && !timer->GetTimerType()->AllowsDelete())
     {
       return false;
     }

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -141,6 +141,12 @@ namespace PVR
     bool IsReadOnly() const { return (m_iAttributes & PVR_TIMER_TYPE_IS_READONLY) > 0; }
 
     /*!
+     * @brief Check whether this type allows deletion.
+     * @return True if type allows deletion, false otherwise.
+     */
+    bool AllowsDelete() const { return !IsReadOnly() || SupportsReadOnlyDelete(); }
+
+    /*!
      * @brief Check whether this type forbids creation of new timers of this type.
      * @return True if new instances are forbidden, false otherwise.
      */
@@ -279,6 +285,12 @@ namespace PVR
      * @return True if any channel is supported, false otherwise.
      */
     bool SupportsAnyChannel() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL) > 0; }
+
+    /*!
+     * @brief Check whether this type supports deletion of an otherwise read-only timer.
+     * @return True if read-only deletion is supported, false otherwise.
+     */
+    bool SupportsReadOnlyDelete() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE) > 0; }
 
     /*!
      * @brief Obtain a list with all possible values for the priority attribute.


### PR DESCRIPTION
This PR adds a new PVR flag, PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE, and updates the PVR API to 5.10.3 (compatible with 5.10.0)

## Description
The new flag is intended to allow PVRs to specify timer types that are generally read-only in nature but still allow deletion through Kodi.  The existing PVR_TIMER_TYPE_IS_READONLY flag does not allow deletion when specified as a PVR timer type flag.

## Motivation and Context
Admittedly this is a niche case that may only benefit my PVR client addon (https://github.com/djp952/pvr.hdhomerundvr).  The motivation is that timers/timer rules may be generally read-only in nature in that the user cannot modify the parameters of the timer (rule), but that also excludes them from deleting the timer (rule) in the existing implementation.  This proposed change adds a flag that indicates a read-only timer can still be deleted by the user.

## How Has This Been Tested?
This has been tested using my own PVR client (https://github.com/djp952/pvr.hdhomerundvr) for the HDHomeRun DVR system, on Windows 10 x64 using the latest XBMC code available at the time of the PR.  I set breakpoints at each place the existing PVRTimerType::IsReadOnly() is invoked and made a determination if my proposed function PVRTimerType::SupportsReadOnlyDelete() should be invoked to negate that result.  I only found two places where this would be relevant - when deciding if the "Delete" option should be shown, and again when the Delete Timer operation is invoked.

To unit test the change, I incremented the PVR API to version 5.10.3 and added a handful of MANUAL timers via my PVR.  I confirmed that I did not have to increment the PVR API version in my addon.xml file, and stepped through the aforementioned breakpoints.  The Kodi UI presented me with Delete option(s) that were not available prior to the change, and they worked as expected.  I also confirmed that the Edit option(s) that were now presented display a read-only view of the Timer (Rule) as expected.

It may go without saying, but I recommend ksooo review this PR and decide if it's too much of a niche case for inclusion or if there is a more ambitious plan in the works for future versions that would negate this change or otherwise render it useless.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
