### PR TITLE
Games: Fix crash on game close after controller disconnects

### DIFF
--- a/xbmc/games/ports/Port.cpp
+++ b/xbmc/games/ports/Port.cpp
@@ -40,9 +40,15 @@ void CPort::RegisterInput(JOYSTICK::IInputProvider *provider)
 void CPort::UnregisterInput(JOYSTICK::IInputProvider *provider)
 {
   // Unregister in reverse order
+  if (provider == nullptr)
+    m_appInput->UnregisterInputProvider();
   m_appInput.reset();
-  provider->UnregisterInputHandler(this);
-  provider->UnregisterInputHandler(m_inputSink.get());
+
+  if (provider != nullptr)
+  {
+    provider->UnregisterInputHandler(this);
+    provider->UnregisterInputHandler(m_inputSink.get());
+  }
 }
 
 std::string CPort::ControllerID() const

--- a/xbmc/input/joysticks/keymaps/KeymapHandling.cpp
+++ b/xbmc/input/joysticks/keymaps/KeymapHandling.cpp
@@ -95,9 +95,11 @@ void CKeymapHandling::LoadKeymaps()
 
 void CKeymapHandling::UnloadKeymaps()
 {
-  for (auto it = m_inputHandlers.rbegin(); it != m_inputHandlers.rend(); ++it)
-    m_inputProvider->UnregisterInputHandler(it->get());
-
+  if (m_inputProvider != nullptr)
+  {
+    for (auto it = m_inputHandlers.rbegin(); it != m_inputHandlers.rend(); ++it)
+      m_inputProvider->UnregisterInputHandler(it->get());
+  }
   m_inputHandlers.clear();
   m_keymaps.clear();
 }

--- a/xbmc/input/joysticks/keymaps/KeymapHandling.h
+++ b/xbmc/input/joysticks/keymaps/KeymapHandling.h
@@ -37,6 +37,15 @@ namespace JOYSTICK
     virtual ~CKeymapHandling();
 
     /*!
+     * \brief Unregister the input provider
+     *
+     * Call this if the input provider is invalidated, such as if a user
+     * disconnects a controller. This prevents accessing the invalidated
+     * input provider when keymaps are unloaded upon destruction.
+     */
+    void UnregisterInputProvider() { m_inputProvider = nullptr; }
+
+    /*!
      * \brief
      */
     IInputReceiver *GetInputReceiver(const std::string &controllerId) const;
@@ -54,7 +63,7 @@ namespace JOYSTICK
     void UnloadKeymaps();
 
     // Construction parameter
-    IInputProvider *const m_inputProvider;
+    IInputProvider *m_inputProvider;
     const bool m_pPromiscuous;
     const IKeymapEnvironment *const m_environment;
 


### PR DESCRIPTION
This fixes a crash that occurs when a controller is disconnected before gameplay ends, such as a wireless controller running out of batteries.

The crash occurs because CKeymapHandling unregisters itself with the peripheral object when destructed. However, if the peripheral was unplugged and the object deleted, then CKeymapHandling tries to unregister itself with the dangling pointer.

To fix this, we preemptively set CKeymapHandling:: m_inputProvider to null when we detect that the peripheral no longer exists. Then, on destruction, we can do a null check to avoid accessing a dangling pointer.

## Motivation and Context
Batteries died... things went boom.

## How Has This Been Tested?
Tested on OSX by yanking the batteries from my Xbox 360 controller. No more crash on game close.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
