### PR TITLE
[fix][win10] relocate InitOSKeymap after #14511

### DIFF
--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -53,8 +53,6 @@ void App::Initialize(const CoreApplicationView& applicationView)
 
   // At this point we have access to the device.
   // We can create the device-dependent resources.
-  CWinEventsWin10::InitOSKeymap();
-
   // Initialise Winsock
   WSADATA wd;
   WSAStartup(MAKEWORD(2, 2), &wd);

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -109,6 +109,8 @@ size_t CWinEventsWin10::GetQueueSize()
 
 void CWinEventsWin10::InitEventHandlers(const CoreWindow& window)
 {
+  CWinEventsWin10::InitOSKeymap();
+
   //window->SetPointerCapture();
 
   // window


### PR DESCRIPTION
## Description
CServiceBroker::GetSettingsComponent() is called at a time where it doesn't exist

## Motivation and Context
fixes hard crash on start

## How Has This Been Tested?
started Kodi and pressed a few buttons

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
