### PR TITLE
[depends] export TOOLCHAIN & HOST for android in binaddons cmake toolchain

### DIFF
--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -77,6 +77,8 @@ endif()
 if(CORE_SYSTEM_NAME STREQUAL android)
   set(NDKROOT @use_ndk_path@)
   set(SDKROOT @use_sdk_path@)
+  set(TOOLCHAIN @use_toolchain@)
+  set(HOST @use_host@)
   string(REPLACE ":" ";" SDK_BUILDTOOLS_PATH "@build_tools_path@")
 endif()
 


### PR DESCRIPTION
## Motivation and Context
`TOOLCHAIN` location is required for building OpenSSL 1.1.1.
`HOST` isn't needed yet, but it is in the general `Toolchain.cmake` so I added that too.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
