### PR TITLE
fixed: add-on creation is not thread safe

### DIFF
--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 
+CCriticalSection ImageFactory::m_createSec;
+
 using namespace ADDON;
 
 IImage* ImageFactory::CreateLoader(const std::string& strFileName)
@@ -42,6 +44,7 @@ IImage* ImageFactory::CreateLoaderFromMimeType(const std::string& strMimeType)
     std::vector<std::string> mime = StringUtils::Split(addonInfo->Type(ADDON_IMAGEDECODER)->GetValue("@mimetype").asString(), "|");
     if (std::find(mime.begin(), mime.end(), strMimeType) != mime.end())
     {
+      CSingleLock lock(m_createSec);
       CImageDecoder* result = new CImageDecoder(addonInfo);
       result->Create(strMimeType);
       return result;

--- a/xbmc/guilib/imagefactory.h
+++ b/xbmc/guilib/imagefactory.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "iimage.h"
+#include "threads/CriticalSection.h"
 #include "URL.h"
 
 class ImageFactory
@@ -20,4 +21,7 @@ public:
   static IImage* CreateLoader(const std::string& strFileName);
   static IImage* CreateLoader(const CURL& url);
   static IImage* CreateLoaderFromMimeType(const std::string& strMimeType);
+
+private:
+  static CCriticalSection m_createSec; //!< Critical section for add-on creation.
 };


### PR DESCRIPTION
so we have to put creation step in a critical section. this lead to crashes in thumb creation which runs on multiple threads. discovered while implementing the heif decoder add-on.