### PR TITLE
[games] Fix crash in PCSX ReARMed with BIOS

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -252,8 +252,6 @@ bool CGameClient::OpenFile(const CFileItem& file, RETRO::IStreamManager& streamM
 
   CloseFile();
 
-  Streams().Initialize(streamManager);
-
   GAME_ERROR error = GAME_ERROR_FAILED;
 
   try { LogError(error = m_struct.toAddon.LoadGame(path.c_str()), "LoadGame()"); }
@@ -262,13 +260,11 @@ bool CGameClient::OpenFile(const CFileItem& file, RETRO::IStreamManager& streamM
   if (error != GAME_ERROR_NO_ERROR)
   {
     NotifyError(error);
-    Streams().Deinitialize();
     return false;
   }
 
   if (!InitializeGameplay(file.GetPath(), streamManager, input))
   {
-    Streams().Deinitialize();
     return false;
   }
 
@@ -286,8 +282,6 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
 
   CloseFile();
 
-  Streams().Initialize(streamManager);
-
   GAME_ERROR error = GAME_ERROR_FAILED;
 
   try { LogError(error = m_struct.toAddon.LoadStandalone(), "LoadStandalone()"); }
@@ -296,13 +290,11 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
   if (error != GAME_ERROR_NO_ERROR)
   {
     NotifyError(error);
-    Streams().Deinitialize();
     return false;
   }
 
   if (!InitializeGameplay("", streamManager, input))
   {
-    Streams().Deinitialize();
     return false;
   }
 
@@ -313,6 +305,7 @@ bool CGameClient::InitializeGameplay(const std::string& gamePath, RETRO::IStream
 {
   if (LoadGameInfo())
   {
+    Streams().Initialize(streamManager);
     Input().Start(input);
 
     m_bIsPlaying      = true;


### PR DESCRIPTION
## Description
Moves Streams().Initialize() back to InitializeGameplay() to solve the crash in PCSX ReARMed libretro core when run with BIOS. This is partial revert of commit https://github.com/xbmc/xbmc/pull/14146/commits/2bbd26fe51d36f0e0f55696d84a43a8910578288.

## Motivation and Context
The issue was introduced as part of the PR #14146.

It is discussed here:
https://github.com/kodi-game/game.libretro.pcsx-rearmed/issues/13

This needs more testing and approval from @garbear.

## How Has This Been Tested?
LibreELEC on Amlogic MX2. So far 2 days without crash.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
