### PR TITLE
[cmake] Show error when required platform deps are explicitly disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ foreach(depspec ${PLATFORM_REQUIRED_DEPS})
   # optional subdirectory for the specified platform to get built.
   split_dependency_specification(${depspec} dep version)
   string(TOUPPER ${dep} depup)
+  if(NOT ${ENABLE_${depup}} STREQUAL AUTO AND NOT ${ENABLE_${depup}})
+    message(WARNING "Your request to disable the dependency ${dep} required on platform ${CORE_PLATFORM_NAME} was ignored. Please choose another platform or add \"-DENABLE_${depup}=ON\" to your CMake command line to resolve this warning.")
+  endif()
   set(ENABLE_${depup} "ON" CACHE BOOL "Force enabling required ${depup} support" FORCE)
 endforeach()
 


### PR DESCRIPTION
If a user disables a dependency on build with `-DENABLE_XXX=OFF`, but the dep is a required dependency of the platform, it automatically gets reactivated without any information.

This PR makes this an error, so the user is aware of the problem and can decide what to do. I'd also be fine with just showing a message though, but I fear that it would get lost in the stream of other CMake messages.