### PR TITLE
[python] Check version of cryptography module

### DIFF
--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -102,6 +102,13 @@ public:
   void UnloadExtensionLibs();
 
 private:
+  /**
+   * Check minimum required version of Python cryptography module
+   *
+   * If version is below 1.7, there could be random OpenSSL errors, see
+   * https://github.com/pyca/pyopenssl/issues/542#issuecomment-312968275
+   */
+  bool CheckCryptographyVersion();
   void Finalize();
 
   CCriticalSection    m_critSection;


### PR DESCRIPTION
We have had multiple issues with Ubuntu 16.04 using an outdated version
of the Python cryptography module that causes strange SSL behavior.
Example for this is not being able to connect to SSL sites.

This commit introduces a check on initialization of the interpreter
to make sure that we use a compatible version.

See also:
https://github.com/pyca/pyopenssl/issues/542#issuecomment-312968275
https://forum.kodi.tv/showthread.php?tid=335786

I just put the check inside the interpreter initialization - not sure if it's the most appropriate place? Also I don't have much experience with Python so please check.

## How Has This Been Tested?
Build/Run on Linux x64

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
