### PR TITLE
Resolution: Use v17 behaviour if whitelist is not present

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2090,7 +2090,7 @@
           <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14085" help="36356">
-          <level>1</level>
+          <level>3</level>
           <constraints>
             <options>modes</options>
             <default></default>

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -67,6 +67,7 @@ public:
   const RESOLUTION_INFO& GetCurrentResolutionInfo() const { return GetResolutionInfo(m_currentResolution); }
   RESOLUTION_INFO& GetCurrentResolutionInfo() { return GetResolutionInfo(m_currentResolution); }
   RESOLUTION GetResFromString(const std::string &strResolution) { return GetResolutionFromString(strResolution); }
+  std::string GetStringFromRes(const RESOLUTION resolution, float refreshrate = 0.0f) { return GetStringFromResolution(resolution, refreshrate); }
 
   void ApplyCalibrations();
   void UpdateCalibrations();

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -75,6 +75,24 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
 
   std::vector<CVariant> indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+  if (indexList.empty())
+  {
+    CLog::Log(LOGDEBUG, "Whitelist is empty using default one");
+    std::vector<RESOLUTION> candidates;
+    RESOLUTION_INFO info;
+    std::string resString;
+    CServiceBroker::GetWinSystem()->GetGfxContext().GetAllowedResolutions(candidates);
+    for (const auto& c : candidates)
+    {
+      info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(c);
+      if (info.iScreenHeight >= curr.iScreenHeight && info.iScreenWidth >= curr.iScreenWidth &&
+          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK))
+      {
+        resString = CDisplaySettings::GetInstance().GetStringFromRes(c);
+        indexList.push_back(resString);
+      }
+    }
+  }
 
   CLog::Log(LOGDEBUG, "Trying to find exact refresh rate");
 


### PR DESCRIPTION
## Description
V18 combines the old Adjust Refreshrate Feature with a whitelist
This changed behaviour as users don't expect that they need to alter two settings, e.g. enable Adjust Refreshrate and also fill the Whitelist which is in a different settings menu

## Motivation and Context
Restore out of the box usability

## How Has This Been Tested?
It was not tested at all - I will do this on the weekend

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
