### PR TITLE
VideoLayerBridgeDRMPRIME: unmap previous buffer when current buffer is reused

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -164,6 +164,10 @@ void CVideoLayerBridgeDRMPRIME::UpdateVideoPlane()
   if (!m_buffer || !m_buffer->m_fb_id)
     return;
 
+  // release the buffer that is no longer presented on screen
+  Release(m_prev_buffer);
+  m_prev_buffer = nullptr;
+
   struct plane* plane = m_DRM->GetVideoPlane();
   m_DRM->AddProperty(plane, "FB_ID", m_buffer->m_fb_id);
   m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->crtc->crtc_id);


### PR DESCRIPTION
## Description
This PR makes the drm prime video layer bridge release the buffer that is no longer presented on screen when the currently presented buffer is reused.

## Motivation and Context
When seeking H264 video using libva-v4l2-request or v4l2-request hwaccel there is a chance Kodi will keep reference on a frame from two different buffer pools (each pool holding 20 pre-allocated frames).
When ffmpeg tries to initiate a third hwaccel instance and a new buffer pool a device may run out of cma memory resulting in a failed seek and stuck playback.
This change makes it possible to release a previously presented buffer before a new frame is ready to be presented, as a result freeing one of the two buffer pools and making room for the new one.

## How Has This Been Tested?
Tested on an Allwinner H3 device (256 MiB cma memory) with [v4l2-request hwaccel](https://github.com/Kwiboo/FFmpeg/compare/4.0.3-Leia-Beta5...v4l2-request-hwaccel) and DRM PRIME renderer, this PR makes seeking a 1080p H264 video possible.
Still needs testing on a Rockchip device using rkmpp decoder and an Amlogic device using v4l2-m2m decoder.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
