### PR TITLE
DVDAudioCodecPassthrough: Fix off-by-one-frame timestamps

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -111,15 +111,17 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
       if (m_nextPts != DVD_NOPTS_VALUE)
       {
         m_currentPts = m_nextPts;
-        m_nextPts = DVD_NOPTS_VALUE;
+        m_nextPts = packet.pts;
       }
       else if (packet.pts != DVD_NOPTS_VALUE)
       {
         m_currentPts = packet.pts;
       }
     }
-
-    m_nextPts = packet.pts;
+    else
+    {
+      m_nextPts = packet.pts;
+    }
   }
 
   if (pData && !m_backlogSize)


### PR DESCRIPTION
CDVDAudioCodecPassthrough contains simple two-slot queue for keeping
track of PTS timestamps of incoming and outgoing frames.

However, if both m_currentPts and m_nextPts are NOPTS (like they
initially are), the PTS from the incoming frame is assigned to both
m_currentPts and m_nextPts.
When the next frame arrives, its PTS is put to m_nextPts and m_nextPts
value is moved to m_currentPts.

This causes m_currentPts to stay permanently one frame behind as long as
one frame is output for each input frame.

If two frames are input before an output frame at some point (e.g. for
DTS-HD extension header lookahead), m_nextPts will get overwritten and
the timestamps will be OK from that point on (as the frame data itself
is one frame permanently "delayed" as well).

Fix the issue by only assigning incoming packet PTS to m_nextPts when it
was not assigned to m_currentPts.

The timestamp handling here is still very simplistic and will not
account properly for things like skipped/corrupted audio frames - in
those cases off-by-one-frame timestamps may still occur. Fixing those
would require a larger rework of the code.