### PR TITLE
[skin.estouchy] Fix order in Recent Movies

### DIFF
--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -107,7 +107,7 @@
 							<texture border="5">thumb_focus.png</texture>
 						</control>
 					</focusedlayout>
-				<content target="movies" sortby="date" limit="10">videodb://recentlyaddedmovies/</content>
+				<content target="movies" limit="10">videodb://recentlyaddedmovies/</content>
 				</control>
 				<control type="panel" id="2200">
 					<visible>Library.HasContent(TVShows) + Container(9010).HasFocus(2)</visible>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The order set for Recent Movies is both broken and unnecessary. The movies are being shown in alphabetical order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Issue  #14832

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
The movie starting with J was re-added to the library to make sure the alphabetical order was not longer being used.

## Screenshots (if appropriate):
![screenshot from 2018-11-09 17-26-21](https://user-images.githubusercontent.com/9676118/48274926-aad82080-e444-11e8-9073-2cb9eea11b5e.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
