### PR TITLE
[Android] more frame timing optimizations

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -128,6 +128,7 @@ std::vector<androidPackage> CXBMCApp::m_applications;
 CVideoSyncAndroid* CXBMCApp::m_syncImpl = NULL;
 CEvent CXBMCApp::m_vsyncEvent;
 std::vector<CActivityResultEvent*> CXBMCApp::m_activityResultEvents;
+
 int64_t CXBMCApp::m_frameTimeNanos = 0;
 float CXBMCApp::m_refreshRate = 0.0f;
 
@@ -1186,10 +1187,21 @@ void CXBMCApp::doFrame(int64_t frameTimeNanos)
 
   // Calculate the time, when next surface buffer should be rendered
   m_frameTimeNanos = frameTimeNanos;
-  if (m_refreshRate)
-    m_frameTimeNanos += static_cast<int64_t>(1500000000ll / m_refreshRate);
 
   m_vsyncEvent.Set();
+}
+
+int64_t CXBMCApp::GetNextFrameTime()
+{
+  if (m_refreshRate > 0.0001f)
+    return m_frameTimeNanos + static_cast<int64_t>(1500000000ll / m_refreshRate);
+  else
+    return m_frameTimeNanos;
+}
+
+float CXBMCApp::GetFrameLatencyMs()
+{
+  return (CurrentHostCounter() - m_frameTimeNanos) * 0.000001;
 }
 
 bool CXBMCApp::WaitVSync(unsigned int milliSeconds)

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -191,7 +191,8 @@ public:
   void ProcessSlow();
 
   static bool WaitVSync(unsigned int milliSeconds);
-  static int64_t GetNextFrameTime(){ return m_frameTimeNanos; };
+  static int64_t GetNextFrameTime();
+  static float GetFrameLatencyMs();
 
   bool getVideosurfaceInUse();
   void setVideosurfaceInUse(bool videosurfaceInUse);

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -98,6 +98,11 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
   CXBMCApp::get()->WaitVSync(1000);
 }
 
+float CWinSystemAndroidGLESContext::GetFrameLatencyAdjustment()
+{
+  return CXBMCApp::GetFrameLatencyMs();
+}
+
 EGLDisplay CWinSystemAndroidGLESContext::GetEGLDisplay() const
 {
   return m_pGLContext.GetEGLDisplay();

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.h
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.h
@@ -31,6 +31,8 @@ public:
 
   virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 
+  float GetFrameLatencyAdjustment() override;
+
   EGLDisplay GetEGLDisplay() const;
   EGLSurface GetEGLSurface() const;
   EGLContext GetEGLContext() const;


### PR DESCRIPTION
## Description
Implement WinSystemAndroidGLESContext::GetFrameLatencyAdjustment used by Rendermanager to allow better timings when rendering video frames.

The adjustment calculates by time(call of the function) - time(realVSync)

## Motivation and Context
Get better 3:2 pulldown results

## How Has This Been Tested?
WETEK Hub / NVidia shield -> passed
Amazon FTV 4K -> failed because of OS issues (AML clock does not work well with kodi clock)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
