### PR TITLE
[macos] Support all display resolutions available for the given screen.

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -221,6 +221,39 @@ size_t DisplayBitsPerPixelForMode(CGDisplayModeRef mode)
   return bitsPerPixel;
 }
 
+CFArrayRef GetAllDisplayModes(CGDirectDisplayID display)
+{
+  int value = 1;
+
+  CFNumberRef number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &value);
+  if (!number)
+  {
+    CLog::Log(LOGERROR, "GetAllDisplayModes - could not create Number!");
+    return NULL;
+  }
+
+  CFStringRef key = kCGDisplayShowDuplicateLowResolutionModes;
+  CFDictionaryRef options = CFDictionaryCreate(kCFAllocatorDefault, (const void **)&key, (const void **)&number, 1, NULL, NULL);
+  CFRelease(number);
+
+  if (!options)
+  {
+    CLog::Log(LOGERROR, "GetAllDisplayModes - could not create Dictionary!");
+    return NULL;
+  }
+
+  CFArrayRef displayModes = CGDisplayCopyAllDisplayModes(display, options);
+  CFRelease(options);
+
+  if (!displayModes)
+  {
+    CLog::Log(LOGERROR, "GetAllDisplayModes - no displaymodes found!");
+    return NULL;
+  }
+
+  return displayModes;
+}
+
 // mimic former behavior of deprecated CGDisplayBestModeForParameters
 CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display, size_t bitsPerPixel, size_t width, size_t height, boolean_t &match)
 {
@@ -233,7 +266,8 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display, size_t bitsPerPixel
   // Try to find a mode with the requested depth and equal or greater dimensions first.
   // If no match is found, try to find a mode with greater depth and same or greater dimensions.
   // If still no match is found, just use the current mode.
-  CFArrayRef allModes = CGDisplayCopyAllDisplayModes(display, NULL);
+  CFArrayRef allModes = GetAllDisplayModes(display);
+
   for(int i = 0; i < CFArrayGetCount(allModes); i++)	{
     CGDisplayModeRef mode = (CGDisplayModeRef)CFArrayGetValueAtIndex(allModes, i);
 
@@ -494,13 +528,10 @@ CGDisplayModeRef GetMode(int width, int height, double refreshrate, int screenId
 
   CLog::Log(LOGDEBUG, "GetMode looking for suitable mode with %d x %d @ %f Hz on display %d\n", width, height, refreshrate, screenIdx);
 
-  CFArrayRef displayModes = CGDisplayCopyAllDisplayModes(GetDisplayID(screenIdx), nullptr);
+  CFArrayRef displayModes = GetAllDisplayModes(GetDisplayID(screenIdx));
 
-  if (NULL == displayModes)
-  {
-    CLog::Log(LOGERROR, "GetMode - no displaymodes found!");
+  if (!displayModes)
     return NULL;
-  }
 
   for (int i=0; i < CFArrayGetCount(displayModes); ++i)
   {
@@ -1320,7 +1351,7 @@ void CWinSystemOSX::FillInVideoModes()
     double refreshrate;
     RESOLUTION_INFO res;
 
-    CFArrayRef displayModes = CGDisplayCopyAllDisplayModes(GetDisplayID(disp), nullptr);
+    CFArrayRef displayModes = GetAllDisplayModes(GetDisplayID(disp));
     NSString *dispName = screenNameForDisplay(GetDisplayID(disp));
 
     CLog::Log(LOGNOTICE, "Display %i has name %s", disp, [dispName UTF8String]);


### PR DESCRIPTION
Change macOS WinSystem implementation to support *all* display resolutions available for the given screen.

I have a late 2016 MBP running macOS Mojave at the default display resolution, which technically maps to 1680*1050.

<img width="664" alt="screenshot 2018-11-01 at 09 57 58" src="https://user-images.githubusercontent.com/3226626/47842330-ab294980-ddbc-11e8-86ce-9e851c65ed8c.png">

Unfortunately, Kodi did not detect/use this (my desktop) resolution. I saw multiple log lines

```
2018-10-31 23:17:35.837243+0100 kodi.bin[53081:2275592] Debug Print: GetMode - no match found!
```
Every time I entered Settings->System, Kodi was switching display to the best match it could find (which was not my desktop resolution!), asking whether I want to keep that (non-optimal resolution) and even when declined, unwanted shit happened, because Kodi was not able to switch back to the actual desktop resolution, because it did not know about it. The correct resolution did not appear in the list with the possible display resolutions. I had to "fix" guisettings.xml manually every time after I entered Settings->System...

This PR changes the way Kodi obtains the display resilutions from the OS to actually get all resolutions, not just a subset:

![screenshot001](https://user-images.githubusercontent.com/3226626/47842694-bd57b780-ddbd-11e8-8b81-5d46a88204ca.png)

Credits for the idea for the fix: https://stackoverflow.com/questions/30859718/cgdisplaycopyalldisplaymodes-leaves-out-one-valid-mode
