### PR TITLE
[Android] prevent passing negative pts values to mediacodec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -171,6 +171,7 @@ protected:
 
   uint32_t m_OutputDuration, m_fpsDuration;
   int64_t m_lastPTS;
+  double m_dtsShift;
 
   static std::atomic<bool> m_InstanceGuard;
 


### PR DESCRIPTION
## Description
Prevent passing negative PTS values to mediacodec decoder because they are not supported.

## Motivation and Context
For some PVR addons streams start with negative DTS / PTS timing values which lead to wrong output PTS and stream stills.

## How Has This Been Tested?
Runtime tested on Wetek HUB

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
