### PR TITLE
[PVR] Fix CID 188792:  Memory - illegal accesses  (WRAPPER_ESCAPE).

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -656,7 +656,8 @@ public:
     m_strIMDBNumber(kodiTag->IMDBNumber()),
     m_strEpisodeName(kodiTag->EpisodeName(true)),
     m_strIconPath(kodiTag->Icon()),
-    m_strSeriesLink(kodiTag->SeriesLink())
+    m_strSeriesLink(kodiTag->SeriesLink()),
+    m_strGenreDescription(kodiTag->GetGenresLabel())
   {
     time_t t;
     kodiTag->StartAsUTC().GetAsTime(t);
@@ -688,7 +689,7 @@ public:
     strEpisodeName = m_strEpisodeName.c_str();
     strIconPath = m_strIconPath.c_str();
     strSeriesLink = m_strSeriesLink.c_str();
-    strGenreDescription = kodiTag->GetGenresLabel().c_str();
+    strGenreDescription = m_strGenreDescription.c_str();
   }
 
   virtual ~CAddonEpgTag() = default;
@@ -705,6 +706,7 @@ private:
   std::string m_strEpisodeName;
   std::string m_strIconPath;
   std::string m_strSeriesLink;
+  std::string m_strGenreDescription;
 };
 
 PVR_ERROR CPVRClient::IsRecordable(const CConstPVREpgInfoTagPtr &tag, bool &bIsRecordable) const


### PR DESCRIPTION
Fixes a Coverity issue introduced by #14616.

<pre>
*** CID 188792:  Memory - illegal accesses  (WRAPPER_ESCAPE)
/xbmc/addons/PVRClient.cpp: 691 in PVR::CAddonEpgTag::CAddonEpgTag(std::shared_ptr<const PVR::CPVREpgInfoTag>)()
685         strDirector = m_strDirector.c_str();
686         strWriter = m_strWriter.c_str();
687         strIMDBNumber = m_strIMDBNumber.c_str();
688         strEpisodeName = m_strEpisodeName.c_str();
689         strIconPath = m_strIconPath.c_str();
690         strSeriesLink = m_strSeriesLink.c_str();
>>>     CID 188792:  Memory - illegal accesses  (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string const" escapes into "this->strGenreDescription", but is destroyed when it exits scope.
691         strGenreDescription = kodiTag->GetGenresLabel().c_str();
692       }
693     
694       virtual ~CAddonEpgTag() = default;
695     
696     private:
</pre>