### PR TITLE
LibInputHandler: Don't block shutdown forever

### DIFF
--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -136,7 +136,7 @@ void CLibInputHandler::Process()
 
   while (!m_bStop)
   {
-    epoll_wait(epollFd, &event, 1, -1);
+    epoll_wait(epollFd, &event, 1, 200);
 
     ret = libinput_dispatch(m_li);
     if (ret < 0)


### PR DESCRIPTION
On Shutdown we would wait forever. This checks if we received an event after max 200 ms.