### PR TITLE
CAppParamParser: add new tty argument for gbm windowing

### DIFF
--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -62,6 +62,7 @@ void CAppParamParser::DisplayHelp()
   printf("  --test\t\tEnable test mode. [FILE] required.\n");
   printf("  --settings=<filename>\t\tLoads specified file after advancedsettings.xml replacing any settings specified\n");
   printf("  \t\t\t\tspecified file must exist in special://xbmc/system/\n");
+  printf("  --tty=<tty>\t\tStart session on alternative tty. e.g. --tty=/dev/tty4 (GBM windowing only)\n");
   exit(0);
 }
 
@@ -83,6 +84,8 @@ void CAppParamParser::ParseArg(const std::string &arg)
     m_testmode = true;
   else if (arg.substr(0, 11) == "--settings=")
     m_settingsFile = arg.substr(11);
+  else if (arg.substr(0, 6) == "--tty=")
+    m_tty = arg.substr(6);
   else if (arg.length() != 0 && arg[0] != '-')
   {
     const CFileItemPtr item = std::make_shared<CFileItem>(arg);

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -62,7 +62,9 @@ void CAppParamParser::DisplayHelp()
   printf("  --test\t\tEnable test mode. [FILE] required.\n");
   printf("  --settings=<filename>\t\tLoads specified file after advancedsettings.xml replacing any settings specified\n");
   printf("  \t\t\t\tspecified file must exist in special://xbmc/system/\n");
-  printf("  --tty=<tty>\t\tStart session on alternative tty. e.g. --tty=/dev/tty4 (GBM windowing only)\n");
+#if defined(HAVE_GBM)
+  printf("  --tty=<tty>\t\tStart session on alternative tty. e.g. --tty=/dev/tty4\n");
+#endif
   exit(0);
 }
 

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -30,6 +30,7 @@ public:
   bool m_platformDirectories = true;
   bool m_testmode = false;
   bool m_standAlone = false;
+  std::string m_tty;
 
 private:
   void ParseArg(const std::string &arg);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -355,6 +355,7 @@ bool CApplication::Create(const CAppParamParser &params)
   m_bPlatformDirectories = params.m_platformDirectories;
   m_bTestMode = params.m_testmode;
   m_bStandalone = params.m_standAlone;
+  m_tty = params.m_tty;
 
   m_pSettingsComponent.reset(new CSettingsComponent());
   m_pSettingsComponent->Init(params);

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -311,6 +311,7 @@ public:
   bool PlatformDirectoriesEnabled() { return m_bPlatformDirectories; }
   bool IsStandAlone() { return m_bStandalone; }
   bool IsEnableTestMode() { return m_bTestMode; }
+  std::string GetTTY() { return m_tty; }
 
   bool IsAppFocused() const { return m_AppFocused; }
 
@@ -439,6 +440,7 @@ protected:
   unsigned int m_lastRenderTime = 0;
   bool m_skipGuiRender = false;
 
+  std::string m_tty;
   bool m_bStandalone = false;
   bool m_bTestMode = false;
   bool m_bSystemScreenSaverEnable = false;

--- a/xbmc/windowing/gbm/VTUtils.cpp
+++ b/xbmc/windowing/gbm/VTUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "VTUtils.h"
 
+#include "Application.h"
 #include "platform/MessagePrinter.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -23,7 +24,16 @@ using namespace KODI::WINDOWING::GBM;
 
 bool CVTUtils::OpenTTY()
 {
-  m_ttyDevice = ttyname(STDIN_FILENO);
+  std::string tty = g_application.GetTTY();
+
+  if (!tty.empty())
+  {
+    m_ttyDevice = tty;
+  }
+  else
+  {
+    m_ttyDevice = ttyname(STDIN_FILENO);
+  }
 
   m_fd.attach(open(m_ttyDevice.c_str(), O_RDWR | O_CLOEXEC));
   if (m_fd < 0)


### PR DESCRIPTION
Since no one had any strong feelings when I asked yesterday I figured I would PR this just to get some more exposure.

This allows us to specify the tty to start kodi on. This is especially useful for starting kodi-gbm from an ssh session. This **does not** allow kodi to change VT's automatically as that would require `sudo` rights. So you still have to select a valid VT for this to work.

```
kodi -fs --standalone --tty=/dev/tty1
```

This is all done in similar fashion to how weston does it upstream.
see, https://gitlab.freedesktop.org/wayland/weston/blob/master/libweston/weston-launch.c#L525-588