### PR TITLE
[Bugfix][Android] fix handling of controller DPAD buttons

### DIFF
--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -162,6 +162,11 @@ bool CAndroidJoystickState::Initialize(const CJNIViewInputDevice& inputDevice)
   m_buttons.push_back({ { AKEYCODE_BUTTON_R2 } });
   m_buttons.push_back({ { AKEYCODE_BUTTON_THUMBL } });
   m_buttons.push_back({ { AKEYCODE_BUTTON_THUMBR } });
+  m_buttons.push_back({ { AKEYCODE_DPAD_UP } });
+  m_buttons.push_back({ { AKEYCODE_DPAD_RIGHT } });
+  m_buttons.push_back({ { AKEYCODE_DPAD_DOWN } });
+  m_buttons.push_back({ { AKEYCODE_DPAD_LEFT } });
+  m_buttons.push_back({ { AKEYCODE_DPAD_CENTER} });
 
   // check if there are no buttons or axes at all
   if (GetButtonCount() == 0 && GetAxisCount() == 0)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Currently when mapping a controller on Android, the mapping of the DPAD buttons is not stored in the generated buttonmaps. Accordign to @garbear it's related to those buttons not being added to the state handler, which this PR fixes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
DPAD not working in any game on Android

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
not yet tested - waiting on testbuild by jenkins (to test it, I need a build that includes the changes from this PR and #14944 )

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
