### PR TITLE
[addons] remove never set value on CAddonInfo

### DIFF
--- a/xbmc/addons/AddonInfo.h
+++ b/xbmc/addons/AddonInfo.h
@@ -133,7 +133,6 @@ namespace ADDON
     const CDateTime& LastUsed() const { return m_lastUsed; }
     const std::string& Origin() const { return m_origin; }
     uint64_t PackageSize() const { return m_packageSize; }
-    const std::string& Language() const { return m_language; }
     const InfoMap& ExtraInfo() const { return m_extrainfo; }
     bool MeetsVersion(const AddonVersion &version) const;
 
@@ -174,7 +173,6 @@ namespace ADDON
     CDateTime m_lastUsed;
     std::string m_origin;
     uint64_t m_packageSize = 0;
-    std::string m_language;
     std::string m_libname;
     InfoMap m_extrainfo;
   };


### PR DESCRIPTION
## Description
This removes the function "Language()" from the CAddonInfo class, which was never set and can lead to corruption if someone wants to use it.

This value is available via ExtraInfo().

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
Make the Addon System better :-)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Does compile.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
