### PR TITLE
libinput: check CSettingsComponent for nullptr

### DIFF
--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -99,12 +99,16 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
 
 CLibInputSettings::~CLibInputSettings()
 {
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  if (settings)
-  {
-    settings->GetSettingsManager()->UnregisterSettingOptionsFiller("libinputkeyboardlayout");
-    settings->GetSettingsManager()->UnregisterCallback(this);
-  }
+  CSettingsComponent *settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return;
+
+  const std::shared_ptr<CSettings> settings = settingsComponent->GetSettings();
+  if (!settings)
+    return;
+
+  settings->GetSettingsManager()->UnregisterSettingOptionsFiller("libinputkeyboardlayout");
+  settings->GetSettingsManager()->UnregisterCallback(this);
 }
 
 void CLibInputSettings::SettingOptionsKeyboardLayoutsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)


### PR DESCRIPTION
This fixes an issue introduced in #14511 

This occurs during shutdown
```
Thread 1 (Thread 0x7f45ccbcee40 (LWP 7643)):
#0  0x0000000001fdaab2 in CSettings::CSettings() (this=0x7ffe9337d110) at /home/lukas/Documents/git/xbmc/xbmc/settings/Settings.h:383
#1  0x0000000001fdaafd in std::shared_ptr<CSettings>::shared_ptr(std::shared_ptr<CSettings> const&) (this=0x7ffe9337d110) at /usr/include/c++/8/bits/shared_ptr.h:129
#2  0x0000000001fd9733 in CSettingsComponent::GetSettings() (this=0x0) at /home/lukas/Documents/git/xbmc/xbmc/settings/SettingsComponent.cpp:71
#3  0x00000000016ca8eb in CLibInputSettings::~CLibInputSettings() (this=0x647f8a0, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/platform/linux/input/LibInputSettings.cpp:100
#4  0x00000000016ca9d6 in non-virtual thunk to CLibInputSettings::~CLibInputSettings() () at /home/lukas/Documents/git/xbmc/xbmc/platform/linux/input/LibInputSettings.h:27
#5  0x0000000006348f00 in  ()
#6  0x000000000647f8a0 in  ()
#7  0x00007ffe9337d1a0 in  ()
#8  0x00000000016c1948 in std::default_delete<CLibInputSettings>::operator()(CLibInputSettings*) const (this=0x647f8a0, __ptr=0x6348f00) at /usr/include/c++/8/bits/unique_ptr.h:81
```