### PR TITLE
[GBM] add vt handler utility

### DIFF
--- a/xbmc/windowing/gbm/CMakeLists.txt
+++ b/xbmc/windowing/gbm/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES OptionalsReg.cpp
             DRMLegacy.cpp
             DRMAtomic.cpp
             OffScreenModeSetting.cpp
+            VTUtils.cpp
             WinSystemGbmEGLContext.cpp)
 
 set(HEADERS OptionalsReg.h
@@ -14,6 +15,7 @@ set(HEADERS OptionalsReg.h
             DRMLegacy.h
             DRMAtomic.h
             OffScreenModeSetting.h
+            VTUtils.h
             WinSystemGbmEGLContext.h)
 
 if (OPENGL_FOUND)

--- a/xbmc/windowing/gbm/VTUtils.cpp
+++ b/xbmc/windowing/gbm/VTUtils.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VTUtils.h"
+
+#include "platform/MessagePrinter.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <linux/major.h>
+#include <linux/kd.h>
+#include <linux/vt.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
+using namespace KODI::WINDOWING::GBM;
+
+bool CVTUtils::OpenTTY()
+{
+  m_ttyDevice = ttyname(STDIN_FILENO);
+
+  m_fd.attach(open(m_ttyDevice.c_str(), O_RDWR | O_CLOEXEC));
+  if (m_fd < 0)
+  {
+    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: failed to open tty: %s",  m_ttyDevice));
+    CLog::Log(LOGERROR, "CVTUtils::%s - failed to open tty: %s", __FUNCTION__, m_ttyDevice);
+    return false;
+  }
+
+  struct stat buf;
+  if (fstat(m_fd, &buf) == -1 || major(buf.st_rdev) != TTY_MAJOR || minor(buf.st_rdev) == 0)
+  {
+    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: %s is not a vt",  m_ttyDevice));
+    CLog::Log(LOGERROR, "CVTUtils::%s - %s is not a vt", __FUNCTION__, m_ttyDevice);
+    return false;
+  }
+
+  int kdMode{-1};
+  auto ret = ioctl(m_fd, KDGETMODE, &kdMode);
+  if (ret)
+  {
+    CLog::Log(LOGERROR, "CVTUtils::%s - failed to get VT mode: %s", __FUNCTION__, strerror(errno));
+    return false;
+  }
+
+  if (kdMode != KD_TEXT)
+  {
+    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: %s is already in graphics mode, is another display server running?", m_ttyDevice));
+    CLog::Log(LOGERROR, "CVTUtils::%s - %s is already in graphics mode, is another display server running?", __FUNCTION__, m_ttyDevice);
+    return false;
+  }
+
+  CLog::Log(LOGNOTICE, "CVTUtils::%s - opened tty: %s", __FUNCTION__, m_ttyDevice.c_str());
+
+  return true;
+}

--- a/xbmc/windowing/gbm/VTUtils.h
+++ b/xbmc/windowing/gbm/VTUtils.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/utils/FileHandle.h"
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace GBM
+{
+
+class CVTUtils
+{
+public:
+  CVTUtils() = default;
+  ~CVTUtils() = default;
+
+  bool OpenTTY();
+
+private:
+  KODI::UTILS::POSIX::CFileHandle m_fd;
+  std::string m_ttyDevice;
+};
+
+}
+}
+}

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -73,6 +73,11 @@ CWinSystemGbm::CWinSystemGbm() :
 
 bool CWinSystemGbm::InitWindowSystem()
 {
+  if (!m_vt.OpenTTY())
+  {
+    return false;
+  }
+
   m_DRM = std::make_shared<CDRMAtomic>();
 
   if (!m_DRM->InitDrm())

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -17,6 +17,7 @@
 #include "windowing/WinSystem.h"
 #include "DRMUtils.h"
 #include "VideoLayerBridge.h"
+#include "VTUtils.h"
 
 class IDispResource;
 
@@ -79,6 +80,9 @@ protected:
   XbmcThreads::EndTime m_dispResetTimer;
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
   std::unique_ptr<CLibInputHandler> m_libinput;
+
+private:
+  CVTUtils m_vt;
 };
 
 }


### PR DESCRIPTION
This allows us to control the virtual terminal and allows us to bail out if it's not in a state that we want.

@wsnipex this PR in combination with #14625 will allow `kodi-gbm` to fail gracefully when trying to run from and x11 session.

```
lukas@nuc8i7hnk ~/git/xbmc/build$ kodi -fs --standalone
ERROR: /dev/pts/2 is not a vt
ERROR: Unable to create GUI. Exiting
```
We can probably make this more verbose so it's more obvious what the issue is.