### PR TITLE
RetroPlayer: Modernize OpenGL rendering

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -56,7 +56,6 @@ namespace RETRO
 
     // Public renderer interface
     virtual void Flush();
-    virtual void Deinitialize() { }
 
     // Get render settings
     const CRenderSettings &GetRenderSettings() const { return m_renderSettings; }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
@@ -82,8 +82,6 @@ void CRPRendererGBM::Render(uint8_t alpha)
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  GLuint vertexVBO;
-  GLuint indexVBO;
   struct PackedVertex
   {
     float x, y, z;
@@ -114,8 +112,7 @@ void CRPRendererGBM::Render(uint8_t alpha)
   vertex[1].u1 = vertex[2].u1 = rect.x2;
   vertex[2].v1 = vertex[3].v1 = rect.y2;
 
-  glGenBuffers(1, &vertexVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
   glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
 
   glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLuint*>(offsetof(PackedVertex, x)));
@@ -124,8 +121,7 @@ void CRPRendererGBM::Render(uint8_t alpha)
   glEnableVertexAttribArray(vertLoc);
   glEnableVertexAttribArray(loc);
 
-  glGenBuffers(1, &indexVBO);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
   glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f), (colour[3] / 255.0f));
@@ -135,9 +131,7 @@ void CRPRendererGBM::Render(uint8_t alpha)
   glDisableVertexAttribArray(loc);
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glDeleteBuffers(1, &vertexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-  glDeleteBuffers(1, &indexVBO);
 
   m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.cpp
@@ -49,11 +49,6 @@ CRPRendererGBM::CRPRendererGBM(const CRenderSettings &renderSettings, CRenderCon
   m_textureTarget = GL_TEXTURE_EXTERNAL_OES;
 }
 
-CRPRendererGBM::~CRPRendererGBM()
-{
-  Deinitialize();
-}
-
 void CRPRendererGBM::Render(uint8_t alpha)
 {
   CRenderBufferGBM *renderBuffer = static_cast<CRenderBufferGBM*>(m_renderBuffer);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h
@@ -29,7 +29,7 @@ namespace RETRO
   {
   public:
     CRPRendererGBM(const CRenderSettings &renderSettings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool);
-    ~CRPRendererGBM() override;
+    ~CRPRendererGBM() override = default;
 
   protected:
     // implementation of CRPRendererOpenGLES

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -41,6 +41,10 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings &renderSettings, CRen
 {
   // Initialize CRPRendererOpenGL
   m_clearColour = m_context.UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+
+  glGenBuffers(1, &m_mainIndexVBO);
+  glGenBuffers(1, &m_mainVertexVBO);
+  glGenBuffers(1, &m_blackbarsVertexVBO);
 }
 
 CRPRendererOpenGL::~CRPRendererOpenGL()
@@ -216,10 +220,7 @@ void CRPRendererOpenGL::DrawBlackBars()
     count += 6;
   }
 
-  GLuint vertexVBO;
-
-  glGenBuffers(1, &vertexVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_blackbarsVertexVBO);
   glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex)*count, &vertices[0], GL_STATIC_DRAW);
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
@@ -229,7 +230,6 @@ void CRPRendererOpenGL::DrawBlackBars()
 
   glDisableVertexAttribArray(posLoc);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glDeleteBuffers(1, &vertexVBO);
 
   m_context.DisableGUIShader();
 }
@@ -264,8 +264,6 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  GLuint vertexVBO;
-  GLuint indexVBO;
   struct PackedVertex
   {
     float x, y, z;
@@ -296,8 +294,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   vertex[1].u1 = vertex[2].u1 = rect.x2;
   vertex[2].v1 = vertex[3].v1 = rect.y2;
 
-  glGenBuffers(1, &vertexVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
   glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
 
   glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, x)));
@@ -306,20 +303,25 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   glEnableVertexAttribArray(vertLoc);
   glEnableVertexAttribArray(loc);
 
-  glGenBuffers(1, &indexVBO);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
   glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f), (colour[3] / 255.0f));
+
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
   glDisableVertexAttribArray(vertLoc);
   glDisableVertexAttribArray(loc);
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glDeleteBuffers(1, &vertexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-  glDeleteBuffers(1, &indexVBO);
 
   m_context.DisableGUIShader();
+}
+
+void CRPRendererOpenGL::Deinitialize()
+{
+  glDeleteBuffers(1, &m_mainIndexVBO);
+  glDeleteBuffers(1, &m_mainVertexVBO);
+  glDeleteBuffers(1, &m_blackbarsVertexVBO);
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -83,7 +83,12 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings &renderSettings, CRen
 
 CRPRendererOpenGL::~CRPRendererOpenGL()
 {
-  Deinitialize();
+  glDeleteBuffers(1, &m_mainIndexVBO);
+  glDeleteBuffers(1, &m_mainVertexVBO);
+  glDeleteBuffers(1, &m_blackbarsVertexVBO);
+
+  glDeleteVertexArrays(1, &m_mainVAO);
+  glDeleteVertexArrays(1, &m_blackbarsVAO);
 }
 
 void CRPRendererOpenGL::RenderInternal(bool clear, uint8_t alpha)
@@ -332,14 +337,4 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
-}
-
-void CRPRendererOpenGL::Deinitialize()
-{
-  glDeleteBuffers(1, &m_mainIndexVBO);
-  glDeleteBuffers(1, &m_mainVertexVBO);
-  glDeleteBuffers(1, &m_blackbarsVertexVBO);
-
-  glDeleteVertexArrays(1, &m_mainVAO);
-  glDeleteVertexArrays(1, &m_blackbarsVAO);
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -42,9 +42,43 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings &renderSettings, CRen
   // Initialize CRPRendererOpenGL
   m_clearColour = m_context.UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
 
-  glGenBuffers(1, &m_mainIndexVBO);
+  // Set up main screen VAO/VBOs
+  glGenVertexArrays(1, &m_mainVAO);
+  glBindVertexArray(m_mainVAO);
+
   glGenBuffers(1, &m_mainVertexVBO);
+  glGenBuffers(1, &m_mainIndexVBO);
+
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+  GLint vertLoc = m_context.GUIShaderGetPos();
+  GLint loc = m_context.GUIShaderGetCoord0();
+  m_context.DisableGUIShader();
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+  glEnableVertexAttribArray(vertLoc);
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, x)));
+  glEnableVertexAttribArray(loc);
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, u1)));
+
+  // Set up black bars VAO/VBO
+  glGenVertexArrays(1, &m_blackbarsVAO);
+  glBindVertexArray(m_blackbarsVAO);
+
   glGenBuffers(1, &m_blackbarsVertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_blackbarsVertexVBO);
+
+  m_context.EnableGUIShader(GL_SHADER_METHOD::DEFAULT);
+  GLint posLoc = m_context.GUIShaderGetPos();
+  m_context.DisableGUIShader();
+
+  glEnableVertexAttribArray(posLoc);
+  glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
+
+  // Unbind everything just to be safe
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
 CRPRendererOpenGL::~CRPRendererOpenGL()
@@ -121,17 +155,10 @@ void CRPRendererOpenGL::DrawBlackBars()
 {
   glDisable(GL_BLEND);
 
-  struct Svertex
-  {
-    float x;
-    float y;
-    float z;
-  };
   Svertex vertices[24];
   GLubyte count = 0;
 
   m_context.EnableGUIShader(GL_SHADER_METHOD::DEFAULT);
-  GLint posLoc = m_context.GUIShaderGetPos();
   GLint uniCol = m_context.GUIShaderGetUniCol();
 
   glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
@@ -220,15 +247,15 @@ void CRPRendererOpenGL::DrawBlackBars()
     count += 6;
   }
 
+  glBindVertexArray(m_blackbarsVAO);
+
   glBindBuffer(GL_ARRAY_BUFFER, m_blackbarsVertexVBO);
   glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex)*count, &vertices[0], GL_STATIC_DRAW);
 
-  glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
-  glEnableVertexAttribArray(posLoc);
-
   glDrawArrays(GL_TRIANGLES, 0, count);
 
-  glDisableVertexAttribArray(posLoc);
+  // Unbind VAO/VBO just to be safe
+  glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
@@ -264,14 +291,8 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-  struct PackedVertex
-  {
-    float x, y, z;
-    float u1, v1;
-  } vertex[4];
+  PackedVertex vertex[4];
 
-  GLint vertLoc = m_context.GUIShaderGetPos();
-  GLint loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
 
   // Setup color values
@@ -294,27 +315,21 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   vertex[1].u1 = vertex[2].u1 = rect.x2;
   vertex[2].v1 = vertex[3].v1 = rect.y2;
 
+  glBindVertexArray(m_mainVAO);
+  
   glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
   glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
 
-  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, x)));
-  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, u1)));
-
-  glEnableVertexAttribArray(vertLoc);
-  glEnableVertexAttribArray(loc);
-
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+  // No need to bind the index VBO, it's part of VAO state
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
   glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f), (colour[3] / 255.0f));
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
-  glDisableVertexAttribArray(vertLoc);
-  glDisableVertexAttribArray(loc);
-
+  // Unbind VAO/VBO just to be safe
+  glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
 }
@@ -324,4 +339,7 @@ void CRPRendererOpenGL::Deinitialize()
   glDeleteBuffers(1, &m_mainIndexVBO);
   glDeleteBuffers(1, &m_mainVertexVBO);
   glDeleteBuffers(1, &m_blackbarsVertexVBO);
+
+  glDeleteVertexArrays(1, &m_mainVAO);
+  glDeleteVertexArrays(1, &m_blackbarsVAO);
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -44,6 +44,18 @@ namespace RETRO
     static bool SupportsScalingMethod(SCALINGMETHOD method);
 
   protected:
+    struct PackedVertex
+    {
+      float x, y, z;
+      float u1, v1;
+    };
+    struct Svertex
+    {
+      float x;
+      float y;
+      float z;
+    };
+    
     // implementation of CRPBaseRenderer
     void RenderInternal(bool clear, uint8_t alpha) override;
     void FlushInternal() override;
@@ -63,8 +75,11 @@ namespace RETRO
 
     virtual void Render(uint8_t alpha);
 
-    GLuint m_mainIndexVBO;
+    GLuint m_mainVAO;
     GLuint m_mainVertexVBO;
+    GLuint m_mainIndexVBO;
+
+    GLuint m_blackbarsVAO;
     GLuint m_blackbarsVertexVBO;
     
     GLenum m_textureTarget = GL_TEXTURE_2D;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -39,6 +39,7 @@ namespace RETRO
     // implementation of CRPBaseRenderer
     bool Supports(RENDERFEATURE feature) const override;
     SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
+    void Deinitialize() override;
 
     static bool SupportsScalingMethod(SCALINGMETHOD method);
 
@@ -62,6 +63,10 @@ namespace RETRO
 
     virtual void Render(uint8_t alpha);
 
+    GLuint m_mainIndexVBO;
+    GLuint m_mainVertexVBO;
+    GLuint m_blackbarsVertexVBO;
+    
     GLenum m_textureTarget = GL_TEXTURE_2D;
     float m_clearColour = 0.0f;
   };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -39,7 +39,6 @@ namespace RETRO
     // implementation of CRPBaseRenderer
     bool Supports(RENDERFEATURE feature) const override;
     SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
-    void Deinitialize() override;
 
     static bool SupportsScalingMethod(SCALINGMETHOD method);
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -51,7 +51,9 @@ CRPRendererOpenGLES::CRPRendererOpenGLES(const CRenderSettings &renderSettings, 
 
 CRPRendererOpenGLES::~CRPRendererOpenGLES()
 {
-  Deinitialize();
+  glDeleteBuffers(1, &m_mainIndexVBO);
+  glDeleteBuffers(1, &m_mainVertexVBO);
+  glDeleteBuffers(1, &m_blackbarsVertexVBO);
 }
 
 void CRPRendererOpenGLES::RenderInternal(bool clear, uint8_t alpha)
@@ -318,11 +320,4 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
   m_context.DisableGUIShader();
-}
-
-void CRPRendererOpenGLES::Deinitialize()
-{
-  glDeleteBuffers(1, &m_mainIndexVBO);
-  glDeleteBuffers(1, &m_mainVertexVBO);
-  glDeleteBuffers(1, &m_blackbarsVertexVBO);
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -44,6 +44,7 @@ namespace RETRO
     // implementation of CRPBaseRenderer
     bool Supports(RENDERFEATURE feature) const override;
     SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
+    void Deinitialize() override;
 
     static bool SupportsScalingMethod(SCALINGMETHOD method);
 
@@ -66,7 +67,10 @@ namespace RETRO
     void DrawBlackBars();
 
     virtual void Render(uint8_t alpha);
-
+    
+    GLuint m_mainIndexVBO;
+    GLuint m_mainVertexVBO;
+    GLuint m_blackbarsVertexVBO;
     GLenum m_textureTarget = GL_TEXTURE_2D;
     float m_clearColour = 0.0f;
   };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -44,7 +44,6 @@ namespace RETRO
     // implementation of CRPBaseRenderer
     bool Supports(RENDERFEATURE feature) const override;
     SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
-    void Deinitialize() override;
 
     static bool SupportsScalingMethod(SCALINGMETHOD method);
 
@@ -67,7 +66,7 @@ namespace RETRO
     void DrawBlackBars();
 
     virtual void Render(uint8_t alpha);
-    
+
     GLuint m_mainIndexVBO;
     GLuint m_mainVertexVBO;
     GLuint m_blackbarsVertexVBO;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -224,11 +224,6 @@ CRPWinRenderer::CRPWinRenderer(const CRenderSettings &renderSettings, CRenderCon
 {
 }
 
-CRPWinRenderer::~CRPWinRenderer()
-{
-  Deinitialize();
-}
-
 bool CRPWinRenderer::ConfigureInternal()
 {
   CRenderSystemDX *renderingDx = static_cast<CRenderSystemDX*>(m_context.Rendering());

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -99,7 +99,7 @@ namespace RETRO
   {
   public:
     CRPWinRenderer(const CRenderSettings &renderSettings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool);
-    ~CRPWinRenderer() override;
+    ~CRPWinRenderer() override = default;
 
     // implementation of CRPBaseRenderer
     bool Supports(RENDERFEATURE feature) const override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
* Use of more modern OpenGL practices by using [Vertex Array Objects](https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Array_Object).
* An optimization to not generate Vertex Buffer Objects every frame, since that's unnecessary and inadvisable.
This was also done for the GLES renderer, not possible for the former change because it's not supported.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
* It's more modern
* It's faster

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
**GL**: Tried 'game.libretro.2048' on RetroPlayer, it renders as it did before.
**GLES**: Untested, but the code changed is identical to the GL commit (which I tested by itself on GL and worked).

## Screenshots (if appropriate):
Not necessary, nothing visual changed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
