### PR TITLE
Add missing epoll header

### DIFF
--- a/xbmc/platform/linux/FDEventMonitor.h
+++ b/xbmc/platform/linux/FDEventMonitor.h
@@ -8,13 +8,12 @@
 
 #pragma once
 
-#include <vector>
-#include <map>
-
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
-
 #include "utils/GlobalsHandling.h"
+#include <map>
+#include <sys/epoll.h>
+#include <vector>
 
 /**
  * Monitor a file descriptor with callback on poll() events.


### PR DESCRIPTION
## Motivation and Context
Without the epoll header our FileMonitor works "by accident" because ffmpeg
redefines the symbol that would be missing.

## How Has This Been Tested?
Tested on Linux GBM GL/GLES.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

