### PR TITLE
[depends] binary-addons: fix install directories for android & linux

### DIFF
--- a/tools/depends/target/binary-addons/Makefile
+++ b/tools/depends/target/binary-addons/Makefile
@@ -1,5 +1,5 @@
 BUILDDIR := $(shell pwd)
-ADDONS := all
+ADDONS ?= all
 ADDON_SRC_PREFIX :=
 
 -include ../../Makefile.include

--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -19,9 +19,10 @@ ifeq ($(CMAKE),)
   CMAKE = cmake
 endif
 
-CMAKE_EXTRA = -DPACKAGE_ZIP=ON
+CMAKE_EXTRA =
 ifeq (darwin, $(findstring darwin, $(HOST)))
     INSTALL_PREFIX = ../../../../../addons/
+    CMAKE_EXTRA = -DPACKAGE_ZIP=ON
 endif
 
 ifneq ($(PREFIX),)


### PR DESCRIPTION
## Description
- Enabling `PACKAGE_ZIP` changes the install location of the addons and breaks the android packaging script. So it's reverted back to the state before #14594. For building addons for the binary addons via jenkins this (-DPACKAGE_ZIP=ON) will be passed as additional argument.
- Setting ADDONS from outside is needed for jenkins to specify which addons should be directly packaged. The make command isn't directly called (`prepare-xbmc` -> `make-binary-addons` -> make), so setting ADDONS before calling `prepare-xbmc` doesn't work.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
