### PR TITLE
[Win10][filesystem] Restore SMB support to Window 10 UWP version using native UWP APIs

### DIFF
--- a/tools/windows/packaging/uwp/package.appxmanifest.in
+++ b/tools/windows/packaging/uwp/package.appxmanifest.in
@@ -228,8 +228,10 @@
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="internetClientServer" />
-    <Capability Name="codeGeneration" />
     <Capability Name="privateNetworkClientServer" />
+    <Capability Name="allJoyn" />
+    <Capability Name="codeGeneration" />
+    <uap:Capability Name="enterpriseAuthentication" />
     <uap:Capability Name="musicLibrary" />
     <uap:Capability Name="picturesLibrary" />
     <uap:Capability Name="removableStorage" />

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -35,6 +35,7 @@
 #include "platform/win32/filesystem/Win32Directory.h"
 #ifdef TARGET_WINDOWS_STORE
 #include "platform/win10/filesystem/WinLibraryDirectory.h"
+#include "platform/win10/filesystem/UwpSMBDirectory.h"
 #endif
 #endif
 #ifdef HAS_FILESYSTEM_SMB
@@ -135,6 +136,8 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
   if (url.IsProtocol("events")) return new CEventsDirectory();
 #ifdef TARGET_WINDOWS_STORE
   if (CWinLibraryDirectory::IsValid(url)) return new CWinLibraryDirectory();
+  if (url.IsProtocol("smb"))
+    return new CUwpSMBDirectory();
 #endif
 
   bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -14,6 +14,7 @@
 #include "platform/win32/filesystem/Win32File.h"
 #ifdef TARGET_WINDOWS_STORE
 #include "platform/win10/filesystem/WinLibraryFile.h"
+#include "platform/win10/filesystem/UwpSMBFile.h"
 #endif
 #endif // TARGET_WINDOWS
 #include "CurlFile.h"
@@ -127,6 +128,8 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   else if (url.IsProtocol("resource")) return new CResourceFile();
 #ifdef TARGET_WINDOWS_STORE
   else if (CWinLibraryFile::IsValid(url)) return new CWinLibraryFile();
+  else if (url.IsProtocol("smb"))
+    return new CUwpSMBFile();
 #endif
 
   bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();

--- a/xbmc/platform/win10/CustomBuffer.h
+++ b/xbmc/platform/win10/CustomBuffer.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2011-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Storage.Streams.h>
+
+namespace winrt
+{
+using namespace Windows::Foundation;
+}
+using namespace winrt::Windows::ApplicationModel;
+using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Windows::Security::Cryptography;
+using namespace winrt::Windows::Storage;
+using namespace winrt::Windows::Storage::Streams;
+
+struct __declspec(uuid("905a0fef-bc53-11df-8c49-001e4fc686da")) IBufferByteAccess : ::IUnknown
+{
+  virtual HRESULT __stdcall Buffer(void** value) = 0;
+};
+
+struct CustomBuffer : winrt::implements<CustomBuffer, IBuffer, IBufferByteAccess>
+{
+  void* m_address;
+  uint32_t m_capacity;
+  uint32_t m_length;
+
+  CustomBuffer(void* address, uint32_t capacity)
+      : m_address(address)
+      , m_capacity(capacity)
+      , m_length(0)
+  {
+  }
+  uint32_t Capacity() const
+  {
+    return m_capacity;
+  }
+  uint32_t Length() const
+  {
+    return m_length;
+  }
+  void Length(uint32_t length)
+  {
+    m_length = length;
+  }
+
+  HRESULT __stdcall Buffer(void** value) final
+  {
+    *value = m_address;
+    return S_OK;
+  }
+};

--- a/xbmc/platform/win10/filesystem/CMakeLists.txt
+++ b/xbmc/platform/win10/filesystem/CMakeLists.txt
@@ -1,7 +1,11 @@
-set(SOURCES WinLibraryDirectory.cpp
+set(SOURCES UwpSMBDirectory.cpp
+            UwpSMBFile.cpp
+            WinLibraryDirectory.cpp
             WinLibraryFile.cpp)
 
-set(HEADERS WinLibraryDirectory.h
+set(HEADERS UwpSMBDirectory.h
+            UwpSMBFile.h
+            WinLibraryDirectory.h
             WinLibraryFile.h)
 
 core_add_library(platform_win10_filesystem)

--- a/xbmc/platform/win10/filesystem/UwpSMBDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/UwpSMBDirectory.cpp
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "UwpSMBDirectory.h"
+#include "FileItem.h"
+#include "URL.h"
+#include "platform/win10/AsyncHelpers.h"
+#include "platform/win32/CharsetConverter.h"
+#include "platform/win32/WIN32Util.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+#include <string>
+#include <winrt/Windows.Storage.FileProperties.h>
+
+using namespace XFILE;
+using namespace KODI::PLATFORM::WINDOWS;
+using namespace winrt::Windows::Storage;
+using namespace winrt::Windows::Storage::FileProperties;
+using namespace winrt::Windows::Storage::Search;
+using namespace winrt::Windows::Foundation::Collections;
+namespace winrt
+{
+using namespace Windows::Foundation;
+}
+
+bool CUwpSMBDirectory::GetDirectory(const CURL& url, CFileItemList& items)
+{
+  items.Clear();
+
+  auto folder = GetFolder(url);
+  if (!folder)
+    return false;
+
+  // We accept win-lib://library/path[/]
+  std::string path = url.Get();
+  URIUtils::AddSlashAtEnd(path); //be sure the dir ends with a slash
+
+  auto vectorView = Wait(folder.GetItemsAsync());
+  for (auto& item : vectorView)
+  {
+    std::string itemName = FromW(item.Name().c_str());
+
+    CFileItemPtr pItem(new CFileItem(itemName));
+    pItem->m_bIsFolder =
+        (item.Attributes() & FileAttributes::Directory) == FileAttributes::Directory;
+    IStorageItemProperties storageItemProperties = item.as<IStorageItemProperties>();
+    if (item != nullptr)
+    {
+      pItem->m_strTitle = FromW(storageItemProperties.DisplayName().c_str());
+    }
+
+    if (pItem->m_bIsFolder)
+      pItem->SetPath(path + itemName + "/");
+    else
+      pItem->SetPath(path + itemName);
+
+    if (itemName.front() == '.')
+      pItem->SetProperty("file:hidden", true);
+
+    auto props = Wait(item.GetBasicPropertiesAsync());
+
+    pItem->m_dateTime = winrt::clock::to_FILETIME(props.DateModified());
+    if (!pItem->m_bIsFolder)
+      pItem->m_dwSize = static_cast<int64_t>(props.Size());
+
+    items.Add(pItem);
+  }
+
+  return true;
+}
+
+bool CUwpSMBDirectory::Create(const CURL& url)
+{
+  auto folder = GetFolder(url);
+  if (folder) // already exists
+    return true;
+
+  CURL parentUrl = CURL(URIUtils::GetParentPath(url.Get()));
+  folder = GetFolder(parentUrl);
+  if (!folder)
+  {
+    return false;
+  }
+
+  try
+  {
+    std::wstring wStrPath = ToW(url.GetFileNameWithoutPath());
+    Wait(folder.CreateFolderAsync(wStrPath));
+  }
+  catch (const winrt::hresult_error&)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool CUwpSMBDirectory::Exists(const CURL& url)
+{
+  return GetFolder(url) != nullptr;
+}
+
+bool CUwpSMBDirectory::Remove(const CURL& url)
+{
+  auto folder = GetFolder(url);
+  if (folder)
+  {
+    try
+    {
+      Wait(folder.DeleteAsync(StorageDeleteOption::PermanentDelete));
+      return true;
+    }
+    catch (const winrt::hresult_error& ex)
+    {
+      std::string error = FromW(ex.message().c_str());
+      CLog::LogF(LOGERROR, __FUNCTION__, "unable remove folder '%s' with error", url.Get(),
+                 error.c_str());
+    }
+  }
+  return false;
+}
+
+StorageFolder CUwpSMBDirectory::GetFolder(const CURL& url)
+{
+  StorageFolder folder{nullptr};
+
+  std::string requestedPath = CWIN32Util::SmbToUnc(url.GetRedacted());
+  try
+  {
+    folder = Wait(StorageFolder::GetFolderFromPathAsync(KODI::PLATFORM::WINDOWS::ToW(requestedPath)));
+    if (folder == nullptr)
+    {
+      return nullptr;
+    }
+  }
+  catch (const winrt::hresult_error& ex)
+  {
+    std::string error = FromW(ex.message().c_str());
+    CLog::LogF(LOGERROR, "unable to get folder '%s' with error %s - requestedPath(%s)",
+               url.GetRedacted().c_str(), error.c_str(), requestedPath.c_str());
+  }
+
+  return folder;
+}
+
+int CUwpSMBDirectory::StatDirectory(const CURL& url, struct __stat64* statData)
+{
+  if (!statData)
+    return -1;
+
+  auto dir = GetFolder(url);
+  if (dir == nullptr)
+    return -1;
+
+  /* set st_gid */
+  statData->st_gid = 0; // UNIX group ID is always zero on Win32
+  /* set st_uid */
+  statData->st_uid = 0; // UNIX user ID is always zero on Win32
+  /* set st_ino */
+  statData->st_ino = 0; // inode number is not implemented on Win32
+
+  statData->st_atime = 0;
+  statData->st_ctime = 0;
+  statData->st_mtime = 0;
+
+  auto requestedProps = Wait(dir.Properties().RetrievePropertiesAsync(
+      {L"System.DateAccessed", L"System.DateCreated", L"System.DateModified"}));
+
+  if (requestedProps.HasKey(L"System.DateAccessed") && 
+      requestedProps.Lookup(L"System.DateAccessed"))
+  {
+    auto dateAccessed = requestedProps.Lookup(L"System.DateAccessed").as<winrt::IPropertyValue>();
+    if (dateAccessed)
+    {
+      statData->st_atime = winrt::clock::to_time_t(dateAccessed.GetDateTime());
+    }
+  }
+  if (requestedProps.HasKey(L"System.DateCreated") && 
+      requestedProps.Lookup(L"System.DateCreated"))
+  {
+    auto dateCreated = requestedProps.Lookup(L"System.DateCreated").as<winrt::IPropertyValue>();
+    if (dateCreated)
+    {
+      statData->st_ctime = winrt::clock::to_time_t(dateCreated.GetDateTime());
+    }
+  }
+  if (requestedProps.HasKey(L"System.DateModified") && 
+      requestedProps.Lookup(L"System.DateModified"))
+  {
+    auto dateModified = requestedProps.Lookup(L"System.DateModified").as<winrt::IPropertyValue>();
+    if (dateModified)
+    {
+      statData->st_mtime = winrt::clock::to_time_t(dateModified.GetDateTime());
+    }
+  }
+
+  statData->st_dev = 0;
+  statData->st_rdev = statData->st_dev;
+  /* set st_nlink */
+  statData->st_nlink = 0;
+  /* set st_mode */
+  statData->st_mode = _S_IREAD | _S_IFDIR | _S_IEXEC; // only read permission for directory from library
+  // copy user RWX rights to group rights
+  statData->st_mode |= (statData->st_mode & (_S_IREAD | _S_IWRITE | _S_IEXEC)) >> 3;
+  // copy user RWX rights to other rights
+  statData->st_mode |= (statData->st_mode & (_S_IREAD | _S_IWRITE | _S_IEXEC)) >> 6;
+
+  return 0;
+}

--- a/xbmc/platform/win10/filesystem/UwpSMBDirectory.h
+++ b/xbmc/platform/win10/filesystem/UwpSMBDirectory.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2011-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "filesystem/IDirectory.h"
+
+namespace XFILE
+{
+  class CUwpSMBFile;
+
+  class CUwpSMBDirectory : public IDirectory
+  {
+    friend CUwpSMBFile;
+  public:
+    CUwpSMBDirectory() = default;
+    virtual ~CUwpSMBDirectory(void) = default;
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items) override;
+    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
+    virtual bool Create(const CURL& url) override;
+    virtual bool Exists(const CURL& url) override;
+    virtual bool Remove(const CURL& url) override;
+
+  private:
+    static winrt::Windows::Storage::StorageFolder GetFolder(const CURL &url);
+    static int StatDirectory(const CURL& url, struct __stat64* statData);
+  };
+}

--- a/xbmc/platform/win10/filesystem/UwpSMBDirectory.h
+++ b/xbmc/platform/win10/filesystem/UwpSMBDirectory.h
@@ -21,7 +21,6 @@ namespace XFILE
     CUwpSMBDirectory() = default;
     virtual ~CUwpSMBDirectory(void) = default;
     virtual bool GetDirectory(const CURL& url, CFileItemList& items) override;
-    DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_ONCE; };
     virtual bool Create(const CURL& url) override;
     virtual bool Exists(const CURL& url) override;
     virtual bool Remove(const CURL& url) override;

--- a/xbmc/platform/win10/filesystem/UwpSMBFile.cpp
+++ b/xbmc/platform/win10/filesystem/UwpSMBFile.cpp
@@ -1,0 +1,456 @@
+/*
+ *  Copyright (C) 2011-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "UwpSMBFile.h"
+#include "UwpSMBDirectory.h"
+#include "platform/win10/AsyncHelpers.h"
+#include "platform/win32/CharsetConverter.h"
+#include "platform/win32/WIN32Util.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "URL.h"
+
+#include <robuffer.h>
+#include <string>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Security.Cryptography.h>
+#include <winrt/Windows.Storage.AccessCache.h>
+#include <winrt/Windows.Storage.FileProperties.h>
+#include <winrt/Windows.Storage.Search.h>
+#include <winrt/Windows.Storage.Streams.h>
+
+using namespace XFILE;
+using namespace KODI::PLATFORM::WINDOWS;
+namespace winrt
+{
+using namespace Windows::Foundation;
+}
+using namespace winrt::Windows::ApplicationModel;
+using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Windows::Security::Cryptography;
+using namespace winrt::Windows::Storage;
+using namespace winrt::Windows::Storage::AccessCache;
+using namespace winrt::Windows::Storage::Search;
+using namespace winrt::Windows::Storage::Streams;
+
+struct __declspec(uuid("905a0fef-bc53-11df-8c49-001e4fc686da")) IBufferByteAccess : ::IUnknown
+{
+  virtual HRESULT __stdcall Buffer(void** value) = 0;
+};
+
+struct CustomBuffer : winrt::implements<CustomBuffer, IBuffer, IBufferByteAccess>
+{
+  void* m_address;
+  uint32_t m_capacity;
+  uint32_t m_length;
+
+  CustomBuffer(void* address, uint32_t capacity)
+      : m_address(address)
+      , m_capacity(capacity)
+      , m_length(0)
+  {
+  }
+  uint32_t Capacity() const
+  {
+    return m_capacity;
+  }
+  uint32_t Length() const
+  {
+    return m_length;
+  }
+  void Length(uint32_t length)
+  {
+    m_length = length;
+  }
+
+  HRESULT __stdcall Buffer(void** value) final
+  {
+    *value = m_address;
+    return S_OK;
+  }
+};
+
+bool CUwpSMBFile::IsValid(const CURL& url)
+{
+  return !url.GetFileName().empty();
+}
+
+bool CUwpSMBFile::Open(const CURL& url)
+{
+  return OpenIntenal(url, FileAccessMode::Read);
+}
+
+bool CUwpSMBFile::OpenForWrite(const CURL& url, bool bOverWrite)
+{
+  return OpenIntenal(url, FileAccessMode::ReadWrite);
+}
+
+void CUwpSMBFile::Close()
+{
+  if (m_fileStream != nullptr)
+  {
+    // see https://docs.microsoft.com/en-us/uwp/api/windows.storage.streams.irandomaccessstream
+    // m_fileStream->Close(); // where it is?
+    m_fileStream = nullptr;
+  }
+  if (m_sFile)
+    m_sFile = nullptr;
+}
+
+ssize_t CUwpSMBFile::Read(void* lpBuf, size_t uiBufSize)
+{
+  if (!m_fileStream)
+    return -1;
+
+  IBuffer buf = winrt::make<CustomBuffer>(lpBuf, static_cast<uint32_t>(uiBufSize));
+  Wait(m_fileStream.ReadAsync(buf, buf.Capacity(), InputStreamOptions::None));
+
+  return static_cast<intptr_t>(buf.Length());
+}
+
+ssize_t CUwpSMBFile::Write(const void* lpBuf, size_t uiBufSize)
+{
+  if (!m_fileStream || !m_allowWrite)
+    return -1;
+
+  uint8_t* buff = (uint8_t*)lpBuf;
+  auto winrt_buffer = CryptographicBuffer::CreateFromByteArray({buff, buff + uiBufSize});
+
+  uint32_t result = Wait(m_fileStream.WriteAsync(winrt_buffer));
+  return static_cast<intptr_t>(result);
+}
+
+int64_t CUwpSMBFile::Seek(int64_t iFilePosition, int iWhence)
+{
+  if (m_fileStream != nullptr)
+  {
+    int64_t pos = iFilePosition;
+    if (iWhence == SEEK_CUR)
+      pos += m_fileStream.Position();
+    else if (iWhence == SEEK_END)
+      pos += m_fileStream.Size();
+
+    uint64_t seekTo;
+    if (pos < 0)
+      seekTo = 0;
+    else if (static_cast<uint64_t>(pos) > m_fileStream.Size())
+      seekTo = m_fileStream.Size();
+    else
+      seekTo = static_cast<uint64_t>(pos);
+
+    m_fileStream.Seek(seekTo);
+    return GetPosition();
+  }
+  return -1;
+}
+
+int CUwpSMBFile::Truncate(int64_t toSize)
+{
+  // not allowed
+  return -1;
+}
+
+int64_t CUwpSMBFile::GetPosition()
+{
+  if (m_fileStream != nullptr)
+    return static_cast<int64_t>(m_fileStream.Position());
+
+  return -1;
+}
+
+int64_t CUwpSMBFile::GetLength()
+{
+  if (m_fileStream != nullptr)
+    return m_fileStream.Size();
+
+  return 0;
+}
+
+void CUwpSMBFile::Flush()
+{
+  if (m_fileStream != nullptr)
+    m_fileStream.FlushAsync();
+}
+
+bool CUwpSMBFile::Delete(const CURL& url)
+{
+  bool success = false;
+  auto file = GetFile(url);
+  if (file)
+  {
+    try
+    {
+      Wait(file.DeleteAsync());
+    }
+    catch (const winrt::hresult_error&)
+    {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+bool CUwpSMBFile::Rename(const CURL& urlCurrentName, const CURL& urlNewName)
+{
+  if (!IsValid(urlNewName))
+    return false;
+
+  auto currFile = GetFile(urlCurrentName);
+  if (currFile)
+  {
+    auto destFile = GetFile(urlNewName);
+    if (destFile)
+    {
+      // replace exiting
+      try
+      {
+        Wait(currFile.MoveAndReplaceAsync(destFile));
+      }
+      catch (const winrt::hresult_error&)
+      {
+        return false;
+      }
+      return true;
+    }
+
+    // move
+    CURL defFolder = CURL(urlNewName.GetWithoutFilename());
+    StorageFolder destFolder = CUwpSMBDirectory::GetFolder(defFolder);
+    if (destFolder != nullptr)
+    {
+      try
+      {
+        Wait(currFile.MoveAsync(destFolder));
+      }
+      catch (const winrt::hresult_error&)
+      {
+        return false;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CUwpSMBFile::SetHidden(const CURL& url, bool hidden)
+{
+  return false;
+}
+
+bool CUwpSMBFile::Exists(const CURL& url)
+{
+  return GetFile(url) != nullptr;
+}
+
+int CUwpSMBFile::Stat(const CURL& url, struct __stat64* statData)
+{
+  if (URIUtils::HasSlashAtEnd(url.GetFileName(), false))
+  {
+    // stat for directory
+    return CUwpSMBDirectory::StatDirectory(url, statData);
+  }
+  else
+  {
+    auto file = GetFile(url);
+    return Stat(file, statData);
+  }
+}
+
+int CUwpSMBFile::Stat(struct __stat64* statData)
+{
+  return Stat(m_sFile, statData);
+}
+
+bool CUwpSMBFile::IsInAccessList(const CURL& url)
+{
+  using KODI::PLATFORM::WINDOWS::FromW;
+
+  try
+  {
+    auto localPath = FromW(ApplicationData::Current().LocalFolder().Path().c_str());
+    auto packagePath = FromW(Package::Current().InstalledLocation().Path().c_str());
+
+    // don't check files inside local folder and installation folder
+    if (StringUtils::StartsWithNoCase(url.Get(), localPath) ||
+        StringUtils::StartsWithNoCase(url.Get(), packagePath))
+      return false;
+
+    return IsInList(url, StorageApplicationPermissions::FutureAccessList()) ||
+           IsInList(url, StorageApplicationPermissions::MostRecentlyUsedList());
+  }
+  catch (const winrt::hresult_error& ex)
+  {
+    std::string strError = FromW(ex.message().c_str());
+    CLog::LogF(LOGERROR, "unexpected error occurs during WinRT API call: {}", strError);
+  }
+  return false;
+}
+
+bool CUwpSMBFile::OpenIntenal(const CURL& url, FileAccessMode mode)
+{
+  // cannot open directories
+  if (URIUtils::HasSlashAtEnd(url.GetFileName(), false))
+    return false;
+
+  try
+  {
+    if (mode == FileAccessMode::Read)
+    {
+      m_sFile = GetFile(url);
+    }
+    else if (mode == FileAccessMode::ReadWrite)
+    {
+      auto destFolder = CURL(URIUtils::GetParentPath(url.Get()));
+      auto folder = CUwpSMBDirectory::GetFolder(destFolder);
+      if (folder)
+      {
+        std::wstring fileNameW = ToW(url.GetFileNameWithoutPath());
+        m_sFile = Wait(folder.CreateFileAsync(fileNameW, CreationCollisionOption::ReplaceExisting));
+        if (m_sFile)
+          m_allowWrite = true;
+      }
+    }
+
+    if (m_sFile)
+      m_fileStream = Wait(m_sFile.OpenAsync(mode));
+  }
+  catch (const winrt::hresult_error& ex)
+  {
+    std::string error = FromW(ex.message().c_str());
+    CLog::LogF(LOGERROR, "an exception occurs while openning a file '%s' (mode: %s) : %s",
+               url.GetRedacted().c_str(), mode == FileAccessMode::Read ? "r" : "rw", error.c_str());
+    return false;
+  }
+
+  return m_fileStream != nullptr;
+}
+
+StorageFile CUwpSMBFile::GetFile(const CURL& url)
+{
+  // check that url is library url
+  //if (CWinLibraryDirectory::IsValid(url))
+  if (true)
+  {
+    std::string requestedPath = CWIN32Util::SmbToUnc(url.GetRedacted());
+    try
+    {
+      StorageFile file = Wait(StorageFile::GetFileFromPathAsync(KODI::PLATFORM::WINDOWS::ToW(requestedPath)));
+      if (file == nullptr)
+      {
+        return nullptr;
+      }
+
+      return file;
+    }
+    catch (const winrt::hresult_error& ex)
+    {
+      std::string error = FromW(ex.message().c_str());
+      CLog::LogF(LOGERROR, "unable to get file '%s' with error %s - requestedPath(%s)",
+                 url.GetRedacted().c_str(), error.c_str(), requestedPath.c_str());
+    }
+  }
+  else if (url.IsProtocol("file") || url.GetProtocol().empty())
+  {
+    // check that a file in feature access list or most rescently used list
+    // search in FAL
+    IStorageItemAccessList list = StorageApplicationPermissions::FutureAccessList();
+    winrt::hstring token = GetTokenFromList(url, list);
+    if (token.empty())
+    {
+      // serach in MRU list
+      list = StorageApplicationPermissions::MostRecentlyUsedList();
+      token = GetTokenFromList(url, list);
+    }
+    if (!token.empty())
+      return Wait(list.GetFileAsync(token));
+  }
+
+  return nullptr;
+}
+
+bool CUwpSMBFile::IsInList(const CURL& url, const IStorageItemAccessList& list)
+{
+  auto token = GetTokenFromList(url, list);
+  return !token.empty();
+}
+
+winrt::hstring CUwpSMBFile::GetTokenFromList(const CURL& url, const IStorageItemAccessList& list)
+{
+  AccessListEntryView listview = list.Entries();
+  if (listview.Size() == 0)
+    return winrt::hstring();
+
+  using KODI::PLATFORM::WINDOWS::ToW;
+  std::wstring filePathW = ToW(url.Get());
+
+  for (auto&& listEntry : listview)
+  {
+    if (listEntry.Metadata == filePathW)
+    {
+      return listEntry.Token;
+    }
+  }
+
+  return winrt::hstring();
+}
+
+int CUwpSMBFile::Stat(const StorageFile& file, struct __stat64* statData)
+{
+  if (!statData)
+    return -1;
+
+  if (file == nullptr)
+    return -1;
+
+  /* set st_gid */
+  statData->st_gid = 0; // UNIX group ID is always zero on Win32
+  /* set st_uid */
+  statData->st_uid = 0; // UNIX user ID is always zero on Win32
+  /* set st_ino */
+  statData->st_ino = 0; // inode number is not implemented on Win32
+
+  auto requestedProps = Wait(file.Properties().RetrievePropertiesAsync(
+      {L"System.DateAccessed", L"System.DateCreated", L"System.DateModified", L"System.Size"}));
+
+  auto dateAccessed = requestedProps.Lookup(L"System.DateAccessed").as<winrt::IPropertyValue>();
+  if (dateAccessed)
+  {
+    statData->st_atime = winrt::clock::to_time_t(dateAccessed.GetDateTime());
+  }
+  auto dateCreated = requestedProps.Lookup(L"System.DateCreated").as<winrt::IPropertyValue>();
+  if (dateCreated)
+  {
+    statData->st_ctime = winrt::clock::to_time_t(dateCreated.GetDateTime());
+  }
+  auto dateModified = requestedProps.Lookup(L"System.DateModified").as<winrt::IPropertyValue>();
+  if (dateModified)
+  {
+    statData->st_mtime = winrt::clock::to_time_t(dateModified.GetDateTime());
+  }
+  auto fileSize = requestedProps.Lookup(L"System.Size").as<winrt::IPropertyValue>();
+  if (fileSize)
+  {
+    /* set st_size */
+    statData->st_size = fileSize.GetInt64();
+  }
+
+  statData->st_dev = 0;
+  statData->st_rdev = statData->st_dev;
+  /* set st_nlink */
+  statData->st_nlink = 1;
+  /* set st_mode */
+  statData->st_mode = _S_IREAD; // only read permission for file from library
+  // copy user RWX rights to group rights
+  statData->st_mode |= (statData->st_mode & (_S_IREAD | _S_IWRITE | _S_IEXEC)) >> 3;
+  // copy user RWX rights to other rights
+  statData->st_mode |= (statData->st_mode & (_S_IREAD | _S_IWRITE | _S_IEXEC)) >> 6;
+
+  return 0;
+}

--- a/xbmc/platform/win10/filesystem/UwpSMBFile.h
+++ b/xbmc/platform/win10/filesystem/UwpSMBFile.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2011-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "filesystem/IFile.h"
+#include <winrt/Windows.Storage.AccessCache.h>
+
+namespace XFILE
+{
+  class CUwpSMBFile : public IFile
+  {
+  public:
+    CUwpSMBFile::CUwpSMBFile() = default;
+    virtual CUwpSMBFile::~CUwpSMBFile(void) = default;
+
+    virtual bool Open(const CURL& url);
+    virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
+    virtual void Close();
+
+    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
+    virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
+    virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
+    virtual int Truncate(int64_t toSize);
+    virtual int64_t GetPosition();
+    virtual int64_t GetLength();
+    virtual void Flush();
+
+    virtual bool Delete(const CURL& url);
+    virtual bool Rename(const CURL& urlCurrentName, const CURL& urlNewName);
+    virtual bool SetHidden(const CURL& url, bool hidden);
+    virtual bool Exists(const CURL& url);
+    virtual int Stat(const CURL& url, struct __stat64* statData);
+    virtual int Stat(struct __stat64* statData);
+
+    static IFile* Get(const CURL& url);
+    static bool IsValid(const CURL& url);
+
+    static bool IsInAccessList(const CURL& url);
+
+  private:
+    bool OpenIntenal(const CURL& url, winrt::Windows::Storage::FileAccessMode mode);
+    winrt::Windows::Storage::StorageFile GetFile(const CURL& url);
+    static bool IsInList(const CURL& url, const winrt::Windows::Storage::AccessCache::IStorageItemAccessList& list);
+    static winrt::hstring GetTokenFromList(const CURL& url, const winrt::Windows::Storage::AccessCache::IStorageItemAccessList& list);
+    static int Stat(const winrt::Windows::Storage::StorageFile& file, struct __stat64* statData);
+
+    bool m_allowWrite = false;
+    winrt::Windows::Storage::StorageFile m_sFile = nullptr;
+    winrt::Windows::Storage::Streams::IRandomAccessStream m_fileStream = nullptr;
+  };
+}

--- a/xbmc/platform/win10/filesystem/UwpSMBFile.h
+++ b/xbmc/platform/win10/filesystem/UwpSMBFile.h
@@ -9,49 +9,44 @@
 #pragma once
 
 #include "filesystem/IFile.h"
-#include <winrt/Windows.Storage.AccessCache.h>
 
 namespace XFILE
 {
-  class CUwpSMBFile : public IFile
-  {
-  public:
-    CUwpSMBFile::CUwpSMBFile() = default;
-    virtual CUwpSMBFile::~CUwpSMBFile(void) = default;
+class CUwpSMBFile : public IFile
+{
+public:
+  CUwpSMBFile::CUwpSMBFile() = default;
+  virtual CUwpSMBFile::~CUwpSMBFile(void) = default;
 
-    virtual bool Open(const CURL& url);
-    virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
-    virtual void Close();
+  virtual bool Open(const CURL& url);
+  virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
+  virtual void Close();
 
-    virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
-    virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
-    virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
-    virtual int Truncate(int64_t toSize);
-    virtual int64_t GetPosition();
-    virtual int64_t GetLength();
-    virtual void Flush();
+  virtual ssize_t Read(void* lpBuf, size_t uiBufSize);
+  virtual ssize_t Write(const void* lpBuf, size_t uiBufSize);
+  virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
+  virtual int Truncate(int64_t toSize);
+  virtual int64_t GetPosition();
+  virtual int64_t GetLength();
+  virtual void Flush();
 
-    virtual bool Delete(const CURL& url);
-    virtual bool Rename(const CURL& urlCurrentName, const CURL& urlNewName);
-    virtual bool SetHidden(const CURL& url, bool hidden);
-    virtual bool Exists(const CURL& url);
-    virtual int Stat(const CURL& url, struct __stat64* statData);
-    virtual int Stat(struct __stat64* statData);
+  virtual bool Delete(const CURL& url);
+  virtual bool Rename(const CURL& urlCurrentName, const CURL& urlNewName);
+  virtual bool SetHidden(const CURL& url, bool hidden);
+  virtual bool Exists(const CURL& url);
+  virtual int Stat(const CURL& url, struct __stat64* statData);
+  virtual int Stat(struct __stat64* statData);
 
-    static IFile* Get(const CURL& url);
-    static bool IsValid(const CURL& url);
+  static IFile* Get(const CURL& url);
+  static bool IsValid(const CURL& url);
 
-    static bool IsInAccessList(const CURL& url);
+private:
+  bool OpenIntenal(const CURL& url, winrt::Windows::Storage::FileAccessMode mode);
+  winrt::Windows::Storage::StorageFile GetFile(const CURL& url);
+  static int Stat(const winrt::Windows::Storage::StorageFile& file, struct __stat64* statData);
 
-  private:
-    bool OpenIntenal(const CURL& url, winrt::Windows::Storage::FileAccessMode mode);
-    winrt::Windows::Storage::StorageFile GetFile(const CURL& url);
-    static bool IsInList(const CURL& url, const winrt::Windows::Storage::AccessCache::IStorageItemAccessList& list);
-    static winrt::hstring GetTokenFromList(const CURL& url, const winrt::Windows::Storage::AccessCache::IStorageItemAccessList& list);
-    static int Stat(const winrt::Windows::Storage::StorageFile& file, struct __stat64* statData);
-
-    bool m_allowWrite = false;
-    winrt::Windows::Storage::StorageFile m_sFile = nullptr;
-    winrt::Windows::Storage::Streams::IRandomAccessStream m_fileStream = nullptr;
-  };
-}
+  bool m_allowWrite = false;
+  winrt::Windows::Storage::StorageFile m_sFile = nullptr;
+  winrt::Windows::Storage::Streams::IRandomAccessStream m_fileStream = nullptr;
+};
+} // namespace XFILE

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -19,14 +19,11 @@
 
 using namespace XFILE;
 using namespace KODI::PLATFORM::WINDOWS;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::Storage::FileProperties;
 using namespace winrt::Windows::Storage::Search;
-using namespace winrt::Windows::Foundation::Collections;
-namespace winrt
-{
-using namespace Windows::Foundation;
-}
 
 bool CWinLibraryDirectory::GetStoragePath(std::string library, std::string& path)
 {

--- a/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
@@ -9,6 +9,7 @@
 #include "WinLibraryFile.h"
 #include "WinLibraryDirectory.h"
 #include "platform/win10/AsyncHelpers.h"
+#include "platform/win10/CustomBuffer.h"
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/WIN32Util.h"
 #include "utils/log.h"
@@ -27,40 +28,14 @@
 
 using namespace XFILE;
 using namespace KODI::PLATFORM::WINDOWS;
-namespace winrt
-{
-  using namespace Windows::Foundation;
-}
 using namespace winrt::Windows::ApplicationModel;
+using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Windows::Security::Cryptography;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::Storage::AccessCache;
 using namespace winrt::Windows::Storage::Search;
 using namespace winrt::Windows::Storage::Streams;
-
-struct __declspec(uuid("905a0fef-bc53-11df-8c49-001e4fc686da")) IBufferByteAccess : ::IUnknown
-{
-  virtual HRESULT __stdcall Buffer(void** value) = 0;
-};
-
-struct CustomBuffer : winrt::implements<CustomBuffer, IBuffer, IBufferByteAccess>
-{
-  void *m_address;
-  uint32_t m_capacity;
-  uint32_t m_length;
-
-  CustomBuffer(void *address, uint32_t capacity) : m_address(address), m_capacity(capacity), m_length(0) { }
-  uint32_t Capacity() const { return m_capacity; }
-  uint32_t Length() const { return m_length; }
-  void Length(uint32_t length) { m_length = length; }
-
-  HRESULT __stdcall Buffer(void** value) final
-  {
-    *value = m_address;
-    return S_OK;
-  }
-};
 
 CWinLibraryFile::CWinLibraryFile() = default;
 CWinLibraryFile::~CWinLibraryFile(void) = default;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This pull request adds support for the UWP version of Kodi to properly handle SMB Shares. This change was tested exclusively on Win10 1803 and 1809 as I have no XBOX One to test against. The research I did indicated that this code should work identically on the XBOX One.

The support for SMB is provided by using the same UWP APIs as normal file access. UWP doesn't require special APIs to access SMB shares. There was a need to adjust the permissions of the APPX package to add the "enterpriseAuthentication" permission which allows a UWP application to access SMB shares without using the FilePicker API. Following the code and layout of both the WinLibrary* and the Win32SMB* code, I created a UwpSmbFile and UwpSmbDirectory to allow UWP Kodi to handle SMB shares.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The reason for these changes and improvements was to restore the ability of the Windows 10 UWP version to handle SMB shares. SMB support currently works in the Kodi 17.6 UWP release. While testing one of the Kodi 18 Alpha releases using my current setup, I noticed that I could no longer connect to SMB shares. My setup requires access to SMB shares as I use the "PVR WMC client" which leverages SMB shares for both live TV and recorded TV. Even after trying to use the "SMB Support (libsmb2)" Virtual Filesystem add-on, it still didn't work. 

After investigating the refactoring of the SMB and other filesystem code over the last year, it seemed like I could easily return the SMB support to the UWP version. I added the UWP SMB by following the same layout and pattern as the WinLibrary* and Win32SMB* code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
This change was tested by running the APPX (Windows Store) package on both a Windows 10 1803 and 1809 system and doing the following steps. Validations and comparisons were preformed against a Kodi 18 Beta5 and a Kodi 17.6 instance configured identically.
1. Install the APPX Package
2. Starting Kodi
3. Configuring and enabling PVR WMC Client to point at a ServerWMC instance. Ensuring that the connection to the "Recorded TV" SMB share didn't error. If the UWP SMB code was not work it would fail immediately upon enabling the PVR WMC Client addon. Validated the Kodi.log for any errors related to the UwpClient* code.
4. Validate the "TV - Recordings" Sections works.
4a. Look through the "Recordings" section and validate the contents against controlled setup.
4b. Deleted a single recording
4c. Deleted a Folder with single recording
4d. Deleted a Folder with multiple recordings
4e. Watched a Recording
5. Validated Guide
5a. Ensured Guide data matched
5b. Started Recording and watch the recording.
5c. Watched a live program.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
