### PR TITLE
OpenGL(ES) debugging improvements

### DIFF
--- a/xbmc/guilib/Shader.h
+++ b/xbmc/guilib/Shader.h
@@ -32,11 +32,17 @@ namespace Shaders {
     virtual bool InsertSource(const std::string& filename, const std::string& loc);
     bool OK() const { return m_compiled; }
 
+    std::string GetName() const { return m_filenames; }
+    std::string GetSourceWithLineNumbers() const;
+
   protected:
     std::string m_source;
     std::string m_lastLog;
     std::vector<std::string> m_attr;
     bool m_compiled = false;
+
+  private:
+    std::string m_filenames;
   };
 
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -9,15 +9,20 @@
 #include "guilib/DirtyRegion.h"
 #include "windowing/GraphicContext.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "RenderSystemGLES.h"
 #include "rendering/MatrixGL.h"
-#include "utils/log.h"
 #include "utils/GLUtils.h"
+#include "utils/log.h"
 #include "utils/TimeUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/MathUtils.h"
 #ifdef TARGET_POSIX
 #include "XTimeUtils.h"
+#endif
+
+#if defined(TARGET_LINUX)
+#include "utils/EGLUtils.h"
 #endif
 
 CRenderSystemGLES::CRenderSystemGLES()
@@ -72,6 +77,30 @@ bool CRenderSystemGLES::InitRenderSystem()
   }
 
   m_RenderExtensions += " ";
+
+//! @todo remove TARGET_RASPBERRY_PI when Raspberry Pi updates their GL headers
+#if defined(GL_KHR_debug) && defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_openGlDebugging)
+  {
+    if (IsExtSupported("GL_KHR_debug"))
+    {
+      auto glDebugMessageCallback = CEGLUtils::GetRequiredProcAddress<PFNGLDEBUGMESSAGECALLBACKKHRPROC>("glDebugMessageCallbackKHR");
+      auto glDebugMessageControl = CEGLUtils::GetRequiredProcAddress<PFNGLDEBUGMESSAGECONTROLKHRPROC>("glDebugMessageControlKHR");
+
+      glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR);
+      glDebugMessageCallback(KODI::UTILS::GL::GlErrorCallback, nullptr);
+
+      // ignore shader compilation information
+      glDebugMessageControl(GL_DEBUG_SOURCE_SHADER_COMPILER_KHR, GL_DEBUG_TYPE_OTHER_KHR, GL_DONT_CARE, 0, nullptr, GL_FALSE);
+
+      CLog::Log(LOGDEBUG, "OpenGL(ES): debugging enabled");
+    }
+    else
+    {
+      CLog::Log(LOGDEBUG, "OpenGL(ES): debugging requested but the required extension isn't available (GL_KHR_debug)");
+    }
+  }
+#endif
 
   LogGraphicsInfo();
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -433,6 +433,8 @@ void CAdvancedSettings::Initialize()
   m_extraLogEnabled = false;
   m_extraLogLevels = 0;
 
+  m_openGlDebugging = false;
+
   m_userAgent = g_sysinfo.GetUserAgent();
 
   m_initialized = true;
@@ -1228,6 +1230,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     for(std::vector<std::string>::iterator it = steps.begin(); it != steps.end(); ++it)
       m_seekSteps.push_back(atoi((*it).c_str()));
   }
+
+  XMLUtils::GetBoolean(pRootElement, "opengldebugging", m_openGlDebugging);
 
   // load in the settings overrides
   CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(pRootElement);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -381,6 +381,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     False to show at the bottom of video (default) */
     bool m_videoAssFixedWorks;
 
+    bool m_openGlDebugging;
+
     std::string m_userAgent;
 
   private:

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -321,6 +321,15 @@ bool CEGLContextUtils::CreateContext(CEGLAttributesVec contextAttribs)
   if (CEGLUtils::HasExtension(m_eglDisplay, "EGL_IMG_context_priority"))
     contextAttribs.Add({{EGL_CONTEXT_PRIORITY_LEVEL_IMG, EGL_CONTEXT_PRIORITY_HIGH_IMG}});
 
+//! @todo remove when Raspberry Pi updates their EGL headers
+#if !defined(TARGET_RASPBERRY_PI)
+  if (CEGLUtils::HasExtension(m_eglDisplay, "EGL_KHR_create_context") &&
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_openGlDebugging)
+  {
+    contextAttribs.Add({{EGL_CONTEXT_FLAGS_KHR, EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR}});
+  }
+#endif
+
   m_eglContext = eglCreateContext(m_eglDisplay, eglConfig,
                                   EGL_NO_CONTEXT, contextAttribs.Get());
 

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -7,47 +7,83 @@
  */
 
 #include "GLUtils.h"
+
 #include "log.h"
 #include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "rendering/MatrixGL.h"
 #include "rendering/RenderSystem.h"
+#include "utils/StringUtils.h"
 
-void _VerifyGLState(const char* szfile, const char* szfunction, int lineno){
-#if defined(HAS_GL) && defined(_DEBUG)
-#define printMatrix(matrix)                                             \
-  {                                                                     \
-    for (int ixx = 0 ; ixx<4 ; ixx++)                                   \
-      {                                                                 \
-        CLog::Log(LOGDEBUG, "% 3.3f % 3.3f % 3.3f % 3.3f ",             \
-                  matrix[ixx*4], matrix[ixx*4+1], matrix[ixx*4+2],      \
-                  matrix[ixx*4+3]);                                     \
-      }                                                                 \
-  }
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_logLevel < LOG_LEVEL_DEBUG_FREEMEM)
-    return;
+#include <map>
+#include <utility>
+
+namespace
+{
+
+#define X(VAL) std::make_pair(VAL, #VAL)
+std::map<GLenum, const char*> glErrors =
+{
+  // please keep attributes in accordance to:
+  // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetError.xhtml
+  X(GL_NO_ERROR),
+  X(GL_INVALID_ENUM),
+  X(GL_INVALID_VALUE),
+  X(GL_INVALID_OPERATION),
+  X(GL_INVALID_FRAMEBUFFER_OPERATION),
+  X(GL_OUT_OF_MEMORY),
+#if defined(HAS_GL)
+  X(GL_STACK_UNDERFLOW),
+  X(GL_STACK_OVERFLOW),
+#endif
+};
+#undef X
+
+} // namespace
+
+static void PrintMatrix(const GLfloat* matrix, std::string matrixName)
+{
+  CLog::Log(LOGDEBUG, "{}:\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}",
+                      matrixName,
+                      matrix[0], matrix[1], matrix[2], matrix[3],
+                      matrix[4], matrix[5], matrix[6], matrix[7],
+                      matrix[8], matrix[9], matrix[10], matrix[11],
+                      matrix[12], matrix[13], matrix[14], matrix[15]);
+}
+
+void _VerifyGLState(const char* szfile, const char* szfunction, int lineno)
+{
   GLenum err = glGetError();
-  if (err==GL_NO_ERROR)
+  if (err == GL_NO_ERROR)
+  {
     return;
-  CLog::Log(LOGERROR, "GL ERROR: %s\n", gluErrorString(err));
+  }
+
+  auto error = glErrors.find(err);
+  if (error != glErrors.end())
+  {
+    CLog::Log(LOGERROR, "GL(ES) ERROR: {}", error->second);
+  }
+
   if (szfile && szfunction)
-      CLog::Log(LOGERROR, "In file:%s function:%s line:%d", szfile, szfunction, lineno);
-  GLboolean bools[16];
+  {
+    CLog::Log(LOGERROR, "In file: {} function: {} line: {}", szfile, szfunction, lineno);
+  }
+
+  GLboolean scissors;
+  glGetBooleanv(GL_SCISSOR_TEST, &scissors);
+  CLog::Log(LOGDEBUG, "Scissor test enabled: {}", scissors == GL_TRUE ? "True" : "False");
+
   GLfloat matrix[16];
   glGetFloatv(GL_SCISSOR_BOX, matrix);
-  CLog::Log(LOGDEBUG, "Scissor box: %f, %f, %f, %f", matrix[0], matrix[1], matrix[2], matrix[3]);
-  glGetBooleanv(GL_SCISSOR_TEST, bools);
-  CLog::Log(LOGDEBUG, "Scissor test enabled: %d", (int)bools[0]);
+  CLog::Log(LOGDEBUG, "Scissor box: {}, {}, {}, {}", matrix[0], matrix[1], matrix[2], matrix[3]);
+
   glGetFloatv(GL_VIEWPORT, matrix);
-  CLog::Log(LOGDEBUG, "Viewport: %f, %f, %f, %f", matrix[0], matrix[1], matrix[2], matrix[3]);
-  glGetFloatv(GL_PROJECTION_MATRIX, matrix);
-  CLog::Log(LOGDEBUG, "Projection Matrix:");
-  printMatrix(matrix);
-  glGetFloatv(GL_MODELVIEW_MATRIX, matrix);
-  CLog::Log(LOGDEBUG, "Modelview Matrix:");
-  printMatrix(matrix);
-//  abort();
-#endif
+  CLog::Log(LOGDEBUG, "Viewport: {}, {}, {}, {}", matrix[0], matrix[1], matrix[2], matrix[3]);
+
+  PrintMatrix(glMatrixProject.Get(), "Projection Matrix");
+  PrintMatrix(glMatrixModview.Get(), "Modelview Matrix");
 }
 
 void LogGraphicsInfo()

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -38,9 +38,74 @@ std::map<GLenum, const char*> glErrors =
   X(GL_STACK_OVERFLOW),
 #endif
 };
+
+std::map<GLenum, const char*> glErrorSource =
+{
+//! @todo remove TARGET_RASPBERRY_PI when Raspberry Pi updates their GL headers
+#if defined(HAS_GLES) && defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
+  X(GL_DEBUG_SOURCE_API_KHR),
+  X(GL_DEBUG_SOURCE_WINDOW_SYSTEM_KHR),
+  X(GL_DEBUG_SOURCE_SHADER_COMPILER_KHR),
+  X(GL_DEBUG_SOURCE_THIRD_PARTY_KHR),
+  X(GL_DEBUG_SOURCE_APPLICATION_KHR),
+  X(GL_DEBUG_SOURCE_OTHER_KHR),
+#endif
+};
+
+std::map<GLenum, const char*> glErrorType =
+{
+//! @todo remove TARGET_RASPBERRY_PI when Raspberry Pi updates their GL headers
+#if defined(HAS_GLES) && defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
+  X(GL_DEBUG_TYPE_ERROR_KHR),
+  X(GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_KHR),
+  X(GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR),
+  X(GL_DEBUG_TYPE_PORTABILITY_KHR),
+  X(GL_DEBUG_TYPE_PERFORMANCE_KHR),
+  X(GL_DEBUG_TYPE_OTHER_KHR),
+  X(GL_DEBUG_TYPE_MARKER_KHR),
+#endif
+};
+
+std::map<GLenum, const char*> glErrorSeverity =
+{
+//! @todo remove TARGET_RASPBERRY_PI when Raspberry Pi updates their GL headers
+#if defined(HAS_GLES) && defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
+  X(GL_DEBUG_SEVERITY_HIGH_KHR),
+  X(GL_DEBUG_SEVERITY_MEDIUM_KHR),
+  X(GL_DEBUG_SEVERITY_LOW_KHR),
+  X(GL_DEBUG_SEVERITY_NOTIFICATION_KHR),
+#endif
+};
 #undef X
 
 } // namespace
+
+void KODI::UTILS::GL::GlErrorCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam)
+{
+  std::string sourceStr;
+  std::string typeStr;
+  std::string severityStr;
+
+  auto glSource = glErrorSource.find(source);
+  if (glSource != glErrorSource.end())
+  {
+    sourceStr = glSource->second;
+  }
+
+  auto glType = glErrorType.find(type);
+  if (glType != glErrorType.end())
+  {
+    typeStr = glType->second;
+  }
+
+  auto glSeverity = glErrorSeverity.find(severity);
+  if (glSeverity != glErrorSeverity.end())
+  {
+    severityStr = glSeverity->second;
+  }
+
+  CLog::Log(LOGDEBUG, "OpenGL(ES) Debugging:\nSource: {}\nType: {}\nSeverity: {}\nID: {}\nMessage: {}", sourceStr, typeStr, severityStr, id, message);
+}
 
 static void PrintMatrix(const GLfloat* matrix, std::string matrixName)
 {

--- a/xbmc/utils/GLUtils.h
+++ b/xbmc/utils/GLUtils.h
@@ -21,6 +21,19 @@
 
 #include "system_gl.h"
 
+namespace KODI
+{
+namespace UTILS
+{
+namespace GL
+{
+
+void GlErrorCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
+
+}
+}
+}
+
 void _VerifyGLState(const char* szfile, const char* szfunction, int lineno);
 #if defined(GL_DEBUGGING) && (defined(HAS_GL) || defined(HAS_GLES))
 #define VerifyGLState() _VerifyGLState(__FILE__, __FUNCTION__, __LINE__)


### PR DESCRIPTION
This change allows us to actually use the `VerifyGLState()` calls that are littered throughout our render system.

Using these changes we can get valuable information about debugging our OpenGL(ES) systems.

This also add a new OpenGL(ES) logging component to enable this logging.

So now you will see errors like so
```
14:34:49.921 T:139935484173888   ERROR: In file: /home/lukas/Documents/git/xbmc/xbmc/guilib/TextureGL.cpp function: LoadToGPU line: 202
14:34:49.921 T:139935484173888   DEBUG: Scissor test enabled: True
14:34:49.921 T:139935484173888   DEBUG: Scissor box: 0, 0, 1920, 1080
14:34:49.921 T:139935484173888   DEBUG: Viewport: 0, 0, 1920, 1080
14:34:49.921 T:139935484173888   DEBUG: Projection Matrix:
                                             1.125      0.000      0.000      0.000
                                             0.000      2.000      0.000      0.000
                                             0.000      0.000     -1.020     -1.000
                                             0.000      0.000     -1090.909   0.000
14:34:49.921 T:139935484173888   DEBUG: Modelview Matrix:
                                             1.000      0.000      0.000      0.000
                                             0.000     -1.000      0.000      0.000
                                             0.000      0.000     -1.000      0.000
                                            -960.000    540.000   -1080.000   1.000
```

More and/or different GL debugging can also be added later.

The only thing I'm not sure about here is if we should hard fail like I have it set after 5 OpenGL(ES) errors. Otherwise the errors will run up the log (if you have OpenGL(ES) component logging enabled) and kodi will continue to function.

The last commit adds the shader source to log if it failed to compile. This has been an issue for a while because we manipulate the shader source by inserting and appending to it. This creates an issue where the error line thrown by the glsl compilation doesn't match what is in the source file. With this we can clearly see the line that is provided by the error.

This now shows up like so:
```
14:34:49.507 T:139935484173888   ERROR: 0:32(7): error: syntax error, unexpected NEW_IDENTIFIER, expecting ',' or ';'
14:34:49.507 T:139935484173888   ERROR: GL: Error compiling fragment shader: gles_shader_fonts.frag gles_tonemap.frag
14:34:49.507 T:139935484173888   DEBUG: GL: fragment shader source:
                                              1: /*
                                              2:  *      Copyright (C) 2010-2013 Team XBMC
                                              3:  *      http://xbmc.org
                                              4:  *
                                              5:  *  This Program is free software; you can redistribute it and/or modify
                                              6:  *  it under the terms of the GNU General Public License as published by
                                              7:  *  the Free Software Foundation; either version 2, or (at your option)
                                              8:  *  any later version.
                                              9:  *
                                             10:  *  This Program is distributed in the hope that it will be useful,
                                             11:  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
                                             12:  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
                                             13:  *  GNU General Public License for more details.
                                             14:  *
                                             15:  *  You should have received a copy of the GNU General Public License
                                             16:  *  along with XBMC; see the file COPYING.  If not, see
                                             17:  *  <http://www.gnu.org/licenses/>.
                                             18:  *
                                             19:  */
                                             20:
                                             21: #version 100
                                             22:
                                             23: precision mediump float;
                                             24: uniform sampler2D m_samp0;
                                             25: varying vec4 m_cord0;
                                             26: varying lowp vec4 m_colour;
                                             27:
                                             28: void main ()
                                             29: {
                                             30:   vec4 rgb;
                                             31:
                                             32:   yolo swag
                                             33:
                                             34:   rgb.rgb = m_colour.rgb;
                                             35:   rgb.a = m_colour.a * texture2D(m_samp0, m_cord0.xy).a;
                                             36:
                                             37: #if defined(KODI_LIMITED_RANGE)
                                             38:   rgb.rgb *= (235.0 - 16.0) / 255.0;
                                             39:   rgb.rgb += 16.0 / 255.0;
                                             40: #endif
                                             41:
                                             42:   gl_FragColor = rgb;
                                             43: }
                                             44: float tonemap(float val)
                                             45: {
                                             46:   return val * (1.0 + val / (m_toneP1 * m_toneP1)) / (1.0 + val);
                                             47: }
                                             48:
```

So you can clearly see the error is at line `32` (among other problems)