### PR TITLE
[GUI] re-evaluate playcount (watched state) when reading from filecache

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -469,6 +469,8 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strAlbum;
     ar >> m_artist;
     ar >> m_playCount;
+    //re-evaluate the playcount
+    m_playCount = PLAYCOUNT_NOT_SET;
     ar >> m_lastPlayed;
     ar >> m_iTop250;
     ar >> m_iSeason;


### PR DESCRIPTION
## Description
Re-evaluate playcount (watched state) when reading from filecache, because filecache is not updated when watchstate changes.

## Motivation and Context
Depending on race conditions GUI watched state can be wrong after reading a directory from file-cache.
Reason is that "unwatched" is stored in filecache for "not set" entries.

## How Has This Been Tested?
Netflix addon on Wetek Hub:

- Navigate into a seson, watch one episode
- Play another episode, press stop -> watchstate for the first played episode is in most cases unwatched
- Press back, and select seson again -> episode is marked watched (correct)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
