### PR TITLE
[docs] Missing docs for ListItem.NextDuration

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5148,6 +5148,8 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  _string_,
 ///     @return The duration of the next item (PVR) in the format <b>hh:mm:ss</b>.
 ///     @note <b>hh:</b> will be omitted if hours value is zero.
+///     <p><hr>
+///     @skinning_v18 **[New Infolabel]** \link ListItem_NextDuration `ListItem.NextDuration`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.NextDuration(format)`</b>,
@@ -5156,6 +5158,8 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The duration of the next item (PVR) in different formats.
 ///     @param format [opt] The format of the return time value.
 ///     See \ref TIME_FORMAT for the list of possible values.
+///     <p><hr>
+///     @skinning_v18 **[New Infolabel]** \link ListItem_NextDuration_format `ListItem.NextDuration(format)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.ChannelGroup`</b>,

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -42,6 +42,7 @@
    - \link PVR_TimeshiftProgressDuration_format `PVR.TimeshiftProgressDuration(format)`\endlink
    - \link PVR_TimeshiftProgressEndTime `PVR.TimeshiftProgressEndTime`\endlink
    - \link PVR_TimeshiftProgressEndTime_format `PVR.TimeshiftProgressEndTime(format)`\endlink
+   - \link ListItem_NextDuration_format `ListItem.NextDuration(format)` \endlink
   <p>
  */
 enum TIME_FORMAT { TIME_FORMAT_GUESS       =  0, ///< usually used as the fallback value if the format value is empty


### PR DESCRIPTION
## Description
Adds `@skinning_v18` xrefitems for `ListItem.NextDuration` and `ListItem.NextDuration(format)` introduced in https://github.com/xbmc/xbmc/commit/4943937eaacb2351d36d4cd50aa26324857cf9b5#diff-127e5f2786eb19ac8e0e2f04b3bf8306.

## Motivation and Context
Complete docs and changelog for Leia.

