### PR TITLE
EGLUtils: allow selecting a high priority EGL context

### DIFF
--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 #include <stdexcept>
+#include <vector>
 
 #include <EGL/egl.h>
 
@@ -36,6 +37,54 @@ public:
 
 private:
   CEGLUtils();
+};
+
+/**
+ * Convenience wrapper for heap-allocated EGL attribute arrays
+ *
+ * The wrapper makes sure that the key/value pairs are always written in actual
+ * pairs and  that the array is always terminated with EGL_NONE.
+ */
+class CEGLAttributesVec
+{
+public:
+  struct EGLAttribute
+  {
+    EGLint key;
+    EGLint value;
+  };
+
+  /**
+   * Add multiple attributes
+   *
+   * The array is automatically terminated with EGL_NONE
+   */
+  void Add(std::initializer_list<EGLAttribute> const& attributes)
+  {
+    for (auto const& attribute : attributes)
+    {
+      m_attributes.insert(m_attributes.begin(), attribute.value);
+      m_attributes.insert(m_attributes.begin(), attribute.key);
+    }
+  }
+
+  /**
+   * Add one attribute
+   *
+   * The array is automatically terminated with EGL_NONE
+   */
+  void Add(EGLAttribute const& attribute)
+  {
+    Add({attribute});
+  }
+
+  EGLint const * Get() const
+  {
+    return m_attributes.data();
+  }
+
+private:
+  std::vector<EGLint> m_attributes{EGL_NONE};
 };
 
 /**

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -184,7 +184,7 @@ public:
 
   bool CreateSurface(EGLNativeWindowType nativeWindow);
   bool CreatePlatformSurface(void* nativeWindow, EGLNativeWindowType nativeWindowLegacy);
-  bool CreateContext(const EGLint* contextAttribs);
+  bool CreateContext(CEGLAttributesVec contextAttribs);
   bool BindContext();
   void Destroy();
   void DestroySurface();

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
@@ -31,10 +31,8 @@ bool CWinSystemAmlogicGLESContext::InitWindowSystem()
     return false;
   }
 
-  const EGLint contextAttribs[] =
-  {
-    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
 
   if (!m_pGLContext.CreateContext(contextAttribs))
   {

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -32,10 +32,8 @@ bool CWinSystemAndroidGLESContext::InitWindowSystem()
     return false;
   }
 
-  const EGLint contextAttribs[] =
-  {
-    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
 
   if (!m_pGLContext.CreateContext(contextAttribs))
   {

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -123,19 +123,16 @@ bool CWinSystemGbmGLContext::CreateContext()
   const EGLint glMajor = 3;
   const EGLint glMinor = 2;
 
-  const EGLint contextAttribs[] = {
-    EGL_CONTEXT_MAJOR_VERSION_KHR, glMajor,
-    EGL_CONTEXT_MINOR_VERSION_KHR, glMinor,
-    EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
-    EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_MAJOR_VERSION_KHR, glMajor},
+                      {EGL_CONTEXT_MINOR_VERSION_KHR, glMinor},
+                      {EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR}});
 
   if (!m_eglContext.CreateContext(contextAttribs))
   {
-    const EGLint fallbackContextAttribs[] = {
-      EGL_CONTEXT_CLIENT_VERSION, 2,
-      EGL_NONE
-    };
+    CEGLAttributesVec fallbackContextAttribs;
+    fallbackContextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
+
     if (!m_eglContext.CreateContext(fallbackContextAttribs))
     {
       CLog::Log(LOGERROR, "EGL context creation failed");

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -132,10 +132,9 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 
 bool CWinSystemGbmGLESContext::CreateContext()
 {
-  const EGLint contextAttribs[] = {
-    EGL_CONTEXT_CLIENT_VERSION, 2,
-    EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
+
   if (!m_eglContext.CreateContext(contextAttribs))
   {
     CLog::Log(LOGERROR, "EGL context creation failed");

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -44,10 +44,8 @@ bool CWinSystemRpiGLESContext::InitWindowSystem()
     return false;
   }
 
-  const EGLint contextAttribs[] =
-  {
-    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
 
   if (!m_pGLContext.CreateContext(contextAttribs))
   {

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -53,19 +53,16 @@ bool CWinSystemWaylandEGLContextGL::CreateContext()
   const EGLint glMajor = 3;
   const EGLint glMinor = 2;
 
-  const EGLint contextAttribs[] = {
-    EGL_CONTEXT_MAJOR_VERSION_KHR, glMajor,
-    EGL_CONTEXT_MINOR_VERSION_KHR, glMinor,
-    EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
-    EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_MAJOR_VERSION_KHR, glMajor},
+                      {EGL_CONTEXT_MINOR_VERSION_KHR, glMinor},
+                      {EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR}});
 
   if (!m_eglContext.CreateContext(contextAttribs))
   {
-    const EGLint fallbackContextAttribs[] = {
-      EGL_CONTEXT_CLIENT_VERSION, 2,
-      EGL_NONE
-    };
+    CEGLAttributesVec fallbackContextAttribs;
+    fallbackContextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
+
     if (!m_eglContext.CreateContext(fallbackContextAttribs))
     {
       CLog::Log(LOGERROR, "EGL context creation failed");

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -50,10 +50,9 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
 
 bool CWinSystemWaylandEGLContextGLES::CreateContext()
 {
-  const EGLint contextAttribs[] = {
-    EGL_CONTEXT_CLIENT_VERSION, 2,
-    EGL_NONE
-  };
+  CEGLAttributesVec contextAttribs;
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
+
   if (!m_eglContext.CreateContext(contextAttribs))
   {
     CLog::Log(LOGERROR, "EGL context creation failed");


### PR DESCRIPTION
I also had to change to use `CEGLAttributes` so we could add the `EGL_CONTEXT_PRIORITY_LEVEL_IMG`
 attribute easily.
```
    This extension allows an EGLContext to be created with a priority
    hint. It is possible that an implementation will not honour the
    hint, especially if there are constraints on the number of high
    priority contexts available in the system, or system policy limits
    access to high priority contexts to appropriate system privilege
    level. A query is provided to find the real priority level assigned
    to the context after creation.
```

see, https://www.khronos.org/registry/EGL/extensions/IMG/EGL_IMG_context_priority.txt