### PR TITLE
[Android] remove mpeg4 HD restriction / use dts for unknown pts for mpeg4

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -183,6 +183,7 @@ protected:
   mpeg2_sequence  *m_mpeg2_sequence;
   int             m_src_offset[4];
   int             m_src_stride[4];
+  bool            m_useDTSforPTS;
 
   // CJNISurfaceHolderCallback interface
 public:


### PR DESCRIPTION
## Description
Currently MediaCodec decoder only allow mpeg4 for streams >= 800 width.
Most mpeg4 streams work well with the decoder, so we should let it open also for SD.

The demo mpeg4 stream I'm using comes only with DTS but not PTS, we use now DTS for PTS in this case to avoid stutter.

## Motivation and Context
mpeg4 streams < width 800 are currently decoded with ffmpeg which fails on very low povered devices.

Kodi forum thread: https://forum.kodi.tv/showthread.php?tid=332945&pid=2799844#pid2799844

## How Has This Been Tested?
NVidia shield, play https://mega.nz/#!7mYR0KDD!eXyMIrasuf2qdJw288wORrWBMG7R1W1PKyQF_FbeHeM

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
