### PR TITLE
[docs] Fix roadmap template markup

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap_item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap_item.md
@@ -21,7 +21,7 @@ about: Create a roadmap/todo suggestion item (Team Kodi members only!)
 
 
 
-###Additional context, screenshots or links**
+### Additional context, screenshots or links
 Here are some relevant links or screenshots
 <!--- Put your text below this line -->
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Markup of the template now shows ### instead of making the text a header