### PR TITLE
AEStreamParser: Handle DTS-HD streams with occasional non-HD frames

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -623,6 +623,16 @@ unsigned int CAEStreamParser::SyncDTS(uint8_t *data, unsigned int size)
       m_coreSize = m_fsize;
       m_fsize += hd_size;
     }
+    else if (m_hasSync && (m_info.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD_MA ||
+                           m_info.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD))
+    {
+      /* We have a DTS-HD stream but the HD extension is missing for this
+       * frame. Continue to consider it as a DTS-HD stream to avoid
+       * interruptions as standard DTS frames can still be packed like they
+       * were DTS-HD. */
+      m_coreSize = m_fsize;
+      dataType = m_info.m_type;
+    }
 
     unsigned int sampleRate = DTSSampleRates[sfreq];
     if (!m_hasSync || skip || dataType != m_info.m_type || sampleRate != m_info.m_sampleRate || dtsBlocks != m_dtsBlocks)


### PR DESCRIPTION
Sample "DAS_EXPERIMENT (1)-001.mkv" contains a DTS-HD stream with
occasional DTS frames without a DTS-HD extension. This causes
AEStreamParser to constantly switch between considering it as DTS and
DTS-HD, causing audio output to be unusable due to constant audio
interface reconfiguration.

Fix that by simply not transitioning from DTS-HD to DTS even if the HD
extension is missing. The non-HD frames can be IEC 61937 packed like
they were HD frames, with no glitches in audio output.

Tested the problematic sample to work OK with a Denon AVR-X2100W.