### PR TITLE
ApplicationPlayer: Fixup mixed playlists, really reopen new player

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -126,6 +126,7 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
     {
       CSingleLock lock(m_playerLock);
       m_pPlayer.reset();
+      player.reset();
     }
   }
 


### PR DESCRIPTION
Another fixup. Basically we get a shared_ptr called player pointing to m_pPlayer, increasing the refcount.

When we detect a needed player change we try to reset m_pPlayer  (reducing refcount) but player still in scope holding a ptr to this original shared_ptr and therefore we don't create a new player as player is still valid.

Open for better fixes. How a bout a weak_ptr? Better scope?