### PR TITLE
[games] Show installed game clients first

### DIFF
--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -57,6 +57,7 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &
   {
     // Turn the addons into items
     CFileItemList items;
+    CFileItemList installableItems;
     for (const auto &candidate : candidates)
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(candidate, candidate->ID()));
@@ -68,9 +69,12 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &
     for (const auto &addon : installable)
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(addon, addon->ID()));
-      items.Add(std::move(item));
+      installableItems.Add(std::move(item));
     }
     items.Sort(SortByLabel, SortOrderAscending);
+    installableItems.Sort(SortByLabel, SortOrderAscending);
+
+    items.Append(installableItems);
 
     dialog->SetItems(items);
 


### PR DESCRIPTION
## Description
Changes the sort order of game clients in the selection dialog so that the installed clients are shown first.

## Motivation and Context
Currently even if there is only a few emulators installed you still need to scroll through all the available cores every time you run the game. This PR moves the installed cores to the top of the list.
This is a temporary solution which improves the usability for Kodi 18 until there is a game database.

## How Has This Been Tested?
Installed cores are shown first.

## Screenshots (if appropriate):
![screenshot002](https://user-images.githubusercontent.com/13847813/48673140-40a33800-eb36-11e8-8977-a2cd4a4ada63.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
