### PR TITLE
DVDVideoCodecAndroidMediaCodec: Revert c15ff2d9f6e - to accelerate dvds

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -396,7 +396,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open - %s\n", "null size, cannot handle");
     goto FAIL;
   }
-  else if (hints.stills || hints.dvd)
+  else if (hints.stills)
   {
     // Won't work reliably
     goto FAIL;


### PR DESCRIPTION
Happy regression testing. Was demanded by users here: https://forum.kodi.tv/showthread.php?tid=332945&page=4

From technical pov stills and dvds are nowadays a solved problem on most platforms. Let's see how we regress.