### PR TITLE
[Estuary] Adjust eventlog entry height so that it can display two full lines of text.

### DIFF
--- a/addons/skin.estuary/xml/EventLog.xml
+++ b/addons/skin.estuary/xml/EventLog.xml
@@ -48,7 +48,7 @@
 							<left>160</left>
 							<top>45</top>
 							<right>20</right>
-							<height>60</height>
+							<height>80</height>
 							<aligny>top</aligny>
 							<textcolor>grey</textcolor>
 							<label>$INFO[ListItem.Property(Event.Description)]</label>
@@ -95,7 +95,7 @@
 							<left>160</left>
 							<top>45</top>
 							<right>20</right>
-							<height>60</height>
+							<height>80</height>
 							<aligny>top</aligny>
 							<label>$INFO[ListItem.Property(Event.Description)]</label>
 						</control>


### PR DESCRIPTION
Before:

![screenshot001](https://user-images.githubusercontent.com/3226626/48931006-69d81580-eef4-11e8-837d-bdd852f28ad7.png)

After:

![screenshot002](https://user-images.githubusercontent.com/3226626/48931015-70668d00-eef4-11e8-83ff-aae0743ce886.png)

@ronie good to go?

EDIT: The screen shots contain a spoiler for a feature I'm working on... ;-)