### PR TITLE
[music] Fix compilation with taglib versions < 1.11

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -59,6 +59,10 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 
+#if TAGLIB_MAJOR_VERSION <= 1 && TAGLIB_MINOR_VERSION < 11
+#include "utils/Base64.h"
+#endif
+
 using namespace TagLib;
 using namespace MUSIC_INFO;
 


### PR DESCRIPTION
Reported here: https://github.com/xbmc/xbmc/commit/ab3789b72870072a766de62d13ea16c273d13dba#commitcomment-31000074