### PR TITLE
[cmake] fix building with internal fmt

### DIFF
--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -40,6 +40,7 @@ if(ENABLE_INTERNAL_FMT)
                       PREFIX ${CORE_BUILD_DIR}/fmt
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                                 -DCMAKE_INSTALL_LIBDIR=lib
                                  -DFMT_DOC=OFF
                                  -DFMT_TEST=OFF
                                  "${EXTRA_ARGS}"


### PR DESCRIPTION
## Description
Some distros have `lib64` as default value for `CMAKE_INSTALL_LIBDIR`, but Kodi only searches fmt in lib folder.

## Motivation and Context
fixes #14829

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
