### PR TITLE
[GBM] use systemd logind if available to authenticate a user session

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -313,3 +313,14 @@ if(CPACK_GENERATOR)
     message(FATAL_ERROR "DEB Generator: Can't configure CPack to generate Debian packages on non-linux systems.")
   endif()
 endif()
+
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
+  if(DBUS_FOUND)
+    configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/${APP_NAME_LC}@.service.sample.in
+                   ${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}@.service.sample @ONLY)
+
+    install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}@.service.sample
+            DESTINATION ${APP_PREFIX}/share/doc/${APP_NAME_LC}/examples/
+            COMPONENT kodi-systemd-service)
+  endif()
+endif()

--- a/tools/Linux/kodi@.service.sample.in
+++ b/tools/Linux/kodi@.service.sample.in
@@ -1,0 +1,42 @@
+[Unit]
+Description=@APP_NAME_LC@ on %i
+After=systemd-user-sessions.service sound.target network-online.target
+
+# D-Bus is necessary for contacting logind. Logind is required.
+Wants=dbus.socket
+After=dbus.socket
+
+Conflicts=getty@%i.service
+Before=graphical.target
+
+# On systems without virtual consoles, don't start @APP_NAME_LC@
+ConditionPathExists=/dev/tty0
+
+[Service]
+# Change to your user of choice
+User=@APP_NAME_LC@
+PAMName=login
+ExecStart=@bindir@/@APP_NAME_LC@ -fs --standalone
+Type=simple
+Restart=on-abort
+RestartSec=5
+KillMode=control-group
+
+# A virtual terminal is needed.
+TTYPath=/dev/%i
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+
+# Fail to start if not controlling the tty.
+StandardOutput=tty
+StandardInput=tty
+StandardError=journal
+
+# Log this user with utmp, letting it show up with commands 'w' and 'who'.
+UtmpIdentifier=%i
+UtmpMode=user
+
+[Install]
+WantedBy=graphical.target
+DefaultInstance=tty7

--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -23,4 +23,14 @@ if(DBUS_FOUND)
                       DBusUtil.h)
 endif()
 
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
+  if(DBUS_FOUND)
+    list(APPEND SOURCES LogindUtils.cpp)
+    list(APPEND HEADERS LogindUtils.h)
+  endif()
+
+  list(APPEND SOURCES SessionUtils.cpp)
+  list(APPEND HEADERS SessionUtils.h)
+endif()
+
 core_add_library(linuxsupport)

--- a/xbmc/platform/linux/DBusMessage.cpp
+++ b/xbmc/platform/linux/DBusMessage.cpp
@@ -157,6 +157,11 @@ bool CDBusMessage::SendAsync(DBusBusType type)
   return dbus_connection_send(con, m_message.get(), nullptr);
 }
 
+bool CDBusMessage::SendAsync(DBusConnection* con)
+{
+  return dbus_connection_send(con, m_message.get(), nullptr);
+}
+
 DBusMessage *CDBusMessage::Send(DBusConnection *con, CDBusError& error)
 {
   m_reply.reset(dbus_connection_send_with_reply_and_block(con, m_message.get(), -1, error));

--- a/xbmc/platform/linux/DBusMessage.h
+++ b/xbmc/platform/linux/DBusMessage.h
@@ -106,6 +106,7 @@ public:
 
   bool SendAsyncSystem();
   bool SendAsyncSession();
+  bool SendAsync(DBusConnection* con);
 
   DBusMessage *Send(DBusBusType type);
   DBusMessage *Send(DBusBusType type, CDBusError& error);

--- a/xbmc/platform/linux/LogindUtils.cpp
+++ b/xbmc/platform/linux/LogindUtils.cpp
@@ -1,0 +1,226 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "LogindUtils.h"
+
+#include "SessionUtils.h"
+#include "utils/log.h"
+
+#include "platform/linux/DBusMessage.h"
+
+#include <sys/sysmacros.h>
+
+namespace
+{
+constexpr auto logindService{"org.freedesktop.login1"};
+constexpr auto logindObject{"/org/freedesktop/login1"};
+constexpr auto logindManagerInterface{"org.freedesktop.login1.Manager"};
+constexpr auto logindSessionInterface{"org.freedesktop.login1.Session"};
+} // namespace
+
+int CLogindUtils::Open(const std::string& path, int flags)
+{
+  struct stat st;
+  int ret = stat(path.c_str(), &st);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "logind: stat failed for: {}", path);
+    return -1;
+  }
+
+  if (!S_ISCHR(st.st_mode))
+  {
+    CLog::Log(LOGERROR, "logind: invalid device passed");
+    return -1;
+  }
+
+  int fd = TakeDevice(m_sessionPath, major(st.st_rdev), minor(st.st_rdev));
+  if (fd < 0)
+    return fd;
+
+  ret = fcntl(fd, F_GETFL);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "logind: F_GETFL failed");
+    Close(fd);
+    return -1;
+  }
+
+  if (flags & O_NONBLOCK)
+  {
+    ret = fcntl(fd, F_SETFL, O_NONBLOCK);
+    if (ret < 0)
+    {
+      CLog::Log(LOGERROR, "logind: F_SETFL failed");
+      Close(fd);
+      return -1;
+    }
+  }
+
+  return fd;
+}
+
+void CLogindUtils::Close(int fd)
+{
+  struct stat st;
+  int ret = fstat(fd, &st);
+  close(fd);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "logind: cannot fstat fd: {}", fd);
+    return;
+  }
+
+  if (!S_ISCHR(st.st_mode))
+  {
+    CLog::Log(LOGERROR, "logind: invalid device passed");
+    return;
+  }
+
+  ReleaseDevice(m_sessionPath, major(st.st_rdev), minor(st.st_rdev));
+}
+
+std::string CLogindUtils::GetSessionPath()
+{
+  CDBusMessage message(logindService, logindObject, logindManagerInterface, "GetSessionByPID");
+  message.AppendArguments<uint32_t>(getpid());
+
+  CDBusError error;
+  auto reply = message.Send(m_connection, error);
+  if (!reply)
+  {
+    CLog::Log(LOGERROR, "logind: GetSessionByPID failed: ({})", error.Message());
+    return "";
+  }
+
+  // left this c-style for now as our dbus methods don't accept DBUS_TYPE_OBJECT_PATH
+  char* path;
+  auto b = dbus_message_get_args(reply, nullptr, DBUS_TYPE_OBJECT_PATH, &path, DBUS_TYPE_INVALID);
+
+  if (!b)
+  {
+    CLog::Log(LOGERROR, "logind: failed to get session path");
+    return "";
+  }
+
+  return std::string{path};
+}
+
+int CLogindUtils::TakeDevice(const std::string& sessionPath, uint32_t major, uint32_t minor)
+{
+  CDBusMessage message(logindService, sessionPath, logindSessionInterface, "TakeDevice");
+  message.AppendArguments<uint32_t, uint32_t>(major, minor);
+
+  CDBusError error;
+  auto reply = message.Send(m_connection, error);
+  if (!reply)
+  {
+    CLog::Log(LOGERROR, "logind: TakeDevice failed for session: {} ({})", sessionPath,
+              error.Message());
+    return -1;
+  }
+
+  // left this c-style for now as our dbus methods don't accept DBUS_TYPE_UNIX_FD
+  int fd;
+  dbus_bool_t active;
+  auto b = dbus_message_get_args(reply, nullptr, DBUS_TYPE_UNIX_FD, &fd, DBUS_TYPE_BOOLEAN, &active,
+                                 DBUS_TYPE_INVALID);
+
+  if (!b)
+  {
+    CLog::Log(LOGERROR, "logind: failed to get unix fd");
+    return -1;
+  }
+
+  return fd;
+}
+
+void CLogindUtils::ReleaseDevice(const std::string& sessionPath, uint32_t major, uint32_t minor)
+{
+  CDBusMessage message(logindService, sessionPath, logindSessionInterface, "ReleaseDevice");
+  message.AppendArguments<uint32_t, uint32_t>(major, minor);
+
+  if (!message.SendAsyncSystem())
+  {
+    CLog::Log(LOGERROR, "logind: ReleaseDevice failed");
+  }
+}
+
+bool CLogindUtils::TakeControl()
+{
+  CDBusMessage message(logindService, m_sessionPath, logindSessionInterface, "TakeControl");
+
+  message.AppendArgument<bool>(false);
+
+  CDBusError error;
+  auto reply = message.Send(m_connection, error);
+
+  if (!reply)
+  {
+    CLog::Log(LOGERROR, "logind: cannot take control over session: {} ({})", m_sessionPath,
+              error.Message());
+    return false;
+  }
+
+  return true;
+}
+
+void CLogindUtils::ReleaseControl()
+{
+  CDBusMessage message(logindService, m_sessionPath, logindSessionInterface, "ReleaseControl");
+  message.SendAsync(m_connection);
+}
+
+bool CLogindUtils::Activate()
+{
+  CDBusMessage message(logindService, m_sessionPath, logindSessionInterface, "Activate");
+
+  if (!message.SendAsync(m_connection))
+  {
+    CLog::Log(LOGERROR, "logind: cannot activate session: {}", m_sessionPath);
+    return false;
+  }
+
+  return true;
+}
+
+bool CLogindUtils::Connect()
+{
+  if (!m_connection.Connect(DBUS_BUS_SYSTEM, false))
+  {
+    CLog::Log(LOGERROR, "logind: cannot connect to system dbus");
+    return false;
+  }
+
+  m_sessionPath = GetSessionPath();
+
+  if (m_sessionPath.empty())
+  {
+    CLog::Log(LOGERROR, "logind: no dbus session available, cannot register session");
+    return false;
+  }
+
+  if (!TakeControl())
+  {
+    return false;
+  }
+
+  if (!Activate())
+  {
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "logind: successfully registered session: {}", m_sessionPath);
+
+  return true;
+}
+
+void CLogindUtils::Destroy()
+{
+  ReleaseControl();
+}

--- a/xbmc/platform/linux/LogindUtils.h
+++ b/xbmc/platform/linux/LogindUtils.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/linux/DBusUtil.h"
+#include "platform/linux/SessionUtils.h"
+
+class CLogindUtils : public CSessionUtils
+{
+public:
+  CLogindUtils() = default;
+  ~CLogindUtils() = default;
+
+  int Open(const std::string& path, int flags) override;
+  void Close(int fd) override;
+
+  bool Connect() override;
+  void Destroy() override;
+
+private:
+  std::string GetSessionPath();
+
+  int TakeDevice(const std::string& sessionPath, uint32_t major, uint32_t minor);
+  void ReleaseDevice(const std::string& sessionPath, uint32_t major, uint32_t minor);
+
+  bool TakeControl();
+  void ReleaseControl();
+
+  bool Activate();
+
+  std::string m_sessionPath;
+
+  CDBusConnection m_connection;
+};

--- a/xbmc/platform/linux/SessionUtils.cpp
+++ b/xbmc/platform/linux/SessionUtils.cpp
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SessionUtils.h"
+
+#if defined(HAS_DBUS)
+#include "platform/linux/LogindUtils.h"
+#endif
+
+#include <fcntl.h>
+#include <unistd.h>
+
+std::shared_ptr<CSessionUtils> CSessionUtils::GetSession()
+{
+#if defined(HAS_DBUS)
+  return std::make_shared<CLogindUtils>();
+#endif
+  return std::make_shared<CSessionUtils>();
+}
+
+int CSessionUtils::Open(const std::string& path, int flags)
+{
+  return open(path.c_str(), O_RDWR | flags);
+}
+
+void CSessionUtils::Close(int fd)
+{
+  close(fd);
+}

--- a/xbmc/platform/linux/SessionUtils.h
+++ b/xbmc/platform/linux/SessionUtils.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+class CSessionUtils
+{
+public:
+  static std::shared_ptr<CSessionUtils> GetSession();
+
+  virtual int Open(const std::string& path, int flags);
+  virtual void Close(int fd);
+
+  virtual bool Connect() { return true; }
+  virtual void Destroy() {}
+};

--- a/xbmc/platform/linux/input/LibInputHandler.h
+++ b/xbmc/platform/linux/input/LibInputHandler.h
@@ -20,11 +20,12 @@ class CLibInputKeyboard;
 class CLibInputPointer;
 class CLibInputSettings;
 class CLibInputTouch;
+class CSessionUtils;
 
 class CLibInputHandler : CThread
 {
 public:
-  CLibInputHandler();
+  CLibInputHandler(std::shared_ptr<CSessionUtils> session);
   ~CLibInputHandler() override;
 
   void Start();
@@ -46,5 +47,6 @@ private:
   std::unique_ptr<CLibInputSettings> m_settings;
   std::unique_ptr<CLibInputTouch> m_touch;
   std::vector<libinput_device*> m_devices;
+  std::shared_ptr<CSessionUtils> m_session;
 };
 

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -20,8 +20,8 @@ namespace GBM
 class CDRMAtomic : public CDRMUtils
 {
 public:
-  CDRMAtomic() = default;
-  ~CDRMAtomic() override { DestroyDrm(); };
+  CDRMAtomic(std::shared_ptr<CSessionUtils> session) : CDRMUtils(session) {}
+  ~CDRMAtomic() override = default;
   void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
   bool SetActive(bool active) override;

--- a/xbmc/windowing/gbm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/DRMLegacy.h
@@ -20,8 +20,8 @@ namespace GBM
 class CDRMLegacy : public CDRMUtils
 {
 public:
-  CDRMLegacy() = default;
-  ~CDRMLegacy() override { DestroyDrm(); };
+  CDRMLegacy(std::shared_ptr<CSessionUtils> session) : CDRMUtils(session) {}
+  ~CDRMLegacy() override = default;
   void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
   bool SetActive(bool active) override;

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -11,15 +11,16 @@
 #include "GBMUtils.h"
 #include "windowing/Resolution.h"
 
-#include "platform/posix/utils/FileHandle.h"
-
 #include <map>
+#include <memory>
 #include <vector>
 
 #include <drm_fourcc.h>
 #include <gbm.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+
+class CSessionUtils;
 
 namespace KODI
 {
@@ -84,8 +85,8 @@ struct drm_fb
 class CDRMUtils
 {
 public:
-  CDRMUtils();
-  virtual ~CDRMUtils() = default;
+  CDRMUtils(std::shared_ptr<CSessionUtils> session);
+  virtual ~CDRMUtils();
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) {};
   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) { return false; };
   virtual bool SetActive(bool active) { return false; };
@@ -122,7 +123,7 @@ protected:
   static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object);
   static void FreeProperties(struct drm_object *object);
 
-  KODI::UTILS::POSIX::CFileHandle m_fd;
+  int m_fd;
   struct connector *m_connector = nullptr;
   struct encoder *m_encoder = nullptr;
   struct crtc *m_crtc = nullptr;
@@ -150,12 +151,14 @@ private:
   RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
   bool CheckConnector(int connectorId);
 
-  KODI::UTILS::POSIX::CFileHandle m_renderFd;
+  int m_renderFd;
   std::string m_module;
 
   drmModeResPtr m_drm_resources = nullptr;
 
   std::vector<crtc*> m_crtcs;
+
+  std::shared_ptr<CSessionUtils> m_session;
 };
 
 }

--- a/xbmc/windowing/gbm/OffScreenModeSetting.h
+++ b/xbmc/windowing/gbm/OffScreenModeSetting.h
@@ -20,8 +20,8 @@ namespace GBM
 class COffScreenModeSetting : public CDRMUtils
 {
 public:
-  COffScreenModeSetting() = default;
-  ~COffScreenModeSetting() override { DestroyDrm(); };
+  COffScreenModeSetting(std::shared_ptr<CSessionUtils> session) : CDRMUtils(session) {}
+  ~COffScreenModeSetting() override = default;
   void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
   bool SetActive(bool active) override { return false; }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -87,7 +87,7 @@ bool CWinSystemGbm::InitWindowSystem()
     return false;
   }
 
-  m_libinput.reset(new CLibInputHandler());
+  m_libinput.reset(new CLibInputHandler(m_session));
   m_libinput->Start();
 
   m_DRM = std::make_shared<CDRMAtomic>();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -120,6 +120,9 @@ bool CWinSystemGbm::DestroyWindowSystem()
 {
   m_GBM->DestroyDevice();
 
+  if (m_DRM)
+    m_DRM->DestroyDrm();
+
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - deinitialized DRM", __FUNCTION__);
 
   m_libinput.reset();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -90,21 +90,21 @@ bool CWinSystemGbm::InitWindowSystem()
   m_libinput.reset(new CLibInputHandler(m_session));
   m_libinput->Start();
 
-  m_DRM = std::make_shared<CDRMAtomic>();
+  m_DRM = std::make_shared<CDRMAtomic>(m_session);
 
   if (!m_DRM->InitDrm())
   {
     CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize Atomic DRM", __FUNCTION__);
     m_DRM.reset();
 
-    m_DRM = std::make_shared<CDRMLegacy>();
+    m_DRM = std::make_shared<CDRMLegacy>(m_session);
 
     if (!m_DRM->InitDrm())
     {
       CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize Legacy DRM", __FUNCTION__);
       m_DRM.reset();
 
-      m_DRM = std::make_shared<COffScreenModeSetting>();
+      m_DRM = std::make_shared<COffScreenModeSetting>(m_session);
       if (!m_DRM->InitDrm())
       {
         CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize off screen DRM", __FUNCTION__);

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -20,6 +20,7 @@
 #include <EGL/egl.h>
 #include <gbm.h>
 
+class CSessionUtils;
 class IDispResource;
 
 namespace KODI
@@ -74,6 +75,8 @@ protected:
   XbmcThreads::EndTime m_dispResetTimer;
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
   std::unique_ptr<CLibInputHandler> m_libinput;
+
+  std::shared_ptr<CSessionUtils> m_session;
 };
 
 }


### PR DESCRIPTION
This provides us with the ability to authenticate the user session with systemd-logind. We want to do this because we need the ability to open `/dev/dri/card*` and `/dev/input/event*` devices which are typically only available to privileged users.

__I did not do the logind changes for aml and rpi as I don't really care to and most likely those platforms aren't being used on a normal desktop anyways.__

This will be needed for in the future when LibreELEC eventually runs Kodi as a non root user.

I don't love the `CSessionUtils` class stuff but I'm not sure if there is a better way to "override" a static method. If anyone has better ideas here please share.

**This will also break starting kodi from an ssh session.** For that I have included a sample `kodi@.service` file. This will allow a user to run `systemctl start kodi@tty7` and have kodi run on the specified tty. This can even be run from a normal terminal and systemd will switch to the specified tty and start kodi (you will have to manually switch back when exiting kodi). The only thing to be aware of is that you must change the `User=` property in the service file to your user of choice.

I don't like ifdefing for `DBUS` but it is an optional dependency so I have no choice.

@pkerling if you can look at the dbus stuff that would be great.

