### PR TITLE
AESinkAUDIOTRACK: Only enable multi channel float for Android 7 or later

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -1005,7 +1005,10 @@ void CAESinkAUDIOTRACK::UpdateAvailablePCMCapabilities()
 
   int encoding = CJNIAudioFormat::ENCODING_PCM_16BIT;
   m_sinkSupportsFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_STEREO, CJNIAudioFormat::ENCODING_PCM_FLOAT);
-  m_sinkSupportsMultiChannelFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND, CJNIAudioFormat::ENCODING_PCM_FLOAT);
+  // Only try for Android 7 or later - there are a lot of old devices that open successfully
+  // but won't work correctly under the hood (famouse example: old FireTV)
+  if (CJNIAudioManager::GetSDKVersion() > 23)
+    m_sinkSupportsMultiChannelFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND, CJNIAudioFormat::ENCODING_PCM_FLOAT);
 
   if (m_sinkSupportsFloat)
   {


### PR DESCRIPTION
Has issues on old FireTV. Therefore only enable it for Android 7 or later.

As with the original changeset this needs testing. Means: Play a multi channel file and see if you still get all speakers. PCM not passthrough.