### PR TITLE
[settings/osx] - hide the fakefullscreen setting. 

### DIFF
--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -4,6 +4,9 @@
     <category id="display">
       <group id="1">
         <setting id="videoscreen.resolution" label="131" />
+        <setting id="videoscreen.fakefullscreen">
+          <visible>false</visible>
+        </setting>
       </group>
     </category>
     <category id="audio">


### PR DESCRIPTION
Non-Fake fullscreen is deprecated since 10.7 and non-working since 10.8. Apple suggests fake fullscreen by using a fullscreen window - and we are doing so.