### PR TITLE
Fix remote access to images accidentally blocked by Cve 2017 5982 patch

### DIFF
--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -160,6 +160,8 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
     translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_AUDIOCDS_RECORDINGPATH), FileName);
   else if (RootDir == "screenshots")
     translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_DEBUG_SCREENSHOTPATH), FileName);
+  else if (RootDir == "musicartistsinfo")
+    translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER), FileName);
   else if (RootDir == "musicplaylists")
     translatedPath = URIUtils::AddFileToFolder(CUtil::MusicPlaylistsLocation(), FileName);
   else if (RootDir == "videoplaylists")

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -236,10 +236,12 @@ bool CFileUtils::CheckFileAccessAllowed(const std::string &filePath)
   // ALLOW kodi paths
   const std::vector<std::string> whitelist = {
     CSpecialProtocol::TranslatePath("special://home"),
-    CSpecialProtocol::TranslatePath("special://xbmc")
+    CSpecialProtocol::TranslatePath("special://xbmc"),
+    CSpecialProtocol::TranslatePath("special://musicartistsinfo")
   };
 
   // image urls come in the form of image://... sometimes with a / appended at the end
+  // and can be embedded in a music or video file image://music@...
   // strip this off to get the real file path
   bool isImage = false;
   std::string decodePath = CURL::Decode(filePath);
@@ -249,6 +251,8 @@ bool CFileUtils::CheckFileAccessAllowed(const std::string &filePath)
     isImage = true;
     decodePath.erase(pos, 8);
     URIUtils::RemoveSlashAtEnd(decodePath);
+    if (StringUtils::StartsWith(decodePath, "music@") || StringUtils::StartsWith(decodePath, "video@"))
+      decodePath.erase(pos, 6);
   }
 
   // check blacklist


### PR DESCRIPTION
Unfortunately the protection implemented for the CVE 2017  5982 exploit  #14501 is still blocking valid remote access to some images, which means missing artwork on Chorus and Kore etc.

Adust it to allow web server and JSON API access to images:
- embedded in media files (where they are on sources that allow sharing).  
These are requested with path like  "image://music@C:\MyMusic\Sheryl Crow\Feels Like Home\01 Shotgun.flac/" and the real path needed more stripping before searching sources.

 - artist art held in the nominated Artist Information folder (that may not be a source)
This folder is added to the whitelist of valid Kodi folders

@wsnipex  a few more adjustments. 
@MartijnKaijser I would really like to get this into Beta5 release either by merging quickly or delaying release