### PR TITLE
Settings component: Add  profile manager

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -434,12 +434,6 @@ bool CApplication::Create(const CAppParamParser &params)
   // Init our DllLoaders emu env
   init_emu_environ();
 
-  if (!m_ServiceManager->InitStageOnePointFive())
-    return false;
-
-  CSpecialProtocol::RegisterProfileManager(m_ServiceManager->GetProfileManager());
-  XFILE::IDirectory::RegisterProfileManager(m_ServiceManager->GetProfileManager());
-
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
   CLog::Log(LOGNOTICE, "Starting %s (%s). Platform: %s %s %d-bit", CSysInfo::GetAppName().c_str(), CSysInfo::GetVersion().c_str(),
             g_sysinfo.GetBuildTargetPlatformName().c_str(), g_sysinfo.GetBuildTargetCpuFamily().c_str(), g_sysinfo.GetXbmcBitness());
@@ -535,25 +529,19 @@ bool CApplication::Create(const CAppParamParser &params)
   // set avutil callback
   av_log_set_callback(ff_avutil_log);
 
-  // Initialize default Settings - don't move
-  CLog::Log(LOGNOTICE, "load settings...");
-
-  // load the actual values
-  const std::shared_ptr<CSettings> settings = m_pSettingsComponent->GetSettings();
-  if (!settings->Load())
-  {
-    CLog::Log(LOGFATAL, "unable to load settings");
+  CLog::Log(LOGINFO, "loading settings");
+  if (!m_pSettingsComponent->Load())
     return false;
-  }
-  settings->SetLoaded();
 
   CLog::Log(LOGINFO, "creating subdirectories");
-  CLog::Log(LOGINFO, "userdata folder: %s", CURL::GetRedacted(m_ServiceManager->GetProfileManager().GetProfileUserDataFolder()).c_str());
+  const std::shared_ptr<CProfilesManager> profilesManager = m_pSettingsComponent->GetProfilesManager();
+  const std::shared_ptr<CSettings> settings = m_pSettingsComponent->GetSettings();
+  CLog::Log(LOGINFO, "userdata folder: %s", CURL::GetRedacted(profilesManager->GetProfileUserDataFolder()).c_str());
   CLog::Log(LOGINFO, "recording folder: %s", CURL::GetRedacted(settings->GetString(CSettings::SETTING_AUDIOCDS_RECORDINGPATH)).c_str());
   CLog::Log(LOGINFO, "screenshots folder: %s", CURL::GetRedacted(settings->GetString(CSettings::SETTING_DEBUG_SCREENSHOTPATH)).c_str());
-  CDirectory::Create(m_ServiceManager->GetProfileManager().GetUserDataFolder());
-  CDirectory::Create(m_ServiceManager->GetProfileManager().GetProfileUserDataFolder());
-  m_ServiceManager->GetProfileManager().CreateProfileFolders();
+  CDirectory::Create(profilesManager->GetUserDataFolder());
+  CDirectory::Create(profilesManager->GetProfileUserDataFolder());
+  profilesManager->CreateProfileFolders();
 
   update_emu_environ();//apply the GUI settings
 
@@ -569,7 +557,7 @@ bool CApplication::Create(const CAppParamParser &params)
   m_pWinSystem = CWinSystemBase::CreateWinSystem();
   CServiceBroker::RegisterWinSystem(m_pWinSystem.get());
 
-  if (!m_ServiceManager->InitStageTwo(params))
+  if (!m_ServiceManager->InitStageTwo(params, m_pSettingsComponent->GetProfilesManager()->GetProfileUserDataFolder()))
   {
     return false;
   }
@@ -736,7 +724,9 @@ bool CApplication::Initialize()
   if (!LoadLanguage(false))
     return false;
 
-  m_ServiceManager->GetEventLog().Add(EventPtr(new CNotificationEvent(
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+
+  profilesManager->GetEventLog().Add(EventPtr(new CNotificationEvent(
     StringUtils::Format(g_localizeStrings.Get(177).c_str(), g_sysinfo.GetAppName().c_str()),
     StringUtils::Format(g_localizeStrings.Get(178).c_str(), g_sysinfo.GetAppName().c_str()),
     "special://xbmc/media/icon256x256.png", EventLevel::Basic)));
@@ -824,14 +814,14 @@ bool CApplication::Initialize()
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SPLASH);
 
     if (settings->GetBool(CSettings::SETTING_MASTERLOCK_STARTUPLOCK) &&
-        m_ServiceManager->GetProfileManager().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-        !m_ServiceManager->GetProfileManager().GetMasterProfile().getLockCode().empty())
+        profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+        !profilesManager->GetMasterProfile().getLockCode().empty())
     {
       g_passwordManager.CheckStartUpLock();
     }
 
     // check if we should use the login screen
-    if (m_ServiceManager->GetProfileManager().UsingLoginScreen())
+    if (profilesManager->UsingLoginScreen())
     {
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_LOGIN_SCREEN);
     }
@@ -857,7 +847,7 @@ bool CApplication::Initialize()
 
   CJSONRPC::Initialize();
 
-  if (!m_ServiceManager->InitStageThree())
+  if (!m_ServiceManager->InitStageThree(profilesManager))
   {
     CLog::Log(LOGERROR, "Application - Init3 failed");
   }
@@ -867,7 +857,7 @@ bool CApplication::Initialize()
   CLog::Log(LOGINFO, "removing tempfiles");
   CUtil::RemoveTempFiles();
 
-  if (!m_ServiceManager->GetProfileManager().UsingLoginScreen())
+  if (!profilesManager->UsingLoginScreen())
   {
     UpdateLibraries();
     SetLoggingIn(false);
@@ -880,7 +870,7 @@ bool CApplication::Initialize()
   RegisterActionListener(&CPlayerController::GetInstance());
 
   CServiceBroker::GetRepositoryUpdater().Start();
-  if (!m_ServiceManager->GetProfileManager().UsingLoginScreen())
+  if (!profilesManager->UsingLoginScreen())
     CServiceBroker::GetServiceAddons().Start();
 
   CLog::Log(LOGNOTICE, "initialize done");
@@ -2280,7 +2270,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     {
       const int profile = pMsg->param1;
       if (profile >= 0)
-        m_ServiceManager->GetProfileManager().LoadProfile(static_cast<unsigned int>(profile));
+        CServiceBroker::GetSettingsComponent()->GetProfilesManager()->LoadProfile(static_cast<unsigned int>(profile));
     }
 
     break;
@@ -2476,10 +2466,6 @@ bool CApplication::Cleanup()
     if (m_ServiceManager)
       m_ServiceManager->DeinitStageTwo();
 
-    XFILE::IDirectory::UnregisterProfileManager();
-    CSpecialProtocol::UnregisterProfileManager();
-    m_ServiceManager->DeinitStageOnePointFive();
-
 #ifdef TARGET_POSIX
     CXHandle::DumpObjectTracker();
 
@@ -2554,7 +2540,7 @@ void CApplication::Stop(int exitCode)
     g_sysinfo.SetTotalUptime(g_sysinfo.GetTotalUptime() + (int)(CTimeUtils::GetFrameTime() / 60000));
 
     // Update the settings information (volume, uptime etc. need saving)
-    if (CFile::Exists(m_ServiceManager->GetProfileManager().GetSettingsFile()))
+    if (CFile::Exists(CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetSettingsFile()))
     {
       CLog::Log(LOGNOTICE, "Saving settings");
       CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
@@ -3124,7 +3110,7 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
     resumeBookmark.timeInSeconds = 0.0f;
   }
 
-  if (m_ServiceManager->GetProfileManager().GetCurrentProfile().canWriteDatabases())
+  if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteDatabases())
   {
     CSaveFileState::DoWork(fileItem, resumeBookmark, playCountUpdate);
   }
@@ -3424,9 +3410,11 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
   if (m_screensaverActive && !m_screensaverIdInUse.empty())
   {
     if (m_iScreenSaveLock == 0)
-      if (m_ServiceManager->GetProfileManager().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-          (m_ServiceManager->GetProfileManager().UsingLoginScreen() || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MASTERLOCK_STARTUPLOCK)) &&
-          m_ServiceManager->GetProfileManager().GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+    {
+      const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+      if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+          (profilesManager->UsingLoginScreen() || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MASTERLOCK_STARTUPLOCK)) &&
+          profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
           m_screensaverIdInUse != "screensaver.xbmc.builtin.dim" && m_screensaverIdInUse != "screensaver.xbmc.builtin.black" && m_screensaverIdInUse != "visualization")
       {
         m_iScreenSaveLock = 2;
@@ -3436,6 +3424,7 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
         if (pWindow)
           pWindow->OnMessage(msg);
       }
+    }
     if (m_iScreenSaveLock == -1)
     {
       m_iScreenSaveLock = 0;

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -79,10 +79,8 @@ void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool
   g_application.WakeUpScreenSaverAndDPMS();  // turn off the screensaver if it's active
 
 #ifdef HAS_CDDA_RIPPER
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
-
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) == AUTOCD_RIP &&
-      pInfo->IsAudio(1) && !profileManager.GetCurrentProfile().musicLocked())
+      pInfo->IsAudio(1) && !CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().musicLocked())
   {
     CCDDARipper::GetInstance().RipCD();
   }
@@ -156,11 +154,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
   bool bAllowMusic = true;
   if (!g_passwordManager.IsMasterLockUnlocked(false))
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-    bAllowVideo = !profileManager.GetCurrentProfile().videoLocked();
-//    bAllowPictures = !profileManager.GetCurrentProfile().picturesLocked();
-    bAllowMusic = !profileManager.GetCurrentProfile().musicLocked();
+    bAllowVideo = !profilesManager->GetCurrentProfile().videoLocked();
+//    bAllowPictures = !profilesManager->GetCurrentProfile().picturesLocked();
+    bAllowMusic = !profilesManager->GetCurrentProfile().musicLocked();
   }
 
   // is this a root folder we have to check the content to determine a disc type

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -22,7 +22,7 @@
 #include "filesystem/File.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "xbmc/settings/lib/Setting.h"
@@ -80,7 +80,7 @@ void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool
 
 #ifdef HAS_CDDA_RIPPER
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) == AUTOCD_RIP &&
-      pInfo->IsAudio(1) && !CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().musicLocked())
+      pInfo->IsAudio(1) && !CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().musicLocked())
   {
     CCDDARipper::GetInstance().RipCD();
   }
@@ -154,11 +154,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
   bool bAllowMusic = true;
   if (!g_passwordManager.IsMasterLockUnlocked(false))
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-    bAllowVideo = !profilesManager->GetCurrentProfile().videoLocked();
-//    bAllowPictures = !profilesManager->GetCurrentProfile().picturesLocked();
-    bAllowMusic = !profilesManager->GetCurrentProfile().musicLocked();
+    bAllowVideo = !profileManager->GetCurrentProfile().videoLocked();
+//    bAllowPictures = !profileManager->GetCurrentProfile().picturesLocked();
+    bAllowMusic = !profileManager->GetCurrentProfile().musicLocked();
   }
 
   // is this a root folder we have to check the content to determine a disc type

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -42,13 +42,13 @@ CGUIPassword::~CGUIPassword(void) = default;
 
 bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   // \brief Tests if the user is allowed to access the share folder
   // \param pItem The share folder item to access
   // \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
   // \return If access is granted, returns \e true
-  if (profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   while (pItem->m_iHasLock > 1)
@@ -129,17 +129,17 @@ bool CGUIPassword::CheckStartUpLock()
   if (g_passwordManager.iMasterLockRetriesLeft == 0)
     g_passwordManager.iMasterLockRetriesLeft = 1;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  std::string strPassword = profileManager.GetMasterProfile().getLockCode();
+  std::string strPassword = profilesManager->GetMasterProfile().getLockCode();
 
-  if (profileManager.GetMasterProfile().getLockMode() == 0)
+  if (profilesManager->GetMasterProfile().getLockMode() == 0)
     iVerifyPasswordResult = 0;
   else
   {
     for (int i=1; i <= g_passwordManager.iMasterLockRetriesLeft; i++)
     {
-      iVerifyPasswordResult = VerifyPassword(profileManager.GetMasterProfile().getLockMode(), strPassword, strHeader);
+      iVerifyPasswordResult = VerifyPassword(profilesManager->GetMasterProfile().getLockMode(), strPassword, strHeader);
       if (iVerifyPasswordResult != 0 )
       {
         std::string strLabel1;
@@ -169,9 +169,9 @@ bool CGUIPassword::CheckStartUpLock()
 
 bool CGUIPassword::SetMasterLockMode(bool bDetails)
 {
-  CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  CProfile* profile = profileManager.GetProfile(0);
+  CProfile* profile = profilesManager->GetProfile(0);
   if (profile)
   {
     CProfile::CLock locks = profile->GetLocks();
@@ -195,17 +195,17 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
   if (g_passwordManager.bMasterUser)
     return true;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   int iProfileToCheck = iProfile;
   if (iProfile == -1)
-    iProfileToCheck = profileManager.GetCurrentProfileIndex();
+    iProfileToCheck = profilesManager->GetCurrentProfileIndex();
 
   if (iProfileToCheck == 0)
     return IsMasterLockUnlocked(prompt,bCanceled);
   else
   {
-    const CProfile *profile = profileManager.GetProfile(iProfileToCheck);
+    const CProfile *profile = profilesManager->GetProfile(iProfileToCheck);
     if (!profile)
       return false;
 
@@ -213,7 +213,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
       return (profile->getLockMode() == LOCK_MODE_EVERYONE);
 
     if (profile->getDate().empty() &&
-       (profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+       (profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
         profile->getLockMode() == LOCK_MODE_EVERYONE))
     {
       // user hasn't set a password and this is the first time they've used this account
@@ -223,7 +223,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
     }
     else
     {
-      if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         return CheckLock(profile->getLockMode(),profile->getLockCode(),20095,bCanceled);
     }
   }
@@ -244,15 +244,15 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if ((LOCK_MODE_EVERYONE < profileManager.GetMasterProfile().getLockMode() && !bMasterUser) && !bPromptUser)
+  if ((LOCK_MODE_EVERYONE < profilesManager->GetMasterProfile().getLockMode() && !bMasterUser) && !bPromptUser)
   {
     // not unlocked, but calling code doesn't want to prompt user
     return false;
   }
 
-  if (g_passwordManager.bMasterUser || profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (g_passwordManager.bMasterUser || profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   if (iMasterLockRetriesLeft == 0)
@@ -263,9 +263,9 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
 
   // no, unlock since we are allowed to prompt
   std::string strHeading = g_localizeStrings.Get(20075);
-  std::string strPassword = profileManager.GetMasterProfile().getLockCode();
+  std::string strPassword = profilesManager->GetMasterProfile().getLockCode();
 
-  int iVerifyPasswordResult = VerifyPassword(profileManager.GetMasterProfile().getLockMode(), strPassword, strHeading);
+  int iVerifyPasswordResult = VerifyPassword(profilesManager->GetMasterProfile().getLockMode(), strPassword, strHeading);
   if (1 == iVerifyPasswordResult)
     UpdateMasterLockRetryCount(false);
 
@@ -325,11 +325,11 @@ bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, i
 {
   bCanceled = false;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   if (btnType == LOCK_MODE_EVERYONE ||
       strPassword == "-" ||
-      profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
       g_passwordManager.bMasterUser)
   {
     return true;
@@ -346,9 +346,9 @@ bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, i
 
 bool CGUIPassword::CheckSettingLevelLock(const SettingLevel& level, bool enforce /*=false*/)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  LOCK_LEVEL::SETTINGS_LOCK lockLevel = profileManager.GetCurrentProfile().settingsLockLevel();
+  LOCK_LEVEL::SETTINGS_LOCK lockLevel = profilesManager->GetCurrentProfile().settingsLockLevel();
 
   if (lockLevel == LOCK_LEVEL::NONE)
     return true;
@@ -409,7 +409,7 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       iSwitch = WINDOW_VIDEO_NAV;
   }
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   switch (iSwitch)
   {
@@ -417,25 +417,25 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       return CheckSettingLevelLock(CViewStateSettings::GetInstance().GetSettingLevel());
       break;
     case WINDOW_ADDON_BROWSER:  // Addons
-      bCheckPW = profileManager.GetCurrentProfile().addonmanagerLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().addonmanagerLocked();
       break;
     case WINDOW_FILES:          // Files
-      bCheckPW = profileManager.GetCurrentProfile().filesLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().filesLocked();
       break;
     case WINDOW_PROGRAMS:       // Programs
-      bCheckPW = profileManager.GetCurrentProfile().programsLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().programsLocked();
       break;
     case WINDOW_MUSIC_NAV:      // Music
-      bCheckPW = profileManager.GetCurrentProfile().musicLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().musicLocked();
       break;
     case WINDOW_VIDEO_NAV:      // Video
-      bCheckPW = profileManager.GetCurrentProfile().videoLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().videoLocked();
       break;
     case WINDOW_PICTURES:       // Pictures
-      bCheckPW = profileManager.GetCurrentProfile().picturesLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().picturesLocked();
       break;
     case WINDOW_GAMES:          // Games
-      bCheckPW = profileManager.GetCurrentProfile().gamesLocked();
+      bCheckPW = profilesManager->GetCurrentProfile().gamesLocked();
       break;
     case WINDOW_SETTINGS_PROFILES:
       bCheckPW = true;
@@ -509,9 +509,9 @@ void CGUIPassword::RemoveSourceLocks()
 
 bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (g_passwordManager.bMasterUser || profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (g_passwordManager.bMasterUser || profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   // try to find the best matching source

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -14,7 +14,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogNumeric.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "Util.h"
@@ -42,13 +42,13 @@ CGUIPassword::~CGUIPassword(void) = default;
 
 bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   // \brief Tests if the user is allowed to access the share folder
   // \param pItem The share folder item to access
   // \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
   // \return If access is granted, returns \e true
-  if (profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   while (pItem->m_iHasLock > 1)
@@ -129,17 +129,17 @@ bool CGUIPassword::CheckStartUpLock()
   if (g_passwordManager.iMasterLockRetriesLeft == 0)
     g_passwordManager.iMasterLockRetriesLeft = 1;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::string strPassword = profilesManager->GetMasterProfile().getLockCode();
+  std::string strPassword = profileManager->GetMasterProfile().getLockCode();
 
-  if (profilesManager->GetMasterProfile().getLockMode() == 0)
+  if (profileManager->GetMasterProfile().getLockMode() == 0)
     iVerifyPasswordResult = 0;
   else
   {
     for (int i=1; i <= g_passwordManager.iMasterLockRetriesLeft; i++)
     {
-      iVerifyPasswordResult = VerifyPassword(profilesManager->GetMasterProfile().getLockMode(), strPassword, strHeader);
+      iVerifyPasswordResult = VerifyPassword(profileManager->GetMasterProfile().getLockMode(), strPassword, strHeader);
       if (iVerifyPasswordResult != 0 )
       {
         std::string strLabel1;
@@ -169,9 +169,9 @@ bool CGUIPassword::CheckStartUpLock()
 
 bool CGUIPassword::SetMasterLockMode(bool bDetails)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  CProfile* profile = profilesManager->GetProfile(0);
+  CProfile* profile = profileManager->GetProfile(0);
   if (profile)
   {
     CProfile::CLock locks = profile->GetLocks();
@@ -195,17 +195,17 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
   if (g_passwordManager.bMasterUser)
     return true;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   int iProfileToCheck = iProfile;
   if (iProfile == -1)
-    iProfileToCheck = profilesManager->GetCurrentProfileIndex();
+    iProfileToCheck = profileManager->GetCurrentProfileIndex();
 
   if (iProfileToCheck == 0)
     return IsMasterLockUnlocked(prompt,bCanceled);
   else
   {
-    const CProfile *profile = profilesManager->GetProfile(iProfileToCheck);
+    const CProfile *profile = profileManager->GetProfile(iProfileToCheck);
     if (!profile)
       return false;
 
@@ -213,7 +213,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
       return (profile->getLockMode() == LOCK_MODE_EVERYONE);
 
     if (profile->getDate().empty() &&
-       (profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+       (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
         profile->getLockMode() == LOCK_MODE_EVERYONE))
     {
       // user hasn't set a password and this is the first time they've used this account
@@ -223,7 +223,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
     }
     else
     {
-      if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         return CheckLock(profile->getLockMode(),profile->getLockCode(),20095,bCanceled);
     }
   }
@@ -244,15 +244,15 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if ((LOCK_MODE_EVERYONE < profilesManager->GetMasterProfile().getLockMode() && !bMasterUser) && !bPromptUser)
+  if ((LOCK_MODE_EVERYONE < profileManager->GetMasterProfile().getLockMode() && !bMasterUser) && !bPromptUser)
   {
     // not unlocked, but calling code doesn't want to prompt user
     return false;
   }
 
-  if (g_passwordManager.bMasterUser || profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (g_passwordManager.bMasterUser || profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   if (iMasterLockRetriesLeft == 0)
@@ -263,9 +263,9 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
 
   // no, unlock since we are allowed to prompt
   std::string strHeading = g_localizeStrings.Get(20075);
-  std::string strPassword = profilesManager->GetMasterProfile().getLockCode();
+  std::string strPassword = profileManager->GetMasterProfile().getLockCode();
 
-  int iVerifyPasswordResult = VerifyPassword(profilesManager->GetMasterProfile().getLockMode(), strPassword, strHeading);
+  int iVerifyPasswordResult = VerifyPassword(profileManager->GetMasterProfile().getLockMode(), strPassword, strHeading);
   if (1 == iVerifyPasswordResult)
     UpdateMasterLockRetryCount(false);
 
@@ -325,11 +325,11 @@ bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, i
 {
   bCanceled = false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (btnType == LOCK_MODE_EVERYONE ||
       strPassword == "-" ||
-      profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
       g_passwordManager.bMasterUser)
   {
     return true;
@@ -346,9 +346,9 @@ bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, i
 
 bool CGUIPassword::CheckSettingLevelLock(const SettingLevel& level, bool enforce /*=false*/)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  LOCK_LEVEL::SETTINGS_LOCK lockLevel = profilesManager->GetCurrentProfile().settingsLockLevel();
+  LOCK_LEVEL::SETTINGS_LOCK lockLevel = profileManager->GetCurrentProfile().settingsLockLevel();
 
   if (lockLevel == LOCK_LEVEL::NONE)
     return true;
@@ -409,7 +409,7 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       iSwitch = WINDOW_VIDEO_NAV;
   }
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   switch (iSwitch)
   {
@@ -417,25 +417,25 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       return CheckSettingLevelLock(CViewStateSettings::GetInstance().GetSettingLevel());
       break;
     case WINDOW_ADDON_BROWSER:  // Addons
-      bCheckPW = profilesManager->GetCurrentProfile().addonmanagerLocked();
+      bCheckPW = profileManager->GetCurrentProfile().addonmanagerLocked();
       break;
     case WINDOW_FILES:          // Files
-      bCheckPW = profilesManager->GetCurrentProfile().filesLocked();
+      bCheckPW = profileManager->GetCurrentProfile().filesLocked();
       break;
     case WINDOW_PROGRAMS:       // Programs
-      bCheckPW = profilesManager->GetCurrentProfile().programsLocked();
+      bCheckPW = profileManager->GetCurrentProfile().programsLocked();
       break;
     case WINDOW_MUSIC_NAV:      // Music
-      bCheckPW = profilesManager->GetCurrentProfile().musicLocked();
+      bCheckPW = profileManager->GetCurrentProfile().musicLocked();
       break;
     case WINDOW_VIDEO_NAV:      // Video
-      bCheckPW = profilesManager->GetCurrentProfile().videoLocked();
+      bCheckPW = profileManager->GetCurrentProfile().videoLocked();
       break;
     case WINDOW_PICTURES:       // Pictures
-      bCheckPW = profilesManager->GetCurrentProfile().picturesLocked();
+      bCheckPW = profileManager->GetCurrentProfile().picturesLocked();
       break;
     case WINDOW_GAMES:          // Games
-      bCheckPW = profilesManager->GetCurrentProfile().gamesLocked();
+      bCheckPW = profileManager->GetCurrentProfile().gamesLocked();
       break;
     case WINDOW_SETTINGS_PROFILES:
       bCheckPW = true;
@@ -509,9 +509,9 @@ void CGUIPassword::RemoveSourceLocks()
 
 bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (g_passwordManager.bMasterUser || profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (g_passwordManager.bMasterUser || profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   // try to find the best matching source

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -22,7 +22,7 @@
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "playlists/SmartPlayList.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/log.h"
@@ -55,14 +55,14 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
 
   m_bIsVideo = context == PARTYMODECONTEXT_VIDEO;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (!strXspPath.empty()) //if a path to a smartplaylist is supplied use it
     partyModePath = strXspPath;
   else if (m_bIsVideo)
-    partyModePath = profilesManager->GetUserDataItem("PartyMode-Video.xsp");
+    partyModePath = profileManager->GetUserDataItem("PartyMode-Video.xsp");
   else
-    partyModePath = profilesManager->GetUserDataItem("PartyMode.xsp");
+    partyModePath = profileManager->GetUserDataItem("PartyMode.xsp");
 
   playlistLoaded=playlist.Load(partyModePath);
 

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -23,6 +23,7 @@
 #include "playlists/PlayList.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/log.h"
 #include "utils/Random.h"
@@ -54,14 +55,14 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
 
   m_bIsVideo = context == PARTYMODECONTEXT_VIDEO;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   if (!strXspPath.empty()) //if a path to a smartplaylist is supplied use it
     partyModePath = strXspPath;
   else if (m_bIsVideo)
-    partyModePath = profileManager.GetUserDataItem("PartyMode-Video.xsp");
+    partyModePath = profilesManager->GetUserDataItem("PartyMode-Video.xsp");
   else
-    partyModePath = profileManager.GetUserDataItem("PartyMode.xsp");
+    partyModePath = profilesManager->GetUserDataItem("PartyMode.xsp");
 
   playlistLoaded=playlist.Load(partyModePath);
 

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "PasswordManager.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "URL.h"
 #include "utils/XMLUtils.h"
@@ -134,9 +134,9 @@ void CPasswordManager::Load()
 {
   Clear();
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::string passwordsFile = profilesManager->GetUserDataItem("passwords.xml");
+  std::string passwordsFile = profileManager->GetUserDataItem("passwords.xml");
   if (XFILE::CFile::Exists(passwordsFile))
   {
     CXBMCTinyXML doc;
@@ -185,9 +185,9 @@ void CPasswordManager::Save() const
     XMLUtils::SetPath(path, "to", i->second);
   }
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  doc.SaveFile(profilesManager->GetUserDataItem("passwords.xml"));
+  doc.SaveFile(profileManager->GetUserDataItem("passwords.xml"));
 }
 
 std::string CPasswordManager::GetLookupPath(const CURL &url) const

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -11,6 +11,7 @@
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "URL.h"
 #include "utils/XMLUtils.h"
+#include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "filesystem/File.h"
@@ -133,9 +134,9 @@ void CPasswordManager::Load()
 {
   Clear();
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  std::string passwordsFile = profileManager.GetUserDataItem("passwords.xml");
+  std::string passwordsFile = profilesManager->GetUserDataItem("passwords.xml");
   if (XFILE::CFile::Exists(passwordsFile))
   {
     CXBMCTinyXML doc;
@@ -184,9 +185,9 @@ void CPasswordManager::Save() const
     XMLUtils::SetPath(path, "to", i->second);
   }
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  doc.SaveFile(profileManager.GetUserDataItem("passwords.xml"));
+  doc.SaveFile(profilesManager->GetUserDataItem("passwords.xml"));
 }
 
 std::string CPasswordManager::GetLookupPath(const CURL &url) const

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -8,6 +8,8 @@
 
 #include "ServiceBroker.h"
 #include "Application.h"
+#include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "windowing/WinSystem.h"
 
 using namespace KODI;
@@ -198,14 +200,15 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
   return g_application.m_ServiceManager->GetDatabaseManager();
 }
 
+// @todo to be removed with next commit
 CProfilesManager& CServiceBroker::GetProfileManager()
 {
-  return g_application.m_ServiceManager->GetProfileManager();
+  return *m_pSettingsComponent->GetProfilesManager();
 }
 
 CEventLog& CServiceBroker::GetEventLog()
 {
-  return g_application.m_ServiceManager->GetEventLog();
+  return m_pSettingsComponent->GetProfilesManager()->GetEventLog();
 }
 
 CGUIComponent* CServiceBroker::m_pGUI = nullptr;

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -200,12 +200,6 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
   return g_application.m_ServiceManager->GetDatabaseManager();
 }
 
-// @todo to be removed with next commit
-CProfilesManager& CServiceBroker::GetProfileManager()
-{
-  return *m_pSettingsComponent->GetProfilesManager();
-}
-
 CEventLog& CServiceBroker::GetEventLog()
 {
   return m_pSettingsComponent->GetProfilesManager()->GetEventLog();

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -8,7 +8,7 @@
 
 #include "ServiceBroker.h"
 #include "Application.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "windowing/WinSystem.h"
 
@@ -202,7 +202,7 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
 
 CEventLog& CServiceBroker::GetEventLog()
 {
-  return m_pSettingsComponent->GetProfilesManager()->GetEventLog();
+  return m_pSettingsComponent->GetProfileManager()->GetEventLog();
 }
 
 CGUIComponent* CServiceBroker::m_pGUI = nullptr;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -48,7 +48,6 @@ class CPowerManager;
 class CWeatherManager;
 class CPlayerCoreFactory;
 class CDatabaseManager;
-class CProfilesManager;
 class CEventLog;
 class CGUIComponent;
 class CAppInboundProtocol;
@@ -105,8 +104,6 @@ public:
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();
   static CDatabaseManager &GetDatabaseManager();
-  // @todo to be removed with next commit
-  static CProfilesManager &GetProfileManager();
   static CEventLog &GetEventLog();
 
   static CGUIComponent* GetGUI();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -105,6 +105,7 @@ public:
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();
   static CDatabaseManager &GetDatabaseManager();
+  // @todo to be removed with next commit
   static CProfilesManager &GetProfileManager();
   static CEventLog &GetEventLog();
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -19,7 +19,7 @@
 #include "games/GameServices.h"
 #include "peripherals/Peripherals.h"
 #include "PlayListPlayer.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "utils/log.h"
 #include "input/InputManager.h"
 #include "interfaces/AnnouncementManager.h"
@@ -164,7 +164,7 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params, const std::str
 }
 
 // stage 3 is called after successful initialization of WindowManager
-bool CServiceManager::InitStageThree(const std::shared_ptr<CProfilesManager>& profilesManager)
+bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& profileManager)
 {
   // Peripherals depends on strings being loaded before stage 3
   m_peripherals->Initialise();
@@ -172,12 +172,12 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfilesManager>& pr
   m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager,
     *m_gameRenderManager,
     *m_peripherals,
-    *profilesManager));
+    *profileManager));
 
   m_contextMenuManager->Init();
   m_PVRManager->Init();
 
-  m_playerCoreFactory.reset(new CPlayerCoreFactory(*profilesManager));
+  m_playerCoreFactory.reset(new CPlayerCoreFactory(*profileManager));
 
   init_level = 3;
   return true;

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -78,13 +78,11 @@ public:
 
   bool InitForTesting();
   bool InitStageOne();
-  bool InitStageOnePointFive(); // Services that need our DllLoaders emu env
-  bool InitStageTwo(const CAppParamParser &params);
-  bool InitStageThree();
+  bool InitStageTwo(const CAppParamParser &params, const std::string& profilesUserDataFolder);
+  bool InitStageThree(const std::shared_ptr<CProfilesManager>& profilesManager);
   void DeinitTesting();
   void DeinitStageThree();
   void DeinitStageTwo();
-  void DeinitStageOnePointFive();
   void DeinitStageOne();
 
   ADDON::CAddonMgr& GetAddonMgr();
@@ -122,10 +120,6 @@ public:
   CPlayerCoreFactory &GetPlayerCoreFactory();
 
   CDatabaseManager &GetDatabaseManager();
-
-  CProfilesManager &GetProfileManager();
-
-  CEventLog &GetEventLog();
 
 protected:
   struct delete_dataCacheCore
@@ -169,5 +163,4 @@ protected:
   std::unique_ptr<CWeatherManager> m_weatherManager;
   std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;
   std::unique_ptr<CDatabaseManager> m_databaseManager;
-  std::unique_ptr<CProfilesManager> m_profileManager;
 };

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -67,7 +67,7 @@ class CInputManager;
 class CFileExtensionProvider;
 class CPlayerCoreFactory;
 class CDatabaseManager;
-class CProfilesManager;
+class CProfileManager;
 class CEventLog;
 
 class CServiceManager
@@ -79,7 +79,7 @@ public:
   bool InitForTesting();
   bool InitStageOne();
   bool InitStageTwo(const CAppParamParser &params, const std::string& profilesUserDataFolder);
-  bool InitStageThree(const std::shared_ptr<CProfilesManager>& profilesManager);
+  bool InitStageThree(const std::shared_ptr<CProfileManager>& profileManager);
   void DeinitTesting();
   void DeinitStageThree();
   void DeinitStageTwo();

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -13,6 +13,7 @@
 #include "threads/SingleLock.h"
 #include "utils/Crc32.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -55,13 +56,13 @@ bool CTextureCache::IsCachedImage(const std::string &url) const
   if (!CURL::IsFullPath(url))
     return true;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   if (URIUtils::PathHasParent(url, "special://skin", true) ||
       URIUtils::PathHasParent(url, "special://temp", true) ||
       URIUtils::PathHasParent(url, "resource://", true) ||
       URIUtils::PathHasParent(url, "androidapp://", true)   ||
-      URIUtils::PathHasParent(url, profileManager.GetThumbnailsFolder(), true))
+      URIUtils::PathHasParent(url, profilesManager->GetThumbnailsFolder(), true))
     return true;
 
   return false;
@@ -255,9 +256,9 @@ std::string CTextureCache::GetCacheFile(const std::string &url)
 
 std::string CTextureCache::GetCachedPath(const std::string &file)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  return URIUtils::AddFileToFolder(profileManager.GetThumbnailsFolder(), file);
+  return URIUtils::AddFileToFolder(profilesManager->GetThumbnailsFolder(), file);
 }
 
 void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -9,7 +9,7 @@
 #include "TextureCache.h"
 #include "TextureCacheJob.h"
 #include "filesystem/File.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "threads/SingleLock.h"
 #include "utils/Crc32.h"
 #include "settings/AdvancedSettings.h"
@@ -56,13 +56,13 @@ bool CTextureCache::IsCachedImage(const std::string &url) const
   if (!CURL::IsFullPath(url))
     return true;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (URIUtils::PathHasParent(url, "special://skin", true) ||
       URIUtils::PathHasParent(url, "special://temp", true) ||
       URIUtils::PathHasParent(url, "resource://", true) ||
       URIUtils::PathHasParent(url, "androidapp://", true)   ||
-      URIUtils::PathHasParent(url, profilesManager->GetThumbnailsFolder(), true))
+      URIUtils::PathHasParent(url, profileManager->GetThumbnailsFolder(), true))
     return true;
 
   return false;
@@ -256,9 +256,9 @@ std::string CTextureCache::GetCacheFile(const std::string &url)
 
 std::string CTextureCache::GetCachedPath(const std::string &file)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  return URIUtils::AddFileToFolder(profilesManager->GetThumbnailsFolder(), file);
+  return URIUtils::AddFileToFolder(profileManager->GetThumbnailsFolder(), file);
 }
 
 void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -46,7 +46,7 @@
 #ifdef HAS_UPNP
 #include "filesystem/UPnPDirectory.h"
 #endif
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "utils/RegExp.h"
 #include "windowing/GraphicContext.h"
 #include "guilib/TextureManager.h"
@@ -663,9 +663,9 @@ void CUtil::GetDVDDriveIcon(const std::string& strPath, std::string& strIcon)
 
 void CUtil::RemoveTempFiles()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::string searchPath = profilesManager->GetDatabaseFolder();
+  std::string searchPath = profileManager->GetDatabaseFolder();
   CFileItemList items;
   if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".tmp", DIR_FLAG_NO_FILE_DIRS))
     return;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -663,9 +663,9 @@ void CUtil::GetDVDDriveIcon(const std::string& strPath, std::string& strIcon)
 
 void CUtil::RemoveTempFiles()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  std::string searchPath = profileManager.GetDatabaseFolder();
+  std::string searchPath = profilesManager->GetDatabaseFolder();
   CFileItemList items;
   if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".tmp", DIR_FLAG_NO_FILE_DIRS))
     return;

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -14,7 +14,7 @@
 #include "dialogs/GUIDialogContextMenu.h"
 #include "URL.h"
 #include "FileItem.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/lib/SettingsManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -28,7 +28,7 @@
 
 #define PLAYERCOREFACTORY_XML "playercorefactory.xml"
 
-CPlayerCoreFactory::CPlayerCoreFactory(const CProfilesManager &profileManager) :
+CPlayerCoreFactory::CPlayerCoreFactory(const CProfileManager &profileManager) :
   m_profileManager(profileManager)
 {
   m_settings = CServiceBroker::GetSettingsComponent()->GetSettings();

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -21,7 +21,7 @@ class TiXmlElement;
 class CFileItem;
 class CPlayerCoreConfig;
 class CPlayerSelectionRule;
-class CProfilesManager;
+class CProfileManager;
 class CSettings;
 class IPlayer;
 class IPlayerCallback;
@@ -29,7 +29,7 @@ class IPlayerCallback;
 class CPlayerCoreFactory : public ISettingsHandler
 {
 public:
-  CPlayerCoreFactory(const CProfilesManager &profileManager);
+  CPlayerCoreFactory(const CProfileManager &profileManager);
   CPlayerCoreFactory(const CPlayerCoreFactory&) = delete;
   CPlayerCoreFactory& operator=(CPlayerCoreFactory const&) = delete;
   ~CPlayerCoreFactory() override;
@@ -55,7 +55,7 @@ public:
 private:
   // Construction parameters
   std::shared_ptr<CSettings> m_settings;
-  const CProfilesManager &m_profileManager;
+  const CProfileManager &m_profileManager;
 
   int GetPlayerIndex(const std::string& strCoreName) const;
   std::string GetPlayerName(size_t idx) const;

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -11,6 +11,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/File.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
@@ -215,7 +216,7 @@ bool CDatabase::DatasetLayout::HasFilterFields()
 }
 
 CDatabase::CDatabase() :
-  m_profileManager(CServiceBroker::GetProfileManager())
+  m_profileManager(*CServiceBroker::GetSettingsComponent()->GetProfilesManager())
 {
   m_openCount = 0;
   m_sqlite = true;

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -10,7 +10,7 @@
 #include "settings/AdvancedSettings.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/File.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/SortUtils.h"
@@ -216,7 +216,7 @@ bool CDatabase::DatasetLayout::HasFilterFields()
 }
 
 CDatabase::CDatabase() :
-  m_profileManager(*CServiceBroker::GetSettingsComponent()->GetProfilesManager())
+  m_profileManager(*CServiceBroker::GetSettingsComponent()->GetProfileManager())
 {
   m_openCount = 0;
   m_sqlite = true;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -19,7 +19,7 @@ namespace dbiplus {
 
 class DatabaseSettings; // forward
 class CDbUrl;
-class CProfilesManager;
+class CProfileManager;
 struct SortDescription;
 
 class CDatabase
@@ -243,7 +243,7 @@ protected:
 
 protected:
   // Construction parameters
-  const CProfilesManager &m_profileManager;
+  const CProfileManager &m_profileManager;
 
 private:
   void InitSettings(DatabaseSettings &dbSettings);

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -211,7 +211,7 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
   // Next, Add buttons to the ContextMenu that should ONLY be visible for sources and not autosourced items
   CMediaSource *share = GetShare(type, item.get());
 
-  if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
+  if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
   {
     if (share)
     {
@@ -233,9 +233,9 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
     if (!GetDefaultShareNameByType(type).empty())
       buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // Clear Default
   }
-  if (share && LOCK_MODE_EVERYONE != CServiceBroker::GetProfileManager().GetMasterProfile().getLockMode())
+  if (share && LOCK_MODE_EVERYONE != CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode())
   {
-    if (share->m_iHasLock == 0 && (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
+    if (share->m_iHasLock == 0 && (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
       buttons.Add(CONTEXT_BUTTON_ADD_LOCK, 12332);
     else if (share->m_iHasLock == 1)
       buttons.Add(CONTEXT_BUTTON_REMOVE_LOCK, 12335);
@@ -268,7 +268,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
   switch (button)
   {
   case CONTEXT_BUTTON_EDIT_SOURCE:
-    if (CServiceBroker::GetProfileManager().IsMasterProfile())
+    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
@@ -280,16 +280,16 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
   case CONTEXT_BUTTON_REMOVE_SOURCE:
   {
-    if (CServiceBroker::GetProfileManager().IsMasterProfile())
+    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
     }
     else
     {
-      if (!CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsMasterLockUnlocked(false))
+      if (!CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsMasterLockUnlocked(false))
         return false;
-      if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+      if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
         return false;
     }
     // prompt user if they want to really delete the source
@@ -307,7 +307,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
     return true;
   }
   case CONTEXT_BUTTON_SET_DEFAULT:
-    if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
     else if (!g_passwordManager.IsMasterLockUnlocked(true))
       return false;
@@ -317,7 +317,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
     return true;
 
   case CONTEXT_BUTTON_CLEAR_DEFAULT:
-    if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
     else if (!g_passwordManager.IsMasterLockUnlocked(true))
       return false;
@@ -327,7 +327,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
   case CONTEXT_BUTTON_SET_THUMB:
     {
-      if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+      if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
         return false;
       else if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -20,7 +20,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "GUIDialogMediaSource.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "storage/MediaManager.h"
 #include "guilib/GUIWindowManager.h"
@@ -211,7 +211,7 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
   // Next, Add buttons to the ContextMenu that should ONLY be visible for sources and not autosourced items
   CMediaSource *share = GetShare(type, item.get());
 
-  if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
+  if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
   {
     if (share)
     {
@@ -233,9 +233,9 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
     if (!GetDefaultShareNameByType(type).empty())
       buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // Clear Default
   }
-  if (share && LOCK_MODE_EVERYONE != CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode())
+  if (share && LOCK_MODE_EVERYONE != CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetMasterProfile().getLockMode())
   {
-    if (share->m_iHasLock == 0 && (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
+    if (share->m_iHasLock == 0 && (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
       buttons.Add(CONTEXT_BUTTON_ADD_LOCK, 12332);
     else if (share->m_iHasLock == 1)
       buttons.Add(CONTEXT_BUTTON_REMOVE_LOCK, 12335);
@@ -268,7 +268,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
   switch (button)
   {
   case CONTEXT_BUTTON_EDIT_SOURCE:
-    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->IsMasterProfile())
+    if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
@@ -280,16 +280,16 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
   case CONTEXT_BUTTON_REMOVE_SOURCE:
   {
-    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->IsMasterProfile())
+    if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
     }
     else
     {
-      if (!CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsMasterLockUnlocked(false))
+      if (!CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsMasterLockUnlocked(false))
         return false;
-      if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+      if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
         return false;
     }
     // prompt user if they want to really delete the source
@@ -307,7 +307,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
     return true;
   }
   case CONTEXT_BUTTON_SET_DEFAULT:
-    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
     else if (!g_passwordManager.IsMasterLockUnlocked(true))
       return false;
@@ -317,7 +317,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
     return true;
 
   case CONTEXT_BUTTON_CLEAR_DEFAULT:
-    if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
     else if (!g_passwordManager.IsMasterLockUnlocked(true))
       return false;
@@ -327,7 +327,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
   case CONTEXT_BUTTON_SET_THUMB:
     {
-      if (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+      if (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
         return false;
       else if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -27,7 +27,7 @@
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "filesystem/MultiPathDirectory.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
 #include "input/Key.h"
@@ -419,8 +419,8 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   OnSort();
 
   if (m_Directory->GetPath().empty() && m_addNetworkShareEnabled &&
-     (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-      CServiceBroker::GetSettingsComponent()->GetProfilesManager()->IsMasterProfile() || g_passwordManager.bMasterUser))
+     (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      CServiceBroker::GetSettingsComponent()->GetProfileManager()->IsMasterProfile() || g_passwordManager.bMasterUser))
   { // we are in the virtual directory - add the "Add Network Location" item
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1032)));
     pItem->SetPath("net://");

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -29,6 +29,7 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/SettingsComponent.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
@@ -418,8 +419,8 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   OnSort();
 
   if (m_Directory->GetPath().empty() && m_addNetworkShareEnabled &&
-     (CServiceBroker::GetProfileManager().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-      CServiceBroker::GetProfileManager().IsMasterProfile() || g_passwordManager.bMasterUser))
+     (CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      CServiceBroker::GetSettingsComponent()->GetProfilesManager()->IsMasterProfile() || g_passwordManager.bMasterUser))
   { // we are in the virtual directory - add the "Add Network Location" item
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1032)));
     pItem->SetPath("net://");

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -21,7 +21,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "Util.h"
@@ -144,9 +144,9 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       if (!startupList.empty())
       {
         int party = 0;
-        if (URIUtils::PathEquals(startupList, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode.xsp")))
+        if (URIUtils::PathEquals(startupList, CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetUserDataItem("PartyMode.xsp")))
           party = 1;
-        else if (URIUtils::PathEquals(startupList, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode-Video.xsp")))
+        else if (URIUtils::PathEquals(startupList, CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetUserDataItem("PartyMode-Video.xsp")))
           party = 2;
 
         if ((party && !XFILE::CFile::Exists(startupList)) ||
@@ -614,9 +614,9 @@ bool CGUIDialogSmartPlaylistEditor::EditPlaylist(const std::string &path, const 
   if (!editor) return false;
 
   editor->m_mode = type;
-  if (URIUtils::PathEquals(path, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode.xsp")))
+  if (URIUtils::PathEquals(path, CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetUserDataItem("PartyMode.xsp")))
     editor->m_mode = "partymusic";
-  if (URIUtils::PathEquals(path, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode-Video.xsp")))
+  if (URIUtils::PathEquals(path, CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetUserDataItem("PartyMode-Video.xsp")))
     editor->m_mode = "partyvideo";
 
   CSmartPlaylist playlist;

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -144,9 +144,9 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       if (!startupList.empty())
       {
         int party = 0;
-        if (URIUtils::PathEquals(startupList, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode.xsp")))
+        if (URIUtils::PathEquals(startupList, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode.xsp")))
           party = 1;
-        else if (URIUtils::PathEquals(startupList, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode-Video.xsp")))
+        else if (URIUtils::PathEquals(startupList, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode-Video.xsp")))
           party = 2;
 
         if ((party && !XFILE::CFile::Exists(startupList)) ||
@@ -614,9 +614,9 @@ bool CGUIDialogSmartPlaylistEditor::EditPlaylist(const std::string &path, const 
   if (!editor) return false;
 
   editor->m_mode = type;
-  if (URIUtils::PathEquals(path, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode.xsp")))
+  if (URIUtils::PathEquals(path, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode.xsp")))
     editor->m_mode = "partymusic";
-  if (URIUtils::PathEquals(path, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode-Video.xsp")))
+  if (URIUtils::PathEquals(path, CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem("PartyMode-Video.xsp")))
     editor->m_mode = "partyvideo";
 
   CSmartPlaylist playlist;

--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -15,7 +15,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -11,7 +11,7 @@
 #include "File.h"
 #include "Directory.h"
 #include "Util.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "ServiceBroker.h"
 #include "utils/URIUtils.h"
 

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -18,9 +18,9 @@
 using namespace KODI::MESSAGING;
 using namespace XFILE;
 
-const CProfilesManager *IDirectory::m_profileManager = nullptr;
+const CProfileManager *IDirectory::m_profileManager = nullptr;
 
-void IDirectory::RegisterProfileManager(const CProfilesManager &profileManager)
+void IDirectory::RegisterProfileManager(const CProfileManager &profileManager)
 {
   m_profileManager = &profileManager;
 }

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -12,7 +12,7 @@
 #include "utils/Variant.h"
 
 class CFileItemList;
-class CProfilesManager;
+class CProfileManager;
 class CURL;
 
 namespace XFILE
@@ -49,7 +49,7 @@ namespace XFILE
 class IDirectory
 {
 public:
-  static void RegisterProfileManager(const CProfilesManager &profileManager);
+  static void RegisterProfileManager(const CProfileManager &profileManager);
   static void UnregisterProfileManager();
 
   IDirectory();
@@ -163,7 +163,7 @@ protected:
    */
   void RequireAuthentication(const CURL& url);
 
-  static const CProfilesManager *m_profileManager;
+  static const CProfileManager *m_profileManager;
 
   std::string m_strFileMask;  ///< Holds the file mask specified by SetMask()
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -9,7 +9,7 @@
 #include "LibraryDirectory.h"
 #include "Directory.h"
 #include "playlists/SmartPlayList.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "SmartPlaylistDirectory.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -12,7 +12,7 @@
 #include "Util.h"
 #include "FileItem.h"
 #include "File.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "guilib/TextureManager.h"
 #include "storage/MediaManager.h"

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -11,7 +11,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "windowing/GraphicContext.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -24,9 +24,9 @@
 #include "utils/StringUtils.h"
 #endif
 
-const CProfilesManager *CSpecialProtocol::m_profileManager = nullptr;
+const CProfileManager *CSpecialProtocol::m_profileManager = nullptr;
 
-void CSpecialProtocol::RegisterProfileManager(const CProfilesManager &profileManager)
+void CSpecialProtocol::RegisterProfileManager(const CProfileManager &profileManager)
 {
   m_profileManager = &profileManager;
 }

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -11,7 +11,7 @@
 #include <map>
 #include <string>
 
-class CProfilesManager;
+class CProfileManager;
 
 // static class for path translation from our special:// URLs.
 
@@ -44,7 +44,7 @@ class CURL;
 class CSpecialProtocol
 {
 public:
-  static void RegisterProfileManager(const CProfilesManager &profileManager);
+  static void RegisterProfileManager(const CProfileManager &profileManager);
   static void UnregisterProfileManager();
 
   static void SetProfilePath(const std::string &path);
@@ -68,7 +68,7 @@ public:
   static std::string TranslatePathConvertCase(const std::string& path);
 
 private:
-  static const CProfilesManager *m_profileManager;
+  static const CProfileManager *m_profileManager;
 
   static void SetPath(const std::string &key, const std::string &path);
   static std::string GetPath(const std::string &key);

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -10,7 +10,7 @@
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/GameSettings.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 
 using namespace KODI;
 using namespace GAME;
@@ -18,7 +18,7 @@ using namespace GAME;
 CGameServices::CGameServices(CControllerManager &controllerManager,
                              RETRO:: CGUIGameRenderManager &renderManager,
                              PERIPHERALS::CPeripherals &peripheralManager,
-                             const CProfilesManager &profileManager) :
+                             const CProfileManager &profileManager) :
   m_controllerManager(controllerManager),
   m_gameRenderManager(renderManager),
   m_profileManager(profileManager),

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -13,7 +13,7 @@
 #include <memory>
 #include <string>
 
-class CProfilesManager;
+class CProfileManager;
 
 namespace PERIPHERALS
 {
@@ -38,7 +38,7 @@ namespace GAME
     CGameServices(CControllerManager &controllerManager,
                   RETRO::CGUIGameRenderManager &renderManager,
                   PERIPHERALS::CPeripherals &peripheralManager,
-                  const CProfilesManager &profileManager);
+                  const CProfileManager &profileManager);
     ~CGameServices();
 
     ControllerPtr GetController(const std::string& controllerId);
@@ -57,7 +57,7 @@ namespace GAME
     // Construction parameters
     CControllerManager &m_controllerManager;
     RETRO::CGUIGameRenderManager &m_gameRenderManager;
-    const CProfilesManager &m_profileManager;
+    const CProfileManager &m_profileManager;
 
     // Game services
     std::unique_ptr<CGameSettings> m_gameSettings;

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -251,22 +251,22 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       }
       return true;
     case SYSTEM_PROFILENAME:
-      value = CServiceBroker::GetProfileManager().GetCurrentProfile().getName();
+      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().getName();
       return true;
     case SYSTEM_PROFILECOUNT:
-      value = StringUtils::Format("{0}", CServiceBroker::GetProfileManager().GetNumberOfProfiles());
+      value = StringUtils::Format("{0}", CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetNumberOfProfiles());
       return true;
     case SYSTEM_PROFILEAUTOLOGIN:
     {
-      CProfilesManager& profilesMgr = CServiceBroker::GetProfileManager();
-      int iProfileId = profilesMgr.GetAutoLoginProfileId();
-      if ((iProfileId < 0) || !profilesMgr.GetProfileName(iProfileId, value))
+      const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+      int iProfileId = profilesManager->GetAutoLoginProfileId();
+      if ((iProfileId < 0) || !profilesManager->GetProfileName(iProfileId, value))
         value = g_localizeStrings.Get(37014); // Last used profile
       return true;
     }
     case SYSTEM_PROFILETHUMB:
     {
-      const std::string& thumb = CServiceBroker::GetProfileManager().GetCurrentProfile().getThumb();
+      const std::string& thumb = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().getThumb();
       value = thumb.empty() ? "DefaultUser.png" : thumb;
       return true;
     }
@@ -515,7 +515,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = g_application.IsDPMSActive();
       return true;
     case SYSTEM_HASLOCKS:
-      value = CServiceBroker::GetProfileManager().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE;
+      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE;
       return true;
     case SYSTEM_HAS_PVR:
       value = true;
@@ -536,7 +536,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
 #endif
       return true;
     case SYSTEM_ISMASTER:
-      value = CServiceBroker::GetProfileManager().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
+      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
       return true;
     case SYSTEM_ISFULLSCREEN:
       value = CServiceBroker::GetWinSystem()->IsFullScreen();
@@ -557,7 +557,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_showExitButton;
       return true;
     case SYSTEM_HAS_LOGINSCREEN:
-      value = CServiceBroker::GetProfileManager().UsingLoginScreen();
+      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->UsingLoginScreen();
       return true;
     case SYSTEM_INTERNET_STATE:
     {

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -24,7 +24,7 @@
 #include "platform/linux/XMemUtils.h"
 #endif
 #include "powermanagement/PowerManager.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -251,22 +251,22 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       }
       return true;
     case SYSTEM_PROFILENAME:
-      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().getName();
+      value = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().getName();
       return true;
     case SYSTEM_PROFILECOUNT:
-      value = StringUtils::Format("{0}", CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetNumberOfProfiles());
+      value = StringUtils::Format("{0}", CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetNumberOfProfiles());
       return true;
     case SYSTEM_PROFILEAUTOLOGIN:
     {
-      const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
-      int iProfileId = profilesManager->GetAutoLoginProfileId();
-      if ((iProfileId < 0) || !profilesManager->GetProfileName(iProfileId, value))
+      const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
+      int iProfileId = profileManager->GetAutoLoginProfileId();
+      if ((iProfileId < 0) || !profileManager->GetProfileName(iProfileId, value))
         value = g_localizeStrings.Get(37014); // Last used profile
       return true;
     }
     case SYSTEM_PROFILETHUMB:
     {
-      const std::string& thumb = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfile().getThumb();
+      const std::string& thumb = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().getThumb();
       value = thumb.empty() ? "DefaultUser.png" : thumb;
       return true;
     }
@@ -515,7 +515,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = g_application.IsDPMSActive();
       return true;
     case SYSTEM_HASLOCKS:
-      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE;
+      value = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE;
       return true;
     case SYSTEM_HAS_PVR:
       value = true;
@@ -536,7 +536,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
 #endif
       return true;
     case SYSTEM_ISMASTER:
-      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
+      value = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
       return true;
     case SYSTEM_ISFULLSCREEN:
       value = CServiceBroker::GetWinSystem()->IsFullScreen();
@@ -557,7 +557,7 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_showExitButton;
       return true;
     case SYSTEM_HAS_LOGINSCREEN:
-      value = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->UsingLoginScreen();
+      value = CServiceBroker::GetSettingsComponent()->GetProfileManager()->UsingLoginScreen();
       return true;
     case SYSTEM_INTERNET_STATE:
     {

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -11,6 +11,7 @@
 #include "filesystem/File.h"
 #include "input/remote/IRRemote.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -38,7 +39,7 @@ void CIRTranslator::Load(const std::string &irMapName)
   else
     CLog::Log(LOGDEBUG, "CIRTranslator::Load - no system %s found, skipping", irMapName.c_str());
 
-  irMapPath = CServiceBroker::GetProfileManager().GetUserDataItem(irMapName);
+  irMapPath = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem(irMapName);
   if (XFILE::CFile::Exists(irMapPath))
     success |= LoadIRMap(irMapPath);
   else

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -10,7 +10,7 @@
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
 #include "input/remote/IRRemote.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -39,7 +39,7 @@ void CIRTranslator::Load(const std::string &irMapName)
   else
     CLog::Log(LOGDEBUG, "CIRTranslator::Load - no system %s found, skipping", irMapName.c_str());
 
-  irMapPath = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetUserDataItem(irMapName);
+  irMapPath = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetUserDataItem(irMapName);
   if (XFILE::CFile::Exists(irMapPath))
     success |= LoadIRMap(irMapPath);
   else

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -28,7 +28,7 @@ class CButtonTranslator;
 class CCustomControllerTranslator;
 class CJoystickMapper;
 class CKey;
-class CProfilesManager;
+class CProfileManager;
 class CTouchTranslator;
 class IKeymapEnvironment;
 class IWindowKeymap;

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -18,6 +18,7 @@
 #include "GUIUserMessages.h"
 #include "profiles/ProfilesManager.h"
 #include "ServiceBroker.h"
+#include "settings/SettingsComponent.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
 
@@ -30,13 +31,13 @@ using namespace KODI::MESSAGING;
  */
 static int LoadProfile(const std::vector<std::string>& params)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  int index = profileManager.GetProfileIndex(params[0]);
+  int index = profilesManager->GetProfileIndex(params[0]);
   bool prompt = (params.size() == 2 && StringUtils::EqualsNoCase(params[1], "prompt"));
   bool bCanceled;
   if (index >= 0
-      && (profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
+      && (profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
         || g_passwordManager.IsProfileLockUnlocked(index,bCanceled,prompt)))
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, index);
@@ -50,8 +51,8 @@ static int LoadProfile(const std::vector<std::string>& params)
  */
 static int LogOff(const std::vector<std::string>& params)
 {
-  CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
-  profileManager.LogOff();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  profilesManager->LogOff();
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -16,7 +16,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "ServiceBroker.h"
 #include "settings/SettingsComponent.h"
 #include "Util.h"
@@ -31,13 +31,13 @@ using namespace KODI::MESSAGING;
  */
 static int LoadProfile(const std::vector<std::string>& params)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  int index = profilesManager->GetProfileIndex(params[0]);
+  int index = profileManager->GetProfileIndex(params[0]);
   bool prompt = (params.size() == 2 && StringUtils::EqualsNoCase(params[1], "prompt"));
   bool bCanceled;
   if (index >= 0
-      && (profilesManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
+      && (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
         || g_passwordManager.IsProfileLockUnlocked(index,bCanceled,prompt)))
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, index);
@@ -51,8 +51,8 @@ static int LoadProfile(const std::vector<std::string>& params)
  */
 static int LogOff(const std::vector<std::string>& params)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
-  profilesManager->LogOff();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  profileManager->LogOff();
 
   return 0;
 }

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -10,7 +10,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
 #include "utils/Variant.h"
@@ -22,13 +22,13 @@ using KODI::UTILITY::CDigest;
 
 JSONRPC_STATUS CProfilesOperations::GetProfiles(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   CFileItemList listItems;
 
-  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); ++i)
+  for (unsigned int i = 0; i < profileManager->GetNumberOfProfiles(); ++i)
   {
-    const CProfile *profile = profilesManager->GetProfile(i);
+    const CProfile *profile = profileManager->GetProfile(i);
     CFileItemPtr item(new CFileItem(profile->getName()));
     item->SetArt("thumb", profile->getThumb());
     listItems.Add(item);
@@ -44,11 +44,11 @@ JSONRPC_STATUS CProfilesOperations::GetProfiles(const std::string &method, ITran
       for (CVariant::iterator_array profileiter = result["profiles"].begin_array(); profileiter != result["profiles"].end_array(); ++profileiter)
       {
         std::string profilename = (*profileiter)["label"].asString();
-        int index = profilesManager->GetProfileIndex(profilename);
-        const CProfile *profile = profilesManager->GetProfile(index);
+        int index = profileManager->GetProfileIndex(profilename);
+        const CProfile *profile = profileManager->GetProfile(index);
         LockType locktype = LOCK_MODE_UNKNOWN;
         if (index == 0)
-          locktype = profilesManager->GetMasterProfile().getLockMode();
+          locktype = profileManager->GetMasterProfile().getLockMode();
         else
           locktype = profile->getLockMode();
         (*profileiter)["lockmode"] = locktype;
@@ -61,9 +61,9 @@ JSONRPC_STATUS CProfilesOperations::GetProfiles(const std::string &method, ITran
 
 JSONRPC_STATUS CProfilesOperations::GetCurrentProfile(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  const CProfile& currentProfile = profilesManager->GetCurrentProfile();
+  const CProfile& currentProfile = profileManager->GetCurrentProfile();
   CVariant profileVariant = CVariant(CVariant::VariantTypeObject);
   profileVariant["label"] = currentProfile.getName();
   for (CVariant::const_iterator_array propertyiter = parameterObject["properties"].begin_array(); propertyiter != parameterObject["properties"].end_array(); ++propertyiter)
@@ -84,16 +84,16 @@ JSONRPC_STATUS CProfilesOperations::GetCurrentProfile(const std::string &method,
 
 JSONRPC_STATUS CProfilesOperations::LoadProfile(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   std::string profilename = parameterObject["profile"].asString();
-  int index = profilesManager->GetProfileIndex(profilename);
+  int index = profileManager->GetProfileIndex(profilename);
 
   if (index < 0)
     return InvalidParams;
 
   // get the profile
-  const CProfile *profile = profilesManager->GetProfile(index);
+  const CProfile *profile = profileManager->GetProfile(index);
   if (profile == NULL)
     return InvalidParams;
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -38,7 +38,7 @@
 #include "network/cddb.h"
 #include "network/Network.h"
 #include "playlists/SmartPlayList.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -30,7 +30,7 @@
 #include "music/MusicUtils.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicNav.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "ServiceBroker.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -524,11 +524,11 @@ void CGUIDialogMusicInfo::Update()
 
   }
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   // Disable the Choose Art button if the user isn't allowed it
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
-    profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+    profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
 }
 
 void CGUIDialogMusicInfo::SetLabel(int iControl, const std::string& strLabel)
@@ -568,8 +568,8 @@ void CGUIDialogMusicInfo::FetchComplete()
 void CGUIDialogMusicInfo::RefreshInfo()
 {
   // Double check we have permission (button should be hidden when not)
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
-  if (!profilesManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  if (!profileManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
     return;
 
   // Check if scanning

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -524,11 +524,11 @@ void CGUIDialogMusicInfo::Update()
 
   }
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   // Disable the Choose Art button if the user isn't allowed it
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
-    profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+    profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
 }
 
 void CGUIDialogMusicInfo::SetLabel(int iControl, const std::string& strLabel)
@@ -568,8 +568,8 @@ void CGUIDialogMusicInfo::FetchComplete()
 void CGUIDialogMusicInfo::RefreshInfo()
 {
   // Double check we have permission (button should be hidden when not)
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
-  if (!profileManager.GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  if (!profilesManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
     return;
 
   // Check if scanning

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -23,7 +23,7 @@
 #include "music/MusicUtils.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicBase.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "ServiceBroker.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
@@ -240,9 +240,9 @@ void CGUIDialogSongInfo::OnInitWindow()
     CONTROL_ENABLE(CONTROL_USERRATING);
 
   // Disable the Choose Art button if the user isn't allowed it
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
-    profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+    profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
 
   SET_CONTROL_HIDDEN(CONTROL_BTN_REFRESH);
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -26,6 +26,7 @@
 #include "profiles/ProfilesManager.h"
 #include "ServiceBroker.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "TextureCache.h"
 #include "Util.h"
@@ -239,9 +240,9 @@ void CGUIDialogSongInfo::OnInitWindow()
     CONTROL_ENABLE(CONTROL_USERRATING);
 
   // Disable the Choose Art button if the user isn't allowed it
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
-    profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+    profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
 
   SET_CONTROL_HIDDEN(CONTROL_BTN_REFRESH);
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);

--- a/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
@@ -9,7 +9,7 @@
 #include "MusicInfoTagLoaderCDDA.h"
 #include "network/cddb.h"
 #include "MusicInfoTag.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
@@ -46,11 +46,11 @@ bool CMusicInfoTagLoaderCDDA::Load(const std::string& strFileName, CMusicInfoTag
     if (pCdInfo == NULL)
       return bResult;
 
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     // Prepare cddb
     Xcddb cddb;
-    cddb.setCacheDir(profilesManager->GetCDDBFolder());
+    cddb.setCacheDir(profileManager->GetCDDBFolder());
 
     int iTrack = atoi(strFileName.substr(13, strFileName.size() - 13 - 5).c_str());
 

--- a/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
@@ -10,6 +10,7 @@
 #include "network/cddb.h"
 #include "MusicInfoTag.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
@@ -45,11 +46,11 @@ bool CMusicInfoTagLoaderCDDA::Load(const std::string& strFileName, CMusicInfoTag
     if (pCdInfo == NULL)
       return bResult;
 
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
     // Prepare cddb
     Xcddb cddb;
-    cddb.setCacheDir(profileManager.GetCDDBFolder());
+    cddb.setCacheDir(profilesManager->GetCDDBFolder());
 
     int iTrack = atoi(strFileName.substr(13, strFileName.size() - 13 - 5).c_str());
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -515,7 +515,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
   if (item)
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
     if (item && !item->IsParentFolder())
     {
@@ -560,7 +560,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
           !item->IsPlugin() && !item->IsMusicDb()         &&
           !item->IsLibraryFolder() &&
           !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
-          (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+          (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
@@ -578,7 +578,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
     // enable CDDB lookup if the current dir is CDDA
     if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsCDDA() &&
-       (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+       (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       buttons.Add(CONTEXT_BUTTON_CDDB, 16002);
     }
@@ -956,9 +956,9 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
     // add in the "New Playlist" item if we're in the playlists folder
     if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))
     {
-      const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+      const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-      CFileItemPtr newPlaylist(new CFileItem(profileManager.GetUserDataItem("PartyMode.xsp"),false));
+      CFileItemPtr newPlaylist(new CFileItem(profilesManager->GetUserDataItem("PartyMode.xsp"),false));
       newPlaylist->SetLabel(g_localizeStrings.Get(16035));
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetIconImage("DefaultPartyMode.png");

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -40,7 +40,7 @@
 #include "filesystem/File.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "storage/MediaManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
@@ -515,7 +515,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
   if (item)
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     if (item && !item->IsParentFolder())
     {
@@ -560,7 +560,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
           !item->IsPlugin() && !item->IsMusicDb()         &&
           !item->IsLibraryFolder() &&
           !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
-          (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+          (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
@@ -578,7 +578,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
     // enable CDDB lookup if the current dir is CDDA
     if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsCDDA() &&
-       (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+       (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       buttons.Add(CONTEXT_BUTTON_CDDB, 16002);
     }
@@ -956,9 +956,9 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
     // add in the "New Playlist" item if we're in the playlists folder
     if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))
     {
-      const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+      const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-      CFileItemPtr newPlaylist(new CFileItem(profilesManager->GetUserDataItem("PartyMode.xsp"),false));
+      CFileItemPtr newPlaylist(new CFileItem(profileManager->GetUserDataItem("PartyMode.xsp"),false));
       newPlaylist->SetLabel(g_localizeStrings.Get(16035));
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetIconImage("DefaultPartyMode.png");

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -576,7 +576,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
     item = m_vecItems->Get(itemNumber);
   if (item)
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
     // are we in the playlists location?
     bool inPlaylists = m_vecItems->IsPath(CUtil::MusicPlaylistsLocation()) ||
@@ -605,7 +605,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         !item->IsPath("add") && !item->IsParentFolder() &&
         !item->IsPlugin() &&
         !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
-        (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+        (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
@@ -669,7 +669,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
         if (item->HasVideoInfoTag() && !item->m_bIsFolder)
         {
-          if ((profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
+          if ((profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
           {
             buttons.Add(CONTEXT_BUTTON_RENAME, 16105);
             buttons.Add(CONTEXT_BUTTON_DELETE, 646);

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -20,7 +20,7 @@
 #include "PartyModeManager.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "video/VideoDatabase.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoNav.h"
@@ -576,7 +576,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
     item = m_vecItems->Get(itemNumber);
   if (item)
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     // are we in the playlists location?
     bool inPlaylists = m_vecItems->IsPath(CUtil::MusicPlaylistsLocation()) ||
@@ -605,7 +605,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         !item->IsPath("add") && !item->IsParentFolder() &&
         !item->IsPlugin() &&
         !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
-        (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+        (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
@@ -669,7 +669,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
         if (item->HasVideoInfoTag() && !item->m_bIsFolder)
         {
-          if ((profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
+          if ((profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
           {
             buttons.Add(CONTEXT_BUTTON_RENAME, 16105);
             buttons.Add(CONTEXT_BUTTON_DELETE, 646);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -604,9 +604,9 @@ bool CGUIWindowMusicPlayList::OnContextButton(int itemNumber, CONTEXT_BUTTON but
 
   case CONTEXT_BUTTON_EDIT_PARTYMODE:
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-    std::string playlist = profileManager.GetUserDataItem("PartyMode.xsp");
+    std::string playlist = profilesManager->GetUserDataItem("PartyMode.xsp");
     if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist))
     {
       // apply new rules

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -24,7 +24,7 @@
 #include "input/Key.h"
 #include "GUIUserMessages.h"
 #include "favourites/FavouritesService.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -604,9 +604,9 @@ bool CGUIWindowMusicPlayList::OnContextButton(int itemNumber, CONTEXT_BUTTON but
 
   case CONTEXT_BUTTON_EDIT_PARTYMODE:
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-    std::string playlist = profilesManager->GetUserDataItem("PartyMode.xsp");
+    std::string playlist = profileManager->GetUserDataItem("PartyMode.xsp");
     if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist))
     {
       // apply new rules

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -26,7 +26,7 @@
 #include "utils/log.h"
 #include "URL.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "GUIUserMessages.h"
@@ -652,10 +652,10 @@ CUPnP::StartServer()
 {
     if (!m_ServerHolder->m_Device.IsNull()) return false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     // load upnpserver.xml
-    std::string filename = URIUtils::AddFileToFolder(profilesManager->GetUserDataFolder(), "upnpserver.xml");
+    std::string filename = URIUtils::AddFileToFolder(profileManager->GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::GetInstance().Load(filename);
 
     // create the server with a XBox compatible friendlyname and UUID from upnpserver.xml if found
@@ -735,9 +735,9 @@ bool CUPnP::StartRenderer()
     if (!m_RendererHolder->m_Device.IsNull())
       return false;
 
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-    std::string filename = URIUtils::AddFileToFolder(profilesManager->GetUserDataFolder(), "upnpserver.xml");
+    std::string filename = URIUtils::AddFileToFolder(profileManager->GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::GetInstance().Load(filename);
 
     m_RendererHolder->m_Device = CreateRenderer(CUPnPSettings::GetInstance().GetRendererPort());

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -652,10 +652,10 @@ CUPnP::StartServer()
 {
     if (!m_ServerHolder->m_Device.IsNull()) return false;
 
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
     // load upnpserver.xml
-    std::string filename = URIUtils::AddFileToFolder(profileManager.GetUserDataFolder(), "upnpserver.xml");
+    std::string filename = URIUtils::AddFileToFolder(profilesManager->GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::GetInstance().Load(filename);
 
     // create the server with a XBox compatible friendlyname and UUID from upnpserver.xml if found
@@ -732,11 +732,12 @@ CUPnP::CreateRenderer(int port /* = 0 */)
 +---------------------------------------------------------------------*/
 bool CUPnP::StartRenderer()
 {
-    if (!m_RendererHolder->m_Device.IsNull()) return false;
+    if (!m_RendererHolder->m_Device.IsNull())
+      return false;
 
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-    std::string filename = URIUtils::AddFileToFolder(profileManager.GetUserDataFolder(), "upnpserver.xml");
+    std::string filename = URIUtils::AddFileToFolder(profilesManager->GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::GetInstance().Load(filename);
 
     m_RendererHolder->m_Device = CreateRenderer(CUPnPSettings::GetInstance().GetRendererPort());

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -9,7 +9,7 @@
 #include "LIRC.h"
 #include "AppInboundProtocol.h"
 #include "ServiceBroker.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
@@ -40,7 +40,7 @@ void CLirc::Start()
 
 void CLirc::Process()
 {
-  m_profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
+  m_profileId = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfileId();
   m_irTranslator.Load("Lircmap.xml");
 
   // make sure work-around (CheckDaemon) uses the same socket path as lirc_init
@@ -83,7 +83,7 @@ void CLirc::Process()
       }
       if (code != nullptr)
       {
-        int profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
+        int profileId = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfileId();
         if (m_profileId != profileId)
         {
           m_profileId = profileId;

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -40,7 +40,7 @@ void CLirc::Start()
 
 void CLirc::Process()
 {
-  m_profileId = CServiceBroker::GetProfileManager().GetCurrentProfileId();
+  m_profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
   m_irTranslator.Load("Lircmap.xml");
 
   // make sure work-around (CheckDaemon) uses the same socket path as lirc_init
@@ -83,9 +83,10 @@ void CLirc::Process()
       }
       if (code != nullptr)
       {
-        if (m_profileId != CServiceBroker::GetProfileManager().GetCurrentProfileId())
+        int profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
+        if (m_profileId != profileId)
         {
-          m_profileId = CServiceBroker::GetProfileManager().GetCurrentProfileId();
+          m_profileId = profileId;
           m_irTranslator.Load("Lircmap.xml");
         }
         ProcessCode(code);

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -11,6 +11,7 @@
 #include "IrssMessage.h"
 #include "platform/win32/CharsetConverter.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
 
@@ -62,7 +63,7 @@ void CIRServerSuite::Initialize()
 
 void CIRServerSuite::Process()
 {
-  m_profileId = CServiceBroker::GetProfileManager().GetCurrentProfileId();
+  m_profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
   m_irTranslator.Load(IRSS_MAP_FILENAME);
 
   bool logging = true;
@@ -367,9 +368,10 @@ bool CIRServerSuite::HandleRemoteEvent(CIrssMessage& message)
     deviceName[devicenamelength] = '\0';
     keycode[keycodelength] = '\0';
 
-    if (m_profileId != CServiceBroker::GetProfileManager().GetCurrentProfileId())
+    int profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
+    if (m_profileId != profileId)
     {
-      m_profileId = CServiceBroker::GetProfileManager().GetCurrentProfileId();
+      m_profileId = profileId;
       m_irTranslator.Load(IRSS_MAP_FILENAME);
     }
 

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -10,7 +10,7 @@
 #include "AppInboundProtocol.h"
 #include "IrssMessage.h"
 #include "platform/win32/CharsetConverter.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
@@ -63,7 +63,7 @@ void CIRServerSuite::Initialize()
 
 void CIRServerSuite::Process()
 {
-  m_profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
+  m_profileId = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfileId();
   m_irTranslator.Load(IRSS_MAP_FILENAME);
 
   bool logging = true;
@@ -368,7 +368,7 @@ bool CIRServerSuite::HandleRemoteEvent(CIrssMessage& message)
     deviceName[devicenamelength] = '\0';
     keycode[keycodelength] = '\0';
 
-    int profileId = CServiceBroker::GetSettingsComponent()->GetProfilesManager()->GetCurrentProfileId();
+    int profileId = CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfileId();
     if (m_profileId != profileId)
     {
       m_profileId = profileId;

--- a/xbmc/profiles/CMakeLists.txt
+++ b/xbmc/profiles/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SOURCES Profile.cpp
-            ProfilesManager.cpp)
+            ProfileManager.cpp)
 
 set(HEADERS Profile.h
-            ProfilesManager.h)
+            ProfileManager.h)
 
 core_add_library(profiles)

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "ProfilesManager.h"
+#include "ProfileManager.h"
 #include "DatabaseManager.h"
 #include "FileItem.h"
 #include "GUIInfoManager.h"
@@ -76,7 +76,7 @@ using namespace XFILE;
 
 static CProfile EmptyProfile;
 
-CProfilesManager::CProfilesManager() :
+CProfileManager::CProfileManager() :
     m_usingLoginScreen(false),
     m_profileLoadedForLogin(false),
     m_autoLoginProfile(-1),
@@ -87,11 +87,11 @@ CProfilesManager::CProfilesManager() :
 {
 }
 
-CProfilesManager::~CProfilesManager()
+CProfileManager::~CProfileManager()
 {
 }
 
-void CProfilesManager::Initialize(const std::shared_ptr<CSettings>& settings)
+void CProfileManager::Initialize(const std::shared_ptr<CSettings>& settings)
 {
   m_settings = settings;
 
@@ -107,13 +107,13 @@ void CProfilesManager::Initialize(const std::shared_ptr<CSettings>& settings)
   m_settings->GetSettingsManager()->RegisterCallback(this, settingSet);
 }
 
-void CProfilesManager::Uninitialize()
+void CProfileManager::Uninitialize()
 {
   m_settings->GetSettingsManager()->UnregisterCallback(this);
   m_settings->GetSettingsManager()->UnregisterSettingsHandler(this);
 }
 
-void CProfilesManager::OnSettingsLoaded()
+void CProfileManager::OnSettingsLoaded()
 {
   // check them all
   std::string strDir = m_settings->GetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH);
@@ -129,18 +129,18 @@ void CProfilesManager::OnSettingsLoaded()
   CDirectory::Create(URIUtils::AddFileToFolder(strDir,"mixed"));
 }
 
-void CProfilesManager::OnSettingsSaved() const
+void CProfileManager::OnSettingsSaved() const
 {
   // save mastercode
   Save();
 }
 
-void CProfilesManager::OnSettingsCleared()
+void CProfileManager::OnSettingsCleared()
 {
   Clear();
 }
 
-bool CProfilesManager::Load()
+bool CProfileManager::Load()
 {
   bool ret = true;
   const std::string file = PROFILES_FILE;
@@ -179,13 +179,13 @@ bool CProfilesManager::Load()
       }
       else
       {
-        CLog::Log(LOGERROR, "CProfilesManager: error loading %s, no <profiles> node", file.c_str());
+        CLog::Log(LOGERROR, "CProfileManager: error loading %s, no <profiles> node", file.c_str());
         ret = false;
       }
     }
     else
     {
-      CLog::Log(LOGERROR, "CProfilesManager: error loading %s, Line %d\n%s", file.c_str(), profilesDoc.ErrorRow(), profilesDoc.ErrorDesc());
+      CLog::Log(LOGERROR, "CProfileManager: error loading %s, Line %d\n%s", file.c_str(), profilesDoc.ErrorRow(), profilesDoc.ErrorDesc());
       ret = false;
     }
   }
@@ -216,7 +216,7 @@ bool CProfilesManager::Load()
   return ret;
 }
 
-bool CProfilesManager::Save() const
+bool CProfileManager::Save() const
 {
   const std::string file = PROFILES_FILE;
 
@@ -240,7 +240,7 @@ bool CProfilesManager::Save() const
   return xmlDoc.SaveFile(file);
 }
 
-void CProfilesManager::Clear()
+void CProfileManager::Clear()
 {
   CSingleLock lock(m_critical);
   m_usingLoginScreen = false;
@@ -251,7 +251,7 @@ void CProfilesManager::Clear()
   m_profiles.clear();
 }
 
-void CProfilesManager::PrepareLoadProfile(unsigned int profileIndex)
+void CProfileManager::PrepareLoadProfile(unsigned int profileIndex)
 {
   CContextMenuManager &contextMenuManager = CServiceBroker::GetContextMenuManager();
   ADDON::CServiceAddonManager &serviceAddons = CServiceBroker::GetServiceAddons();
@@ -269,7 +269,7 @@ void CProfilesManager::PrepareLoadProfile(unsigned int profileIndex)
     networkManager.NetworkMessage(CNetwork::SERVICES_DOWN, 1);
 }
 
-bool CProfilesManager::LoadProfile(unsigned int index)
+bool CProfileManager::LoadProfile(unsigned int index)
 {
   PrepareLoadProfile(index);
 
@@ -312,7 +312,7 @@ bool CProfilesManager::LoadProfile(unsigned int index)
   // load the new settings
   if (!settings->Load())
   {
-    CLog::Log(LOGFATAL, "CProfilesManager: unable to load settings for profile \"%s\"", m_profiles.at(index).getName().c_str());
+    CLog::Log(LOGFATAL, "CProfileManager: unable to load settings for profile \"%s\"", m_profiles.at(index).getName().c_str());
     return false;
   }
   settings->SetLoaded();
@@ -366,7 +366,7 @@ bool CProfilesManager::LoadProfile(unsigned int index)
   return true;
 }
 
-void CProfilesManager::FinalizeLoadProfile()
+void CProfileManager::FinalizeLoadProfile()
 {
   CContextMenuManager &contextMenuManager = CServiceBroker::GetContextMenuManager();
   ADDON::CServiceAddonManager &serviceAddons = CServiceBroker::GetServiceAddons();
@@ -433,7 +433,7 @@ void CProfilesManager::FinalizeLoadProfile()
   }
 }
 
-void CProfilesManager::LogOff()
+void CProfileManager::LogOff()
 {
   CNetworkBase &networkManager = CServiceBroker::GetNetwork();
 
@@ -458,7 +458,7 @@ void CProfilesManager::LogOff()
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
 }
 
-bool CProfilesManager::DeleteProfile(unsigned int index)
+bool CProfileManager::DeleteProfile(unsigned int index)
 {
   CSingleLock lock(m_critical);
   const CProfile *profile = GetProfile(index);
@@ -506,7 +506,7 @@ bool CProfilesManager::DeleteProfile(unsigned int index)
   return Save();
 }
 
-void CProfilesManager::CreateProfileFolders()
+void CProfileManager::CreateProfileFolders()
 {
   CDirectory::Create(GetDatabaseFolder());
   CDirectory::Create(GetCDDBFolder());
@@ -524,7 +524,7 @@ void CProfilesManager::CreateProfileFolders()
   CDirectory::Create("special://profile/keymaps");
 }
 
-const CProfile& CProfilesManager::GetMasterProfile() const
+const CProfile& CProfileManager::GetMasterProfile() const
 {
   CSingleLock lock(m_critical);
   if (!m_profiles.empty())
@@ -534,17 +534,17 @@ const CProfile& CProfilesManager::GetMasterProfile() const
   return EmptyProfile;
 }
 
-const CProfile& CProfilesManager::GetCurrentProfile() const
+const CProfile& CProfileManager::GetCurrentProfile() const
 {
   CSingleLock lock(m_critical);
   if (m_currentProfile < m_profiles.size())
     return m_profiles[m_currentProfile];
 
-  CLog::Log(LOGERROR, "CProfilesManager: current profile index ({0}) is outside of the valid range ({1})", m_currentProfile, m_profiles.size());
+  CLog::Log(LOGERROR, "CProfileManager: current profile index ({0}) is outside of the valid range ({1})", m_currentProfile, m_profiles.size());
   return EmptyProfile;
 }
 
-const CProfile* CProfilesManager::GetProfile(unsigned int index) const
+const CProfile* CProfileManager::GetProfile(unsigned int index) const
 {
   CSingleLock lock(m_critical);
   if (index < m_profiles.size())
@@ -553,7 +553,7 @@ const CProfile* CProfilesManager::GetProfile(unsigned int index) const
   return NULL;
 }
 
-CProfile* CProfilesManager::GetProfile(unsigned int index)
+CProfile* CProfileManager::GetProfile(unsigned int index)
 {
   CSingleLock lock(m_critical);
   if (index < m_profiles.size())
@@ -562,7 +562,7 @@ CProfile* CProfilesManager::GetProfile(unsigned int index)
   return NULL;
 }
 
-int CProfilesManager::GetProfileIndex(const std::string &name) const
+int CProfileManager::GetProfileIndex(const std::string &name) const
 {
   CSingleLock lock(m_critical);
   for (int i = 0; i < static_cast<int>(m_profiles.size()); i++)
@@ -574,7 +574,7 @@ int CProfilesManager::GetProfileIndex(const std::string &name) const
   return -1;
 }
 
-void CProfilesManager::AddProfile(const CProfile &profile)
+void CProfileManager::AddProfile(const CProfile &profile)
 {
   CSingleLock lock(m_critical);
   // data integrity check - covers off migration from old profiles.xml,
@@ -584,14 +584,14 @@ void CProfilesManager::AddProfile(const CProfile &profile)
   m_profiles.push_back(profile);
 }
 
-void CProfilesManager::UpdateCurrentProfileDate()
+void CProfileManager::UpdateCurrentProfileDate()
 {
   CSingleLock lock(m_critical);
   if (m_currentProfile < m_profiles.size())
     m_profiles[m_currentProfile].setDate();
 }
 
-void CProfilesManager::LoadMasterProfileForLogin()
+void CProfileManager::LoadMasterProfileForLogin()
 {
   CSingleLock lock(m_critical);
   // save the previous user
@@ -605,7 +605,7 @@ void CProfilesManager::LoadMasterProfileForLogin()
   }
 }
 
-bool CProfilesManager::GetProfileName(const unsigned int profileId, std::string& name) const
+bool CProfileManager::GetProfileName(const unsigned int profileId, std::string& name) const
 {
   CSingleLock lock(m_critical);
   const CProfile *profile = GetProfile(profileId);
@@ -616,12 +616,12 @@ bool CProfilesManager::GetProfileName(const unsigned int profileId, std::string&
   return true;
 }
 
-std::string CProfilesManager::GetUserDataFolder() const
+std::string CProfileManager::GetUserDataFolder() const
 {
   return GetMasterProfile().getDirectory();
 }
 
-std::string CProfilesManager::GetProfileUserDataFolder() const
+std::string CProfileManager::GetProfileUserDataFolder() const
 {
   if (m_currentProfile == 0)
     return GetUserDataFolder();
@@ -629,7 +629,7 @@ std::string CProfilesManager::GetProfileUserDataFolder() const
   return URIUtils::AddFileToFolder(GetUserDataFolder(), GetCurrentProfile().getDirectory());
 }
 
-std::string CProfilesManager::GetDatabaseFolder() const
+std::string CProfileManager::GetDatabaseFolder() const
 {
   if (GetCurrentProfile().hasDatabases())
     return URIUtils::AddFileToFolder(GetProfileUserDataFolder(), "Database");
@@ -637,12 +637,12 @@ std::string CProfilesManager::GetDatabaseFolder() const
   return URIUtils::AddFileToFolder(GetUserDataFolder(), "Database");
 }
 
-std::string CProfilesManager::GetCDDBFolder() const
+std::string CProfileManager::GetCDDBFolder() const
 {
   return URIUtils::AddFileToFolder(GetDatabaseFolder(), "CDDB");
 }
 
-std::string CProfilesManager::GetThumbnailsFolder() const
+std::string CProfileManager::GetThumbnailsFolder() const
 {
   if (GetCurrentProfile().hasDatabases())
     return URIUtils::AddFileToFolder(GetProfileUserDataFolder(), "Thumbnails");
@@ -650,17 +650,17 @@ std::string CProfilesManager::GetThumbnailsFolder() const
   return URIUtils::AddFileToFolder(GetUserDataFolder(), "Thumbnails");
 }
 
-std::string CProfilesManager::GetVideoThumbFolder() const
+std::string CProfileManager::GetVideoThumbFolder() const
 {
   return URIUtils::AddFileToFolder(GetThumbnailsFolder(), "Video");
 }
 
-std::string CProfilesManager::GetBookmarksThumbFolder() const
+std::string CProfileManager::GetBookmarksThumbFolder() const
 {
   return URIUtils::AddFileToFolder(GetVideoThumbFolder(), "Bookmarks");
 }
 
-std::string CProfilesManager::GetLibraryFolder() const
+std::string CProfileManager::GetLibraryFolder() const
 {
   if (GetCurrentProfile().hasDatabases())
     return URIUtils::AddFileToFolder(GetProfileUserDataFolder(), "library");
@@ -668,7 +668,7 @@ std::string CProfilesManager::GetLibraryFolder() const
   return URIUtils::AddFileToFolder(GetUserDataFolder(), "library");
 }
 
-std::string CProfilesManager::GetSavestatesFolder() const
+std::string CProfileManager::GetSavestatesFolder() const
 {
   if (GetCurrentProfile().hasDatabases())
     return URIUtils::AddFileToFolder(GetProfileUserDataFolder(), "Savestates");
@@ -676,7 +676,7 @@ std::string CProfilesManager::GetSavestatesFolder() const
   return URIUtils::AddFileToFolder(GetUserDataFolder(), "Savestates");
 }
 
-std::string CProfilesManager::GetSettingsFile() const
+std::string CProfileManager::GetSettingsFile() const
 {
   std::string settings;
   if (m_currentProfile == 0)
@@ -685,7 +685,7 @@ std::string CProfilesManager::GetSettingsFile() const
   return "special://profile/guisettings.xml";
 }
 
-std::string CProfilesManager::GetUserDataItem(const std::string& strFile) const
+std::string CProfileManager::GetUserDataItem(const std::string& strFile) const
 {
   std::string path;
   path = "special://profile/" + strFile;
@@ -699,12 +699,12 @@ std::string CProfilesManager::GetUserDataItem(const std::string& strFile) const
   return path;
 }
 
-CEventLog& CProfilesManager::GetEventLog()
+CEventLog& CProfileManager::GetEventLog()
 {
   return m_eventLogs->GetEventLog(GetCurrentProfileId());
 }
 
-void CProfilesManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
+void CProfileManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
 {
   if (setting == nullptr)
     return;
@@ -714,7 +714,7 @@ void CProfilesManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
     GetEventLog().ShowFullEventLog();
 }
 
-void CProfilesManager::SetCurrentProfileId(unsigned int profileId)
+void CProfileManager::SetCurrentProfileId(unsigned int profileId)
 {
   CSingleLock lock(m_critical);
   m_currentProfile = profileId;

--- a/xbmc/profiles/ProfileManager.h
+++ b/xbmc/profiles/ProfileManager.h
@@ -22,14 +22,14 @@ class CEventLogManager;
 class CSettings;
 class TiXmlNode;
 
-class CProfilesManager : protected ISettingsHandler,
+class CProfileManager : protected ISettingsHandler,
                          protected ISettingCallback
 {
 public:
-  CProfilesManager();
-  CProfilesManager(const CProfilesManager&) = delete;
-  CProfilesManager& operator=(CProfilesManager const&) = delete;
-  ~CProfilesManager() override;
+  CProfileManager();
+  CProfileManager(const CProfileManager&) = delete;
+  CProfileManager& operator=(CProfileManager const&) = delete;
+  ~CProfileManager() override;
 
   void Initialize(const std::shared_ptr<CSettings>& settings);
   void Uninitialize();

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -31,6 +31,9 @@ public:
   CProfilesManager& operator=(CProfilesManager const&) = delete;
   ~CProfilesManager() override;
 
+  void Initialize(const std::shared_ptr<CSettings>& settings);
+  void Uninitialize();
+
   void OnSettingsLoaded() override;
   void OnSettingsSaved() const override;
   void OnSettingsCleared() override;
@@ -42,7 +45,6 @@ public:
     after special://masterprofile/ has been defined.
     \param file XML file to load.
     */
-  bool Load(const std::string &file);
 
   bool Save() const;
   /*! \brief Save the user profile information to disk
@@ -50,7 +52,6 @@ public:
     \param file XML file to save.
     \return true on success, false on failure to save
     */
-  bool Save(const std::string &file) const;
 
   void Clear();
 

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -9,7 +9,7 @@
 #include "GUIWindowSettingsProfile.h"
 #include "windows/GUIWindowFileManager.h"
 #include "profiles/Profile.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
@@ -56,9 +56,9 @@ int CGUIWindowSettingsProfile::GetSelectedItem()
 
 void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (iItem == (int)profilesManager->GetNumberOfProfiles())
+  if (iItem == (int)profileManager->GetNumberOfProfiles())
     return;
 
   // popup the context menu
@@ -76,7 +76,7 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 
   if (choice == 2)
   {
-    if (profilesManager->DeleteProfile(iItem))
+    if (profileManager->DeleteProfile(iItem))
       iItem--;
   }
 
@@ -110,7 +110,7 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
           iAction == ACTION_MOUSE_RIGHT_CLICK
         )
         {
-          const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+          const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
           CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PROFILES);
           CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
@@ -118,13 +118,13 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
           if (iAction == ACTION_CONTEXT_MENU || iAction == ACTION_MOUSE_RIGHT_CLICK)
           {
             //contextmenu
-            if (iItem <= static_cast<int>(profilesManager->GetNumberOfProfiles()) - 1)
+            if (iItem <= static_cast<int>(profileManager->GetNumberOfProfiles()) - 1)
             {
               OnPopupMenu(iItem);
             }
             return true;
           }
-          else if (iItem < static_cast<int>(profilesManager->GetNumberOfProfiles()))
+          else if (iItem < static_cast<int>(profileManager->GetNumberOfProfiles()))
           {
             if (CGUIDialogProfileSettings::ShowForProfile(iItem))
             {
@@ -137,10 +137,10 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
 
             return false;
           }
-          else if (iItem > static_cast<int>(profilesManager->GetNumberOfProfiles()) - 1)
+          else if (iItem > static_cast<int>(profileManager->GetNumberOfProfiles()) - 1)
           {
-            CDirectory::Create(URIUtils::AddFileToFolder(profilesManager->GetUserDataFolder(),"profiles"));
-            if (CGUIDialogProfileSettings::ShowForProfile(profilesManager->GetNumberOfProfiles()))
+            CDirectory::Create(URIUtils::AddFileToFolder(profileManager->GetUserDataFolder(),"profiles"));
+            if (CGUIDialogProfileSettings::ShowForProfile(profileManager->GetNumberOfProfiles()))
             {
               LoadList();
               CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), 2,iItem);
@@ -154,22 +154,22 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_LOGINSCREEN)
       {
-        const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+        const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-        profilesManager->ToggleLoginScreen();
-        profilesManager->Save();
+        profileManager->ToggleLoginScreen();
+        profileManager->Save();
         return true;
       }
       else if (iControl == CONTROL_AUTOLOGIN)
       {
-        const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+        const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-        int currentId = profilesManager->GetAutoLoginProfileId();
+        int currentId = profileManager->GetAutoLoginProfileId();
         int profileId;
         if (GetAutoLoginProfileChoice(profileId) && (currentId != profileId))
         {
-          profilesManager->SetAutoLoginProfileId(profileId);
-          profilesManager->Save();
+          profileManager->SetAutoLoginProfileId(profileId);
+          profileManager->Save();
         }
         return true;
       }
@@ -184,11 +184,11 @@ void CGUIWindowSettingsProfile::LoadList()
 {
   ClearListItems();
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); i++)
+  for (unsigned int i = 0; i < profileManager->GetNumberOfProfiles(); i++)
   {
-    const CProfile *profile = profilesManager->GetProfile(i);
+    const CProfile *profile = profileManager->GetProfile(i);
     CFileItemPtr item(new CFileItem(profile->getName()));
     item->SetLabel2(profile->getDate());
     item->SetArt("thumb", profile->getThumb());
@@ -202,7 +202,7 @@ void CGUIWindowSettingsProfile::LoadList()
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_PROFILES, 0, 0, m_listItems);
   OnMessage(msg);
 
-  if (profilesManager->UsingLoginScreen())
+  if (profileManager->UsingLoginScreen())
   {
     CONTROL_SELECT(CONTROL_LOGINSCREEN);
   }
@@ -231,20 +231,20 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   CGUIDialogSelect *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   if (!dialog) return false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   // add items
   // "Last used profile" option comes first, so up indices by 1
-  int autoLoginProfileId = profilesManager->GetAutoLoginProfileId() + 1;
+  int autoLoginProfileId = profileManager->GetAutoLoginProfileId() + 1;
   CFileItemList items;
   CFileItemPtr item(new CFileItem());
   item->SetLabel(g_localizeStrings.Get(37014)); // Last used profile
   item->SetIconImage("DefaultUser.png");
   items.Add(item);
 
-  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); i++)
+  for (unsigned int i = 0; i < profileManager->GetNumberOfProfiles(); i++)
   {
-    const CProfile *profile = profilesManager->GetProfile(i);
+    const CProfile *profile = profileManager->GetProfile(i);
     std::string locked = g_localizeStrings.Get(profile->getLockMode() > 0 ? 20166 : 20165);
     CFileItemPtr item(new CFileItem(profile->getName()));
     item->SetLabel2(locked); // lock setting

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -24,6 +24,7 @@
 #include "ServiceBroker.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/Variant.h"
 
 using namespace KODI;
@@ -55,9 +56,9 @@ int CGUIWindowSettingsProfile::GetSelectedItem()
 
 void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 {
-  CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (iItem == (int)profileManager.GetNumberOfProfiles())
+  if (iItem == (int)profilesManager->GetNumberOfProfiles())
     return;
 
   // popup the context menu
@@ -75,7 +76,7 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 
   if (choice == 2)
   {
-    if (profileManager.DeleteProfile(iItem))
+    if (profilesManager->DeleteProfile(iItem))
       iItem--;
   }
 
@@ -109,7 +110,7 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
           iAction == ACTION_MOUSE_RIGHT_CLICK
         )
         {
-          const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+          const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
           CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PROFILES);
           CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
@@ -117,13 +118,13 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
           if (iAction == ACTION_CONTEXT_MENU || iAction == ACTION_MOUSE_RIGHT_CLICK)
           {
             //contextmenu
-            if (iItem <= (int)profileManager.GetNumberOfProfiles() - 1)
+            if (iItem <= static_cast<int>(profilesManager->GetNumberOfProfiles()) - 1)
             {
               OnPopupMenu(iItem);
             }
             return true;
           }
-          else if (iItem < (int)profileManager.GetNumberOfProfiles())
+          else if (iItem < static_cast<int>(profilesManager->GetNumberOfProfiles()))
           {
             if (CGUIDialogProfileSettings::ShowForProfile(iItem))
             {
@@ -136,10 +137,10 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
 
             return false;
           }
-          else if (iItem > (int)profileManager.GetNumberOfProfiles() - 1)
+          else if (iItem > static_cast<int>(profilesManager->GetNumberOfProfiles()) - 1)
           {
-            CDirectory::Create(URIUtils::AddFileToFolder(profileManager.GetUserDataFolder(),"profiles"));
-            if (CGUIDialogProfileSettings::ShowForProfile(profileManager.GetNumberOfProfiles()))
+            CDirectory::Create(URIUtils::AddFileToFolder(profilesManager->GetUserDataFolder(),"profiles"));
+            if (CGUIDialogProfileSettings::ShowForProfile(profilesManager->GetNumberOfProfiles()))
             {
               LoadList();
               CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), 2,iItem);
@@ -153,22 +154,22 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_LOGINSCREEN)
       {
-        CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+        const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-        profileManager.ToggleLoginScreen();
-        profileManager.Save();
+        profilesManager->ToggleLoginScreen();
+        profilesManager->Save();
         return true;
       }
       else if (iControl == CONTROL_AUTOLOGIN)
       {
-        CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+        const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-        int currentId = profileManager.GetAutoLoginProfileId();
+        int currentId = profilesManager->GetAutoLoginProfileId();
         int profileId;
         if (GetAutoLoginProfileChoice(profileId) && (currentId != profileId))
         {
-          profileManager.SetAutoLoginProfileId(profileId);
-          profileManager.Save();
+          profilesManager->SetAutoLoginProfileId(profileId);
+          profilesManager->Save();
         }
         return true;
       }
@@ -183,11 +184,11 @@ void CGUIWindowSettingsProfile::LoadList()
 {
   ClearListItems();
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  for (unsigned int i = 0; i < profileManager.GetNumberOfProfiles(); i++)
+  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); i++)
   {
-    const CProfile *profile = profileManager.GetProfile(i);
+    const CProfile *profile = profilesManager->GetProfile(i);
     CFileItemPtr item(new CFileItem(profile->getName()));
     item->SetLabel2(profile->getDate());
     item->SetArt("thumb", profile->getThumb());
@@ -201,7 +202,7 @@ void CGUIWindowSettingsProfile::LoadList()
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_PROFILES, 0, 0, m_listItems);
   OnMessage(msg);
 
-  if (profileManager.UsingLoginScreen())
+  if (profilesManager->UsingLoginScreen())
   {
     CONTROL_SELECT(CONTROL_LOGINSCREEN);
   }
@@ -230,20 +231,20 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   CGUIDialogSelect *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   if (!dialog) return false;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   // add items
   // "Last used profile" option comes first, so up indices by 1
-  int autoLoginProfileId = profileManager.GetAutoLoginProfileId() + 1;
+  int autoLoginProfileId = profilesManager->GetAutoLoginProfileId() + 1;
   CFileItemList items;
   CFileItemPtr item(new CFileItem());
   item->SetLabel(g_localizeStrings.Get(37014)); // Last used profile
   item->SetIconImage("DefaultUser.png");
   items.Add(item);
 
-  for (unsigned int i = 0; i < profileManager.GetNumberOfProfiles(); i++)
+  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); i++)
   {
-    const CProfile *profile = profileManager.GetProfile(i);
+    const CProfile *profile = profilesManager->GetProfile(i);
     std::string locked = g_localizeStrings.Get(profile->getLockMode() > 0 ? 20166 : 20165);
     CFileItemPtr item(new CFileItem(profile->getName()));
     item->SetLabel2(locked); // lock setting

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -25,7 +25,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -325,9 +325,9 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
   if (!pItem)
     return false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profilesManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+  if (profileManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
     return false;
 
   // setup our thumb list

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -325,9 +325,9 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
   if (!pItem)
     return false;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (profileManager.GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+  if (profilesManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
     return false;
 
   // setup our thumb list

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -50,10 +50,10 @@ CAdvancedSettings::CAdvancedSettings()
 
 void CAdvancedSettings::OnSettingsLoaded()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   // load advanced settings
-  Load(profileManager);
+  Load(*profilesManager);
 
   // default players?
   CLog::Log(LOGNOTICE, "Default Video Player: %s", m_videoDefaultPlayer.c_str());

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -21,7 +21,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "LangInfo.h"
 #include "network/DNSNameCache.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
 #include "settings/Settings.h"
@@ -50,10 +50,10 @@ CAdvancedSettings::CAdvancedSettings()
 
 void CAdvancedSettings::OnSettingsLoaded()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   // load advanced settings
-  Load(*profilesManager);
+  Load(*profileManager);
 
   // default players?
   CLog::Log(LOGNOTICE, "Default Video Player: %s", m_videoDefaultPlayer.c_str());
@@ -431,7 +431,7 @@ void CAdvancedSettings::Initialize()
   m_initialized = true;
 }
 
-bool CAdvancedSettings::Load(const CProfilesManager &profileManager)
+bool CAdvancedSettings::Load(const CProfileManager &profileManager)
 {
   // NOTE: This routine should NOT set the default of any of these parameters
   //       it should instead use the versions of GetString/Integer/Float that

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -25,7 +25,7 @@
 #define CACHE_BUFFER_MODE_REMOTE        4
 
 class CAppParamParser;
-class CProfilesManager;
+class CProfileManager;
 class CSettingsManager;
 class CVariant;
 
@@ -117,7 +117,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void Uninitialize(CSettingsManager& settingsMgr);
     bool Initialized() const { return m_initialized; };
     void AddSettingsFile(const std::string &filename);
-    bool Load(const CProfilesManager &profileManager);
+    bool Load(const CProfileManager &profileManager);
 
     static void GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_TVSHOWLIST& settings);
     static void GetCustomRegexps(TiXmlElement *pRootElement, std::vector<std::string> &settings);

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -22,7 +22,7 @@
 #include "music/MusicLibraryQueue.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -14,6 +14,7 @@
 #include "Util.h"
 #include "filesystem/File.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -43,13 +44,13 @@ CMediaSourceSettings& CMediaSourceSettings::GetInstance()
 
 std::string CMediaSourceSettings::GetSourcesFile()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   std::string file;
-  if (profileManager.GetCurrentProfile().hasSources())
-    file = profileManager.GetProfileUserDataFolder();
+  if (profilesManager->GetCurrentProfile().hasSources())
+    file = profilesManager->GetProfileUserDataFolder();
   else
-    file = profileManager.GetUserDataFolder();
+    file = profilesManager->GetUserDataFolder();
 
   return URIUtils::AddFileToFolder(file, SOURCES_FILE);
 }

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -13,7 +13,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -44,13 +44,13 @@ CMediaSourceSettings& CMediaSourceSettings::GetInstance()
 
 std::string CMediaSourceSettings::GetSourcesFile()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   std::string file;
-  if (profilesManager->GetCurrentProfile().hasSources())
-    file = profilesManager->GetProfileUserDataFolder();
+  if (profileManager->GetCurrentProfile().hasSources())
+    file = profileManager->GetProfileUserDataFolder();
   else
-    file = profilesManager->GetUserDataFolder();
+    file = profileManager->GetUserDataFolder();
 
   return URIUtils::AddFileToFolder(file, SOURCES_FILE);
 }

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -13,7 +13,7 @@
 #include "MediaSource.h"
 #include "settings/lib/ISettingsHandler.h"
 
-class CProfilesManager;
+class CProfileManager;
 class TiXmlNode;
 
 class CMediaSourceSettings : public ISettingsHandler

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -26,7 +26,7 @@
 #include "network/WebServer.h"
 #endif
 #include "peripherals/Peripherals.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRSettings.h"
@@ -258,7 +258,7 @@ bool LessThanOrEqual(const std::string &condition, const std::string &value, Set
   return lhs <= rhs;
 }
 
-const CProfilesManager *CSettingConditions::m_profileManager = nullptr;
+const CProfileManager *CSettingConditions::m_profileManager = nullptr;
 std::set<std::string> CSettingConditions::m_simpleConditions;
 std::map<std::string, SettingConditionCheck> CSettingConditions::m_complexConditions;
 
@@ -390,7 +390,7 @@ void CSettingConditions::Deinitialize()
 const CProfile& CSettingConditions::GetCurrentProfile()
 {
   if (!m_profileManager)
-    m_profileManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager().get();
+    m_profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager().get();
 
   if (m_profileManager)
     return m_profileManager->GetCurrentProfile();

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -31,6 +31,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/PVRSettings.h"
 #include "settings/SettingAddon.h"
+#include "settings/SettingsComponent.h"
 #if defined(HAS_LIBAMCODEC)
 #include "utils/AMLUtils.h"
 #endif // defined(HAS_LIBAMCODEC)
@@ -389,7 +390,7 @@ void CSettingConditions::Deinitialize()
 const CProfile& CSettingConditions::GetCurrentProfile()
 {
   if (!m_profileManager)
-    m_profileManager = &CServiceBroker::GetProfileManager();
+    m_profileManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager().get();
 
   if (m_profileManager)
     return m_profileManager->GetCurrentProfile();

--- a/xbmc/settings/SettingConditions.h
+++ b/xbmc/settings/SettingConditions.h
@@ -14,7 +14,7 @@
 #include "settings/lib/SettingConditions.h"
 
 class CProfile;
-class CProfilesManager;
+class CProfileManager;
 
 class CSettingConditions
 {
@@ -31,7 +31,7 @@ public:
 
 private:
   // Initialization parameters
-  static const CProfilesManager *m_profileManager;
+  static const CProfileManager *m_profileManager;
 
   static std::set<std::string> m_simpleConditions;
   static std::map<std::string, SettingConditionCheck> m_complexConditions;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -49,6 +49,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/SettingsComponent.h"
 #include "settings/SettingConditions.h"
 #include "settings/SettingUtils.h"
 #include "settings/SkinSettings.h"
@@ -452,9 +453,9 @@ bool CSettings::Initialize()
 
 bool CSettings::Load()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  return Load(profileManager.GetSettingsFile());
+  return Load(profilesManager->GetSettingsFile());
 }
 
 bool CSettings::Load(const std::string &file)
@@ -480,9 +481,9 @@ bool CSettings::Load(const std::string &file)
 
 bool CSettings::Save()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  return Save(profileManager.GetSettingsFile());
+  return Save(profilesManager->GetSettingsFile());
 }
 
 bool CSettings::Save(const std::string &file)
@@ -969,9 +970,9 @@ void CSettings::UninitializeISettingCallbacks()
 
 bool CSettings::Reset()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  std::string settingsFile = profileManager.GetSettingsFile();
+  const std::string settingsFile = profilesManager->GetSettingsFile();
 
   // try to delete the settings file
   if (XFILE::CFile::Exists(settingsFile, false) && !XFILE::CFile::Delete(settingsFile))

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -42,7 +42,7 @@
 #include "utils/AMLUtils.h"
 #endif // defined(HAS_LIBAMCODEC)
 #include "powermanagement/PowerTypes.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "pvr/PVRSettings.h"
 #include "pvr/windows/GUIWindowPVRGuide.h"
 #include "ServiceBroker.h"
@@ -453,9 +453,9 @@ bool CSettings::Initialize()
 
 bool CSettings::Load()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  return Load(profilesManager->GetSettingsFile());
+  return Load(profileManager->GetSettingsFile());
 }
 
 bool CSettings::Load(const std::string &file)
@@ -481,9 +481,9 @@ bool CSettings::Load(const std::string &file)
 
 bool CSettings::Save()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  return Save(profilesManager->GetSettingsFile());
+  return Save(profileManager->GetSettingsFile());
 }
 
 bool CSettings::Save(const std::string &file)
@@ -970,9 +970,9 @@ void CSettings::UninitializeISettingCallbacks()
 
 bool CSettings::Reset()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  const std::string settingsFile = profilesManager->GetSettingsFile();
+  const std::string settingsFile = profileManager->GetSettingsFile();
 
   // try to delete the settings file
   if (XFILE::CFile::Exists(settingsFile, false) && !XFILE::CFile::Delete(settingsFile))

--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -22,7 +22,7 @@
 #ifdef TARGET_WINDOWS
 #include "platform/Environment.h"
 #endif
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -34,7 +34,7 @@ CSettingsComponent::CSettingsComponent()
 {
   m_advancedSettings.reset(new CAdvancedSettings());
   m_settings.reset(new CSettings());
-  m_profilesManager.reset(new CProfilesManager());
+  m_profileManager.reset(new CProfileManager());
 }
 
 CSettingsComponent::~CSettingsComponent()
@@ -58,7 +58,7 @@ void CSettingsComponent::Init(const CAppParamParser &params)
     m_advancedSettings->Initialize(params, *m_settings->GetSettingsManager());
     URIUtils::RegisterAdvancedSettings(*m_advancedSettings);
 
-    m_profilesManager->Initialize(m_settings);
+    m_profileManager->Initialize(m_settings);
 
     CServiceBroker::RegisterSettingsComponent(this);
 
@@ -70,14 +70,14 @@ bool CSettingsComponent::Load()
 {
   if (m_state == State::INITED)
   {
-    if (!m_profilesManager->Load())
+    if (!m_profileManager->Load())
     {
       CLog::Log(LOGFATAL, "unable to load profile");
       return false;
     }
 
-    CSpecialProtocol::RegisterProfileManager(*m_profilesManager);
-    XFILE::IDirectory::RegisterProfileManager(*m_profilesManager);
+    CSpecialProtocol::RegisterProfileManager(*m_profileManager);
+    XFILE::IDirectory::RegisterProfileManager(*m_profileManager);
 
     if (!m_settings->Load())
     {
@@ -113,7 +113,7 @@ void CSettingsComponent::Deinit()
       XFILE::IDirectory::UnregisterProfileManager();
       CSpecialProtocol::UnregisterProfileManager();
     }
-    m_profilesManager->Uninitialize();
+    m_profileManager->Uninitialize();
 
     URIUtils::UnregisterAdvancedSettings();
     m_advancedSettings->Uninitialize(*m_settings->GetSettingsManager());
@@ -133,9 +133,9 @@ std::shared_ptr<CAdvancedSettings> CSettingsComponent::GetAdvancedSettings()
   return m_advancedSettings;
 }
 
-std::shared_ptr<CProfilesManager> CSettingsComponent::GetProfilesManager()
+std::shared_ptr<CProfileManager> CSettingsComponent::GetProfileManager()
 {
-  return m_profilesManager;
+  return m_profileManager;
 }
 
 bool CSettingsComponent::InitDirectoriesLinux(bool bPlatformDirectories)

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -21,22 +21,56 @@ public:
   CSettingsComponent();
   virtual ~CSettingsComponent();
 
+  /*!
+   * @brief Initialize all subcomponents with system default values (loaded from code, system settings files, ...).
+   * @param params The command line params passed to the app.
+   */
   void Init(const CAppParamParser &params);
+
+  /*!
+   * @brief Initialize all subcomponents with user values (loaded from user settings files, according to active profile).
+   * @return true on success, false otherwise.
+   */
   bool Load();
+
+  /*!
+   * @brief Deinitialize all subcomponents.
+   */
   void Deinit();
 
+  /*!
+   * @brief Get access to the settings subcomponent.
+   * @return the settings subcomponent.
+   */
   std::shared_ptr<CSettings> GetSettings();
-  std::shared_ptr<CAdvancedSettings> GetAdvancedSettings();
-  std::shared_ptr<CProfilesManager> GetProfilesManager();
 
-protected:
-  std::shared_ptr<CSettings> m_settings;
-  std::shared_ptr<CAdvancedSettings> m_advancedSettings;
-  std::shared_ptr<CProfilesManager> m_profilesManager;
+  /*!
+   * @brief Get access to the advanced settings subcomponent.
+   * @return the advanced settings subcomponent.
+   */
+  std::shared_ptr<CAdvancedSettings> GetAdvancedSettings();
+
+  /*!
+   * @brief Get access to the profiles manager subcomponent.
+   * @return the profiles manager subcomponent.
+   */
+  std::shared_ptr<CProfilesManager> GetProfilesManager();
 
 private:
   bool InitDirectoriesLinux(bool bPlatformDirectories);
   bool InitDirectoriesOSX(bool bPlatformDirectories);
   bool InitDirectoriesWin32(bool bPlatformDirectories);
   void CreateUserDirs() const;
+
+  enum class State
+  {
+    DEINITED,
+    INITED,
+    LOADED
+  };
+  State m_state = State::DEINITED;
+
+  std::shared_ptr<CSettings> m_settings;
+  std::shared_ptr<CAdvancedSettings> m_advancedSettings;
+  std::shared_ptr<CProfilesManager> m_profilesManager;
 };

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -12,6 +12,7 @@
 
 class CAppParamParser;
 class CAdvancedSettings;
+class CProfilesManager;
 class CSettings;
 
 class CSettingsComponent
@@ -21,14 +22,17 @@ public:
   virtual ~CSettingsComponent();
 
   void Init(const CAppParamParser &params);
+  bool Load();
   void Deinit();
 
   std::shared_ptr<CSettings> GetSettings();
   std::shared_ptr<CAdvancedSettings> GetAdvancedSettings();
+  std::shared_ptr<CProfilesManager> GetProfilesManager();
 
 protected:
   std::shared_ptr<CSettings> m_settings;
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
+  std::shared_ptr<CProfilesManager> m_profilesManager;
 
 private:
   bool InitDirectoriesLinux(bool bPlatformDirectories);

--- a/xbmc/settings/SettingsComponent.h
+++ b/xbmc/settings/SettingsComponent.h
@@ -12,7 +12,7 @@
 
 class CAppParamParser;
 class CAdvancedSettings;
-class CProfilesManager;
+class CProfileManager;
 class CSettings;
 
 class CSettingsComponent
@@ -54,7 +54,7 @@ public:
    * @brief Get access to the profiles manager subcomponent.
    * @return the profiles manager subcomponent.
    */
-  std::shared_ptr<CProfilesManager> GetProfilesManager();
+  std::shared_ptr<CProfileManager> GetProfileManager();
 
 private:
   bool InitDirectoriesLinux(bool bPlatformDirectories);
@@ -72,5 +72,5 @@ private:
 
   std::shared_ptr<CSettings> m_settings;
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
-  std::shared_ptr<CProfilesManager> m_profilesManager;
+  std::shared_ptr<CProfileManager> m_profileManager;
 };

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -12,6 +12,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
+#include "profiles/ProfilesManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -89,6 +90,10 @@ void TestBasicEnvironment::SetUp()
     TearDown();
     SetUpError();
   }
+
+  const CProfile profile("special://temp");
+  m_pSettingsComponent->GetProfilesManager()->AddProfile(profile);
+  m_pSettingsComponent->GetProfilesManager()->CreateProfileFolders();
 
   if (!g_application.m_ServiceManager->InitForTesting())
     exit(1);

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -12,7 +12,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -92,8 +92,8 @@ void TestBasicEnvironment::SetUp()
   }
 
   const CProfile profile("special://temp");
-  m_pSettingsComponent->GetProfilesManager()->AddProfile(profile);
-  m_pSettingsComponent->GetProfilesManager()->CreateProfileFolders();
+  m_pSettingsComponent->GetProfileManager()->AddProfile(profile);
+  m_pSettingsComponent->GetProfileManager()->CreateProfileFolders();
 
   if (!g_application.m_ServiceManager->InitForTesting())
     exit(1);

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -20,6 +20,7 @@
 #include "profiles/ProfilesManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/RssReader.h"
@@ -94,11 +95,11 @@ void CRssManager::Stop()
 
 bool CRssManager::Load()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   CSingleLock lock(m_critical);
 
-  std::string rssXML = profileManager.GetUserDataItem("RssFeeds.xml");
+  std::string rssXML = profilesManager->GetUserDataItem("RssFeeds.xml");
   if (!CFile::Exists(rssXML))
     return false;
 

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -17,7 +17,7 @@
 #include "interfaces/builtins/Builtins.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -95,11 +95,11 @@ void CRssManager::Stop()
 
 bool CRssManager::Load()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   CSingleLock lock(m_critical);
 
-  std::string rssXML = profilesManager->GetUserDataItem("RssFeeds.xml");
+  std::string rssXML = profileManager->GetUserDataItem("RssFeeds.xml");
   if (!CFile::Exists(rssXML))
     return false;
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -38,7 +38,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/SmartPlayList.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -153,10 +153,10 @@ void CGUIDialogAudioSettings::OnSettingAction(std::shared_ptr<const CSetting> se
 
 void CGUIDialogAudioSettings::Save()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
-      profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
   // prompt user if they are sure

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -24,7 +24,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
@@ -153,10 +153,10 @@ void CGUIDialogAudioSettings::OnSettingAction(std::shared_ptr<const CSetting> se
 
 void CGUIDialogAudioSettings::Save()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
-      profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
   // prompt user if they are sure

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -17,7 +17,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "guilib/GUIWindowManager.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -173,10 +173,10 @@ void CGUIDialogSubtitleSettings::OnSettingAction(std::shared_ptr<const CSetting>
 
 void CGUIDialogSubtitleSettings::Save()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
-      profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
   // prompt user if they are sure

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -23,7 +23,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
@@ -173,10 +173,10 @@ void CGUIDialogSubtitleSettings::OnSettingAction(std::shared_ptr<const CSetting>
 
 void CGUIDialogSubtitleSettings::Save()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
-      profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
   // prompt user if they are sure

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -419,11 +419,11 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
 
   if (hasImage)
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
     auto crc = Crc32::ComputeFromLowerCase(g_application.CurrentFile());
     bookmark.thumbNailImage = StringUtils::Format("%08x_%i.jpg", crc, (int)bookmark.timeInSeconds);
-    bookmark.thumbNailImage = URIUtils::AddFileToFolder(profileManager.GetBookmarksThumbFolder(), bookmark.thumbNailImage);
+    bookmark.thumbNailImage = URIUtils::AddFileToFolder(profilesManager->GetBookmarksThumbFolder(), bookmark.thumbNailImage);
 
     if (!CPicture::CreateThumbnailFromSurface(pixels, width, height, width * 4,
                                                          bookmark.thumbNailImage))

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -13,7 +13,7 @@
 #include "pictures/Picture.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "view/ViewState.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "settings/AdvancedSettings.h"
 #include "FileItem.h"
@@ -419,11 +419,11 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
 
   if (hasImage)
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     auto crc = Crc32::ComputeFromLowerCase(g_application.CurrentFile());
     bookmark.thumbNailImage = StringUtils::Format("%08x_%i.jpg", crc, (int)bookmark.timeInSeconds);
-    bookmark.thumbNailImage = URIUtils::AddFileToFolder(profilesManager->GetBookmarksThumbFolder(), bookmark.thumbNailImage);
+    bookmark.thumbNailImage = URIUtils::AddFileToFolder(profileManager->GetBookmarksThumbFolder(), bookmark.thumbNailImage);
 
     if (!CPicture::CreateThumbnailFromSurface(pixels, width, height, width * 4,
                                                          bookmark.thumbNailImage))

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -235,16 +235,16 @@ void CGUIDialogVideoInfo::OnInitWindow()
   m_hasUpdatedUserrating = false;
   m_bViewReview = true;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   // Disable video user rating button for plugins as they don't have tables to save this
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin());
 
   VIDEODB_CONTENT_TYPE type = static_cast<VIDEODB_CONTENT_TYPE>(m_movieItem->GetVideoContentType());
   if (type == VIDEODB_CONTENT_TVSHOWS || type == VIDEODB_CONTENT_MOVIES)
-    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART, (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
 
@@ -1384,12 +1384,12 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
   if (!DeleteVideoItemFromDatabase(item, unavailable))
     return false;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   // check if the user is allowed to delete the actual file as well
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION) &&
-      (profileManager.GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-       !profileManager.GetCurrentProfile().filesLocked() ||
+      (profilesManager->GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+       !profilesManager->GetCurrentProfile().filesLocked() ||
        g_passwordManager.IsMasterLockUnlocked(true)))
   {
     std::string strDeletePath = item->GetVideoInfoTag()->GetPath();

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -31,7 +31,7 @@
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "storage/MediaManager.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -235,16 +235,16 @@ void CGUIDialogVideoInfo::OnInitWindow()
   m_hasUpdatedUserrating = false;
   m_bViewReview = true;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   // Disable video user rating button for plugins as they don't have tables to save this
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin());
 
   VIDEODB_CONTENT_TYPE type = static_cast<VIDEODB_CONTENT_TYPE>(m_movieItem->GetVideoContentType());
   if (type == VIDEODB_CONTENT_TVSHOWS || type == VIDEODB_CONTENT_MOVIES)
-    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART, (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART, (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
 
@@ -1384,12 +1384,12 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
   if (!DeleteVideoItemFromDatabase(item, unavailable))
     return false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   // check if the user is allowed to delete the actual file as well
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION) &&
-      (profilesManager->GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-       !profilesManager->GetCurrentProfile().filesLocked() ||
+      (profileManager->GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+       !profileManager->GetCurrentProfile().filesLocked() ||
        g_passwordManager.IsMasterLockUnlocked(true)))
   {
     std::string strDeletePath = item->GetVideoInfoTag()->GetPath();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -17,7 +17,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
 #include "settings/MediaSettings.h"
@@ -210,10 +210,10 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_VIDEO_CALIBRATION)
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     // launch calibration window
-    if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
+    if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
         g_passwordManager.CheckSettingLevelLock(CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION)->GetLevel()))
       return;
     CServiceBroker::GetGUI()->GetWindowManager().ForceActivateWindow(WINDOW_SCREEN_CALIBRATION);
@@ -225,9 +225,9 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
 
 void CGUIDialogVideoSettings::Save()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+  if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
       !g_passwordManager.CheckSettingLevelLock(::SettingLevel::Expert))
     return;
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -210,10 +210,10 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_VIDEO_CALIBRATION)
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
     // launch calibration window
-    if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
+    if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
         g_passwordManager.CheckSettingLevelLock(CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION)->GetLevel()))
       return;
     CServiceBroker::GetGUI()->GetWindowManager().ForceActivateWindow(WINDOW_SCREEN_CALIBRATION);
@@ -225,9 +225,9 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
 
 void CGUIDialogVideoSettings::Save()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+  if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
       !g_passwordManager.CheckSettingLevelLock(::SettingLevel::Expert))
     return;
 

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -18,6 +18,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "profiles/ProfilesManager.h"
+#include "settings/SettingsComponent.h"
 #include "ServiceBroker.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
@@ -43,9 +44,9 @@ bool CVideoLibraryMarkWatchedJob::operator==(const CJob* job) const
 
 bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (!profileManager.GetCurrentProfile().canWriteDatabases())
+  if (!profilesManager->GetCurrentProfile().canWriteDatabases())
     return false;
 
   CFileItemList items;

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -17,7 +17,7 @@
 #endif
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "ServiceBroker.h"
 #include "utils/URIUtils.h"
@@ -44,9 +44,9 @@ bool CVideoLibraryMarkWatchedJob::operator==(const CJob* job) const
 
 bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (!profilesManager->GetCurrentProfile().canWriteDatabases())
+  if (!profileManager->GetCurrentProfile().canWriteDatabases())
     return false;
 
   CFileItemList items;

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -20,6 +20,7 @@
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
 
@@ -42,9 +43,9 @@ bool CVideoLibraryResetResumePointJob::operator==(const CJob* job) const
 
 bool CVideoLibraryResetResumePointJob::Work(CVideoDatabase &db)
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (!profileManager.GetCurrentProfile().canWriteDatabases())
+  if (!profilesManager->GetCurrentProfile().canWriteDatabases())
     return false;
 
   CFileItemList items;

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -17,7 +17,7 @@
 #ifdef HAS_UPNP
 #include "network/upnp/UPnP.h"
 #endif
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "settings/SettingsComponent.h"
@@ -43,9 +43,9 @@ bool CVideoLibraryResetResumePointJob::operator==(const CJob* job) const
 
 bool CVideoLibraryResetResumePointJob::Work(CVideoDatabase &db)
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (!profilesManager->GetCurrentProfile().canWriteDatabases())
+  if (!profileManager->GetCurrentProfile().canWriteDatabases())
     return false;
 
   CFileItemList items;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -34,7 +34,7 @@
 #include "filesystem/Directory.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/PlayList.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
@@ -161,10 +161,10 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         }
         else if (iAction == ACTION_DELETE_ITEM)
         {
-          const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+          const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
           // is delete allowed?
-          if (profilesManager->GetCurrentProfile().canWriteDatabases())
+          if (profileManager->GetCurrentProfile().canWriteDatabases())
           {
             // must be at the title window
             if (GetID() == WINDOW_VIDEO_NAV)
@@ -375,10 +375,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     }
   }
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   // quietly return if Internet lookups are disabled
-  if (!profilesManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+  if (!profileManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
     return false;
 
   if (!info)
@@ -1139,10 +1139,10 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
   if (item->IsStack())
     item->m_bIsFolder = true;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-      profilesManager->GetCurrentProfile().filesLocked())
+  if (profileManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+      profileManager->GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
@@ -1250,9 +1250,9 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
   // add in the "New Playlist" item if we're in the playlists folder
   if ((items.GetPath() == "special://videoplaylists/") && !items.Contains("newplaylist://"))
   {
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-    CFileItemPtr newPlaylist(new CFileItem(profilesManager->GetUserDataItem("PartyMode-Video.xsp"),false));
+    CFileItemPtr newPlaylist(new CFileItem(profileManager->GetUserDataItem("PartyMode-Video.xsp"),false));
     newPlaylist->SetLabel(g_localizeStrings.Get(16035));
     newPlaylist->SetLabelPreformatted(true);
     newPlaylist->SetIconImage("DefaultPartyMode.png");

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -161,10 +161,10 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         }
         else if (iAction == ACTION_DELETE_ITEM)
         {
-          const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+          const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
           // is delete allowed?
-          if (profileManager.GetCurrentProfile().canWriteDatabases())
+          if (profilesManager->GetCurrentProfile().canWriteDatabases())
           {
             // must be at the title window
             if (GetID() == WINDOW_VIDEO_NAV)
@@ -375,10 +375,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     }
   }
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   // quietly return if Internet lookups are disabled
-  if (!profileManager.GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+  if (!profilesManager->GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
     return false;
 
   if (!info)
@@ -1139,10 +1139,10 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
   if (item->IsStack())
     item->m_bIsFolder = true;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (profileManager.GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-      profileManager.GetCurrentProfile().filesLocked())
+  if (profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+      profilesManager->GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
@@ -1250,9 +1250,9 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
   // add in the "New Playlist" item if we're in the playlists folder
   if ((items.GetPath() == "special://videoplaylists/") && !items.Contains("newplaylist://"))
   {
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-    CFileItemPtr newPlaylist(new CFileItem(profileManager.GetUserDataItem("PartyMode-Video.xsp"),false));
+    CFileItemPtr newPlaylist(new CFileItem(profilesManager->GetUserDataItem("PartyMode-Video.xsp"),false));
     newPlaylist->SetLabel(g_localizeStrings.Get(16035));
     newPlaylist->SetLabelPreformatted(true);
     newPlaylist->SetIconImage("DefaultPartyMode.png");

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -28,7 +28,7 @@
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -893,7 +893,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
   CVideoDatabaseDirectory dir;
   NODE_TYPE node = dir.GetDirectoryChildType(m_vecItems->GetPath());
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   if (!item)
   {
@@ -904,7 +904,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     // get the usual shares
     CGUIDialogContextMenu::GetContextButtons("video", item, buttons);
     if (!item->IsDVD() && item->GetPath() != "add" && !item->IsParentFolder() &&
-        (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+        (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       CVideoDatabase database;
       database.Open();
@@ -962,7 +962,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       GetScraperForItem(item.get(), info, settings);
 
       // can we update the database?
-      if (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
+      if (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
       {
         if (!g_application.IsVideoScanning() && item->IsVideoDb() && item->HasVideoInfoTag() &&
            (item->GetVideoInfoTag()->m_type == MediaTypeMovie ||          // movies
@@ -1124,9 +1124,9 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
   {
     CLog::Log(LOGDEBUG, "%s called on '%s' but file doesn't exist", __FUNCTION__, item->GetPath().c_str());
 
-    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-    if (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
+    if (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
     {
       if (!CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(item, true))
         return true;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -893,7 +893,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
   CVideoDatabaseDirectory dir;
   NODE_TYPE node = dir.GetDirectoryChildType(m_vecItems->GetPath());
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   if (!item)
   {
@@ -904,7 +904,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     // get the usual shares
     CGUIDialogContextMenu::GetContextButtons("video", item, buttons);
     if (!item->IsDVD() && item->GetPath() != "add" && !item->IsParentFolder() &&
-        (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+        (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       CVideoDatabase database;
       database.Open();
@@ -962,7 +962,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       GetScraperForItem(item.get(), info, settings);
 
       // can we update the database?
-      if (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
+      if (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
       {
         if (!g_application.IsVideoScanning() && item->IsVideoDb() && item->HasVideoInfoTag() &&
            (item->GetVideoInfoTag()->m_type == MediaTypeMovie ||          // movies
@@ -1124,9 +1124,9 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
   {
     CLog::Log(LOGDEBUG, "%s called on '%s' but file doesn't exist", __FUNCTION__, item->GetPath().c_str());
 
-    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+    const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-    if (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
+    if (profilesManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
     {
       if (!CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(item, true))
         return true;

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -389,9 +389,9 @@ bool CGUIViewState::HideParentDirItems()
 
 bool CGUIViewState::DisableAddSourceButtons()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (profileManager.GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
+  if (profilesManager->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
     return !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWADDSOURCEBUTTONS);
 
   return true;

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -14,7 +14,7 @@
 #include "music/GUIViewStateMusic.h"
 #include "video/GUIViewStateVideo.h"
 #include "pictures/GUIViewStatePictures.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "programs/GUIViewStatePrograms.h"
 #include "games/windows/GUIViewStateWindowGames.h"
 #include "PlayListPlayer.h"
@@ -389,9 +389,9 @@ bool CGUIViewState::HideParentDirItems()
 
 bool CGUIViewState::DisableAddSourceButtons()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profilesManager->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
+  if (profileManager->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
     return !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWADDSOURCEBUTTONS);
 
   return true;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -983,7 +983,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return true;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   CFileItemPtr pItem = m_vecItems->Get(iItem);
 
@@ -995,12 +995,12 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 
   if (pItem->GetPath() == "add" || pItem->GetPath() == "sources://add/") // 'add source button' in empty root
   {
-    if (profileManager.IsMasterProfile())
+    if (profilesManager->IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
     }
-    else if (!profileManager.GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    else if (!profilesManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
 
     if (OnAddMediaSource())
@@ -1041,7 +1041,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     if ( pItem->m_bIsShareOrDrive )
     {
       const std::string& strLockType=m_guiState->GetLockType();
-      if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         if (!strLockType.empty() && !g_passwordManager.IsItemUnlocked(pItem.get(), strLockType))
             return true;
 
@@ -1050,8 +1050,8 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     }
 
     // check for the partymode playlist items - they may not exist yet
-    if ((pItem->GetPath() == profileManager.GetUserDataItem("PartyMode.xsp")) ||
-        (pItem->GetPath() == profileManager.GetUserDataItem("PartyMode-Video.xsp")))
+    if ((pItem->GetPath() == profilesManager->GetUserDataItem("PartyMode.xsp")) ||
+        (pItem->GetPath() == profilesManager->GetUserDataItem("PartyMode-Video.xsp")))
     {
       // party mode playlist item - if it doesn't exist, prompt for user to define it
       if (!XFILE::CFile::Exists(pItem->GetPath()))
@@ -1592,9 +1592,9 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
   if (item->IsPlayList())
     item->m_bIsFolder = false;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (profileManager.GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profileManager.GetCurrentProfile().filesLocked())
+  if (profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profilesManager->GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
@@ -1618,9 +1618,9 @@ void CGUIMediaWindow::OnRenameItem(int iItem)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  if (profileManager.GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profileManager.GetCurrentProfile().filesLocked())
+  if (profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profilesManager->GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -45,7 +45,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "network/Network.h"
 #include "playlists/PlayList.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -983,7 +983,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return true;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   CFileItemPtr pItem = m_vecItems->Get(iItem);
 
@@ -995,12 +995,12 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 
   if (pItem->GetPath() == "add" || pItem->GetPath() == "sources://add/") // 'add source button' in empty root
   {
-    if (profilesManager->IsMasterProfile())
+    if (profileManager->IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
     }
-    else if (!profilesManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    else if (!profileManager->GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
 
     if (OnAddMediaSource())
@@ -1041,7 +1041,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     if ( pItem->m_bIsShareOrDrive )
     {
       const std::string& strLockType=m_guiState->GetLockType();
-      if (profilesManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         if (!strLockType.empty() && !g_passwordManager.IsItemUnlocked(pItem.get(), strLockType))
             return true;
 
@@ -1050,8 +1050,8 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     }
 
     // check for the partymode playlist items - they may not exist yet
-    if ((pItem->GetPath() == profilesManager->GetUserDataItem("PartyMode.xsp")) ||
-        (pItem->GetPath() == profilesManager->GetUserDataItem("PartyMode-Video.xsp")))
+    if ((pItem->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) ||
+        (pItem->GetPath() == profileManager->GetUserDataItem("PartyMode-Video.xsp")))
     {
       // party mode playlist item - if it doesn't exist, prompt for user to define it
       if (!XFILE::CFile::Exists(pItem->GetPath()))
@@ -1592,9 +1592,9 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
   if (item->IsPlayList())
     item->m_bIsFolder = false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profilesManager->GetCurrentProfile().filesLocked())
+  if (profileManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profileManager->GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
@@ -1618,9 +1618,9 @@ void CGUIMediaWindow::OnRenameItem(int iItem)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  if (profilesManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profilesManager->GetCurrentProfile().filesLocked())
+  if (profileManager->GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profileManager->GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -149,18 +149,18 @@ void CGUIWindowLoginScreen::FrameMove()
       m_iSelectedItem = m_viewControl.GetSelectedItem();
   }
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, profileManager.GetNumberOfProfiles());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, profilesManager->GetNumberOfProfiles());
   SET_CONTROL_LABEL(CONTROL_LABEL_SELECTED_PROFILE,strLabel);
   CGUIWindow::FrameMove();
 }
 
 void CGUIWindowLoginScreen::OnInitWindow()
 {
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  m_iSelectedItem = static_cast<int>(profileManager.GetLastUsedProfileIndex());
+  m_iSelectedItem = static_cast<int>(profilesManager->GetLastUsedProfileIndex());
 
   // Update list/thumb control
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
@@ -190,11 +190,11 @@ void CGUIWindowLoginScreen::Update()
 {
   m_vecItems->Clear();
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
-  for (unsigned int i = 0; i < profileManager.GetNumberOfProfiles(); ++i)
+  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); ++i)
   {
-    const CProfile *profile = profileManager.GetProfile(i);
+    const CProfile *profile = profilesManager->GetProfile(i);
 
     CFileItemPtr item(new CFileItem(profile->getName()));
 
@@ -221,7 +221,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return false;
 
-  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
 
   CFileItemPtr pItem = m_vecItems->Get(iItem);
   bool bSelect = pItem->IsSelected();
@@ -238,7 +238,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
   if (choice == 2)
   {
-    if (g_passwordManager.CheckLock(profileManager.GetMasterProfile().getLockMode(), profileManager.GetMasterProfile().getLockCode(), 20075))
+    if (g_passwordManager.CheckLock(profilesManager->GetMasterProfile().getLockMode(), profilesManager->GetMasterProfile().getLockCode(), 20075))
       g_passwordManager.iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
     else // be inconvenient
       CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
@@ -251,7 +251,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
     CGUIDialogProfileSettings::ShowForProfile(m_viewControl.GetSelectedItem());
 
   //NOTE: this can potentially (de)select the wrong item if the filelisting has changed because of an action above.
-  if (iItem < static_cast<int>(profileManager.GetNumberOfProfiles()))
+  if (iItem < static_cast<int>(profilesManager->GetNumberOfProfiles()))
     m_vecItems->Get(iItem)->Select(bSelect);
 
   return false;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -21,7 +21,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/Profile.h"
-#include "profiles/ProfilesManager.h"
+#include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
@@ -149,18 +149,18 @@ void CGUIWindowLoginScreen::FrameMove()
       m_iSelectedItem = m_viewControl.GetSelectedItem();
   }
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, profilesManager->GetNumberOfProfiles());
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, profileManager->GetNumberOfProfiles());
   SET_CONTROL_LABEL(CONTROL_LABEL_SELECTED_PROFILE,strLabel);
   CGUIWindow::FrameMove();
 }
 
 void CGUIWindowLoginScreen::OnInitWindow()
 {
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  m_iSelectedItem = static_cast<int>(profilesManager->GetLastUsedProfileIndex());
+  m_iSelectedItem = static_cast<int>(profileManager->GetLastUsedProfileIndex());
 
   // Update list/thumb control
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
@@ -190,11 +190,11 @@ void CGUIWindowLoginScreen::Update()
 {
   m_vecItems->Clear();
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  for (unsigned int i = 0; i < profilesManager->GetNumberOfProfiles(); ++i)
+  for (unsigned int i = 0; i < profileManager->GetNumberOfProfiles(); ++i)
   {
-    const CProfile *profile = profilesManager->GetProfile(i);
+    const CProfile *profile = profileManager->GetProfile(i);
 
     CFileItemPtr item(new CFileItem(profile->getName()));
 
@@ -221,7 +221,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return false;
 
-  const std::shared_ptr<CProfilesManager> profilesManager = CServiceBroker::GetSettingsComponent()->GetProfilesManager();
+  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   CFileItemPtr pItem = m_vecItems->Get(iItem);
   bool bSelect = pItem->IsSelected();
@@ -238,7 +238,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
   if (choice == 2)
   {
-    if (g_passwordManager.CheckLock(profilesManager->GetMasterProfile().getLockMode(), profilesManager->GetMasterProfile().getLockCode(), 20075))
+    if (g_passwordManager.CheckLock(profileManager->GetMasterProfile().getLockMode(), profileManager->GetMasterProfile().getLockCode(), 20075))
       g_passwordManager.iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
     else // be inconvenient
       CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
@@ -251,7 +251,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
     CGUIDialogProfileSettings::ShowForProfile(m_viewControl.GetSelectedItem());
 
   //NOTE: this can potentially (de)select the wrong item if the filelisting has changed because of an action above.
-  if (iItem < static_cast<int>(profilesManager->GetNumberOfProfiles()))
+  if (iItem < static_cast<int>(profileManager->GetNumberOfProfiles()))
     m_vecItems->Get(iItem)->Select(bSelect);
 
   return false;


### PR DESCRIPTION
This is a followup to #14511 and makes the Profile Manager a subcomponent of CServiceBroker::SettingsComponent.

I runtime-tested the changes on macOS and Linux, latest Kodi master.

