### PR TITLE
[cmake/Xcode] - fix missing text and icon resources when using target Xcode

### DIFF
--- a/cmake/scripts/ios/Install.cmake
+++ b/cmake/scripts/ios/Install.cmake
@@ -21,19 +21,13 @@ set(BUNDLE_RESOURCES ${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/ios/Default-568h@2
                      ${CMAKE_SOURCE_DIR}/tools/darwin/packaging/media/ios/rounded/AppIcon76x76.png
                      ${CMAKE_SOURCE_DIR}/tools/darwin/packaging/media/ios/rounded/AppIcon76x76@2x.png)
 
-if(CMAKE_GENERATOR STREQUAL Xcode)
-  set(RESOURCE_LOCATION ${APP_NAME}.app)
-else()
-  set(RESOURCE_LOCATION ".")
-endif()
-
 target_sources(${APP_NAME_LC} PRIVATE ${BUNDLE_RESOURCES})
 foreach(file IN LISTS BUNDLE_RESOURCES)
-  set_source_files_properties(${file} PROPERTIES MACOSX_PACKAGE_LOCATION ${RESOURCE_LOCATION})
+  set_source_files_properties(${file} PROPERTIES MACOSX_PACKAGE_LOCATION .)
 endforeach()
 
 target_sources(${APP_NAME_LC} PRIVATE ${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/ios/English.lproj/InfoPlist.strings)
-set_source_files_properties(${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/ios/English.lproj/InfoPlist.strings PROPERTIES MACOSX_PACKAGE_LOCATION "${RESOURCE_LOCATION}/English.lproj")
+set_source_files_properties(${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/ios/English.lproj/InfoPlist.strings PROPERTIES MACOSX_PACKAGE_LOCATION "./English.lproj")
 
 # Options for code signing propagated as env vars to Codesign.command via Xcode
 set(IOS_CODE_SIGN_IDENTITY "" CACHE STRING "Code Sign Identity")


### PR DESCRIPTION
When using Xcode as cmake generator the launch images, app icons and text resources were placed into Kodi.app/Kodi.app instead of Kodi.app.

Not sure if this changed with recent Xcode versions or not - but it resulted in broken app bundle when using Xcode.
Jenkins uses make generator and was not affected.