### PR TITLE
[FIX] Music Brainz uses 1-5 ratings not 1-10

### DIFF
--- a/addons/metadata.common.musicbrainz.org/addon.xml
+++ b/addons/metadata.common.musicbrainz.org/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.common.musicbrainz.org"
        name="MusicBrainz Scraper Library"
-        version="2.2.0"
+        version="2.2.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>

--- a/addons/metadata.common.musicbrainz.org/musicbrainz.xml
+++ b/addons/metadata.common.musicbrainz.org/musicbrainz.xml
@@ -155,7 +155,7 @@
 	</GetMBAlbumRatingByMBID>
 	<ParseMBAlbumRating dest="5">
 		<RegExp input="$$2" output="&lt;details&gt;\1&lt;/details&gt;" dest="5">
-			<RegExp input="$$1" output="&lt;rating&gt;\1&lt;/rating&gt;" dest="2">
+			<RegExp input="$$1" output="&lt;rating max=&quot;5.0&quot;&gt;\1&lt;/rating&gt;" dest="2">
 				<expression noclean="1">&lt;/primary-type&gt;&lt;rating votes-count="[^"]*"&gt;(\d)</expression>
 			</RegExp>
 			<expression noclean="1">(.+)</expression>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Set the max rating for Music Brainz to 5 so Kodi can correctly convert to a 1-10 scale

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes incorrect album ratings when using Music Brainz as the album rating provider in Universal Album Scraper

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Yes, tested on many albums and compared with results on Music Brainz site

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
