### PR TITLE
[docs] Game_Control should be a subpage of skin_controls

### DIFF
--- a/xbmc/guilib/_Controls.dox
+++ b/xbmc/guilib/_Controls.dox
@@ -11,6 +11,7 @@ manual will explain each and every control in detail.
 - \subpage skin_Edit_control - used as an input control for the osd keyboard and other input fields.
 - \subpage Fade_Label_Control - used to show multiple pieces of text in the same position, by fading from one to the other.
 - \subpage Fixed_List_Container - used for a list of items with a fixed focus. Same as the \ref Wrap_List_Container "Wrap List Container" except it doesn't wrap.
+- \subpage Game_Control - used to display the currently playing game, with optional effects, whilst in the GUI.
 - \subpage Group_Control -  used to group controls together.
 - \subpage Group_List_Control - special case of the group control that forms a scrolling list of controls.
 - \subpage Image_Control - used to show an image.


### PR DESCRIPTION
## Description
Right now the game control doxygen page is shown as a menu entry on doxygen side bar. It should be in fact grouped with all the other skin controls.

## Motivation and Context
Proper documentation for Leia. Group all skin controls on the same place.

## How Has This Been Tested?
Compiled docs and manual testing

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
