### PR TITLE
VAAPI: add error and info callbacks

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -58,6 +58,16 @@ const std::string SETTING_VIDEOPLAYER_USEVAAPIVP8 = "videoplayer.usevaapivp8";
 const std::string SETTING_VIDEOPLAYER_USEVAAPIVP9 = "videoplayer.usevaapivp9";
 const std::string SETTING_VIDEOPLAYER_PREFERVAAPIRENDER = "videoplayer.prefervaapirender";
 
+void VAAPI::VaErrorCallback(void *user_context, const char *message)
+{
+  CLog::Log(LOGERROR, "libva error: {}", message);
+}
+
+void VAAPI::VaInfoCallback(void *user_context, const char *message)
+{
+  CLog::Log(LOGDEBUG, "libva info: {}", message);
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
@@ -188,6 +198,11 @@ bool CVAAPIContext::CreateContext()
     return false;
   }
 
+#if VA_CHECK_VERSION(1, 0, 0)
+  vaSetErrorCallback(m_display, VaErrorCallback, nullptr);
+  vaSetInfoCallback(m_display, VaInfoCallback, nullptr);
+#endif
+
   int major_version, minor_version;
   if (!CheckSuccess(vaInitialize(m_display, &major_version, &minor_version)))
   {
@@ -211,6 +226,11 @@ void CVAAPIContext::DestroyContext()
   delete[] m_profiles;
   if (m_display)
     CheckSuccess(vaTerminate(m_display));
+
+#if VA_CHECK_VERSION(1, 0, 0)
+  vaSetErrorCallback(m_display, nullptr, nullptr);
+  vaSetInfoCallback(m_display, nullptr, nullptr);
+#endif
 }
 
 void CVAAPIContext::QueryCaps()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -38,6 +38,9 @@ class CProcessInfo;
 namespace VAAPI
 {
 
+void VaErrorCallback(void *user_context, const char *message);
+void VaInfoCallback(void *user_context, const char *message);
+
 //-----------------------------------------------------------------------------
 // VAAPI data structs
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
These callbacks display the same info that is printed on stdout. This change will make it show in our debug log.

```
14:16:24.909 T:139669216497216    INFO: libva info: VA-API version 1.1.0
14:16:24.909 T:139669216497216    INFO: libva info: va_getDriverName() returns 0
14:16:24.909 T:139669216497216    INFO: libva info: Trying to open /usr/lib64/dri/i965_drv_video.so
14:16:24.909 T:139669216497216    INFO: libva info: Found init function __vaDriverInit_1_1
14:16:24.911 T:139669216497216    INFO: libva info: va_openDriver() returns 0
```