### PR TITLE
[Android] Dispatch runUIThread messages on own HandlerThread

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -17,6 +17,7 @@ import android.view.View;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.widget.RelativeLayout;
 
 import @APP_PACKAGE@.channels.util.TvUtil;
@@ -292,7 +293,11 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
 
   private void runNativeOnUiThread(final long funcAddr, final long variantAddr)
   {
-    runOnUiThread(new Runnable()
+    HandlerThread runThread = new HandlerThread("KodiRunUI");
+    runThread.start();
+    Handler runHandler = new Handler(runThread.getLooper());
+
+    runHandler.post(new Runnable()
     {
       @Override
       public void run()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1003,8 +1003,14 @@ void CXBMCApp::onReceive(CJNIIntent intent)
       m_hdmiPlugged = newstate;
       if (m_hdmiPlugged != m_hdmiReportedState)
       {
-        dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(m_hdmiPlugged);
-        m_hdmiReportedState = m_hdmiPlugged;
+        if (g_application.IsInitialized())
+        {
+          CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
+          if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
+            dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHDMIState(m_hdmiPlugged);
+
+          m_hdmiReportedState = m_hdmiPlugged;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
Dispatch runOnUIThread using an own HandlerThread to allow waiting

## Motivation and Context
Switching from kodi to Andrid home and then back, kodi main thread is waiting 5 seconds for the result of a function called with CJNIMainActivity::runOnUIThread.
Reason is that Runnable java object is in messagequeue which is processed by main thread, too.

This change creates an own HandlerThread for processing the call. That allows us to wait for the function asynchronously called with runOnUIThread.

## How Has This Been Tested?
- NVIDIA shield
- Start Kodi avoiding refresh / res mode switch (kodi runs same res / refreshrate as Android UI)
- return to Android home
- return to kodi

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
