### PR TITLE
EGLUtils: log the egl version, vendor and extensions

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -131,14 +131,22 @@ bool CEGLContextUtils::CreatePlatformDisplay(void* nativeDisplay, EGLNativeDispl
 
 bool CEGLContextUtils::InitializeDisplay(EGLint renderableType, EGLint renderingApi, EGLint visualId)
 {
-  int major, minor;
-  if (!eglInitialize(m_eglDisplay, &major, &minor))
+  if (!eglInitialize(m_eglDisplay, nullptr, nullptr))
   {
     CEGLUtils::LogError("failed to initialize EGL display");
     Destroy();
     return false;
   }
-  CLog::Log(LOGINFO, "EGL v%d.%d", major, minor);
+
+  const char *value;
+  value = eglQueryString(m_eglDisplay, EGL_VERSION);
+  CLog::Log(LOGNOTICE, "EGL_VERSION = %s", value ? value : "NULL");
+
+  value = eglQueryString(m_eglDisplay, EGL_VENDOR);
+  CLog::Log(LOGNOTICE, "EGL_VENDOR = %s", value ? value : "NULL");
+
+  value = eglQueryString(m_eglDisplay, EGL_EXTENSIONS);
+  CLog::Log(LOGNOTICE, "EGL_EXTENSIONS = %s", value ? value : "NULL");
 
   if (eglBindAPI(renderingApi) != EGL_TRUE)
   {

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -148,6 +148,9 @@ bool CEGLContextUtils::InitializeDisplay(EGLint renderableType, EGLint rendering
   value = eglQueryString(m_eglDisplay, EGL_EXTENSIONS);
   CLog::Log(LOGNOTICE, "EGL_EXTENSIONS = %s", value ? value : "NULL");
 
+  value = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
+  CLog::Log(LOGNOTICE, "EGL_CLIENT_EXTENSIONS = %s", value ? value : "NULL");
+
   if (eglBindAPI(renderingApi) != EGL_TRUE)
   {
     CEGLUtils::LogError("failed to bind EGL API");


### PR DESCRIPTION
We log the same relevant GL(ES) let's do the same with the EGL info

```
13:31:45.393 T:140737353776704  NOTICE: EGL_VERSION = 1.5 (DRI2)
13:31:45.393 T:140737353776704  NOTICE: EGL_VENDOR = Mesa Project
13:31:45.393 T:140737353776704  NOTICE: EGL_EXTENSIONS = EGL_ANDROID_native_fence_sync EGL_EXT_buffer_age EGL_EXT_create_context_robustness EGL_EXT_image_dma_buf_import EGL_KHR_cl_event2 EGL_KHR_config_attribs EGL_KHR_create_context EGL_KHR_create_context_no_error ...
```
similar GL(ES) info
```
13:31:45.485 T:140737353776704  NOTICE: GL_VENDOR = X.Org
13:31:45.485 T:140737353776704  NOTICE: GL_RENDERER = AMD VEGAM (DRM 3.27.0, 4.19.0-0.rc2.git1.1.fc30.x86_64, LLVM 8.0.0)
13:31:45.485 T:140737353776704  NOTICE: GL_VERSION = OpenGL ES 3.2 Mesa 18.3.0-devel
13:31:45.485 T:140737353776704  NOTICE: GL_SHADING_LANGUAGE_VERSION = OpenGL ES GLSL ES 3.20
13:31:45.485 T:140737353776704  NOTICE: GL_EXTENSIONS = GL_AMD_framebuffer_multisample_advanced GL_AMD_performance_monitor GL_ANDROID_extension_pack_es31a GL_ANGLE_texture_compression_dxt3 ...
```