### PR TITLE
VideoPlayer: release reference to m_pInputStream after usage

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4444,6 +4444,8 @@ bool CVideoPlayer::OnAction(const CAction &action)
     }
   }
 
+  pMenus.reset();
+
   switch (action.GetID())
   {
     case ACTION_NEXT_ITEM:


### PR DESCRIPTION
this fixes #15055 

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  m_pInputStream reference count is greater than 1

Thread 58 "VideoPlayer" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fff437fe700 (LWP 27185)]
0x00007ffff0ed3eab in raise () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ffff0ed3eab in raise () from /lib64/libc.so.6
#1  0x00007ffff0ebe5b9 in abort () from /lib64/libc.so.6
#2  0x00007ffff12e8a9b in __gnu_cxx::__verbose_terminate_handler() [clone .cold.1] () from /lib64/libstdc++.so.6
#3  0x00007ffff12eeefc in __cxxabiv1::__terminate(void (*)()) () from /lib64/libstdc++.so.6
#4  0x00007ffff12eef57 in std::terminate() () from /lib64/libstdc++.so.6
#5  0x00007ffff12ef1b8 in __cxa_throw () from /lib64/libstdc++.so.6
#6  0x0000000001a7320f in CVideoPlayer::OnExit (this=0x6cfd670) at /home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/VideoPlayer.cpp:2529
#7  0x0000000001d49f5e in CThread::Action (this=0x6cfd6c0) at /home/lukas/Documents/git/xbmc/xbmc/threads/Thread.cpp:211
#8  0x0000000001d49be8 in CThread::staticThread (data=0x6cfd6c0) at /home/lukas/Documents/git/xbmc/xbmc/threads/Thread.cpp:116
#9  0x00007ffff7bbe594 in start_thread () from /lib64/libpthread.so.0
#10 0x00007ffff0f96ecf in clone () from /lib64/libc.so.6
```

