### PR TITLE
[PVR][Estuary] Misc RDS changes

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
@@ -231,7 +231,6 @@
 					<font>font36_title</font>
 					<label>$LOCALIZE[14304]</label>
 				</control>
-
 				<control type="label">
 					<top>50</top>
 					<width>780</width>
@@ -264,32 +263,6 @@
 					<label>$INFO[RDS.GetLine(0)]</label>
 					<scroll>true</scroll>
 				</control>
-
-<!--				<control type="grouplist">
-					<top>50</top>
-					<width>780</width>
-					<height>170</height>
-					<orientation>vertical</orientation>
-					<include content="RDSInfoLine">
-						<param name="value" value="RDS.GetLine(3)" />
-					</include>
-					<include content="RDSInfoLine">
-						<param name="value" value="RDS.GetLine(2)" />
-					</include>
-					<include content="RDSInfoLine">
-						<param name="value" value="RDS.GetLine(1)" />
-					</include>
-					<include content="RDSInfoLine">
-						<param name="value" value="RDS.GetLine(0)" />
-					</include>
-				</control> -->
-<!--				<control type="textbox">
-					<top>50</top>
-					<width>780</width>
-					<height>170</height>
-					<align>justify</align>
-					<label>$INFO[RDS.GetLine(3)][CR]$INFO[RDS.GetLine(2)][CR]$INFO[RDS.GetLine(1)][CR]$INFO[RDS.GetLine(0)]</label>
-				</control> -->
 			</control>
 
 			<include content="InfoDialogTopBarInfo">

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -290,7 +290,14 @@
 				<top>180</top>
 				<height>25</height>
 				<label>[COLOR grey]$LOCALIZE[19031]:[/COLOR] $INFO[VideoPlayer.NextStartTime] - $INFO[VideoPlayer.NextEndTime]: $INFO[VideoPlayer.NextTitle]</label>
-				<visible>VideoPlayer.HasEpg</visible>
+				<visible>VideoPlayer.HasEpg + !RDS.HasRadioText</visible>
+			</control>
+			<control type="label">
+				<left>260</left>
+				<top>180</top>
+				<height>25</height>
+				<label>[COLOR grey]$LOCALIZE[14304]: [/COLOR]$INFO[RDS.GetLine(0)]</label>
+				<visible>RDS.HasRadioText</visible>
 			</control>
 		</control>
 		<control type="group">

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -325,7 +325,7 @@
 				</control>
 			</control>
 		</control>
-  </include>
+	</include>
 	<include name="RDSInfoLine">
 		<control type="grouplist">
 			<visible>!String.IsEmpty($PARAM[value])</visible>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -33,7 +33,6 @@
 #include "video/VideoDatabase.h"
 #include "music/MusicDatabase.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRRadioRDSInfoTag.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
@@ -428,7 +427,6 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_pvrChannelInfoTag = item.m_pvrChannelInfoTag;
   m_pvrRecordingInfoTag = item.m_pvrRecordingInfoTag;
   m_pvrTimerInfoTag = item.m_pvrTimerInfoTag;
-  m_pvrRadioRDSInfoTag = item.m_pvrRadioRDSInfoTag;
   m_addonInfo = item.m_addonInfo;
   m_eventLogEntry = item.m_eventLogEntry;
 
@@ -502,7 +500,6 @@ void CFileItem::Reset()
   m_pvrChannelInfoTag.reset();
   m_pvrRecordingInfoTag.reset();
   m_pvrTimerInfoTag.reset();
-  m_pvrRadioRDSInfoTag.reset();
   delete m_pictureInfoTag;
   m_pictureInfoTag=NULL;
   delete m_gameInfoTag;
@@ -560,13 +557,6 @@ void CFileItem::Archive(CArchive& ar)
     }
     else
       ar << 0;
-    if (m_pvrRadioRDSInfoTag)
-    {
-      ar << 1;
-      ar << *m_pvrRadioRDSInfoTag;
-    }
-    else
-      ar << 0;
     if (m_pictureInfoTag)
     {
       ar << 1;
@@ -620,9 +610,6 @@ void CFileItem::Archive(CArchive& ar)
       ar >> *GetVideoInfoTag();
     ar >> iType;
     if (iType == 1)
-      ar >> *m_pvrRadioRDSInfoTag;
-    ar >> iType;
-    if (iType == 1)
       ar >> *GetPictureInfoTag();
     ar >> iType;
     if (iType == 1)
@@ -650,9 +637,6 @@ void CFileItem::Serialize(CVariant& value) const
 
   if (m_videoInfoTag)
     (*m_videoInfoTag).Serialize(value["videoInfoTag"]);
-
-  if (m_pvrRadioRDSInfoTag)
-    m_pvrRadioRDSInfoTag->Serialize(value["rdsInfoTag"]);
 
   if (m_pictureInfoTag)
     (*m_pictureInfoTag).Serialize(value["pictureInfoTag"]);
@@ -864,11 +848,6 @@ bool CFileItem::IsInProgressPVRRecording() const
 bool CFileItem::IsPVRTimer() const
 {
   return HasPVRTimerInfoTag();
-}
-
-bool CFileItem::IsPVRRadioRDS() const
-{
-  return HasPVRRadioRDSInfoTag();
 }
 
 bool CFileItem::IsDiscStub() const
@@ -1608,11 +1587,6 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
   if (item.HasMusicInfoTag())
   {
     *GetMusicInfoTag() = *item.GetMusicInfoTag();
-    SetInvalid();
-  }
-  if (item.HasPVRRadioRDSInfoTag())
-  {
-    m_pvrRadioRDSInfoTag = item.m_pvrRadioRDSInfoTag;
     SetInvalid();
   }
   if (item.HasPictureInfoTag())

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -228,7 +228,6 @@ public:
   bool IsDeletedPVRRecording() const;
   bool IsInProgressPVRRecording() const;
   bool IsPVRTimer() const;
-  bool IsPVRRadioRDS() const;
   bool IsType(const char *ext) const;
   bool IsVirtualDirectoryRoot() const;
   bool IsReadOnly() const;
@@ -315,21 +314,6 @@ public:
   inline const PVR::CPVRTimerInfoTagPtr GetPVRTimerInfoTag() const
   {
     return m_pvrTimerInfoTag;
-  }
-
-  inline bool HasPVRRadioRDSInfoTag() const
-  {
-    return m_pvrRadioRDSInfoTag.get() != NULL;
-  }
-
-  inline const PVR::CPVRRadioRDSInfoTagPtr GetPVRRadioRDSInfoTag() const
-  {
-    return m_pvrRadioRDSInfoTag;
-  }
-
-  inline void SetPVRRadioRDSInfoTag(const PVR::CPVRRadioRDSInfoTagPtr& tag)
-  {
-    m_pvrRadioRDSInfoTag = tag;
   }
 
   /*!
@@ -583,7 +567,6 @@ private:
   PVR::CPVRChannelPtr m_pvrChannelInfoTag;
   PVR::CPVRRecordingPtr m_pvrRecordingInfoTag;
   PVR::CPVRTimerInfoTagPtr m_pvrTimerInfoTag;
-  PVR::CPVRRadioRDSInfoTagPtr m_pvrRadioRDSInfoTag;
   CPictureInfoTag* m_pictureInfoTag;
   std::shared_ptr<const ADDON::IAddon> m_addonInfo;
   KODI::GAME::CGameInfoTag* m_gameInfoTag;

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -535,7 +535,8 @@ bool CDVDRadioRDSData::OpenStream(CDVDStreamInfo hints)
 void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 {
   // wait until buffers are empty
-  if (bWaitForBuffers) m_messageQueue.WaitUntilEmpty();
+  if (bWaitForBuffers)
+    m_messageQueue.WaitUntilEmpty();
 
   m_messageQueue.Abort();
 
@@ -546,6 +547,8 @@ void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 
   m_messageQueue.End();
   m_currentInfoTag.reset();
+  m_currentChannel->SetRadioRDSInfoTag(m_currentInfoTag);
+  m_currentChannel.reset();
 }
 
 void CDVDRadioRDSData::ResetRDSCache()
@@ -609,10 +612,10 @@ void CDVDRadioRDSData::ResetRDSCache()
   m_RTPlus_Starttime = time(NULL);
   m_RTPlus_GenrePresent = false;
 
-  m_currentInfoTag = CPVRRadioRDSInfoTag::CreateDefaultTag();
+  m_currentInfoTag = std::make_shared<CPVRRadioRDSInfoTag>();
   m_currentChannel = g_application.CurrentFileItem().GetPVRChannelInfoTag();
-  g_application.CurrentFileItem().SetPVRRadioRDSInfoTag(m_currentInfoTag);
-  CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(g_application.CurrentFileItem());
+  if (m_currentChannel)
+    m_currentChannel->SetRadioRDSInfoTag(m_currentInfoTag);
 
   // send a message to all windows to tell them to update the radiotext
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);

--- a/xbmc/interfaces/legacy/InfoTagRadioRDS.cpp
+++ b/xbmc/interfaces/legacy/InfoTagRadioRDS.cpp
@@ -7,21 +7,19 @@
  */
 
 #include "InfoTagRadioRDS.h"
+#include "pvr/channels/PVRChannel.h"
 #include "utils/StringUtils.h"
 
 namespace XBMCAddon
 {
   namespace xbmc
   {
-    InfoTagRadioRDS::InfoTagRadioRDS()
-    {
-      PVR::CPVRRadioRDSInfoTagPtr empty;
-      infoTag = empty;
-    }
+    InfoTagRadioRDS::InfoTagRadioRDS() = default;
 
-    InfoTagRadioRDS::InfoTagRadioRDS(const PVR::CPVRRadioRDSInfoTagPtr tag)
+    InfoTagRadioRDS::InfoTagRadioRDS(const PVR::CPVRChannelPtr& channel)
     {
-      infoTag = tag;
+      if (channel)
+        infoTag = channel->GetRadioRDSInfoTag();
     }
 
     InfoTagRadioRDS::~InfoTagRadioRDS() = default;

--- a/xbmc/interfaces/legacy/InfoTagRadioRDS.h
+++ b/xbmc/interfaces/legacy/InfoTagRadioRDS.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
 #include "AddonClass.h"
 
@@ -49,7 +50,7 @@ namespace XBMCAddon
 
     public:
 #ifndef SWIG
-      explicit InfoTagRadioRDS(const PVR::CPVRRadioRDSInfoTagPtr tag);
+      explicit InfoTagRadioRDS(const PVR::CPVRChannelPtr& channel);
 #endif
       InfoTagRadioRDS();
       ~InfoTagRadioRDS() override;

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -396,8 +396,8 @@ namespace XBMCAddon
         throw PlayerException("Kodi is not playing any music file with RDS");
 
       std::shared_ptr<CFileItem> item = g_application.CurrentFileItemPtr();
-      if (item && item->HasPVRRadioRDSInfoTag())
-        return new InfoTagRadioRDS(item->GetPVRRadioRDSInfoTag());
+      if (item && item->HasPVRChannelInfoTag())
+        return new InfoTagRadioRDS(item->GetPVRChannelInfoTag());
 
       return new InfoTagRadioRDS();
     }

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -396,18 +396,6 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
     return false;
   }
 
-  if (item->HasPVRRadioRDSInfoTag())
-  {
-    switch (info.m_info)
-    {
-      case MUSICPLAYER_CHANNEL_NAME:
-        strValue = item->GetPVRRadioRDSInfoTag()->GetProgStation();
-        if (!strValue.empty())
-          return true;
-        break; // try to get channel name from channel tag
-    }
-  }
-
   CPVREpgInfoTagPtr epgTag;
   CPVRChannelPtr channel;
   if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
@@ -593,6 +581,16 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
     switch (info.m_info)
     {
       case MUSICPLAYER_CHANNEL_NAME:
+      {
+        const std::shared_ptr<CPVRRadioRDSInfoTag> rdsTag = channel->GetRadioRDSInfoTag();
+        if (rdsTag)
+        {
+          strValue = rdsTag->GetProgStation();
+          if (!strValue.empty())
+            return true;
+        }
+        // fall-thru is intended
+      }
       case VIDEOPLAYER_CHANNEL_NAME:
       case LISTITEM_CHANNEL_NAME:
         strValue = channel->ChannelName();
@@ -827,7 +825,10 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem *item, const CGUIInfo &info, std::
 
 bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem *item, const CGUIInfo &info, std::string &strValue) const
 {
-  const CPVRRadioRDSInfoTagPtr tag = item->GetPVRRadioRDSInfoTag();
+  if (!item->HasPVRChannelInfoTag())
+    return false;
+
+  const std::shared_ptr<CPVRRadioRDSInfoTag> tag = item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
     switch (info.m_info)
@@ -1280,7 +1281,10 @@ bool CPVRGUIInfo::GetPVRBool(const CFileItem *item, const CGUIInfo &info, bool& 
 
 bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem *item, const CGUIInfo &info, bool &bValue) const
 {
-  const CPVRRadioRDSInfoTagPtr tag = item->GetPVRRadioRDSInfoTag();
+  if (!item->HasPVRChannelInfoTag())
+    return false;
+
+  const std::shared_ptr<CPVRRadioRDSInfoTag> tag = item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
     switch (info.m_info)

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -281,6 +281,18 @@ bool CPVRChannel::SetLocked(bool bIsLocked)
   return false;
 }
 
+std::shared_ptr<CPVRRadioRDSInfoTag> CPVRChannel::GetRadioRDSInfoTag() const
+{
+  CSingleLock lock(m_critSection);
+  return m_rdsTag;
+}
+
+void CPVRChannel::SetRadioRDSInfoTag(const std::shared_ptr<CPVRRadioRDSInfoTag>& tag)
+{
+  CSingleLock lock(m_critSection);
+  m_rdsTag = tag;
+}
+
 bool CPVRChannel::IsRecording(void) const
 {
   return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*this);

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -27,6 +27,7 @@ class CFileItemList;
 namespace PVR
 {
   class CPVRChannelGroupInternal;
+  class CPVRRadioRDSInfoTag;
 
   /** PVR Channel class */
   class CPVRChannel : public Observable,
@@ -147,6 +148,18 @@ namespace PVR
      * @return If recording, gets the recording if the add-on provides the epg id in recordings
      */
     CPVRRecordingPtr GetRecording(void) const;
+
+    /*!
+     * @brief Obtain the Radio RDS data for this channel, if available.
+     * @return The Radio RDS data or nullptr.
+     */
+    std::shared_ptr<CPVRRadioRDSInfoTag> GetRadioRDSInfoTag() const;
+
+    /*!
+     * @brief Set the Radio RDS data for the channel.
+     * @param tag The RDS data.
+     */
+    void SetRadioRDSInfoTag(const std::shared_ptr<CPVRRadioRDSInfoTag>& tag);
 
     /*!
      * @return True if this channel has a corresponding recording, false otherwise
@@ -443,7 +456,8 @@ namespace PVR
     std::string      m_strChannelName;          /*!< the name for this channel used by XBMC */
     time_t           m_iLastWatched;            /*!< last time channel has been watched */
     bool             m_bChanged;                /*!< true if anything in this entry was changed that needs to be persisted */
-    CPVRChannelNumber m_channelNumber;         /*!< the number this channel has in the currently selected channel group */
+    CPVRChannelNumber m_channelNumber;          /*!< the number this channel has in the currently selected channel group */
+    std::shared_ptr<CPVRRadioRDSInfoTag> m_rdsTag; /*! < the radio rds data, if available for the channel. */
     //@}
 
     /*! @name EPG related channel data

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -20,11 +20,6 @@
 
 using namespace PVR;
 
-CPVRRadioRDSInfoTagPtr CPVRRadioRDSInfoTag::CreateDefaultTag()
-{
-  return CPVRRadioRDSInfoTagPtr(new CPVRRadioRDSInfoTag());
-}
-
 CPVRRadioRDSInfoTag::CPVRRadioRDSInfoTag(void)
 {
   Clear();

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -27,6 +27,8 @@ CPVRRadioRDSInfoTag::CPVRRadioRDSInfoTag(void)
 
 void CPVRRadioRDSInfoTag::Serialize(CVariant& value) const
 {
+  CSingleLock lock(m_critSection);
+
   value["strLanguage"] = m_strLanguage;
   value["strCountry"] = m_strCountry;
   value["strTitle"] = m_strTitle;
@@ -52,6 +54,8 @@ void CPVRRadioRDSInfoTag::Serialize(CVariant& value) const
 
 void CPVRRadioRDSInfoTag::Archive(CArchive& ar)
 {
+  CSingleLock lock(m_critSection);
+
   if (ar.IsStoring())
   {
     ar << m_strLanguage;
@@ -104,74 +108,74 @@ void CPVRRadioRDSInfoTag::Archive(CArchive& ar)
 
 bool CPVRRadioRDSInfoTag::operator==(const CPVRRadioRDSInfoTag &right) const
 {
-  return !(*this != right);
+  if (this == &right)
+    return true;
+
+  CSingleLock lock(m_critSection);
+  return (m_strLanguage == right.m_strLanguage &&
+          m_strCountry == right.m_strCountry &&
+          m_strTitle == right.m_strTitle &&
+          m_strBand == right.m_strBand &&
+          m_strArtist == right.m_strArtist &&
+          m_strComposer == right.m_strComposer &&
+          m_strConductor == right.m_strConductor &&
+          m_strAlbum == right.m_strAlbum &&
+          m_iAlbumTracknumber == right.m_iAlbumTracknumber &&
+          m_strInfoNews == right.m_strInfoNews &&
+          m_strInfoNewsLocal == right.m_strInfoNewsLocal &&
+          m_strInfoSport == right.m_strInfoSport &&
+          m_strInfoStock == right.m_strInfoStock &&
+          m_strInfoWeather == right.m_strInfoWeather &&
+          m_strInfoLottery == right.m_strInfoLottery &&
+          m_strInfoOther == right.m_strInfoOther &&
+          m_strProgStyle == right.m_strProgStyle &&
+          m_strProgHost == right.m_strProgHost &&
+          m_strProgStation == right.m_strProgStation &&
+          m_strProgWebsite == right.m_strProgWebsite &&
+          m_strProgNow == right.m_strProgNow &&
+          m_strProgNext == right.m_strProgNext &&
+          m_strPhoneHotline == right.m_strPhoneHotline &&
+          m_strEMailHotline == right.m_strEMailHotline &&
+          m_strPhoneStudio == right.m_strPhoneStudio &&
+          m_strEMailStudio == right.m_strEMailStudio &&
+          m_strSMSStudio == right.m_strSMSStudio &&
+          m_strRadioStyle == right.m_strRadioStyle &&
+          m_strInfoHoroscope == right.m_strInfoHoroscope &&
+          m_strInfoCinema == right.m_strInfoCinema &&
+          m_strComment == right.m_strComment &&
+          m_strEditorialStaff == right.m_strEditorialStaff &&
+          m_bHaveRadiotext == right.m_bHaveRadiotext &&
+          m_bHaveRadiotextPlus == right.m_bHaveRadiotextPlus);
 }
 
-bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& tag) const
+bool CPVRRadioRDSInfoTag::operator !=(const CPVRRadioRDSInfoTag& right) const
 {
-  if (this == &tag) return false;
-  if (m_strLanguage != tag.m_strLanguage) return true;
-  if (m_strCountry != tag.m_strCountry) return true;
-  if (m_strTitle != tag.m_strTitle) return true;
-  if (m_strBand != tag.m_strBand) return true;
-  if (m_strArtist != tag.m_strArtist) return true;
-  if (m_strComposer != tag.m_strComposer) return true;
-  if (m_strConductor != tag.m_strConductor) return true;
-  if (m_strAlbum != tag.m_strAlbum) return true;
-  if (m_iAlbumTracknumber != tag.m_iAlbumTracknumber) return true;
-  if (m_strInfoNews != tag.m_strInfoNews) return true;
-  if (m_strInfoNewsLocal != tag.m_strInfoNewsLocal) return true;
-  if (m_strInfoSport != tag.m_strInfoSport) return true;
-  if (m_strInfoStock != tag.m_strInfoStock) return true;
-  if (m_strInfoWeather != tag.m_strInfoWeather) return true;
-  if (m_strInfoLottery != tag.m_strInfoLottery) return true;
-  if (m_strInfoOther != tag.m_strInfoOther) return true;
-  if (m_strProgStyle != tag.m_strProgStyle) return true;
-  if (m_strProgHost != tag.m_strProgHost) return true;
-  if (m_strProgStation != tag.m_strProgStation) return true;
-  if (m_strProgWebsite != tag.m_strProgWebsite) return true;
-  if (m_strProgNow != tag.m_strProgNow) return true;
-  if (m_strProgNext != tag.m_strProgNext) return true;
-  if (m_strPhoneHotline != tag.m_strPhoneHotline) return true;
-  if (m_strEMailHotline != tag.m_strEMailHotline) return true;
-  if (m_strPhoneStudio != tag.m_strPhoneStudio) return true;
-  if (m_strEMailStudio != tag.m_strEMailStudio) return true;
-  if (m_strSMSStudio != tag.m_strSMSStudio) return true;
-  if (m_strRadioStyle != tag.m_strRadioStyle) return true;
-  if (m_strInfoHoroscope != tag.m_strInfoHoroscope) return true;
-  if (m_strInfoCinema != tag.m_strInfoCinema) return true;
-  if (m_strComment != tag.m_strComment) return true;
-  if (m_strEditorialStaff != tag.m_strEditorialStaff) return true;
+  if (this == &right)
+    return false;
 
-  if (m_bHaveRadiotext != tag.m_bHaveRadiotext) return true;
-  if (m_bHaveRadiotextPlus != tag.m_bHaveRadiotextPlus) return true;
-
-  return false;
+  return !(*this == right);
 }
 
 void CPVRRadioRDSInfoTag::Clear()
 {
+  CSingleLock lock(m_critSection);
+
   m_RDS_SpeechActive = false;
+
+  ResetSongInformation();
 
   m_strLanguage.erase();
   m_strCountry.erase();
-  m_strTitle.erase();
-  m_strBand.erase();
-  m_strArtist.erase();
-  m_strComposer.erase();
-  m_strConductor.erase();
-  m_strAlbum.erase();
   m_strComment.erase();
-  m_iAlbumTracknumber = 0;
-  m_strInfoNews.clear();
-  m_strInfoNewsLocal.clear();
-  m_strInfoSport.clear();
-  m_strInfoStock.clear();
-  m_strInfoWeather.clear();
-  m_strInfoLottery.clear();
-  m_strInfoOther.clear();
-  m_strInfoHoroscope.clear();
-  m_strInfoCinema.clear();
+  m_strInfoNews.Clear();
+  m_strInfoNewsLocal.Clear();
+  m_strInfoSport.Clear();
+  m_strInfoStock.Clear();
+  m_strInfoWeather.Clear();
+  m_strInfoLottery.Clear();
+  m_strInfoOther.Clear();
+  m_strInfoHoroscope.Clear();
+  m_strInfoCinema.Clear();
   m_strProgStyle.erase();
   m_strProgHost.erase();
   m_strProgStation.erase();
@@ -182,7 +186,7 @@ void CPVRRadioRDSInfoTag::Clear()
   m_strEMailStudio.erase();
   m_strSMSStudio.erase();
   m_strRadioStyle = "unknown";
-  m_strEditorialStaff.clear();
+  m_strEditorialStaff.Clear();
 
   m_bHaveRadiotext = false;
   m_bHaveRadiotextPlus = false;
@@ -190,6 +194,8 @@ void CPVRRadioRDSInfoTag::Clear()
 
 void CPVRRadioRDSInfoTag::ResetSongInformation()
 {
+  CSingleLock lock(m_critSection);
+
   m_strTitle.erase();
   m_strBand.erase();
   m_strArtist.erase();
@@ -201,573 +207,478 @@ void CPVRRadioRDSInfoTag::ResetSongInformation()
 
 void CPVRRadioRDSInfoTag::SetSpeechActive(bool active)
 {
+  CSingleLock lock(m_critSection);
   m_RDS_SpeechActive = active;
 }
 
 void CPVRRadioRDSInfoTag::SetLanguage(const std::string& strLanguage)
 {
+  CSingleLock lock(m_critSection);
   m_strLanguage = Trim(strLanguage);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetLanguage() const
 {
+  CSingleLock lock(m_critSection);
   return m_strLanguage;
 }
 
 void CPVRRadioRDSInfoTag::SetCountry(const std::string& strCountry)
 {
+  CSingleLock lock(m_critSection);
   m_strCountry = Trim(strCountry);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetCountry() const
 {
+  CSingleLock lock(m_critSection);
   return m_strCountry;
 }
 
 void CPVRRadioRDSInfoTag::SetTitle(const std::string& strTitle)
 {
+  CSingleLock lock(m_critSection);
   m_strTitle = Trim(strTitle);
 }
 
 void CPVRRadioRDSInfoTag::SetArtist(const std::string& strArtist)
 {
+  CSingleLock lock(m_critSection);
   m_strArtist = Trim(strArtist);
 }
 
 void CPVRRadioRDSInfoTag::SetBand(const std::string& strBand)
 {
+  CSingleLock lock(m_critSection);
   m_strBand = Trim(strBand);
   g_charsetConverter.unknownToUTF8(m_strBand);
 }
 
 void CPVRRadioRDSInfoTag::SetComposer(const std::string& strComposer)
 {
+  CSingleLock lock(m_critSection);
   m_strComposer = Trim(strComposer);
   g_charsetConverter.unknownToUTF8(m_strComposer);
 }
 
 void CPVRRadioRDSInfoTag::SetConductor(const std::string& strConductor)
 {
+  CSingleLock lock(m_critSection);
   m_strConductor = Trim(strConductor);
   g_charsetConverter.unknownToUTF8(m_strConductor);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbum(const std::string& strAlbum)
 {
+  CSingleLock lock(m_critSection);
   m_strAlbum = Trim(strAlbum);
   g_charsetConverter.unknownToUTF8(m_strAlbum);
 }
 
 void CPVRRadioRDSInfoTag::SetAlbumTrackNumber(int track)
 {
+  CSingleLock lock(m_critSection);
   m_iAlbumTracknumber = track;
 }
 
 void CPVRRadioRDSInfoTag::SetComment(const std::string& strComment)
 {
+  CSingleLock lock(m_critSection);
   m_strComment = Trim(strComment);
   g_charsetConverter.unknownToUTF8(m_strComment);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetTitle() const
 {
+  CSingleLock lock(m_critSection);
   return m_strTitle;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetArtist() const
 {
+  CSingleLock lock(m_critSection);
   return m_strArtist;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetBand() const
 {
+  CSingleLock lock(m_critSection);
   return m_strBand;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetComposer() const
 {
+  CSingleLock lock(m_critSection);
   return m_strComposer;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetConductor() const
 {
+  CSingleLock lock(m_critSection);
   return m_strConductor;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetAlbum() const
 {
+  CSingleLock lock(m_critSection);
   return m_strAlbum;
 }
 
 int CPVRRadioRDSInfoTag::GetAlbumTrackNumber() const
 {
+  CSingleLock lock(m_critSection);
   return m_iAlbumTracknumber;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetComment() const
 {
+  CSingleLock lock(m_critSection);
   return m_strComment;
 }
 
 void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
 {
-  std::string tmpStr = Trim(strNews);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoNews.size(); ++i)
-  {
-    if (m_strInfoNews[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoNews.size() >= 10)
-    m_strInfoNews.pop_front();
-
-  m_strInfoNews.emplace_back(std::move(tmpStr));
-
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoNews.Add(strNews);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoNews.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoNews[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoNews.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
 {
-  std::string tmpStr = Trim(strNews);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoNewsLocal.size(); ++i)
-  {
-    if (m_strInfoNewsLocal[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoNewsLocal.size() >= 10)
-    m_strInfoNewsLocal.pop_back();
-
-  m_strInfoNewsLocal.emplace_front(std::move(tmpStr));
-
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoNewsLocal.Add(strNews);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoNewsLocal.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoNewsLocal[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoNewsLocal.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
 {
-  std::string tmpStr = Trim(strSport);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoSport.size(); ++i)
-  {
-    if (m_strInfoSport[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoSport.size() >= 10)
-    m_strInfoSport.pop_back();
-
-  m_strInfoSport.emplace_front(std::move(tmpStr));
-
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoSport.Add(strSport);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoSport.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoSport[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoSport.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
 {
-  std::string tmpStr = Trim(strStock);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoStock.size(); ++i)
-  {
-    if (m_strInfoStock[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoStock.size() >= 10)
-    m_strInfoStock.pop_back();
-
-  m_strInfoStock.emplace_front(std::move(tmpStr));
-
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoStock.Add(strStock);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoStock.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoStock[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoStock.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
 {
-  std::string tmpStr = Trim(strWeather);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoWeather.size(); ++i)
-  {
-    if (m_strInfoWeather[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoWeather.size() >= 10)
-    m_strInfoWeather.pop_back();
-
-  m_strInfoWeather.emplace_front(std::move(tmpStr));
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoWeather.Add(strWeather);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoWeather.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoWeather[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoWeather.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
 {
-  std::string tmpStr = Trim(strLottery);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoLottery.size(); ++i)
-  {
-    if (m_strInfoLottery[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoLottery.size() >= 10)
-    m_strInfoLottery.pop_back();
-
-  m_strInfoLottery.emplace_front(std::move(tmpStr));
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoLottery.Add(strLottery);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoLottery.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoLottery[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoLottery.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff)
 {
-  std::string tmpStr = Trim(strEditorialStaff);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strEditorialStaff.size(); ++i)
-  {
-    if (m_strEditorialStaff[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strEditorialStaff.size() >= 10)
-    m_strEditorialStaff.pop_back();
-
-  m_strEditorialStaff.push_front(tmpStr);
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strEditorialStaff.Add(strEditorialStaff);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strEditorialStaff.size(); ++i)
-  {
-    std::string tmpStr = m_strEditorialStaff[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strEditorialStaff.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
 {
-  std::string tmpStr = Trim(strHoroscope);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoHoroscope.size(); ++i)
-  {
-    if (m_strInfoHoroscope[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoHoroscope.size() >= 10)
-    m_strInfoHoroscope.pop_back();
-
-  m_strInfoHoroscope.emplace_front(std::move(tmpStr));
-  // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoHoroscope.Add(strHoroscope);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoHoroscope.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoHoroscope[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoHoroscope.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
 {
-  std::string tmpStr = Trim(strCinema);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoCinema.size(); ++i)
-  {
-    if (m_strInfoCinema[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoCinema.size() >= 10)
-    m_strInfoCinema.pop_back();
-
-  m_strInfoCinema.emplace_front(std::move(tmpStr));
-  // send a message to all windows to tell them to update the fileitem radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoCinema.Add(strCinema);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoCinema.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoCinema[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoCinema.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
 {
-  std::string tmpStr = Trim(strOther);
-  g_charsetConverter.unknownToUTF8(tmpStr);
-
-  for (unsigned i = 0; i < m_strInfoOther.size(); ++i)
-  {
-    if (m_strInfoOther[i].compare(tmpStr) == 0)
-      return;
-  }
-
-  if (m_strInfoOther.size() >= 10)
-    m_strInfoOther.pop_back();
-
-  m_strInfoOther.emplace_front(std::move(tmpStr));
-  // send a message to all windows to tell them to update the fileitem radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+  CSingleLock lock(m_critSection);
+  m_strInfoOther.Add(strOther);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoOther() const
 {
-  std::string retStr = "";
-  for (unsigned i = 0; i < m_strInfoOther.size(); ++i)
-  {
-    std::string tmpStr = m_strInfoOther[i];
-    tmpStr.insert(tmpStr.end(),'\n');
-    retStr += tmpStr;
-  }
-
-  return retStr;
+  CSingleLock lock(m_critSection);
+  return m_strInfoOther.GetText();
 }
 
 void CPVRRadioRDSInfoTag::SetProgStation(const std::string& strProgStation)
 {
+  CSingleLock lock(m_critSection);
   m_strProgStation = Trim(strProgStation);
   g_charsetConverter.unknownToUTF8(m_strProgStation);
 }
 
 void CPVRRadioRDSInfoTag::SetProgHost(const std::string& strProgHost)
 {
+  CSingleLock lock(m_critSection);
   m_strProgHost = Trim(strProgHost);
   g_charsetConverter.unknownToUTF8(m_strProgHost);
 }
 
 void CPVRRadioRDSInfoTag::SetProgStyle(const std::string& strProgStyle)
 {
+  CSingleLock lock(m_critSection);
   m_strProgStyle = Trim(strProgStyle);
   g_charsetConverter.unknownToUTF8(m_strProgStyle);
 }
 
 void CPVRRadioRDSInfoTag::SetProgWebsite(const std::string& strWebsite)
 {
+  CSingleLock lock(m_critSection);
   m_strProgWebsite = Trim(strWebsite);
   g_charsetConverter.unknownToUTF8(m_strProgWebsite);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNow(const std::string& strNow)
 {
+  CSingleLock lock(m_critSection);
   m_strProgNow = Trim(strNow);
   g_charsetConverter.unknownToUTF8(m_strProgNow);
 }
 
 void CPVRRadioRDSInfoTag::SetProgNext(const std::string& strNext)
 {
+  CSingleLock lock(m_critSection);
   m_strProgNext = Trim(strNext);
   g_charsetConverter.unknownToUTF8(m_strProgNext);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneHotline(const std::string& strHotline)
 {
+  CSingleLock lock(m_critSection);
   m_strPhoneHotline = Trim(strHotline);
   g_charsetConverter.unknownToUTF8(m_strPhoneHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailHotline(const std::string& strHotline)
 {
+  CSingleLock lock(m_critSection);
   m_strEMailHotline = Trim(strHotline);
   g_charsetConverter.unknownToUTF8(m_strEMailHotline);
 }
 
 void CPVRRadioRDSInfoTag::SetPhoneStudio(const std::string& strPhone)
 {
+  CSingleLock lock(m_critSection);
   m_strPhoneStudio = Trim(strPhone);
   g_charsetConverter.unknownToUTF8(m_strPhoneStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetEMailStudio(const std::string& strEMail)
 {
+  CSingleLock lock(m_critSection);
   m_strEMailStudio = Trim(strEMail);
   g_charsetConverter.unknownToUTF8(m_strEMailStudio);
 }
 
 void CPVRRadioRDSInfoTag::SetSMSStudio(const std::string& strSMS)
 {
+  CSingleLock lock(m_critSection);
   m_strSMSStudio = Trim(strSMS);
   g_charsetConverter.unknownToUTF8(m_strSMSStudio);
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStyle() const
 {
+  CSingleLock lock(m_critSection);
   return m_strProgStyle;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgHost() const
 {
+  CSingleLock lock(m_critSection);
   return m_strProgHost;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgStation() const
 {
+  CSingleLock lock(m_critSection);
   return m_strProgStation;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgWebsite() const
 {
+  CSingleLock lock(m_critSection);
   return m_strProgWebsite;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgNow() const
 {
+  CSingleLock lock(m_critSection);
   return m_strProgNow;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetProgNext() const
 {
+  CSingleLock lock(m_critSection);
   return m_strProgNext;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetPhoneHotline() const
 {
+  CSingleLock lock(m_critSection);
   return m_strPhoneHotline;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetEMailHotline() const
 {
+  CSingleLock lock(m_critSection);
   return m_strEMailHotline;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetPhoneStudio() const
 {
+  CSingleLock lock(m_critSection);
   return m_strPhoneStudio;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetEMailStudio() const
 {
+  CSingleLock lock(m_critSection);
   return m_strEMailStudio;
 }
 
 const std::string& CPVRRadioRDSInfoTag::GetSMSStudio() const
 {
+  CSingleLock lock(m_critSection);
   return m_strSMSStudio;
 }
 
-std::string CPVRRadioRDSInfoTag::Trim(const std::string &value) const
+void CPVRRadioRDSInfoTag::SetRadioStyle(const std::string& style)
+{
+  CSingleLock lock(m_critSection);
+  m_strRadioStyle = style;
+}
+
+const std::string CPVRRadioRDSInfoTag::GetRadioStyle() const
+{
+  CSingleLock lock(m_critSection);
+  return m_strRadioStyle;
+}
+
+void CPVRRadioRDSInfoTag::SetPlayingRadiotext(bool yesNo)
+{
+  CSingleLock lock(m_critSection);
+  m_bHaveRadiotext = yesNo;
+}
+
+bool CPVRRadioRDSInfoTag::IsPlayingRadiotext() const
+{
+  CSingleLock lock(m_critSection);
+  return m_bHaveRadiotext;
+}
+
+void CPVRRadioRDSInfoTag::SetPlayingRadiotextPlus(bool yesNo)
+{
+  CSingleLock lock(m_critSection);
+  m_bHaveRadiotextPlus = yesNo;
+}
+
+bool CPVRRadioRDSInfoTag::IsPlayingRadiotextPlus() const
+{
+  CSingleLock lock(m_critSection);
+  return m_bHaveRadiotextPlus;
+}
+
+std::string CPVRRadioRDSInfoTag::Trim(const std::string &value)
 {
   std::string trimmedValue(value);
   StringUtils::TrimLeft(trimmedValue);
   StringUtils::TrimRight(trimmedValue, " \n\r");
   return trimmedValue;
+}
+
+bool CPVRRadioRDSInfoTag::Info::operator==(const CPVRRadioRDSInfoTag::Info &right) const
+{
+  if (this == &right)
+    return true;
+
+  return (m_infoText == right.m_infoText &&
+          m_data == right.m_data);
+}
+
+void CPVRRadioRDSInfoTag::Info::Clear()
+{
+  m_data.clear();
+  m_infoText.clear();
+}
+
+void CPVRRadioRDSInfoTag::Info::Add(const std::string& text)
+{
+  std::string tmp = Trim(text);
+  g_charsetConverter.unknownToUTF8(tmp);
+
+  if (std::find(m_data.begin(), m_data.end(), text) != m_data.end())
+    return;
+
+  if (m_data.size() >= 10)
+    m_data.pop_front();
+
+  m_data.emplace_back(std::move(tmp));
+
+  m_infoText.clear();
+  for (const std::string& data : m_data)
+  {
+    m_infoText += data;
+    m_infoText += '\n';
+  }
+
+  // send a message to all windows to tell them to update the radiotext
+  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.h
@@ -11,11 +11,8 @@
 #include <deque>
 #include <string>
 
-#include "XBDateTime.h"
 #include "utils/IArchivable.h"
 #include "utils/ISerializable.h"
-
-#include "pvr/PVRTypes.h"
 
 namespace PVR
 {
@@ -23,21 +20,8 @@ namespace PVR
 class CPVRRadioRDSInfoTag final : public IArchivable, public ISerializable
 {
 public:
-  /*!
-   * @brief Create a new empty event .
-   */
-  static CPVRRadioRDSInfoTagPtr CreateDefaultTag();
-
-private:
-  /*!
-   * @brief Create a new empty event.
-   */
   CPVRRadioRDSInfoTag(void);
 
-  CPVRRadioRDSInfoTag(const CPVRRadioRDSInfoTag& tag) = delete;
-  const CPVRRadioRDSInfoTag& operator =(const CPVRRadioRDSInfoTag& tag) = delete;
-
-public:
   bool operator ==(const CPVRRadioRDSInfoTag& tag) const;
   bool operator !=(const CPVRRadioRDSInfoTag& tag) const;
 
@@ -179,5 +163,9 @@ protected:
 
   bool m_bHaveRadiotext;
   bool m_bHaveRadiotextPlus;
+
+private:
+  CPVRRadioRDSInfoTag(const CPVRRadioRDSInfoTag& tag) = delete;
+  const CPVRRadioRDSInfoTag& operator =(const CPVRRadioRDSInfoTag& tag) = delete;
 };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
@@ -8,9 +8,9 @@
 
 #include "GUIDialogPVRRadioRDSInfo.h"
 
-#include "Application.h"
 #include "FileItem.h"
 #include "GUIUserMessages.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUISpinControl.h"
 #include "guilib/GUITextBox.h"
@@ -18,6 +18,8 @@
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
 
 using namespace PVR;
@@ -57,7 +59,11 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
     }
     else if (iControl == SPIN_CONTROL_INFO)
     {
-      const CPVRRadioRDSInfoTagPtr currentRDS = g_application.CurrentFileItem().GetPVRRadioRDSInfoTag();
+      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+      if (!channel)
+        return false;
+
+      const std::shared_ptr<CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
       if (!currentRDS)
         return false;
 
@@ -108,26 +114,30 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
     CGUISpinControl *spin = static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO));
     CGUITextBox *textbox = static_cast<CGUITextBox*>(GetControl(TEXT_INFO));
 
-    if (IsActive() && spin && textbox && message.GetParam1() == GUI_MSG_UPDATE_RADIOTEXT &&
-        g_application.GetAppPlayer().IsPlaying() &&
-        g_application.CurrentFileItem().HasPVRRadioRDSInfoTag())
+    if (spin && textbox && message.GetParam1() == GUI_MSG_UPDATE_RADIOTEXT && IsActive())
     {
-      const CPVRRadioRDSInfoTagPtr currentRDS = g_application.CurrentFileItem().GetPVRRadioRDSInfoTag();
+      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+      if (channel)
+      {
+        const std::shared_ptr<CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
+        if (currentRDS)
+        {
+          UpdateControls(spin, 29916, INFO_NEWS, m_LabelInfoNewsPresent, textbox, currentRDS->GetInfoNews(), m_LabelInfoNews);
+          UpdateControls(spin, 29917, INFO_NEWS_LOCAL, m_LabelInfoNewsLocalPresent, textbox, currentRDS->GetInfoNewsLocal(), m_LabelInfoNewsLocal);
+          UpdateControls(spin, 29918, INFO_SPORT, m_LabelInfoSportPresent, textbox, currentRDS->GetInfoSport(), m_LabelInfoSport);
+          UpdateControls(spin,   400, INFO_WEATHER, m_LabelInfoWeatherPresent, textbox, currentRDS->GetInfoWeather(), m_LabelInfoWeather);
+          UpdateControls(spin, 29919, INFO_LOTTERY, m_LabelInfoLotteryPresent, textbox, currentRDS->GetInfoLottery(), m_LabelInfoLottery);
+          UpdateControls(spin, 29920, INFO_STOCK, m_LabelInfoStockPresent, textbox, currentRDS->GetInfoStock(), m_LabelInfoStock);
+          UpdateControls(spin, 29921, INFO_OTHER, m_LabelInfoOtherPresent, textbox, currentRDS->GetInfoOther(), m_LabelInfoOther);
+          UpdateControls(spin, 19602, INFO_CINEMA, m_LabelInfoCinemaPresent, textbox, currentRDS->GetInfoCinema(), m_LabelInfoCinema);
+          UpdateControls(spin, 29922, INFO_HOROSCOPE, m_LabelInfoHoroscopePresent, textbox, currentRDS->GetInfoHoroscope(), m_LabelInfoHoroscope);
 
-      UpdateControls(spin, 29916, INFO_NEWS, m_LabelInfoNewsPresent, textbox, currentRDS->GetInfoNews(), m_LabelInfoNews);
-      UpdateControls(spin, 29917, INFO_NEWS_LOCAL, m_LabelInfoNewsLocalPresent, textbox, currentRDS->GetInfoNewsLocal(), m_LabelInfoNewsLocal);
-      UpdateControls(spin, 29918, INFO_SPORT, m_LabelInfoSportPresent, textbox, currentRDS->GetInfoSport(), m_LabelInfoSport);
-      UpdateControls(spin,   400, INFO_WEATHER, m_LabelInfoWeatherPresent, textbox, currentRDS->GetInfoWeather(), m_LabelInfoWeather);
-      UpdateControls(spin, 29919, INFO_LOTTERY, m_LabelInfoLotteryPresent, textbox, currentRDS->GetInfoLottery(), m_LabelInfoLottery);
-      UpdateControls(spin, 29920, INFO_STOCK, m_LabelInfoStockPresent, textbox, currentRDS->GetInfoStock(), m_LabelInfoStock);
-      UpdateControls(spin, 29921, INFO_OTHER, m_LabelInfoOtherPresent, textbox, currentRDS->GetInfoOther(), m_LabelInfoOther);
-      UpdateControls(spin, 19602, INFO_CINEMA, m_LabelInfoCinemaPresent, textbox, currentRDS->GetInfoCinema(), m_LabelInfoCinema);
-      UpdateControls(spin, 29922, INFO_HOROSCOPE, m_LabelInfoHoroscopePresent, textbox, currentRDS->GetInfoHoroscope(), m_LabelInfoHoroscope);
-
-      if (m_InfoPresent)
-        SET_CONTROL_VISIBLE(CONTROL_INFO_LIST);
-      else
-        SET_CONTROL_HIDDEN(CONTROL_INFO_LIST);
+          if (m_InfoPresent)
+            SET_CONTROL_VISIBLE(CONTROL_INFO_LIST);
+          else
+            SET_CONTROL_HIDDEN(CONTROL_INFO_LIST);
+        }
+      }
     }
   }
 
@@ -192,7 +202,11 @@ void CGUIDialogPVRRadioRDSInfo::OnInitWindow()
 
   SET_CONTROL_HIDDEN(CONTROL_INFO_LIST);
 
-  const CPVRRadioRDSInfoTagPtr currentRDS = g_application.CurrentFileItem().GetPVRRadioRDSInfoTag();
+  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+  if (!channel)
+    return;
+
+  const std::shared_ptr<CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
   if (!currentRDS)
     return;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
@@ -42,7 +42,15 @@ using namespace PVR;
 
 CGUIDialogPVRRadioRDSInfo::CGUIDialogPVRRadioRDSInfo(void)
   : CGUIDialog(WINDOW_DIALOG_PVR_RADIO_RDS_INFO, "DialogPVRRadioRDSInfo.xml")
-  , m_rdsItem(new CFileItem)
+  , m_InfoNews(29916, INFO_NEWS)
+  , m_InfoNewsLocal(29917, INFO_NEWS_LOCAL)
+  , m_InfoSport(29918, INFO_SPORT)
+  , m_InfoWeather(400, INFO_WEATHER)
+  , m_InfoLottery(29919, INFO_LOTTERY)
+  , m_InfoStock(29920, INFO_STOCK)
+  , m_InfoOther(29921, INFO_OTHER)
+  , m_InfoCinema(19602, INFO_CINEMA)
+  , m_InfoHoroscope(29922, INFO_HOROSCOPE)
 {
 }
 
@@ -111,97 +119,48 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
   }
   else if (message.GetMessage() == GUI_MSG_NOTIFY_ALL)
   {
-    CGUISpinControl *spin = static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO));
-    CGUITextBox *textbox = static_cast<CGUITextBox*>(GetControl(TEXT_INFO));
-
-    if (spin && textbox && message.GetParam1() == GUI_MSG_UPDATE_RADIOTEXT && IsActive())
+    if (message.GetParam1() == GUI_MSG_UPDATE_RADIOTEXT && IsActive())
     {
-      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
-      if (channel)
-      {
-        const std::shared_ptr<CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
-        if (currentRDS)
-        {
-          UpdateControls(spin, 29916, INFO_NEWS, m_LabelInfoNewsPresent, textbox, currentRDS->GetInfoNews(), m_LabelInfoNews);
-          UpdateControls(spin, 29917, INFO_NEWS_LOCAL, m_LabelInfoNewsLocalPresent, textbox, currentRDS->GetInfoNewsLocal(), m_LabelInfoNewsLocal);
-          UpdateControls(spin, 29918, INFO_SPORT, m_LabelInfoSportPresent, textbox, currentRDS->GetInfoSport(), m_LabelInfoSport);
-          UpdateControls(spin,   400, INFO_WEATHER, m_LabelInfoWeatherPresent, textbox, currentRDS->GetInfoWeather(), m_LabelInfoWeather);
-          UpdateControls(spin, 29919, INFO_LOTTERY, m_LabelInfoLotteryPresent, textbox, currentRDS->GetInfoLottery(), m_LabelInfoLottery);
-          UpdateControls(spin, 29920, INFO_STOCK, m_LabelInfoStockPresent, textbox, currentRDS->GetInfoStock(), m_LabelInfoStock);
-          UpdateControls(spin, 29921, INFO_OTHER, m_LabelInfoOtherPresent, textbox, currentRDS->GetInfoOther(), m_LabelInfoOther);
-          UpdateControls(spin, 19602, INFO_CINEMA, m_LabelInfoCinemaPresent, textbox, currentRDS->GetInfoCinema(), m_LabelInfoCinema);
-          UpdateControls(spin, 29922, INFO_HOROSCOPE, m_LabelInfoHoroscopePresent, textbox, currentRDS->GetInfoHoroscope(), m_LabelInfoHoroscope);
-
-          if (m_InfoPresent)
-            SET_CONTROL_VISIBLE(CONTROL_INFO_LIST);
-          else
-            SET_CONTROL_HIDDEN(CONTROL_INFO_LIST);
-        }
-      }
+      UpdateInfoControls();
     }
   }
 
   return CGUIDialog::OnMessage(message);
 }
 
-void CGUIDialogPVRRadioRDSInfo::InitControls(CGUISpinControl* spin, uint32_t iSpinLabelId, uint32_t iSpinControlId, bool& bSpinLabelPresent,
-                                             CGUITextBox* textbox, const std::string& textboxValue)
-{
-  // if there is a text for the given spinner item...
-  if (!textboxValue.empty())
-  {
-    // add a new spinner item to the control...
-    spin->AddLabel(g_localizeStrings.Get(iSpinLabelId), iSpinControlId);
-    bSpinLabelPresent = true;
-
-    // and if it was the first item, fill the textbox and select the spinner item.
-    if (!m_InfoPresent)
-    {
-      textbox->SetInfo(textboxValue);
-      spin->SetValue(iSpinControlId);
-      m_InfoPresent = true;
-    }
-  }
-}
-
-void CGUIDialogPVRRadioRDSInfo::UpdateControls(CGUISpinControl* spin, uint32_t iSpinLabelId, uint32_t iSpinControlId, bool& bSpinLabelPresent,
-                                               CGUITextBox* textbox, const std::string& textboxNewValue, std::string& textboxCurrentValue)
-{
-  if (!textboxNewValue.empty())
-  {
-    if (!bSpinLabelPresent)
-    {
-      spin->AddLabel(g_localizeStrings.Get(iSpinLabelId), iSpinControlId);
-      bSpinLabelPresent = true;
-    }
-
-    if (textboxCurrentValue != textboxNewValue)
-    {
-      spin->SetValue(iSpinControlId);
-      textboxCurrentValue = textboxNewValue;
-      textbox->SetInfo(textboxNewValue);
-      m_InfoPresent = true;
-    }
-  }
-}
-
 void CGUIDialogPVRRadioRDSInfo::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();
 
-  m_LabelInfoNewsPresent      = false;
-  m_LabelInfoNewsLocalPresent = false;
-  m_LabelInfoSportPresent     = false;
-  m_LabelInfoWeatherPresent   = false;
-  m_LabelInfoLotteryPresent   = false;
-  m_LabelInfoStockPresent     = false;
-  m_LabelInfoOtherPresent     = false;
-  m_LabelInfoHoroscopePresent = false;
-  m_LabelInfoCinemaPresent    = false;
-  m_InfoPresent               = false;
+  InitInfoControls();
+}
 
+void CGUIDialogPVRRadioRDSInfo::InitInfoControls()
+{
   SET_CONTROL_HIDDEN(CONTROL_INFO_LIST);
 
+  CGUISpinControl* spin = static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO));
+  if (spin)
+    spin->Clear();
+
+  CGUITextBox* textbox = static_cast<CGUITextBox*>(GetControl(TEXT_INFO));
+
+  m_InfoNews.Init(spin, textbox);
+  m_InfoNewsLocal.Init(spin, textbox);
+  m_InfoSport.Init(spin, textbox);
+  m_InfoWeather.Init(spin, textbox);
+  m_InfoLottery.Init(spin, textbox);
+  m_InfoStock.Init(spin, textbox);
+  m_InfoOther.Init(spin, textbox);
+  m_InfoCinema.Init(spin, textbox);
+  m_InfoHoroscope.Init(spin, textbox);
+
+  if (spin && textbox)
+    UpdateInfoControls();
+}
+
+void CGUIDialogPVRRadioRDSInfo::UpdateInfoControls()
+{
   const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
   if (!channel)
     return;
@@ -210,36 +169,51 @@ void CGUIDialogPVRRadioRDSInfo::OnInitWindow()
   if (!currentRDS)
     return;
 
-  CGUISpinControl *spin = static_cast<CGUISpinControl*>(GetControl(SPIN_CONTROL_INFO));
-  if (!spin)
-    return; // not an error; not every skin must implement this.
+  bool bInfoPresent = m_InfoNews.Update(currentRDS->GetInfoNews());
+  bInfoPresent |= m_InfoNewsLocal.Update(currentRDS->GetInfoNewsLocal());
+  bInfoPresent |= m_InfoSport.Update(currentRDS->GetInfoSport());
+  bInfoPresent |= m_InfoWeather.Update(currentRDS->GetInfoWeather());
+  bInfoPresent |= m_InfoLottery.Update(currentRDS->GetInfoLottery());
+  bInfoPresent |= m_InfoStock.Update(currentRDS->GetInfoStock());
+  bInfoPresent |= m_InfoOther.Update(currentRDS->GetInfoOther());
+  bInfoPresent |= m_InfoCinema.Update(currentRDS->GetInfoCinema());
+  bInfoPresent |= m_InfoHoroscope.Update(currentRDS->GetInfoHoroscope());
 
-  spin->Clear();
-
-  CGUITextBox *textbox = static_cast<CGUITextBox*>(GetControl(TEXT_INFO));
-  if (!textbox)
-    return; // not an error; not every skin must implement this.
-
-  InitControls(spin, 29916, INFO_NEWS, m_LabelInfoNewsPresent, textbox, currentRDS->GetInfoNews());
-  InitControls(spin, 29917, INFO_NEWS_LOCAL, m_LabelInfoNewsLocalPresent, textbox, currentRDS->GetInfoNewsLocal());
-  InitControls(spin, 29918, INFO_SPORT, m_LabelInfoSportPresent, textbox, currentRDS->GetInfoSport());
-  InitControls(spin,   400, INFO_WEATHER, m_LabelInfoWeatherPresent, textbox, currentRDS->GetInfoWeather());
-  InitControls(spin, 29919, INFO_LOTTERY, m_LabelInfoLotteryPresent, textbox, currentRDS->GetInfoLottery());
-  InitControls(spin, 29920, INFO_STOCK, m_LabelInfoStockPresent, textbox, currentRDS->GetInfoStock());
-  InitControls(spin, 29921, INFO_OTHER, m_LabelInfoOtherPresent, textbox, currentRDS->GetInfoOther());
-  InitControls(spin, 19602, INFO_CINEMA, m_LabelInfoCinemaPresent, textbox, currentRDS->GetInfoCinema());
-  InitControls(spin, 29922, INFO_HOROSCOPE, m_LabelInfoHoroscopePresent, textbox, currentRDS->GetInfoHoroscope());
-
-  if (m_InfoPresent)
+  if (bInfoPresent)
     SET_CONTROL_VISIBLE(CONTROL_INFO_LIST);
 }
 
-void CGUIDialogPVRRadioRDSInfo::OnDeinitWindow(int nextWindowID)
+CGUIDialogPVRRadioRDSInfo::InfoControl::InfoControl(uint32_t iSpinLabelId, uint32_t iSpinControlId)
+: m_iSpinLabelId(iSpinLabelId),
+  m_iSpinControlId(iSpinControlId)
 {
-  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
-CFileItemPtr CGUIDialogPVRRadioRDSInfo::GetCurrentListItem(int offset)
+void CGUIDialogPVRRadioRDSInfo::InfoControl::Init(CGUISpinControl* spin, CGUITextBox* textbox)
 {
-  return m_rdsItem;
+  m_spinControl = spin;
+  m_textbox = textbox;
+  m_bSpinLabelPresent = false;
+  m_textboxValue.clear();
+}
+
+bool CGUIDialogPVRRadioRDSInfo::InfoControl::Update(const std::string& textboxValue)
+{
+  if (m_spinControl && m_textbox && !textboxValue.empty())
+  {
+    if (!m_bSpinLabelPresent)
+    {
+      m_spinControl->AddLabel(g_localizeStrings.Get(m_iSpinLabelId), m_iSpinControlId);
+      m_bSpinLabelPresent = true;
+    }
+
+    if (m_textboxValue != textboxValue)
+    {
+      m_spinControl->SetValue(m_iSpinControlId);
+      m_textboxValue = textboxValue;
+      m_textbox->SetInfo(textboxValue);
+      return true;
+    }
+  }
+  return false;
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.h
@@ -21,47 +21,38 @@ namespace PVR
     CGUIDialogPVRRadioRDSInfo(void);
     ~CGUIDialogPVRRadioRDSInfo(void) override = default;
     bool OnMessage(CGUIMessage& message) override;
-    bool HasListItems() const override { return true; }
-    CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
   protected:
     void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
 
   private:
-    void InitControls(CGUISpinControl* spin, uint32_t iSpinLabelId, uint32_t iSpinControlId, bool& bSpinLabelPresent,
-                      CGUITextBox* textbox, const std::string& textboxValue);
-    void UpdateControls(CGUISpinControl* spin, uint32_t iSpinLabelId, uint32_t iSpinControlId, bool& bSpinLabelPresent,
-                        CGUITextBox* textbox, const std::string& textboxNewValue, std::string& textboxCurrentValue);
+    class InfoControl
+    {
+    public:
+      InfoControl(uint32_t iSpinLabelId, uint32_t iSpinControlId);
+      void Init(CGUISpinControl* spin, CGUITextBox* textbox);
+      bool Update(const std::string& textboxValue);
 
-    CFileItemPtr m_rdsItem;
+    private:
+      CGUISpinControl* m_spinControl = nullptr;
+      uint32_t m_iSpinLabelId = 0;
+      uint32_t m_iSpinControlId = 0;
+      CGUITextBox* m_textbox = nullptr;
+      bool m_bSpinLabelPresent = false;
+      std::string m_textboxValue;
+    };
 
-    bool m_InfoPresent = false;
-    bool m_LabelInfoNewsPresent = false;
-    std::string m_LabelInfoNews;
+    void InitInfoControls();
+    void UpdateInfoControls();
 
-    bool m_LabelInfoNewsLocalPresent = false;
-    std::string m_LabelInfoNewsLocal;
-
-    bool m_LabelInfoWeatherPresent = false;
-    std::string m_LabelInfoWeather;
-
-    bool m_LabelInfoLotteryPresent = false;
-    std::string m_LabelInfoLottery;
-
-    bool m_LabelInfoSportPresent = false;
-    std::string m_LabelInfoSport;
-
-    bool m_LabelInfoStockPresent = false;
-    std::string m_LabelInfoStock;
-
-    bool m_LabelInfoOtherPresent = false;
-    std::string m_LabelInfoOther;
-
-    bool m_LabelInfoCinemaPresent = false;
-    std::string m_LabelInfoCinema;
-
-    bool m_LabelInfoHoroscopePresent = false;
-    std::string m_LabelInfoHoroscope;
+    InfoControl m_InfoNews;
+    InfoControl m_InfoNewsLocal;
+    InfoControl m_InfoSport;
+    InfoControl m_InfoWeather;
+    InfoControl m_InfoLottery;
+    InfoControl m_InfoStock;
+    InfoControl m_InfoOther;
+    InfoControl m_InfoCinema;
+    InfoControl m_InfoHoroscope;
   };
 }


### PR DESCRIPTION
Some RDS related changes:

* Cleanup: Remove `CPVRRadioRDSInfoTag` member from `CFileItem` and make it a `CPVRChannel` property. No need and no functional gain to bloat `CFileItem` with this. Currently, an RDS tag is always tied to a `CPVRChannel`, so make it "part" of it. This change also fixes a bug with channel preview mode, where the rds tag got lost.

* Refactor `CPVRRadioRDSInfoTag` and make it thread-safe. It is called from multiple threads. It worked only by luck so far.

* Refactor `CGUIDialogPVRRadioRDSInfo`.

* Estuary: Display RDS info line in PVR channel OSD.

![screenshot001](https://user-images.githubusercontent.com/3226626/47956671-564a2680-dfa8-11e8-8508-d6df000e3d0f.png)

@AlwinEsch good to go?
@ronie are the skin changes okay?
 