### PR TITLE
[GLES] VideoPlayer: more cleanup

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -60,8 +60,9 @@ bool CRendererDRMPRIMEGLES::CreateTexture(int index)
 
   DeleteTexture(index);
 
-  std::memset(&im, 0, sizeof(im));
-  std::memset(&plane, 0, sizeof(CYuvPlane));
+  im = {};
+  plane = {};
+
   im.height = m_sourceHeight;
   im.width  = m_sourceWidth;
   im.cshift_x = 1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -157,8 +157,8 @@ bool CRendererVAAPI::CreateTexture(int index)
 
   DeleteTexture(index);
 
-  memset(&im, 0, sizeof(im));
-  memset(&planes, 0, sizeof(CYuvPlane[YuvImage::MAX_PLANES]));
+  im = {};
+  std::fill(std::begin(planes), std::end(planes), CYuvPlane{});
   im.height = m_sourceHeight;
   im.width  = m_sourceWidth;
   im.cshift_x = 1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -12,14 +12,14 @@
 
 #include "system_gl.h"
 
-#include "FrameBufferObject.h"
-#include "xbmc/guilib/Shader.h"
+#include "BaseRenderer.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "cores/VideoSettings.h"
+#include "FrameBufferObject.h"
+#include "guilib/Shader.h"
 #include "RenderFlags.h"
 #include "RenderInfo.h"
 #include "windowing/GraphicContext.h"
-#include "BaseRenderer.h"
-#include "xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 
 extern "C" {
 #include "libavutil/mastering_display_metadata.h"
@@ -54,14 +54,6 @@ enum RenderQuality
   RQ_SOFTWARE
 };
 
-#define PLANE_Y 0
-#define PLANE_U 1
-#define PLANE_V 2
-
-#define FIELD_FULL 0
-#define FIELD_TOP 1
-#define FIELD_BOT 2
-
 class CEvent;
 
 class CLinuxRendererGLES : public CBaseRenderer
@@ -95,6 +87,10 @@ public:
   virtual bool Supports(ESCALINGMETHOD method) override;
 
 protected:
+  static const int FIELD_FULL{0};
+  static const int FIELD_TOP{1};
+  static const int FIELD_BOT{2};
+
   virtual void Render(unsigned int flags, int index);
   virtual void RenderUpdateVideo(bool clear, unsigned int flags = 0, unsigned int alpha = 255);
 
@@ -127,8 +123,6 @@ protected:
   void RenderFromFBO();
   void RenderSinglePass(int index, int field); // single pass glsl renderer
 
-  GLint GetInternalFormat(GLint format, int bpp);
-
   // hooks for HwDec Renderered
   virtual bool LoadShadersHook() { return false; };
   virtual bool RenderHook(int idx) { return false; };
@@ -157,25 +151,22 @@ protected:
 
   struct CYuvPlane
   {
-    GLuint id;
-    CRect rect;
+    GLuint id{0};
+    CRect rect{0, 0, 0, 0};
 
-    float width;
-    float height;
+    float width{0.0};
+    float height{0.0};
 
-    unsigned texwidth;
-    unsigned texheight;
+    unsigned texwidth{0};
+    unsigned texheight{0};
 
     //pixels per texel
-    unsigned pixpertex_x;
-    unsigned pixpertex_y;
+    unsigned pixpertex_x{0};
+    unsigned pixpertex_y{0};
   };
 
   struct CPictureBuffer
   {
-    CPictureBuffer();
-    ~CPictureBuffer() = default;
-
     CYuvPlane fields[MAX_FIELDS][YuvImage::MAX_PLANES];
     YuvImage image;
 
@@ -188,9 +179,9 @@ protected:
     int m_srcTextureBits{8};
     bool m_srcFullRange;
 
-    bool hasDisplayMetadata = false;
+    bool hasDisplayMetadata{false};
     AVMasteringDisplayMetadata displayMetadata;
-    bool hasLightMetadata = false;
+    bool hasLightMetadata{false};
     AVContentLightMetadata lightMetadata;
   };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -35,12 +35,7 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format, AVColorPrimar
 
   m_convertFullRange = false;
 
-  if (m_format == SHADER_YV12 ||
-      m_format == SHADER_YV12_9 ||
-      m_format == SHADER_YV12_10 ||
-      m_format == SHADER_YV12_12 ||
-      m_format == SHADER_YV12_14 ||
-      m_format == SHADER_YV12_16)
+  if (m_format == SHADER_YV12)
     m_defines += "#define XBMC_YV12\n";
   else if (m_format == SHADER_NV12)
     m_defines += "#define XBMC_NV12\n";
@@ -48,9 +43,6 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format, AVColorPrimar
     m_defines += "#define XBMC_NV12_RRG\n";
   else
     CLog::Log(LOGERROR, "GLES: BaseYUV2RGBGLSLShader - unsupported format %d", m_format);
-
-  CLog::Log(LOGDEBUG, "GLES: BaseYUV2RGBGLSLShader - srcPrimaries {}", srcPrimaries);
-  CLog::Log(LOGDEBUG, "GLES: BaseYUV2RGBGLSLShader - dstPrimaries {}", dstPrimaries);
 
   if (dstPrimaries != srcPrimaries)
   {


### PR DESCRIPTION
this cleanup involve the following:
 - c++ initializers
 - coding standard cleanup
 - fixes for compile warnings with gcc 8


```
/home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp:65:43: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct CLinuxRendererGLES::CYuvPlane'; use assignment or value-initialization instead [-Wclass-memaccess]
   std::memset(&plane, 0, sizeof(CYuvPlane));
                                           ^
In file included from /home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp:9:
/home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h:155:10: note: 'struct CLinuxRendererGLES::CYuvPlane' declared here
   struct CYuvPlane
          ^~~~~~~~~
```