### PR TITLE
Remove redundant -std=c++11 build option

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -374,7 +374,7 @@ case $host in
     esac
     platform_cflags+=" -arch $use_cpu -m$platform_min_version"
     platform_ldflags+=" -arch $use_cpu -m$platform_min_version -isysroot $use_sdk_path -stdlib=libc++"
-    platform_cxxflags+=" -arch $use_cpu -m$platform_min_version -std=c++11 -stdlib=libc++"
+    platform_cxxflags+=" -arch $use_cpu -m$platform_min_version -stdlib=libc++"
     platform_includes="-isysroot $use_sdk_path"
     deps_dir="${sdk_name}_${use_cpu}-target-${build_type}"
     AC_CHECK_LIB([z], [main], has_zlib=1, AC_MSG_WARN("No zlib support in toolchain. Will build libz."); has_zlib=0)


### PR DESCRIPTION
## Description
`-std=c++11` option is redundant in build variable `$platform_cxxflags` since it's already in variable `$cxx11_flags` in file `configure.ac`

Run `./configure --host=x86_64-apple-darwin` to see no redundant option in variable `cxxflags`.

```sh
#------- configuration -------#
-e ccache:		 no
-e build type:	 debug
-e toolchain:	 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain
-e cpu:		 x86_64
-e host:		 x86_64-apple-darwin
-e cflags:		 -fheinous-gnu-extensions -no-cpp-precomp -arch x86_64 -mmacosx-version-min=10.9 -g -D_DEBUG 
-e cxxflags:	 -std=c++11 -no-cpp-precomp -arch x86_64 -mmacosx-version-min=10.9 -stdlib=libc++ -g -D_DEBUG 
-e ldflags:	 -Wl,-search_paths_first -arch x86_64 -mmacosx-version-min=10.9 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -stdlib=libc++  -liconv 
-e ffmpeg options:	 
-e prefix:		 /Users/Shared/xbmc-depends
-e depends:	 /Users/Shared/xbmc-depends/macosx10.13_x86_64-target-debug
```

## How Has This Been Tested?
Build successfully.

## Types of change
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] All new and existing tests passed
