### PR TITLE
[docs] Add a fall back issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,85 @@
+---
+name: Problem report
+about: Create an extensive report to help us document a problem
+
+---
+<!--- Please fill out this template to the best of your ability. You can always edit this issue once you have created it. -->
+<!--- Read the following link before you create a new problem report: https://kodi.wiki/view/HOW-TO:Submit_a_bug_report  -->
+## Bug report
+### Describe the bug
+Here is a clear and concise description of what the problem is:
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+<!--- A bug report that is not clear will be closed -->
+<!--- Put your text below this line -->
+
+
+
+## Expected Behavior
+Here is a clear and concise description of what was expected to happen:
+<!--- Tell us what should happen -->
+<!--- Put your text below this line -->
+
+
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+<!--- Put your text below this line -->
+
+
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+<!--- Put your text below this line -->
+
+
+
+### To Reproduce
+Steps to reproduce the behavior:
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+<!--- Put your text below this line -->
+1. 
+2.
+3.
+
+
+### Debuglog
+<!--- Put your text below this line -->
+<!--- A debuglog is always mandatory when creating an issue. Provide one! -->
+The debuglog can be found here:
+
+
+
+### Screenshots 
+Here are some links or screenshots to help explain the problem:
+<!--- Put your text below this line -->
+
+
+
+## Additional context or screenshots (if appropriate)
+Here is some additional context or explanation that might help:
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+<!--- Put your text below this line -->
+
+
+
+### Your Environment
+Used Operating system:
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+<!--- Put your text below this line. Checkboxes can easily be ticked once issue is created -->
+ - [ ] Android
+ - [ ] iOS
+ - [ ] Linux
+ - [ ] OSX
+ - [ ] Raspberri-Pi
+ - [ ] Windows
+ - [ ] Windows UWP
+
+ - Operating system version/name:
+ - Kodi version:
+
+
+
+<!--- End of this issue -->
+*note: Once the issue is made we require you to update it with new information or Kodi versions should that be required.
+Team Kodi will consider your problem report however, we will not make any promises the problem will be solved.*


### PR DESCRIPTION
Github on mobile doesn't recognise the multiple template option so we need to fallback to the same template one level up.
