### PR TITLE
[DetectDVDType]: fix Crash due to non-checked error state

### DIFF
--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -328,6 +328,11 @@ DWORD CDetectDVDMedia::GetTrayState()
     }
     laststatus = status;
     m_cdio->cdio_destroy(cdio);
+    
+    if (status == DRIVER_OP_UNSUPPORTED)
+    {
+      return DRIVE_NONE;
+    }
   }
   else
     return DRIVE_NOT_READY;


### PR DESCRIPTION
in case DRIVER_OP_UNSUPPORTED is returned when checking traystate - ensure to treat it as NO_DVD_DRIVE. This fixes a crash where some raw disk on osx is wrongly detected as DVD Drive due to m_dwTrayState is initialised as TRAY_CLOSED_MEDIA_PRESENT and status is not checked for errors.

## How Has This Been Tested?
User with an iMac who had that Crash on Startup has confirmed the fix.

