### PR TITLE
[PVR] Ensure PVR_MENUHOOK dialog is always opened, even for one item.

### DIFF
--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1489,7 +1489,7 @@ namespace PVR
       }
 
       int selection = 0;
-      if (hookIDs.size() > 1)
+      if (!hookIDs.empty())
       {
         pDialog->Open();
         selection = pDialog->GetSelectedItem();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The PVR_MENUHOOK allows a PVR client to create a "client actions"
sub-menu in the PVR system (timers, epg, etc.)

Previously, if there are multiple options in the sub-menu then a dialog
is displayed to select the option. But, if there is only one option
in the sub-menu then it is automatically selected and actioned.

So, if the sub-menu has the option "delete forever" and the user
presses "context menu" and then selects "client actions", then the
recording would be deleted without any user action (or knowledge of
what the sub-menu option is). This can be demonstrated with "pvr.demo".

With this change, we always open the selection dialog to allow the user to see and
explicitly select the option or press the existing "cancel" button on
the dialog.

AFAICT, existing clients have either zero or multiple items in the sub-menu.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

I wanted to add a client action menu to pvr.hts that will only
have one item. I don't want the item auto-selected since
the user does not know what will occur when they press
"client actions".

AFAICT, existing pvr clients either have no menu, or menus
with multiple items, so this change should not affect UI for 
existing clients.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Build and run with pvr.demo and pvr.mythtv and with local
pvr.hts changes.

## Screenshots (if appropriate):
The dialog (post-change) is like this:
![custom-menu](https://user-images.githubusercontent.com/31170571/46582856-805e0680-ca45-11e8-87aa-8f6592ff62c2.png)
Previously no dialog is displayed and the item would be actioned immediately.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
