### PR TITLE
AMLCodec: fix contrast setting

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2206,8 +2206,8 @@ void CAMLCodec::SetVideoZoom(const float zoom)
 void CAMLCodec::SetVideoContrast(const int contrast)
 {
   // input contrast range is 0 to 100 with default of 50.
-  // output contrast range is -255 to 255 with default of 0.
-  int aml_contrast = (255 * (contrast - 50)) / 50;
+  // output contrast range is -127 to 127 with default of 0.
+  int aml_contrast = (127 * (contrast - 50)) / 50;
   SysfsUtils::SetInt("/sys/class/video/contrast", aml_contrast);
 }
 void CAMLCodec::SetVideoBrightness(const int brightness)


### PR DESCRIPTION
## Description'

This fixes contrast setting to match what the kernel expects.

## Motivation and Context
This can be fixed in the kernel; but changes are unlikely to be made here for a variety of platforms; so this quick fix is probably better. 

## How Has This Been Tested?

Tested on AMLogic 3.10 and 3.14

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
