### PR TITLE
[PVR] Performance: Try to fetch missing EPG tag from backend at most every 30 secs.

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -931,8 +931,10 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
           }
         }
 
-        if (!m_epgTag)
+        if (!m_epgTag && m_epTagRefetchTimeout.IsTimePast())
         {
+          m_epTagRefetchTimeout.Set(30000); // try to fetch missing epg tag from backend at most every 30 secs
+
           time_t startTime = 0;
           time_t endTime = 0;
 
@@ -942,6 +944,7 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
 
           if (startTime > 0 && endTime > 0)
           {
+            // try to fetch missing epg tag from backend
             const CPVREpgInfoTagPtr epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0), true);
             if (epgTag)
             {

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -25,6 +25,7 @@
 #include "XBDateTime.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 #include "utils/ISerializable.h"
 
 #include "pvr/PVRTypes.h"
@@ -319,5 +320,7 @@ namespace PVR
     mutable unsigned int  m_iEpgUid;   /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
     mutable CPVREpgInfoTagPtr m_epgTag; /*!< epg info tag matching m_iEpgUid. */
     mutable CPVRChannelPtr m_channel;
+
+    mutable XbmcThreads::EndTime m_epTagRefetchTimeout;
   };
 }


### PR DESCRIPTION
If fetching missing EPG tags from backend on demand fails (for some reason) this can have serious performance implications as fetching might be retried very often in a short time period, for instance when opening the PVR timer window (periodic update of some gui labels):

<img width="300" alt="screenshot 2018-11-05 at 21 21 03" src="https://user-images.githubusercontent.com/3226626/48026802-5a607a80-e147-11e8-9223-c1e27413db6c.png">

This PR ensures that fetching a missing EPG tag for a timer from backend is done at most once per 30 seconds.

BTW: I ran into this issue after I bricked my tvheadend epg database.

@Jalle19 good to go?