### PR TITLE
[docs] Properly document Python API removed functions in changelog

### DIFF
--- a/docs/doxygen/Doxyfile.doxy
+++ b/docs/doxygen/Doxyfile.doxy
@@ -249,6 +249,7 @@ ALIASES                = "table_start=<table width= 100% style= border bgcolor= 
                          "python_class{1}=\htmlonly <h4><code><span style=\"font-style: italic;\">Class: </span><span style=\"font-style: bold;\"><font color=31363b><big>\1</big></font></span></code></h4> \endhtmlonly" \
                          "python_class_with_rev{2}=\htmlonly <h4><code><span style=\"font-style: italic;\">Class: </span><span style=\"font-style: bold;\"><font color=31363b><big>\1</big></font></span></code><span style="float:right;"><small>\2</small></span></h4> \endhtmlonly" \
                          "doc_header{1}=\htmlonly <h3><span style=\"text-decoration: underline;\"><span  style=\"font-style: italic;\"><span style=\"color: rgb(102, 102, 102);\">\1</span></span></span></h3> \endhtmlonly" \
+                         "python_removed_function{3}=\htmlonly <dl class=\"reflist\"><dt>Member <a class="el" href=\"\2\">\1</a> (...)</dt><dd>\3</dd></dl>\endhtmlonly" \
                          "python_v12=\xrefitem python_v12 \"v12 Python API changes\" \"\"" \
                          "python_v13=\xrefitem python_v13 \"v13 Python API changes\" \"\"" \
                          "python_v14=\xrefitem python_v14 \"v14 Python API changes\" \"\"" \

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -151,6 +151,16 @@ web applications or frameworks for the Python programming language.
 */
 /*!
 @page python_v17 Python API v17
+\python_removed_function{
+      getCaptureState,
+      http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmc.html#RenderCapture-getCaptureState,
+      <b>xbmc.RenderCapture().getCaptureState()</b> function was removed completely.
+}
+\python_removed_function{
+      waitForCaptureStateChangeEvent,
+      http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmc.html#RenderCapture-waitForCaptureStateChangeEvent,
+      <b>xbmc.RenderCapture().waitForCaptureStateChangeEvent()</b> function was removed completely.
+}
 */
 /*!
 @page python_v16 Python API v16

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -109,6 +109,8 @@ namespace XBMCAddon
       /// Get image format
       ///
       /// @return                        Format of captured image: 'BGRA'
+      ///
+      ///
       ///-----------------------------------------------------------------------
       /// @python_v17 Image will now always be returned in BGRA
       ///
@@ -132,6 +134,8 @@ namespace XBMCAddon
       /// @return                    Captured image as a bytearray
       ///
       /// @note The size of the image is m_width * m_height * 4
+      ///
+      ///
       ///-----------------------------------------------------------------------
       /// @python_v17 Added the option to specify wait time in msec.
       ///
@@ -156,6 +160,8 @@ namespace XBMCAddon
       ///
       /// @param width               Width capture image should be rendered to
       /// @param height              Height capture image should should be rendered to
+      ///
+      ///
       ///-----------------------------------------------------------------------
       /// @python_v17 Removed the option to pass **flags**
       ///
@@ -175,24 +181,6 @@ namespace XBMCAddon
         m_buffer = new uint8_t[m_width*m_height*4];
         g_application.GetAppPlayer().RenderCapture(m_captureId, m_width, m_height, CAPTUREFLAG_CONTINUOUS);
       }
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-      ///
-      /// \ingroup python_xbmc_RenderCapture
-      /// @brief \python_func{ getCaptureState() }
-      ///-----------------------------------------------------------------------
-      /// @python_v17 Removed function completely.
-      ///
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-      ///
-      /// \ingroup python_xbmc_RenderCapture
-      /// @brief \python_func{ waitForCaptureStateChangeEvent() }
-      ///-----------------------------------------------------------------------
-      /// @python_v17 Removed function completely.
-      ///
-#endif
 
 // hide these from swig
 #ifndef SWIG


### PR DESCRIPTION
## Description
To have a complete changelog for the Python API we need to take into account method definitions that were removed from the API. Those methods should somehow also point to the method definition in older revisions of the documentation since they are no longer available.

## Motivation and Context
While browsing our old python documentation for the `RenderCapture` module I noticed (apart from the broken stuff) that two methods were not available in our current docs: `getCaptureState()` and `waitForCaptureStateChangeEvent()`. By tracking what happened with them, I found the documentation was there but, as both C++ function definitions were removed, it was annotating an inline function that did not belong to the API (`GetPixels()`). 
Furthermore, the removal comments were also pointing to this function in the changelog of Kodi v17 (see image below).

~~As in the future the python API is likely to change with more functions being removed I decided to create a new page to document such functions (which mimics the same layout of current API functions) allowing Python devs to have a complete changelog (and find out how to use the method in older Kodi versions). In this new page, when a method is **completely** removed (including the function definition) it can be documented like below~~

To avoid creating a new page or introducing boilerplate methods, I decided to create a new doxygen command to document removed functions. Those entries should be added to the specific page where the removed functions apply (e.g. `@page python_v17 Python API v17`). To add a new function just do something like exemplified below:

```
\python_removed_function{
      getCaptureState,
      http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmc.html#RenderCapture-getCaptureState,
      <b>xbmc.RenderCapture().getCaptureState()</b> function was removed completely.
}
```
Where each field represents the following:
- The name of the removed method
- The link to the method documentation in prior revisions of our docs
- The message to display in the changelog

This structure mimics all the other changes already available in the page resulting in the entries illustrated in the screenshots


## How Has This Been Tested?
Compiled docs and manual testing

## Screenshots (if appropriate):
**Before**:
![alt text](https://i.imgur.com/2E4ey7F.png "Before")

**After**:
![alt text](https://i.imgur.com/s1vn5Ej.png "After")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
