### PR TITLE
[settings] Parser for oldsettings - Fix label settings starting with integers

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1319,20 +1319,21 @@ bool CAddonSettings::ParseOldLabel(const TiXmlElement* element, const std::strin
   labelId = -1;
   if (element == nullptr)
     return false;
+  
+  // label value as a string
+  std::string labelString;
+  element->QueryStringAttribute("label", &labelString);
 
-  // try to parse the label as a translation number
-  if (element->QueryIntAttribute("label", &labelId) == TIXML_SUCCESS && labelId >= 0)
+
+  // try to parse the label as a pure number, i.e. a localized string
+  char *endptr;
+  labelId = std::strtol(labelString.c_str(), &endptr, 10);
+  if (endptr == nullptr || *endptr == '\0')
     return true;
 
-  std::string labelString;
 
-  // try to parse the label as a string
-  const auto labelStringPtr = element->Attribute("label");
-  if (labelStringPtr != nullptr)
-    labelString = labelStringPtr;
-
-  bool parsed = !labelString.empty();
   // as a last resort use the setting's identifier as a label
+  bool parsed = !labelString.empty();
   if (!parsed)
     labelString = settingId;
 


### PR DESCRIPTION
## Description
This fixes a regression on addon settings (old parser) in which the label starts with an integer value. At the moment Kodi tries to parse the label as a localized string.
Closes https://github.com/xbmc/xbmc/issues/15064 

## Motivation and Context
`QueryIntAttribute` grabs the integer values at the start of the label and ignores the fact the label may have a few more characters after the int.

Not sure if a more elegant solution is possible - I currently just compare the grabbed int as a string with the whole value as string and only return if they are the same.

## How Has This Been Tested?
Using:
```
<setting id="testerror" type="bool" label="12MyLabel" default="true" /> -> 12MyLabel
<setting id="testonlynumber" type="bool" label="12" default="true" /> -> Temperature
<setting id="testonlystring" type="bool" label="MyLabel" default="true" /> -> MyLabel
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
