### PR TITLE
[DemuxClient] Call SetStreamProps only if OpenStream succeeds

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -639,13 +639,16 @@ void CDVDDemuxClient::OpenStream(int id)
 {
   // OpenStream may change some parameters
   // in this case we need to reset our stream properties
-  if (m_IDemux && m_IDemux->OpenStream(id))
+  if (m_IDemux)
   {
+    bool bOpenStream = m_IDemux->OpenStream(id);
+
     CDemuxStream *stream(m_IDemux->GetStream(id));
     if (stream && stream->type == STREAM_VIDEO)
       m_videoStreamPlaying = id;
 
-    SetStreamProps(stream, m_streams, true);
+    if (bOpenStream)
+      SetStreamProps(stream, m_streams, true);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -125,7 +125,7 @@ public:
     virtual CDemuxStream* GetStream(int iStreamId) const = 0;
     virtual std::vector<CDemuxStream*> GetStreams() const = 0;
     virtual void EnableStream(int iStreamId, bool enable) {};
-    virtual bool OpenStream(int iStreamId) { return true; };
+    virtual bool OpenStream(int iStreamId) { return false; };
     virtual int GetNrOfStreams() const = 0;
     virtual void SetSpeed(int iSpeed) = 0;
     virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) = 0;


### PR DESCRIPTION
## Description
Fixes issues introduced by https://github.com/xbmc/xbmc/pull/15010

## Motivation and Context
PVR is currently broken

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
