### PR TITLE
Adjust PVR context menus for timer and timer rule objects

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10551,7 +10551,7 @@ msgstr ""
 #. Label for context menu entry to open settings dialog for a timer (read-only)
 #: xbmc/pvr/PVRContextMenus.cpp
 msgctxt "#19241"
-msgid "View timer information"
+msgid "View timer"
 msgstr ""
 
 #. Label for context menu entry to open settings dialog for a timer
@@ -10920,7 +10920,13 @@ msgctxt "#19303"
 msgid "Use simple timeshift OSD"
 msgstr ""
 
-#empty strings from id 19304 to 19498
+#. Label for context menu entry to open settings dialog for a timer rule (read-only)
+#: xbmc/pvr/PVRContextMenus.cpp
+msgctxt "#19304"
+msgid "View timer rule"
+msgstr ""
+
+#empty strings from id 19305 to 19498
 
 #. label for epg genre value
 #: xbmc/epg/Epg.cpp
@@ -14062,7 +14068,13 @@ msgctxt "#21482"
 msgid "Subtitle track count"
 msgstr ""
 
-#empty strings from id 21483 to 21601
+#. Label for controls used to view something (e.g. a context menu entry to open read-only timer settings dialog)
+#: xbmc/pvr/PVRContextMenus.cpp
+msgctxt "#21483"
+msgid "View"
+msgstr ""
+
+#empty strings from id 21484 to 21601
 
 #: xbmc/Util.cpp
 msgctxt "#21602"


### PR DESCRIPTION
## Description
Adjusts the PVR timer and timer rule GUI context menus to be a little more consistent.  

Specifically "Edit Timer Rule" has been adjusted to use View instead of Edit if the timer rule is read only, "Delete Timer Rule" will only be visible if the rule allows deletion, and "Edit Timer" is always visible and toggled between Edit and View verbiage based on the ability to edit the timer.

I also changed the (English) string for "View Timer Information" to "View Timer", as I think that is more consistent with "Edit Timer" and "Delete Timer".  A new string was added for the generalized "View" text.  Not sure I put that where you guys would want it, though, I followed what was done for the generalized "Edit" string.

| Type | Constraint | Context Menus |
| :--- | :--- | :--- |
| Timer Rule | Editable | Edit / Delete |
| Timer Rule | Read-only | View |
| Timer Rule | Delete-only | View / Delete |
| Timer | Editable | Edit / Delete |
| Timer | Read-only | View |
| Timer | Delete-only | View / Delete|
| EPG Timer | Editable | Edit Timer / Delete Timer |
| EPG Timer | Read-only | View Timer |
| EPG Timer | Delete-only | View Timer / Delete Timer |

Timers with a parent timer rule will also display the appropriate View/Edit/Delete Timer Rule entries, and obey the existing rules (edit: for example, a timer created by a timer rule is implicitly read-only so it still shows View rather than Edit, none of that appears to have broke/changed).  Adding all those cases above would have made the table unreasonable to look at.

## Motivation and Context
No pressing concerns are solved by this PR, I had just noted while testing a prior PR that the menus could be more consistent.

## How Has This Been Tested?
Tested on Windows x64 by manipulating timers and timer rules in my PVR to verify the use cases.

## Screenshots (if appropriate):
I captured screen shots of each of the cases listed above, I'll just attach a few here. LMK if you want them all attached.
![timer_editable_with_parent](https://user-images.githubusercontent.com/706055/46535931-e8acbc80-c87a-11e8-99c5-863c6747d32e.png)
![epg_editable_with_parent](https://user-images.githubusercontent.com/706055/46536042-3f19fb00-c87b-11e8-9d37-c7578818715d.png)
![timerrule_readonly_with_delete](https://user-images.githubusercontent.com/706055/46536058-480acc80-c87b-11e8-83c0-01cb4a90e1cd.png)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
