### PR TITLE
[JSON RPC] Resume offset use from within  PlaylistPlayer Player.Open

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -136,6 +136,20 @@ int CPlayListPlayer::GetNextSong(int offset) const
   return song;
 }
 
+void CPlayListPlayer::SetSongResume(int iPlaylist, int iIndex, unsigned int iOffset)
+{
+  if (iPlaylist == PLAYLIST_NONE)
+    return;
+
+  const CPlayList& playlist = GetPlaylist(iPlaylist);
+  if (playlist.size() <= 0 || playlist.size() < iIndex + 1 )
+    return;
+
+  playlist[iIndex]->m_lStartOffset = iOffset;
+
+  return;
+}
+
 int CPlayListPlayer::GetNextSong()
 {
   if (m_iCurrentPlayList == PLAYLIST_NONE)

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -91,6 +91,8 @@ public:
    */
   int GetNextSong(int offset) const;
 
+  void SetSongResume(int iPlaylist, int iIndex, unsigned int iOffset);
+
   /*! \brief Set the active playlist
    \param playList Values can be PLAYLIST_NONE, PLAYLIST_MUSIC or PLAYLIST_VIDEO
    \sa GetCurrentPlaylist

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -518,7 +518,8 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
 
   if (parameterObject["item"].isMember("playlistid"))
   {
-    int playlistid = (int)parameterObject["item"]["playlistid"].asInteger();
+    int playlistid = static_cast<int>(parameterObject["item"]["playlistid"].asInteger());
+    int playlistStartPosition = static_cast<int>(parameterObject["item"]["position"].asInteger());
 
     if (playlistid < PLAYLIST_PICTURE)
     {
@@ -528,9 +529,14 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
       // Apply the "repeat" option if available
       if (!optionRepeat.isNull())
         CServiceBroker::GetPlaylistPlayer().SetRepeat(playlistid, (REPEAT_STATE)ParseRepeatState(optionRepeat), false);
-    }
 
-    int playlistStartPosition = (int)parameterObject["item"]["position"].asInteger();
+      if (optionResume.isBoolean() && optionResume.asBoolean())
+        CServiceBroker::GetPlaylistPlayer().SetSongResume(playlistid, playlistStartPosition, STARTOFFSET_RESUME);
+      else if (optionResume.isObject())
+        CServiceBroker::GetPlaylistPlayer().SetSongResume(playlistid, playlistStartPosition, static_cast<int>(CUtil::ConvertSecsToMilliSecs(ParseTimeInSeconds(optionResume))));
+      else if (optionResume.isInteger())
+        CServiceBroker::GetPlaylistPlayer().SetSongResume(playlistid, playlistStartPosition, static_cast<int>(CUtil::ConvertSecsToMilliSecs(optionResume.asInteger())));
+    }
 
     switch (playlistid)
     {


### PR DESCRIPTION
## Description
Using the already existing position parameter in the JSON Request this allows to also use the resume option when starting a specific item in a playlist.

This enables remotes to resume playback from a certain position when using playlists (for example to resume TV Shows with multiple episodes in the playlist).

@DaveTBlake is a bump for the JSON RPC API version needed for this? As there is no change in the schema.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
