### PR TITLE
[Settings] Fix regression for time oldformat setting

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1056,15 +1056,19 @@ bool CDateTime::SetFromDBDate(const std::string &date)
 
 bool CDateTime::SetFromDBTime(const std::string &time)
 {
-  if (time.size() < 8)
+  if (time.size() < 5)
     return false;
-  // assumes format:
-  // HH:MM:SS
-  int hour, minute, second;
 
+  int hour;
+  int minute;
+  
+  int second = 0;
+  // HH:MM or HH:MM:SS
   hour   = atoi(time.substr(0, 2).c_str());
   minute = atoi(time.substr(3, 2).c_str());
-  second = atoi(time.substr(6, 2).c_str());
+  // HH:MM:SS
+  if (time.size() == 8)
+    second = atoi(time.substr(6, 2).c_str());
 
   return SetTime(hour, minute, second);
 }

--- a/xbmc/settings/SettingDateTime.h
+++ b/xbmc/settings/SettingDateTime.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "settings/lib/Setting.h"
+#include "utils/TimeUtils.h"
 
 class CSettingDate : public CSettingString
 {
@@ -40,5 +41,5 @@ public:
   bool CheckValidity(const std::string &value) const override;
 
   CDateTime GetTime() const { return CDateTime::FromDBTime(GetValue()); }
-  bool SetTime(const CDateTime& time) { return SetValue(time.GetAsDBTime()); }
+  bool SetTime(const CDateTime& time) { return SetValue(CTimeUtils::WithoutSeconds(time.GetAsDBTime())); }
 };

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -648,14 +648,7 @@ bool CGUIControlButtonSetting::OnClick()
 
       SYSTEMTIME systemtime;
       settingTime->GetTime().GetAsSystemTime(systemtime);
-      /* TODO
-      if (value.size() >= 5)
-      {
-        // assumes HH:MM
-        systemtime.wHour = atoi(value.substr(0, 2).c_str());
-        systemtime.wMinute = atoi(value.substr(3, 2).c_str());
-      }
-      */
+
       if (CGUIDialogNumeric::ShowAndGetTime(systemtime, Localize(buttonControl->GetHeading())))
         SetValid(settingTime->SetTime(CDateTime(systemtime)));
     }

--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -94,3 +94,8 @@ CDateTime CTimeUtils::GetLocalTime(time_t time)
 
   return result;
 }
+
+std::string CTimeUtils::WithoutSeconds(const std::string hhmmss)
+{
+  return hhmmss.substr(0, 5);
+}

--- a/xbmc/utils/TimeUtils.h
+++ b/xbmc/utils/TimeUtils.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <time.h>
+#include <string>
 
 class CDateTime;
 
@@ -22,7 +23,12 @@ public:
   static void UpdateFrameTime(bool flip); ///< update the frame time.  Not threadsafe
   static unsigned int GetFrameTime(); ///< returns the frame time in MS.  Not threadsafe
   static CDateTime GetLocalTime(time_t time);
-
+  
+  /*!
+   * @brief Returns a time string without seconds, i.e: HH:MM
+   * @param hhmmss Time string in the format HH:MM:SS
+  */
+  static std::string WithoutSeconds(const std::string hhmmss);
 private:
   static unsigned int frameTime;
 };

--- a/xbmc/utils/TimeUtils.h
+++ b/xbmc/utils/TimeUtils.h
@@ -20,8 +20,18 @@ int64_t CurrentHostFrequency(void);
 class CTimeUtils
 {
 public:
-  static void UpdateFrameTime(bool flip); ///< update the frame time.  Not threadsafe
-  static unsigned int GetFrameTime(); ///< returns the frame time in MS.  Not threadsafe
+  
+  /*!
+   * @brief Update the time frame
+   * @note Not threadsafe
+   */
+  static void UpdateFrameTime(bool flip);
+  
+  /*!
+   * @brief Returns the frame time in MS
+   * @note Not threadsafe
+   */
+  static unsigned int GetFrameTime();
   static CDateTime GetLocalTime(time_t time);
   
   /*!


### PR DESCRIPTION
## Description
This PR fixes a regression in addon settings for leia when using settings with `type="time"` introduced with the settings rework. The issue is documented here: https://forum.kodi.tv/showthread.php?tid=326633&pid=2687641#pid2687641 

## Motivation and Context
Settings with type `time` use the `HH:MM` format. From the wiki:

`<setting id="record_time" type="time" label="32031" default="13:13"/>`

During the setting rework, the parser for the old settings broke the setting since the provided value is smaller than 8 ( it incorrectly uses HH:MM:SS). Also, when changing the setting and despite dialog numeric does not contemplate seconds the stored value includes 59 seconds by default. Example:

User introduces `12:21` -> kodi stores `12:21:59`.

No idea who to ping so feel free to review or ping someone.

## How Has This Been Tested?
Compiled and runtime tested in OSX with a `time` setting in one of my addons.

## Screenshots (if appropriate):

Master:
![alt text](https://i.imgur.com/CWFVGjs.png "master")

This PR:
![alt text](https://i.imgur.com/sm1dUMZ.png "PR")

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
