### PR TITLE
Allow a clean shutdown on window system failure

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1374,22 +1374,26 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
   else if (!m_saveSkinOnUnloading)
     m_saveSkinOnUnloading = true;
 
-  CServiceBroker::GetGUI()->GetAudioManager().Enable(false);
+  CGUIComponent *gui = CServiceBroker::GetGUI();
+  if (gui)
+  {
+    gui->GetAudioManager().Enable(false);
 
-  CServiceBroker::GetGUI()->GetWindowManager().DeInitialize();
-  CTextureCache::GetInstance().Deinitialize();
+    gui->GetWindowManager().DeInitialize();
+    CTextureCache::GetInstance().Deinitialize();
 
-  // remove the skin-dependent window
-  CServiceBroker::GetGUI()->GetWindowManager().Delete(WINDOW_DIALOG_FULLSCREEN_INFO);
+    // remove the skin-dependent window
+    gui->GetWindowManager().Delete(WINDOW_DIALOG_FULLSCREEN_INFO);
 
-  CServiceBroker::GetGUI()->GetTextureManager().Cleanup();
-  CServiceBroker::GetGUI()->GetLargeTextureManager().CleanupUnusedImages(true);
+    gui->GetTextureManager().Cleanup();
+    gui->GetLargeTextureManager().CleanupUnusedImages(true);
 
-  g_fontManager.Clear();
+    g_fontManager.Clear();
 
-  CServiceBroker::GetGUI()->GetColorManager().Clear();
+    gui->GetColorManager().Clear();
 
-  CServiceBroker::GetGUI()->GetInfoManager().Clear();
+    gui->GetInfoManager().Clear();
+  }
 
 //  The g_SkinInfo shared_ptr ought to be reset here
 // but there are too many places it's used without checking for NULL
@@ -2435,10 +2439,19 @@ bool CApplication::Cleanup()
     m_globalScreensaverInhibitor.Release();
     m_screensaverInhibitor.Release();
 
-    CServiceBroker::GetRenderSystem()->DestroyRenderSystem();
-    CServiceBroker::GetWinSystem()->DestroyWindow();
-    CServiceBroker::GetWinSystem()->DestroyWindowSystem();
-    CServiceBroker::GetGUI()->GetWindowManager().DestroyWindows();
+    CRenderSystemBase *renderSystem = CServiceBroker::GetRenderSystem();
+    if (renderSystem)
+      renderSystem->DestroyRenderSystem();
+
+    CWinSystemBase *winSystem = CServiceBroker::GetWinSystem();
+    if (winSystem)
+    {
+      winSystem->DestroyWindow();
+      winSystem->DestroyWindowSystem();
+    }
+
+    if (m_pGUI)
+      m_pGUI->GetWindowManager().DestroyWindows();
 
     CLog::Log(LOGNOTICE, "unload sections");
 
@@ -2473,8 +2486,11 @@ bool CApplication::Cleanup()
     while(1); // execution ends
 #endif
 
-    m_pGUI->Deinit();
-    m_pGUI.reset();
+    if (m_pGUI)
+    {
+      m_pGUI->Deinit();
+      m_pGUI.reset();
+    }
 
     // Cleanup was called more than once on exit during my tests
     if (m_ServiceManager)
@@ -3294,19 +3310,24 @@ bool CApplication::IsFullScreen()
 
 void CApplication::StopPlaying()
 {
-  int iWin = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
-  if (m_appPlayer.IsPlaying())
+  CGUIComponent *gui = CServiceBroker::GetGUI();
+
+  if (gui)
   {
-    m_appPlayer.ClosePlayer();
+    int iWin = gui->GetWindowManager().GetActiveWindow();
+    if (m_appPlayer.IsPlaying())
+    {
+      m_appPlayer.ClosePlayer();
 
-    // turn off visualisation window when stopping
-    if ((iWin == WINDOW_VISUALISATION ||
-         iWin == WINDOW_FULLSCREEN_VIDEO ||
-         iWin == WINDOW_FULLSCREEN_GAME) &&
-         !m_bStop)
-      CServiceBroker::GetGUI()->GetWindowManager().PreviousWindow();
+      // turn off visualisation window when stopping
+      if ((iWin == WINDOW_VISUALISATION ||
+           iWin == WINDOW_FULLSCREEN_VIDEO ||
+           iWin == WINDOW_FULLSCREEN_GAME) &&
+           !m_bStop)
+        gui->GetWindowManager().PreviousWindow();
 
-    g_partyModeManager.Disable();
+      g_partyModeManager.Disable();
+    }
   }
 }
 

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -47,6 +47,8 @@ extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
   if (renderGUI && !g_application.CreateGUI())
   {
     CMessagePrinter::DisplayError("ERROR: Unable to create GUI. Exiting");
+    g_application.Stop(EXITCODE_QUIT);
+    g_application.Cleanup();
     return status;
   }
   if (!g_application.Initialize())

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -24,7 +24,6 @@
 
 CRenderSystemGL::CRenderSystemGL() : CRenderSystemBase()
 {
-  m_pShader.reset(new CGLShader*[SM_MAX]);
 }
 
 CRenderSystemGL::~CRenderSystemGL() = default;
@@ -612,66 +611,59 @@ void CRenderSystemGL::InitialiseShaders()
     defines += "#define KODI_LIMITED_RANGE 1\n";
   }
 
-  m_pShader[SM_DEFAULT] = new CGLShader("gl_shader_vert_default.glsl", "gl_shader_frag_default.glsl", defines);
+  m_pShader[SM_DEFAULT].reset(new CGLShader("gl_shader_vert_default.glsl", "gl_shader_frag_default.glsl", defines));
   if (!m_pShader[SM_DEFAULT]->CompileAndLink())
   {
     m_pShader[SM_DEFAULT]->Free();
-    delete m_pShader[SM_DEFAULT];
-    m_pShader[SM_DEFAULT] = nullptr;
+    m_pShader[SM_DEFAULT].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_default.glsl - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE] = new CGLShader("gl_shader_frag_texture.glsl", defines);
+  m_pShader[SM_TEXTURE].reset(new CGLShader("gl_shader_frag_texture.glsl", defines));
   if (!m_pShader[SM_TEXTURE]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE]->Free();
-    delete m_pShader[SM_TEXTURE];
-    m_pShader[SM_TEXTURE] = nullptr;
+    m_pShader[SM_TEXTURE].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture.glsl - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_LIM] = new CGLShader("gl_shader_frag_texture_lim.glsl", defines);
+  m_pShader[SM_TEXTURE_LIM].reset(new CGLShader("gl_shader_frag_texture_lim.glsl", defines));
   if (!m_pShader[SM_TEXTURE_LIM]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE_LIM]->Free();
-    delete m_pShader[SM_TEXTURE_LIM];
-    m_pShader[SM_TEXTURE_LIM] = nullptr;
+    m_pShader[SM_TEXTURE_LIM].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture_lim.glsl - compile and link failed");
   }
 
-  m_pShader[SM_MULTI] = new CGLShader("gl_shader_frag_multi.glsl", defines);
+  m_pShader[SM_MULTI].reset(new CGLShader("gl_shader_frag_multi.glsl", defines));
   if (!m_pShader[SM_MULTI]->CompileAndLink())
   {
     m_pShader[SM_MULTI]->Free();
-    delete m_pShader[SM_MULTI];
-    m_pShader[SM_MULTI] = nullptr;
+    m_pShader[SM_MULTI].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_multi.glsl - compile and link failed");
   }
 
-  m_pShader[SM_FONTS] = new CGLShader("gl_shader_frag_fonts.glsl", defines);
+  m_pShader[SM_FONTS].reset(new CGLShader("gl_shader_frag_fonts.glsl", defines));
   if (!m_pShader[SM_FONTS]->CompileAndLink())
   {
     m_pShader[SM_FONTS]->Free();
-    delete m_pShader[SM_FONTS];
-    m_pShader[SM_FONTS] = nullptr;
+    m_pShader[SM_FONTS].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_fonts.glsl - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_NOBLEND] = new CGLShader("gl_shader_frag_texture_noblend.glsl", defines);
+  m_pShader[SM_TEXTURE_NOBLEND].reset(new CGLShader("gl_shader_frag_texture_noblend.glsl", defines));
   if (!m_pShader[SM_TEXTURE_NOBLEND]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE_NOBLEND]->Free();
-    delete m_pShader[SM_TEXTURE_NOBLEND];
-    m_pShader[SM_TEXTURE_NOBLEND] = nullptr;
+    m_pShader[SM_TEXTURE_NOBLEND].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_texture_noblend.glsl - compile and link failed");
   }
 
-  m_pShader[SM_MULTI_BLENDCOLOR] = new CGLShader("gl_shader_frag_multi_blendcolor.glsl", defines);
+  m_pShader[SM_MULTI_BLENDCOLOR].reset(new CGLShader("gl_shader_frag_multi_blendcolor.glsl", defines));
   if (!m_pShader[SM_MULTI_BLENDCOLOR]->CompileAndLink())
   {
     m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-    delete m_pShader[SM_MULTI_BLENDCOLOR];
-    m_pShader[SM_MULTI_BLENDCOLOR] = nullptr;
+    m_pShader[SM_MULTI_BLENDCOLOR].reset();
     CLog::Log(LOGERROR, "GUI Shader gl_shader_frag_multi_blendcolor.glsl - compile and link failed");
   }
 }
@@ -680,38 +672,31 @@ void CRenderSystemGL::ReleaseShaders()
 {
   if (m_pShader[SM_DEFAULT])
     m_pShader[SM_DEFAULT]->Free();
-  delete m_pShader[SM_DEFAULT];
-  m_pShader[SM_DEFAULT] = nullptr;
+  m_pShader[SM_DEFAULT].reset();
 
   if (m_pShader[SM_TEXTURE])
     m_pShader[SM_TEXTURE]->Free();
-  delete m_pShader[SM_TEXTURE];
-  m_pShader[SM_TEXTURE] = nullptr;
+  m_pShader[SM_TEXTURE].reset();
 
   if (m_pShader[SM_TEXTURE_LIM])
     m_pShader[SM_TEXTURE_LIM]->Free();
-  delete m_pShader[SM_TEXTURE_LIM];
-  m_pShader[SM_TEXTURE_LIM] = nullptr;
+  m_pShader[SM_TEXTURE_LIM].reset();
 
   if (m_pShader[SM_MULTI])
     m_pShader[SM_MULTI]->Free();
-  delete m_pShader[SM_MULTI];
-  m_pShader[SM_MULTI] = nullptr;
+  m_pShader[SM_MULTI].reset();
 
   if (m_pShader[SM_FONTS])
     m_pShader[SM_FONTS]->Free();
-  delete m_pShader[SM_FONTS];
-  m_pShader[SM_FONTS] = nullptr;
+  m_pShader[SM_FONTS].reset();
 
   if (m_pShader[SM_TEXTURE_NOBLEND])
     m_pShader[SM_TEXTURE_NOBLEND]->Free();
-  delete m_pShader[SM_TEXTURE_NOBLEND];
-  m_pShader[SM_TEXTURE_NOBLEND] = nullptr;
+  m_pShader[SM_TEXTURE_NOBLEND].reset();
 
   if (m_pShader[SM_MULTI_BLENDCOLOR])
     m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-  delete m_pShader[SM_MULTI_BLENDCOLOR];
-  m_pShader[SM_MULTI_BLENDCOLOR] = nullptr;
+  m_pShader[SM_MULTI_BLENDCOLOR].reset();
 }
 
 void CRenderSystemGL::EnableShader(ESHADERMETHOD method)

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -13,6 +13,9 @@
 #include "rendering/RenderSystem.h"
 #include "utils/Color.h"
 
+#include <array>
+#include <memory>
+
 enum ESHADERMETHOD
 {
   SM_DEFAULT = 0,
@@ -98,7 +101,7 @@ protected:
 
   GLint m_viewPort[4];
 
-  std::unique_ptr<CGLShader*[]> m_pShader;
+  std::array<std::unique_ptr<CGLShader>, SM_MAX> m_pShader;
   ESHADERMETHOD m_method = SM_DEFAULT;
   GLuint m_vertexArray = GL_NONE;
 };

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -23,7 +23,6 @@
 CRenderSystemGLES::CRenderSystemGLES()
  : CRenderSystemBase()
 {
-  m_pShader.reset(new CGLESShader*[SM_MAX]);
 }
 
 CRenderSystemGLES::~CRenderSystemGLES()
@@ -375,112 +374,96 @@ void CRenderSystemGLES::InitialiseShaders()
     defines += "#define KODI_LIMITED_RANGE 1\n";
   }
 
-  m_pShader[SM_DEFAULT] = new CGLESShader("gles_shader.vert", "gles_shader_default.frag", defines);
+  m_pShader[SM_DEFAULT].reset(new CGLESShader("gles_shader.vert", "gles_shader_default.frag", defines));
   if (!m_pShader[SM_DEFAULT]->CompileAndLink())
   {
     m_pShader[SM_DEFAULT]->Free();
-    delete m_pShader[SM_DEFAULT];
-    m_pShader[SM_DEFAULT] = nullptr;
+    m_pShader[SM_DEFAULT].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_default.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE] = new CGLESShader("gles_shader_texture.frag", defines);
+  m_pShader[SM_TEXTURE].reset(new CGLESShader("gles_shader_texture.frag", defines));
   if (!m_pShader[SM_TEXTURE]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE]->Free();
-    delete m_pShader[SM_TEXTURE];
-    m_pShader[SM_TEXTURE] = nullptr;
+    m_pShader[SM_TEXTURE].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture.frag - compile and link failed");
   }
 
-  m_pShader[SM_MULTI] = new CGLESShader("gles_shader_multi.frag", defines);
+  m_pShader[SM_MULTI].reset(new CGLESShader("gles_shader_multi.frag", defines));
   if (!m_pShader[SM_MULTI]->CompileAndLink())
   {
     m_pShader[SM_MULTI]->Free();
-    delete m_pShader[SM_MULTI];
-    m_pShader[SM_MULTI] = nullptr;
+    m_pShader[SM_MULTI].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_multi.frag - compile and link failed");
   }
 
-  m_pShader[SM_FONTS] = new CGLESShader("gles_shader_fonts.frag", defines);
+  m_pShader[SM_FONTS].reset(new CGLESShader("gles_shader_fonts.frag", defines));
   if (!m_pShader[SM_FONTS]->CompileAndLink())
   {
     m_pShader[SM_FONTS]->Free();
-    delete m_pShader[SM_FONTS];
-    m_pShader[SM_FONTS] = nullptr;
+    m_pShader[SM_FONTS].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_fonts.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_NOBLEND] = new CGLESShader("gles_shader_texture_noblend.frag", defines);
+  m_pShader[SM_TEXTURE_NOBLEND].reset(new CGLESShader("gles_shader_texture_noblend.frag", defines));
   if (!m_pShader[SM_TEXTURE_NOBLEND]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE_NOBLEND]->Free();
-    delete m_pShader[SM_TEXTURE_NOBLEND];
-    m_pShader[SM_TEXTURE_NOBLEND] = nullptr;
+    m_pShader[SM_TEXTURE_NOBLEND].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_texture_noblend.frag - compile and link failed");
   }
 
-  m_pShader[SM_MULTI_BLENDCOLOR] = new CGLESShader("gles_shader_multi_blendcolor.frag", defines);
+  m_pShader[SM_MULTI_BLENDCOLOR].reset(new CGLESShader("gles_shader_multi_blendcolor.frag", defines));
   if (!m_pShader[SM_MULTI_BLENDCOLOR]->CompileAndLink())
   {
     m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-    delete m_pShader[SM_MULTI_BLENDCOLOR];
-    m_pShader[SM_MULTI_BLENDCOLOR] = nullptr;
+    m_pShader[SM_MULTI_BLENDCOLOR].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_multi_blendcolor.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_RGBA] = new CGLESShader("gles_shader_rgba.frag", defines);
+  m_pShader[SM_TEXTURE_RGBA].reset(new CGLESShader("gles_shader_rgba.frag", defines));
   if (!m_pShader[SM_TEXTURE_RGBA]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE_RGBA]->Free();
-    delete m_pShader[SM_TEXTURE_RGBA];
-    m_pShader[SM_TEXTURE_RGBA] = nullptr;
+    m_pShader[SM_TEXTURE_RGBA].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR] = new CGLESShader("gles_shader_rgba_blendcolor.frag", defines);
+  m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR].reset(new CGLESShader("gles_shader_rgba_blendcolor.frag", defines));
   if (!m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
-    delete m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR];
-    m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR] = nullptr;
+    m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_blendcolor.frag - compile and link failed");
   }
 
-  m_pShader[SM_TEXTURE_RGBA_BOB] = new CGLESShader("gles_shader_rgba_bob.frag", defines);
+  m_pShader[SM_TEXTURE_RGBA_BOB].reset(new CGLESShader("gles_shader_rgba_bob.frag", defines));
   if (!m_pShader[SM_TEXTURE_RGBA_BOB]->CompileAndLink())
   {
     m_pShader[SM_TEXTURE_RGBA_BOB]->Free();
-    delete m_pShader[SM_TEXTURE_RGBA_BOB];
-    m_pShader[SM_TEXTURE_RGBA_BOB] = nullptr;
+    m_pShader[SM_TEXTURE_RGBA_BOB].reset();
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_bob.frag - compile and link failed");
   }
 
   if (IsExtSupported("GL_OES_EGL_image_external"))
   {
-    m_pShader[SM_TEXTURE_RGBA_OES] = new CGLESShader("gles_shader_rgba_oes.frag", defines);
+    m_pShader[SM_TEXTURE_RGBA_OES].reset(new CGLESShader("gles_shader_rgba_oes.frag", defines));
     if (!m_pShader[SM_TEXTURE_RGBA_OES]->CompileAndLink())
     {
       m_pShader[SM_TEXTURE_RGBA_OES]->Free();
-      delete m_pShader[SM_TEXTURE_RGBA_OES];
-      m_pShader[SM_TEXTURE_RGBA_OES] = nullptr;
+      m_pShader[SM_TEXTURE_RGBA_OES].reset();
       CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_oes.frag - compile and link failed");
     }
 
 
-    m_pShader[SM_TEXTURE_RGBA_BOB_OES] = new CGLESShader("gles_shader_rgba_bob_oes.frag", defines);
+    m_pShader[SM_TEXTURE_RGBA_BOB_OES].reset(new CGLESShader("gles_shader_rgba_bob_oes.frag", defines));
     if (!m_pShader[SM_TEXTURE_RGBA_BOB_OES]->CompileAndLink())
     {
       m_pShader[SM_TEXTURE_RGBA_BOB_OES]->Free();
-      delete m_pShader[SM_TEXTURE_RGBA_BOB_OES];
-      m_pShader[SM_TEXTURE_RGBA_BOB_OES] = nullptr;
+      m_pShader[SM_TEXTURE_RGBA_BOB_OES].reset();
       CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_bob_oes.frag - compile and link failed");
     }
-  }
-  else
-  {
-    m_pShader[SM_TEXTURE_RGBA_OES] = nullptr;
-    m_pShader[SM_TEXTURE_RGBA_BOB_OES] = nullptr;
   }
 }
 
@@ -488,58 +471,47 @@ void CRenderSystemGLES::ReleaseShaders()
 {
   if (m_pShader[SM_DEFAULT])
     m_pShader[SM_DEFAULT]->Free();
-  delete m_pShader[SM_DEFAULT];
-  m_pShader[SM_DEFAULT] = nullptr;
+  m_pShader[SM_DEFAULT].reset();
 
   if (m_pShader[SM_TEXTURE])
     m_pShader[SM_TEXTURE]->Free();
-  delete m_pShader[SM_TEXTURE];
-  m_pShader[SM_TEXTURE] = nullptr;
+  m_pShader[SM_TEXTURE].reset();
 
   if (m_pShader[SM_MULTI])
     m_pShader[SM_MULTI]->Free();
-  delete m_pShader[SM_MULTI];
-  m_pShader[SM_MULTI] = nullptr;
+  m_pShader[SM_MULTI].reset();
 
   if (m_pShader[SM_FONTS])
     m_pShader[SM_FONTS]->Free();
-  delete m_pShader[SM_FONTS];
-  m_pShader[SM_FONTS] = nullptr;
+  m_pShader[SM_FONTS].reset();
 
   if (m_pShader[SM_TEXTURE_NOBLEND])
     m_pShader[SM_TEXTURE_NOBLEND]->Free();
-  delete m_pShader[SM_TEXTURE_NOBLEND];
-  m_pShader[SM_TEXTURE_NOBLEND] = nullptr;
+  m_pShader[SM_TEXTURE_NOBLEND].reset();
 
   if (m_pShader[SM_MULTI_BLENDCOLOR])
     m_pShader[SM_MULTI_BLENDCOLOR]->Free();
-  delete m_pShader[SM_MULTI_BLENDCOLOR];
-  m_pShader[SM_MULTI_BLENDCOLOR] = nullptr;
+  m_pShader[SM_MULTI_BLENDCOLOR].reset();
 
   if (m_pShader[SM_TEXTURE_RGBA])
     m_pShader[SM_TEXTURE_RGBA]->Free();
-  delete m_pShader[SM_TEXTURE_RGBA];
-  m_pShader[SM_TEXTURE_RGBA] = nullptr;
+  m_pShader[SM_TEXTURE_RGBA].reset();
 
   if (m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR])
     m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR]->Free();
-  delete m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR];
-  m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR] = nullptr;
+  m_pShader[SM_TEXTURE_RGBA_BLENDCOLOR].reset();
 
   if (m_pShader[SM_TEXTURE_RGBA_BOB])
     m_pShader[SM_TEXTURE_RGBA_BOB]->Free();
-  delete m_pShader[SM_TEXTURE_RGBA_BOB];
-  m_pShader[SM_TEXTURE_RGBA_BOB] = nullptr;
+  m_pShader[SM_TEXTURE_RGBA_BOB].reset();
 
   if (m_pShader[SM_TEXTURE_RGBA_OES])
     m_pShader[SM_TEXTURE_RGBA_OES]->Free();
-  delete m_pShader[SM_TEXTURE_RGBA_OES];
-  m_pShader[SM_TEXTURE_RGBA_OES] = nullptr;
+  m_pShader[SM_TEXTURE_RGBA_OES].reset();
 
   if (m_pShader[SM_TEXTURE_RGBA_BOB_OES])
     m_pShader[SM_TEXTURE_RGBA_BOB_OES]->Free();
-  delete m_pShader[SM_TEXTURE_RGBA_BOB_OES];
-  m_pShader[SM_TEXTURE_RGBA_BOB_OES] = nullptr;
+  m_pShader[SM_TEXTURE_RGBA_BOB_OES].reset();
 }
 
 void CRenderSystemGLES::EnableGUIShader(ESHADERMETHOD method)

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -13,6 +13,8 @@
 #include "utils/Color.h"
 #include "GLESShader.h"
 
+#include <array>
+
 enum ESHADERMETHOD
 {
   SM_DEFAULT,
@@ -97,7 +99,7 @@ protected:
 
   std::string m_RenderExtensions;
 
-  std::unique_ptr<CGLESShader*[]> m_pShader;
+  std::array<std::unique_ptr<CGLESShader>, SM_MAX> m_pShader;
   ESHADERMETHOD m_method = SM_DEFAULT;
 
   GLint      m_viewPort[4];

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -39,7 +39,15 @@ CWeatherManager::CWeatherManager(void) : CInfoLoader(30 * 60 * 1000) // 30 minut
 
 CWeatherManager::~CWeatherManager(void)
 {
-  CServiceBroker::GetSettingsComponent()->GetSettings()->GetSettingsManager()->UnregisterCallback(this);
+  CSettingsComponent *settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return;
+
+  const std::shared_ptr<CSettings> settings = settingsComponent->GetSettings();
+  if (!settings)
+    return;
+
+  settings->GetSettingsManager()->UnregisterCallback(this);
 }
 
 std::string CWeatherManager::BusyInfo(int info) const

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -113,6 +113,9 @@ bool CWinSystemGbm::DestroyWindowSystem()
   m_GBM->DestroyDevice();
 
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - deinitialized DRM", __FUNCTION__);
+
+  m_libinput.reset();
+
   return true;
 }
 


### PR DESCRIPTION
I have been investigating why we segfault when windowing cannot be initialized.

This allows a clean shutdown if `false` is return somewhere in `InitWinSystem()`

If this isn't desired it would still be nice to add the nullptr checks