### PR TITLE
[depends][python27] Prevent exception when none argument passed

### DIFF
--- a/tools/depends/target/python27/urllib.patch
+++ b/tools/depends/target/python27/urllib.patch
@@ -1,5 +1,22 @@
 --- a/Lib/urllib.py
 +++ b/Lib/urllib.py
+@@ -1300,10 +1300,11 @@
+ 
+ def quote_plus(s, safe=''):
+     """Quote the query fragment of a URL; replacing ' ' with '+'"""
+-    if ' ' in s:
+-        s = quote(s, safe + ' ')
+-        return s.replace(' ', '+')
+-    return quote(s, safe)
++    if not s is None:
++		if ' ' in s:
++			s = quote(s, safe + ' ')
++			return s.replace(' ', '+')
++		return quote(s, safe)
+ 
+ def urlencode(query, doseq=0):
+     """Encode a sequence of two-element tuples or dictionary into a URL query string.
+
 @@ -1437,7 +1437,6 @@
  
  


### PR DESCRIPTION
## Description
This PR prevents a python exception 
Add check for none value

## Motivation and Context
Prevent following exception
      File "C:\Program Files\Kodi\system\python\Lib\urllib.py", line 1303, in quote_plus
                                                if ' ' in s:
                                            TypeError: argument of type 'NoneType' is not iterable 

## How Has This Been Tested?
Tested on kodi for windows and libreelec

## Screenshots (if appropriate):

## Types of change
- [X ] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
