### PR TITLE
[filemanager] Fix crash due to multiple busy dialog request.

### DIFF
--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -444,6 +444,13 @@ void CGUIWindowFileManager::UpdateItemCounts()
 
 bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
 {
+  if (m_updating)
+  {
+    CLog::Log(LOGWARNING, "CGUIWindowFileManager::Update - updating in progress");
+    return true;
+  }
+  CUpdateGuard ug(m_updating);
+
   // get selected item
   int iItem = GetSelectedItem(iList);
   std::string strSelectedItem = "";

--- a/xbmc/windows/GUIWindowFileManager.h
+++ b/xbmc/windows/GUIWindowFileManager.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -77,7 +78,6 @@ protected:
   bool bCheckShareConnectivity;
   std::string strCheckSharePath;
 
-
   XFILE::CVirtualDirectory m_rootDir;
   CFileItemList* m_vecItems[2];
   typedef std::vector <CFileItem*> ::iterator ivecItems;
@@ -86,4 +86,20 @@ protected:
   CDirectoryHistory m_history[2];
 
   int m_errorHeading, m_errorLine;
+private:
+  std::atomic_bool m_updating = {false};
+  class CUpdateGuard
+  {
+  public:
+    CUpdateGuard(std::atomic_bool &update) : m_update(update)
+    {
+      m_update = true;
+    }
+    ~CUpdateGuard()
+    {
+      m_update = false;
+    }
+  private:
+    std::atomic_bool &m_update;
+  };
 };


### PR DESCRIPTION
This fixes a crash in filemanager window I encountered while ejecting a DVD via contextmenu.

<pre>
Crash while ejecting a Bluray Disc from file manager:


Thread 1 (Thread 0x7fe1a7fdd8c0 (LWP 774)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007fe1a5bfa524 in __GI_abort () at abort.c:79
#2  0x00007fe1a5adc943 in ?? () from /usr/lib/libstdc++.so.6
#3  0x00007fe1a5ae2986 in ?? () from /usr/lib/libstdc++.so.6
#4  0x00007fe1a5ae29c1 in std::terminate() () from /usr/lib/libstdc++.so.6
#5  0x00007fe1a5ae2bf3 in __cxa_throw () from /usr/lib/libstdc++.so.6
#6  0x0000000000b25ce8 in CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) ()
#7  0x0000000000b25e66 in CGUIDialogBusy::Wait(IRunnable*, unsigned int, bool) ()
#8  0x0000000000c1ceb6 in CGUIWindowFileManager::GetDirectory(int, std::string const&, CFileItemList&) ()
#9  0x0000000000c1d807 in CGUIWindowFileManager::Update(int, std::string const&) ()
#10 0x0000000000c20102 in CGUIWindowFileManager::OnMessage(CGUIMessage&) ()
#11 0x0000000000b22ee0 in CGUIWindowManager::SendMessage(CGUIMessage&) ()
#12 0x0000000000b230f7 in CGUIWindowManager::DispatchThreadMessages() ()
#13 0x0000000000a59acd in CApplication::Process() ()
#14 0x0000000000b0ce36 in CGUIWindowManager::ProcessRenderLoop(bool) ()
#15 0x0000000000b25d2e in CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) ()
#16 0x0000000000b25e66 in CGUIDialogBusy::Wait(IRunnable*, unsigned int, bool) ()
#17 0x0000000000c1ceb6 in CGUIWindowFileManager::GetDirectory(int, std::string const&, CFileItemList&) ()
#18 0x0000000000c1d807 in CGUIWindowFileManager::Update(int, std::string const&) ()
#19 0x0000000000c1e759 in CGUIWindowFileManager::Refresh() ()
#20 0x0000000000c1ee10 in CGUIWindowFileManager::OnPopupMenu(int, int, bool) ()
#21 0x0000000000c20564 in CGUIWindowFileManager::OnMessage(CGUIMessage&) ()
#22 0x0000000000b48c42 in CGUIBaseContainer::OnClick(int) ()
#23 0x0000000000b15cfd in CGUIWindow::OnAction(CAction const&) ()
#24 0x0000000000c1f76b in CGUIWindowFileManager::OnAction(CAction const&) ()
#25 0x0000000000b28454 in CGUIWindowManager::HandleAction(CAction const&) const ()
#26 0x0000000000b284c0 in CGUIWindowManager::OnAction(CAction const&) const ()
#27 0x0000000000a5677d in CApplication::OnAction(CAction const&) ()
#28 0x0000000000b8f44c in CInputManager::HandleKey(CKey const&) ()
#29 0x0000000000b90623 in CInputManager::ProcessPeripherals(float) ()
#30 0x0000000000b90651 in CInputManager::Process(int, float) ()
#31 0x0000000000a57ff7 in CApplication::FrameMove(bool, bool) ()
#32 0x0000000000a1e46d in CXBApplicationEx::Run(CAppParamParser const&) ()
#33 0x0000000000b77849 in XBMC_Run ()
#34 0x0000000000792780 in main ()</pre>

This is another one of the category "multiple updates are running at the same time and requesting a busy dialog". We already fixed a couple of these in `CGUIMediaWindow` (and at other places). I used the same approach for the fix (actually workaround) as we did for the other cases.

Please note that `CGUIWindowFileManager` is not derived from `CGUIMediaWindow`.

@FernetMenta good to go?