### PR TITLE
[addons] bump repository.xbmc.org to 3.1.3

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.xbmc.org"
 		name="Kodi Add-on repository"
-		version="3.1.2"
+		version="3.1.3"
 		provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.addon" version="12.0.0"/>


### PR DESCRIPTION
## Motivation and Context
This is required, that the repo gets re-evaluated with the new new platform identifiers introduced at #13600.
