### PR TITLE
OMXPlayerVideo: Send PLAYER_AVCHANGE message when stereo mode changes 

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -662,20 +662,20 @@ void OMXPlayerVideo::SetVideoRect(const CRect &InSrcRect, const CRect &InDestRec
 
   if (stereoMode == "left_right")
   {
-    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_HORIZONTAL;
+    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_VERTICAL;
   }
   else if (stereoMode == "right_left")
   {
-    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_HORIZONTAL;
+    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_VERTICAL;
     stereo_invert = true;
   }
   else if (stereoMode == "top_bottom")
   {
-    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_VERTICAL;
+    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_HORIZONTAL;
   }
   else if (stereoMode == "bottom_top")
   {
-    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_VERTICAL;
+    video_stereo_mode = RENDER_STEREO_MODE_SPLIT_HORIZONTAL;
     stereo_invert = true;
   }
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -310,6 +310,13 @@ void OMXPlayerVideo::Output(double pts, bool bDropPacket)
   omvb->m_state = MMAL::MMALStateBypass;
   picture.videoBuffer = omvb;
 
+  if (m_processInfo.GetVideoStereoMode() != GetStereoMode())
+  {
+    m_processInfo.SetVideoStereoMode(picture.stereoMode);
+    // signal about changes in video parameters
+    m_messageParent.Put(new CDVDMsg(CDVDMsg::PLAYER_AVCHANGE));
+  }
+
   m_renderManager.AddVideoPicture(picture, m_bAbortOutput, EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE, (m_syncState == ESyncState::SYNC_STARTING));
 }
 


### PR DESCRIPTION
## Description
Send PLAYER_AVCHANGE message from omxplayer when stereo mode changes as that triggers 3d switching.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/14907

## How Has This Been Tested?
Last night's milhouse nightly. Reported has confirmed issue is resolved.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
