### PR TITLE
[PVR] Fix CPVRGUITimerInfo::TimerInfoToggle().

### DIFF
--- a/xbmc/pvr/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/PVRGUITimerInfo.cpp
@@ -56,14 +56,19 @@ bool CPVRGUITimerInfo::TimerInfoToggle()
     return true;
   }
 
-  if ((int) (XbmcThreads::SystemClockMillis() - m_iTimerInfoToggleStart) > CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRInfoToggleInterval)
+  if (static_cast<int>(XbmcThreads::SystemClockMillis() - m_iTimerInfoToggleStart) >
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRInfoToggleInterval)
   {
     unsigned int iPrevious = m_iTimerInfoToggleCurrent;
     unsigned int iBoundary = m_iRecordingTimerAmount > 0 ? m_iRecordingTimerAmount : m_iTimerAmount;
     if (++m_iTimerInfoToggleCurrent > iBoundary - 1)
       m_iTimerInfoToggleCurrent = 0;
 
-    return m_iTimerInfoToggleCurrent != iPrevious;
+    if (m_iTimerInfoToggleCurrent != iPrevious)
+    {
+      m_iTimerInfoToggleStart = XbmcThreads::SystemClockMillis();
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
When more than one recording is active at a time, the recordings displayed in Estuary's "currently recording" widget, where toggled every 0.5 seconds, regardless of the respective value configured in advanced settings.

@Jalle19 you originally wrote that code. I moved it only to another class some time ago. So, you seem to be the perfect person for a review. ;-)