### PR TITLE
[Android] Bump libandroidjni git sha / safety check event dispatch

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=482232cc05102021e955e9d907b0047801fa47b4
+VERSION=aa12538cc5090d061d34b5fd7385d939ea82ce8b
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/platform/android/activity/AndroidKey.cpp
+++ b/xbmc/platform/android/activity/AndroidKey.cpp
@@ -312,6 +312,10 @@ bool CAndroidKey::onKeyboardEvent(AInputEvent *event)
 
 void CAndroidKey::XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint16_t unicode, bool up)
 {
+  CWinSystemAndroid* winSystem(dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem()));
+  if (!winSystem)
+    return;
+
   XBMC_Event newEvent;
   memset(&newEvent, 0, sizeof(newEvent));
 
@@ -323,5 +327,5 @@ void CAndroidKey::XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint1
   newEvent.key.keysym.mod = (XBMCMod)modifiers;
 
   //CXBMCApp::android_printf("XBMC_Key(%u, %u, 0x%04X, %d)", code, key, modifiers, up);
-  dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->MessagePush(&newEvent);
+  winSystem->MessagePush(&newEvent);
 }


### PR DESCRIPTION
## Description
See title

## Motivation and Context
- On factory state devices DRM openSession segfaults kodi.
- Potential segfaults for early key events

## How Has This Been Tested?
AFTV, start kodi

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
