### PR TITLE
Fix RES_DESKTOP calibration setting assignement

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -497,7 +497,7 @@ void CDisplaySettings::ApplyCalibrations()
   for (ResolutionInfos::const_iterator itCal = m_calibrations.begin(); itCal != m_calibrations.end(); ++itCal)
   {
     // find resolutions
-    for (size_t res = 0; res < m_resolutions.size(); ++res)
+    for (size_t res = RES_DESKTOP; res < m_resolutions.size(); ++res)
     {
       if (res == RES_WINDOW)
         continue;
@@ -548,23 +548,23 @@ void CDisplaySettings::ApplyCalibrations()
 void CDisplaySettings::UpdateCalibrations()
 {
   CSingleLock lock(m_critical);
-  for (size_t res = RES_DESKTOP; res < m_resolutions.size(); ++res)
-  {
-    // find calibration
-    bool found = false;
-    for (ResolutionInfos::iterator itCal = m_calibrations.begin(); itCal != m_calibrations.end(); ++itCal)
-    {
-      if (StringUtils::EqualsNoCase(itCal->strMode, m_resolutions[res].strMode))
-      {
-        //! @todo erase calibrations with default values
-        *itCal = m_resolutions[res];
-        found = true;
-        break;
-      }
-    }
 
-    if (!found)
-      m_calibrations.push_back(m_resolutions[res]);
+  // Add new (unique) resolutions
+  for (ResolutionInfos::const_iterator res(m_resolutions.cbegin() + RES_DESKTOP + 1); res != m_resolutions.cend(); ++res)
+    if (std::find_if(m_calibrations.cbegin(), m_calibrations.cend(),
+      [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(res->strMode, info.strMode); }) == m_resolutions.cend())
+        m_calibrations.push_back(*res);
+
+  for (auto &cal : m_calibrations)
+  {
+    ResolutionInfos::const_iterator res(std::find_if(m_resolutions.cbegin()+ RES_DESKTOP, m_resolutions.cend(),
+      [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(cal.strMode, info.strMode); }));
+
+    if (res != m_resolutions.cend())
+    {
+      //! @todo erase calibrations with default values
+      cal = *res;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Fix calibration settings set for RES_DESKTOP to be properly serialized to guisettings.

## Motivation and Context
RES_DESKTOP display mode is listed twice in our resolutions, once at RES_DESKTOP position, and again in one of the RES_USER positions. Changing calibration of RES_DESKTOP only applies to the first entry, while serializing the settings are overwritten by the old settings from RES_USER entry.

-> After kodi restart all settings made previously for RES_DESKTOP are lost

## How Has This Been Tested?
- NVIDIA shield, start kodi (kodi runs in Android Mode (1080p@59.94)
- change subtitle position in settings::system::display::calibration from 1046 to 1000
- restart kodi, go back to calibration::settings. 

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
