### PR TITLE
FullscreenGame: Remove OSD toggle action

### DIFF
--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
@@ -80,10 +80,6 @@ bool CGameWindowFullScreen::OnAction(const CAction &action)
   switch (action.GetID())
   {
   case ACTION_SHOW_OSD:
-  {
-    ToggleOSD();
-    return true;
-  }
   case ACTION_TRIGGER_OSD:
   {
     TriggerOSD();
@@ -194,20 +190,6 @@ void CGameWindowFullScreen::OnDeinitWindow(int nextWindowID)
   CGUIWindow::OnDeinitWindow(nextWindowID);
 
   CServiceBroker::GetWinSystem()->GetGfxContext().SetFullScreenVideo(false); //! @todo
-}
-
-void CGameWindowFullScreen::ToggleOSD()
-{
-  CGUIDialog *pOSD = GetOSD();
-  if (pOSD != nullptr)
-  {
-    if (pOSD->IsDialogRunning())
-      pOSD->Close();
-    else
-      pOSD->Open();
-  }
-
-  MarkDirtyRegion();
 }
 
 void CGameWindowFullScreen::TriggerOSD()

--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.h
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.h
@@ -44,7 +44,6 @@ namespace RETRO
     void OnInitWindow() override;
 
   private:
-    void ToggleOSD();
     void TriggerOSD();
     CGUIDialog *GetOSD();
 


### PR DESCRIPTION
This PR is a simple one. We'll never need to close the OSD from the fullscreen game window, because the fullscreen game window can only receive the toggle action if the OSD is already closed.

## Motivation and Context
Reduction of unreachable code.

## How Has This Been Tested?
Code was unreachable, so this shouldn't have any effect. I confirmed that the OSD can still be opened from the fullscreen game window.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
