### PR TITLE
Fix NDK r18 Android x86 ffmpeg dependency build

### DIFF
--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -38,6 +38,7 @@ ifeq ($(OS), android)
       ffmpg_config += --cpu=cortex-a9
     else
       ffmpg_config += --cpu=i686 --disable-mmx
+      ffmpg_config += --extra-cflags=-no-integrated-as --extra-cflags=-mno-stackrealign
     endif
   endif
   ffmpg_config += --target-os=linux --extra-libs=-liconv --disable-linux-perf


### PR DESCRIPTION
## Description
After the switch to NDK r18, the Android x86 ffmpeg dependency no longer builds properly.  The ffmpeg source code isn't entirely compatible with the r18 clang toolset.

## Motivation and Context
This PR adds a couple extra CFLAGs to the Android x86 ffmpeg Makefile to disable use of the clang integrated assembler and deal with an additional API level 21 incompatibility.

## How Has This Been Tested?
Tested on Ubuntu 16.04 using the environment as specified in the Android Build README.md.  After the change all dependencies, including ffmpeg 4.0.2, build successfully for the x86 platform.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
