### PR TITLE
[VideoPlayer] SetResolution synchronously instead RM::TriggerResolution

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3747,7 +3747,8 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
     {
       double framerate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
-      m_renderManager.TriggerUpdateResolution(static_cast<float>(framerate), hint.width, hint.stereo_mode);
+      RESOLUTION res = CResolutionUtils::ChooseBestResolution(static_cast<float>(framerate), hint.width, hint.height, !hint.stereo_mode.empty());
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
     }
   }
 


### PR DESCRIPTION
## Description
Process initial resolution change (if requested in settings / from stream) synchronously on VideoPlayer startup instead using the asynchronous RenderManager::TriggerUpdateResolution.

## Motivation and Context
If user has enabled "Adjust display refresh rate" and whitelist includes a resolution matching to the stream to play, we switch resolution / refresh rate on supported devices.

The current async workflow can lead to rough video startup.

This PR processes the ResolutionChange (for fullscreen video playback) before VP initializes the underlying processes. Video playback with resolution change starts with getting screen black and smooth playback afterwards.

Please note, that handling of resolution changes during playback is not changed, its still async.

## How Has This Been Tested?
- Android NVIDIA Shield
- Start kodi in 59.97 Hz
- Enable "Adjust display refresh rate"
- Activate 1080p@50 in whitelist
- Play a 1080p@50 movie 

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
