### PR TITLE
ApplicationPlayer: Fix playlists by correctly switching players

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -120,6 +120,14 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
       return true;
     }
   }
+  else if (player && player->m_name != newPlayer)
+  {
+    CloseFile();
+    {
+      CSingleLock lock(m_playerLock);
+      m_pPlayer.reset();
+    }
+  }
 
   if (!player)
   {


### PR DESCRIPTION
Fixes mixed playlists. In that case we need to switch from e.g. paplayer to videoplayer or another player. Fix was posted by Fernet on slack.