### PR TITLE
EGLUtils: rework the way we choose the egl config

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -93,7 +93,7 @@ bool CEGLContextUtils::CreateDisplay(EGLNativeDisplayType nativeDisplay, EGLint 
   return InitializeDisplay(renderableType, renderingApi);
 }
 
-bool CEGLContextUtils::CreatePlatformDisplay(void* nativeDisplay, EGLNativeDisplayType nativeDisplayLegacy, EGLint renderableType, EGLint renderingApi)
+bool CEGLContextUtils::CreatePlatformDisplay(void* nativeDisplay, EGLNativeDisplayType nativeDisplayLegacy, EGLint renderableType, EGLint renderingApi, EGLint visualId)
 {
   if (m_eglDisplay != EGL_NO_DISPLAY)
   {
@@ -123,10 +123,11 @@ bool CEGLContextUtils::CreatePlatformDisplay(void* nativeDisplay, EGLNativeDispl
   {
     return CreateDisplay(nativeDisplayLegacy, renderableType, renderingApi);
   }
-  return InitializeDisplay(renderableType, renderingApi);
+
+  return InitializeDisplay(renderableType, renderingApi, visualId);
 }
 
-bool CEGLContextUtils::InitializeDisplay(EGLint renderableType, EGLint renderingApi)
+bool CEGLContextUtils::InitializeDisplay(EGLint renderableType, EGLint renderingApi, EGLint visualId)
 {
   int major, minor;
   if (!eglInitialize(m_eglDisplay, &major, &minor))
@@ -144,40 +145,63 @@ bool CEGLContextUtils::InitializeDisplay(EGLint renderableType, EGLint rendering
     return false;
   }
 
+  if (!ChooseConfig(renderableType, visualId))
+    return false;
+
+  return true;
+}
+
+bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId)
+{
+  EGLint numMatched{0};
+
   EGLint surfaceType = EGL_WINDOW_BIT;
   // for the non-trivial dirty region modes, we need the EGL buffer to be preserved across updates
   if (g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_COST_REDUCTION ||
       g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_UNION)
     surfaceType |= EGL_SWAP_BEHAVIOR_PRESERVED_BIT;
 
-  EGLint attribs[] =
-  {
-    EGL_RED_SIZE, 8,
-    EGL_GREEN_SIZE, 8,
-    EGL_BLUE_SIZE, 8,
-    EGL_ALPHA_SIZE, 8,
-    EGL_DEPTH_SIZE, 16,
-    EGL_STENCIL_SIZE, 0,
-    EGL_SAMPLE_BUFFERS, 0,
-    EGL_SAMPLES, 0,
-    EGL_SURFACE_TYPE, surfaceType,
-    EGL_RENDERABLE_TYPE, renderableType,
-    EGL_NONE
-  };
+  CEGLAttributes<10> attribs;
+  attribs.Add({{EGL_RED_SIZE, 8},
+               {EGL_GREEN_SIZE, 8},
+               {EGL_BLUE_SIZE, 8},
+               {EGL_ALPHA_SIZE, 2},
+               {EGL_DEPTH_SIZE, 16},
+               {EGL_STENCIL_SIZE, 0},
+               {EGL_SAMPLE_BUFFERS, 0},
+               {EGL_SAMPLES, 0},
+               {EGL_SURFACE_TYPE, surfaceType},
+               {EGL_RENDERABLE_TYPE, renderableType}});
 
-  EGLint neglconfigs = 0;
-  if (eglChooseConfig(m_eglDisplay, attribs, &m_eglConfig, 1, &neglconfigs) != EGL_TRUE)
+  if (eglChooseConfig(m_eglDisplay, attribs.Get(), nullptr, 0, &numMatched) != EGL_TRUE)
   {
     CEGLUtils::LogError("failed to query number of EGL configs");
     Destroy();
     return false;
   }
 
-  if (neglconfigs <= 0)
+  std::vector<EGLConfig> eglConfigs(numMatched);
+
+  if (eglChooseConfig(m_eglDisplay, attribs.Get(), eglConfigs.data(), numMatched, &numMatched) != EGL_TRUE)
   {
-    CLog::Log(LOGERROR, "No suitable EGL configs found");
+    CEGLUtils::LogError("failed to find EGL configs with appropriate attributes");
     Destroy();
     return false;
+  }
+
+  for (const auto &eglConfig: eglConfigs)
+  {
+    m_eglConfig = eglConfig;
+
+    if (visualId == 0)
+      break;
+
+    EGLint id{0};
+    if (eglGetConfigAttrib(m_eglDisplay, m_eglConfig, EGL_NATIVE_VISUAL_ID, &id) != EGL_TRUE)
+      CEGLUtils::LogError("failed to query EGL attibute EGL_NATIVE_VISUAL_ID");
+
+    if (visualId == id)
+      break;
   }
 
   return true;

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -131,7 +131,7 @@ public:
    * \param nativeDisplay native display to use with eglGetPlatformDisplayEXT
    * \param nativeDisplayLegacy native display to use with eglGetDisplay
    */
-  bool CreatePlatformDisplay(void* nativeDisplay, EGLNativeDisplayType nativeDisplayLegacy, EGLint renderableType, EGLint renderingApi);
+  bool CreatePlatformDisplay(void* nativeDisplay, EGLNativeDisplayType nativeDisplayLegacy, EGLint renderableType, EGLint renderingApi, EGLint visualId = 0);
 
   bool CreateSurface(EGLNativeWindowType nativeWindow);
   bool CreatePlatformSurface(void* nativeWindow, EGLNativeWindowType nativeWindowLegacy);
@@ -162,7 +162,8 @@ public:
   }
 
 private:
-  bool InitializeDisplay(EGLint renderableType, EGLint renderingApi);
+  bool InitializeDisplay(EGLint renderableType, EGLint renderingApi, EGLint visualId = 0);
+  bool ChooseConfig(EGLint renderableType, EGLint visualId);
   void SurfaceAttrib();
 
   EGLenum m_platform{EGL_NONE};

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -99,9 +99,9 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
   if (rendered)
   {
     if (videoLayer)
-      m_overlay_plane->format = DRM_FORMAT_ARGB8888;
+      m_overlay_plane->format = CDRMUtils::FourCCWithAlpha(m_overlay_plane->format);
     else
-      m_overlay_plane->format = DRM_FORMAT_XRGB8888;
+      m_overlay_plane->format = CDRMUtils::FourCCWithoutAlpha(m_overlay_plane->format);
 
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -727,3 +727,13 @@ std::vector<RESOLUTION_INFO> CDRMUtils::GetModes()
 
   return resolutions;
 }
+
+uint32_t CDRMUtils::FourCCWithAlpha(uint32_t fourcc)
+{
+  return (fourcc & 0xFFFFFF00) | static_cast<uint32_t>('A');
+}
+
+uint32_t CDRMUtils::FourCCWithoutAlpha(uint32_t fourcc)
+{
+  return (fourcc & 0xFFFFFF00) | static_cast<uint32_t>('X');
+}

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -89,6 +89,9 @@ public:
   virtual bool AddProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
   virtual bool SetProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
 
+  static uint32_t FourCCWithAlpha(uint32_t fourcc);
+  static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+
 protected:
   bool OpenDrm(bool needConnector);
   uint32_t GetPropertyId(struct drm_object *object, const char *name);

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -22,7 +22,10 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
-  if (!m_eglContext.CreatePlatformDisplay(m_GBM->GetDevice(), m_GBM->GetDevice(), renderableType, apiType))
+  // we need to provide an alpha format to egl to workaround a mesa bug
+  int visualId = CDRMUtils::FourCCWithAlpha(CWinSystemGbm::GetDrm()->GetOverlayPlane()->format);
+
+  if (!m_eglContext.CreatePlatformDisplay(m_GBM->GetDevice(), m_GBM->GetDevice(), renderableType, apiType, visualId))
   {
     return false;
   }


### PR DESCRIPTION
This changes the egl config selection to be more inline with what upstream projects do (read weston). This will also allow us more control in the future to select different contexts.

This is needed to allow for more features in the future like 10bit output and MSAA selection.

Only tested on GBM but it shouldn't break other systems due to the default `visual id = 0`

see, https://github.com/wayland-project/weston/commit/77c1a5b7dc6056717659eaef4034bb4d1bdc48f0
and, https://cgit.freedesktop.org/mesa/kmscube/commit/?id=56c3917ffd1f05942246e2532ca4a5707554a2fc