### PR TITLE
[pvr] Verify parent timer rule is deletable before prompting to delete it

### DIFF
--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -830,10 +830,11 @@ namespace PVR
   bool CPVRGUIActions::ConfirmDeleteTimer(const CPVRTimerInfoTagPtr &timer, bool &bDeleteRule) const
   {
     bool bConfirmed(false);
+    const CPVRTimerInfoTagPtr parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
 
-    if (timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT)
+    if (parentTimer && parentTimer->HasTimerType() && parentTimer->GetTimerType()->AllowsDelete())
     {
-      // timer was scheduled by a timer rule. prompt user for confirmation for deleting the timer rule, including scheduled timers.
+      // timer was scheduled by a deletable timer rule. prompt user for confirmation for deleting the timer rule, including scheduled timers.
       bool bCancel(false);
       bDeleteRule = CGUIDialogYesNo::ShowAndGetInput(CVariant{122}, // "Confirm delete"
                                                      CVariant{840}, // "Do you want to delete only this timer or also the timer rule that has scheduled it?"


### PR DESCRIPTION
## Description
This is a minor change to prevent the user from being prompted to delete a parent timer rule that is incapable of being deleted.

## Motivation and Context
If a child timer is flagged as editable/deletable but its parent timer rule is not, the application was prompting the user to optionally delete the parent timer rule, which is an operation that cannot succeed.  This change verifies that the parent timer rule can be deleted before prompting the user. I had noticed this behavior while working up previous PRs and thought it would be a good idea to try and correct it.  PVR implementers may not expect a request to delete a timer rule that has been flagged as read-only to come in to their DeleteTimer() implementation.

## How Has This Been Tested?
Tested on Windows x64 using my own PVR client.  I manually made adjustments to the timers and timer rules it creates to verify that a deletable timer with both a deletable and non-deletable parent timer rule behaved as expected.  I also unlinked the timers from the parent timer rules to verify that the existing logic for deleting existing standalone timers has not been altered.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

>> I promise no more PVR pull requests from me for a while.  Thanks as always!