### PR TITLE
[wayland] Centralize seat handling

### DIFF
--- a/xbmc/windowing/wayland/CMakeLists.txt
+++ b/xbmc/windowing/wayland/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES Connection.cpp
             OSScreenSaverIdleInhibitUnstableV1.cpp
             Registry.cpp
             Seat.cpp
+            SeatInputProcessing.cpp
             SeatSelection.cpp
             ShellSurface.cpp
             ShellSurfaceWlShell.cpp
@@ -35,6 +36,7 @@ set(HEADERS Connection.h
             OSScreenSaverIdleInhibitUnstableV1.h
             Registry.h
             Seat.h
+            SeatInputProcessing.h
             SeatSelection.h
             ShellSurface.h
             ShellSurfaceWlShell.h

--- a/xbmc/windowing/wayland/InputProcessorKeyboard.h
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.h
@@ -12,9 +12,8 @@
 #include <cstdint>
 #include <memory>
 
-#include <wayland-client-protocol.hpp>
-
 #include "input/XBMC_keysym.h"
+#include "Seat.h"
 #include "threads/Timer.h"
 #include "windowing/XBMC_events.h"
 #include "XkbcommonKeymap.h"
@@ -35,10 +34,17 @@ public:
   virtual ~IInputHandlerKeyboard() = default;
 };
 
-class CInputProcessorKeyboard
+class CInputProcessorKeyboard final : public IRawInputHandlerKeyboard
 {
 public:
-  CInputProcessorKeyboard(wayland::keyboard_t const& keyboard, IInputHandlerKeyboard& handler);
+  CInputProcessorKeyboard(IInputHandlerKeyboard& handler);
+
+  void OnKeyboardKeymap(CSeat* seat, wayland::keyboard_keymap_format format, std::string const& keymap) override;
+  void OnKeyboardEnter(CSeat* seat, std::uint32_t serial, wayland::surface_t surface, wayland::array_t keys) override;
+  void OnKeyboardLeave(CSeat* seat, std::uint32_t serial, wayland::surface_t surface) override;
+  void OnKeyboardKey(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::uint32_t key, wayland::keyboard_key_state state) override;
+  void OnKeyboardModifiers(CSeat* seat, std::uint32_t serial, std::uint32_t modsDepressed, std::uint32_t modsLatched, std::uint32_t modsLocked, std::uint32_t group) override;
+  void OnKeyboardRepeatInfo(CSeat* seat, std::int32_t rate, std::int32_t delay) override;
 
 private:
   CInputProcessorKeyboard(CInputProcessorKeyboard const& other) = delete;
@@ -48,7 +54,6 @@ private:
   XBMC_Event SendKey(unsigned char scancode, XBMCKey key, std::uint16_t unicodeCodepoint, bool pressed);
   void KeyRepeatTimeout();
 
-  wayland::keyboard_t m_keyboard;
   IInputHandlerKeyboard& m_handler;
 
   std::unique_ptr<CXkbcommonContext> m_xkbContext;

--- a/xbmc/windowing/wayland/InputProcessorTouch.cpp
+++ b/xbmc/windowing/wayland/InputProcessorTouch.cpp
@@ -12,76 +12,81 @@
 
 using namespace KODI::WINDOWING::WAYLAND;
 
-CInputProcessorTouch::CInputProcessorTouch(wayland::touch_t const& touch, wayland::surface_t const& surface)
-: m_touch{touch}, m_surface{surface}
+CInputProcessorTouch::CInputProcessorTouch(wayland::surface_t const& surface)
+: m_surface{surface}
 {
-  m_touch.on_down() = [this](std::uint32_t, std::uint32_t time, wayland::surface_t surface, std::int32_t id, double x, double y)
-  {
-    if (surface != m_surface)
-    {
-      return;
-    }
+}
 
-    // Find free Kodi pointer number
-    int kodiPointer{-1};
-    // Not optimal, but irrelevant for the small number of iterations
-    for (int testPointer{0}; testPointer < CGenericTouchInputHandler::MAX_POINTERS; testPointer++)
-    {
-      if (std::all_of(m_touchPoints.cbegin(), m_touchPoints.cend(),
-                      [=](decltype(m_touchPoints)::value_type const& pair)
-                      {
-                        return (pair.second.kodiPointerNumber != testPointer);
-                      }))
-      {
-        kodiPointer = testPointer;
-        break;
-      }
-    }
+void CInputProcessorTouch::OnTouchDown(CSeat* seat, std::uint32_t serial, std::uint32_t time, wayland::surface_t surface, std::int32_t id, double x, double y)
+{
+  if (surface != m_surface)
+  {
+    return;
+  }
 
-    if (kodiPointer != -1)
-    {
-      auto it = m_touchPoints.emplace(std::piecewise_construct, std::forward_as_tuple(id), std::forward_as_tuple(time, kodiPointer, x * m_coordinateScale, y * m_coordinateScale, 0.0f)).first;
-      SendTouchPointEvent(TouchInputDown, it->second);
-    }
-  };
-  m_touch.on_up() = [this](std::uint32_t, std::uint32_t time, std::int32_t id)
+  // Find free Kodi pointer number
+  int kodiPointer{-1};
+  // Not optimal, but irrelevant for the small number of iterations
+  for (int testPointer{0}; testPointer < CGenericTouchInputHandler::MAX_POINTERS; testPointer++)
   {
-    auto it = m_touchPoints.find(id);
-    if (it != m_touchPoints.end())
+    if (std::all_of(m_touchPoints.cbegin(), m_touchPoints.cend(),
+                    [=](decltype(m_touchPoints)::value_type const& pair)
+                    {
+                      return (pair.second.kodiPointerNumber != testPointer);
+                    }))
     {
-      auto& point = it->second;
-      point.lastEventTime = time;
-      SendTouchPointEvent(TouchInputUp, point);
-      m_touchPoints.erase(it);
+      kodiPointer = testPointer;
+      break;
     }
-  };
-  m_touch.on_motion() = [this](std::uint32_t time, std::int32_t id, double x, double y)
+  }
+
+  if (kodiPointer != -1)
   {
-    auto it = m_touchPoints.find(id);
-    if (it != m_touchPoints.end())
-    {
-      auto& point = it->second;
-      point.x = x * m_coordinateScale;
-      point.y = y * m_coordinateScale;
-      point.lastEventTime = time;
-      SendTouchPointEvent(TouchInputMove, point);
-    }
-  };
-  m_touch.on_cancel() = [this]()
+    auto it = m_touchPoints.emplace(std::piecewise_construct, std::forward_as_tuple(id), std::forward_as_tuple(time, kodiPointer, x * m_coordinateScale, y * m_coordinateScale, 0.0f)).first;
+    SendTouchPointEvent(TouchInputDown, it->second);
+  }
+}
+
+void CInputProcessorTouch::OnTouchUp(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::int32_t id)
+{
+  auto it = m_touchPoints.find(id);
+  if (it != m_touchPoints.end())
   {
-    AbortTouches();
-  };
-  m_touch.on_shape() = [this](std::int32_t id, double major, double minor)
+    auto& point = it->second;
+    point.lastEventTime = time;
+    SendTouchPointEvent(TouchInputUp, point);
+    m_touchPoints.erase(it);
+  }
+}
+
+void CInputProcessorTouch::OnTouchMotion(CSeat* seat, std::uint32_t time, std::int32_t id, double x, double y)
+{
+  auto it = m_touchPoints.find(id);
+  if (it != m_touchPoints.end())
   {
-    auto it = m_touchPoints.find(id);
-    if (it != m_touchPoints.end())
-    {
-      auto& point = it->second;
-      // Kodi only supports size without shape, so use average of both axes
-      point.size = ((major + minor) / 2.0) * m_coordinateScale;
-      UpdateTouchPoint(point);
-    }
-  };
+    auto& point = it->second;
+    point.x = x * m_coordinateScale;
+    point.y = y * m_coordinateScale;
+    point.lastEventTime = time;
+    SendTouchPointEvent(TouchInputMove, point);
+  }
+}
+
+void CInputProcessorTouch::OnTouchCancel(CSeat* seat)
+{
+  AbortTouches();
+}
+
+void CInputProcessorTouch::OnTouchShape(CSeat* seat, std::int32_t id, double major, double minor)
+{
+  auto it = m_touchPoints.find(id);
+  if (it != m_touchPoints.end())
+  {
+    auto& point = it->second;
+    // Kodi only supports size without shape, so use average of both axes
+    point.size = ((major + minor) / 2.0) * m_coordinateScale;
+    UpdateTouchPoint(point);
+  }
 }
 
 CInputProcessorTouch::~CInputProcessorTouch() noexcept

--- a/xbmc/windowing/wayland/InputProcessorTouch.h
+++ b/xbmc/windowing/wayland/InputProcessorTouch.h
@@ -14,6 +14,7 @@
 #include <wayland-client-protocol.hpp>
 
 #include "input/touch/ITouchInputHandler.h"
+#include "Seat.h"
 
 namespace KODI
 {
@@ -27,12 +28,18 @@ namespace WAYLAND
  *
  * Events go directly to \ref CGenericTouchInputHandler, so no callbacks here
  */
-class CInputProcessorTouch
+class CInputProcessorTouch final : public IRawInputHandlerTouch
 {
 public:
-  CInputProcessorTouch(wayland::touch_t const& touch, wayland::surface_t const& surface);
+  CInputProcessorTouch(wayland::surface_t const& surface);
   ~CInputProcessorTouch() noexcept;
   void SetCoordinateScale(std::int32_t scale) { m_coordinateScale = scale; }
+
+  void OnTouchDown(CSeat* seat, std::uint32_t serial, std::uint32_t time, wayland::surface_t surface, std::int32_t id, double x, double y) override;
+  void OnTouchUp(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::int32_t id) override;
+  void OnTouchMotion(CSeat* seat, std::uint32_t time, std::int32_t id, double x, double y) override;
+  void OnTouchCancel(CSeat* seat) override;
+  void OnTouchShape(CSeat* seat, std::int32_t id, double major, double minor) override;
 
 private:
   CInputProcessorTouch(CInputProcessorTouch const& other) = delete;
@@ -57,7 +64,6 @@ private:
   void UpdateTouchPoint(TouchPoint const& point);
   void AbortTouches();
 
-  wayland::touch_t m_touch;
   wayland::surface_t m_surface;
   std::int32_t m_coordinateScale{1};
 

--- a/xbmc/windowing/wayland/Seat.h
+++ b/xbmc/windowing/wayland/Seat.h
@@ -8,18 +8,12 @@
 
 #pragma once
 
-#include <map>
-#include <memory>
+#include <cstdint>
+#include <set>
 
 #include <wayland-client-protocol.hpp>
 
-#include "input/touch/ITouchInputHandler.h"
-#include "InputProcessorPointer.h"
-#include "InputProcessorKeyboard.h"
-#include "InputProcessorTouch.h"
 #include "SeatSelection.h"
-#include "threads/Timer.h"
-#include "windowing/XBMC_events.h"
 
 namespace KODI
 {
@@ -28,72 +22,90 @@ namespace WINDOWING
 namespace WAYLAND
 {
 
-enum class InputType
-{
-  POINTER,
-  KEYBOARD,
-  TOUCH
-};
+class CSeat;
 
 /**
- * Handler interface for input events from \ref CSeatInputProcessor
+ * Handler for raw wl_keyboard events
+ *
+ * All functions are identical to wl_keyboard, except for the keymap which is
+ * retrieved from its fd and put into a string
  */
-class IInputHandler
+class IRawInputHandlerKeyboard
 {
 public:
-  /**
-   * Handle input event
-   * \param seatGlobalName numeric Wayland global name of the seat the event occured on
-   * \param type input device type that caused the event
-   * \param event XBMC event data
-   */
-  virtual void OnEvent(std::uint32_t seatGlobalName, InputType type, XBMC_Event& event) {}
-  /**
-   * Handle focus enter
-   * \param seatGlobalName numeric Wayland global name of the seat the event occured on
-   * \param type input device type for which the surface has gained the focus
-   */
-  virtual void OnEnter(std::uint32_t seatGlobalName, InputType type) {}
-  /**
-   * Handle focus leave
-   * \param seatGlobalName numeric Wayland global name of the seat the event occured on
-   * \param type input device type for which the surface has lost the focus
-   */
-  virtual void OnLeave(std::uint32_t seatGlobalName, InputType type) {}
-  /**
-   * Handle request for setting the cursor
-   *
-   * When the client gains pointer focus for a surface, a cursor image must be
-   * attached to the pointer. Otherwise the previous pointer image would
-   * be used.
-   *
-   * This request is sent in addition to \ref OnEnter for \ref InputType::POINTER.
-   *
-   * \param pointer pointer instance that needs its cursor set
-   * \param serial Wayland protocol message serial that must be sent back in set_cursor
-   */
-  virtual void OnSetCursor(wayland::pointer_t& pointer, std::uint32_t serial) {}
-
-  virtual ~IInputHandler() = default;
+  virtual void OnKeyboardKeymap(CSeat* seat, wayland::keyboard_keymap_format format, std::string const& keymap) {}
+  virtual void OnKeyboardEnter(CSeat* seat, std::uint32_t serial, wayland::surface_t surface, wayland::array_t keys) {}
+  virtual void OnKeyboardLeave(CSeat* seat, std::uint32_t serial, wayland::surface_t surface) {}
+  virtual void OnKeyboardKey(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::uint32_t key, wayland::keyboard_key_state state) {}
+  virtual void OnKeyboardModifiers(CSeat* seat, std::uint32_t serial, std::uint32_t modsDepressed, std::uint32_t modsLatched, std::uint32_t modsLocked, std::uint32_t group) {}
+  virtual void OnKeyboardRepeatInfo(CSeat* seat, std::int32_t rate, std::int32_t delay) {}
+protected:
+  ~IRawInputHandlerKeyboard() {}
 };
 
 /**
- * Handle all wl_seat-related events and process them into Kodi events
+ * Handler for raw wl_pointer events
+ *
+ * All functions are identical to wl_pointer
  */
-class CSeat : IInputHandlerPointer, IInputHandlerKeyboard
+class IRawInputHandlerPointer
+{
+public:
+  virtual void OnPointerEnter(CSeat* seat, std::uint32_t serial, wayland::surface_t surface, double surfaceX, double surfaceY) {}
+  virtual void OnPointerLeave(CSeat* seat, std::uint32_t serial, wayland::surface_t surface) {}
+  virtual void OnPointerMotion(CSeat* seat, std::uint32_t time, double surfaceX, double surfaceY) {}
+  virtual void OnPointerButton(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::uint32_t button, wayland::pointer_button_state state) {}
+  virtual void OnPointerAxis(CSeat* seat, std::uint32_t time, wayland::pointer_axis axis, double value) {}
+protected:
+  ~IRawInputHandlerPointer() {}
+};
+
+/**
+ * Handler for raw wl_touch events
+ *
+ * All functions are identical to wl_touch
+ */
+class IRawInputHandlerTouch
+{
+public:
+  virtual void OnTouchDown(CSeat* seat, std::uint32_t serial, std::uint32_t time, wayland::surface_t surface, std::int32_t id, double x, double y) {}
+  virtual void OnTouchUp(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::int32_t id) {}
+  virtual void OnTouchMotion(CSeat* seat, std::uint32_t time, std::int32_t id, double x, double y) {}
+  virtual void OnTouchCancel(CSeat* seat) {}
+  virtual void OnTouchShape(CSeat* seat, std::int32_t id, double major, double minor) {}
+protected:
+  ~IRawInputHandlerTouch() {};
+};
+
+/**
+ * Handle all events and requests related to one seat (including input and selection)
+ *
+ * The primary purpose of this class is to act as entry point of Wayland events into
+ * the Kodi world and distribute them further as necessary.
+ * Input events are forwarded to (potentially multiple) handlers. As the Wayland
+ * protocol is not very specific on having multiple wl_seat/wl_pointer instances
+ * and how they interact, having one central instance and then handling everything
+ * in Kodi with multiple handlers is better than each handler having its own
+ * protocol object instance.
+ */
+class CSeat
 {
 public:
   /**
    * Construct seat handler
    * \param globalName Wayland numeric global name of the seat
    * \param seat bound seat_t instance
-   * \param inputSurface surface that receives the input, used for matching
-   *                     pointer focus enter/leave events
    * \param connection connection for retrieving additional globals
-   * \param handler handler that receives events from this seat, must not be null
    */
-  CSeat(std::uint32_t globalName, wayland::seat_t const& seat, wayland::surface_t const& inputSurface, CConnection& connection, IInputHandler& handler);
+  CSeat(std::uint32_t globalName, wayland::seat_t const& seat, CConnection& connection);
   ~CSeat() noexcept;
+
+  void AddRawInputHandlerKeyboard(IRawInputHandlerKeyboard* rawKeyboardHandler);
+  void RemoveRawInputHandlerKeyboard(IRawInputHandlerKeyboard* rawKeyboardHandler);
+  void AddRawInputHandlerPointer(IRawInputHandlerPointer* rawPointerHandler);
+  void RemoveRawInputHandlerPointer(IRawInputHandlerPointer* rawPointerHandler);
+  void AddRawInputHandlerTouch(IRawInputHandlerTouch* rawTouchHandler);
+  void RemoveRawInputHandlerTouch(IRawInputHandlerTouch* rawTouchHandler);
 
   std::uint32_t GetGlobalName() const
   {
@@ -119,38 +131,47 @@ public:
   {
     return m_selection.GetSelectionText();
   }
-  void SetCoordinateScale(std::int32_t scale);
+  /**
+   * Get the wl_seat underlying this seat
+   *
+   * The wl_seat should only be used when strictly necessary, e.g. when
+   * starting a move operation with shell interfaces.
+   * It may not be used to derive further wl_pointer etc. instances.
+   */
+  wayland::seat_t const& GetWlSeat()
+  {
+    return m_seat;
+  }
+
+  /**
+   * Set the cursor of the pointer of this seat
+   *
+   * Parameters are identical wo wl_pointer.set_cursor().
+   * If the seat does not currently have the pointer capability, this is a no-op.
+   */
+  void SetCursor(std::uint32_t serial, wayland::surface_t const& surface, std::int32_t hotspotX, std::int32_t hotspotY);
 
 private:
   CSeat(CSeat const& other) = delete;
   CSeat& operator=(CSeat const& other) = delete;
 
   void HandleOnCapabilities(wayland::seat_capability caps);
-  void HandlePointerCapability(wayland::pointer_t const& pointer);
-  void HandleKeyboardCapability(wayland::keyboard_t const& keyboard);
-  void HandleTouchCapability(wayland::touch_t const& touch);
-
-  void OnKeyboardEnter() override;
-  void OnKeyboardLeave() override;
-  void OnKeyboardEvent(XBMC_Event& event) override;
-
-  void OnPointerEnter(wayland::pointer_t& pointer, std::uint32_t serial) override;
-  void OnPointerLeave() override;
-  void OnPointerEvent(XBMC_Event& event) override;
-
-  void UpdateCoordinateScale();
+  void HandlePointerCapability();
+  void HandleKeyboardCapability();
+  void HandleTouchCapability();
 
   std::uint32_t m_globalName;
-  wayland::seat_t m_seat;
-  wayland::surface_t m_inputSurface;
   std::string m_name{"<unknown>"};
-  std::int32_t m_coordinateScale{1};
 
-  IInputHandler& m_handler;
+  wayland::seat_t m_seat;
+  wayland::pointer_t m_pointer;
+  wayland::keyboard_t m_keyboard;
+  wayland::touch_t m_touch;
 
-  std::unique_ptr<CInputProcessorPointer> m_pointer;
-  std::unique_ptr<CInputProcessorKeyboard> m_keyboard;
-  std::unique_ptr<CInputProcessorTouch> m_touch;
+  std::set<IRawInputHandlerKeyboard*> m_rawKeyboardHandlers;
+  std::set<IRawInputHandlerPointer*> m_rawPointerHandlers;
+  std::set<IRawInputHandlerTouch*> m_rawTouchHandlers;
+
   CSeatSelection m_selection;
 };
 

--- a/xbmc/windowing/wayland/SeatInputProcessing.cpp
+++ b/xbmc/windowing/wayland/SeatInputProcessing.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SeatInputProcessing.h"
+
+#include <cassert>
+
+using namespace KODI::WINDOWING::WAYLAND;
+
+CSeatInputProcessing::CSeatInputProcessing(wayland::surface_t const& inputSurface, IInputHandler& handler)
+: m_inputSurface{inputSurface}, m_handler{handler}
+{
+}
+
+void CSeatInputProcessing::AddSeat(CSeat* seat)
+{
+  assert(m_seats.find(seat->GetGlobalName()) == m_seats.end());
+  auto& seatState = m_seats.emplace(seat->GetGlobalName(), seat).first->second;
+
+  seatState.keyboardProcessor.reset(new CInputProcessorKeyboard(*this));
+  seat->AddRawInputHandlerKeyboard(seatState.keyboardProcessor.get());
+  seatState.pointerProcessor.reset(new CInputProcessorPointer(m_inputSurface, *this));
+  seat->AddRawInputHandlerPointer(seatState.pointerProcessor.get());
+  seatState.touchProcessor.reset(new CInputProcessorTouch(m_inputSurface));
+  seat->AddRawInputHandlerTouch(seatState.touchProcessor.get());
+}
+
+void CSeatInputProcessing::RemoveSeat(CSeat* seat)
+{
+  auto seatStateI = m_seats.find(seat->GetGlobalName());
+  if (seatStateI != m_seats.end())
+  {
+    seat->RemoveRawInputHandlerKeyboard(seatStateI->second.keyboardProcessor.get());
+    seat->RemoveRawInputHandlerPointer(seatStateI->second.pointerProcessor.get());
+    seat->RemoveRawInputHandlerTouch(seatStateI->second.touchProcessor.get());
+    m_seats.erase(seatStateI);
+  }
+}
+
+void CSeatInputProcessing::OnPointerEnter(std::uint32_t seatGlobalName, std::uint32_t serial)
+{
+  m_handler.OnSetCursor(seatGlobalName, serial);
+  m_handler.OnEnter(InputType::POINTER);
+}
+
+void CSeatInputProcessing::OnPointerLeave()
+{
+  m_handler.OnLeave(InputType::POINTER);
+}
+
+void CSeatInputProcessing::OnPointerEvent(XBMC_Event& event)
+{
+  m_handler.OnEvent(InputType::POINTER, event);
+}
+
+void CSeatInputProcessing::OnKeyboardEnter()
+{
+  m_handler.OnEnter(InputType::KEYBOARD);
+}
+
+void CSeatInputProcessing::OnKeyboardLeave()
+{
+  m_handler.OnLeave(InputType::KEYBOARD);
+}
+
+void CSeatInputProcessing::OnKeyboardEvent(XBMC_Event& event)
+{
+  m_handler.OnEvent(InputType::KEYBOARD, event);
+}
+
+void CSeatInputProcessing::SetCoordinateScale(std::int32_t scale)
+{
+  for (auto& seatPair : m_seats)
+  {
+    seatPair.second.touchProcessor->SetCoordinateScale(scale);
+    seatPair.second.pointerProcessor->SetCoordinateScale(scale);
+  }
+}

--- a/xbmc/windowing/wayland/SeatInputProcessing.h
+++ b/xbmc/windowing/wayland/SeatInputProcessing.h
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+
+#include <wayland-client-protocol.hpp>
+
+#include "InputProcessorKeyboard.h"
+#include "InputProcessorPointer.h"
+#include "InputProcessorTouch.h"
+#include "Seat.h"
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace WAYLAND
+{
+
+enum class InputType
+{
+  POINTER,
+  KEYBOARD,
+  TOUCH
+};
+
+/**
+ * Handler interface for input events from \ref CSeatInputProcessor
+ */
+class IInputHandler
+{
+public:
+  /**
+   * Handle input event
+   * \param type input device type that caused the event
+   * \param event XBMC event data
+   */
+  virtual void OnEvent(InputType type, XBMC_Event& event) {}
+  /**
+   * Handle focus enter
+   * \param type input device type for which the surface has gained the focus
+   */
+  virtual void OnEnter(InputType type) {}
+  /**
+   * Handle focus leave
+   * \param type input device type for which the surface has lost the focus
+   */
+  virtual void OnLeave(InputType type) {}
+  /**
+   * Handle request for setting the cursor
+   *
+   * When the client gains pointer focus for a surface, a cursor image must be
+   * attached to the pointer. Otherwise the previous pointer image would
+   * be used.
+   *
+   * This request is sent in addition to \ref OnEnter for \ref InputType::POINTER.
+   *
+   * \param seatGlobalName numeric Wayland global name of the seat the event occured on
+   * \param pointer pointer instance that needs its cursor set
+   * \param serial Wayland protocol message serial that must be sent back in set_cursor
+   */
+  virtual void OnSetCursor(std::uint32_t seatGlobalName, std::uint32_t serial) {}
+
+  virtual ~IInputHandler() = default;
+};
+
+/**
+ * Receive events from all registered wl_seats and process them into Kodi events
+ *
+ * Multi-seat support is not currently implemented completely, but each seat has
+ * separate state.
+ */
+class CSeatInputProcessing final : IInputHandlerPointer, IInputHandlerKeyboard
+{
+public:
+  /**
+   * Construct a seat input processor
+   *
+   * \param inputSurface Surface that events should be processed on (all other surfaces are ignored)
+   * \param handler Mandatory handler for processed input events
+   */
+  CSeatInputProcessing(wayland::surface_t const& inputSurface, IInputHandler& handler);
+  void AddSeat(CSeat* seat);
+  void RemoveSeat(CSeat* seat);
+
+  /**
+   * Set the scale the coordinates should be interpreted at
+   *
+   * Wayland input events are always in surface coordinates, but Kodi only uses
+   * buffer coordinates internally. Use this function to set the scaling
+   * factor between the two and multiply the surface coordinates accordingly
+   * for Kodi events.
+   *
+   * \param scale new buffer-to-surface pixel ratio
+   */
+  void SetCoordinateScale(std::int32_t scale);
+
+private:
+  wayland::surface_t m_inputSurface;
+  IInputHandler& m_handler;
+
+  void OnPointerEnter(std::uint32_t seatGlobalName, std::uint32_t serial) override;
+  void OnPointerLeave() override;
+  void OnPointerEvent(XBMC_Event& event) override;
+
+  void OnKeyboardEnter() override;
+  void OnKeyboardLeave() override;
+  void OnKeyboardEvent(XBMC_Event& event) override;
+
+  struct SeatState
+  {
+    CSeat* seat;
+    std::unique_ptr<CInputProcessorKeyboard> keyboardProcessor;
+    std::unique_ptr<CInputProcessorPointer> pointerProcessor;
+    std::unique_ptr<CInputProcessorTouch> touchProcessor;
+
+    SeatState(CSeat* seat)
+    : seat{seat}
+    {}
+  };
+  std::map<std::uint32_t, SeatState> m_seats;
+};
+
+}
+}
+}

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -23,6 +23,7 @@
 #include "Connection.h"
 #include "Output.h"
 #include "Seat.h"
+#include "SeatInputProcessing.h"
 #include "Signals.h"
 #include "ShellSurface.h"
 #include "platform/linux/OptionalsReg.h"
@@ -114,10 +115,10 @@ protected:
 
 private:
   // IInputHandler
-  void OnEnter(std::uint32_t seatGlobalName, InputType type) override;
-  void OnLeave(std::uint32_t seatGlobalName, InputType type) override;
-  void OnEvent(std::uint32_t seatGlobalName, InputType type, XBMC_Event& event) override;
-  void OnSetCursor(wayland::pointer_t& pointer, std::uint32_t serial) override;
+  void OnEnter(InputType type) override;
+  void OnLeave(InputType type) override;
+  void OnEvent(InputType type, XBMC_Event& event) override;
+  void OnSetCursor(std::uint32_t seatGlobalName, std::uint32_t serial) override;
 
   // IWindowDecorationHandler
   void OnWindowMove(const wayland::seat_t& seat, std::uint32_t serial) override;
@@ -202,8 +203,9 @@ private:
 
   // Seat handling
   // -------------
-  std::map<std::uint32_t, CSeat> m_seatProcessors;
-  CCriticalSection m_seatProcessorsMutex;
+  std::map<std::uint32_t, CSeat> m_seats;
+  CCriticalSection m_seatsMutex;
+  std::unique_ptr<CSeatInputProcessing> m_seatInputProcessing;
   std::map<std::uint32_t, std::shared_ptr<COutput>> m_outputs;
   /// outputs that did not receive their done event yet
   std::map<std::uint32_t, std::shared_ptr<COutput>> m_outputsInPreparation;

--- a/xbmc/windowing/wayland/XkbcommonKeymap.cpp
+++ b/xbmc/windowing/wayland/XkbcommonKeymap.cpp
@@ -16,10 +16,8 @@
 #include "Application.h"
 #include "Util.h"
 #include "utils/log.h"
-#include "platform/posix/utils/Mmap.h"
 
 using namespace KODI::WINDOWING::WAYLAND;
-using namespace KODI::UTILS::POSIX;
 
 namespace
 {
@@ -195,19 +193,16 @@ void CXkbcommonContext::XkbContextDeleter::operator()(xkb_context* ctx) const
   xkb_context_unref(ctx);
 }
 
-std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::KeymapFromSharedMemory(int fd, std::size_t size)
+std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::KeymapFromString(std::string const& keymap)
 {
-  CMmap mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0);
-  auto keymapString = static_cast<const char *> (mmap.Data());
+  std::unique_ptr<xkb_keymap, CXkbcommonKeymap::XkbKeymapDeleter> xkbKeymap{xkb_keymap_new_from_string(m_context.get(), keymap.c_str(), XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS), CXkbcommonKeymap::XkbKeymapDeleter()};
 
-  std::unique_ptr<xkb_keymap, CXkbcommonKeymap::XkbKeymapDeleter> keymap{xkb_keymap_new_from_string(m_context.get(), keymapString, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS), CXkbcommonKeymap::XkbKeymapDeleter()};
-
-  if (!keymap)
+  if (!xkbKeymap)
   {
     throw std::runtime_error("Failed to compile keymap");
   }
 
-  return std::unique_ptr<CXkbcommonKeymap>{new CXkbcommonKeymap(std::move(keymap))};
+  return std::unique_ptr<CXkbcommonKeymap>{new CXkbcommonKeymap(std::move(xkbKeymap))};
 }
 
 std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::KeymapFromNames(const std::string& rules, const std::string& model, const std::string& layout, const std::string& variant, const std::string& options)

--- a/xbmc/windowing/wayland/XkbcommonKeymap.h
+++ b/xbmc/windowing/wayland/XkbcommonKeymap.h
@@ -123,7 +123,7 @@ public:
    * This function does not own the file descriptor. It must not be closed
    * from this function.
    */
-  std::unique_ptr<CXkbcommonKeymap> KeymapFromSharedMemory(int fd, std::size_t size);
+  std::unique_ptr<CXkbcommonKeymap> KeymapFromString(std::string const& keymap);
   std::unique_ptr<CXkbcommonKeymap> KeymapFromNames(const std::string &rules, const std::string &model, const std::string &layout, const std::string &variant, const std::string &options);
 
 private:


### PR DESCRIPTION
Previously, Wayland seat (including input) handling was performed for
the main surface and the window decorations in separate places,
leading to multiple instances of wl_seat, wl_pointer etc.

While not forbidden by the protocol, this has caused aberrant behavior
in compositors such as KWin which were then not able to hide the cursor
image. As it is indeed unclear what should happen with the cursor when
multiple wl_pointer instances are created, the solution of the problem
is to centralize the seat handling on the Kodi side.
There is now only one wl_seat etc. instance that retrieves the events
from the Wayland compositor and distributes them further in the Kodi
application to the relevant components (generating Kodi events or
handling decorations).

Fixes #15002