### PR TITLE
[test] Change kodi-test help text to right names

### DIFF
--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -200,10 +200,10 @@ std::vector<std::string> &CXBMCTestUtils::getGUISettingsFiles()
 }
 
 static const char usage[] =
-"XBMC Test Suite\n"
-"Usage: xbmc-test [options]\n"
+"Kodi Test Suite\n"
+"Usage: kodi-test [options]\n"
 "\n"
-"The following options are recognized by the xbmc-test program.\n"
+"The following options are recognized by the kodi-test program.\n"
 "\n"
 "  --add-testfilefactory-readurl [URL]\n"
 "    Add a url to be used int the TestFileFactory read tests.\n"


### PR DESCRIPTION
## Description
This change the help of the with `./kodi-test -h` returned text.

There was before returned:

```
XBMC Test Suite
Usage: xbmc-test [options]

The following options are recognized by the xbmc-test program.
```

## Motivation and Context
Not direct a required change but want to have the help matching the function :-)

## How Has This Been Tested?
Call with `make test` and then call `./kodi-test -h`

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
