### PR TITLE
Revert "[fix] remove network available checks in C(Directory|File)Factory"

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -137,26 +137,30 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
   if (CWinLibraryDirectory::IsValid(url)) return new CWinLibraryDirectory();
 #endif
 
-  if (url.IsProtocol("ftp") || url.IsProtocol("ftps")) return new CFTPDirectory();
-  if (url.IsProtocol("http") || url.IsProtocol("https")) return new CHTTPDirectory();
-  if (url.IsProtocol("dav") || url.IsProtocol("davs")) return new CDAVDirectory();
+  bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();
+  if (networkAvailable)
+  {
+    if (url.IsProtocol("ftp") || url.IsProtocol("ftps")) return new CFTPDirectory();
+    if (url.IsProtocol("http") || url.IsProtocol("https")) return new CHTTPDirectory();
+    if (url.IsProtocol("dav") || url.IsProtocol("davs")) return new CDAVDirectory();
 #ifdef HAS_FILESYSTEM_SMB
 #ifdef TARGET_WINDOWS
-  if (url.IsProtocol("smb")) return new CWin32SMBDirectory();
+    if (url.IsProtocol("smb")) return new CWin32SMBDirectory();
 #else
-  if (url.IsProtocol("smb")) return new CSMBDirectory();
+    if (url.IsProtocol("smb")) return new CSMBDirectory();
 #endif
 #endif
 #ifdef HAS_UPNP
-  if (url.IsProtocol("upnp")) return new CUPnPDirectory();
+    if (url.IsProtocol("upnp")) return new CUPnPDirectory();
 #endif
-  if (url.IsProtocol("rss") || url.IsProtocol("rsss")) return new CRSSDirectory();
+    if (url.IsProtocol("rss") || url.IsProtocol("rsss")) return new CRSSDirectory();
 #ifdef HAS_ZEROCONF
-  if (url.IsProtocol("zeroconf")) return new CZeroconfDirectory();
+    if (url.IsProtocol("zeroconf")) return new CZeroconfDirectory();
 #endif
 #ifdef HAS_FILESYSTEM_NFS
-  if (url.IsProtocol("nfs")) return new CNFSDirectory();
+    if (url.IsProtocol("nfs")) return new CNFSDirectory();
 #endif
+  }
 
   if (url.IsProtocol("pvr"))
     return new CPVRDirectory();
@@ -170,7 +174,7 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
     }
   }
 
-  CLog::Log(LOGWARNING, "%s - unsupported protocol(%s) in %s", __FUNCTION__, url.GetProtocol().c_str(), url.GetRedacted().c_str() );
+  CLog::Log(LOGWARNING, "%s - %sunsupported protocol(%s) in %s", __FUNCTION__, networkAvailable ? "" : "Network down or ", url.GetProtocol().c_str(), url.GetRedacted().c_str() );
   return NULL;
 }
 

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -129,28 +129,32 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   else if (CWinLibraryFile::IsValid(url)) return new CWinLibraryFile();
 #endif
 
-  if (url.IsProtocol("ftp")
-  ||  url.IsProtocol("ftps")
-  ||  url.IsProtocol("rss")
-  ||  url.IsProtocol("rsss")
-  ||  url.IsProtocol("http")
-  ||  url.IsProtocol("https")) return new CCurlFile();
-  else if (url.IsProtocol("dav") || url.IsProtocol("davs")) return new CDAVFile();
-  else if (url.IsProtocol("shout")) return new CShoutcastFile();
+  bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();
+  if (networkAvailable)
+  {
+    if (url.IsProtocol("ftp")
+    ||  url.IsProtocol("ftps")
+    ||  url.IsProtocol("rss")
+    ||  url.IsProtocol("rsss")
+    ||  url.IsProtocol("http")
+    ||  url.IsProtocol("https")) return new CCurlFile();
+    else if (url.IsProtocol("dav") || url.IsProtocol("davs")) return new CDAVFile();
+    else if (url.IsProtocol("shout")) return new CShoutcastFile();
 #ifdef HAS_FILESYSTEM_SMB
 #ifdef TARGET_WINDOWS
-  else if (url.IsProtocol("smb")) return new CWin32SMBFile();
+    else if (url.IsProtocol("smb")) return new CWin32SMBFile();
 #else
-  else if (url.IsProtocol("smb")) return new CSMBFile();
+    else if (url.IsProtocol("smb")) return new CSMBFile();
 #endif
 #endif
 #ifdef HAS_FILESYSTEM_NFS
-  else if (url.IsProtocol("nfs")) return new CNFSFile();
+    else if (url.IsProtocol("nfs")) return new CNFSFile();
 #endif
 #ifdef HAS_UPNP
-  else if (url.IsProtocol("upnp")) return new CUPnPFile();
+    else if (url.IsProtocol("upnp")) return new CUPnPFile();
 #endif
+  }
 
-  CLog::Log(LOGWARNING, "%s - unsupported protocol(%s) in %s", __FUNCTION__, url.GetProtocol().c_str(), url.GetRedacted().c_str());
+  CLog::Log(LOGWARNING, "%s - %sunsupported protocol(%s) in %s", __FUNCTION__, networkAvailable ? "" : "Network down or ", url.GetProtocol().c_str(), url.GetRedacted().c_str());
   return NULL;
 }


### PR DESCRIPTION
... because it introduces a crash on Kodi startup

This reverts commit 04c23c1f30142c85762aa2e790ce5758fa0f3679.

Although the general idea of that PR is correct, it unfortunately does introduce a 100% reproducible crash on Kodi startup, if the Kodi installation has media sources on SMB shares and no network is available on Kodi startup:

<pre>
(lldb) thread backtrace
* thread #18, name = 'JobWorker', stop reason = signal SIGABRT
    frame #0: 0x00007fff6ac7a23e libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00000001092df850 libsystem_pthread.dylib`pthread_kill + 285
    frame #2: 0x00007fff6abe31c9 libsystem_c.dylib`abort + 127
  * frame #3: 0x0000000108b58ba4 libsmbclient.dylib`talloc_abort(reason="Bad talloc magic value - unknown value") at talloc.c:340
    frame #4: 0x0000000108b58b60 libsmbclient.dylib`talloc_abort_unknown_value at talloc.c:364
    frame #5: 0x0000000108b53092 libsmbclient.dylib`talloc_chunk_from_ptr(ptr=0x000000010b99e2b0) at talloc.c:383
    frame #6: 0x0000000108b54101 libsmbclient.dylib`_talloc_free_internal(ptr=0x000000010b99e2b0, location="libsmb/namequery.c:1850") at talloc.c:963
    frame #7: 0x0000000108b552a8 libsmbclient.dylib`_talloc_free_children_internal(tc=0x000000010b99e190, ptr=0x000000010b99e1f0, location="libsmb/namequery.c:1850") at talloc.c:1472
    frame #8: 0x0000000108b543fd libsmbclient.dylib`_talloc_free_internal(ptr=0x000000010b99e1f0, location="libsmb/namequery.c:1850") at talloc.c:1019
    frame #9: 0x0000000108b552a8 libsmbclient.dylib`_talloc_free_children_internal(tc=0x000000010b99e0d0, ptr=0x000000010b99e130, location="libsmb/namequery.c:1850") at talloc.c:1472
    frame #10: 0x0000000108b543fd libsmbclient.dylib`_talloc_free_internal(ptr=0x000000010b99e130, location="libsmb/namequery.c:1850") at talloc.c:1019
    frame #11: 0x0000000108b552a8 libsmbclient.dylib`_talloc_free_children_internal(tc=0x000000010b99df50, ptr=0x000000010b99dfb0, location="libsmb/namequery.c:1850") at talloc.c:1472
    frame #12: 0x0000000108b543fd libsmbclient.dylib`_talloc_free_internal(ptr=0x000000010b99dfb0, location="libsmb/namequery.c:1850") at talloc.c:1019
    frame #13: 0x0000000108b554e4 libsmbclient.dylib`_talloc_free(ptr=0x000000010b99dfb0, location="libsmb/namequery.c:1850") at talloc.c:1594
    frame #14: 0x000000010854b013 libsmbclient.dylib`name_resolve_bcast_done(subreq=0x000000010b99dfb0) at namequery.c:1850
    frame #15: 0x000000010844397c libsmbclient.dylib`_tevent_req_notify_callback(req=0x000000010b99dfb0, location="libsmb/namequery.c:1687") at tevent_req.c:101
    frame #16: 0x0000000108443a3a libsmbclient.dylib`tevent_req_finish(req=0x000000010b99dfb0, state=TEVENT_REQ_USER_ERROR, location="libsmb/namequery.c:1687") at tevent_req.c:110
    frame #17: 0x0000000108443a86 libsmbclient.dylib`_tevent_req_error(req=0x000000010b99dfb0, error=10483072397370982721, location="libsmb/namequery.c:1687") at tevent_req.c:128
    frame #18: 0x00000001083dd2de libsmbclient.dylib`_tevent_req_nterror(req=0x000000010b99dfb0, status=(v = 3221225793), location="libsmb/namequery.c:1687") at tevent_ntstatus.c:46
    frame #19: 0x00000001085518cc libsmbclient.dylib`name_queries_done(subreq=0x000000010b99e250) at namequery.c:1687
    frame #20: 0x000000010844397c libsmbclient.dylib`_tevent_req_notify_callback(req=0x000000010b99e250, location="libsmb/namequery.c:1221") at tevent_req.c:101
    frame #21: 0x0000000108443a3a libsmbclient.dylib`tevent_req_finish(req=0x000000010b99e250, state=TEVENT_REQ_USER_ERROR, location="libsmb/namequery.c:1221") at tevent_req.c:110
    frame #22: 0x0000000108443b63 libsmbclient.dylib`tevent_req_trigger(ev=0x000000010b99db30, im=0x000000010b99e320, private_data=0x000000010b99e250) at tevent_req.c:166
    frame #23: 0x000000010844239c libsmbclient.dylib`tevent_common_loop_immediate(ev=0x000000010b99db30) at tevent_immediate.c:135
    frame #24: 0x0000000108446455 libsmbclient.dylib`poll_event_loop_once(ev=0x000000010b99db30, location="../lib/tevent/tevent_req.c:210") at tevent_poll.c:649
    frame #25: 0x00000001084401f8 libsmbclient.dylib`_tevent_loop_once(ev=0x000000010b99db30, location="../lib/tevent/tevent_req.c:210") at tevent.c:530
    frame #26: 0x0000000108443cd6 libsmbclient.dylib`tevent_req_poll(req=0x000000010b99dd60, ev=0x000000010b99db30) at tevent_req.c:210
    frame #27: 0x00000001083dd521 libsmbclient.dylib`tevent_req_poll_ntstatus(req=0x000000010b99dd60, ev=0x000000010b99db30, status=0x0000700005da3d48) at tevent_ntstatus.c:106
    frame #28: 0x000000010854b18d libsmbclient.dylib`name_resolve_bcast(name="ALEXANDRIA", name_type=32, mem_ctx=0x000000010b9a1550, return_iplist=0x0000700005da3df8, return_count=0x0000700005da3f6c) at namequery.c:1892
    frame #29: 0x000000010854c84c libsmbclient.dylib`internal_resolve_name(name="ALEXANDRIA", name_type=32, sitename=0x0000000000000000, return_iplist=0x0000700005da3f78, return_count=0x0000700005da3f6c, resolve_order=0x0000000112449720) at namequery.c:2708
    frame #30: 0x000000010854e97a libsmbclient.dylib`resolve_name_list(ctx=0x000000010b99da30, name="ALEXANDRIA", name_type=32, return_ss_arr=0x0000700005da4000, p_num_entries=0x0000700005da4018) at namequery.c:2878
    frame #31: 0x0000000108499dff libsmbclient.dylib`cli_connect_sock_send(mem_ctx=0x000000010b99d830, ev=0x000000010b9a12a0, host="ALEXANDRIA", name_type=32, pss=0x0000000000000000, myname="KAIS-MACBOOK-PRO", port=0) at cliconnect.c:2909
    frame #32: 0x000000010849532c libsmbclient.dylib`cli_connect_nb_send(mem_ctx=0x000000010b9a12a0, ev=0x000000010b9a12a0, host="ALEXANDRIA", dest_ss=0x0000000000000000, port=0, name_type=32, myname="KAIS-MACBOOK-PRO", signing_state=-1, flags=64) at cliconnect.c:3025
    frame #33: 0x0000000108495071 libsmbclient.dylib`cli_connect_nb(host="ALEXANDRIA", dest_ss=0x0000000000000000, port=0, name_type=32, myname="KAIS-MACBOOK-PRO", signing_state=-1, flags=64, pcli=0x0000700005da4490) at cliconnect.c:3085
    frame #34: 0x000000010836fb7f libsmbclient.dylib`SMBC_server_internal(ctx=0x000000010b9880b0, context=0x00000001124440a0, connect_if_not_found=true, server="ALEXANDRIA", port=0, share="Public", pp_workgroup=0x0000700005da46f0, pp_username=0x0000700005da4700, pp_password=0x0000700005da46f8, in_cache=0x0000700005da4567) at libsmb_server.c:462
    frame #35: 0x000000010836ee68 libsmbclient.dylib`SMBC_server(ctx=0x000000010b9880b0, context=0x00000001124440a0, connect_if_not_found=true, server="ALEXANDRIA", port=0, share="Public", pp_workgroup=0x0000700005da46f0, pp_username=0x0000700005da4700, pp_password=0x0000700005da46f8) at libsmb_server.c:675
    frame #36: 0x000000010837169d libsmbclient.dylib`SMBC_stat_ctx(context=0x00000001124440a0, fname="smb://ALEXANDRIA/Public/Shared%20Pictures/folder.jpg", st=0x0000700005da47e8) at libsmb_stat.c:166
    frame #37: 0x000000010835f47d libsmbclient.dylib`smbc_stat(url="smb://ALEXANDRIA/Public/Shared%20Pictures/folder.jpg", st=0x0000700005da47e8) at libsmb_compat.c:320
    frame #38: 0x0000000101dcba80 kodi.bin`XFILE::CSMBFile::Exists(this=0x00000001095b7be0, url=0x0000700005da4c98) at SMBFile.cpp:463
    frame #39: 0x0000000100e64ce1 kodi.bin`XFILE::CFile::Exists(file=0x0000700005da55b0, bUseCache=true) at File.cpp:444
    frame #40: 0x0000000100e6a233 kodi.bin`XFILE::CFile::Exists(strFileName="smb://ALEXANDRIA/Public/Shared Pictures/folder.jpg", bUseCache=true) at File.cpp:419
    frame #41: 0x00000001004372f5 kodi.bin`CProgramThumbLoader::GetLocalThumb(item=0x00000001095b68b0) at ThumbLoader.cpp:115
    frame #42: 0x0000000100436859 kodi.bin`CProgramThumbLoader::FillThumb(this=0x000000010bacc958, item=0x00000001095b68b0) at ThumbLoader.cpp:92
    frame #43: 0x000000010043602b kodi.bin`CProgramThumbLoader::LoadItemCached(this=0x000000010bacc958, pItem=0x00000001095b68b0) at ThumbLoader.cpp:74
    frame #44: 0x0000000100435f83 kodi.bin`CProgramThumbLoader::LoadItem(this=0x000000010bacc958, pItem=0x00000001095b68b0) at ThumbLoader.cpp:63
    frame #45: 0x0000000101763e43 kodi.bin`CDirectoryJob::DoWork(this=0x0000000116c1be20) at DirectoryProvider.cpp:87
    frame #46: 0x00000001024ab62f kodi.bin`CJobWorker::Process(this=0x0000000116e10570) at JobManager.cpp:55
    frame #47: 0x00000001023c2b04 kodi.bin`CThread::Action(this=0x0000000116e10570) at Thread.cpp:202
    frame #48: 0x00000001023c101b kodi.bin`CThread::staticThread(data=0x0000000116e10570) at Thread.cpp:116
    frame #49: 0x00000001092dce35 libsystem_pthread.dylib`_pthread_body + 126
    frame #50: 0x00000001092dfec7 libsystem_pthread.dylib`_pthread_start + 70
    frame #51: 0x00000001092dbe51 libsystem_pthread.dylib`thread_start + 13
</pre>

**My take is that a crash on startup is much worse than the problem fixed by #14918 (Windows-only problems after resume from standby). And unfortunately I have no idea how to properly fix the crash introduced here.** 

I runtime-tested that the crash does not happen anymore after reverting the above mentioned commit on macOS, latest Kodi master, with network disconnected on Kodi startup.