### PR TITLE
Wait for AnnouncementManager thread to exit

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2483,6 +2483,7 @@ bool CApplication::Cleanup()
       m_ServiceManager.reset();
     }
 
+    m_pAnnouncementManager->Deinitialize();
     m_pAnnouncementManager.reset();
 
     m_pSettingsComponent->Deinit();


### PR DESCRIPTION
## Description
Join CAnnounceManager thread on kodi termination

## Motivation and Context
Segfault on kodi termination because of late / uncontrolled thread termination

## How Has This Been Tested?
Win64, start kodi / terminate kodi.
-> Kodi segfault when destructing CLogStateGlobals

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
