### PR TITLE
[Android] evaluate default subtitle position if GUI res != screen res

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20658,6 +20658,7 @@ msgid "Configure audio encoder settings such as quality and compression level"
 msgstr ""
 
 #: system/settings/rbp.xml
+#: system/settings/android.xml
 msgctxt "#37026"
 msgid "Auto"
 msgstr ""
@@ -20668,6 +20669,7 @@ msgid "540"
 msgstr ""
 
 #: system/settings/rbp.xml
+#: system/settings/android.xml
 msgctxt "#37028"
 msgid "720"
 msgstr ""
@@ -20678,6 +20680,7 @@ msgid "900"
 msgstr ""
 
 #: system/settings/rbp.xml
+#: system/settings/android.xml
 msgctxt "#37030"
 msgid "Unlimited"
 msgstr ""
@@ -20772,7 +20775,12 @@ msgctxt "#37045"
 msgid "Extract chapter thumbnails for presentation in the chapters / bookmarks dialogue. This might increase CPU load."
 msgstr ""
 
-#empty strings from id 37046 to 38009
+#: system/settings/android.xml
+msgctxt "#37046"
+msgid "1080"
+msgstr ""
+
+#empty strings from id 37047 to 38009
 
 #: system/settings/rbp.xml
 msgctxt "#38010"

--- a/system/settings/android.xml
+++ b/system/settings/android.xml
@@ -19,7 +19,7 @@
             <options>
               <option label="37026">0</option>    <!-- auto -->
               <option label="37028">720</option>  <!-- 720 -->
-              <option label="37027">1080</option>  <!-- 900 -->
+              <option label="37046">1080</option>  <!-- 1080 -->
               <option label="37030">9999</option> <!-- unlimited -->
             </options>
           </constraints>

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -258,6 +258,7 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
       {
         res.iWidth = std::min(res.iWidth, m_width);
         res.iHeight = std::min(res.iHeight, m_height);
+        res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
       }
       resolutions.push_back(res);
     }

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -170,9 +170,7 @@ void CWinSystemAndroid::UpdateResolutions()
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
     CDisplaySettings::GetInstance().GetResolutionInfo(res_index) = resolutions[i];
 
-    if(resDesktop.iWidth == resolutions[i].iWidth &&
-       resDesktop.iHeight == resolutions[i].iHeight &&
-       resDesktop.iScreenWidth == resolutions[i].iScreenWidth &&
+    if (resDesktop.iScreenWidth == resolutions[i].iScreenWidth &&
        resDesktop.iScreenHeight == resolutions[i].iScreenHeight &&
        (resDesktop.dwFlags & D3DPRESENTFLAG_MODEMASK) == (resolutions[i].dwFlags & D3DPRESENTFLAG_MODEMASK) &&
        fabs(resDesktop.fRefreshRate - resolutions[i].fRefreshRate) < FLT_EPSILON)


### PR DESCRIPTION
## Description
Evaluate default subtitle position if GUI res != screen res

## Motivation and Context
Subtitles on Android are by default outside visible screen area and therefore not visible.
PR fixes this by recalculating the iSubtitle position when we set the GUI resolution (which may differ to screen resolution)

## How Has This Been Tested?
- Shield Android TV on 4K display / default 1080p GUI.
- Play any stream with subtitles, they are not visible

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
