### PR TITLE
[cmake][addons] package CUSTOM_(BINARY|DATA) & ADDITIONAL_BINARY for windows

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -264,13 +264,16 @@ macro (build_addon target prefix libs)
                 COMPONENT ${target}-${${prefix}_VERSION})
       endif()
       if(${prefix}_CUSTOM_BINARY)
-        install(FILES ${LIBRARY_LOCATION} DESTINATION ${target} RENAME ${LIBRARY_FILENAME})
+        install(FILES ${LIBRARY_LOCATION} DESTINATION ${target} RENAME ${LIBRARY_FILENAME}
+                COMPONENT ${target}-${${prefix}_VERSION})
       endif()
       if(${prefix}_CUSTOM_DATA)
-        install(DIRECTORY ${${prefix}_CUSTOM_DATA} DESTINATION ${target}/resources)
+        install(DIRECTORY ${${prefix}_CUSTOM_DATA} DESTINATION ${target}/resources
+                COMPONENT ${target}-${${prefix}_VERSION})
       endif()
       if(${prefix}_ADDITIONAL_BINARY)
-        install(FILES ${${prefix}_ADDITIONAL_BINARY} DESTINATION ${target})
+        install(FILES ${${prefix}_ADDITIONAL_BINARY} DESTINATION ${target}
+                COMPONENT ${target}-${${prefix}_VERSION})
       endif()
     else() # NOT WIN32
       if(NOT CPACK_PACKAGE_DIRECTORY)

--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -153,7 +153,7 @@ macro (build_addon target prefix libs)
       endif()
     endforeach()
 
-    add_library(${target} ${${prefix}_SOURCES})
+    add_library(${target} ${${prefix}_SOURCES} ${${prefix}_HEADERS})
     target_link_libraries(${target} ${${libs}})
     set_target_properties(${target} PROPERTIES VERSION ${${prefix}_VERSION}
                                                SOVERSION ${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}


### PR DESCRIPTION
## Description
- add addon headers to the library, so they show up in Visual Studio
- package all addon related files into the zip on windows

## Motivation and Context
Tried to package `game.libretro.mrboom` and `inputstream.adaptive` on windows (for the binary repo) and files were missing in the generated zip file.

## How Has This Been Tested?
packaged `game.libretro.mrboom` and `inputstream.adaptive`

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
