### PR TITLE
[Android] Provide refreshrate always to XBMCApp

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -514,7 +514,7 @@ void CXBMCApp::SetRefreshRateCallback(CVariant* rateVariant)
   if (window)
   {
     CJNIWindowManagerLayoutParams params = window.getAttributes();
-    if (params.getpreferredRefreshRate() != rate)
+    if (fabs(params.getpreferredRefreshRate() - rate) > 0.001)
     {
       if (g_application.GetAppPlayer().IsPlaying())
       {

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -236,7 +236,7 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
     CXBMCApp::SetDisplayMode(atoi(res.strId.c_str()), res.fRefreshRate);
     s_res_cur_displayMode = res;
   }
-  else if (std::abs(currentRefreshRate() - res.fRefreshRate) > 0.0001)
+  else
     CXBMCApp::SetRefreshRate(res.fRefreshRate);
   CXBMCApp::SetBuffersGeometry(res.iWidth, res.iHeight, 0);
 


### PR DESCRIPTION
## Description
Pass refreshrate to XBMCApp for non-displaymode android versions (<=M)

## Motivation and Context
Releaseing decoded frames (surface) is done with an offset of 1.5 VBLANK times.
For Android <= M the initial refreshrate is not passed properly to XBMCApp which leads to inproper release times (which can lead to stutter)

## How Has This Been Tested?
WETEK HUB, start kodi in the device resolution / refreshrate, and play a video (refreshrate-switch off) 

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
