### PR TITLE
[PVR] Integrate client menu hooks into context menu system

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10277,11 +10277,7 @@ msgctxt "#19194"
 msgid "Continue?"
 msgstr ""
 
-#. label for a context menu entry for pvr client specific actions
-#: xbmc/pvr/PVRContextMenus.cpp
-msgctxt "#19195"
-msgid "Client actions"
-msgstr ""
+#empty string with id 19195
 
 #. value for "pvr client specific actions" dialog headers
 #: xbmc/pvr/PVRGUIActions.cpp

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -14,6 +14,10 @@
 #include "addons/ContextMenuAddon.h"
 #include "ContextMenuItem.h"
 
+namespace PVR
+{
+  struct PVRContextMenuEvent;
+}
 
 using ContextMenuView = std::vector<std::shared_ptr<const IContextMenuItem>>;
 
@@ -44,6 +48,8 @@ private:
 
   void ReloadAddonItems();
   void OnEvent(const ADDON::AddonEvent& event);
+
+  void OnPVREvent(const PVR::PVRContextMenuEvent& event);
 
   ADDON::CAddonMgr& m_addonMgr;
 

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES Addon.cpp
             LanguageResource.cpp
             PluginSource.cpp
             PVRClient.cpp
+            PVRClientMenuHooks.cpp
             Repository.cpp
             RepositoryUpdater.cpp
             Scraper.cpp
@@ -62,6 +63,7 @@ set(HEADERS Addon.h
             LanguageResource.h
             PluginSource.h
             PVRClient.h
+            PVRClientMenuHooks.h
             Repository.h
             RepositoryUpdater.h
             Resource.h

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -178,6 +178,9 @@ void CPVRClient::Destroy(void)
   /* destroy the add-on */
   CAddonDll::Destroy();
 
+  if (m_menuhooks)
+    m_menuhooks->Clear();
+
   /* reset all properties to defaults */
   ResetProperties();
 }

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -23,8 +23,8 @@ namespace PVR
 {
   class CPVRChannelGroups;
   class CPVRTimersContainer;
-
-  typedef std::vector<PVR_MENUHOOK> PVR_MENUHOOKS;
+  class CPVRClientMenuHook;
+  class CPVRClientMenuHooks;
 
   class CPVRClient;
   typedef std::shared_ptr<CPVRClient> CPVRClientPtr;
@@ -393,24 +393,6 @@ namespace PVR
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
     PVR_ERROR FillEpgTagStreamFileItem(CFileItem &fileItem);
-
-    /*!
-     * @return True if this add-on has menu hooks, false otherwise.
-     */
-    bool HasMenuHooks(PVR_MENUHOOK_CAT cat) const;
-
-    /*!
-     * @return The menu hooks for this add-on.
-     */
-    PVR_MENUHOOKS& GetMenuHooks();
-
-    /*!
-     * @brief Call one of the menu hooks of this client.
-     * @param hook The hook to call.
-     * @param item The selected file item for which the hook was called.
-     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
-     */
-    PVR_ERROR CallMenuHook(const PVR_MENUHOOK &hook, const CFileItemPtr item);
 
     //@}
     /** @name PVR EPG methods */
@@ -824,6 +806,20 @@ namespace PVR
     bool GetAddonProperties(void);
 
     /*!
+     * @brief Get the client's menu hooks.
+     * @return The hooks. Guaranteed never to be null.
+     */
+    std::shared_ptr<CPVRClientMenuHooks> GetMenuHooks();
+
+    /*!
+     * @brief Call one of the menu hooks of the client.
+     * @param hook The hook to call.
+     * @param item The item associated with the hook to be called.
+     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+     */
+    PVR_ERROR CallMenuHook(const CPVRClientMenuHook &hook, const CFileItemPtr &item);
+
+    /*!
      * @brief Propagate power management events to this add-on
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
@@ -1071,7 +1067,6 @@ namespace PVR
     PVR_CONNECTION_STATE   m_connectionState;      /*!< the backend connection state */
     PVR_CONNECTION_STATE   m_prevConnectionState;  /*!< the previous backend connection state */
     bool                   m_ignoreClient;         /*!< signals to PVRManager to ignore this client until it has been connected */
-    PVR_MENUHOOKS          m_menuhooks;            /*!< the menu hooks for this add-on */
     CPVRTimerTypes         m_timertypes;           /*!< timer types supported by this backend */
     int                    m_iClientId;            /*!< unique ID of the client */
     mutable int            m_iPriority;            /*!< priority of the client */
@@ -1084,6 +1079,7 @@ namespace PVR
     std::string            m_strFriendlyName;      /*!< the cached friendly name */
     std::string            m_strBackendHostname;   /*!< the cached backend hostname */
     CPVRClientCapabilities m_clientCapabilities;   /*!< the cached add-on's capabilities */
+    std::shared_ptr<CPVRClientMenuHooks> m_menuhooks; /*!< the menu hooks for this add-on */
 
     /* stored strings to make sure const char* members in PVR_PROPERTIES stay valid */
     std::string            m_strUserPath;         /*!< @brief translated path to the user profile */

--- a/xbmc/addons/PVRClientMenuHooks.cpp
+++ b/xbmc/addons/PVRClientMenuHooks.cpp
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRClientMenuHooks.h"
+
+#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/log.h"
+
+namespace PVR
+{
+
+CPVRClientMenuHook::CPVRClientMenuHook(const std::string &addonId, const PVR_MENUHOOK &hook)
+: m_addonId(addonId),
+  m_hook(new PVR_MENUHOOK(hook))
+{
+  if (hook.category != PVR_MENUHOOK_UNKNOWN &&
+      hook.category != PVR_MENUHOOK_ALL &&
+      hook.category != PVR_MENUHOOK_CHANNEL &&
+      hook.category != PVR_MENUHOOK_TIMER &&
+      hook.category != PVR_MENUHOOK_EPG &&
+      hook.category != PVR_MENUHOOK_RECORDING &&
+      hook.category != PVR_MENUHOOK_RECORDING &&
+      hook.category != PVR_MENUHOOK_SETTING)
+    CLog::LogF(LOGERROR, "Unknown PVR_MENUHOOK_CAT value: %d", hook.category);
+}
+
+bool CPVRClientMenuHook::IsAllHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_ALL;
+}
+
+bool CPVRClientMenuHook::IsChannelHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_CHANNEL;
+}
+
+bool CPVRClientMenuHook::IsTimerHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_TIMER;
+}
+
+bool CPVRClientMenuHook::IsEpgHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_EPG;
+}
+
+bool CPVRClientMenuHook::IsRecordingHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_RECORDING;
+}
+
+bool CPVRClientMenuHook::IsDeletedRecordingHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_DELETED_RECORDING;
+}
+
+bool CPVRClientMenuHook::IsSettingsHook() const
+{
+  return m_hook->category == PVR_MENUHOOK_SETTING;
+}
+
+unsigned int CPVRClientMenuHook::GetId() const
+{
+  return m_hook->iHookId;
+}
+
+unsigned int CPVRClientMenuHook::GetLabelId() const
+{
+  return m_hook->iLocalizedStringId;
+}
+
+std::string CPVRClientMenuHook::GetLabel() const
+{
+  return g_localizeStrings.GetAddonString(m_addonId, m_hook->iLocalizedStringId);
+}
+
+void CPVRClientMenuHooks::AddHook(const PVR_MENUHOOK &hook)
+{
+  if (!m_hooks)
+    m_hooks.reset(new std::vector<CPVRClientMenuHook>());
+
+  m_hooks->emplace_back(CPVRClientMenuHook(m_addonId, hook));
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetHooks(std::function<bool(const CPVRClientMenuHook& hook)> function) const
+{
+  std::vector<CPVRClientMenuHook> hooks;
+
+  if (!m_hooks)
+    return hooks;
+
+  for (const CPVRClientMenuHook& hook : *m_hooks)
+  {
+    if (function(hook) || hook.IsAllHook())
+      hooks.emplace_back(hook);
+  }
+  return hooks;
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetChannelHooks() const
+{
+  return GetHooks([](const CPVRClientMenuHook& hook)
+  {
+    return hook.IsChannelHook();
+  });
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetTimerHooks() const
+{
+  return GetHooks([](const CPVRClientMenuHook& hook)
+  {
+    return hook.IsTimerHook();
+  });
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetEpgHooks() const
+{
+  return GetHooks([](const CPVRClientMenuHook& hook)
+  {
+    return hook.IsEpgHook();
+  });
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetRecordingHooks() const
+{
+  return GetHooks([](const CPVRClientMenuHook& hook)
+  {
+    return hook.IsRecordingHook();
+  });
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetDeletedRecordingHooks() const
+{
+  return GetHooks([](const CPVRClientMenuHook& hook)
+  {
+    return hook.IsDeletedRecordingHook();
+  });
+}
+
+std::vector<CPVRClientMenuHook> CPVRClientMenuHooks::GetSettingsHooks() const
+{
+  return GetHooks([](const CPVRClientMenuHook& hook)
+  {
+    return hook.IsSettingsHook();
+  });
+}
+
+} // namespace PVR

--- a/xbmc/addons/PVRClientMenuHooks.h
+++ b/xbmc/addons/PVRClientMenuHooks.h
@@ -25,6 +25,8 @@ namespace PVR
 
     CPVRClientMenuHook(const std::string &addonId, const PVR_MENUHOOK &hook);
 
+    bool operator ==(const CPVRClientMenuHook& right) const;
+
     bool IsAllHook() const;
     bool IsChannelHook() const;
     bool IsTimerHook() const;
@@ -50,7 +52,8 @@ namespace PVR
 
     explicit CPVRClientMenuHooks(const std::string &addonId) : m_addonId(addonId) {}
 
-    void AddHook(const PVR_MENUHOOK &hook);
+    void AddHook(const PVR_MENUHOOK &addonHook);
+    void Clear();
 
     std::vector<CPVRClientMenuHook> GetChannelHooks() const;
     std::vector<CPVRClientMenuHook> GetTimerHooks() const;

--- a/xbmc/addons/PVRClientMenuHooks.h
+++ b/xbmc/addons/PVRClientMenuHooks.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+struct PVR_MENUHOOK;
+
+namespace PVR
+{
+  class CPVRClientMenuHook
+  {
+  public:
+    CPVRClientMenuHook() = delete;
+    virtual ~CPVRClientMenuHook() = default;
+
+    CPVRClientMenuHook(const std::string &addonId, const PVR_MENUHOOK &hook);
+
+    bool IsAllHook() const;
+    bool IsChannelHook() const;
+    bool IsTimerHook() const;
+    bool IsEpgHook() const;
+    bool IsRecordingHook() const;
+    bool IsDeletedRecordingHook() const;
+    bool IsSettingsHook() const;
+
+    unsigned int GetId() const;
+    unsigned int GetLabelId() const;
+    std::string GetLabel() const;
+
+  private:
+    std::string m_addonId;
+    std::shared_ptr<PVR_MENUHOOK> m_hook;
+  };
+
+  class CPVRClientMenuHooks
+  {
+  public:
+    CPVRClientMenuHooks() = default;
+    virtual ~CPVRClientMenuHooks() = default;
+
+    explicit CPVRClientMenuHooks(const std::string &addonId) : m_addonId(addonId) {}
+
+    void AddHook(const PVR_MENUHOOK &hook);
+
+    std::vector<CPVRClientMenuHook> GetChannelHooks() const;
+    std::vector<CPVRClientMenuHook> GetTimerHooks() const;
+    std::vector<CPVRClientMenuHook> GetEpgHooks() const;
+    std::vector<CPVRClientMenuHook> GetRecordingHooks() const;
+    std::vector<CPVRClientMenuHook> GetDeletedRecordingHooks() const;
+    std::vector<CPVRClientMenuHook> GetSettingsHooks() const;
+
+  private:
+    std::vector<CPVRClientMenuHook> GetHooks(std::function<bool(const CPVRClientMenuHook& hook)> function) const;
+
+    std::string m_addonId;
+    std::unique_ptr<std::vector<CPVRClientMenuHook>> m_hooks;
+  };
+}

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -314,7 +314,7 @@ void CPVRActionListener::OnSettingAction(std::shared_ptr<const CSetting> setting
   }
   else if (settingId == CSettings::SETTING_PVRCLIENT_MENUHOOK)
   {
-    CServiceBroker::GetPVRManager().GUIActions()->ProcessMenuHooks(CFileItemPtr());
+    CServiceBroker::GetPVRManager().GUIActions()->ProcessSettingsMenuHooks();
   }
 }
 

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -11,6 +11,7 @@
 #include "ContextMenuItem.h"
 #include "ServiceBroker.h"
 #include "addons/PVRClient.h"
+#include "addons/PVRClientMenuHooks.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/URIUtils.h"
 
@@ -539,37 +540,12 @@ namespace PVR
 
     bool PVRClientMenuHook::IsVisible(const CFileItem &item) const
     {
-      const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(item);
-      if (!client)
-        return false;
-
-      PVR_MENUHOOK_CAT cat = PVR_MENUHOOK_UNKNOWN;
-
-      if (item.HasPVRChannelInfoTag())
-        cat = PVR_MENUHOOK_CHANNEL;
-      else if (item.HasEPGInfoTag())
-        cat = PVR_MENUHOOK_EPG;
-      else if (item.HasPVRTimerInfoTag() &&
-               !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        cat = PVR_MENUHOOK_TIMER;
-      else if (item.HasPVRRecordingInfoTag())
-      {
-        const CPVRRecordingPtr recording = item.GetPVRRecordingInfoTag();
-        if (recording->IsDeleted())
-          cat = PVR_MENUHOOK_DELETED_RECORDING;
-        else
-          cat = PVR_MENUHOOK_RECORDING;
-      }
-
-      if (cat == PVR_MENUHOOK_UNKNOWN)
-        return false;
-
-      return client->HasMenuHooks(cat);
+      return !CServiceBroker::GetPVRManager().GUIActions()->GetItemMenuHooks(item).empty();
     }
 
     bool PVRClientMenuHook::Execute(const CFileItemPtr &item) const
     {
-      return CServiceBroker::GetPVRManager().GUIActions()->ProcessMenuHooks(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->ProcessItemMenuHooks(item);
     }
 
   } // namespace CONEXTMENUITEM

--- a/xbmc/pvr/PVRContextMenus.h
+++ b/xbmc/pvr/PVRContextMenus.h
@@ -11,16 +11,43 @@
 #include <memory>
 #include <vector>
 
+#include "utils/EventStream.h"
+
 class IContextMenuItem;
 
 namespace PVR
 {
+  enum class PVRContextMenuEventAction
+  {
+    ADD_ITEM,
+    REMOVE_ITEM
+  };
+
+  struct PVRContextMenuEvent
+  {
+    PVRContextMenuEvent(const PVRContextMenuEventAction& a, const std::shared_ptr<IContextMenuItem>& i)
+    : action(a), item(i) {}
+
+    PVRContextMenuEventAction action;
+    std::shared_ptr<IContextMenuItem> item;
+  };
+
+  class CPVRClientMenuHook;
+
   class CPVRContextMenuManager
   {
   public:
     static CPVRContextMenuManager& GetInstance();
 
     std::vector<std::shared_ptr<IContextMenuItem>> GetMenuItems() const { return m_items; }
+
+    void AddMenuHook(const CPVRClientMenuHook& hook);
+    void RemoveMenuHook(const CPVRClientMenuHook& hook);
+
+    /*!
+     * @brief Query the events available for CEventStream
+     */
+    CEventStream<PVRContextMenuEvent>& Events() { return m_events; }
 
   private:
     CPVRContextMenuManager();
@@ -29,6 +56,7 @@ namespace PVR
     virtual ~CPVRContextMenuManager() = default;
 
     std::vector<std::shared_ptr<IContextMenuItem>> m_items;
+    CEventSource<PVRContextMenuEvent> m_events;
   };
 
 } // namespace PVR

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1378,68 +1378,6 @@ namespace PVR
     return true;
   }
 
-  std::vector<CPVRClientMenuHook> CPVRGUIActions::GetItemMenuHooks(const CFileItem &item) const
-  {
-    std::vector<CPVRClientMenuHook> itemHooks;
-
-    const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(item);
-    if (client)
-    {
-      const std::shared_ptr<CPVRClientMenuHooks> hooks = client->GetMenuHooks();
-
-      if (item.IsEPG())
-        itemHooks = hooks->GetEpgHooks();
-      else if (item.IsPVRChannel())
-        itemHooks = hooks->GetChannelHooks();
-      else if (item.IsDeletedPVRRecording())
-        itemHooks = hooks->GetDeletedRecordingHooks();
-      else if (item.IsUsablePVRRecording())
-        itemHooks = hooks->GetRecordingHooks();
-      else if (item.IsPVRTimer())
-        itemHooks = hooks->GetTimerHooks();
-    }
-
-    return itemHooks;
-  }
-
-  bool CPVRGUIActions::ProcessItemMenuHooks(const CFileItemPtr &item)
-  {
-    const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(*item);
-    if (!client)
-      return false;
-
-    const std::shared_ptr<CPVRClientMenuHooks> hooks = client->GetMenuHooks();
-
-    const std::vector<CPVRClientMenuHook> itemHooks = GetItemMenuHooks(*item);
-    if (itemHooks.empty())
-      return true; // no matching hooks, no error
-
-    CGUIDialogSelect* pDialog= CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
-    if (!pDialog)
-    {
-      CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_SELECT!");
-      return false;
-    }
-
-    pDialog->Reset();
-    pDialog->SetHeading(CVariant{19196}); // "PVR client specific actions"
-
-    for (const auto& hook : itemHooks)
-    {
-      pDialog->Add(hook.GetLabel());
-    }
-
-    pDialog->Open();
-
-    int selection = pDialog->GetSelectedItem();
-    if (selection < 0)
-      return true; // cancelled
-
-    auto selectedHook = itemHooks.begin();
-    std::advance(selectedHook, selection);
-    return client->CallMenuHook(*selectedHook, item) == PVR_ERROR_NO_ERROR;
-  }
-
   bool CPVRGUIActions::ProcessSettingsMenuHooks()
   {
     CPVRClientMap clients;

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -40,8 +40,6 @@ namespace PVR
     SUCCESS
   };
 
-  class CPVRClientMenuHook;
-
   class CPVRChannelSwitchingInputHandler : public CPVRChannelNumberInputHandler
   {
   public:
@@ -306,20 +304,6 @@ namespace PVR
      * @return True when a channel scan is currently running, false otherwise.
      */
     bool IsRunningChannelScan() const { return m_bChannelScanRunning; }
-
-    /*!
-     * @brief Get client-specific item actions
-     * @param item The item for that the hooks shall be obtained.
-     * @return the actions.
-     */
-    std::vector<CPVRClientMenuHook> GetItemMenuHooks(const CFileItem &item) const;
-
-    /*!
-     * @brief Select and invoke client-specific item actions
-     * @param item The item for that the hooks shall be processed.
-     * @return true on success, false otherwise.
-     */
-    bool ProcessItemMenuHooks(const CFileItemPtr &item);
 
     /*!
      * @brief Select and invoke client-specific settings actions

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -40,6 +40,8 @@ namespace PVR
     SUCCESS
   };
 
+  class CPVRClientMenuHook;
+
   class CPVRChannelSwitchingInputHandler : public CPVRChannelNumberInputHandler
   {
   public:
@@ -306,11 +308,24 @@ namespace PVR
     bool IsRunningChannelScan() const { return m_bChannelScanRunning; }
 
     /*!
-     * @brief Open selection and progress PVR actions.
-     * @param item The selected file item for which the hook was called.
+     * @brief Get client-specific item actions
+     * @param item The item for that the hooks shall be obtained.
+     * @return the actions.
+     */
+    std::vector<CPVRClientMenuHook> GetItemMenuHooks(const CFileItem &item) const;
+
+    /*!
+     * @brief Select and invoke client-specific item actions
+     * @param item The item for that the hooks shall be processed.
      * @return true on success, false otherwise.
      */
-    bool ProcessMenuHooks(const CFileItemPtr &item);
+    bool ProcessItemMenuHooks(const CFileItemPtr &item);
+
+    /*!
+     * @brief Select and invoke client-specific settings actions
+     * @return true on success, false otherwise.
+     */
+    bool ProcessSettingsMenuHooks();
 
     /*!
      * @brief Reset the TV database to it's initial state and delete all the data.

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -160,6 +160,8 @@ namespace PVR
      */
     int EnabledClientAmount(void) const;
 
+    //@}
+
     /*! @name general methods */
     //@{
 


### PR DESCRIPTION
Some pictures say more than 1.000 words (hopefully). ;-)

Before:

* A static context menu item triggering a selection dialog containing the actual items.

![screenshot001](https://user-images.githubusercontent.com/3226626/46978425-36bd8d80-d0cf-11e8-9502-aaa2ba4bbbeb.png)
![screenshot002](https://user-images.githubusercontent.com/3226626/46978432-3d4c0500-d0cf-11e8-9520-f1390b39f7bf.png)

After:

* The items a directly contained in the context menu.

![screenshot000](https://user-images.githubusercontent.com/3226626/46978445-43da7c80-d0cf-11e8-857f-61501b4431a5.png)

To implement this improvement in usability I had to understand the old code first, which ended up in a complete refactoring. TBH, it was really bad design, leaking the PVR Addon API data types up to the PVR GUI layer. Ugly.

I runtime-tested the changes on macOS, latest Kodi master with latest pvr.demo addon.

@Jalle19 might want to review.