### PR TITLE
windowing/gbm: add MSAA settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7349,7 +7349,18 @@ msgctxt "#13521"
 msgid "Choose art type"
 msgstr ""
 
-#empty strings from id 13522 to 13549
+#empty strings from id 13522 to 13539
+
+#: system/settings/settings.xml
+msgctxt "#13540"
+msgid "MSAA (Multisample anti-aliasing)"
+msgstr ""
+
+msgctxt "#13541"
+msgid "Multisample anti-aliasing is the most common type of anti-aliasing that balances out quality and performance. Anti-aliasing is a technique used to smooth otherwise jagged lines or textures by blending the color of an edge with the color of pixels around it. The result should be a more pleasing and realistic appearance, depending on the intensity of the effect."
+msgstr ""
+
+#empty strings from id 13542 to 13549
 
 #: system/settings/settings.xml
 msgctxt "#13550"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2360,6 +2360,15 @@
           </dependencies>
           <control type="spinner" format="integer" />
         </setting>
+        <setting id="videoscreen.msaa" type="integer" label="13540" help="13541">
+          <visible>false</visible>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>msaa</options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
       </group>
       <group id="2" label="14232">
         <setting id="videoscreen.stereoscopicmode" type="integer" label="36500" help="36539">

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -14,6 +14,9 @@
 #include <stdexcept>
 #include <vector>
 
+#include "settings/lib/ISettingsHandler.h"
+#include "settings/Settings.h"
+
 #include <EGL/egl.h>
 
 class CEGLUtils
@@ -158,7 +161,7 @@ private:
   int m_writePosition{};
 };
 
-class CEGLContextUtils final
+class CEGLContextUtils : public ISettingsHandler
 {
 public:
   CEGLContextUtils();
@@ -185,6 +188,7 @@ public:
   bool CreateSurface(EGLNativeWindowType nativeWindow);
   bool CreatePlatformSurface(void* nativeWindow, EGLNativeWindowType nativeWindowLegacy);
   bool CreateContext(CEGLAttributesVec contextAttribs);
+  bool ChooseConfig(EGLint renderableType, EGLint visualId);
   bool BindContext();
   void Destroy();
   void DestroySurface();
@@ -210,9 +214,11 @@ public:
     return m_eglConfig;
   }
 
+  static const std::string SETTING_VIDEOSCREEN_MSAA;
+  static void SettingOptionsMsaaFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+
 private:
   bool InitializeDisplay(EGLint renderableType, EGLint renderingApi, EGLint visualId = 0);
-  bool ChooseConfig(EGLint renderableType, EGLint visualId);
   void SurfaceAttrib();
 
   EGLenum m_platform{EGL_NONE};

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include "settings/lib/ISettingCallback.h"
 #include "utils/EGLUtils.h"
 #include "WinSystemGbm.h"
+
 #include <memory>
 
 namespace KODI
@@ -21,11 +23,9 @@ namespace GBM
 
 class CVaapiProxy;
 
-class CWinSystemGbmEGLContext : public CWinSystemGbm
+class CWinSystemGbmEGLContext : public CWinSystemGbm, public ISettingCallback
 {
 public:
-  virtual ~CWinSystemGbmEGLContext() = default;
-
   bool DestroyWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
@@ -35,10 +35,12 @@ public:
   EGLSurface GetEGLSurface() const;
   EGLContext GetEGLContext() const;
   EGLConfig  GetEGLConfig() const;
+
+  void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
+
 protected:
-  CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension) :
-    m_eglContext(platform, platformExtension)
-  {}
+  CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension);
+  ~CWinSystemGbmEGLContext();
 
   /**
    * Inheriting classes should override InitWindowSystem() without parameters

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -59,11 +59,11 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
 
 bool CWinSystemGbmGLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
-  if (res.iWidth != m_nWidth ||
-      res.iHeight != m_nHeight)
+  CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::%s - creating a new window", __FUNCTION__);
+
+  if (!CreateNewWindow("", fullScreen, res))
   {
-    CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::%s - resolution changed, creating a new window", __FUNCTION__);
-    CreateNewWindow("", fullScreen, res);
+    return false;
   }
 
   if (!m_eglContext.TrySwapBuffers())

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -71,11 +71,11 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
 
 bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
-  if (res.iWidth != m_nWidth ||
-      res.iHeight != m_nHeight)
+  CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::%s - creating a new window", __FUNCTION__);
+
+  if (!CreateNewWindow("", fullScreen, res))
   {
-    CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::%s - resolution changed, creating a new window", __FUNCTION__);
-    CreateNewWindow("", fullScreen, res);
+    return false;
   }
 
   if (!m_eglContext.TrySwapBuffers())


### PR DESCRIPTION
This adds the ability to change the msaa buffer level used in the egl config. This is only usable if the egl extension "EGL_KHR_no_config_context" is present.

I'm not a big fan of the way I enumerate the msaa values available and am open to suggestions about how to improve that.

reference [here](https://gitlab.freedesktop.org/mesa/kmscube/commit/9dcce71e603616ee7a54707e932f962cdf8fb20a)