### PR TITLE
[storage] MediaManager::Onstorage*: Do not show toasts if fullscreen …

### DIFF
--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -685,6 +685,21 @@ std::vector<std::string> CMediaManager::GetDiskUsage()
   return m_platformStorage->GetDiskUsage();
 }
 
+namespace
+{
+void ShowGUINotification(CGUIDialogKaiToast::eMessageType eType, const std::string& caption, const std::string& message)
+{
+  int activeWindow = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
+  if (activeWindow != WINDOW_FULLSCREEN_VIDEO &&
+      activeWindow != WINDOW_FULLSCREEN_GAME &&
+      activeWindow != WINDOW_VISUALISATION &&
+      activeWindow != WINDOW_SLIDESHOW)
+  {
+    CGUIDialogKaiToast::QueueNotification(eType, caption, message, TOAST_DISPLAY_TIME, false);
+  }
+}
+} // unnamed namespace
+
 void CMediaManager::OnStorageAdded(const std::string &label, const std::string &path)
 {
 #ifdef HAS_DVD_DRIVE
@@ -695,18 +710,18 @@ void CMediaManager::OnStorageAdded(const std::string &label, const std::string &
     else
       CJobManager::GetInstance().AddJob(new CAutorunMediaJob(label, path), this, CJob::PRIORITY_HIGH);
   else
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label, TOAST_DISPLAY_TIME, false);
+    ShowGUINotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label);
 #endif
 }
 
 void CMediaManager::OnStorageSafelyRemoved(const std::string &label)
 {
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), label, TOAST_DISPLAY_TIME, false);
+  ShowGUINotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), label);
 }
 
 void CMediaManager::OnStorageUnsafelyRemoved(const std::string &label)
 {
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), label);
+  ShowGUINotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), label);
 }
 
 CMediaManager::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)


### PR DESCRIPTION
…window is active. User is not interested in mount notifications while watching videos etc.

Requested in the forum: https://forum.kodi.tv/showthread.php?tid=337463

@Jalle19 does this look okay, code-wise?

