### PR TITLE
windowing/gbm: authorize drm master if drmSetMaster fails

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -620,7 +620,29 @@ bool CDRMUtils::InitDrm()
     return false;
   }
 
-  drmSetMaster(m_fd);
+  auto ret = drmSetMaster(m_fd);
+  if (ret < 0)
+  {
+    CLog::Log(LOGWARNING, "CDRMUtils::%s - failed to set drm master, will try to authorize instead: %s", __FUNCTION__, strerror(errno));
+
+    drm_magic_t magic;
+
+    ret = drmGetMagic(m_fd, &magic);
+    if (ret < 0)
+    {
+      CLog::Log(LOGERROR, "CDRMUtils::%s - failed to get drm magic: %s", __FUNCTION__, strerror(errno));
+      return false;
+    }
+
+    ret = drmAuthMagic(m_fd, magic);
+    if (ret < 0)
+    {
+      CLog::Log(LOGERROR, "CDRMUtils::%s - failed to authorize drm magic: %s", __FUNCTION__, strerror(errno));
+      return false;
+    }
+
+    CLog::Log(LOGNOTICE, "CDRMUtils::%s - successfully authorized drm magic", __FUNCTION__);
+  }
 
   m_orig_crtc = drmModeGetCrtc(m_fd, m_crtc->crtc->crtc_id);
 
@@ -661,7 +683,12 @@ void CDRMUtils::DestroyDrm()
 {
   RestoreOriginalMode();
 
-  drmDropMaster(m_fd);
+  auto ret = drmDropMaster(m_fd);
+  if (ret < 0)
+  {
+    CLog::Log(LOGDEBUG, "CDRMUtils::%s - failed to drop drm master: %s", __FUNCTION__, strerror(errno));
+  }
+
   m_fd.reset();
 
   drmModeFreeResources(m_drm_resources);


### PR DESCRIPTION
drmSetMaster will fail if there is another master already present.

The documentation on this seems limited though as it also seems to require SYS_CAP_ADMIN (root privileges).

So if this fails we want to authorize with the current drm master. I'm not sure why modesetting was working before but this makes it explicit (could be due to systemd doing something with logind, I'm not sure).

ref: [[1]](https://dri.freedesktop.org/docs/drm/gpu/drm-uapi.html#primary-nodes-drm-master-and-authentication) [[2]](https://dvdhrm.wordpress.com/2013/05/29/drm-render-and-modeset-nodes/)
