### PR TITLE
[docs] onAVStarted and onAVChanged were missing from v18 changelog

### DIFF
--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -222,6 +222,7 @@ namespace XBMCAddon
       /// onAVStarted method.
       ///
       /// Will be called when Kodi has a video- or audiostream.
+      /// @python_v18 New function added.
       ///
       onAVStarted();
 #else
@@ -237,6 +238,7 @@ namespace XBMCAddon
       /// onAVChange method.
       ///
       /// Will be called when Kodi has a video, audio or subtitle stream. Also happens when the stream changes.
+      /// @python_v18 New function added.
       ///
       onAVChange();
 #else
@@ -623,9 +625,7 @@ namespace XBMCAddon
       ///
       /// @throws Exception          If player is not playing a file
       ///
-      ///-----------------------------------------------------------------------
       /// @python_v18 New function added.
-      ///-----------------------------------------------------------------------
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}


### PR DESCRIPTION
## Description
`onAVStarted` and `onAVChanged` exposed to python in https://github.com/xbmc/xbmc/commit/fb50ae8c042ad52a22003ec71ecc35cc725bbd6d#diff-c403255a1a8de83c38dd7edf4f8d7a47 were not tagged with `@python_v18 New function added.` and thus were missing from the changelog. `updateInfoTag ()` was showing a massive font in Python v18 changelog due to the fact of being in-between a block. This PR fixes both issues.

Noted in (cross-reference): https://github.com/xbmc/xbmc/issues/14574

## Motivation and Context
Proper docs for Leia. Changelog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
compiled docs and checked the output

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
