### PR TITLE
Actually destroy window system on application shutdown

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -700,14 +700,6 @@ bool CApplication::InitWindow(RESOLUTION res)
   return true;
 }
 
-bool CApplication::DestroyWindow()
-{
-  bool ret = CServiceBroker::GetWinSystem()->DestroyWindow();
-  CServiceBroker::UnregisterWinSystem();
-  m_pWinSystem.reset();
-  return ret;
-}
-
 bool CApplication::Initialize()
 {
 #if defined(HAS_DVD_DRIVE) && !defined(TARGET_WINDOWS) // somehow this throws an "unresolved external symbol" on win32
@@ -2443,10 +2435,7 @@ bool CApplication::Cleanup()
 
     CWinSystemBase *winSystem = CServiceBroker::GetWinSystem();
     if (winSystem)
-    {
       winSystem->DestroyWindow();
-      winSystem->DestroyWindowSystem();
-    }
 
     if (m_pGUI)
       m_pGUI->GetWindowManager().DestroyWindows();
@@ -2488,6 +2477,14 @@ bool CApplication::Cleanup()
     {
       m_pGUI->Deinit();
       m_pGUI.reset();
+    }
+
+    if (winSystem)
+    {
+      winSystem->DestroyWindowSystem();
+      CServiceBroker::UnregisterWinSystem();
+      winSystem = nullptr;
+      m_pWinSystem.reset();
     }
 
     // Cleanup was called more than once on exit during my tests

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -150,7 +150,6 @@ public:
 
   bool CreateGUI();
   bool InitWindow(RESOLUTION res = RES_INVALID);
-  bool DestroyWindow();
   void StartServices();
   void StopServices();
 


### PR DESCRIPTION
## Description
Destruction of window system should not be left up to global destrcution
in unknown order.

Windowing owns LIRC (due to some reason) thread which otherwise might
try to write log messages when logging has already been shut down.

## Motivation and Context
Errant shutdown crashes and Valgrind report

## How Has This Been Tested?
Build/run Linux x86_64 Wayland