### PR TITLE
Read scaled JPEGs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ else()
 endif()
 add_dependencies(${APP_NAME_LC} ${APP_NAME_LC}-libraries export-files pack-skins)
 whole_archive(_MAIN_LIBRARIES ${core_DEPENDS})
-target_link_libraries(${APP_NAME_LC} ${_MAIN_LIBRARIES} lib${APP_NAME_LC} ${DEPLIBS})
+target_link_libraries(${APP_NAME_LC} ${_MAIN_LIBRARIES} lib${APP_NAME_LC} ${DEPLIBS} jpeg)
 unset(_MAIN_LIBRARIES)
 
 if(WIN32)

--- a/xbmc/guilib/JPEGImage.h
+++ b/xbmc/guilib/JPEGImage.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <vector>
+
+#include <jpeglib.h>
+
+#include "iimage.h"
+#include "TextureFormats.h"
+
+#include <iostream>
+
+class JPEGImage : public IImage
+{
+public:
+  JPEGImage()
+  {
+      m_allocated = false;
+  }
+
+  ~JPEGImage() override
+  {
+    if (m_allocated)
+      jpeg_destroy_decompress(&m_mpoinfo);
+    m_allocated = false;
+  }
+
+  bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int width, unsigned int height) override
+  {
+    // make a copy of data as we need it at decode time.
+    m_data.resize(bufSize);
+      std::cerr << "lifm " << this << " sz = " << bufSize << ", ideal w = " << width << std::endl;
+    std::copy(buffer, buffer+bufSize, m_data.begin());
+struct jpeg_error_mgr jerr;
+
+    m_mpoinfo.err = jpeg_std_error(&jerr);
+    jpeg_create_decompress(&m_mpoinfo);
+    std::cerr << "lifm " << this << " created decomp " <<  std::endl;
+    jpeg_mem_src(&m_mpoinfo, m_data.data(), m_data.size());
+    if (!jpeg_read_header(&m_mpoinfo, true))
+    {
+      jpeg_destroy_decompress(&m_mpoinfo);
+      return false;
+    }
+
+    std::cerr << "lifm " << this << " header parsed, w =  " << m_mpoinfo.image_width <<  std::endl;
+
+    m_allocated = true;
+    m_originalWidth = m_mpoinfo.image_width;
+    m_originalHeight = m_mpoinfo.image_height;
+
+    m_mpoinfo.scale_denom = std::max(m_mpoinfo.scale_denom,
+      (m_originalWidth * m_mpoinfo.scale_num) / (width * m_mpoinfo.scale_num));
+
+    m_mpoinfo.scale_denom = std::max(m_mpoinfo.scale_denom,
+      (m_originalHeight * m_mpoinfo.scale_num) / (height * m_mpoinfo.scale_num));
+
+    m_mpoinfo.scale_denom = std::min(16u, m_mpoinfo.scale_denom);
+
+    jpeg_calc_output_dimensions(&m_mpoinfo);
+
+    m_width = m_mpoinfo.output_width;
+    m_height = m_mpoinfo.output_height;
+
+    std::cerr << "lifm " << this << " will scale to " << m_mpoinfo.scale_num << "/" << m_mpoinfo.scale_denom << std::endl;
+
+    return true;
+  }
+
+  bool CreateThumbnailFromSurface(unsigned char*, unsigned int, unsigned int,
+                                    unsigned int, unsigned int, const std::string&,
+                                    unsigned char*&, unsigned int&) override { return false; }
+
+  bool Decode(unsigned char * const pixels, unsigned int width, unsigned int height,
+              unsigned int pitch, unsigned int format) override
+  {
+
+    struct jpeg_error_mgr jerr;
+
+    m_mpoinfo.err = jpeg_std_error(&jerr);
+
+    jpeg_start_decompress(&m_mpoinfo);
+    JSAMPARRAY buffer;
+    int const row_stride = m_mpoinfo.output_width * m_mpoinfo.output_components;
+    buffer = (*m_mpoinfo.mem->alloc_sarray)((j_common_ptr)&m_mpoinfo, JPOOL_IMAGE, row_stride, 1);
+
+    std::cerr << "deco" << this << "img height = " << m_mpoinfo.image_height << ", height = " << height
+      << ", output_height = " << m_mpoinfo.output_height << std::endl;
+
+    int line = 0;
+
+    while (m_mpoinfo.output_scanline < m_mpoinfo.output_height) {
+      size_t nl = jpeg_read_scanlines(&m_mpoinfo, buffer, 1);
+
+
+      // std::cerr << "decode " << this << " output = " << m_mpoinfo.output_scanline << std::endl;
+      unsigned char* dst = pixels + line * pitch;
+
+      for (size_t i = 0; i < row_stride; i += m_mpoinfo.output_components) {
+        *dst++ = buffer[0][i+2];
+        *dst++ = buffer[0][i+1];
+        *dst++ = buffer[0][i];
+        if (format == XB_FMT_A8R8G8B8)
+            *dst++ = 0xff;
+      }
+
+      line += nl;
+    }
+
+    std::cerr << "decode " << this << " done, pos = " << m_mpoinfo.output_scanline << std::endl;
+    jpeg_finish_decompress(&m_mpoinfo);
+
+    return true;
+  }
+
+private:
+  bool m_allocated = false;
+  jpeg_decompress_struct m_mpoinfo = {};
+  std::vector<unsigned char> m_data;
+};

--- a/xbmc/guilib/JPEGImage.h
+++ b/xbmc/guilib/JPEGImage.h
@@ -5,14 +5,15 @@
 #include <jpeglib.h>
 
 #include "iimage.h"
+#include "FFmpegImage.h"
 #include "TextureFormats.h"
 
 #include <iostream>
 
-class JPEGImage : public IImage
+class JPEGImage : public CFFmpegImage
 {
 public:
-  JPEGImage()
+  JPEGImage(std::string const & mime) : CFFmpegImage(mime)
   {
       m_allocated = false;
   }
@@ -65,10 +66,6 @@ struct jpeg_error_mgr jerr;
 
     return true;
   }
-
-  bool CreateThumbnailFromSurface(unsigned char*, unsigned int, unsigned int,
-                                    unsigned int, unsigned int, const std::string&,
-                                    unsigned char*&, unsigned int&) override { return false; }
 
   bool Decode(unsigned char * const pixels, unsigned int width, unsigned int height,
               unsigned int pitch, unsigned int format) override

--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -8,6 +8,7 @@
 
 #include "imagefactory.h"
 #include "guilib/FFmpegImage.h"
+#include "guilib/JPEGImage.h"
 #include "addons/ImageDecoder.h"
 #include "addons/binary-addons/BinaryAddonBase.h"
 #include "utils/Mime.h"
@@ -51,5 +52,9 @@ IImage* ImageFactory::CreateLoaderFromMimeType(const std::string& strMimeType)
     }
   }
 
-  return new CFFmpegImage(strMimeType);
+  if (strMimeType == "image/jpeg") {
+    return new JPEGImage();
+  } else {
+    return new CFFmpegImage(strMimeType);
+  }
 }

--- a/xbmc/guilib/imagefactory.cpp
+++ b/xbmc/guilib/imagefactory.cpp
@@ -52,8 +52,10 @@ IImage* ImageFactory::CreateLoaderFromMimeType(const std::string& strMimeType)
     }
   }
 
-  if (strMimeType == "image/jpeg") {
-    return new JPEGImage();
+  std::cerr << "mime = " << strMimeType << std::endl;
+
+  if (strMimeType == "image/jpeg" || strMimeType == "image/jpg") {
+    return new JPEGImage(strMimeType);
   } else {
     return new CFFmpegImage(strMimeType);
   }


### PR DESCRIPTION
## Description

Use libjpeg-turbo's `scale_num` /  `scale_denom` capabilities to get a nice performance boost when reading JPEGs. 

I'd only like to get some feedback of something like this seems acceptable. I know the code is a pile of garbage as-is, but it works for testing and the improvement is substantial. As this change introduces no new dependecies (libjpeg-turbo is already a hard dependecy of Kodi, as I see it) and does not introduce new features (but improves the performance of an existing feature), I opted not to implement it as an addon. If the direction this is going seems ok, I'd

  * clean up the code formatting
  * add error handling
  * figure out how to properly link Kodi with libjpeg
  * ...
  * whatever needs to be done :smiley: 

## Motivation and Context

For thumbnailing/showing large JPEG files, the full image is decoded / held in memory / scaled down, which is wasteful. This patch reads only a fraction of the data (for large images, where it hurts most). For details refer to

> https://github.com/LuaDist/libjpeg/blob/master/libjpeg.txt#L1151

> Smaller scaling ratios permit significantly faster decoding since fewer pixels need be processed and a simpler IDCT method can be used.

(it's the same for libjpeg-turbo, but this is the first link google spat at me)

## How Has This Been Tested?

I tried the prototype on my x86-64 development machine and my Amlogic based box attached to the TV. Works as intended and, yep, it's faster.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed