### PR TITLE
[Feature][skin.estuary] add support for artist-slideshow add-on

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -759,3 +759,9 @@ msgstr ""
 msgctxt "#31166"
 msgid "Profile avatar"
 msgstr ""
+
+#. Label of a setting
+#: /xml/SkinSettings.xml
+msgctxt "#31167"
+msgid "Animate background"
+msgstr ""

--- a/addons/skin.estuary/xml/Custom_1105_MusicOSDSettings.xml
+++ b/addons/skin.estuary/xml/Custom_1105_MusicOSDSettings.xml
@@ -31,6 +31,12 @@
 						<onclick>Skin.ToggleSetting(hide_background_fanart)</onclick>
 						<selected>!Skin.HasSetting(hide_background_fanart)</selected>
 					</control>
+					<control type="radiobutton" id="5002">
+						<label>$LOCALIZE[31167]</label>
+						<include>DialogSettingButton</include>
+						<onclick>Skin.ToggleSetting(animate_background_fanart)</onclick>
+						<selected>Skin.HasSetting(animate_background_fanart)</selected>
+					</control>
 					<control type="button" id="5004">
 						<width>600</width>
 						<include>DialogSettingButton</include>

--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -2,25 +2,37 @@
 <window>
 	<defaultcontrol></defaultcontrol>
 	<backgroundcolor>background</backgroundcolor>
+	<onload condition="System.HasAddon(script.artistslideshow) + !Skin.HasSetting(hide_background_fanart)">RunScript(script.artistslideshow)</onload>
 	<controls>
 		<control type="visualisation" id="2">
 			<include>FullScreenDimensions</include>
 			<visible>Player.HasAudio</visible>
 		</control>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>100%</width>
-			<height>100%</height>
-			<aspectratio>scale</aspectratio>
-			<fadetime>400</fadetime>
-			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
-			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
-			<texture background="true" colordiffuse="88FFFFFF">$INFO[Player.Art(fanart)]</texture>
+		<control type="group">
+			<depth>DepthBackground</depth>
+			<include>FullScreenDimensions</include>
 			<visible>!Skin.HasSetting(hide_background_fanart)</visible>
+			<animation effect="zoom" start="105" end="130" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(animate_background_fanart)">Conditional</animation>
+			<animation effect="slide" start="-30,-30" end="30,30" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(animate_background_fanart)">Conditional</animation>
+			<control type="image">
+				<aspectratio>scale</aspectratio>
+				<fadetime>400</fadetime>
+				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+				<texture background="true" colordiffuse="88FFFFFF">$INFO[Player.Art(fanart)]</texture>
+			</control>
+			<control type="multiimage">
+				<aspectratio>scale</aspectratio>
+				<timeperimage>10000</timeperimage>
+				<randomize>true</randomize>
+				<fadetime>600</fadetime>
+				<loop>yes</loop>
+				<imagepath background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow)]</imagepath>
+				<visible>System.HasAddon(script.artistslideshow)</visible>
+			</control>
 		</control>
 		<control type="group">
-			<animation effect="fade" start="100" end="30" time="0" condition="!String.IsEmpty(Player.Art(fanart)) | Visualisation.Enabled">Conditional</animation>
+			<animation effect="fade" start="100" end="30" time="0" condition="!Skin.HasSetting(hide_background_fanart) + [!String.IsEmpty(Player.Art(fanart)) | Visualisation.Enabled | System.HasAddon(script.artistslideshow)]">Conditional</animation>
 			<include>ColoredBackgroundImages</include>
 		</control>
 		<control type="group">


### PR DESCRIPTION
## Description
This adds support for the artistslideshow add-on in case it got installed by the users. It's no requirement or anything, just calls it when it's installed.
I also added a new setting to the MusicOSD settings that allows to animate the background (pan and zoom animation).

## Motivation and Context
Had written a PR for it a year or more ago against phils repo which was considered "upstream" back then, but it never got merged. And since I miss it, I thought I give it another try.

## How Has This Been Tested?
Tested on Windows

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
