### PR TITLE
[pvr] CPVRRecording::GetResumePoint(): Performance: Update resume poi…

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -302,8 +302,12 @@ bool CPVRRecording::SetResumePoint(double timeInSeconds, double totalTimeInSecon
 CBookmark CPVRRecording::GetResumePoint() const
 {
   const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
-  if (client && client->GetClientCapabilities().SupportsRecordingsLastPlayedPosition())
+  if (client && client->GetClientCapabilities().SupportsRecordingsLastPlayedPosition() &&
+      m_resumePointRefetchTimeout.IsTimePast())
   {
+    // @todo: root cause should be fixed. details: https://github.com/xbmc/xbmc/pull/14961
+    m_resumePointRefetchTimeout.Set(10000); // update resume point from backend at most every 10 secs
+
     int pos = -1;
     client->GetRecordingLastPlayedPosition(*this, pos);
 

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -29,6 +29,7 @@
 
 #include "XBDateTime.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "threads/SystemClock.h"
 #include "video/VideoInfoTag.h"
 
 #include "pvr/PVRTypes.h"
@@ -320,6 +321,7 @@ namespace PVR
     bool         m_bRadio;        /*!< radio or tv recording */
     int          m_iGenreType = 0;    /*!< genre type */
     int          m_iGenreSubType = 0; /*!< genre subtype */
+    mutable XbmcThreads::EndTime m_resumePointRefetchTimeout;
 
     void UpdatePath(void);
   };


### PR DESCRIPTION
…nt from backend at most every 10 secs.

Fixes a performance problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=337834

@Jalle19 good to go?