### PR TITLE
windowing/gbm: use the drm render node fd for the vaapi proxy

### DIFF
--- a/cmake/modules/FindLibDRM.cmake
+++ b/cmake/modules/FindLibDRM.cmake
@@ -14,7 +14,7 @@
 #   LibDRM::LibDRM   - The LibDRM library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBDRM libdrm>=2.4.71 QUIET)
+  pkg_check_modules(PC_LIBDRM libdrm>=2.4.74 QUIET)
 endif()
 
 find_path(LIBDRM_INCLUDE_DIR NAMES drm.h

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -250,7 +250,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
       pConfig->device_type == AV_HWDEVICE_TYPE_DRM)
   {
     CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-    if (av_hwdevice_ctx_create(&m_pCodecContext->hw_device_ctx, AV_HWDEVICE_TYPE_DRM, winSystem->GetDevicePath().c_str(), nullptr, 0) < 0)
+    if (av_hwdevice_ctx_create(&m_pCodecContext->hw_device_ctx, AV_HWDEVICE_TYPE_DRM, drmGetDeviceNameFromFd2(winSystem->GetDrm()->GetFileDescriptor()), nullptr, 0) < 0)
     {
       CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unable to create hwdevice context", __FUNCTION__);
       avcodec_free_context(&m_pCodecContext);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -558,6 +558,12 @@ bool CDRMUtils::OpenDrm(bool needConnector)
 
       CLog::Log(LOGDEBUG, "CDRMUtils::%s - opened device: %s using module: %s", __FUNCTION__, drmGetDeviceNameFromFd2(m_fd), module);
 
+      m_renderFd.attach(drmOpenWithType(module, nullptr, DRM_NODE_RENDER));
+      if (m_renderFd)
+      {
+        CLog::Log(LOGDEBUG, "CDRMUtils::%s - opened render node: %s using module: %s", __FUNCTION__, drmGetDeviceNameFromFd2(m_renderFd), module);
+      }
+
       return true;
     }
   }
@@ -687,6 +693,7 @@ void CDRMUtils::DestroyDrm()
     CLog::Log(LOGDEBUG, "CDRMUtils::%s - failed to drop drm master: %s", __FUNCTION__, strerror(errno));
   }
 
+  m_renderFd.reset();
   m_fd.reset();
 
   drmModeFreeResources(m_drm_resources);

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -94,6 +94,7 @@ public:
 
   std::string GetModule() const { return m_module; }
   int GetFileDescriptor() const { return m_fd; }
+  int GetRenderNodeFileDescriptor() const { return m_renderFd; }
   struct plane* GetPrimaryPlane() const { return m_primary_plane; }
   struct plane* GetOverlayPlane() const { return m_overlay_plane; }
   std::vector<uint64_t> *GetPrimaryPlaneModifiersForFormat(uint32_t format) { return &m_primary_plane->modifiers_map[format]; }
@@ -145,6 +146,7 @@ private:
   RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
   bool CheckConnector(int connectorId);
 
+  KODI::UTILS::POSIX::CFileHandle m_renderFd;
   int m_crtc_index;
   std::string m_module;
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -93,7 +93,6 @@ public:
   virtual void DestroyDrm();
 
   std::string GetModule() const { return m_module; }
-  std::string GetDevicePath() const { return m_device_path; }
   int GetFileDescriptor() const { return m_fd; }
   struct plane* GetPrimaryPlane() const { return m_primary_plane; }
   struct plane* GetOverlayPlane() const { return m_overlay_plane; }
@@ -148,7 +147,6 @@ private:
 
   int m_crtc_index;
   std::string m_module;
-  std::string m_device_path;
 
   drmModeResPtr m_drm_resources = nullptr;
   drmModeCrtcPtr m_orig_crtc = nullptr;

--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -26,47 +26,26 @@ namespace GBM
 class CVaapiProxy : public VAAPI::IVaapiWinSystem
 {
 public:
-  CVaapiProxy() = default;
+  CVaapiProxy(int fd) : m_fd(fd) {};
   virtual ~CVaapiProxy() = default;
   VADisplay GetVADisplay() override;
   void *GetEGLDisplay() override { return eglDisplay; };
 
   VADisplay vaDpy;
   void *eglDisplay;
+
+private:
+  int m_fd{-1};
 };
 
 VADisplay CVaapiProxy::GetVADisplay()
 {
-  int const buf_size{128};
-  char name[buf_size];
-  int fd{-1};
-
-  // 128 is the start of the NUM in renderD<NUM>
-  for (int i = 128; i < (128 + 16); i++)
-  {
-    snprintf(name, buf_size, "/dev/dri/renderD%u", i);
-
-    fd = open(name, O_RDWR);
-
-    if (fd < 0)
-    {
-      continue;
-    }
-
-    auto display = vaGetDisplayDRM(fd);
-
-    if (display != nullptr)
-    {
-      return display;
-    }
-  }
-
-  return nullptr;
+  return vaGetDisplayDRM(m_fd);
 }
 
-CVaapiProxy* VaapiProxyCreate()
+CVaapiProxy* VaapiProxyCreate(int fd)
 {
-  return new CVaapiProxy();
+  return new CVaapiProxy(fd);
 }
 
 void VaapiProxyDelete(CVaapiProxy *proxy)
@@ -107,7 +86,7 @@ class CVaapiProxy
 {
 };
 
-CVaapiProxy* VaapiProxyCreate()
+CVaapiProxy* VaapiProxyCreate(int fd)
 {
   return nullptr;
 }

--- a/xbmc/windowing/gbm/OptionalsReg.h
+++ b/xbmc/windowing/gbm/OptionalsReg.h
@@ -21,7 +21,7 @@ namespace GBM
 {
 class CVaapiProxy;
 
-CVaapiProxy* VaapiProxyCreate();
+CVaapiProxy* VaapiProxyCreate(int fd);
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy);
 void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -61,7 +61,6 @@ public:
   void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge) { m_videoLayerBridge = bridge; };
 
   std::string GetModule() const { return m_DRM->GetModule(); }
-  std::string GetDevicePath() const { return m_DRM->GetDevicePath(); }
   struct gbm_device *GetGBMDevice() const { return m_GBM->GetDevice(); }
   std::shared_ptr<CDRMUtils> GetDrm() const { return m_DRM; }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -45,7 +45,7 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   }
 
   bool general, deepColor;
-  m_vaapiProxy.reset(VaapiProxyCreate());
+  m_vaapiProxy.reset(VaapiProxyCreate(m_DRM->GetRenderNodeFileDescriptor()));
   VaapiProxyConfig(m_vaapiProxy.get(), m_eglContext.GetEGLDisplay());
   VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -53,7 +53,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   }
 
   bool general, deepColor;
-  m_vaapiProxy.reset(GBM::VaapiProxyCreate());
+  m_vaapiProxy.reset(GBM::VaapiProxyCreate(m_DRM->GetRenderNodeFileDescriptor()));
   GBM::VaapiProxyConfig(m_vaapiProxy.get(), m_eglContext.GetEGLDisplay());
   GBM::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
 


### PR DESCRIPTION
This allows us to reuse the fd from the drm system to get the vaapi display.

This is needed in case there is multiple dri devices available so we can use the correct one for our output.

In my case I have a haydes canyon NUC that has two dri devices (card0 and card1) and only the amd devices has a connected output. The intel output is just for transcoding.