### PR TITLE
Game API: v1.1.0 - Sync with RetroPlayer test builds

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -203,12 +203,12 @@ bool EnableMouse(bool enable, const game_controller* controller);
  * To connect a multitap to the console's first port, the multitap's controller
  * info is set using the port address:
  *
- *     1
+ *     /1
  *
  * To connect a SNES controller to the second port of the multitap, the
  * controller info is next set using the address:
  *
- *     1/game.controller.multitap/2
+ *     /1/game.controller.multitap/2
  *
  * Any attempts to connect a controller to a port on a disconnected multitap
  * will return false.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -153,31 +153,42 @@ game_input_topology* GetTopology();
 void FreeTopology(game_input_topology* topology);
 
 /*!
+ * \brief Set the layouts for known controllers
+ *
+ * \param controllers The controller layouts
+ * \param controller_count The number of items in the array
+ *
+ * After loading the input topology, the frontend will call this with
+ * controller layouts for all controllers discovered in the topology.
+ */
+void SetControllerLayouts(const game_controller_layout* controllers, unsigned int controller_count);
+
+/*!
  * \brief Enable/disable keyboard input using the specified controller
  *
  * \param enable True to enable input, false otherwise
- * \param controller The controller info if enabling, or unused if disabling
+ * \param controller_id The controller ID if enabling, or unused if disabling
  *
  * \return True if keyboard input was enabled, false otherwise
  */
-bool EnableKeyboard(bool enable, const game_controller* controller);
+bool EnableKeyboard(bool enable, const char* controller_id);
 
 /*!
  * \brief Enable/disable mouse input using the specified controller
  *
  * \param enable True to enable input, false otherwise
- * \param controller The controller info if enabling, or unused if disabling
+ * \param controller_id The controller ID if enabling, or unused if disabling
  *
  * \return True if mouse input was enabled, false otherwise
  */
-bool EnableMouse(bool enable, const game_controller* controller);
+bool EnableMouse(bool enable, const char* controller_id);
 
 /*!
  * \brief Connect/disconnect a controller to a port on the virtual game console
  *
  * \param connect True to connect a controller, false to disconnect
  * \param port_address The address of the port
- * \param controller The controller info if connecting, or unused if disconnecting
+ * \param controller_id The controller ID if connecting, or unused if disconnecting
  * \return True if the \p controller was (dis-)connected to the port, false otherwise
  *
  * The address is a string that allows traversal of the controller topology.
@@ -213,7 +224,7 @@ bool EnableMouse(bool enable, const game_controller* controller);
  * Any attempts to connect a controller to a port on a disconnected multitap
  * will return false.
  */
-bool ConnectController(bool connect, const char* port_address, const game_controller* controller);
+bool ConnectController(bool connect, const char* port_address, const char* controller_id);
 
 /*!
  * \brief Notify the add-on of an input event
@@ -310,6 +321,7 @@ void __declspec(dllexport) get_addon(void* ptr)
   pClient->toAddon.HasFeature               = HasFeature;
   pClient->toAddon.GetTopology              = GetTopology;
   pClient->toAddon.FreeTopology             = FreeTopology;
+  pClient->toAddon.SetControllerLayouts     = SetControllerLayouts;
   pClient->toAddon.EnableKeyboard           = EnableKeyboard;
   pClient->toAddon.EnableMouse              = EnableMouse;
   pClient->toAddon.ConnectController        = ConnectController;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -446,19 +446,27 @@ typedef enum GAME_PORT_TYPE
   GAME_PORT_CONTROLLER,
 } GAME_PORT_TYPE;
 
-typedef struct game_controller
+typedef struct game_controller_layout
 {
-  const char*  controller_id;
+  char*        controller_id;
   bool         provides_input; // False for multitaps
+  char**       digital_buttons;
   unsigned int digital_button_count;
+  char**       analog_buttons;
   unsigned int analog_button_count;
+  char**       analog_sticks;
   unsigned int analog_stick_count;
+  char**       accelerometers;
   unsigned int accelerometer_count;
+  char**       keys;
   unsigned int key_count;
+  char**       rel_pointers;
   unsigned int rel_pointer_count;
+  char**       abs_pointers;
   unsigned int abs_pointer_count;
+  char**       motors;
   unsigned int motor_count;
-} ATTRIBUTE_PACKED game_controller;
+} ATTRIBUTE_PACKED game_controller_layout;
 
 struct game_input_port;
 
@@ -680,9 +688,10 @@ typedef struct KodiToAddonFuncTable_Game
   bool        (__cdecl* HasFeature)(const char*, const char*);
   game_input_topology* (__cdecl* GetTopology)();
   void        (__cdecl* FreeTopology)(game_input_topology*);
-  bool        (__cdecl* EnableKeyboard)(bool, const game_controller*);
-  bool        (__cdecl* EnableMouse)(bool, const game_controller*);
-  bool        (__cdecl* ConnectController)(bool, const char*, const game_controller*);
+  void        (__cdecl* SetControllerLayouts)(const game_controller_layout*, unsigned int);
+  bool        (__cdecl* EnableKeyboard)(bool, const char*);
+  bool        (__cdecl* EnableMouse)(bool, const char*);
+  bool        (__cdecl* ConnectController)(bool, const char*, const char*);
   bool        (__cdecl* InputEvent)(const game_input_event*);
   size_t      (__cdecl* SerializeSize)(void);
   GAME_ERROR  (__cdecl* Serialize)(uint8_t*, size_t);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_game.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_game.h
@@ -135,15 +135,15 @@ public:
   // --- Input callbacks -------------------------------------------------------
 
   /*!
-  * \brief Notify the port of an input event
-  *
-  * \param event The input event
-  *
-  * Input events can arrive for the following sources:
-  *   - GAME_INPUT_EVENT_MOTOR
-  *
-  * \return true if the event was handled, false otherwise
-  */
+   * \brief Notify the port of an input event
+   *
+   * \param event The input event
+   *
+   * Input events can arrive for the following sources:
+   *   - GAME_INPUT_EVENT_MOTOR
+   *
+   * \return true if the event was handled, false otherwise
+   */
   bool InputEvent(const game_input_event& event)
   {
     return m_callbacks->toKodi.InputEvent(m_callbacks->toKodi.kodiInstance, &event);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -75,8 +75,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_XML_ID    "kodi.binary.instance.audioencoder"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "1.0.38"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "1.0.38"
+#define ADDON_INSTANCE_VERSION_GAME                   "1.0.39"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "1.0.39"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "kodi_game_dll.h" \
                                                       "kodi_game_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -75,8 +75,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_XML_ID    "kodi.binary.instance.audioencoder"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "1.0.39"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "1.0.39"
+#define ADDON_INSTANCE_VERSION_GAME                   "1.1.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "1.1.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "kodi_game_dll.h" \
                                                       "kodi_game_types.h" \

--- a/xbmc/games/addons/input/CMakeLists.txt
+++ b/xbmc/games/addons/input/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES GameClientDevice.cpp
+set(SOURCES GameClientController.cpp
+            GameClientDevice.cpp
             GameClientHardware.cpp
             GameClientInput.cpp
             GameClientJoystick.cpp
@@ -8,7 +9,8 @@ set(SOURCES GameClientDevice.cpp
             GameClientTopology.cpp
 )
 
-set(HEADERS GameClientDevice.h
+set(HEADERS GameClientController.h
+            GameClientDevice.h
             GameClientHardware.h
             GameClientInput.h
             GameClientJoystick.h

--- a/xbmc/games/addons/input/GameClientController.cpp
+++ b/xbmc/games/addons/input/GameClientController.cpp
@@ -1,0 +1,139 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameClientController.h"
+#include "GameClientInput.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerFeature.h"
+#include "games/controllers/ControllerLayout.h"
+#include "games/controllers/ControllerTopology.h"
+
+#include <algorithm>
+#include <vector>
+
+using namespace KODI;
+using namespace GAME;
+
+CGameClientController::CGameClientController(CGameClientInput &input, ControllerPtr controller) :
+  m_input(input),
+  m_controller(std::move(controller)),
+  m_controllerId(m_controller->ID())
+{
+  // Generate arrays of features
+  for (const CControllerFeature &feature : m_controller->Features())
+  {
+    // Skip feature if not supported by the game client
+    if (!m_input.HasFeature(m_controller->ID(), feature.Name()))
+      continue;
+
+    // Add feature to array of the appropriate type
+    switch (feature.Type())
+    {
+      case FEATURE_TYPE::SCALAR:
+      {
+        switch (feature.InputType())
+        {
+          case JOYSTICK::INPUT_TYPE::DIGITAL:
+            m_digitalButtons.emplace_back(const_cast<char*>(feature.Name().c_str()));
+            break;
+          case JOYSTICK::INPUT_TYPE::ANALOG:
+            m_analogButtons.emplace_back(const_cast<char*>(feature.Name().c_str()));
+            break;
+          default:
+            break;
+        }
+        break;
+      }
+      case FEATURE_TYPE::ANALOG_STICK:
+        m_analogSticks.emplace_back(const_cast<char*>(feature.Name().c_str()));
+        break;
+      case FEATURE_TYPE::ACCELEROMETER:
+        m_accelerometers.emplace_back(const_cast<char*>(feature.Name().c_str()));
+        break;
+      case FEATURE_TYPE::KEY:
+        m_keys.emplace_back(const_cast<char*>(feature.Name().c_str()));
+        break;
+      case FEATURE_TYPE::RELPOINTER:
+        m_relPointers.emplace_back(const_cast<char*>(feature.Name().c_str()));
+        break;
+      case FEATURE_TYPE::ABSPOINTER:
+        m_absPointers.emplace_back(const_cast<char*>(feature.Name().c_str()));
+        break;
+      case FEATURE_TYPE::MOTOR:
+        m_motors.emplace_back(const_cast<char*>(feature.Name().c_str()));
+        break;
+      default:
+        break;
+    }
+  }
+
+  //! @todo Sort vectors
+}
+
+game_controller_layout CGameClientController::TranslateController() const
+{
+  game_controller_layout controllerStruct{};
+
+  controllerStruct.controller_id = const_cast<char*>(m_controllerId.c_str());
+  controllerStruct.provides_input = m_controller->Layout().Topology().ProvidesInput();
+
+  if (!m_digitalButtons.empty())
+  {
+    controllerStruct.digital_buttons = const_cast<char**>(m_digitalButtons.data());
+    controllerStruct.digital_button_count = m_digitalButtons.size();
+  }
+  if (!m_analogButtons.empty())
+  {
+    controllerStruct.analog_buttons = const_cast<char**>(m_analogButtons.data());
+    controllerStruct.analog_button_count = m_analogButtons.size();
+  }
+  if (!m_analogSticks.empty())
+  {
+    controllerStruct.analog_sticks = const_cast<char**>(m_analogSticks.data());
+    controllerStruct.analog_stick_count = m_analogSticks.size();
+  }
+  if (!m_accelerometers.empty())
+  {
+    controllerStruct.accelerometers = const_cast<char**>(m_accelerometers.data());
+    controllerStruct.accelerometer_count = m_accelerometers.size();
+  }
+  if (!m_keys.empty())
+  {
+    controllerStruct.keys = const_cast<char**>(m_keys.data());
+    controllerStruct.key_count = m_keys.size();
+  }
+  if (!m_relPointers.empty())
+  {
+    controllerStruct.rel_pointers = const_cast<char**>(m_relPointers.data());
+    controllerStruct.rel_pointer_count = m_relPointers.size();
+  }
+  if (!m_absPointers.empty())
+  {
+    controllerStruct.abs_pointers = const_cast<char**>(m_absPointers.data());
+    controllerStruct.abs_pointer_count = m_absPointers.size();
+  }
+  if (!m_motors.empty())
+  {
+    controllerStruct.motors = const_cast<char**>(m_motors.data());
+    controllerStruct.motor_count = m_motors.size();
+  }
+
+  return controllerStruct;
+}

--- a/xbmc/games/addons/input/GameClientController.h
+++ b/xbmc/games/addons/input/GameClientController.h
@@ -1,0 +1,70 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "games/controllers/ControllerTypes.h"
+
+#include <vector>
+
+namespace KODI
+{
+namespace GAME
+{
+  class CGameClientInput;
+
+  /*!
+   * \brief A container for the layout of a controller connected to a game
+   *        client input port
+   */
+  class CGameClientController
+  {
+  public:
+    /*!
+     * \brief Construct a controller layout
+     *
+     * \brief controller The controller add-on
+     */
+    CGameClientController(CGameClientInput &input, ControllerPtr controller);
+
+    /*!
+     * \brief Get a controller layout for the Game API
+     */
+    game_controller_layout TranslateController() const;
+
+  private:
+    // Construction parameters
+    CGameClientInput &m_input;
+    const ControllerPtr m_controller;
+
+    // Buffer parameters
+    std::string m_controllerId;
+    std::vector<char*> m_digitalButtons;
+    std::vector<char*> m_analogButtons;
+    std::vector<char*> m_analogSticks;
+    std::vector<char*> m_accelerometers;
+    std::vector<char*> m_keys;
+    std::vector<char*> m_relPointers;
+    std::vector<char*> m_absPointers;
+    std::vector<char*> m_motors;
+  };
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -31,6 +31,7 @@ namespace JOYSTICK
 namespace GAME
 {
   class CGameClient;
+  class CGameClientController;
   class CGameClientHardware;
   class CGameClientJoystick;
   class CGameClientKeyboard;
@@ -91,6 +92,7 @@ namespace GAME
 
     // Private input helpers
     void LoadTopology();
+    void SetControllerLayouts(const ControllerVector &controllers);
     void ProcessJoysticks();
     PortMap MapJoysticks(const PERIPHERALS::PeripheralVector &peripheralJoysticks,
                          const JoystickMap &gameClientjoysticks) const;
@@ -105,6 +107,8 @@ namespace GAME
     // Input properties
     IGameInputCallback *m_inputCallback = nullptr;
     std::unique_ptr<CGameClientTopology> m_topology;
+    using ControllerLayoutMap = std::map<std::string, std::unique_ptr<CGameClientController>>;
+    ControllerLayoutMap m_controllerLayouts;
     JoystickMap m_joysticks;
     PortMap m_portMap;
     std::unique_ptr<CGameClientKeyboard> m_keyboard;

--- a/xbmc/games/addons/input/GameClientTopology.cpp
+++ b/xbmc/games/addons/input/GameClientTopology.cpp
@@ -98,9 +98,9 @@ std::string CGameClientTopology::MakeAddress(const std::string &baseAddress, con
   std::ostringstream address;
 
   if (!baseAddress.empty())
-    address << baseAddress << CONTROLLER_ADDRESS_SEPARATOR;
+    address << baseAddress;
 
-  address << nodeId;
+  address << CONTROLLER_ADDRESS_SEPARATOR << nodeId;
 
   return address.str();
 }

--- a/xbmc/games/controllers/types/ControllerTree.cpp
+++ b/xbmc/games/controllers/types/ControllerTree.cpp
@@ -49,6 +49,22 @@ void CControllerNode::SetController(ControllerPtr controller)
   m_controller = std::move(controller);
 }
 
+void CControllerNode::GetControllers(ControllerVector &controllers) const
+{
+  const ControllerPtr &myController = m_controller;
+
+  auto it = std::find_if(controllers.begin(), controllers.end(),
+    [&myController](const ControllerPtr &controller)
+    {
+      return myController->ID() == controller->ID();
+    });
+
+  if (it == controllers.end())
+    controllers.emplace_back(m_controller);
+
+  m_hub->GetControllers(controllers);
+}
+
 void CControllerNode::SetAddress(std::string address)
 {
   m_address = std::move(address);
@@ -261,6 +277,22 @@ bool CControllerHub::IsControllerAccepted(const std::string &portAddress,
   }
 
   return bAccepted;
+}
+
+ControllerVector CControllerHub::GetControllers() const
+{
+  ControllerVector controllers;
+  GetControllers(controllers);
+  return controllers;
+}
+
+void CControllerHub::GetControllers(ControllerVector &controllers) const
+{
+  for (const CControllerPortNode &port : m_ports)
+  {
+    for (const CControllerNode &node : port.CompatibleControllers())
+      node.GetControllers(controllers);
+  }
 }
 
 const CControllerPortNode &CControllerHub::GetPort(const std::string &address) const

--- a/xbmc/games/controllers/types/ControllerTree.h
+++ b/xbmc/games/controllers/types/ControllerTree.h
@@ -49,6 +49,8 @@ namespace GAME
     const ControllerPtr &Controller() const { return m_controller; }
     void SetController(ControllerPtr controller);
 
+    void GetControllers(ControllerVector &controllers) const;
+
     /*!
      * \brief Address given to the node by the implementation
      */
@@ -222,6 +224,8 @@ namespace GAME
     bool IsControllerAccepted(const std::string &controllerId) const;
     bool IsControllerAccepted(const std::string &portAddress,
                               const std::string &controllerId) const;
+    ControllerVector GetControllers() const;
+    void GetControllers(ControllerVector &controllers) const;
 
     const CControllerPortNode &GetPort(const std::string &address) const;
 


### PR DESCRIPTION
This brings the Game API to v1.1.0, which has been the version in my test builds since July. The refactoring is entirely logical/documentation, so there is no change in behavior. See commit descriptions for details.

Requires https://github.com/kodi-game/game.libretro/pull/47.

## Motivation and Context
So back in July I did some work on RetroPlayer. I had a new vision for savestates, and it required a new approach to input handling. I ultimately never completed the final vision, but the underlying Game API refactors were complete, so I've been shipping them in my test builds since then.

However, I delayed PRing these refactors until the savestate renovation was complete, because there's enough github noise as it is. I've been carrying them in my test builds every since, because why not -- the extra testing doesn't hurt.

Fast forward to 18 days ago when #14508 was merged, which included half of this refactoring (the non-API-breaking half). Unfortunately, my splitting of commits into individual chunks resulting in a single line being placed in the wrong commit, breaking game input.

Now I realize that the version I ship in Leia needs to be the version that's been tested heavily since July. Omitting these API changes bit my ass once, and I worry that if I don't merge the second half of the refactoring, I'll leave more bugs in master.

## How Has This Been Tested?
In RetroPlayer test builds since July.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
