### PR TITLE
windowing/gbm: avoid crashing if ttyname returns NULL

### DIFF
--- a/xbmc/windowing/gbm/VTUtils.cpp
+++ b/xbmc/windowing/gbm/VTUtils.cpp
@@ -39,21 +39,19 @@ bool CVTUtils::OpenTTY()
     return false;
   }
 
-  m_ttyDevice = ttyDevice;
-
-  m_fd.attach(open(m_ttyDevice.c_str(), O_RDWR | O_CLOEXEC));
+  m_fd.attach(open(ttyDevice, O_RDWR | O_CLOEXEC));
   if (m_fd < 0)
   {
-    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: failed to open tty: %s",  m_ttyDevice));
-    CLog::Log(LOGERROR, "CVTUtils::%s - failed to open tty: %s", __FUNCTION__, m_ttyDevice);
+    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: failed to open tty: %s", ttyDevice));
+    CLog::Log(LOGERROR, "CVTUtils::%s - failed to open tty: %s", __FUNCTION__, ttyDevice);
     return false;
   }
 
   struct stat buf;
   if (fstat(m_fd, &buf) == -1 || major(buf.st_rdev) != TTY_MAJOR || minor(buf.st_rdev) == 0)
   {
-    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: %s is not a vt",  m_ttyDevice));
-    CLog::Log(LOGERROR, "CVTUtils::%s - %s is not a vt", __FUNCTION__, m_ttyDevice);
+    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: %s is not a vt", ttyDevice));
+    CLog::Log(LOGERROR, "CVTUtils::%s - %s is not a vt", __FUNCTION__, ttyDevice);
     return false;
   }
 
@@ -67,12 +65,12 @@ bool CVTUtils::OpenTTY()
 
   if (kdMode != KD_TEXT)
   {
-    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: %s is already in graphics mode, is another display server running?", m_ttyDevice));
-    CLog::Log(LOGERROR, "CVTUtils::%s - %s is already in graphics mode, is another display server running?", __FUNCTION__, m_ttyDevice);
+    CMessagePrinter::DisplayError(StringUtils::Format("ERROR: %s is already in graphics mode, is another display server running?", ttyDevice));
+    CLog::Log(LOGERROR, "CVTUtils::%s - %s is already in graphics mode, is another display server running?", __FUNCTION__, ttyDevice);
     return false;
   }
 
-  CLog::Log(LOGNOTICE, "CVTUtils::%s - opened tty: %s", __FUNCTION__, m_ttyDevice.c_str());
+  CLog::Log(LOGNOTICE, "CVTUtils::%s - opened tty: %s", __FUNCTION__, ttyDevice);
 
   return true;
 }

--- a/xbmc/windowing/gbm/VTUtils.h
+++ b/xbmc/windowing/gbm/VTUtils.h
@@ -27,7 +27,6 @@ public:
 
 private:
   KODI::UTILS::POSIX::CFileHandle m_fd;
-  std::string m_ttyDevice;
 };
 
 }


### PR DESCRIPTION
This will avoid us hard crashing when `ttyname` return `NULL`. This happens when STDIN isn't conntected to any tty and is defaulted to `/dev/null`

see, http://man7.org/linux/man-pages/man3/ttyname.3.html
and, https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Logging%20and%20Standard%20Input/Output