### PR TITLE
Allow InternetStreams on LAN to search for .nfo and image files for videos

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -741,7 +741,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
 {
   if (m_strPath.empty()
    || IsPath("add")
-   || IsInternetStream()
+   || (IsInternetStream() && !URIUtils::IsOnLAN(GetDynPath()))
    || IsParentFolder()
    || IsVirtualDirectoryRoot()
    || IsPlugin()

--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
@@ -23,7 +23,7 @@ IVideoInfoTagLoader* CVideoInfoTagLoaderFactory::CreateLoader(const CFileItem& i
                                                               bool forceRefresh)
 {
   // don't try to read tags for streams
-  if (item.IsInternetStream())
+  if (item.IsInternetStream() && !URIUtils::IsOnLAN(item.GetDynPath()))
     return nullptr;
 
   if (item.IsPlugin() && info && info->ID() == "metadata.local")


### PR DESCRIPTION
## Description
Allow Internet Streams on LAN to search for .nfo and image files for videos

Allow Internet Streams on LAN to search for .nfo and image files for videos
## Motivation and Context
Allow Internet Streams on LAN to search for .nfo and image files. There does not seem to be a reason to avoid this functionality. I'm sure I cannot be alone in using http to serve videos on my LAN as it is ubiquitous and fast, and clients do not need write access. For home, or any other videos which are not on scraper sites, no allow .nfo and thumb/poster images is a hindrance.

Originally pull request #15022. Asked to squash commits. Followed a howto which broke my repo, didn't have time to fix (for 2  0.5 lines of code) so re-forked and re-pulled.

N/A

## How Has This Been Tested?
Have ran against my library at home which has some .nfo and images for videos which work with smb, but not http until this fix.

Kodi on linux (Arch)
Video, .nfo and images served via http on a Synology NAS.
Added Movie and TV Show "Web server directory (HTTP)" sources

It doesn't appear to.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
