### PR TITLE
[windows] make-addons: remove surrounding quotation marks

### DIFF
--- a/tools/buildsteps/windows/make-addons.bat
+++ b/tools/buildsteps/windows/make-addons.bat
@@ -10,16 +10,16 @@ SET store=
 
 SETLOCAL EnableDelayedExpansion
 FOR %%b IN (%*) DO (
-  IF %%b == install (
+  IF %%~b == install (
     SET install=true
-  ) ELSE ( IF %%b == clean (
+  ) ELSE ( IF %%~b == clean (
     SET clean=true
-  ) ELSE ( IF %%b == package (
+  ) ELSE ( IF %%~b == package (
     SET package=true
-  ) ELSE ( IF %%b == win10 (
+  ) ELSE ( IF %%~b == win10 (
     SET store=store
   ) ELSE (
-    SET addon=!addon! %%b
+    SET addon=!addon! %%~b
   ))))
 )
 SETLOCAL DisableDelayedExpansion


### PR DESCRIPTION
## Motivation and Context
This allows to pass a regex without having to escape the special characters multiple times

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
