### PR TITLE
libinput: check that the user is part of the input group

### DIFF
--- a/xbmc/platform/linux/input/LibInputHandler.h
+++ b/xbmc/platform/linux/input/LibInputHandler.h
@@ -35,6 +35,7 @@ private:
   void ProcessEvent(libinput_event *ev);
   void DeviceAdded(libinput_device *dev);
   void DeviceRemoved(libinput_device *dev);
+  void CheckInputGroup();
 
   udev *m_udev;
   libinput *m_li;


### PR DESCRIPTION
This will make it so that Kodi cannot start without input when using libinput handling.

Without this if a user isn't part of the `input` group kodi would start but you could not do anything or exit which is a significant problem.