### PR TITLE
Extend IsRemote check to some vfs paths (closes #14817)

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -598,6 +598,18 @@ bool URIUtils::IsRemote(const std::string& strFile)
 
   if (IsSourcesPath(strFile))
     return false;
+  
+  if (IsVideoDb(strFile) || IsMusicDb(strFile))
+    return false;
+  
+  if (IsLibraryFolder(strFile))
+    return false;
+  
+  if (IsPlugin(strFile))
+    return false;
+  
+  if (IsAndroidApp(strFile))
+    return false;
 
   if (!url.IsLocal())
     return true;

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -378,6 +378,11 @@ TEST_F(TestURIUtils, IsRemote)
   EXPECT_TRUE(URIUtils::IsRemote("https://path/to/file"));
   EXPECT_FALSE(URIUtils::IsRemote("addons://user/"));
   EXPECT_FALSE(URIUtils::IsRemote("sources://video/"));
+  EXPECT_FALSE(URIUtils::IsRemote("videodb://movies/titles"));
+  EXPECT_FALSE(URIUtils::IsRemote("musicdb://genres/"));
+  EXPECT_FALSE(URIUtils::IsRemote("library://video/"));
+  EXPECT_FALSE(URIUtils::IsRemote("androidapp://app"));
+  EXPECT_FALSE(URIUtils::IsRemote("plugin://plugin.video.id"));
 }
 
 TEST_F(TestURIUtils, IsSmb)


### PR DESCRIPTION
## Description
This PR extends the `IsRemote` check to: 
- `videodb://`
- `musicdb://`
- `library://`
- `plugin://`
- `androidapp://`

 vfs paths, returning false to the check. Closes https://github.com/xbmc/xbmc/issues/14817

Credits go to @garbear for tracking the root cause in the issue comments.

## Motivation and Context
Kodi stucks on "Loading directory" when it is used without Internet connection and the user navigates to the movie or tvshow library.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Run time tested in OSX and respective test extended.

## Screenshots (if appropriate):
**Before**:
![before](https://i.imgur.com/nb8H5uM.png "Before")
**After**:
![after](https://i.imgur.com/p9iD0rD.png "After")

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
