### PR TITLE
AEStreamParser: Fix E-AC-3 dependent stream passthrough (trac#17871)

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -216,6 +216,8 @@ int CAEStreamParser::AddData(uint8_t *data, unsigned int size, uint8_t **buffer/
 
     if (!m_needBytes)
       GetPacket(buffer, bufferSize);
+    else if (bufferSize)
+      *bufferSize = 0;
 
     return consumed;
   }

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -93,6 +93,7 @@ private:
 
   void GetPacket(uint8_t **buffer, unsigned int *bufferSize);
   unsigned int DetectType(uint8_t *data, unsigned int size);
+  bool TrySyncAC3(uint8_t *data, unsigned int size, bool resyncing);
   unsigned int SyncAC3(uint8_t *data, unsigned int size);
   unsigned int SyncDTS(uint8_t *data, unsigned int size);
   unsigned int SyncTrueHD(uint8_t *data, unsigned int size);

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -87,13 +87,12 @@ private:
   unsigned int m_coreSize = 0;         /* core size for dtsHD */
   unsigned int m_dtsBlocks = 0;
   unsigned int m_fsize = 0;
-  unsigned int m_fsizeMain = 0;        /* used for EAC3 substreams */
   int m_substreams = 0;       /* used for TrueHD  */
   AVCRC m_crcTrueHD[1024];  /* TrueHD crc table */
 
   void GetPacket(uint8_t **buffer, unsigned int *bufferSize);
   unsigned int DetectType(uint8_t *data, unsigned int size);
-  bool TrySyncAC3(uint8_t *data, unsigned int size, bool resyncing);
+  bool TrySyncAC3(uint8_t *data, unsigned int size, bool resyncing, bool wantEAC3dependent);
   unsigned int SyncAC3(uint8_t *data, unsigned int size);
   unsigned int SyncDTS(uint8_t *data, unsigned int size);
   unsigned int SyncTrueHD(uint8_t *data, unsigned int size);


### PR DESCRIPTION
This fixes E-AC-3 dependent stream passthrough that got broken by FFmpeg 4.0 update: https://trac.kodi.tv/ticket/17871

There is one non-behavior-altering refactoring commit and then two fix commits, the latter of which is the bigger change with a commit message containing details about the issue(s) and the approach taken to fix them.

I've tested that the code now seems to work properly with standard AC-3, standard E-AC-3, and dependent-substream E-AC-3 regardless of whether the dependent frames are input as separate or combined.