### PR TITLE
[Android] pass AV_NOPTS_VALUE for OMX video decoders

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -171,6 +171,7 @@ protected:
 
   uint32_t m_OutputDuration, m_fpsDuration;
   int64_t m_lastPTS;
+  int64_t m_invalidPTSValue = 0;
   double m_dtsShift;
 
   static std::atomic<bool> m_InstanceGuard;


### PR DESCRIPTION
## Description
We have to distinguish between mediacodec decoders when passing invalid (unknown) PTS values.
AMLogic expects 0, OMX expects AV_NOPTS_VALUE. Passing the correct PTS value leads to smooth playback for streams which have discontinous PTS values 

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=338106&pid=2800264#pid2800264

## How Has This Been Tested?
Playback of sample stream linked in forum post (see prev. section) 

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)