### PR TITLE
[addons] remove CAddonDll::GetSetting() is calling the parent only

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -371,11 +371,6 @@ void CAddonDll::SaveSettings()
     TransferSettings();
 }
 
-std::string CAddonDll::GetSetting(const std::string& key)
-{
-  return CAddon::GetSetting(key);
-}
-
 ADDON_STATUS CAddonDll::TransferSettings()
 {
   bool restart = false;

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -35,7 +35,6 @@ namespace ADDON
 
     // addon settings
     void SaveSettings() override;
-    std::string GetSetting(const std::string& key) override;
 
     ADDON_STATUS Create(ADDON_TYPE type, void* funcTable, void* info);
     void Destroy();


### PR DESCRIPTION
## Description
This removes a never-used implementation of a function which only calls its parent. This means that a C ++ addon can no longer pass its own defned settings via a function (it was never used), so this parent declaration will never make sense.

## Motivation and Context
Cleanup

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
