### PR TITLE
fixed: Low read rate detection logic when VideoPlayer uses filecache

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1809,10 +1809,10 @@ bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
   if (!m_pInputStream->GetCacheStatus(&status))
     return false;
 
-  uint64_t &cached = status.forward;
-  unsigned &currate = status.currate;
-  unsigned &maxrate = status.maxrate;
-  float &cache_level = status.level;
+  const uint64_t &cached = status.forward;
+  const unsigned &currate = status.currate;
+  const unsigned &maxrate = status.maxrate;
+  const bool &lowspeed = status.lowspeed;
 
   int64_t length = m_pInputStream->GetLength();
   int64_t remain = length - m_pInputStream->Seek(0, SEEK_CUR);
@@ -1837,13 +1837,7 @@ bool CVideoPlayer::GetCachingTimes(double& level, double& delay, double& offset)
 
   delay = cache_left - play_left;
 
-  /* NOTE: We can only reliably test for low readrate, when the cache is not
-   * already *near* full. This is because as soon as it's full the average-
-   * rate will become approximately the current-rate which can flag false
-   * low read-rate conditions. To work around this we don't check the currate at 100%
-   * but between 80% and 90%
-   */
-  if (cache_level > 0.8 && cache_level < 0.9 && currate < maxrate)
+  if (lowspeed)
   {
     CLog::Log(LOGDEBUG, "Readrate %u is too low with %u required", currate, maxrate);
     level = -1.0;                          /* buffer is full & our read rate is too low  */

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -94,6 +94,9 @@ CFileCache::CFileCache(const unsigned int flags)
   , m_writeRate(0)
   , m_writeRateActual(0)
   , m_forwardCacheSize(0)
+  , m_forward(0)
+  , m_bFilling(false)
+  , m_bLowSpeedDetected(false)
   , m_fileSize(0)
   , m_flags(flags)
 {
@@ -106,6 +109,9 @@ CFileCache::CFileCache(CCacheStrategy *pCache, bool bDeleteCache /* = true */)
   , m_writeRate(0)
   , m_writeRateActual(0)
   , m_forwardCacheSize(0)
+  , m_forward(0)
+  , m_bFilling(false)
+  , m_bLowSpeedDetected(false)
 {
   m_pCache = pCache;
   m_bDeleteCache = bDeleteCache;
@@ -220,6 +226,9 @@ bool CFileCache::Open(const CURL& url)
   m_writePos = 0;
   m_writeRate = 1024 * 1024;
   m_writeRateActual = 0;
+  m_forward = 0;
+  m_bFilling = true;
+  m_bLowSpeedDetected = false;
   m_seekEvent.Reset();
   m_seekEnded.Reset();
 
@@ -279,6 +288,12 @@ void CFileCache::Process()
         average.Reset(m_writePos, bCompleteReset); // Can only recalculate new average from scratch after a full reset (empty cache)
         limiter.Reset(m_writePos);
         m_nSeekResult = m_seekPos;
+        if (bCompleteReset)
+        {
+          m_forward = 0;
+          m_bFilling = true;
+          m_bLowSpeedDetected = false;
+        }
       }
 
       m_seekEnded.Set();
@@ -401,6 +416,28 @@ void CFileCache::Process()
     // under estimate write rate by a second, to
     // avoid uncertainty at start of caching
     m_writeRateActual = average.Rate(m_writePos, 1000);
+
+    // Update forward cache size
+    m_forward = m_pCache->WaitForData(0, 0);
+
+    // NOTE: Hysteresis (20-80%) for filling-logic
+    const float level = (m_forwardCacheSize == 0) ? 0.0 : (float) m_forward / m_forwardCacheSize;
+    if (level > 0.8f)
+    {
+     /* NOTE: We can only reliably test for low speed condition, when the cache is *really*
+      * filling. This is because as soon as it's full the average-
+      * rate will become approximately the current-rate which can flag false
+      * low read-rate conditions.
+      */
+      if (m_bFilling && m_writeRateActual < m_writeRate)
+        m_bLowSpeedDetected = true;
+
+      m_bFilling = false;
+    }
+    else if (level < 0.2f)
+    {
+      m_bFilling = true;
+    }
   }
 }
 
@@ -569,10 +606,11 @@ int CFileCache::IoControl(EIoControl request, void* param)
   if (request == IOCTRL_CACHE_STATUS)
   {
     SCacheStatus* status = (SCacheStatus*)param;
-    status->forward = m_pCache->WaitForData(0, 0);
-    status->level   = (m_forwardCacheSize == 0) ? 0.0 : (float) status->forward / m_forwardCacheSize;
+    status->forward = m_forward;
     status->maxrate = m_writeRate;
     status->currate = m_writeRateActual;
+    status->lowspeed = m_bLowSpeedDetected;
+    m_bLowSpeedDetected = false; // Reset flag
     return 0;
   }
 

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -71,6 +71,9 @@ namespace XFILE
     unsigned m_writeRate;
     unsigned m_writeRateActual;
     int64_t m_forwardCacheSize;
+    int64_t m_forward;
+    bool m_bFilling;
+    bool m_bLowSpeedDetected;
     std::atomic<int64_t> m_fileSize;
     unsigned int m_flags;
     CCriticalSection m_sync;

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -51,7 +51,7 @@ struct SCacheStatus
   uint64_t forward;  /**< number of bytes cached forward of current position */
   unsigned maxrate;  /**< maximum number of bytes per second cache is allowed to fill */
   unsigned currate;  /**< average read rate from source file since last position change */
-  float    level;    /**< cache level (0.0 - 1.0) */
+  bool     lowspeed; /**< cache low speed condition detected? */
 };
 
 typedef enum {


### PR DESCRIPTION
## Description
This fixes a long standing bug with VideoPlayer's "cache low fill rate detection logic". I already attempted to quick-fix this in the past but unfortunately that didn't work out well. This finally really fixes the issue and also stops those incorrect (and annoying) toasts claiming the cache fill speed is too low when performing forward jumps.

## How Has This Been Tested?
Thoroughly tested on my development machine :)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
