### PR TITLE
Windowing: GBM - make sure connector is connected before doing a modeset

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -16,6 +16,7 @@
 #include <EGL/egl.h>
 #include <unistd.h>
 
+#include "platform/linux/XTimeUtils.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "windowing/GraphicContext.h"
@@ -33,6 +34,9 @@ CDRMUtils::CDRMUtils()
 
 bool CDRMUtils::SetMode(const RESOLUTION_INFO& res)
 {
+  if (!CheckConnector(m_connector->connector->connector_id))
+    return false;
+
   m_mode = &m_connector->connector->modes[atoi(res.strId.c_str())];
   m_width = res.iWidth;
   m_height = res.iHeight;
@@ -736,4 +740,24 @@ uint32_t CDRMUtils::FourCCWithAlpha(uint32_t fourcc)
 uint32_t CDRMUtils::FourCCWithoutAlpha(uint32_t fourcc)
 {
   return (fourcc & 0xFFFFFF00) | static_cast<uint32_t>('X');
+}
+
+bool CDRMUtils::CheckConnector(int connector_id)
+{
+  struct connector connectorcheck;
+  unsigned retryCnt = 7;
+
+  connectorcheck.connector = drmModeGetConnector(m_fd, connector_id);
+  while (connectorcheck.connector->connection != DRM_MODE_CONNECTED  && retryCnt > 0)
+  {
+    retryCnt--;
+    Sleep(1000);
+    drmModeFreeConnector(connectorcheck.connector);
+    connectorcheck.connector = drmModeGetConnector(m_fd, connector_id);
+  }
+
+  int finalConnectionState = connectorcheck.connector->connection;
+  drmModeFreeConnector(connectorcheck.connector);
+
+  return finalConnectionState == DRM_MODE_CONNECTED;
 }

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -750,6 +750,7 @@ bool CDRMUtils::CheckConnector(int connector_id)
   connectorcheck.connector = drmModeGetConnector(m_fd, connector_id);
   while (connectorcheck.connector->connection != DRM_MODE_CONNECTED  && retryCnt > 0)
   {
+    CLog::Log(LOGDEBUG, "CDRMUtils::%s - connector is disconnected", __FUNCTION__);
     retryCnt--;
     Sleep(1000);
     drmModeFreeConnector(connectorcheck.connector);

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -124,6 +124,7 @@ private:
   bool RestoreOriginalMode();
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
   RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
+  bool CheckConnector(int connectorId);
 
   int m_crtc_index;
   std::string m_module;


### PR DESCRIPTION
On Intel hardware we lose audio as soon as we do a modeset when
the connector is disconnected.
This double checks if the connector is still connected and does 7 tries with a delay of 1s in between.
If the connector is still disconnected after 7 tries, the modeset fails.
I chose 7 retries because my AVR disconnects HDMI on startup for up to 6 seconds.

## Motivation and Context
I have my AVR on EDID passthrough.
However when I turn it on the AVR disconnects the HDMI signal for X seconds.
If a modeset occurs in this period, we end up with no audio.

Also when switching between HDMI inputs, my AVR disconnects HDMI for some time.
If a modeswitch happens within this timeframe -> no audio.

## How Has This Been Tested?
Tested on Linux GBM GL/GLES and my AVR connected.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

PS.: Not sure what milestone to set for this.