### PR TITLE
Fix crash on exit when checking of libgpg-error lock object size.

### DIFF
--- a/tools/depends/target/libgpg-error/Makefile
+++ b/tools/depends/target/libgpg-error/Makefile
@@ -25,6 +25,11 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)
+ifeq ($(OS),ios)
+ifeq ($(CPU),arm64)
+	cp $(PLATFORM)/src/syscfg/lock-obj-pub.aarch64-apple-darwin.h $(PLATFORM)/src/syscfg/lock-obj-pub.arm-apple-darwin.h
+endif
+endif
 ifeq ($(OS),android)
 ifeq ($(CPU),arm64-v8a)
 	cp lock-obj-pub.aarch64-unknown-linux-android.h $(PLATFORM)/src/syscfg/lock-obj-pub.linux-android.h


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
iOS/tvOS platform related. This PR patches a makefile of libgpg-error project to make the size of lib's lock object fits native mutex.  
<!--- Describe your change in detail here -->
It may be done by choosing the "right" header file from lib's repository. Just before building of the project, it copies pre-created (by project maintainer) header file for **aarch64-apple-darwin** architecture, over the file for "our" build architecture **arm-apple-darwin**.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Every time when you exit Kodi on iOS/tvOS platform, the application crashes in posse-lock.c file on assertion
`if (sizeof (gpgrt_lock_t) < sizeof (_gpgrt_lock_t))
    {
      assert (!"sizeof lock obj");
      abort ();
    }`
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Run and exit from application under debugger. Before changes debugger stops on assert() call. After applying of PR you should not see this code anymore.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed