### PR TITLE
[Android] switch renderGUI based on surface existance instead onPause/onSuspend

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -238,8 +238,6 @@ void CXBMCApp::onResume()
   // Re-request Visible Behind
   if ((m_playback_state & PLAYBACK_STATE_PLAYING) && (m_playback_state & PLAYBACK_STATE_VIDEO))
     RequestVisibleBehind(true);
-
-  g_application.SetRenderGUI(true);
 }
 
 void CXBMCApp::onPause()
@@ -259,7 +257,6 @@ void CXBMCApp::onPause()
     g_application.SwitchToFullScreen(true);
 
   EnableWakeLock(false);
-  g_application.SetRenderGUI(false);
   m_hasReqVisible = false;
 }
 
@@ -1389,12 +1386,14 @@ void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
   {
     XBMC_SetupDisplay();
   }
+  g_application.SetRenderGUI(true);
 }
 
 void CXBMCApp::surfaceDestroyed(CJNISurfaceHolder holder)
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
   // If we have exited XBMC, it no longer exists.
+  g_application.SetRenderGUI(false);
   if (!m_exiting)
   {
     XBMC_DestroyDisplay();

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -90,7 +90,7 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
 {
   // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
   // we can't actually do anything about it
-  if (rendered && !m_pGLContext.TrySwapBuffers() && eglGetError() != EGL_BAD_SURFACE)
+  if (rendered && !m_pGLContext.TrySwapBuffers())
   {
     CEGLUtils::LogError("eglSwapBuffers failed");
     throw std::runtime_error("eglSwapBuffers failed");


### PR DESCRIPTION
## Description
Stop rendering GUI if surface is destroyed / start rendering GUI after surface is created.
This handling was before incorrectly handled in onPause / onResume.

## Motivation and Context
- Fix eglSwapBuffer exceptions (kodi termination)
- Reenable VisibleBehind (for Android < O 

## How Has This Been Tested?

Press Home button, navigate back to kodi on:
- Shield TV 2017 (video is paused)
- WETEK Hub (video plays in background)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
