### PR TITLE
whitelist movie set artwork from scrapers/NFO files

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -321,6 +321,7 @@ void CAdvancedSettings::Initialize()
   m_videoTvShowExtraArt = {};
   m_videoTvSeasonExtraArt = {};
   m_videoMovieExtraArt = {};
+  m_videoMovieSetExtraArt = {};
   m_videoMusicVideoExtraArt = {};
 
   m_iEpgUpdateCheckInterval = 300; /* check if tables need to be updated every 5 minutes */
@@ -800,6 +801,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     SetExtraArtwork(pElement->FirstChildElement("tvshowextraart"), m_videoTvShowExtraArt);
     SetExtraArtwork(pElement->FirstChildElement("tvseasonextraart"), m_videoTvSeasonExtraArt);
     SetExtraArtwork(pElement->FirstChildElement("movieextraart"), m_videoMovieExtraArt);
+    SetExtraArtwork(pElement->FirstChildElement("moviesetextraart"), m_videoMovieSetExtraArt);
     SetExtraArtwork(pElement->FirstChildElement("musicvideoextraart"), m_videoMusicVideoExtraArt);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -269,6 +269,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_videoTvShowExtraArt;
     std::vector<std::string> m_videoTvSeasonExtraArt;
     std::vector<std::string> m_videoMovieExtraArt;
+    std::vector<std::string> m_videoMovieSetExtraArt;
     std::vector<std::string> m_videoMusicVideoExtraArt;
 
     bool m_bVideoScannerIgnoreErrors;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4515,7 +4515,7 @@ bool CVideoDatabase::HasArtForItem(int mediaId, const MediaType &mediaType)
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
-    std::string sql = PrepareSQL("SELECT count(*) FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
+    std::string sql = PrepareSQL("SELECT 1 FROM art WHERE media_id=%i AND media_type='%s' LIMIT 1", mediaId, mediaType.c_str());
     m_pDS2->query(sql);
     bool result = !m_pDS2->eof();
     m_pDS2->close();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1443,6 +1443,11 @@ namespace VIDEO
     std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(ContentToMediaType(content, pItem->m_bIsFolder));
     bool lookForThumb = find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end() &&
                         art.find("thumb") == art.end();
+    if (content == CONTENT_MOVIES)
+    {
+      for (std::string artType : CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection))
+        artTypes.push_back("set." + artType);
+    }
     // find local art
     if (useLocal)
     {

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -251,10 +251,19 @@ std::vector<std::string> CVideoThumbLoader::GetArtTypes(const std::string &type)
         ret.push_back(artType);
     }
   }
-  else if (type == MediaTypeMovie || type == MediaTypeVideoCollection)
+  else if (type == MediaTypeMovie)
   {
     ret = {"poster", "fanart"};
     for (auto& artType : advancedSettings->m_videoMovieExtraArt)
+    {
+      if (find(ret.begin(), ret.end(), artType) == ret.end())
+        ret.push_back(artType);
+    }
+  }
+  else if (type == MediaTypeVideoCollection)
+  {
+    ret = {"poster", "fanart"};
+    for (auto& artType : advancedSettings->m_videoMovieSetExtraArt)
     {
       if (find(ret.begin(), ret.end(), artType) == ret.end())
         ret.push_back(artType);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoThumbLoader.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <utility>
 
@@ -223,36 +224,54 @@ std::vector<std::string> CVideoThumbLoader::GetArtTypes(const std::string &type)
 {
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   std::vector<std::string> ret;
-  std::vector<std::string> extraart;
   if (type == MediaTypeEpisode)
   {
-    ret = { "thumb" };
-    extraart = advancedSettings->m_videoEpisodeExtraArt;
+    ret = {"thumb"};
+    for (auto& artType : advancedSettings->m_videoEpisodeExtraArt)
+    {
+      if (find(ret.begin(), ret.end(), artType) == ret.end())
+        ret.push_back(artType);
+    }
   }
   else if (type == MediaTypeTvShow)
   {
-    ret = { "poster", "fanart", "banner" };
-    extraart = advancedSettings->m_videoTvShowExtraArt;
+    ret = {"poster", "fanart", "banner"};
+    for (auto& artType : advancedSettings->m_videoTvShowExtraArt)
+    {
+      if (find(ret.begin(), ret.end(), artType) == ret.end())
+        ret.push_back(artType);
+    }
   }
   else if (type == MediaTypeSeason)
   {
-    ret = { "poster", "fanart", "banner" };
-    extraart = advancedSettings->m_videoTvSeasonExtraArt;
+    ret = {"poster", "fanart", "banner"};
+    for (auto& artType : advancedSettings->m_videoTvSeasonExtraArt)
+    {
+      if (find(ret.begin(), ret.end(), artType) == ret.end())
+        ret.push_back(artType);
+    }
   }
   else if (type == MediaTypeMovie || type == MediaTypeVideoCollection)
   {
-    ret = { "poster", "fanart" };
-    extraart = advancedSettings->m_videoMovieExtraArt;
+    ret = {"poster", "fanart"};
+    for (auto& artType : advancedSettings->m_videoMovieExtraArt)
+    {
+      if (find(ret.begin(), ret.end(), artType) == ret.end())
+        ret.push_back(artType);
+    }
   }
   else if (type == MediaTypeMusicVideo)
   {
-    ret = { "poster", "fanart" };
-    extraart = advancedSettings->m_videoMusicVideoExtraArt;
+    ret = {"poster", "fanart"};
+    for (auto& artType : advancedSettings->m_videoMusicVideoExtraArt)
+    {
+      if (find(ret.begin(), ret.end(), artType) == ret.end())
+        ret.push_back(artType);
+    }
   }
   else if (type.empty()) // unknown, just the basics
     ret = { "poster", "fanart", "banner", "thumb" };
 
-  ret.insert(ret.end(), extraart.begin(), extraart.end());
   return ret;
 }
 


### PR DESCRIPTION
## Description
Apply the whitelist from #13859 to the movie set artwork from #13563. No set artwork from the file system yet (I hope to implement that for v19), but configuring the whitelist like other media types is still helpful.

First commit avoids adding duplicate artwork types to the "Choose art" dialog if hard-coded art types are added to AS.xml and the second commit fixes a derp in the late-added query from the second PR. The third commit actually does the thing.

## How Has This Been Tested?
Runtime tested.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
