### PR TITLE
windowing/gbm: rename planes

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -38,7 +38,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
     CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-    if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane &&
+    if (winSystem && winSystem->GetDrm()->GetVideoPlane()->plane &&
         std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
       return new CRendererDRMPRIME();
   }
@@ -49,7 +49,7 @@ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 void CRendererDRMPRIME::Register()
 {
   CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-  if (winSystem && winSystem->GetDrm()->GetPrimaryPlane()->plane &&
+  if (winSystem && winSystem->GetDrm()->GetVideoPlane()->plane &&
       std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
   {
     CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)->SetVisible(true);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -28,7 +28,7 @@ CVideoLayerBridgeDRMPRIME::~CVideoLayerBridgeDRMPRIME()
 void CVideoLayerBridgeDRMPRIME::Disable()
 {
   // disable video plane
-  struct plane* plane = m_DRM->GetPrimaryPlane();
+  struct plane* plane = m_DRM->GetVideoPlane();
   m_DRM->AddProperty(plane, "FB_ID", 0);
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
 }
@@ -129,7 +129,7 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
 
 void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
-  struct plane* plane = m_DRM->GetPrimaryPlane();
+  struct plane* plane = m_DRM->GetVideoPlane();
   if (m_DRM->SupportsProperty(plane, "COLOR_ENCODING") &&
       m_DRM->SupportsProperty(plane, "COLOR_RANGE"))
   {
@@ -146,7 +146,7 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
     return;
   }
 
-  struct plane* plane = m_DRM->GetPrimaryPlane();
+  struct plane* plane = m_DRM->GetVideoPlane();
   m_DRM->AddProperty(plane, "FB_ID", buffer->m_fb_id);
   m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
   m_DRM->AddProperty(plane, "SRC_X", 0);
@@ -164,7 +164,7 @@ void CVideoLayerBridgeDRMPRIME::UpdateVideoPlane()
   if (!m_buffer || !m_buffer->m_fb_id)
     return;
 
-  struct plane* plane = m_DRM->GetPrimaryPlane();
+  struct plane* plane = m_DRM->GetVideoPlane();
   m_DRM->AddProperty(plane, "FB_ID", m_buffer->m_fb_id);
   m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);
 }

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -52,22 +52,22 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
 
   if (rendered)
   {
-    AddProperty(m_overlay_plane, "FB_ID", fb_id);
-    AddProperty(m_overlay_plane, "CRTC_ID", m_crtc->crtc->crtc_id);
-    AddProperty(m_overlay_plane, "SRC_X", 0);
-    AddProperty(m_overlay_plane, "SRC_Y", 0);
-    AddProperty(m_overlay_plane, "SRC_W", m_width << 16);
-    AddProperty(m_overlay_plane, "SRC_H", m_height << 16);
-    AddProperty(m_overlay_plane, "CRTC_X", 0);
-    AddProperty(m_overlay_plane, "CRTC_Y", 0);
-    AddProperty(m_overlay_plane, "CRTC_W", m_mode->hdisplay);
-    AddProperty(m_overlay_plane, "CRTC_H", m_mode->vdisplay);
+    AddProperty(m_gui_plane, "FB_ID", fb_id);
+    AddProperty(m_gui_plane, "CRTC_ID", m_crtc->crtc->crtc_id);
+    AddProperty(m_gui_plane, "SRC_X", 0);
+    AddProperty(m_gui_plane, "SRC_Y", 0);
+    AddProperty(m_gui_plane, "SRC_W", m_width << 16);
+    AddProperty(m_gui_plane, "SRC_H", m_height << 16);
+    AddProperty(m_gui_plane, "CRTC_X", 0);
+    AddProperty(m_gui_plane, "CRTC_Y", 0);
+    AddProperty(m_gui_plane, "CRTC_W", m_mode->hdisplay);
+    AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay);
   }
   else if (videoLayer && !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls())
   {
     // disable gui plane when video layer is active and gui has no visible controls
-    AddProperty(m_overlay_plane, "FB_ID", 0);
-    AddProperty(m_overlay_plane, "CRTC_ID", 0);
+    AddProperty(m_gui_plane, "FB_ID", 0);
+    AddProperty(m_gui_plane, "CRTC_ID", 0);
   }
 
   auto ret = drmModeAtomicCommit(m_fd, m_req, flags | DRM_MODE_ATOMIC_TEST_ONLY, nullptr);
@@ -101,9 +101,9 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
   if (rendered)
   {
     if (videoLayer)
-      m_overlay_plane->SetFormat(CDRMUtils::FourCCWithAlpha(m_overlay_plane->GetFormat()));
+      m_gui_plane->SetFormat(CDRMUtils::FourCCWithAlpha(m_gui_plane->GetFormat()));
     else
-      m_overlay_plane->SetFormat(CDRMUtils::FourCCWithoutAlpha(m_overlay_plane->GetFormat()));
+      m_gui_plane->SetFormat(CDRMUtils::FourCCWithoutAlpha(m_gui_plane->GetFormat()));
 
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -104,10 +104,10 @@ public:
   std::string GetModule() const { return m_module; }
   int GetFileDescriptor() const { return m_fd; }
   int GetRenderNodeFileDescriptor() const { return m_renderFd; }
-  struct plane* GetPrimaryPlane() const { return m_primary_plane; }
-  struct plane* GetOverlayPlane() const { return m_overlay_plane; }
-  std::vector<uint64_t> *GetPrimaryPlaneModifiersForFormat(uint32_t format) { return &m_primary_plane->modifiers_map[format]; }
-  std::vector<uint64_t> *GetOverlayPlaneModifiersForFormat(uint32_t format) { return &m_overlay_plane->modifiers_map[format]; }
+  struct plane* GetVideoPlane() const { return m_video_plane; }
+  struct plane* GetGuiPlane() const { return m_gui_plane; }
+  std::vector<uint64_t> *GetVideoPlaneModifiersForFormat(uint32_t format) { return &m_video_plane->modifiers_map[format]; }
+  std::vector<uint64_t> *GetGuiPlaneModifiersForFormat(uint32_t format) { return &m_gui_plane->modifiers_map[format]; }
   struct crtc* GetCrtc() const { return m_crtc; }
 
   virtual RESOLUTION_INFO GetCurrentMode();
@@ -132,8 +132,8 @@ protected:
   struct connector *m_connector = nullptr;
   struct encoder *m_encoder = nullptr;
   struct crtc *m_crtc = nullptr;
-  struct plane *m_primary_plane = nullptr;
-  struct plane *m_overlay_plane = nullptr;
+  struct plane *m_video_plane = nullptr;
+  struct plane *m_gui_plane = nullptr;
   drmModeModeInfo *m_mode = nullptr;
 
   int m_width = 0;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -32,15 +32,15 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
-  uint32_t visualId = m_DRM->GetOverlayPlane()->GetFormat();
+  uint32_t visualId = m_DRM->GetGuiPlane()->GetFormat();
 
   // prefer alpha visual id, fallback to non-alpha visual id
   if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
       !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
   {
     // fallback to 8bit format if no EGL config was found for 10bit
-    m_DRM->GetOverlayPlane()->useFallbackFormat = true;
-    visualId = m_DRM->GetOverlayPlane()->GetFormat();
+    m_DRM->GetGuiPlane()->useFallbackFormat = true;
+    visualId = m_DRM->GetGuiPlane()->GetFormat();
 
     if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
         !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
@@ -76,7 +76,7 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   }
 
   uint32_t format = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
-  std::vector<uint64_t> *modifiers = m_DRM->GetOverlayPlaneModifiersForFormat(format);
+  std::vector<uint64_t> *modifiers = m_DRM->GetGuiPlaneModifiersForFormat(format);
 
   if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(), modifiers->size()))
   {


### PR DESCRIPTION
## Description
This PR renames the primary/overlay drm planes to video/gui to match the usage in code.

## Motivation and Context
We no longer look for primary/overlay planes, e.g. on amlogic the video plane is an overlay plane behind the primary plane and on rockchip the video plane is the primary plane.

## How Has This Been Tested?
Running Kodi on my Tinker Board S / Rock64 still works.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
