### PR TITLE
GUIMediaWindow: Add "Get more..." link to add-on sources dir

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13893,7 +13893,7 @@ msgid "Internet connection required."
 msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
-#: xbmc/filesystem/AddonsDirectory.cpp
+#: xbmc/windows/GUIMediaWindow.cpp
 #: addons/skin.estuary/xml/DialogGameControllers.xml
 #: addons/skin.estuary/xml/Includes.xml
 #: addons/skin.estuary/xml/MyGames.xml

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -781,6 +781,20 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
     }
   }
 
+  // Add "Get more..." link for add-on sources
+  if (StringUtils::StartsWith(strDirectory, "addons://sources/"))
+  {
+    std::string content = pathToUrl.GetFileName();
+    size_t slashPos = content.find('/');
+    if (slashPos != std::string::npos)
+      content = content.substr(0, slashPos);
+    CFileItemPtr item(new CFileItem("addons://more/" + content, true));
+    item->SetLabel(g_localizeStrings.Get(21452)); // "Get more..."
+    item->SetIconImage("DefaultAddon.png");
+    item->SetSpecialSort(SortSpecialOnBottom);
+    items.Add(std::move(item));
+  }
+
   // clear the filter
   SetProperty("filter", "");
   m_canFilterAdvanced = false;


### PR DESCRIPTION
Problem: When the user enters an empty add-ons source, the add-on browser can be opened from the left menu, but this menu is well hidden and not accessible to new users.

This PR adds a "Get more..." link to hook the user up with add-ons. This makes game (and other) add-ons easier to install for new users.

There is still some problems, so I'm opening this PR to get feedback.

It should be noted that, at one point, this link was added at the VFS level. This PR adds it at the media window level, so there are still some paths where the link is missing.

## How Has This Been Tested?
Tested on Linux with no add-ons. There is still some problems (see below).

## Screenshots (if appropriate):
After this PR:

![screenshot from 2018-10-18 13-43-30](https://user-images.githubusercontent.com/531482/47183002-d18ab780-d2db-11e8-9207-203540af70c2.png)

However, this only works when the path is `addons://sources/<content>/`. For the video add-ons node, the path is `library://video/addons.xml/` which uses the following XML:

```xml
<node order="60" type="folder">
	<label>1037</label>
	<icon>DefaultAddonVideo.png</icon>
	<path>addons://sources/video/</path>
</node>
```

As a result, "Get more..." is not shown at first, but if the user backs out of the folder and re-enters, then the "Get more..." link shows up.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
