### PR TITLE
[cmake] Rework FindJsonSchemaBuilder on the model of FindTextureBuilder

### DIFF
--- a/cmake/modules/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/FindJsonSchemaBuilder.cmake
@@ -3,24 +3,39 @@
 # ---------------------
 # Finds the JsonSchemaBuilder
 #
+# If WITH_JSONSCHEMABUILDER is defined and points to a directory,
+# this path will be used to search for the JsonSchemaBuilder binary
+#
+#
 # This will define the following (imported) targets::
 #
 #   JsonSchemaBuilder::JsonSchemaBuilder   - The JsonSchemaBuilder executable
 
 if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
-  if(KODI_DEPENDSBUILD OR CMAKE_CROSSCOMPILING)
+  if(KODI_DEPENDSBUILD)
     add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
-    if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
-      set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
-                                                                 IMPORTED_LOCATION "${DEPENDENCIES_DIR}/bin/json-rpc/JsonSchemaBuilder")
-    else()
-      set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
-                                                                 IMPORTED_LOCATION "${NATIVEPREFIX}/bin/JsonSchemaBuilder")
-    endif()
-    set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES FOLDER Tools)
+    set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
+                                                       IMPORTED_LOCATION "${NATIVEPREFIX}/bin/JsonSchemaBuilder")
+  elseif(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
+    add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
+    set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
+                                                       IMPORTED_LOCATION "${DEPENDENCIES_DIR}/bin/json-rpc/JsonSchemaBuilder")
   else()
-    add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/JsonSchemaBuilder build/jsonschemabuilder)
-    add_executable(JsonSchemaBuilder::JsonSchemaBuilder ALIAS JsonSchemaBuilder)
-    set_target_properties(JsonSchemaBuilder PROPERTIES FOLDER Tools)
+    if(WITH_JSONSCHEMABUILDER)
+      get_filename_component(_jsbpath ${WITH_JSONSCHEMABUILDER} ABSOLUTE)
+      find_program(JSONSCHEMABUILDER_EXECUTABLE JsonSchemaBuilder PATHS ${_jsbpath})
+
+      include(FindPackageHandleStandardArgs)
+      find_package_handle_standard_args(JsonSchemaBuilder DEFAULT_MSG JSONSCHEMABUILDER_EXECUTABLE)
+      if(JSONSCHEMABUILDER_FOUND)
+        add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
+        set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
+                                                           IMPORTED_LOCATION "${JSONSCHEMABUILDER_EXECUTABLE}")
+      endif()
+      mark_as_advanced(JSONSCHEMABUILDER)
+    else()
+      add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/JsonSchemaBuilder build/jsonschemabuilder)
+      add_executable(JsonSchemaBuilder::JsonSchemaBuilder ALIAS JsonSchemaBuilder)
+    endif()
   endif()
 endif()


### PR DESCRIPTION
## Description
It allows to specify the location of the JsonSchemaBuilder
binary with the WITH_JSONSCHEMABUILDER cmake variable.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
JsonSchemaBuilder and TextureBuilder are currently the two binaries that need to be previously compiled when cross compiling Kodi because they are not available from outside of project.
It ease the cross-compilation of Kodi by allowing to specify the directory where JsonSchemaBuilder is located on the host.

## How Has This Been Tested?
It has been tested on my Linux machine, but definitely needs testing on other systems, especially Windows

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
