### PR TITLE
[Aplication] Don't flip GFXContext if GUIRender is forced off

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1528,7 +1528,7 @@ void CApplication::Render()
     return;
 
   // render gui layer
-  if (!m_skipGuiRender)
+  if (m_renderGUI && !m_skipGuiRender)
   {
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode())
     {


### PR DESCRIPTION
## Description
We still Render GUI even CApplication::m_skipGUIRender is set to true

## Motivation and Context
We throw an exception if eglSwapBuffer fails -> kodi terminates

## How Has This Been Tested?
Android on shield TV 4K, play a movie, switch to "Android Home"

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
