### PR TITLE
Remove ARB postfix from GL functions

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
@@ -76,7 +76,7 @@ EShaderFormat CRendererVTB::GetShaderFormat()
 bool CRendererVTB::LoadShadersHook()
 {
   CLog::Log(LOGNOTICE, "GL: Using CVBREF render method");
-  m_textureTarget = GL_TEXTURE_RECTANGLE_ARB;
+  m_textureTarget = GL_TEXTURE_RECTANGLE;
   return false;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -174,13 +174,6 @@ bool CLinuxRendererGL::ValidateRenderTarget()
 {
   if (!m_bValidated)
   {
-    //!@todo remove extension check?
-    if (!CServiceBroker::GetRenderSystem()->IsExtSupported("GL_ARB_texture_non_power_of_two") &&
-         CServiceBroker::GetRenderSystem()->IsExtSupported("GL_ARB_texture_rectangle"))
-    {
-      m_textureTarget = GL_TEXTURE_RECTANGLE;
-    }
-
     // function pointer for texture might change in
     // call to LoadShaders
     glFinish();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -942,20 +942,6 @@ void CLinuxRendererGL::LoadShaders(int field)
     }
   }
 
-  // determine whether GPU supports NPOT textures
-  if (!m_renderSystem->IsExtSupported("GL_ARB_texture_non_power_of_two"))
-  {
-    if (!m_renderSystem->IsExtSupported("GL_ARB_texture_rectangle"))
-    {
-      CLog::Log(LOGWARNING, "GL: GL_ARB_texture_rectangle not supported and OpenGL version is not 2.x");
-    }
-    else
-      CLog::Log(LOGNOTICE, "GL: NPOT textures are supported through GL_ARB_texture_rectangle extension");
-  }
-  else
-    CLog::Log(LOGNOTICE, "GL: NPOT texture support detected");
-
-
   if (m_pboSupported)
   {
     CLog::Log(LOGNOTICE, "GL: Using GL_ARB_pixel_buffer_object");

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
@@ -160,7 +160,7 @@ void CRenderCaptureGL::BeginRender()
   if (m_asyncSupported)
   {
     if (!m_pbo)
-      glGenBuffersARB(1, &m_pbo);
+      glGenBuffers(1, &m_pbo);
 
     if (UseOcclusionQuery() && m_occlusionQuerySupported)
     {
@@ -276,8 +276,8 @@ void CRenderCaptureGL::PboToBuffer()
     SetState(CAPTURESTATE_FAILED);
   }
 
-  glUnmapBufferARB(GL_PIXEL_PACK_BUFFER);
-  glBindBufferARB(GL_PIXEL_PACK_BUFFER, 0);
+  glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 #endif
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.h
@@ -15,6 +15,7 @@
 
 #include "threads/Event.h"
 
+
 enum ECAPTURESTATE
 {
   CAPTURESTATE_WORKING,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -69,7 +69,7 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
     shadername = "gl_convolution-4x4.glsl";
 
     if (m_floattex)
-      m_internalformat = GL_RGBA16F_ARB;
+      m_internalformat = GL_RGBA16F;
     else
       m_internalformat = GL_RGBA;
   }
@@ -79,7 +79,7 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
     shadername = "gl_convolution-6x6.glsl";
 
     if (m_floattex)
-      m_internalformat = GL_RGB16F_ARB;
+      m_internalformat = GL_RGB16F;
     else
       m_internalformat = GL_RGB;
   }

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -44,6 +44,8 @@ bool CRenderSystemGL::InitRenderSystem()
     m_RenderVersion = ver;
   }
 
+  CLog::Log(LOGNOTICE, "CRenderSystemGL::%s - Version: %s, Major: %d, Minor: %d", __FUNCTION__, ver, m_RenderVersionMajor, m_RenderVersionMinor);
+
   m_RenderExtensions  = " ";
   if (m_RenderVersionMajor > 3 ||
       (m_RenderVersionMajor == 3 && m_RenderVersionMinor >= 2))
@@ -161,28 +163,28 @@ bool CRenderSystemGL::ResetRenderSystem(int width, int height)
     ResetGLErrors();
 
     GLint maxtex;
-    glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS_ARB, &maxtex);
+    glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &maxtex);
 
     //some sanity checks
     GLenum error = glGetError();
     if (error != GL_NO_ERROR)
     {
-      CLog::Log(LOGERROR, "ResetRenderSystem() GL_MAX_TEXTURE_IMAGE_UNITS_ARB returned error %i", (int)error);
+      CLog::Log(LOGERROR, "ResetRenderSystem() GL_MAX_TEXTURE_IMAGE_UNITS returned error %i", (int)error);
       maxtex = 3;
     }
     else if (maxtex < 1 || maxtex > 32)
     {
-      CLog::Log(LOGERROR, "ResetRenderSystem() GL_MAX_TEXTURE_IMAGE_UNITS_ARB returned invalid value %i", (int)maxtex);
+      CLog::Log(LOGERROR, "ResetRenderSystem() GL_MAX_TEXTURE_IMAGE_UNITS returned invalid value %i", (int)maxtex);
       maxtex = 3;
     }
 
     //reset texture matrix for all textures
     for (GLint i = 0; i < maxtex; i++)
     {
-      glActiveTextureARB(GL_TEXTURE0 + i);
+      glActiveTexture(GL_TEXTURE0 + i);
       glMatrixTexture.Load();
     }
-    glActiveTextureARB(GL_TEXTURE0);
+    glActiveTexture(GL_TEXTURE0);
   }
 
   glBlendFunc(GL_SRC_ALPHA, GL_ONE);

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -107,11 +107,6 @@ bool CRenderSystemGL::InitRenderSystem()
 
   InitialiseShaders();
 
-  if (IsExtSupported("GL_ARB_texture_non_power_of_two"))
-    m_supportsNPOT = true;
-  else
-    m_supportsNPOT = false;
-
   return true;
 }
 
@@ -279,7 +274,7 @@ bool CRenderSystemGL::IsExtSupported(const char* extension) const
 
 bool CRenderSystemGL::SupportsNPOT(bool dxt) const
 {
-  return m_supportsNPOT;
+  return true;
 }
 
 void CRenderSystemGL::PresentRender(bool rendered, bool videoLayer)

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -93,7 +93,6 @@ protected:
   bool m_bVsyncInit = false;
   int m_width;
   int m_height;
-  bool m_supportsNPOT = true;
 
   std::string m_RenderExtensions;
 


### PR DESCRIPTION
## Description
We use a lot of ARB functions that are already in standard GL.
Remove the ARB postfix where possible as it's not needed anymore.

The first commit is not intended to change behaviour.
If so, it's a mistake and I'm happy if someone tells me so.
Anyway if nobody has objections I'd squash them before merge, because
imho they belong together.

## Motivation and Context
If you compile mesa with libglvnd and then link against libOpenGL.so
all ARB symbols are missing and it results in unresolved external references.
According to mesa devs it is not guaranteed in the ABI that ARB symbols
are exposed.

## How Has This Been Tested?
Tested with a custom LibreELEC build.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

I'd suggest to not include for 18.
