### PR TITLE
windowing/gbm: set default plane formats and use the getter methods

### DIFF
--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -101,9 +101,9 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
   if (rendered)
   {
     if (videoLayer)
-      m_overlay_plane->format = CDRMUtils::FourCCWithAlpha(m_overlay_plane->GetFormat());
+      m_overlay_plane->SetFormat(CDRMUtils::FourCCWithAlpha(m_overlay_plane->GetFormat()));
     else
-      m_overlay_plane->format = CDRMUtils::FourCCWithoutAlpha(m_overlay_plane->GetFormat());
+      m_overlay_plane->SetFormat(CDRMUtils::FourCCWithoutAlpha(m_overlay_plane->GetFormat()));
 
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -73,7 +73,7 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
     struct drm_fb *fb = static_cast<drm_fb *>(gbm_bo_get_user_data(bo));
     if(fb)
     {
-      if (m_overlay_plane->format == fb->format)
+      if (m_overlay_plane->GetFormat() == fb->format)
         return fb;
       else
         DrmFbDestroyCallback(bo, gbm_bo_get_user_data(bo));
@@ -82,7 +82,7 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
 
   struct drm_fb *fb = new drm_fb;
   fb->bo = bo;
-  fb->format = m_overlay_plane->format;
+  fb->format = m_overlay_plane->GetFormat();
 
   uint32_t width,
            height,
@@ -425,15 +425,13 @@ bool CDRMUtils::FindPlanes()
 
   m_primary_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_VIDEO_PLANE);
   m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_GUI_10_PLANE);
-  m_overlay_plane->format = DRM_FORMAT_XRGB2101010;
-  m_overlay_plane->fallbackFormat = DRM_FORMAT_XRGB8888;
 
   /* fallback to 8bit plane if 10bit plane doesn't exist */
   if (m_overlay_plane->plane == nullptr)
   {
     drmModeFreePlane(m_overlay_plane->plane);
     m_overlay_plane->plane = FindPlane(plane_resources, m_crtc_index, KODI_GUI_PLANE);
-    m_overlay_plane->format = DRM_FORMAT_XRGB8888;
+    m_overlay_plane->SetFormat(DRM_FORMAT_XRGB8888);
   }
 
   drmModeFreePlaneResources(plane_resources);

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -44,9 +44,16 @@ struct drm_object
 struct plane : drm_object
 {
   drmModePlanePtr plane = nullptr;
-  uint32_t format{0};
-  uint32_t fallbackFormat{0};
   bool useFallbackFormat{false};
+  std::map<uint32_t, std::vector<uint64_t>> modifiers_map;
+
+  void SetFormat(uint32_t newFormat)
+  {
+    if (useFallbackFormat)
+      fallbackFormat = newFormat;
+    else
+      format = newFormat;
+  }
 
   uint32_t GetFormat()
   {
@@ -56,7 +63,9 @@ struct plane : drm_object
     return format;
   }
 
-  std::map<uint32_t, std::vector<uint64_t>> modifiers_map;
+private:
+  uint32_t format{DRM_FORMAT_XRGB2101010};
+  uint32_t fallbackFormat{DRM_FORMAT_XRGB8888};
 };
 
 struct connector : drm_object


### PR DESCRIPTION
@a1rwulf this should fix offscreen modesetting (I hope) by setting default plane formats.

to go in after #14785 due to rebasing

@Kwiboo can look at this too