### PR TITLE
Fix empty VideoResolution for certain 4K videos

### DIFF
--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -570,8 +570,11 @@ std::string CStreamDetails::VideoDimsToResolutionDescription(int iWidth, int iHe
   else if (iWidth <= 1920 && iHeight <= 1080)
     return "1080";
   // 4K
-  else if (iWidth * iHeight >= 6000000)
+  else if (iWidth <= 4096 && iHeight <= 2160)
     return "4K";
+  // 8K
+  else if (iWidth <= 8192 && iHeight <= 4320)
+    return "8K";
   else
     return "";
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Changes the logic for detecting 4K videos and also adds support for 8K.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
4K videos using a 2.76:1 aspect ratio (eg Hateful 8) are not detected as 4K because their height is so low and the VideoResolution label ends up being left empty.
This fixes the problem and also adds 8K support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on Confluence.

## Screenshots (if appropriate):
4K 2.76:1
![screenshot001](https://user-images.githubusercontent.com/133808/47704619-27385b80-dc1c-11e8-9924-8ec8c584f33d.png)
8K
![screenshot000](https://user-images.githubusercontent.com/133808/47704628-2e5f6980-dc1c-11e8-8118-c6e443b36c87.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
