### PR TITLE
[video] Fix #14847 - Take 3 ;-)

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -35,6 +35,8 @@ void CSaveFileState::DoWork(CFileItem& item,
 
   if (item.HasVideoInfoTag() && StringUtils::StartsWith(item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
     progressTrackingFile = item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
+  else if (item.HasVideoInfoTag() && item.IsVideoDb())
+    progressTrackingFile = item.GetVideoInfoTag()->m_strFileNameAndPath; // we need the file url of the video db item to create the bookmark
   else if (item.HasProperty("original_listitem_url"))
   {
     // only use original_listitem_url for Python, UPnP and Bluray sources


### PR DESCRIPTION
CSaveFileState::DoWork: For videodb items, use m_strFileNameAndPath, not GetPath(). Fixes #14847.

Take 3. Supercedes #14862, fixes #14847 - this time without path manipulation of existing item.

@FernetMenta this one should actually be good to go - no hacks this time, imo. ;-)