### PR TITLE
[estuary] add default addon image fallback in addon browser

### DIFF
--- a/addons/skin.estuary/xml/AddonBrowser.xml
+++ b/addons/skin.estuary/xml/AddonBrowser.xml
@@ -17,7 +17,9 @@
 				<visible>Control.IsVisible(55)</visible>
 				<visible>Container.Content(addons) | Container.Content()</visible>
 				<include>Visible_Left</include>
-				<include>ListThumbInfoPanel</include>
+				<include content="ListThumbInfoPanel">
+					<param name="fallback_image" value="DefaultAddon.png" />
+				</include>
 			</control>
 			<include content="TopBar">
 				<param name="breadcrumbs_label" value="$LOCALIZE[24001]" />

--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -160,6 +160,7 @@
 		</definition>
 	</include>
 	<include name="ListThumbInfoPanel">
+		<param name="fallback_image"></param>
 		<param name="flip_bg">false</param>
 		<definition>
 			<control type="group">
@@ -175,7 +176,7 @@
 					<height>470</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
-					<texture background="true">$VAR[IconWallThumbVar]</texture>
+					<texture fallback="$PARAM[fallback_image]" background="true">$VAR[IconWallThumbVar]</texture>
 					<visible>!String.IsEqual(ListItem.DbType,episode)</visible>
 				</control>
 				<control type="image">


### PR DESCRIPTION
## Screenshots (if appropriate):
![old](https://user-images.githubusercontent.com/5367567/48974017-e54cda80-f04c-11e8-9311-3f45784d2610.png)
![new](https://user-images.githubusercontent.com/5367567/48974018-e7af3480-f04c-11e8-9d20-9c348bae166e.png)

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

