### PR TITLE
ActiveAE: Don't return null stream when AE is suspended

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3231,9 +3231,6 @@ IAEStream *CActiveAE::MakeStream(AEAudioFormat &audioFormat, unsigned int option
     return nullptr;
   }
 
-  if (IsSuspended())
-    return NULL;
-
   //! @todo pass number of samples in audio packet
 
   AEAudioFormat format = audioFormat;


### PR DESCRIPTION
If you start playback of an audio file/playlist while
a refreshrate switch is happening, we skip tracks or playback
fails at all.

The IsSuspended check is not necessary, as the MakeStream request
has a timeout of 10s anyway.
So let it fail if the AudioEngine is supsended for more than 10s.

## How Has This Been Tested?
Tested on Linux GBM:
Turn on refreshrate switch.
Set delay after refreshrate to like 4s in order to reproduce more easy.
I've used a json api script to stop playback, fill 4 tracks into a playlist and
start playback of the playlist.
The higher the delay, the more tracks get lost.
Set the delay to > 10s to test if the MakeStream call really fails after 10s -> true.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
