### PR TITLE
windowing/gbm: use CFileHandle to handle the fd

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -17,6 +17,7 @@
 
 #include "windowing/Resolution.h"
 #include "GBMUtils.h"
+#include "platform/posix/utils/FileHandle.h"
 
 namespace KODI
 {
@@ -106,7 +107,7 @@ protected:
   static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object);
   static void FreeProperties(struct drm_object *object);
 
-  int m_fd;
+  KODI::UTILS::POSIX::CFileHandle m_fd;
   struct connector *m_connector = nullptr;
   struct encoder *m_encoder = nullptr;
   struct crtc *m_crtc = nullptr;

--- a/xbmc/windowing/gbm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/OffScreenModeSetting.cpp
@@ -22,12 +22,6 @@ bool COffScreenModeSetting::InitDrm()
   return true;
 }
 
-void COffScreenModeSetting::DestroyDrm()
-{
-  close(m_fd);
-  m_fd = -1;
-}
-
 std::vector<RESOLUTION_INFO> COffScreenModeSetting::GetModes()
 {
     std::vector<RESOLUTION_INFO> resolutions;

--- a/xbmc/windowing/gbm/OffScreenModeSetting.h
+++ b/xbmc/windowing/gbm/OffScreenModeSetting.h
@@ -26,7 +26,7 @@ public:
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
   bool SetActive(bool active) override { return false; }
   bool InitDrm() override;
-  void DestroyDrm() override;
+  void DestroyDrm() override {}
 
   RESOLUTION_INFO GetCurrentMode() override;
   std::vector<RESOLUTION_INFO> GetModes() override;


### PR DESCRIPTION
I'm really liking this `CFileHandle` class. Thanks @pkerling! I hope I'm using it right....

Calling `attach` will reset the fd so I don't explicitly `close` and set to `-1` each time.

Maybe I should `reset()` the fd in `DestroyDrm()` just because but I'm not sure if it really matters.