### PR TITLE
changed: remove old shoutcast workaround in curl file

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -625,14 +625,6 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   // Set the lowspeed time very low as it seems Curl takes much longer to detect a lowspeed condition
   g_curlInterface.easy_setopt(h, CURLOPT_LOW_SPEED_TIME, m_lowspeedtime);
 
-  if (m_skipshout)
-    //! @todo
-    //! For shoutcast file, content-length should not be set, and in libcurl there is a bug, if the
-    //! cast file was 302 redirected then getinfo of CURLINFO_CONTENT_LENGTH_DOWNLOAD will return
-    //! the 302 response's body length, which cause the next read request failed, so we ignore
-    //! content-length for shoutcast file to workaround this.
-    g_curlInterface.easy_setopt(h, CURLOPT_IGNORE_CONTENT_LENGTH, 1);
-
   // Setup allowed TLS/SSL ciphers. New versions of cURL may deprecate things that are still in use.
   if (!m_cipherlist.empty())
     g_curlInterface.easy_setopt(h, CURLOPT_SSL_CIPHER_LIST, m_cipherlist.c_str());


### PR DESCRIPTION
this bug was fixed in curl 7.26 - many moons ago.

fixes #14631