### PR TITLE
Add more buttons to open the OSD in Live TV

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -169,6 +169,8 @@
   </FullscreenGame>
   <FullscreenLiveTV>
     <joystick profile="game.controller.default">
+      <x>OSD</x>
+      <back>OSD</back>
       <guide>OSD</guide>
       <up>ChannelUp</up>
       <down>ChannelDown</down>


### PR DESCRIPTION
The `<x>` and `<back>` buttons can already be used in FullscreenVideo to open the OSD. With this change, these two buttons can also be used to open the OSD in FullscreenLiveTV.

## Motivation and Context
Better use of a gamepad when watching Live TV. 
Many gamepads don't have enough buttons. Mine doesn't have a "Guide" button, so I don't have any chance to open the OSD in Live TV. But in FullscreenVideo, the `<x>` and `<back>` buttons can already be used to bring up the OSD menu. I think, this can also be done in FullscreenLiveTV.

## How Has This Been Tested?
Tested with gamepad [Dual Analog 4](http://www.thrustmaster.com/en_US/products/dual-analog-4) in Live TV on Windows 10.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
## Checklist:
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
