### PR TITLE
CSaveFileState::DoWork: Use item's dynpath. Fixes #14847

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -31,7 +31,7 @@ void CSaveFileState::DoWork(CFileItem& item,
                             CBookmark& bookmark,
                             bool updatePlayCount)
 {
-  std::string progressTrackingFile = item.GetPath();
+  std::string progressTrackingFile = item.GetDynPath();
 
   if (item.HasVideoInfoTag() && StringUtils::StartsWith(item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
     progressTrackingFile = item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified


### PR DESCRIPTION
This should fix #14847 

Took me a while to find out what went wrong.

If "auto play next item" is activated, a bookmark is set at the respective listitem instance and saved to the video database (table `bookmark`), but with the wrong `idFile"`and thus it never can be associated to the right video file later on (episode table has the correct `idFile`, `bookmark`table hasn't). When leaving and re-entering the video listing, items get recreated by reading values from database, thus the bookmark gets lost.

Reason: video database has a view `episode_view` which gets created from `episode` table values and among others the `bookmark` table:

```c++
 std::string episodeview = PrepareSQL("CREATE VIEW episode_view AS SELECT "
                                      "  episode.*,"
...
                                      "FROM episode"
...
                                       "  LEFT JOIN bookmark ON"
                                      "    bookmark.idFile=episode.idFile AND bookmark.type=1"
 ...
);
```  

The wrong "idFile" is created in `CVideoDatabase::AddFile(const std::string& strFileNameAndPath)`, because the param contains no file url, but a videodb url. 

Interestingly, if "auto play next item" is not activated",  a file url is passed to this method and thus a working bookmark gets stored to the db. But this could be another bug (CFileItem::SetPath somewhere?) I had no time to investigate... There are gazillions of `CFileItem::SetPath` calls in our code base and every of those is a potential bug...

The fix is to use item's dyn path instead of the static path of the item in `CSaveFileState::DoWork`

I tested this very carefully and hope the fix has no bad side effects.