### PR TITLE
[addon browser] check that old-style add-on fanart exists

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -819,7 +819,15 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
   if (CURL(path).GetHostName() == "search")
     strLabel = StringUtils::Format("%s - %s", CAddonInfo::TranslateType(addon->Type(), true).c_str(), addon->Name().c_str());
   item->SetLabel(strLabel);
-  item->SetArt(addon->Art());
+
+  // backwards compatibility with add-ons that don't explicitly declare "assets"
+  ArtMap addonart = addon->Art();
+  if (addonart.find("fanart") != addonart.end() &&
+      !URIUtils::IsInternetStream(addonart["fanart"]) &&
+      !CFile::Exists(addonart["fanart"]))
+    addonart.erase("fanart");
+
+  item->SetArt(std::move(addonart));
   item->SetArt("thumb", addon->Icon());
   item->SetIconImage("DefaultAddon.png");
 

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -103,9 +103,9 @@ void CGUIListItem::SetArt(const std::string &type, const std::string &url)
   }
 }
 
-void CGUIListItem::SetArt(const ArtMap &art)
+void CGUIListItem::SetArt(ArtMap art)
 {
-  m_art = art;
+  m_art = std::move(art);
   SetInvalid();
 }
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -77,7 +77,7 @@ public:
    \param art a type:url map for artwork
    \sa GetArt
    */
-  void SetArt(const ArtMap &art);
+  void SetArt(ArtMap art);
 
   /*! \brief append artwork to an item
    \param art a type:url map for artwork


### PR DESCRIPTION
## Description
When an add-on doesn't have an "&lt;assets&gt;" tag in their addon.xml, Kodi falls back to building a path to the "fanart.jpg" in the addon's base directory, but doesn't check that it actually exists, so can have a path to a file that doesn't exist.

This only works when browsing already installed add-ons, not browsing through a remote repo. Krypton had the same behavior as this PR. Jarvis did something else for remote repos that I can't quite figure, but since this is for backward compatibility I didn't want to spend a lot of time hunting that down.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Skins that key on `String.IsEmpty(ListItem.Art(fanart))` can't fall back to some other fanart, [forum thread](https://forum.kodi.tv/showthread.php?tid=335941).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Quick runtime test.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
