### PR TITLE
Resolution: Don't add half refreshrates by default

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -88,8 +88,15 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       if (info.iScreenHeight >= curr.iScreenHeight && info.iScreenWidth >= curr.iScreenWidth &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK))
       {
-        resString = CDisplaySettings::GetInstance().GetStringFromRes(c);
-        indexList.push_back(resString);
+        // do not add half refreshrates (25, 29.97 by default) as kodi cannot cope with
+        // them on playback start. Especially interlaced content is not properly detected
+        // and this causes ugly double switching.
+        // This won't allow 25p / 30p playback on native refreshrate by default
+        if ((info.fRefreshRate > 30) || (MathUtils::FloatEquals(info.fRefreshRate, 24.0f, 0.1f)))
+        {
+          resString = CDisplaySettings::GetInstance().GetStringFromRes(c);
+          indexList.push_back(resString);
+        }
       }
     }
   }


### PR DESCRIPTION
Kodi cannot reliably distinguish between 25p and 50i or 29.97p and 60i on playback start, especially for LiveTV. Therefore don't expose those modes by default to workaround this issue, so that users don't switch refreshrate twice when zapping.

With an empty whitelist only this will break e.g. 3840@25p playback for HDMI 1.4 users (fallback to 1080p50) and will by default play 1080p25 content at 1080p50 putting more load on embedded systems, cause going through the guilayer twice as often as needed if e.g. subtitle cases.

Background: https://forum.kodi.tv/showthread.php?tid=298462&pid=2798167#pid2798167 or https://github.com/xbmc/xbmc/issues/14973

Obviously users can properly configure their whitelist (Expert Setting) to enable those modes themselves. This above logic will only ever apply if user has enabled Refreshrate switching but has an empty whitelist.