### PR TITLE
[Kodi] Removed unused string

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5572,12 +5572,7 @@ msgctxt "#12022"
 msgid "Resume from {0:s}"
 msgstr ""
 
-#. unused?
-msgctxt "#12023"
-msgid "Play from beginning"
-msgstr ""
-
-#empty strings from id 12024 to 12309
+#empty strings from id 12023 to 12309
 
 #: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml


### PR DESCRIPTION
A quick GH search doesn't brought up anything for the msgctxt 12023. 

"Play from beginning" is also used as msgctxt 12021 and that can be found multiple times at the code. Also there are some file references mentioned.

I also compiled current master with that change and "Play from beginning" is mostly used in context menus where it is still shown, because "12021" is in use for those. 

So I would say, that this one could be removed.

Added the v18 label because it shouldn't brake anything and might be good to go for v18. Not sure which other labels I should set ;)
