### PR TITLE
[cleanup] remove obsolete AudioTrack code

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -171,33 +171,21 @@ jni::CJNIAudioTrack *CAESinkAUDIOTRACK::CreateAudioTrack(int stream, int sampleR
 
   try
   {
-    if (CJNIBase::GetSDKVersion() >= 21)
-    {
-      CJNIAudioAttributesBuilder attrBuilder;
-      attrBuilder.setUsage(CJNIAudioAttributes::USAGE_MEDIA);
-      attrBuilder.setContentType(CJNIAudioAttributes::CONTENT_TYPE_MUSIC);
-      attrBuilder.setLegacyStreamType(CJNIAudioManager::STREAM_MUSIC);
+    CJNIAudioAttributesBuilder attrBuilder;
+    attrBuilder.setUsage(CJNIAudioAttributes::USAGE_MEDIA);
+    attrBuilder.setContentType(CJNIAudioAttributes::CONTENT_TYPE_MUSIC);
+    attrBuilder.setLegacyStreamType(CJNIAudioManager::STREAM_MUSIC);
 
-      CJNIAudioFormatBuilder fmtBuilder;
-      fmtBuilder.setChannelMask(channelMask);
-      fmtBuilder.setEncoding(encoding);
-      fmtBuilder.setSampleRate(sampleRate);
+    CJNIAudioFormatBuilder fmtBuilder;
+    fmtBuilder.setChannelMask(channelMask);
+    fmtBuilder.setEncoding(encoding);
+    fmtBuilder.setSampleRate(sampleRate);
 
-      jniAt = new CJNIAudioTrack(attrBuilder.build(),
-                                 fmtBuilder.build(),
-                                 bufferSize,
-                                 CJNIAudioTrack::MODE_STREAM,
-                                 CJNIAudioManager::AUDIO_SESSION_ID_GENERATE);
-    }
-    else
-    {
-      jniAt = new CJNIAudioTrack(stream,
-                                 sampleRate,
-                                 channelMask,
-                                 encoding,
-                                 bufferSize,
-                                 CJNIAudioTrack::MODE_STREAM);
-    }
+    jniAt = new CJNIAudioTrack(attrBuilder.build(),
+                               fmtBuilder.build(),
+                               bufferSize,
+                               CJNIAudioTrack::MODE_STREAM,
+                               CJNIAudioManager::AUDIO_SESSION_ID_GENERATE);
   }
   catch (const std::invalid_argument& e)
   {


### PR DESCRIPTION
## Description
minimum android sdk is 21

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
