### PR TITLE
CEGLUtils: log the egl attributes of the chosen config

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -23,6 +23,46 @@ namespace
 #ifndef EGL_NO_CONFIG_KHR
 #define EGL_NO_CONFIG_KHR static_cast<EGLConfig>(0)
 #endif
+
+#define X(VAL) std::make_pair(VAL, #VAL)
+std::array<std::pair<EGLint, const char*>, 32> eglAttributes =
+{
+  // please keep attributes in accordance to:
+  // https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglGetConfigAttrib.xhtml
+  X(EGL_ALPHA_SIZE),
+  X(EGL_ALPHA_MASK_SIZE),
+  X(EGL_BIND_TO_TEXTURE_RGB),
+  X(EGL_BIND_TO_TEXTURE_RGBA),
+  X(EGL_BLUE_SIZE),
+  X(EGL_BUFFER_SIZE),
+  X(EGL_COLOR_BUFFER_TYPE),
+  X(EGL_CONFIG_CAVEAT),
+  X(EGL_CONFIG_ID),
+  X(EGL_CONFORMANT),
+  X(EGL_DEPTH_SIZE),
+  X(EGL_GREEN_SIZE),
+  X(EGL_LEVEL),
+  X(EGL_LUMINANCE_SIZE),
+  X(EGL_MAX_PBUFFER_WIDTH),
+  X(EGL_MAX_PBUFFER_HEIGHT),
+  X(EGL_MAX_PBUFFER_PIXELS),
+  X(EGL_MAX_SWAP_INTERVAL),
+  X(EGL_MIN_SWAP_INTERVAL),
+  X(EGL_NATIVE_RENDERABLE),
+  X(EGL_NATIVE_VISUAL_ID),
+  X(EGL_NATIVE_VISUAL_TYPE),
+  X(EGL_RED_SIZE),
+  X(EGL_RENDERABLE_TYPE),
+  X(EGL_SAMPLE_BUFFERS),
+  X(EGL_SAMPLES),
+  X(EGL_STENCIL_SIZE),
+  X(EGL_SURFACE_TYPE),
+  X(EGL_TRANSPARENT_TYPE),
+  X(EGL_TRANSPARENT_RED_VALUE),
+  X(EGL_TRANSPARENT_GREEN_VALUE),
+  X(EGL_TRANSPARENT_BLUE_VALUE)
+};
+#undef X
 }
 
 std::set<std::string> CEGLUtils::GetClientExtensions()
@@ -224,6 +264,18 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId)
 
     if (visualId == id)
       break;
+  }
+
+  CLog::Log(LOGDEBUG, "EGL Config Attributes:");
+
+  for (const auto &eglAttribute : eglAttributes)
+  {
+    EGLint value{0};
+    if (eglGetConfigAttrib(m_eglDisplay, m_eglConfig, eglAttribute.first, &value) != EGL_TRUE)
+      CEGLUtils::LogError(StringUtils::Format("failed to query EGL attibute %s", eglAttribute.second));
+
+    // we only need to print the hex value if it's an actual EGL define
+    CLog::Log(LOGDEBUG, "  %s: %s", eglAttribute.second, (value >= 0x3000 && value <= 0x3200) ? StringUtils::Format("0x%04x", value) : StringUtils::Format("%d", value));
   }
 
   return true;


### PR DESCRIPTION
This allows us to better see what was chosen as an EGL config. Not all values may be relevant but I included them all for clarity.

The log will show like so:
```
10:20:01.409 T:140737353776704   DEBUG: EGL Config Attributes:
10:20:01.409 T:140737353776704   DEBUG:   EGL_ALPHA_SIZE: 8 (0x0008)
10:20:01.409 T:140737353776704   DEBUG:   EGL_ALPHA_MASK_SIZE: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_BIND_TO_TEXTURE_RGB: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_BIND_TO_TEXTURE_RGBA: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_BLUE_SIZE: 8 (0x0008)
10:20:01.409 T:140737353776704   DEBUG:   EGL_BUFFER_SIZE: 32 (0x0020)
10:20:01.409 T:140737353776704   DEBUG:   EGL_COLOR_BUFFER_TYPE: 12430 (0x308e)
10:20:01.409 T:140737353776704   DEBUG:   EGL_CONFIG_CAVEAT: 12344 (0x3038)
10:20:01.409 T:140737353776704   DEBUG:   EGL_CONFIG_ID: 34 (0x0022)
10:20:01.409 T:140737353776704   DEBUG:   EGL_CONFORMANT: 77 (0x004d)
10:20:01.409 T:140737353776704   DEBUG:   EGL_DEPTH_SIZE: 16 (0x0010)
10:20:01.409 T:140737353776704   DEBUG:   EGL_GREEN_SIZE: 8 (0x0008)
10:20:01.409 T:140737353776704   DEBUG:   EGL_LEVEL: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_LUMINANCE_SIZE: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_MAX_PBUFFER_WIDTH: 4096 (0x1000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_MAX_PBUFFER_HEIGHT: 4096 (0x1000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_MAX_PBUFFER_PIXELS: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_MAX_SWAP_INTERVAL: 1 (0x0001)
10:20:01.409 T:140737353776704   DEBUG:   EGL_MIN_SWAP_INTERVAL: 1 (0x0001)
10:20:01.409 T:140737353776704   DEBUG:   EGL_NATIVE_RENDERABLE: 1 (0x0001)
10:20:01.409 T:140737353776704   DEBUG:   EGL_NATIVE_VISUAL_ID: 875713089 (0x34325241)
10:20:01.409 T:140737353776704   DEBUG:   EGL_NATIVE_VISUAL_TYPE: 12344 (0x3038)
10:20:01.409 T:140737353776704   DEBUG:   EGL_RED_SIZE: 8 (0x0008)
10:20:01.409 T:140737353776704   DEBUG:   EGL_RENDERABLE_TYPE: 77 (0x004d)
10:20:01.409 T:140737353776704   DEBUG:   EGL_SAMPLE_BUFFERS: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_SAMPLES: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_STENCIL_SIZE: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_SURFACE_TYPE: 4 (0x0004)
10:20:01.409 T:140737353776704   DEBUG:   EGL_TRANSPARENT_TYPE: 12344 (0x3038)
10:20:01.409 T:140737353776704   DEBUG:   EGL_TRANSPARENT_RED_VALUE: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_TRANSPARENT_GREEN_VALUE: 0 (0x0000)
10:20:01.409 T:140737353776704   DEBUG:   EGL_TRANSPARENT_BLUE_VALUE: 0 (0x0000)
```