### PR TITLE
[Settings] Implement FindIntInList in CSettingList

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <sstream>
+#include <algorithm>
 
 #include "Setting.h"
 #include "SettingDefinitions.h"
@@ -400,6 +401,14 @@ void CSettingList::Reset()
     values.push_back(it->Clone(it->GetId()));
 
   SetValue(values);
+}
+
+bool CSettingList::FindIntInList(int value) const
+{
+  return std::find_if(m_values.cbegin(), m_values.cend(), [&](const SettingPtr& setting)
+  {
+    return setting->GetType() == SettingType::Integer && std::static_pointer_cast<CSettingInt>(setting)->GetValue() == value;
+  }) != m_values.cend();
 }
 
 bool CSettingList::FromString(const std::vector<std::string> &value)

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -194,6 +194,7 @@ public:
   bool SetValue(const SettingList &values);
   const SettingList& GetDefault() const { return m_defaults; }
   void SetDefault(const SettingList &values);
+  bool FindIntInList(int value) const;
 
 protected:
   void copy(const CSettingList &setting);

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -705,15 +705,9 @@ bool CSettingsManager::SetList(const std::string &id, const std::vector< std::sh
 bool CSettingsManager::FindIntInList(const std::string &id, int value) const
 {
   CSharedLock lock(m_settingsCritical);
-  SettingPtr setting = GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingType::List)
-    return false;
+  std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(GetSetting(id)));
 
-  for (const auto item : std::static_pointer_cast<CSettingList>(setting)->GetValue())
-    if (item->GetType() == SettingType::Integer && std::static_pointer_cast<CSettingInt>(item)->GetValue() == value)
-      return true;
-
-  return false;
+  return setting && setting->FindIntInList(value);
 }
 
 bool CSettingsManager::SetDefault(const std::string &id)


### PR DESCRIPTION
## Description
Move implementation CSettingManager::FindIntInList to CSettingList to allow a single retrieval of setting with following multiple integer searches

## Motivation and Context
Performance

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
