### PR TITLE
[VideoPlayer] Check only open video stream for codec-extra-data

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -89,6 +89,7 @@ void CDVDDemuxClient::Dispose()
 void CDVDDemuxClient::DisposeStreams()
 {
   m_streams.clear();
+  m_videoStreamPlaying = -1;
 }
 
 bool CDVDDemuxClient::Reset()
@@ -567,7 +568,8 @@ bool CDVDDemuxClient::IsVideoReady()
 {
   for (const auto& stream : m_streams)
   {
-    if (stream.second->type == STREAM_VIDEO &&
+    if (stream.first == m_videoStreamPlaying &&
+        stream.second->type == STREAM_VIDEO &&
         stream.second->ExtraData == nullptr)
       return false;
   }
@@ -639,7 +641,11 @@ void CDVDDemuxClient::OpenStream(int id)
   // in this case we need to reset our stream properties
   if (m_IDemux && m_IDemux->OpenStream(id))
   {
-    SetStreamProps(m_IDemux->GetStream(id), m_streams, true);
+    CDemuxStream *stream(m_IDemux->GetStream(id));
+    if (stream && stream->type == STREAM_VIDEO)
+      m_videoStreamPlaying = id;
+
+    SetStreamProps(stream, m_streams, true);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -55,5 +55,6 @@ protected:
   int m_displayTime;
   double m_dtsAtDisplayTime;
   std::unique_ptr<DemuxPacket> m_packet;
+  int m_videoStreamPlaying = -1;
 };
 


### PR DESCRIPTION
## Description
see title

## Motivation and Context
This fixes inputstream.adaptives manual stream selection which broke with 
https://github.com/xbmc/xbmc/pull/14408 for manifest files where codec-extra-data must be extracted from media streams.

## How Has This Been Tested?
Android AFTV Gen3 / NX stream

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
