### PR TITLE
[VideoPlayer] Initialize maxspeedadjust / remove roundings in Updateframerate

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -26,7 +26,7 @@ CDVDClock::CDVDClock()
   m_paused = false;
   m_speedAfterPause = DVD_PLAYSPEED_PAUSE;
   m_iDisc = 0;
-  m_maxspeedadjust = 0.0;
+  m_maxspeedadjust = 5.0;
   m_systemAdjust = 0;
   m_speedAdjust = 0;
   m_startClock = 0;
@@ -242,7 +242,7 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
 
   CSingleLock lock(m_speedsection);
 
-  double weight = MathUtils::round_int(rate) / (double)MathUtils::round_int(fps);
+  double weight = rate / fps;
 
   //set the speed of the videoreferenceclock based on fps, refreshrate and maximum speed adjust set by user
   if (m_maxspeedadjust > 0.05)


### PR DESCRIPTION
## Description
Videos without audio doesn't play faster to match near refresh rate because maxspeedadjust is not set in that case and defaults to 0. If maxspeedadjust's value is small (e.g. passthrough), the calculation of the new playspeed is not correct because of historic roundings.

## Motivation and Context
- Stutter for 23.976fps on 50Hz Monitor.

## How Has This Been Tested?
WETEK HUB, play 23.97fps on 50Hz Monitor

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
