### PR TITLE
Fix resolution changes on OSX

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -279,8 +279,10 @@ bool CDisplaySettings::OnSettingChanging(std::shared_ptr<const CSetting> setting
     }
 
     std::string screenmode = GetStringFromResolution(newRes);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(CSettings::SETTING_VIDEOSCREEN_SCREENMODE, screenmode);
+    if (!CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(CSettings::SETTING_VIDEOSCREEN_SCREENMODE, screenmode))
+      return false;
   }
+
   if (settingId == CSettings::SETTING_VIDEOSCREEN_SCREENMODE)
   {
     RESOLUTION oldRes = GetCurrentResolution();

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -403,8 +403,7 @@ void CDisplaySettings::SetCurrentResolution(RESOLUTION resolution, bool save /* 
     std::string mode = GetStringFromResolution(resolution);
     CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(CSettings::SETTING_VIDEOSCREEN_SCREENMODE, mode.c_str());
   }
-
-  if (resolution != m_currentResolution)
+  else if (resolution != m_currentResolution)
   {
     m_currentResolution = resolution;
     SetChanged();


### PR DESCRIPTION
This fixes Kodi entering a weird resolution state on OSX. When I close a video, or toggle fullscreen and cancel, Kodi becomes a window but stays at a high resolution that makes things unreadable in OSX.

The error switching to window mode when closing a video is due to a reentrancy bug. More refactoring may be needed.

The error not updating the resolution when cancelling fullscreen toggle is fixed by adding an early return and changing the return value.

## Motivation and Context
Killed an hour and a half of my plane ride.

## How Has This Been Tested?
Tested when closing a video in fullscreen.

Before: Changed to windowed, bad resolution.

Now: No change in resolution.

Tested when cancelling a fullscreen switch.

Before: Changed back to windowed, bad resolution.

Now: Changes back to windows, correct resolution.

Not tested on other platforms yet.

## Screenshots (if appropriate):
Erroneous windowed mode with bad resolution:

![screen shot 2018-10-01 at 11 15 32 am](https://user-images.githubusercontent.com/531482/46330317-3bf6e480-c5c7-11e8-9db7-68d2ebb5fee7.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
