### PR TITLE
[playlist] Add support for reading XSPF Playlists

### DIFF
--- a/cmake/installdata/test-reference-data.txt
+++ b/cmake/installdata/test-reference-data.txt
@@ -8,3 +8,4 @@ xbmc/filesystem/test/refRARstored.rar
 xbmc/network/test/data/test.html
 xbmc/network/test/data/test.png
 xbmc/network/test/data/test-ranges.txt
+xbmc/playlists/test/test.xspf

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -4,6 +4,7 @@ xbmc/filesystem/test              test/filesystem
 xbmc/interfaces/python/test       test/python
 xbmc/music/tags/test              test/music_tags
 xbmc/network/test                 test/network
+xbmc/playlists/test               test/playlists
 xbmc/threads/test                 test/threads
 xbmc/utils/test                   test/utils
 xbmc/video/test                   test/video

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -340,7 +340,7 @@ void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
   share.strPath = "special://musicplaylists/";
   if (find(shares.begin(), shares.end(), share) == shares.end())
     shares.push_back(share);
-  if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".m3u|.pls|.b4s|.wpl", g_localizeStrings.Get(656), playlist))
+  if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".m3u|.pls|.b4s|.wpl|.xspf", g_localizeStrings.Get(656), playlist))
     LoadPlaylist(playlist);
 }
 

--- a/xbmc/platform/darwin/ios/Info.plist.in
+++ b/xbmc/platform/darwin/ios/Info.plist.in
@@ -320,6 +320,7 @@
           <string>aif</string>
           <string>aiff</string>
           <string>wpl</string>
+          <string>xspf</string>
           <string>ape</string>
           <string>mac</string>
           <string>mpc</string>
@@ -431,6 +432,7 @@
           <string>rar</string>
           <string>001</string>
           <string>wpl</string>
+          <string>xspf</string>
           <string>zip</string>
           <string>vdr</string>
           <string>dvr-ms</string>

--- a/xbmc/playlists/CMakeLists.txt
+++ b/xbmc/playlists/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES PlayListB4S.cpp
             PlayListURL.cpp
             PlayListWPL.cpp
             PlayListXML.cpp
+            PlayListXSPF.cpp
             SmartPlayList.cpp
             SmartPlaylistFileItemListModifier.cpp)
 
@@ -17,6 +18,7 @@ set(HEADERS PlayList.h
             PlayListURL.h
             PlayListWPL.h
             PlayListXML.h
+            PlayListXSPF.h
             SmartPlayList.h
             SmartPlaylistFileItemListModifier.h)
 

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -13,6 +13,7 @@
 #include "PlayListWPL.h"
 #include "PlayListURL.h"
 #include "PlayListXML.h"
+#include "PlayListXSPF.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 
@@ -58,6 +59,9 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
 
     if (strMimeType == "application/vnd.ms-wpl")
       return new CPlayListWPL();
+
+    if (strMimeType == "application/xspf+xml")
+      return new CPlayListXSPF();
   }
 
   std::string path = item.GetDynPath();
@@ -88,6 +92,9 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
 
   if (extension == ".pxml")
     return new CPlayListXML();
+
+  if (extension == ".xspf")
+    return new CPlayListXSPF();
 
   return NULL;
 
@@ -125,12 +132,12 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
 bool CPlayListFactory::IsPlaylist(const CURL& url)
 {
   return URIUtils::HasExtension(url,
-                                ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml");
+                                ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
 }
 
 bool CPlayListFactory::IsPlaylist(const std::string& filename)
 {
   return URIUtils::HasExtension(filename,
-                     ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml");
+                     ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
 }
 

--- a/xbmc/playlists/PlayListXSPF.h
+++ b/xbmc/playlists/PlayListXSPF.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "PlayList.h"
+
+namespace PLAYLIST
+{
+class CPlayListXSPF : public CPlayList
+{
+public:
+  CPlayListXSPF(void);
+  ~CPlayListXSPF(void) override;
+
+  // Implementation of CPlayList
+  bool Load(const std::string& strFileName) override;
+};
+}

--- a/xbmc/playlists/test/CMakeLists.txt
+++ b/xbmc/playlists/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES TestPlayListFactory.cpp
+            TestPlayListXSPF.cpp)
+
+core_add_test_library(playlists_test)

--- a/xbmc/playlists/test/TestPlayListFactory.cpp
+++ b/xbmc/playlists/test/TestPlayListFactory.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2018 Tyler Szabo
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "playlists/PlayListFactory.h"
+
+#include "playlists/PlayList.h"
+#include "playlists/PlayListXSPF.h"
+#include "test/TestUtils.h"
+#include "URL.h"
+
+#include "gtest/gtest.h"
+
+using namespace PLAYLIST;
+
+
+TEST(TestPlayListFactory, XSPF)
+{
+  std::string filename = XBMC_REF_FILE_PATH("/xbmc/playlists/test/newfile.xspf");
+  CURL url("http://example.com/playlists/playlist.xspf");
+  CPlayList* playlist = nullptr;
+
+  EXPECT_TRUE(CPlayListFactory::IsPlaylist(url));
+  EXPECT_TRUE(CPlayListFactory::IsPlaylist(filename));
+
+  playlist = CPlayListFactory::Create(filename);
+  EXPECT_NE(playlist, nullptr);
+
+  if (playlist)
+  {
+    EXPECT_NE(dynamic_cast<CPlayListXSPF*>(playlist), nullptr);
+    delete playlist;
+  }
+}

--- a/xbmc/playlists/test/TestPlayListXSPF.cpp
+++ b/xbmc/playlists/test/TestPlayListXSPF.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2018 Tyler Szabo
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "playlists/PlayListXSPF.h"
+
+#include "test/TestUtils.h"
+#include "utils/URIUtils.h"
+#include "FileItem.h"
+#include "URL.h"
+
+#include "gtest/gtest.h"
+
+using namespace PLAYLIST;
+
+
+TEST(TestPlayListXSPF, Load)
+{
+  std::string filename = XBMC_REF_FILE_PATH("/xbmc/playlists/test/test.xspf");
+  CPlayListXSPF playlist;
+  std::vector<std::string> pathparts;
+  std::vector<std::string>::reverse_iterator it;
+
+  EXPECT_TRUE(playlist.Load(filename));
+
+  EXPECT_EQ(playlist.size(), 5);
+  EXPECT_STREQ(playlist.GetName().c_str(), "Various Music");
+
+
+  ASSERT_GT(playlist.size(), 0);
+  EXPECT_STREQ(playlist[0]->GetLabel().c_str(), "");
+  EXPECT_STREQ(playlist[0]->GetURL().Get().c_str(), "http://example.com/song_1.mp3");
+
+
+  ASSERT_GT(playlist.size(), 1);
+  EXPECT_STREQ(playlist[1]->GetLabel().c_str(), "Relative local file");
+  pathparts = URIUtils::SplitPath(playlist[1]->GetPath());
+  it = pathparts.rbegin();
+  EXPECT_STREQ((*it++).c_str(), "song_2.mp3");
+  EXPECT_STREQ((*it++).c_str(), "path_to");
+  EXPECT_STREQ((*it++).c_str(), "relative");
+  EXPECT_STREQ((*it++).c_str(), "test");
+  EXPECT_STREQ((*it++).c_str(), "playlists");
+  EXPECT_STREQ((*it++).c_str(), "xbmc");
+
+
+  ASSERT_GT(playlist.size(), 2);
+  EXPECT_STREQ(playlist[2]->GetLabel().c_str(), "Don\xC2\x92t Worry, We\xC2\x92ll Be Watching You");
+  pathparts = URIUtils::SplitPath(playlist[2]->GetPath());
+  it = pathparts.rbegin();
+  EXPECT_STREQ((*it++).c_str(), "09 - Don't Worry, We'll Be Watching You.mp3");
+  EXPECT_STREQ((*it++).c_str(), "Making Mirrors");
+  EXPECT_STREQ((*it++).c_str(), "Gotye");
+  EXPECT_STREQ((*it++).c_str(), "Music");
+  EXPECT_STREQ((*it++).c_str(), "jane");
+  EXPECT_STREQ((*it++).c_str(), "Users");
+  EXPECT_STREQ((*it++).c_str(), "C:");
+
+
+  ASSERT_GT(playlist.size(), 3);
+  EXPECT_STREQ(playlist[3]->GetLabel().c_str(), "Rollin' & Scratchin'");
+  pathparts = URIUtils::SplitPath(playlist[3]->GetPath());
+  it = pathparts.rbegin();
+  EXPECT_STREQ((*it++).c_str(), "08 - Rollin' & Scratchin'.mp3");
+  EXPECT_STREQ((*it++).c_str(), "Homework");
+  EXPECT_STREQ((*it++).c_str(), "Daft Punk");
+  EXPECT_STREQ((*it++).c_str(), "Music");
+  EXPECT_STREQ((*it++).c_str(), "jane");
+  EXPECT_STREQ((*it++).c_str(), "home");
+
+
+  ASSERT_GT(playlist.size(), 4);
+  EXPECT_STREQ(playlist[4]->GetLabel().c_str(), "");
+  EXPECT_STREQ(playlist[4]->GetURL().Get().c_str(), "http://example.com/song_2.mp3");
+}

--- a/xbmc/playlists/test/test.xspf
+++ b/xbmc/playlists/test/test.xspf
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<playlist version="1" xmlns="http://xspf.org/ns/0/">
+
+  <!-- title of the playlist -->
+  <title>Various Music</title>
+
+  <!-- name of the author -->
+  <creator>Jane Doe</creator>
+
+  <!-- homepage of the author -->
+  <info>http://example.com/~jane</info>
+
+  <trackList>
+    <track>
+      <location>http://example.com/song_1.mp3</location>
+    </track>
+
+    <track>
+      <title>Relative local file</title>
+      <location>relative/path_to/song_2.mp3</location>
+    </track>
+
+    <track>
+      <!--Absolute Windows path -->
+      <location>file:///C:/Users/jane/Music/Gotye/Making%20Mirrors/09%20-%20Don%27t%20Worry%2C%20We%27ll%20Be%20Watching%20You.mp3</location>
+      <title>Don&#146;t Worry, We&#146;ll Be Watching You</title>
+      <creator>Gotye</creator>
+      <album>Making Mirrors</album>
+      <trackNum>9</trackNum>
+    </track>
+
+    <track>
+      <!--Absolute Linux path -->
+      <location>file:///home/jane/Music/Daft%20Punk/Homework/08%20-%20Rollin%27%20%26%20Scratchin%27.mp3</location>
+      <title>Rollin&#39; &amp; Scratchin&#39;</title>
+      <creator>Daft Punk</creator>
+      <album>Homework</album>
+      <trackNum>8</trackNum>
+    </track>
+
+    <track>
+      <title></title>
+      <location></location>
+    </track>
+
+    <track>
+      <title>Nothing to add for this entry</title>
+    </track>
+
+    <track>
+      <location>http://example.com/song_2.mp3</location>
+    </track>
+  </trackList>
+</playlist>

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -404,8 +404,8 @@ void CAdvancedSettings::Initialize()
   m_databaseVideo.Reset();
 
   m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.rss|.webp|.jp2|.apng";
-  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b";
-  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv|.trp|.f4v";
+  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.xspf|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b";
+  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.xspf|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv|.trp|.f4v";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.zip";
   m_discStubExtensions = ".disc";
   // internal music extensions

--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -490,6 +490,7 @@ static std::map<std::string, std::string> fillMimeTypes()
   mimeTypes.insert(std::pair<std::string, std::string>("xpix",      "application/x-vnd.ls-xpix"));
   mimeTypes.insert(std::pair<std::string, std::string>("xpm",       "image/xpm"));
   mimeTypes.insert(std::pair<std::string, std::string>("x-png",     "image/png"));
+  mimeTypes.insert(std::pair<std::string, std::string>("xspf",      "application/xspf+xml"));
   mimeTypes.insert(std::pair<std::string, std::string>("xsr",       "video/x-amt-showrun"));
   mimeTypes.insert(std::pair<std::string, std::string>("xvid",      "video/x-msvideo"));
   mimeTypes.insert(std::pair<std::string, std::string>("xwd",       "image/x-xwd"));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Allows for .xspf files to be read as playlists

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I wanted to get Kodi to read playlists I had made using VLC. I searched to see if the functionality existed and I came upon this thread https://forum.kodi.tv/showthread.php?tid=209910. While I can convert, I thought it'd be handy to have Kodi also support this (powerful and extensible) format.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Unit tests were created and run on Windows 10 & Linux.
Manual testing was done one Windows 10 64-bit and Ubuntu 18.04.1 64-bit VM.
1. Create a music directory source that contains audio files in subdirectories and playlists that specify paths to those files based on a Windows system's file structure and some from a Linux system's file structure.
2. Add a music directory as a music source
3. Open the file "Files" browser for the music source and locate the playlist files
4. Open the various playlist files and observe how they are populated when the file exists in the given filesystem and are playable. (Note that a playlist that includes location paths but no file exists at that location (on that system) are still loaded, but the respective entries are skipped, this is the behavior specified XSPF.)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
