### PR TITLE
Game OSD: Always show help if no controllers are connected

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -1010,3 +1010,12 @@ void CApplicationPlayer::SetUpdateStreamDetails()
   if (vp)
     vp->SetUpdateStreamDetails();
 }
+
+bool CApplicationPlayer::HasGameAgent()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->HasGameAgent();
+
+  return false;
+}

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -152,6 +152,11 @@ public:
 
   void SetUpdateStreamDetails();
 
+  /*!
+   * \copydoc IPlayer::HasGameAgent
+   */
+  bool HasGameAgent();
+
 private:
   std::shared_ptr<IPlayer> GetInternal() const;
   void CreatePlayer(const CPlayerCoreFactory &factory, const std::string &player, IPlayerCallback& callback);

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -227,6 +227,14 @@ public:
   virtual CVideoSettings GetVideoSettings() { return CVideoSettings(); };
   virtual void SetVideoSettings(CVideoSettings& settings) {};
 
+  /*!
+   * \brief Check if any players are playing a game
+   *
+   * \return True if at least one player has an input device attached to the
+   * game, false otherwise
+   */
+  virtual bool HasGameAgent() { return false; }
+
   std::string m_name;
   std::string m_type;
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -467,6 +467,14 @@ bool CRetroPlayer::IsRenderingVideo()
   return true;
 }
 
+bool CRetroPlayer::HasGameAgent()
+{
+  if (m_gameClient)
+    return m_gameClient->Input().HasAgent();
+
+  return false;
+}
+
 std::string CRetroPlayer::GameClientID() const
 {
   if (m_gameClient)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -66,6 +66,7 @@ namespace RETRO
     void FrameMove() override;
     void Render(bool clear, uint32_t alpha = 255, bool gui = true) override;
     bool IsRenderingVideo() override;
+    bool HasGameAgent() override;
 
     // Implementation of IGameCallback
     std::string GameClientID() const override;

--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
@@ -20,6 +20,8 @@
 #include "guilib/WindowIDs.h"
 #include "input/Action.h"
 #include "input/ActionIDs.h"
+#include "Application.h" //! @todo Remove me
+#include "ApplicationPlayer.h" //! @todo Remove me
 #include "GUIInfoManager.h" //! @todo Remove me
 #include "ServiceBroker.h"
 
@@ -184,6 +186,17 @@ void CGameWindowFullScreen::OnInitWindow()
   GAME::CGameSettings &gameSettings = CServiceBroker::GetGameServices().GameSettings();
   if (gameSettings.ShowOSDHelp())
     TriggerOSD();
+  else
+  {
+    //! @todo We need to route this check through the GUI bridge. By adding the
+    //        dependency to the application player here, we are prevented from
+    //        having multiple players.
+    if (!g_application.GetAppPlayer().HasGameAgent())
+    {
+      gameSettings.SetShowOSDHelp(true);
+      TriggerOSD();
+    }
+  }
 }
 
 void CGameWindowFullScreen::OnDeinitWindow(int nextWindowID)

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -282,6 +282,26 @@ bool CGameClientInput::SupportsMouse() const
   return it != controllers.Ports().end() && !it->CompatibleControllers().empty();
 }
 
+bool CGameClientInput::HasAgent() const
+{
+  //! @todo We check m_portMap instead of m_joysticks because m_joysticks is
+  //        always populated with the default joystick configuration (i.e.
+  //        all ports are connected to the first controller they accept).
+  //        The game has no way of knowing which joysticks are actually being
+  //        controlled by agents -- this information is stored in m_portMap,
+  //        which is not exposed to the game.
+  if (!m_portMap.empty())
+    return true;
+
+  if (m_keyboard)
+    return true;
+
+  if (m_mouse)
+    return true;
+
+  return false;
+}
+
 bool CGameClientInput::OpenKeyboard(const ControllerPtr &controller)
 {
   using namespace JOYSTICK;

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -64,6 +64,9 @@ namespace GAME
     bool SupportsKeyboard() const;
     bool SupportsMouse() const;
 
+    // Agent functions
+    bool HasAgent() const;
+
     // Keyboard functions
     bool OpenKeyboard(const ControllerPtr &controller);
     void CloseKeyboard();


### PR DESCRIPTION
Because who reads?

Currently, the game OSD help dialog (added in https://github.com/xbmc/xbmc/pull/14425) is shown once on first gameplay, then hidden. However, it presents a very important message - controllers are required to play games. Users will ignore this. Over and over again. That's why we keep showing the help dialog as long as they keep trying to launch games without a controller connected.

Noteworthy about this change is the beginning of my "agent" abstraction. Because the term "player" is overloaded (player core and human player), I'm basing the abstractions for my player manager on the word "agent". "Agent" is the game-theoretic term for game players, notably used by reinforcement learning algorithms. I wonder where this is going...

## Motivation and Context
Motivated by comment from @ccope in https://github.com/xbmc/xbmc/issues/14654

## How Has This Been Tested?
Tested on OSX with and without controllers. Need to test cores that use keyboard/mouse.

## Screenshots (if appropriate):
![screen shot 2018-09-30 at 5 21 24 pm](https://user-images.githubusercontent.com/531482/46258565-b7786900-c4d5-11e8-84cd-90ee5a319361.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
