### PR TITLE
Default DVDInputStream::OpenStream to true

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -125,7 +125,7 @@ public:
     virtual CDemuxStream* GetStream(int iStreamId) const = 0;
     virtual std::vector<CDemuxStream*> GetStreams() const = 0;
     virtual void EnableStream(int iStreamId, bool enable) {};
-    virtual bool OpenStream(int iStreamId) { return false; };
+    virtual bool OpenStream(int iStreamId) { return true; };
     virtual int GetNrOfStreams() const = 0;
     virtual void SetSpeed(int iSpeed) = 0;
     virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) = 0;


### PR DESCRIPTION
## Description
Fix for: PVR addons do not show video introduced by https://github.com/xbmc/xbmc/pull/14545

## Motivation and Context
https://github.com/xbmc/xbmc/issues/14969

## How Has This Been Tested?
Untested because of no PVR running


## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
