### PR TITLE
[Settings] Update videoscreen.screen setting when toggling fullscreen…

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -397,8 +397,18 @@ void CDisplaySettings::SetCurrentResolution(RESOLUTION resolution, bool save /* 
 
   if (save)
   {
+    // Save videoscreen.screenmode setting
     std::string mode = GetStringFromResolution(resolution);
     CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(CSettings::SETTING_VIDEOSCREEN_SCREENMODE, mode.c_str());
+
+    // Check if videoscreen.screen setting also needs to be saved
+    // e.g. if ToggleFullscreen is called
+    int currentDisplayMode = GetCurrentDisplayMode();
+    int currentDisplayModeSetting = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOSCREEN_SCREEN);
+    if (currentDisplayMode != currentDisplayModeSetting)
+    {
+      CServiceBroker::GetSettingsComponent()->GetSettings()->SetInt(CSettings::SETTING_VIDEOSCREEN_SCREEN, currentDisplayMode);
+    }
   }
 
   if (resolution != m_currentResolution)


### PR DESCRIPTION
… (closes #14705)

## Description
This is my attempt at solving https://github.com/xbmc/xbmc/issues/14705 . When `ToggleFullscreen` is called (triggered by cmd+F or \ ) the videoscreen.screen setting is never updated. This fixes it by writting the setting in `SetCurrentResolution` which is called by `ToggleFullscreen`.

## Motivation and Context
Fix issues for Leia

## How Has This Been Tested?
Compiled and tested in OSX

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
