### PR TITLE
[addons] Remove game addons from addon-manifest

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -3,10 +3,6 @@
   <addon>audioencoder.kodi.builtin.wma</addon>
   <addon>game.controller.default</addon>
   <addon>game.controller.snes</addon>
-  <!-- TODO: Remove game add-ons when no longer applicable -->
-  <addon optional="true">game.libretro</addon>
-  <addon optional="true">game.libretro.2048</addon>
-  <addon optional="true">game.libretro.mrboom</addon>
   <addon>kodi.binary.global.audioengine</addon>
   <addon>kodi.binary.global.main</addon>
   <addon>kodi.binary.global.general</addon>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The game addons can be removed from manifest as you can install them from repo

