### PR TITLE
[python-scrapers] extended music artwork

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -757,6 +757,7 @@ void DetailsFromFileItem<CAlbum>(const CFileItem &item, CAlbum &album)
   album.fRating = item.GetProperty("album.rating").asFloat();
   album.iUserrating = item.GetProperty("album.user_rating").asInteger32();
   album.iVotes = item.GetProperty("album.votes").asInteger32();
+  album.art = item.GetArt();
 
   int nThumbs = item.GetProperty("album.thumbs").asInteger32();
   ParseThumbs(album.thumbURL, item, nThumbs, "album.thumb");
@@ -777,6 +778,7 @@ void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
   artist.strBiography = FromString(item, "artist.biography");
   artist.strDied = FromString(item, "artist.died");
   artist.strDisbanded = FromString(item, "artist.disbanded");
+  artist.art = item.GetArt();
 
   int nAlbums = item.GetProperty("artist.albums").asInteger32();
   artist.discography.reserve(nAlbums);


### PR DESCRIPTION
currently python based music scrapers can only provide thumb & fanart artwork.
this change will allow those scrapers to provide any type of artwork.