### PR TITLE
[cmake] Download depends zip/tarballs into separate dirs

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -231,7 +231,7 @@ function(add_addon_depends addon searchpath)
                                     -DCMAKE_INCLUDE_PATH=${OUTPUT_DIR}/include)
             endif()
 
-            set(DOWNLOAD_DIR ${BUILD_DIR}/download)
+            set(DOWNLOAD_DIR ${BUILD_DIR}/${id}/download)
             if(EXISTS ${dir}/${id}.sha256)
               file(STRINGS ${dir}/${id}.sha256 sha256sum)
               list(GET sha256sum 0 sha256sum)


### PR DESCRIPTION
@Rechi , @notspiff as discussed on slack:

## Description
When building multiple binary addons at once, their dependencies would
be downloaded into the same directory overriding existing files.

This is only an issue for zip files & tarballs. Depends that are
fetched from git are not affected.

This change is required to change the game addons to download archives instead of fetching from git: https://github.com/fetzerch/kodi-game-scripting/pull/36

## Motivation and Context
Be able to build multiple game addons at once if they specifiy URL/file based depends.

## How Has This Been Tested?
Locally on my machine by building addons with kodi-game-scripting.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
