### PR TITLE
[video] CGUIWindowVideoBase::OnPlayAndQueueMedia: Set correct item path. Fixes #14847

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1103,7 +1103,13 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr &item, std::str
   if (iPlaylist != PLAYLIST_NONE && CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist))
      CServiceBroker::GetPlaylistPlayer().SetShuffle(iPlaylist, false);
 
-  CFileItemPtr movieItem(new CFileItem(*item));
+  const CFileItemPtr movieItem = std::make_shared<CFileItem>(*item);
+  if (movieItem->IsVideoDb())
+  {
+    movieItem->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
+    movieItem->SetProperty("original_listitem_url", item->GetPath());
+  }
+  CLog::Log(LOGDEBUG, "%s %s", __FUNCTION__, CURL::GetRedacted(movieItem->GetPath()).c_str());
 
   // Call the base method to actually queue the items
   // and start playing the given item


### PR DESCRIPTION
CGUIWindowVideoBase::OnPlayAndQueueMedia`: Set correct item path, like `CGUIWindowVideoBase::OnPlayMedia` does 

This is another non-invasive approach to fix #14847 and a replacement for the rejected fix approach in #14859

The fix is not very nice as it sets the path of the item to play which is generally a nogo, but again, we do this at many many places and we do exactly this for the working code path if "auto play next item" is not activated: https://github.com/xbmc/xbmc/blob/master/xbmc/video/windows/GUIWindowVideoBase.cpp#L1087 ff.

So, at least this is consistent and working now.

@FernetMenta is this a nogo or do we want to live with this for v18? I consider this a heavy bug in basic Kodi functionality which would justify the "dirty" fix.

