### PR TITLE
Correctly read artist art after Coverity scan fix

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1912,7 +1912,7 @@ std::vector<std::string> CMusicInfoScanner::GetArtTypesToScan(const MediaType& m
   // Get default types of art that are to be automatically fetched during scanning
   if (mediaType == MediaTypeArtist)
   {
-    arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt;
+    arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistExtraArt;
     arttypes.emplace_back("thumb");
     arttypes.emplace_back("fanart");
   }


### PR DESCRIPTION
Fixes error introduced by Coverity fix #14556 after global slaying, **artist** art setting not being correctly read. Hence local artist art was no longer being automatically fetched.

Thanks Karellen for testing and spotting this.