### PR TITLE
Fix infinite loop when listitem action is "Play"

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -752,7 +752,7 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
 bool CGUIBaseContainer::OnClick(int actionID)
 {
   int subItem = 0;
-  if (actionID == ACTION_SELECT_ITEM || actionID == ACTION_MOUSE_LEFT_CLICK || actionID == ACTION_PLAYER_PLAY)
+  if (actionID == ACTION_SELECT_ITEM || actionID == ACTION_MOUSE_LEFT_CLICK)
   {
     if (m_listProvider)
     { // "select" action


### PR DESCRIPTION
This fixes an infinite loop, noticed in the Game OSD, when clicking the "Play" item.

The Game OSD is a static list container. The top item has "Play" as a click action:

```xml

<control type="list" id="1103">
	<content>
		<item id="2101">
			<description>Pause / Resume button</description>
			<label>$LOCALIZE[35224]</label>
			<label2>Select + X</label2>
			<icon>osd/fullscreen/buttons/play.png</icon>
			<onclick>Play</onclick>
		</item>
```
The problem is the list container considers Play to be equivalent to Select. The GUI receives messages before the player, so it intercepts the Play action as a Select action. This executes the OnClick action, which is Play, and the process continues ad infinitum.

This bug was introduced in https://github.com/xbmc/xbmc/pull/14513.

## Motivation and Context
Discovered while testing Beta 4.

## How Has This Been Tested?
Tested on OSX with several cores.

## Screenshots (if appropriate):
Infinite loop:

![screen shot 2018-10-19 at 12 51 10 pm](https://user-images.githubusercontent.com/531482/47241072-378c4300-d39f-11e8-81ee-0643ffcc7e83.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
