### PR TITLE
[fix][windows] check FirstUnicastAddress for nullptr

### DIFF
--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -74,7 +74,7 @@ void CNetworkInterfaceWin32::GetMacAddressRaw(char rawMac[6]) const
 
 std::string CNetworkInterfaceWin32::GetCurrentIPAddress(void) const
 {
-  return CNetworkBase::GetIpStr(m_adapter.FirstUnicastAddress->Address.lpSockaddr);
+  return m_adapter.FirstUnicastAddress != nullptr ? CNetworkBase::GetIpStr(m_adapter.FirstUnicastAddress->Address.lpSockaddr) : "";
 }
 
 std::string CNetworkInterfaceWin32::GetCurrentNetmask(void) const


### PR DESCRIPTION
## Motivation and Context
fixes #14606

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
