### PR TITLE
Coverity: Fixup constness of iterators

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1041,8 +1041,8 @@ const std::string& CLangInfo::GetSpeedUnitString(CSpeed::Unit speedUnit)
 std::set<std::string> CLangInfo::GetSortTokens() const
 {
   std::set<std::string> sortTokens = m_sortTokens;
-  sortTokens.insert(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_vecTokens.begin(),
-                    CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_vecTokens.end());
+  for (const auto& t : CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_vecTokens)
+    sortTokens.insert(t);
 
   return sortTokens;
 }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1912,15 +1912,14 @@ std::vector<std::string> CMusicInfoScanner::GetArtTypesToScan(const MediaType& m
   // Get default types of art that are to be automatically fetched during scanning
   if (mediaType == MediaTypeArtist)
   {
-    arttypes = { "thumb", "fanart" };
-    arttypes.insert(arttypes.end(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistExtraArt.begin(),
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistExtraArt.end());
+    arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt;
+    arttypes.emplace_back("thumb");
+    arttypes.emplace_back("fanart");
   }
   else if (mediaType == MediaTypeAlbum)
   {
-    arttypes = { "thumb" };
-    arttypes.insert(arttypes.end(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt.begin(),
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt.end());
+    arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt;
+    arttypes.emplace_back("thumb");
   }
 
   return arttypes;


### PR DESCRIPTION
This fixes recent coverity warnings. While the vector has a proper insert method, std::set does not have one that would match. I decidec for a scoped loop here - suggestions welcome.