### PR TITLE
Don't create special://profile/library to enable Kodi system default nodes

### DIFF
--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -510,7 +510,6 @@ void CProfileManager::CreateProfileFolders()
 {
   CDirectory::Create(GetDatabaseFolder());
   CDirectory::Create(GetCDDBFolder());
-  CDirectory::Create(GetLibraryFolder());
 
   // create Thumbnails/*
   CDirectory::Create(GetThumbnailsFolder());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Remove default creation of special://profile/library

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
According to the [Video Node Wiki](https://kodi.wiki/view/Video_nodes) Kodi use system default nodes from special://xbmc/system/library until custom nodes are installed in special://profile/library. This is implemented in [GetNode()](https://github.com/xbmc/xbmc/blob/18.0b3-Leia/xbmc/filesystem/LibraryDirectory.cpp#L155-L159).

But special://profile/library always is created preventing usage of system default nodes.

[Bug report](https://forum.libreelec.tv/thread/13387-kodi-userdata-library-video-nprogressshows-xml-missing-in-le8/?postID=100539#post100539)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
With recent LibreELEC generic master.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
