### PR TITLE
[Android] Fix failing VideoView creation

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -293,11 +293,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
 
   private void runNativeOnUiThread(final long funcAddr, final long variantAddr)
   {
-    HandlerThread runThread = new HandlerThread("KodiRunUI");
-    runThread.start();
-    Handler runHandler = new Handler(runThread.getLooper());
-
-    runHandler.post(new Runnable()
+    runOnUiThread(new Runnable()
     {
       @Override
       public void run()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -565,6 +565,14 @@ void CXBMCApp::SetRefreshRate(float rate)
   if (rate < 1.0)
     return;
 
+  CJNIWindow window = getWindow();
+  if (window)
+  {
+    CJNIWindowManagerLayoutParams params = window.getAttributes();
+    if (fabs(params.getpreferredRefreshRate() - rate) <= 0.001)
+      return;
+  }
+
   m_refreshRate = rate;
 
   m_displayChangeEvent.Reset();
@@ -578,6 +586,15 @@ void CXBMCApp::SetDisplayMode(int mode, float rate)
 {
   if (mode < 1.0)
     return;
+
+  CJNIWindow window = getWindow();
+  if (window)
+  {
+    CJNIWindowManagerLayoutParams params = window.getAttributes();
+    CLog::Log(LOGDEBUG, "XXX %d %d", params.getpreferredDisplayModeId(), mode);
+    if (params.getpreferredDisplayModeId() == mode)
+      return;
+  }
 
   m_displayChangeEvent.Reset();
 


### PR DESCRIPTION
## Description
Fix issues intoduced with https://github.com/xbmc/xbmc/pull/14993 when having refreshrate activated.

## Motivation and Context
On shield, refreshrate switching enabled, 14993 introduces issues when starting videos with refresh / resoluton switch on. This PR reverts handling UI ops in an own thread but solves the 5 second issue in 14993 on a different way.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
