### PR TITLE
[GUI] reinitialize addon path after returning with .. directory item

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -530,6 +530,9 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
           m_vecItems->SetPath(dir);
           resetHistory = true;
         }
+        else if (m_vecItems->GetPath().empty() && URIUtils::PathEquals(dir, m_startDirectory, true))
+          m_vecItems->SetPath(dir);
+
         // check for network up
         if (URIUtils::IsRemote(m_vecItems->GetPath()) && !WaitForNetwork())
         {


### PR DESCRIPTION
## Description
Selecting an addon from kodi home::addons view lead directly to the directory listing provided by the addon. But if you leave the addon by selecting [..] or if the addon has issues on startup, following selections lead to the kodi RootDirectory.

## Motivation and Context
Annoying / inconsistence behaviour for addon selections

## How Has This Been Tested?
- open kodi
- navigate in main menu to addons
- open any addon ([return] key
- navigate to [..], press return
- press Back to return to addon view
- open addon again [return] key

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
