### PR TITLE
CCurlFile::Stat missing easy_release on early return

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1408,7 +1408,11 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   {
     long code;
     if(g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_RESPONSE_CODE, &code) == CURLE_OK && code == 404 )
+    {
+      g_curlInterface.easy_release(&m_state->m_easyHandle, NULL);
+      errno = ENOENT;
       return -1;
+    }
   }
 
   if(result == CURLE_GOT_NOTHING


### PR DESCRIPTION
## Description
After the work on the previous PR I saw this place in the code where it seems to me that the easy_release is missing on the first early return, as all following early returns do an easy_release of the handle.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

