### PR TITLE
[Android] Reset calibrations if GUI limit changes

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -566,6 +566,12 @@ void CDisplaySettings::UpdateCalibrations()
   }
 }
 
+void CDisplaySettings::ClearCalibrations()
+{
+  CSingleLock lock(m_critical);
+  m_calibrations.clear();
+}
+
 DisplayMode CDisplaySettings::GetCurrentDisplayMode() const
 {
   if (GetCurrentResolution() == RES_WINDOW)

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -71,6 +71,7 @@ public:
 
   void ApplyCalibrations();
   void UpdateCalibrations();
+  void ClearCalibrations();
   void ClearCustomResolutions();
 
   float GetZoomAmount() const { return m_zoomAmount; }

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -13,9 +13,10 @@
 
 #include <androidjni/Display.h>
 
+#include "settings/lib/ISettingCallback.h"
 #include "windowing/Resolution.h"
 
-class CAndroidUtils
+class CAndroidUtils : public ISettingCallback
 {
 public:
   CAndroidUtils();
@@ -23,6 +24,10 @@ public:
   virtual bool  GetNativeResolution(RESOLUTION_INFO *res) const;
   virtual bool  SetNativeResolution(const RESOLUTION_INFO &res);
   virtual bool  ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
+
+  // Implementation of ISettingCallback
+  static const std::string SETTING_LIMITGUI;
+  void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
 
 protected:
   mutable int m_width;


### PR DESCRIPTION
## Description
Android and Raspberry PI allow limiting the size of the plane GUI is rendered on.
If calibrations are applied and the limit of the GUI plane is altered, GUI is not scaled correctly.

This PR resets all calibration settings if the user changes the GUI limit

## Motivation and Context
Kodi GUI not usable because its either displayed too small or too big after changing the limit

## How Has This Been Tested?
- NVIDIA shield
- 4K TV, GUI limit (settings:system:Display:limit gui set to Auto (==1080p)
- Select settings::system:Display:calibration (this initializes calibration for 1080p GUI on 4K)
- Change GUI limit to Unlimited (that leads to GUI rendered on 4K plane
- Restart kodi -> Kodi GUI is displayed in the upper left corner, 1/4 in size

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

@popcornmix not sure if same issue exists on rbpi