### PR TITLE
added: flag for vfs add-ons with encoded hostnames in urls

### DIFF
--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -69,8 +69,8 @@ const TestFileData MovieFiles[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\f
                                    { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/art.jpg" },
                                    { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01-art.jpg" },
                                    { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/art.jpg" },
-                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere-art.jpg" },
-                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\art.jpg" },
+                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere-art.jpg" },
+                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true, "g:\\multimedia\\movies\\art.jpg" },
                                    { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/art.jpg" },
                                    { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/art.jpg" },
                                    { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/art.jpg" },
@@ -96,7 +96,7 @@ const TestFileData NoArtFiles[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\f
                                    { "/dir/filename.avi", false, "/dir/filename.tbn" },
                                    { "smb://somepath/file.avi", false, "smb://somepath/file.tbn" },
                                    { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.tbn" },
-                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere.tbn" }};
+                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere.tbn" }};
 
 INSTANTIATE_TEST_CASE_P(NoArt, TestFileItemFallbackArt, ValuesIn(NoArtFiles));
 
@@ -124,7 +124,7 @@ const TestFileData BaseMovies[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\f
                                    { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/" },
                                    { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi" },
                                    { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/" },
-                                   { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\" },
+                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true, "g:\\multimedia\\movies\\" },
                                    { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/" },
                                    { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/" },
                                    { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/" },

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -140,6 +140,16 @@ void CFileExtensionProvider::SetAddonExtensions(const TYPE& type)
         if (addonInfo->Type(type)->GetValue(info2).asBoolean())
           fileFolderExtensions.push_back(ext);
       }
+      if (type == ADDON_VFS)
+      {
+        if (addonInfo->Type(type)->GetValue("@encodedhostname").asBoolean())
+        {
+          std::string prot = addonInfo->Type(type)->GetValue("@protocols").asString();
+          auto prots = StringUtils::Split(prot, "|");
+          for (const std::string& it : prots)
+            m_encoded.push_back(it);
+        }
+      }
     }
   }
 
@@ -167,4 +177,9 @@ void CFileExtensionProvider::OnAddonEvent(const AddonEvent& event)
   {
     SetAddonExtensions();
   }
+}
+
+bool CFileExtensionProvider::EncodedHostName(const std::string& protocol) const
+{
+  return std::find(m_encoded.begin(),m_encoded.end(),protocol) != m_encoded.end();
 }

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -55,6 +55,11 @@ public:
    */
   std::string GetFileFolderExtensions() const;
 
+  /*!
+   * @brief Returns whether a url protocol from add-ons use encoded hostnames
+   */
+  bool EncodedHostName(const std::string& protocol) const;
+
 private:
   std::string GetAddonExtensions(const ADDON::TYPE &type) const;
   std::string GetAddonFileFolderExtensions(const ADDON::TYPE &type) const;
@@ -71,4 +76,7 @@ private:
   // File extension properties
   std::map<ADDON::TYPE, std::string> m_addonExtensions;
   std::map<ADDON::TYPE, std::string> m_addonFileFolderExtensions;
+
+  // Protocols from add-ons with encoded host names
+  std::vector<std::string> m_encoded;
 };

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -275,8 +275,6 @@ void URIUtils::GetCommonPath(std::string& strParent, const std::string& strPath)
 bool URIUtils::HasParentInHostname(const CURL& url)
 {
   return url.IsProtocol("zip")
-      || url.IsProtocol("rar")
-      || url.IsProtocol("archive")
       || url.IsProtocol("apk")
       || url.IsProtocol("bluray")
       || url.IsProtocol("udf")

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -280,7 +280,9 @@ bool URIUtils::HasParentInHostname(const CURL& url)
       || url.IsProtocol("apk")
       || url.IsProtocol("bluray")
       || url.IsProtocol("udf")
-      || url.IsProtocol("xbt");
+      || url.IsProtocol("xbt")
+      || (CServiceBroker::IsBinaryAddonCacheUp() &&
+          CServiceBroker::GetFileExtensionProvider().EncodedHostName(url.GetProtocol()));
 }
 
 bool URIUtils::HasEncodedHostname(const CURL& url)

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -284,13 +284,11 @@ TEST_F(TestURIUtils, IsHD)
   EXPECT_TRUE(URIUtils::IsHD("special://path/to/file"));
   EXPECT_TRUE(URIUtils::IsHD("stack://path/to/file"));
   EXPECT_TRUE(URIUtils::IsHD("zip://path/to/file"));
-  EXPECT_TRUE(URIUtils::IsHD("rar://path/to/file"));
 }
 
 TEST_F(TestURIUtils, IsInArchive)
 {
   EXPECT_TRUE(URIUtils::IsInArchive("zip://path/to/file"));
-  EXPECT_TRUE(URIUtils::IsInArchive("rar://path/to/file"));
 }
 
 TEST_F(TestURIUtils, IsInRAR)
@@ -477,14 +475,12 @@ TEST_F(TestURIUtils, AddFileToFolder)
 TEST_F(TestURIUtils, HasParentInHostname)
 {
   EXPECT_TRUE(URIUtils::HasParentInHostname(CURL("zip://")));
-  EXPECT_TRUE(URIUtils::HasParentInHostname(CURL("rar://")));
   EXPECT_TRUE(URIUtils::HasParentInHostname(CURL("bluray://")));
 }
 
 TEST_F(TestURIUtils, HasEncodedHostname)
 {
   EXPECT_TRUE(URIUtils::HasEncodedHostname(CURL("zip://")));
-  EXPECT_TRUE(URIUtils::HasEncodedHostname(CURL("rar://")));
   EXPECT_TRUE(URIUtils::HasEncodedHostname(CURL("bluray://")));
   EXPECT_TRUE(URIUtils::HasEncodedHostname(CURL("musicsearch://")));
 }
@@ -538,34 +534,34 @@ TEST_F(TestURIUtils, GetRealPath)
 #endif
 
   // test rar/zip paths
-  ref = "rar://%2fpath%2fto%2frar/subpath/to/file";
+  ref = "zip://%2fpath%2fto%2fzip/subpath/to/file";
   EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath(ref).c_str());
 
   // test rar/zip paths
-  ref = "rar://%2fpath%2fto%2frar/subpath/to/file";
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/../subpath/to/file").c_str());
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/./subpath/to/file").c_str());
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/subpath/to/./file").c_str());
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2frar/subpath/to/some/../file").c_str());
+  ref = "zip://%2fpath%2fto%2fzip/subpath/to/file";
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://%2fpath%2fto%2fzip/../subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://%2fpath%2fto%2fzip/./subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://%2fpath%2fto%2fzip/subpath/to/./file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://%2fpath%2fto%2fzip/subpath/to/some/../file").c_str());
 
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2f.%2frar/subpath/to/file").c_str());
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("rar://%2fpath%2fto%2fsome%2f..%2frar/subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://%2fpath%2fto%2f.%2fzip/subpath/to/file").c_str());
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://%2fpath%2fto%2fsome%2f..%2fzip/subpath/to/file").c_str());
 
-  // test rar/zip path in rar/zip path
-  ref ="zip://rar%3a%2f%2f%252Fpath%252Fto%252Frar%2fpath%2fto%2fzip/subpath/to/file";
-  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://rar%3a%2f%2f%252Fpath%252Fto%252Fsome%252F..%252Frar%2fpath%2fto%2fsome%2f..%2fzip/subpath/to/some/../file").c_str());
+  // test zip/zip path
+  ref ="zip://zip%3a%2f%2f%252Fpath%252Fto%252Fzip%2fpath%2fto%2fzip/subpath/to/file";
+  EXPECT_STRCASEEQ(ref.c_str(), URIUtils::GetRealPath("zip://zip%3a%2f%2f%252Fpath%252Fto%252Fsome%252F..%252Fzip%2fpath%2fto%2fsome%2f..%2fzip/subpath/to/some/../file").c_str());
 }
 
 TEST_F(TestURIUtils, UpdateUrlEncoding)
 {
-  std::string oldUrl = "stack://rar://%2fpath%2fto%2farchive%2fsome%2darchive%2dfile%2eCD1%2erar/video.avi , rar://%2fpath%2fto%2farchive%2fsome%2darchive%2dfile%2eCD2%2erar/video.avi";
-  std::string newUrl = "stack://rar://%2fpath%2fto%2farchive%2fsome-archive-file.CD1.rar/video.avi , rar://%2fpath%2fto%2farchive%2fsome-archive-file.CD2.rar/video.avi";
+  std::string oldUrl = "stack://zip://%2fpath%2fto%2farchive%2fsome%2darchive%2dfile%2eCD1%2ezip/video.avi , zip://%2fpath%2fto%2farchive%2fsome%2darchive%2dfile%2eCD2%2ezip/video.avi";
+  std::string newUrl = "stack://zip://%2fpath%2fto%2farchive%2fsome-archive-file.CD1.zip/video.avi , zip://%2fpath%2fto%2farchive%2fsome-archive-file.CD2.zip/video.avi";
 
   EXPECT_TRUE(URIUtils::UpdateUrlEncoding(oldUrl));
   EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
 
-  oldUrl = "rar://%2fpath%2fto%2farchive%2fsome%2darchive%2efile%2erar/video.avi";
-  newUrl = "rar://%2fpath%2fto%2farchive%2fsome-archive.file.rar/video.avi";
+  oldUrl = "zip://%2fpath%2fto%2farchive%2fsome%2darchive%2efile%2ezip/video.avi";
+  newUrl = "zip://%2fpath%2fto%2farchive%2fsome-archive.file.zip/video.avi";
 
   EXPECT_TRUE(URIUtils::UpdateUrlEncoding(oldUrl));
   EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());


### PR DESCRIPTION
So we can remove hardcoded things from core. If this is accepted for v18, I'll update the add-ons.