### PR TITLE
[Estouchy] prevent from getting locked in

### DIFF
--- a/addons/skin.estouchy/xml/DialogConfirm.xml
+++ b/addons/skin.estouchy/xml/DialogConfirm.xml
@@ -52,33 +52,7 @@
 			<height>10</height>
 			<info>System.Progressbar</info>
 		</control>
-		<control type="grouplist" id="9000">
-			<posx>20</posx>
-			<posy>240</posy>
-			<width>660</width>
-			<height>60</height>
-			<itemgap>10</itemgap>
-			<align>center</align>
-			<orientation>horizontal</orientation>
-			<onleft>9000</onleft>
-			<onright>9000</onright>
-			<onup>9000</onup>
-			<ondown>9000</ondown>
-			<control type="button" id="10">
-				<description>OK button</description>
-				<width>200</width>
-				<include>ButtonInfoDialogsCommonValues</include>
-			</control>
-			<control type="button" id="11">
-				<description>Cancel button</description>
-				<width>200</width>
-				<include>ButtonInfoDialogsCommonValues</include>
-			</control>
-			<control type="button" id="12">
-				<description>Custom button</description>
-				<width>200</width>
-				<include>ButtonInfoDialogsCommonValues</include>
-			</control>
-		</control>
+		<include condition="!Window.IsVisible(yesnodialog)">YesNoExtendedButtons</include>
+		<include condition="Window.IsVisible(yesnodialog)">YesNoDefaultButtons</include>
 	</controls>
 </window>

--- a/addons/skin.estouchy/xml/Home.xml
+++ b/addons/skin.estouchy/xml/Home.xml
@@ -146,8 +146,8 @@
 				<height>120</height>
 				<onleft>9002</onleft>
 				<onright>9002</onright>
-				<onup>9001</onup>
-				<ondown>20</ondown>
+				<onup>9000</onup>
+				<ondown>9000</ondown>
 				<pagecontrol></pagecontrol>
 				<scrolltime>300</scrolltime>
 				<orientation>Horizontal</orientation>

--- a/addons/skin.estouchy/xml/Includes.xml
+++ b/addons/skin.estouchy/xml/Includes.xml
@@ -792,8 +792,8 @@
 				<height>760</height>
 				<onleft>9000</onleft>
 				<onright>9003</onright>
-				<onup>10</onup>
-				<ondown>10</ondown>
+				<onup>9002</onup>
+				<ondown>9002</ondown>
 				<scrolltime>300</scrolltime>
 				<orientation>vertical</orientation>
 				<focusposition>1</focusposition>
@@ -2521,6 +2521,61 @@
 			<include>MenuButtonCommonValues</include>
 		</control>
 	</include>
+	<include name="YesNoDefaultButtons">
+		<control type="group">
+			<posx>145</posx>
+			<posy>240</posy>
+			<width>660</width>
+			<height>60</height>
+			<visible>Window.IsVisible(yesnodialog)</visible>
+			<control type="button" id="11">
+				<description>Yes button</description>
+				<posx>0</posx>
+				<posy>0</posy>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+			</control>
+			<control type="button" id="10">
+				<description>No button</description>
+				<posx>210</posx>
+				<posy>0</posy>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+			</control>
+		</control>
+	</include>
+	<include name="YesNoExtendedButtons">
+		<control type="grouplist" id="9000">
+			<posx>20</posx>
+			<posy>240</posy>
+			<width>660</width>
+			<height>60</height>
+			<itemgap>10</itemgap>
+			<align>center</align>
+			<orientation>horizontal</orientation>
+			<onleft>9000</onleft>
+			<onright>9000</onright>
+			<onup>9000</onup>
+			<ondown>9000</ondown>
+			<visible>!Window.IsVisible(yesnodialog)</visible>
+			<control type="button" id="10">
+				<description>OK button</description>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+			</control>
+			<control type="button" id="11">
+				<description>Cancel button</description>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+			</control>
+			<control type="button" id="12">
+				<description>Custom button</description>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+			</control>
+		</control>
+	</include>
+
 	<include name="16x9_xPos_Relocation">
 		<animation effect="slide" start="0,0" end="213,0" time="0" condition="String.IsEqual(Skin.AspectRatio,16:9)">conditional</animation>
 	</include>


### PR DESCRIPTION
Estouchy lacks most of the needed code to be able to navigate around with a keyboard or remote.
not a real problem, since it is designed for touch input only.

problems arise when people who do not have touch (or mouse) select this skin and quickly find out the skin is unusable. it's so unusable, they can't even navigate back to settings in order to select a different skin.

to changes to prevent this problem:

1 make it impossible to select 'yes' (with a keyboard / remote / game controller) when asked if you want to 'keep this skin'. only mouse or touchscreen will be able to select the 'yes' button.

2 make sure people can at least navigate from the homescreen to settings.


ref: https://forum.kodi.tv/showthread.php?tid=330711