### PR TITLE
[PVR] Make 'Simple Timeshift OSD' an advanced setting; remove corresponding standard setting.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10914,11 +10914,7 @@ msgctxt "#19302"
 msgid "Do you want to record the selected programme or to switch to the current programme?"
 msgstr ""
 
-#. pvr setting "Use simple timeshift OSD" value
-#: system/settings/settings.xml
-msgctxt "#19303"
-msgid "Use simple timeshift OSD"
-msgstr ""
+#empty string with id 19303
 
 #. Label for context menu entry to open settings dialog for a timer rule (read-only)
 #: xbmc/pvr/PVRContextMenus.cpp
@@ -18632,17 +18628,12 @@ msgctxt "#36234"
 msgid "Duration of instant recordings when pressing the record button. This value will be taken into account if \"Instant recording action\" is set to \"Record for a fixed period of time\""
 msgstr ""
 
-#. help text for pvr setting "Use simple timeshift OSD"
-#: system/settings/settings.xml
-msgctxt "#36235"
-msgid "Normal timeshift OSD always shows the complete timeshift buffer along with with the currently playing show, whereas the simple timeshift OSD only shows the currently playing show with no visual feedback how far in the timeshift buffer you can jump from the currently playing position."
-msgstr ""
+#empty string with id 36235
 
 #: system/settings/settings.xml
 msgctxt "#36236"
 msgid "If set to a value greater than zero last watched time of channels will be stored the given amount of time after start of channel playback. Otherwise the last watched time will be stored immediately at start of channel playback."
 msgstr ""
-
 
 #: system/settings/settings.xml
 msgctxt "#36237"

--- a/xbmc/pvr/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/PVRGUITimesInfo.cpp
@@ -166,7 +166,7 @@ void CPVRGUITimesInfo::UpdateTimeshiftProgressData()
     time_t start = 0;
     m_playingEpgTag->StartAsUTC().GetAsTime(start);
     if (start < m_iTimeshiftStartTime ||
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMENU_USESIMPLETIMESHIFTOSD))
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRTimeshiftSimpleOSD)
     {
       // playing event started before start of ts buffer or simple ts osd to be used
       m_iTimeshiftProgressStartTime = start;
@@ -189,7 +189,7 @@ void CPVRGUITimesInfo::UpdateTimeshiftProgressData()
     time_t end = 0;
     m_playingEpgTag->EndAsUTC().GetAsTime(end);
     if (end > m_iTimeshiftEndTime ||
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMENU_USESIMPLETIMESHIFTOSD))
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRTimeshiftSimpleOSD)
     {
       // playing event will end after end of ts buffer or simple ts osd to be used
       m_iTimeshiftProgressEndTime = end;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -386,6 +386,7 @@ void CAdvancedSettings::Initialize()
   m_bPVRAutoScanIconsUserSet       = false;
   m_iPVRNumericChannelSwitchTimeout = 2000;
   m_iPVRTimeshiftThreshold = 10;
+  m_bPVRTimeshiftSimpleOSD = true;
 
   m_cacheMemSize = 1024 * 1024 * 20;
   m_cacheBufferMode = CACHE_BUFFER_MODE_INTERNET; // Default (buffer all internet streams/filesystems)
@@ -1117,6 +1118,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pPVR, "autoscaniconsuserset", m_bPVRAutoScanIconsUserSet);
     XMLUtils::GetInt(pPVR, "numericchannelswitchtimeout", m_iPVRNumericChannelSwitchTimeout, 50, 60000);
     XMLUtils::GetInt(pPVR, "timeshiftthreshold", m_iPVRTimeshiftThreshold, 0, 60);
+    XMLUtils::GetBoolean(pPVR, "timeshiftsimpleosd", m_bPVRTimeshiftSimpleOSD);
   }
 
   TiXmlElement* pDatabase = pRootElement->FirstChildElement("videodatabase");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -332,6 +332,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bPVRAutoScanIconsUserSet; /*!< @brief mark channel icons populated by auto scan as "user set" */
     int m_iPVRNumericChannelSwitchTimeout; /*!< @brief time in msecs after that a channel switch occurs after entering a channel number, if confirmchannelswitch is disabled */
     int m_iPVRTimeshiftThreshold; /*!< @brief time diff between current playing time and timeshift buffer end, in seconds, before a playing stream is displayed as timeshifting. */
+    bool m_bPVRTimeshiftSimpleOSD; /*!< @brief use simple timeshift OSD (with progress only for the playing event instead of progress for the whole ts buffer). */
     DatabaseSettings m_databaseMusic; // advanced music database setup
     DatabaseSettings m_databaseVideo; // advanced video database setup
     DatabaseSettings m_databaseTV;    // advanced tv database setup

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -201,7 +201,6 @@ const std::string CSettings::SETTING_PVRMANAGER_GROUPMANAGER = "pvrmanager.group
 const std::string CSettings::SETTING_PVRMANAGER_CHANNELSCAN = "pvrmanager.channelscan";
 const std::string CSettings::SETTING_PVRMANAGER_RESETDB = "pvrmanager.resetdb";
 const std::string CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO = "pvrmenu.displaychannelinfo";
-const std::string CSettings::SETTING_PVRMENU_USESIMPLETIMESHIFTOSD = "pvrmenu.usesimpletimeshiftosd";
 const std::string CSettings::SETTING_PVRMENU_ICONPATH = "pvrmenu.iconpath";
 const std::string CSettings::SETTING_PVRMENU_SEARCHICONS = "pvrmenu.searchicons";
 const std::string CSettings::SETTING_EPG_PAST_DAYSTODISPLAY = "epg.pastdaystodisplay";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -161,7 +161,6 @@ public:
   static const std::string SETTING_PVRMANAGER_CHANNELSCAN;
   static const std::string SETTING_PVRMANAGER_RESETDB;
   static const std::string SETTING_PVRMENU_DISPLAYCHANNELINFO;
-  static const std::string SETTING_PVRMENU_USESIMPLETIMESHIFTOSD;
   static const std::string SETTING_PVRMENU_ICONPATH;
   static const std::string SETTING_PVRMENU_SEARCHICONS;
   static const std::string SETTING_EPG_PAST_DAYSTODISPLAY;


### PR DESCRIPTION
This setting is really very advanced and can easily confuse users if generally exposed in Kodi settings UI, as for example both the used pvr addon(s) and skin must support timeshift to make use of this setting.

@MartijnKaijser fyi
@Jalle19 good to go, code-wise? 

