### PR TITLE
[Android] Dis- Enable GUI onPause / onContinue

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -351,6 +351,8 @@ public:
   */
   void UnlockFrameMoveGuard();
 
+  void SetRenderGUI(bool renderGUI);
+
 protected:
   bool OnSettingsSaving() const override;
   bool Load(const TiXmlNode *settings) override;
@@ -366,7 +368,6 @@ protected:
 
   // inbound protocol
   bool OnEvent(XBMC_Event& newEvent);
-  void SetRenderGUI(bool renderGUI);
 
   /*!
    \brief Delegates the action to all registered action handlers.

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -237,6 +237,8 @@ void CXBMCApp::onResume()
   // Re-request Visible Behind
   if ((m_playback_state & PLAYBACK_STATE_PLAYING) && (m_playback_state & PLAYBACK_STATE_VIDEO))
     RequestVisibleBehind(true);
+
+  g_application.SetRenderGUI(true);
 }
 
 void CXBMCApp::onPause()
@@ -256,6 +258,7 @@ void CXBMCApp::onPause()
     g_application.SwitchToFullScreen(true);
 
   EnableWakeLock(false);
+  g_application.SetRenderGUI(false);
   m_hasReqVisible = false;
 }
 


### PR DESCRIPTION
## Description
- Suspend GUI on Activity::onPause
- Resume GUI on Activity::onResume

## Motivation and Context
Kodi segfaults on shield / oreo if app goes into background (e.g. screensaver)

## How Has This Been Tested?
Launch kodi, wait until OS screensaver starts

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
