### PR TITLE
Controller dialog: Hide features not supported by game add-on

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -127,12 +127,47 @@ void CGameClientInput::Stop()
   m_inputCallback = nullptr;
 }
 
+bool CGameClientInput::HasFeature(const std::string &controllerId, const std::string &featureName) const
+{
+  bool bHasFeature = false;
+
+  try
+  {
+    bHasFeature = m_struct.toAddon.HasFeature(controllerId.c_str(), featureName.c_str());
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in HasFeature()", m_gameClient.ID().c_str());
+
+    // Fail gracefully
+    bHasFeature = true;
+  }
+
+  return bHasFeature;
+}
+
 bool CGameClientInput::AcceptsInput() const
 {
   if (m_inputCallback != nullptr)
     return m_inputCallback->AcceptsInput();
 
   return false;
+}
+
+bool CGameClientInput::InputEvent(const game_input_event &event)
+{
+  bool bHandled = false;
+
+  try
+  {
+    bHandled = m_struct.toAddon.InputEvent(&event);
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
+  }
+
+  return bHandled;
 }
 
 void CGameClientInput::LoadTopology()
@@ -254,7 +289,7 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr &controller)
 
   if (bSuccess)
   {
-    m_keyboard.reset(new CGameClientKeyboard(m_gameClient, controllerId, m_struct.toAddon, keyboards.at(0).get()));
+    m_keyboard.reset(new CGameClientKeyboard(m_gameClient, controllerId, keyboards.at(0).get()));
     return true;
   }
 
@@ -332,7 +367,7 @@ bool CGameClientInput::OpenMouse(const ControllerPtr &controller)
 
   if (bSuccess)
   {
-    m_mouse.reset(new CGameClientMouse(m_gameClient, controllerId, m_struct.toAddon, mice.at(0).get()));
+    m_mouse.reset(new CGameClientMouse(m_gameClient, controllerId, mice.at(0).get()));
     return true;
   }
 
@@ -415,7 +450,7 @@ bool CGameClientInput::OpenJoystick(const std::string &portAddress, const Contro
   {
     PERIPHERALS::EventLockHandlePtr lock = CServiceBroker::GetPeripherals().RegisterEventLock();
 
-    m_joysticks[portAddress].reset(new CGameClientJoystick(m_gameClient, portAddress, controller, m_struct.toAddon));
+    m_joysticks[portAddress].reset(new CGameClientJoystick(m_gameClient, portAddress, controller));
     ProcessJoysticks();
 
     return true;

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -97,6 +97,7 @@ namespace GAME
 
     // Helper functions
     static ControllerVector GetControllers(const CGameClient &gameClient);
+    static void ActivateControllers(CControllerHub &hub);
 
     // Input properties
     IGameInputCallback *m_inputCallback = nullptr;

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -35,6 +35,7 @@ namespace GAME
   class CGameClientJoystick;
   class CGameClientKeyboard;
   class CGameClientMouse;
+  class CGameClientTopology;
   class IGameInputCallback;
 
   class CGameClientInput : protected CGameClientSubsystem,
@@ -58,7 +59,7 @@ namespace GAME
     bool InputEvent(const game_input_event &event);
 
     // Topology functions
-    const CControllerTree &GetControllerTree() const { return m_controllers; }
+    const CControllerTree &GetControllerTree() const;
     bool SupportsKeyboard() const;
     bool SupportsMouse() const;
 
@@ -103,13 +104,12 @@ namespace GAME
 
     // Input properties
     IGameInputCallback *m_inputCallback = nullptr;
-    CControllerTree m_controllers;
+    std::unique_ptr<CGameClientTopology> m_topology;
     JoystickMap m_joysticks;
     PortMap m_portMap;
     std::unique_ptr<CGameClientKeyboard> m_keyboard;
     std::unique_ptr<CGameClientMouse> m_mouse;
     std::unique_ptr<CGameClientHardware> m_hardware;
-    int m_playerLimit = -1; // No limit
   };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -53,7 +53,9 @@ namespace GAME
     void Stop();
 
     // Input functions
+    bool HasFeature(const std::string &controllerId, const std::string &featureName) const;
     bool AcceptsInput() const;
+    bool InputEvent(const game_input_event &event);
 
     // Topology functions
     const CControllerTree &GetControllerTree() const { return m_controllers; }

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -19,14 +19,12 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameClientJoystick::CGameClientJoystick(const CGameClient &gameClient,
+CGameClientJoystick::CGameClientJoystick(CGameClient &gameClient,
                                          const std::string &portAddress,
-                                         const ControllerPtr& controller,
-                                         const KodiToAddonFuncTable_Game &dllStruct) :
+                                         const ControllerPtr& controller) :
   m_gameClient(gameClient),
   m_portAddress(portAddress),
   m_controller(controller),
-  m_dllStruct(dllStruct),
   m_port(new CPort(this))
 {
   assert(m_controller.get() != NULL);
@@ -51,16 +49,7 @@ std::string CGameClientJoystick::ControllerID(void) const
 
 bool CGameClientJoystick::HasFeature(const std::string& feature) const
 {
-  try
-  {
-    return m_dllStruct.HasFeature(m_controller->ID().c_str(), feature.c_str());
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in HasFeature()", m_gameClient.ID().c_str());
-  }
-
-  return false;
+  return m_gameClient.Input().HasFeature(m_controller->ID(), feature);
 }
 
 bool CGameClientJoystick::AcceptsInput(const std::string &feature) const
@@ -70,8 +59,6 @@ bool CGameClientJoystick::AcceptsInput(const std::string &feature) const
 
 bool CGameClientJoystick::OnButtonPress(const std::string& feature, bool bPressed)
 {
-  bool bHandled = false;
-
   game_input_event event;
 
   std::string controllerId = m_controller->ID();
@@ -83,22 +70,11 @@ bool CGameClientJoystick::OnButtonPress(const std::string& feature, bool bPresse
   event.feature_name           = feature.c_str();
   event.digital_button.pressed = bPressed;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
-
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientJoystick::OnButtonMotion(const std::string& feature, float magnitude, unsigned int motionTimeMs)
 {
-  bool bHandled = false;
-
   game_input_event event;
 
   std::string controllerId = m_controller->ID();
@@ -110,22 +86,12 @@ bool CGameClientJoystick::OnButtonMotion(const std::string& feature, float magni
   event.feature_name            = feature.c_str();
   event.analog_button.magnitude = magnitude;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
 
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientJoystick::OnAnalogStickMotion(const std::string& feature, float x, float y, unsigned int motionTimeMs)
 {
-  bool bHandled = false;
-
   game_input_event event;
 
   std::string controllerId = m_controller->ID();
@@ -138,22 +104,11 @@ bool CGameClientJoystick::OnAnalogStickMotion(const std::string& feature, float 
   event.analog_stick.x = x;
   event.analog_stick.y = y;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
-
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientJoystick::OnAccelerometerMotion(const std::string& feature, float x, float y, float z)
 {
-  bool bHandled = false;
-
   game_input_event event;
 
   std::string controllerId = m_controller->ID();
@@ -167,22 +122,11 @@ bool CGameClientJoystick::OnAccelerometerMotion(const std::string& feature, floa
   event.accelerometer.y = y;
   event.accelerometer.z = z;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
-
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientJoystick::OnWheelMotion(const std::string& feature, float position, unsigned int motionTimeMs)
 {
-  bool bHandled = false;
-
   game_input_event event;
 
   std::string controllerId = m_controller->ID();
@@ -194,23 +138,11 @@ bool CGameClientJoystick::OnWheelMotion(const std::string& feature, float positi
   event.feature_name            = feature.c_str();
   event.axis.position           = position;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught while handling wheel \"%s\"",
-              m_gameClient.ID().c_str(), feature.c_str());
-  }
-
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientJoystick::OnThrottleMotion(const std::string& feature, float position, unsigned int motionTimeMs)
 {
-  bool bHandled = false;
-
   game_input_event event;
 
   std::string controllerId = m_controller->ID();
@@ -222,17 +154,7 @@ bool CGameClientJoystick::OnThrottleMotion(const std::string& feature, float pos
   event.feature_name            = feature.c_str();
   event.axis.position           = position;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught while handling throttle \"%s\"",
-              m_gameClient.ID().c_str(), feature.c_str());
-  }
-
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -13,8 +13,6 @@
 
 #include <memory>
 
-struct KodiToAddonFuncTable_Game;
-
 namespace KODI
 {
 namespace JOYSTICK
@@ -43,10 +41,9 @@ namespace GAME
      * \param controller The game controller which is used (for controller mapping).
      * \param dllStruct The emulator or game to which the events are sent.
      */
-    CGameClientJoystick(const CGameClient &addon,
+    CGameClientJoystick(CGameClient &addon,
                         const std::string &portAddress,
-                        const ControllerPtr& controller,
-                        const KodiToAddonFuncTable_Game &dllStruct);
+                        const ControllerPtr& controller);
 
     ~CGameClientJoystick() override;
 
@@ -69,10 +66,9 @@ namespace GAME
 
   private:
     // Construction parameters
-    const CGameClient &m_gameClient;
+    CGameClient &m_gameClient;
     const std::string m_portAddress;
     const ControllerPtr       m_controller;
-    const KodiToAddonFuncTable_Game &m_dllStruct;
 
     // Input parameters
     std::unique_ptr<CPort> m_port;

--- a/xbmc/games/addons/input/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/input/GameClientKeyboard.cpp
@@ -22,13 +22,11 @@ using namespace GAME;
 
 #define BUTTON_INDEX_MASK  0x01ff
 
-CGameClientKeyboard::CGameClientKeyboard(const CGameClient &gameClient,
+CGameClientKeyboard::CGameClientKeyboard(CGameClient &gameClient,
                                          std::string controllerId,
-                                         const KodiToAddonFuncTable_Game &dllStruct,
                                          KEYBOARD::IKeyboardInputProvider *inputProvider) :
   m_gameClient(gameClient),
   m_controllerId(std::move(controllerId)),
-  m_dllStruct(dllStruct),
   m_inputProvider(inputProvider)
 {
   m_inputProvider->RegisterKeyboardHandler(this, false);
@@ -46,16 +44,7 @@ std::string CGameClientKeyboard::ControllerID() const
 
 bool CGameClientKeyboard::HasKey(const KEYBOARD::KeyName &key) const
 {
-  try
-  {
-    return m_dllStruct.HasFeature(ControllerID().c_str(), key.c_str());
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in HasFeature()", m_gameClient.ID().c_str());
-  }
-
-  return false;
+  return m_gameClient.Input().HasFeature(ControllerID(), key);
 }
 
 bool CGameClientKeyboard::OnKeyPress(const KEYBOARD::KeyName &key, KEYBOARD::Modifier mod, uint32_t unicode)
@@ -66,8 +55,6 @@ bool CGameClientKeyboard::OnKeyPress(const KEYBOARD::KeyName &key, KEYBOARD::Mod
     CLog::Log(LOGDEBUG, "GAME: key press ignored, not in fullscreen game");
     return false;
   }
-
-  bool bHandled = false;
 
   game_input_event event;
 
@@ -80,16 +67,7 @@ bool CGameClientKeyboard::OnKeyPress(const KEYBOARD::KeyName &key, KEYBOARD::Mod
   event.key.unicode     = unicode;
   event.key.modifiers   = CGameClientTranslator::GetModifiers(mod);
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
-
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 void CGameClientKeyboard::OnKeyRelease(const KEYBOARD::KeyName &key, KEYBOARD::Modifier mod, uint32_t unicode)
@@ -105,12 +83,5 @@ void CGameClientKeyboard::OnKeyRelease(const KEYBOARD::KeyName &key, KEYBOARD::M
   event.key.unicode     = unicode;
   event.key.modifiers   = CGameClientTranslator::GetModifiers(mod);
 
-  try
-  {
-    m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
+  m_gameClient.Input().InputEvent(event);
 }

--- a/xbmc/games/addons/input/GameClientKeyboard.h
+++ b/xbmc/games/addons/input/GameClientKeyboard.h
@@ -10,8 +10,6 @@
 
 #include "input/keyboard/interfaces/IKeyboardInputHandler.h"
 
-struct KodiToAddonFuncTable_Game;
-
 namespace KODI
 {
 namespace KEYBOARD
@@ -39,9 +37,8 @@ namespace GAME
      * \param dllStruct The emulator or game to which the events are sent.
      * \param inputProvider The interface providing us with keyboard input.
      */
-    CGameClientKeyboard(const CGameClient &gameClient,
+    CGameClientKeyboard(CGameClient &gameClient,
                         std::string controllerId,
-                        const KodiToAddonFuncTable_Game &dllStruct,
                         KEYBOARD::IKeyboardInputProvider *inputProvider);
 
     /*!
@@ -57,9 +54,8 @@ namespace GAME
 
   private:
     // Construction parameters
-    const CGameClient &m_gameClient;
+    CGameClient &m_gameClient;
     const std::string m_controllerId;
-    const KodiToAddonFuncTable_Game &m_dllStruct;
     KEYBOARD::IKeyboardInputProvider *const m_inputProvider;
   };
 }

--- a/xbmc/games/addons/input/GameClientMouse.cpp
+++ b/xbmc/games/addons/input/GameClientMouse.cpp
@@ -19,13 +19,11 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameClientMouse::CGameClientMouse(const CGameClient &gameClient,
+CGameClientMouse::CGameClientMouse(CGameClient &gameClient,
                                    std::string controllerId,
-                                   const KodiToAddonFuncTable_Game &dllStruct,
                                    MOUSE::IMouseInputProvider *inputProvider) :
   m_gameClient(gameClient),
   m_controllerId(std::move(controllerId)),
-  m_dllStruct(dllStruct),
   m_inputProvider(inputProvider)
 {
   inputProvider->RegisterMouseHandler(this, false);
@@ -49,8 +47,6 @@ bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
     return false;
   }
 
-  bool bHandled = false;
-
   const std::string controllerId = ControllerID();
 
   game_input_event event;
@@ -63,16 +59,8 @@ bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
   event.rel_pointer.x   = dx;
   event.rel_pointer.y   = dy;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
 
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 bool CGameClientMouse::OnButtonPress(const std::string& button)
@@ -83,8 +71,6 @@ bool CGameClientMouse::OnButtonPress(const std::string& button)
     return false;
   }
 
-  bool bHandled = false;
-
   game_input_event event;
 
   event.type                   = GAME_INPUT_EVENT_DIGITAL_BUTTON;
@@ -94,16 +80,8 @@ bool CGameClientMouse::OnButtonPress(const std::string& button)
   event.feature_name           = button.c_str();
   event.digital_button.pressed = true;
 
-  try
-  {
-    bHandled = m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
 
-  return bHandled;
+  return m_gameClient.Input().InputEvent(event);
 }
 
 void CGameClientMouse::OnButtonRelease(const std::string& button)
@@ -117,12 +95,6 @@ void CGameClientMouse::OnButtonRelease(const std::string& button)
   event.feature_name           = button.c_str();
   event.digital_button.pressed = false;
 
-  try
-  {
-    m_dllStruct.InputEvent(&event);
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
-  }
+
+  m_gameClient.Input().InputEvent(event);
 }

--- a/xbmc/games/addons/input/GameClientMouse.h
+++ b/xbmc/games/addons/input/GameClientMouse.h
@@ -10,8 +10,6 @@
 
 #include "input/mouse/interfaces/IMouseInputHandler.h"
 
-struct KodiToAddonFuncTable_Game;
-
 namespace KODI
 {
 namespace MOUSE
@@ -39,9 +37,8 @@ namespace GAME
      * \param dllStruct The emulator or game to which the events are sent.
      * \param inputProvider The interface providing us with mouse input.
      */
-    CGameClientMouse(const CGameClient &gameClient,
+    CGameClientMouse(CGameClient &gameClient,
                      std::string controllerId,
-                     const KodiToAddonFuncTable_Game &dllStruct,
                      MOUSE::IMouseInputProvider *inputProvider);
 
     /*!
@@ -57,9 +54,8 @@ namespace GAME
 
   private:
     // Construction parameters
-    const CGameClient &m_gameClient;
+    CGameClient &m_gameClient;
     const std::string m_controllerId;
-    const KodiToAddonFuncTable_Game &m_dllStruct;
     MOUSE::IMouseInputProvider *const m_inputProvider;
   };
 }

--- a/xbmc/games/addons/input/GameClientTopology.cpp
+++ b/xbmc/games/addons/input/GameClientTopology.cpp
@@ -19,14 +19,17 @@ using namespace GAME;
 
 #define CONTROLLER_ADDRESS_SEPARATOR  "/"
 
-CGameClientTopology::CGameClientTopology(GameClientPortVec ports) :
-  m_ports(std::move(ports))
+CGameClientTopology::CGameClientTopology(GameClientPortVec ports, int playerLimit) :
+  m_ports(std::move(ports)),
+  m_playerLimit(playerLimit),
+  m_controllers(GetControllerTree(m_ports))
 {
 }
 
-CControllerTree CGameClientTopology::GetControllerTree() const
+void CGameClientTopology::Clear()
 {
-  return GetControllerTree(m_ports);
+  m_ports.clear();
+  m_controllers.Clear();
 }
 
 CControllerTree CGameClientTopology::GetControllerTree(const GameClientPortVec &ports)

--- a/xbmc/games/addons/input/GameClientTopology.h
+++ b/xbmc/games/addons/input/GameClientTopology.h
@@ -20,9 +20,15 @@ namespace GAME
   class CGameClientTopology
   {
   public:
-    CGameClientTopology(GameClientPortVec ports);
+    CGameClientTopology() = default;
+    CGameClientTopology(GameClientPortVec ports, int playerLimit);
 
-    CControllerTree GetControllerTree() const;
+    void Clear();
+
+    int PlayerLimit() const { return m_playerLimit; }
+
+    const CControllerTree &ControllerTree() const { return m_controllers; }
+    CControllerTree &ControllerTree() { return m_controllers; }
 
   private:
     static CControllerTree GetControllerTree(const GameClientPortVec &ports);
@@ -32,7 +38,12 @@ namespace GAME
     // Utility function
     static std::string MakeAddress(const std::string &baseAddress, const std::string &nodeId);
 
+    // Game API parameters
     GameClientPortVec m_ports;
+    int m_playerLimit = -1;
+
+    // Controller parameters
+    CControllerTree m_controllers;
   };
 }
 }

--- a/xbmc/games/controllers/types/ControllerTree.cpp
+++ b/xbmc/games/controllers/types/ControllerTree.cpp
@@ -10,6 +10,7 @@
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerTopology.h"
 
+#include <algorithm>
 #include <utility>
 
 using namespace KODI;
@@ -34,6 +35,13 @@ CControllerNode &CControllerNode::operator=(const CControllerNode &rhs)
   }
 
   return *this;
+}
+
+void CControllerNode::Clear()
+{
+  m_controller.reset();
+  m_address.clear();
+  m_hub.reset(new CControllerHub);
 }
 
 void CControllerNode::SetController(ControllerPtr controller)
@@ -114,6 +122,16 @@ const CControllerNode &CControllerPortNode::ActiveController() const
     return m_controllers[m_active];
 
   static const CControllerNode invalid{};
+  return invalid;
+}
+
+CControllerNode &CControllerPortNode::ActiveController()
+{
+  if (m_bConnected && m_active < m_controllers.size())
+    return m_controllers[m_active];
+
+  static CControllerNode invalid;
+  invalid.Clear();
   return invalid;
 }
 
@@ -200,6 +218,11 @@ CControllerHub &CControllerHub::operator=(const CControllerHub &rhs)
   }
 
   return *this;
+}
+
+void CControllerHub::Clear()
+{
+  m_ports.clear();
 }
 
 void CControllerHub::SetPorts(ControllerPortVec ports)

--- a/xbmc/games/controllers/types/ControllerTree.h
+++ b/xbmc/games/controllers/types/ControllerTree.h
@@ -37,6 +37,8 @@ namespace GAME
     CControllerNode &operator=(const CControllerNode &rhs);
     ~CControllerNode();
 
+    void Clear();
+
     /*!
      * \brief Controller profile of this code
      *
@@ -60,6 +62,7 @@ namespace GAME
      *         has no available ports
      */
     const CControllerHub &Hub() const { return *m_hub; }
+    CControllerHub &Hub() { return *m_hub; }
     void SetHub(CControllerHub hub);
 
     /*!
@@ -126,6 +129,7 @@ namespace GAME
      * \return The active controller, or invalid if port is disconnected
      */
     const CControllerNode &ActiveController() const;
+    CControllerNode &ActiveController();
     void SetActiveController(unsigned int controllerIndex) { m_active = controllerIndex; }
 
     /*!
@@ -208,7 +212,10 @@ namespace GAME
     CControllerHub &operator=(const CControllerHub &rhs);
     ~CControllerHub();
 
+    void Clear();
+
     bool HasPorts() const { return !m_ports.empty(); }
+    ControllerPortVec &Ports() { return m_ports; }
     const ControllerPortVec &Ports() const { return m_ports; }
     void SetPorts(ControllerPortVec ports);
 

--- a/xbmc/games/controllers/windows/GUIControllerList.h
+++ b/xbmc/games/controllers/windows/GUIControllerList.h
@@ -30,7 +30,7 @@ namespace GAME
   class CGUIControllerList : public IControllerList
   {
   public:
-    CGUIControllerList(CGUIWindow* window, IFeatureList* featureList);
+    CGUIControllerList(CGUIWindow* window, IFeatureList* featureList, GameClientPtr gameClient);
     virtual ~CGUIControllerList(void) { Deinitialize(); }
 
     // implementation of IControllerList

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -207,7 +207,7 @@ void CGUIControllerWindow::OnInitWindow(void)
 
   if (!m_featureList)
   {
-    m_featureList = new CGUIFeatureList(this);
+    m_featureList = new CGUIFeatureList(this, m_gameClient);
     if (!m_featureList->Initialize())
     {
       delete m_featureList;
@@ -217,7 +217,7 @@ void CGUIControllerWindow::OnInitWindow(void)
 
   if (!m_controllerList && m_featureList)
   {
-    m_controllerList = new CGUIControllerList(this, m_featureList);
+    m_controllerList = new CGUIControllerList(this, m_featureList, m_gameClient);
     if (!m_controllerList->Initialize())
     {
       delete m_controllerList;

--- a/xbmc/games/controllers/windows/GUIFeatureList.h
+++ b/xbmc/games/controllers/windows/GUIFeatureList.h
@@ -11,6 +11,7 @@
 #include "IConfigurationWindow.h"
 #include "games/controllers/ControllerFeature.h"
 #include "games/controllers/ControllerTypes.h"
+#include "games/GameTypes.h"
 #include "input/joysticks/JoystickTypes.h"
 
 class CGUIButtonControl;
@@ -26,7 +27,7 @@ namespace GAME
   class CGUIFeatureList : public IFeatureList
   {
   public:
-    CGUIFeatureList(CGUIWindow* window);
+    CGUIFeatureList(CGUIWindow* window, GameClientPtr gameClient);
     virtual ~CGUIFeatureList(void);
 
     // implementation of IFeatureList
@@ -53,7 +54,7 @@ namespace GAME
        */
       bool bIsVirtualKey = false;
     };
-    static std::vector<FeatureGroup> GetFeatureGroups(const std::vector<CControllerFeature>& features);
+    std::vector<FeatureGroup> GetFeatureGroups(const std::vector<CControllerFeature>& features) const;
     std::vector<CGUIButtonControl*> GetButtons(const std::vector<CControllerFeature>& features, unsigned int startIndex);
     CGUIButtonControl* GetSelectKeyButton(const std::vector<CControllerFeature>& features, unsigned int buttonIndex);
 
@@ -66,6 +67,7 @@ namespace GAME
     CGUIImage*              m_guiFeatureSeparator;
 
     // Game window stuff
+    GameClientPtr           m_gameClient;
     ControllerPtr           m_controller;
     IConfigurationWizard*   m_wizard;
   };


### PR DESCRIPTION
A game add-on specifies which libretro buttons it supports using its buttonmap.xml. For example, 2048 is [here](https://github.com/kodi-game/game.libretro.2048/blob/master/game.libretro.2048/resources/buttonmap.xml). Because only a subset of buttons is defined, we can hide the unused buttons in the GUI.

The benefit is a simpler dialog and less ambiguity as to which buttons are used. The downside is the dialog is more confusing, because while no buttons are mysteriously omitted, others are awkwardly omitted. You can see this in the screenshots below, where 2048 is greatly simplified, but Mr.Boom awkwardly leaves out the X button.

I think the benefits outweigh the downsides, but it's debatable.

Another problem currently is that 2048 and Mr.Boom aren't "platforms" and have no controller, so they use the mapping for the default 360 controller. This is confusing, because the user has no way of knowing which actions each button has in the game. MAME faces a similar problem, because button maps can be specific per-game.

## Motivation and Context
Another plane bug bites the dust.

## How Has This Been Tested?
Tested on OSX with 2048 and Mr.Boom.

## Screenshots (if appropriate):
Mapping a controller while playing 2048:

<img width="1920" alt="screen shot 2018-10-01 at 12 35 47 pm" src="https://user-images.githubusercontent.com/531482/46329503-85910080-c5c2-11e8-9b1e-52a7ab87e3bc.png">

Mapping a controller while playing Mr.Boom:

<img width="1920" alt="screen shot 2018-10-01 at 12 36 56 pm" src="https://user-images.githubusercontent.com/531482/46329509-8cb80e80-c5c2-11e8-837b-af2dc6c1339c.png">
