### PR TITLE
[settings] Fix regression (setting reuse)

### DIFF
--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -74,9 +74,9 @@ namespace ADDON
 
     bool ParseSettingVersion(const CXBMCTinyXML& doc, uint32_t& version) const;
 
-    std::shared_ptr<CSettingGroup> ParseOldSettingElement(const TiXmlElement *categoryElement, std::shared_ptr<CSettingCategory> category, std::set<std::string>& actionSettings);
+    std::shared_ptr<CSettingGroup> ParseOldSettingElement(const TiXmlElement *categoryElement, std::shared_ptr<CSettingCategory> category, std::set<std::string>& actionSettings, std::set<std::string>& settingIds);
 
-    std::shared_ptr<CSettingCategory> ParseOldCategoryElement(uint32_t &categoryId, const TiXmlElement * categoryElement, std::set<std::string> &actionSettings);
+    std::shared_ptr<CSettingCategory> ParseOldCategoryElement(uint32_t &categoryId, const TiXmlElement * categoryElement, std::set<std::string> &actionSettings, std::set<std::string>& settingIds);
 
     bool InitializeFromOldSettingDefinitions(const CXBMCTinyXML& doc);
     std::shared_ptr<CSetting> InitializeFromOldSettingAction(std::string settingId, const TiXmlElement *settingElement, const std::string& defaultValue);


### PR DESCRIPTION
## Description
This PR fixes the other known regression in addon settings introduced with the settings rework. In v17 we were able to use settings with the same id in different categories and the respective controls would stay in sync. In v18 this only works on a per-category basis. The issue is reported by @ronie here: https://forum.kodi.tv/showthread.php?tid=326633&pid=2687641#pid2687641

This PR moves the `settingsId` variable prior to the category detection so categories can refer to the same set.

## Motivation and Context
Fix regressions for addons in Leia.

## How Has This Been Tested?
Compiled and tested with the example posted in the linked thread. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
