### PR TITLE
CryptThreading: reset CRYPTO_set_id_callback to nullptr in destructor

### DIFF
--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -55,6 +55,7 @@ CryptThreadingInitializer::~CryptThreadingInitializer()
 {
 #if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
   CSingleLock l(m_locksLock);
+  CRYPTO_set_id_callback(nullptr);
   CRYPTO_set_locking_callback(nullptr);
   m_locks.clear();
 #endif


### PR DESCRIPTION
Not sure if this was just missed before or what. It doesn't seem to change behavior at all it's just for clarity.