### PR TITLE
[Android] block ResolutionChange until onDisplayChanged arrives

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -244,6 +244,7 @@ private:
 
   static CVideoSyncAndroid* m_syncImpl;
   static CEvent m_vsyncEvent;
+  static CEvent m_displayChangeEvent;
 
   void XBMC_Pause(bool pause);
   void XBMC_Stop();

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -93,9 +93,6 @@ static void process_input(struct android_app* app, struct android_poll_source* s
 extern void android_main(struct android_app* state)
 {
   {
-    // make sure that the linker doesn't strip out our glue
-    app_dummy();
-
     // revector inputPollSource.process so we can shut up
     // its useless verbose logging on new events (see ouya)
     // and fix the error in handling multiple input events.


### PR DESCRIPTION
## Description
Block ResolutionChange until onDisplayChanged arrives

## Motivation and Context
If kodi requests a resolution change, we currently return too fast and allow VP to process code which has to be done after the resolution change is finished.

## How Has This Been Tested?
- Android NVIDIA Shield

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
