### PR TITLE
windowing/gbm: fallback to non-alpha visual id

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -279,7 +279,7 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId)
 
   if (visualId != 0 && visualId != id)
   {
-    CLog::Log(LOGDEBUG, "failed to find matching EGL visual id");
+    CLog::Log(LOGDEBUG, "failed to find EGL config with EGL_NATIVE_VISUAL_ID={}", visualId);
     return false;
   }
 
@@ -296,6 +296,14 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId)
   }
 
   return true;
+}
+
+EGLint CEGLContextUtils::GetConfigAttrib(EGLint attribute) const
+{
+  EGLint value{0};
+  if (eglGetConfigAttrib(m_eglDisplay, m_eglConfig, attribute, &value) != EGL_TRUE)
+    CEGLUtils::LogError("failed to query EGL attibute");
+  return value;
 }
 
 bool CEGLContextUtils::CreateContext(CEGLAttributesVec contextAttribs)

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -194,6 +194,7 @@ public:
   bool SetVSync(bool enable);
   bool TrySwapBuffers();
   bool IsPlatformSupported() const;
+  EGLint GetConfigAttrib(EGLint attribute) const;
 
   EGLDisplay GetEGLDisplay() const
   {

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -465,7 +465,7 @@ bool CDRMUtils::FindPlanes()
     CLog::Log(LOGDEBUG, "CDRMUtils::%s - no drm modifiers present for the overlay plane", __FUNCTION__);
     m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_ARGB8888, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
     m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_XRGB8888, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
-    m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_XRGB2101010, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
+    m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_ARGB2101010, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
     m_overlay_plane->modifiers_map.emplace(DRM_FORMAT_XRGB2101010, std::vector<uint64_t>{DRM_FORMAT_MOD_LINEAR});
   }
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -109,54 +109,12 @@ bool CWinSystemGbm::InitWindowSystem()
 
 bool CWinSystemGbm::DestroyWindowSystem()
 {
-  m_GBM->DestroySurface();
   m_GBM->DestroyDevice();
 
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - deinitialized DRM", __FUNCTION__);
 
   m_libinput.reset();
 
-  return true;
-}
-
-bool CWinSystemGbm::CreateNewWindow(const std::string& name,
-                                    bool fullScreen,
-                                    RESOLUTION_INFO& res)
-{
-  //Notify other subsystems that we change resolution
-  OnLostDevice();
-
-  if(!m_DRM->SetMode(res))
-  {
-    CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to set DRM mode", __FUNCTION__);
-    return false;
-  }
-
-  std::vector<uint64_t> *modifiers = m_DRM->GetOverlayPlaneModifiersForFormat(m_DRM->GetOverlayPlane()->format);
-
-  // the gbm format needs alpha support
-  uint32_t format = CDRMUtils::FourCCWithAlpha(m_DRM->GetOverlayPlane()->GetFormat());
-
-  if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(), modifiers->size()))
-  {
-    CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize GBM", __FUNCTION__);
-    return false;
-  }
-
-  m_bFullScreen = fullScreen;
-  m_nWidth = res.iWidth;
-  m_nHeight = res.iHeight;
-  m_fRefreshRate = res.fRefreshRate;
-
-  CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - initialized GBM", __FUNCTION__);
-  return true;
-}
-
-bool CWinSystemGbm::DestroyWindow()
-{
-  m_GBM->DestroySurface();
-
-  CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - deinitialized GBM", __FUNCTION__);
   return true;
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -36,12 +36,6 @@ public:
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
 
-  bool CreateNewWindow(const std::string& name,
-                       bool fullScreen,
-                       RESOLUTION_INFO& res) override;
-
-  bool DestroyWindow() override;
-
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -34,13 +34,16 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
 
   uint32_t visualId = m_DRM->GetOverlayPlane()->GetFormat();
 
-  if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)))
+  // prefer alpha visual id, fallback to non-alpha visual id
+  if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
+      !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
   {
     // fallback to 8bit format if no EGL config was found for 10bit
     m_DRM->GetOverlayPlane()->useFallbackFormat = true;
     visualId = m_DRM->GetOverlayPlane()->GetFormat();
 
-    if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)))
+    if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
+        !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
     {
       return false;
     }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -30,6 +30,7 @@ public:
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
                        RESOLUTION_INFO& res) override;
+  bool DestroyWindow() override;
 
   EGLDisplay GetEGLDisplay() const;
   EGLSurface GetEGLSurface() const;


### PR DESCRIPTION
## Description
This PR fixes an issue starting kodi-gbm with libmali after #14515, ``XRGB8888`` is the expected  `EGL_NATIVE_VISUAL_ID` on mali utgard. Both alpha and non-alpha formats is now treated as valid config.

This needs to be tested with 10-bit + 8-bit fallback using Intel / mesa, ping @lrusak @a1rwulf

## Motivation and Context
kodi-gbm no longer starts using libmali on amlogic and rockchip devices.

```
DEBUG: failed to find matching EGL visual id
DEBUG: Previous line repeats 1 times.
FATAL: CApplication::Create: Unable to init windowing system
```

## How Has This Been Tested?
Kodi master starts on my Rock64 with this patch.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
