### PR TITLE
[joystick.xml] Add buttons for TVGuide and TVChannels

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -176,6 +176,17 @@
       <right>StepForward</right>
     </joystick>
   </FullscreenLiveTV>
+  <TVGuide>
+    <joystick profile="game.controller.default">
+      <start>Select</start>
+      <y>Menu</y>
+    </joystick>
+  </TVGuide>
+  <TVChannels>
+    <joystick profile="game.controller.default">
+      <start>Select</start>
+    </joystick>
+  </TVChannels>
   <FullscreenRadio>
     <joystick profile="game.controller.default">
       <guide>OSD</guide>


### PR DESCRIPTION
This lets the `start` button of a joystick select an element in TVGuide and TVChannels. Also, the `y` button can now be used to open the menu in TVGuide.

## Motivation and Context
When pressing the `start` button on a gamepad in the EPG, the selected item flashes up, but nothing happens. This lets the `start` button actually do something, namely select the item. Also, the `y` button is now used to open the menu in TVGuide, because otherwise, there's no way to open the menu with a gamepad only.

## How Has This Been Tested?
Tested with gamepad in Live TV on Windows 10.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
