### PR TITLE
[Estuary] Two small fixes (musicvis, videofullscreen)

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -275,7 +275,7 @@
 		<value>$LOCALIZE[31000]...</value>
 	</variable>
 	<variable name="OSDSubLabelVar">
-		<value condition="Window.IsActive(visualisation) + Integer.IsGreater(Playlist.Length,1)">$LOCALIZE[554] $INFO[Playlist.Position] / $INFO[Playlist.Length]</value>
+		<value condition="Window.IsActive(visualisation) + Integer.IsGreater(Playlist.Length,1) + Integer.IsGreater(Playlist.Position,0)">$LOCALIZE[554] $INFO[Playlist.Position] / $INFO[Playlist.Length]</value>
 		<value condition="VideoPlayer.Content(musicvideos)">$INFO[VideoPlayer.Artist]$INFO[VideoPlayer.Album, - ]</value>
 		<value condition="VideoPlayer.Content(episodes)">$INFO[VideoPlayer.Season,[COLOR button_focus]S,[/COLOR]]$INFO[VideoPlayer.Episode,[COLOR button_focus]E,: [/COLOR]]$INFO[VideoPlayer.TVShowTitle]</value>
 		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording | PVR.IsPlayingEpgTag">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR button_focus],[/COLOR]) ]$INFO[VideoPlayer.ChannelName] $INFO[VideoPlayer.EpisodeName, - ]</value>

--- a/addons/skin.estuary/xml/VideoFullScreen.xml
+++ b/addons/skin.estuary/xml/VideoFullScreen.xml
@@ -33,7 +33,9 @@
 		</control>
 		<control type="group" id="1">
 			<depth>DepthOSD+</depth>
-			<visible>Player.Caching</visible>
+			<visible>Player.Caching + Integer.IsGreater(Player.CacheLevel,0)</visible>
+			<animation effect="fade" delay="300" time="200">Visible</animation>
+			<animation effect="fade" delay="200" time="150">Hidden</animation>
 			<centerleft>50%</centerleft>
 			<width>110</width>
 			<centertop>50%</centertop>


### PR DESCRIPTION
Fixes two small Estuary glitches - wrong osd sublabel if music playlist not empty but nothing from the list is playing and (ugly) 0% cache progress indicator in video osd.

![screenshot002](https://user-images.githubusercontent.com/3226626/48004996-9af1d100-e112-11e8-838f-2955bbef77e3.png)
 
@ronie good to go?