### PR TITLE
libinput: add support for absolute pointer motion

### DIFF
--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -181,6 +181,9 @@ void CLibInputHandler::ProcessEvent(libinput_event *ev)
     case LIBINPUT_EVENT_POINTER_MOTION:
       m_pointer->ProcessMotion(libinput_event_get_pointer_event(ev));
       break;
+    case LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE:
+      m_pointer->ProcessMotionAbsolute(libinput_event_get_pointer_event(ev));
+      break;
     case LIBINPUT_EVENT_POINTER_AXIS:
       m_pointer->ProcessAxis(libinput_event_get_pointer_event(ev));
       break;

--- a/xbmc/platform/linux/input/LibInputPointer.cpp
+++ b/xbmc/platform/linux/input/LibInputPointer.cpp
@@ -96,6 +96,23 @@ void CLibInputPointer::ProcessMotion(libinput_event_pointer *e)
     appPort->OnEvent(event);
 }
 
+void CLibInputPointer::ProcessMotionAbsolute(libinput_event_pointer *e)
+{
+  m_pos.X = static_cast<int>(libinput_event_pointer_get_absolute_x_transformed(e, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()));
+  m_pos.Y = static_cast<int>(libinput_event_pointer_get_absolute_y_transformed(e, CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()));
+
+  XBMC_Event event;
+  event.type = XBMC_MOUSEMOTION;
+  event.motion.x = static_cast<uint16_t>(m_pos.X);
+  event.motion.y = static_cast<uint16_t>(m_pos.Y);
+
+  CLog::Log(LOGDEBUG, "CLibInputPointer::%s - event.type: %i, event.motion.x: %i, event.motion.y: %i", __FUNCTION__, event.type, event.motion.x, event.motion.y);
+
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(event);
+}
+
 void CLibInputPointer::ProcessAxis(libinput_event_pointer *e)
 {
   unsigned char scroll = 0;

--- a/xbmc/platform/linux/input/LibInputPointer.h
+++ b/xbmc/platform/linux/input/LibInputPointer.h
@@ -24,6 +24,7 @@ public:
 
   void ProcessButton(libinput_event_pointer *e);
   void ProcessMotion(libinput_event_pointer *e);
+  void ProcessMotionAbsolute(libinput_event_pointer *e);
   void ProcessAxis(libinput_event_pointer *e);
 
 private:


### PR DESCRIPTION
This is needed for devices that send absolute pointer motion (such as VNC inputs)