### PR TITLE
Fix broken controller input in games

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -215,6 +215,7 @@ void CGameClientInput::ActivateControllers(CControllerHub &hub)
 {
   for (auto &port : hub.Ports())
   {
+    port.SetConnected(true);
     port.SetActiveController(0);
     ActivateControllers(port.ActiveController().Hub());
   }


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/xbmc/xbmc/pull/14508. Allow me to quote myself:

> There was a rebase error so I included three refactors from my retroplayer-18beta3 branch. These have been in the test builds for quite a while, so not too risky I hope.

Although these commits were in my test branch, a single line was located in the wrong commit, which wasn't included. This PR imports that line.

Closes #14654.

## Motivation and Context
Reported by @AlwinEsch here: https://github.com/xbmc/xbmc/issues/14654

## How Has This Been Tested?
Tested on Linux X11 64-bit. Before no input in games, after working input in games.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
