### PR TITLE
Games: Assign joysticks in order of MRU (last activation)

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -630,6 +630,19 @@ CGameClientInput::PortMap CGameClientInput::MapJoysticks(const PERIPHERALS::Peri
 
   //! @todo Preserve existing joystick ports
 
+  // Sort by order of last button press
+  PERIPHERALS::PeripheralVector sortedJoysticks = peripheralJoysticks;
+  std::sort(sortedJoysticks.begin(), sortedJoysticks.end(),
+    [](const PERIPHERALS::PeripheralPtr &lhs, const PERIPHERALS::PeripheralPtr &rhs)
+    {
+      if (lhs->LastActive().IsValid() && !rhs->LastActive().IsValid())
+        return true;
+      if (!lhs->LastActive().IsValid() && rhs->LastActive().IsValid())
+        return false;
+
+      return lhs->LastActive() > rhs->LastActive();
+    });
+
   unsigned int i = 0;
   for (const auto &it : gameClientjoysticks)
   {
@@ -642,7 +655,7 @@ CGameClientInput::PortMap CGameClientInput::MapJoysticks(const PERIPHERALS::Peri
       break;
 
     // Dereference iterators
-    const PERIPHERALS::PeripheralPtr &peripheralJoystick = peripheralJoysticks[i++];
+    const PERIPHERALS::PeripheralPtr &peripheralJoystick = sortedJoysticks[i++];
     const std::unique_ptr<CGameClientJoystick> &gameClientJoystick = it.second;
 
     // Map input provider to input handler

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -17,6 +17,7 @@
 #include "input/keyboard/interfaces/IKeyboardInputProvider.h"
 #include "input/mouse/interfaces/IMouseInputProvider.h"
 #include "peripherals/PeripheralTypes.h"
+#include "XBDateTime.h"
 
 class TiXmlDocument;
 class CSetting;
@@ -229,6 +230,13 @@ namespace PERIPHERALS
     virtual KODI::JOYSTICK::IDriverReceiver* GetDriverReceiver() { return nullptr; }
 
     virtual IKeymap *GetKeymap(const std::string &controllerId) { return nullptr; }
+
+    /*!
+     * \brief Return the last time this peripheral was active
+     *
+     * \return The time of last activation, or invalid if unknown/never active
+     */
+    virtual CDateTime LastActive() { return CDateTime(); }
 
   protected:
     virtual void ClearSettings(void);

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -199,6 +199,8 @@ bool CPeripheralJoystick::OnButtonMotion(unsigned int buttonIndex, bool bPressed
   if (bPressed && !g_application.IsAppFocused())
     return false;
 
+  m_lastActive = CDateTime::GetCurrentDateTime();
+
   CSingleLock lock(m_handlerMutex);
 
   // Process promiscuous handlers
@@ -239,6 +241,8 @@ bool CPeripheralJoystick::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   // Avoid sending activated input if the app is in the background
   if (state != HAT_STATE::NONE && !g_application.IsAppFocused())
     return false;
+
+  m_lastActive = CDateTime::GetCurrentDateTime();
 
   CSingleLock lock(m_handlerMutex);
 
@@ -316,6 +320,9 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
         break;
     }
   }
+
+  if (bHandled)
+    m_lastActive = CDateTime::GetCurrentDateTime();
 
   return bHandled;
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -52,6 +52,7 @@ namespace PERIPHERALS
     void UnregisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler) override;
     KODI::JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }
     IKeymap *GetKeymap(const std::string &controllerId) override;
+    CDateTime LastActive() override { return m_lastActive; }
 
     bool OnButtonMotion(unsigned int buttonIndex, bool bPressed);
     bool OnHatMotion(unsigned int hatIndex, KODI::JOYSTICK::HAT_STATE state);
@@ -122,5 +123,6 @@ namespace PERIPHERALS
     std::unique_ptr<KODI::JOYSTICK::CDeadzoneFilter> m_deadzoneFilter;
     std::vector<DriverHandler>          m_driverHandlers;
     CCriticalSection                    m_handlerMutex;
+    CDateTime m_lastActive;
   };
 }

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -75,6 +75,8 @@ void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(KODI::KEYBOARD::IKeybo
 
 bool CPeripheralKeyboard::OnKeyPress(const CKey& key)
 {
+  m_lastActive = CDateTime::GetCurrentDateTime();
+
   CSingleLock lock(m_mutex);
 
   bool bHandled = false;

--- a/xbmc/peripherals/devices/PeripheralKeyboard.h
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.h
@@ -28,6 +28,7 @@ namespace PERIPHERALS
     bool InitialiseFeature(const PeripheralFeature feature) override;
     void RegisterKeyboardDriverHandler(KODI::KEYBOARD::IKeyboardDriverHandler* handler, bool bPromiscuous) override;
     void UnregisterKeyboardDriverHandler(KODI::KEYBOARD::IKeyboardDriverHandler* handler) override;
+    CDateTime LastActive() override { return m_lastActive; }
 
     // implementation of IKeyboardDriverHandler
     bool OnKeyPress(const CKey& key) override;
@@ -42,5 +43,6 @@ namespace PERIPHERALS
 
     std::vector<KeyboardHandle> m_keyboardHandlers;
     CCriticalSection m_mutex;
+    CDateTime m_lastActive;
   };
 }

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -93,11 +93,16 @@ bool CPeripheralMouse::OnPosition(int x, int y)
     }
   }
 
+  if (bHandled)
+    m_lastActive = CDateTime::GetCurrentDateTime();
+
   return bHandled;
 }
 
 bool CPeripheralMouse::OnButtonPress(MOUSE::BUTTON_ID button)
 {
+  m_lastActive = CDateTime::GetCurrentDateTime();
+
   CSingleLock lock(m_mutex);
 
   bool bHandled = false;

--- a/xbmc/peripherals/devices/PeripheralMouse.h
+++ b/xbmc/peripherals/devices/PeripheralMouse.h
@@ -28,6 +28,7 @@ namespace PERIPHERALS
     bool InitialiseFeature(const PeripheralFeature feature) override;
     void RegisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler, bool bPromiscuous) override;
     void UnregisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler) override;
+    CDateTime LastActive() override { return m_lastActive; }
 
     // implementation of IMouseDriverHandler
     bool OnPosition(int x, int y) override;
@@ -43,5 +44,6 @@ namespace PERIPHERALS
 
     std::vector<MouseHandle> m_mouseHandlers;
     CCriticalSection m_mutex;
+    CDateTime m_lastActive;
   };
 }


### PR DESCRIPTION
This is a blind attempt to address https://github.com/xbmc/xbmc/issues/14938. It changes the player-assignment order from the OS-supplied one (which doesn't work when Android has virtual joysticks) to a MRU (most recently used) order.

I'm not able to run-time test due to time constraints, so this PR is just to get the conversation started. Hopefully not much more work is needed.

## Motivation and Context
Issue: https://github.com/xbmc/xbmc/issues/14938
Forum thread: https://forum.kodi.tv/showthread.php?tid=335770

## How Has This Been Tested?
Compile-tested on macOS 10.14, no runtime testing.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
