### PR TITLE
[GBM] support 10bit output modes and other fixes

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -262,6 +262,7 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId)
     return false;
   }
 
+  EGLint id{0};
   for (const auto &eglConfig: eglConfigs)
   {
     m_eglConfig = eglConfig;
@@ -269,12 +270,17 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId)
     if (visualId == 0)
       break;
 
-    EGLint id{0};
     if (eglGetConfigAttrib(m_eglDisplay, m_eglConfig, EGL_NATIVE_VISUAL_ID, &id) != EGL_TRUE)
       CEGLUtils::LogError("failed to query EGL attibute EGL_NATIVE_VISUAL_ID");
 
     if (visualId == id)
       break;
+  }
+
+  if (visualId != 0 && visualId != id)
+  {
+    CLog::Log(LOGDEBUG, "failed to find matching EGL visual id");
+    return false;
   }
 
   CLog::Log(LOGDEBUG, "EGL Config Attributes:");

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -101,9 +101,9 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
   if (rendered)
   {
     if (videoLayer)
-      m_overlay_plane->format = CDRMUtils::FourCCWithAlpha(m_overlay_plane->format);
+      m_overlay_plane->format = CDRMUtils::FourCCWithAlpha(m_overlay_plane->GetFormat());
     else
-      m_overlay_plane->format = CDRMUtils::FourCCWithoutAlpha(m_overlay_plane->format);
+      m_overlay_plane->format = CDRMUtils::FourCCWithoutAlpha(m_overlay_plane->GetFormat());
 
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -348,8 +348,7 @@ drmModePlanePtr CDRMUtils::FindPlane(drmModePlaneResPtr resources, int crtc_inde
           {
             case KODI_VIDEO_PLANE:
             {
-              if (SupportsFormat(plane, DRM_FORMAT_NV12) ||
-                  SupportsFormat(plane, DRM_FORMAT_YUV420))
+              if (SupportsFormat(plane, DRM_FORMAT_NV12))
               {
                 CLog::Log(LOGDEBUG, "CDRMUtils::%s - found video plane %u", __FUNCTION__, plane->plane_id);
                 drmModeFreeProperty(p);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -346,7 +346,7 @@ drmModePlanePtr CDRMUtils::FindPlane(drmModePlaneResPtr resources, int crtc_inde
         {
           switch (type)
           {
-            case VIDEO_PLANE:
+            case KODI_VIDEO_PLANE:
             {
               if (SupportsFormat(plane, DRM_FORMAT_NV12) ||
                   SupportsFormat(plane, DRM_FORMAT_YUV420))
@@ -359,7 +359,7 @@ drmModePlanePtr CDRMUtils::FindPlane(drmModePlaneResPtr resources, int crtc_inde
 
               break;
             }
-            case GUI_PLANE:
+            case KODI_GUI_PLANE:
             {
               uint32_t plane_id = 0;
               if (m_primary_plane->plane)
@@ -402,14 +402,14 @@ bool CDRMUtils::FindPlanes()
     return false;
   }
 
-  m_primary_plane->plane = FindPlane(plane_resources, m_crtc_index, VIDEO_PLANE);
-  m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, GUI_PLANE);
+  m_primary_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_VIDEO_PLANE);
+  m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_GUI_PLANE);
 
   if (m_overlay_plane->plane == nullptr && m_primary_plane->plane != nullptr)
   {
     drmModeFreePlane(m_primary_plane->plane);
     m_primary_plane->plane = nullptr;
-    m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, GUI_PLANE);
+    m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_GUI_PLANE);
   }
 
   drmModeFreePlaneResources(plane_resources);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -422,6 +422,7 @@ bool CDRMUtils::FindPlanes()
   m_primary_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_VIDEO_PLANE);
   m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_GUI_10_PLANE);
   m_overlay_plane->format = DRM_FORMAT_XRGB2101010;
+  m_overlay_plane->fallbackFormat = DRM_FORMAT_XRGB8888;
 
   /* fallback to 8bit plane if 10bit plane doesn't exist */
   if (m_overlay_plane->plane == nullptr)

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -27,8 +27,8 @@ namespace GBM
 
 enum EPLANETYPE
 {
-  VIDEO_PLANE,
-  GUI_PLANE
+  KODI_VIDEO_PLANE,
+  KODI_GUI_PLANE
 };
 
 struct drm_object

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -44,6 +44,17 @@ struct plane : drm_object
 {
   drmModePlanePtr plane = nullptr;
   uint32_t format{0};
+  uint32_t fallbackFormat{0};
+  bool useFallbackFormat{false};
+
+  uint32_t GetFormat()
+  {
+    if (useFallbackFormat)
+      return fallbackFormat;
+
+    return format;
+  }
+
   std::map<uint32_t, std::vector<uint64_t>> modifiers_map;
 };
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -28,7 +28,8 @@ namespace GBM
 enum EPLANETYPE
 {
   KODI_VIDEO_PLANE,
-  KODI_GUI_PLANE
+  KODI_GUI_PLANE,
+  KODI_GUI_10_PLANE
 };
 
 struct drm_object
@@ -42,7 +43,7 @@ struct drm_object
 struct plane : drm_object
 {
   drmModePlanePtr plane = nullptr;
-  uint32_t format = DRM_FORMAT_XRGB8888;
+  uint32_t format{0};
   std::map<uint32_t, std::vector<uint64_t>> modifiers_map;
 };
 

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -38,7 +38,7 @@ void CGBMUtils::DestroyDevice()
   }
 }
 
-bool CGBMUtils::CreateSurface(int width, int height, const uint64_t *modifiers, const int modifiers_count)
+bool CGBMUtils::CreateSurface(int width, int height, uint32_t format, const uint64_t *modifiers, const int modifiers_count)
 {
   if (m_surface)
     CLog::Log(LOGWARNING, "CGBMUtils::%s - surface already created", __FUNCTION__);
@@ -47,7 +47,7 @@ bool CGBMUtils::CreateSurface(int width, int height, const uint64_t *modifiers, 
   m_surface = gbm_surface_create_with_modifiers(m_device,
                                                 width,
                                                 height,
-                                                GBM_FORMAT_ARGB8888,
+                                                format,
                                                 modifiers,
                                                 modifiers_count);
 #endif
@@ -56,7 +56,7 @@ bool CGBMUtils::CreateSurface(int width, int height, const uint64_t *modifiers, 
     m_surface = gbm_surface_create(m_device,
                                    width,
                                    height,
-                                   GBM_FORMAT_ARGB8888,
+                                   format,
                                    GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
   }
 

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -24,7 +24,7 @@ public:
   ~CGBMUtils() = default;
   bool CreateDevice(int fd);
   void DestroyDevice();
-  bool CreateSurface(int width, int height, const uint64_t *modifiers, const int modifiers_count);
+  bool CreateSurface(int width, int height, uint32_t format, const uint64_t *modifiers, const int modifiers_count);
   void DestroySurface();
   struct gbm_bo *LockFrontBuffer();
   void ReleaseBuffer();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -139,7 +139,10 @@ bool CWinSystemGbm::CreateNewWindow(const std::string& name,
 
   std::vector<uint64_t> *modifiers = m_DRM->GetOverlayPlaneModifiersForFormat(m_DRM->GetOverlayPlane()->format);
 
-  if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, modifiers->data(), modifiers->size()))
+  // the gbm format needs alpha support
+  uint32_t format = CDRMUtils::FourCCWithAlpha(m_DRM->GetOverlayPlane()->GetFormat());
+
+  if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(), modifiers->size()))
   {
     CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize GBM", __FUNCTION__);
     return false;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -37,7 +37,14 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
 
   if (!m_eglContext.ChooseConfig(renderableType, visualId))
   {
-    return false;
+    // fallback to 8bit format if no EGL config was found for 10bit
+    CWinSystemGbm::GetDrm()->GetOverlayPlane()->useFallbackFormat = true;
+    visualId = CDRMUtils::FourCCWithAlpha(CWinSystemGbm::GetDrm()->GetOverlayPlane()->GetFormat());
+
+    if (!m_eglContext.ChooseConfig(renderableType, visualId))
+    {
+      return false;
+    }
   }
 
   if (!CreateContext())


### PR DESCRIPTION
This is to go alongside #14514 

Much of the configuration should now happen automatically as hardcoded formats are removed.
I have tested this on a AMD Vega m GPU however I don't have a monitor that can support 10 bit output.

This should be tested across all platforms (including older intel platforms cc @wsnipex)

~~Also @Kwiboo please test that this does not break things for you. The only issue I see may be that you don't support `gbm_bo_get_format` but I'm not sure.~~

If anyone has issues please upload the output of the `modetest` utility from libdrm