### PR TITLE
fixed: KODI_BUILD_DIR mirroring of custom data

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -341,10 +341,11 @@ macro (build_addon target prefix libs)
   if(${APP_NAME_UC}_BUILD_DIR)
     file(GLOB_RECURSE files ${CMAKE_CURRENT_SOURCE_DIR}/${target}/*)
     if(${prefix}_CUSTOM_DATA)
+      get_filename_component(dname ${${prefix}_CUSTOM_DATA} NAME)
       add_custom_command(TARGET ${target} POST_BUILD
                          COMMAND ${CMAKE_COMMAND} -E copy_directory
                                  ${${prefix}_CUSTOM_DATA}
-                                 ${${APP_NAME_UC}_BUILD_DIR}/addons/${target}/resources)
+                                 ${${APP_NAME_UC}_BUILD_DIR}/addons/${target}/resources/${dname})
     endif()
     foreach(file ${files})
       string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/${target}/" "" name "${file}")


### PR DESCRIPTION
On install(DIRECTORY), a subfolder is created matching the installed folder. we need to mirror accordingly in the KODI_BUILD_DIR configuration so get consistent paths.