### PR TITLE
[macos] Remove storage mount/unmount popups

### DIFF
--- a/xbmc/platform/darwin/osx/storage/DarwinStorageProvider.cpp
+++ b/xbmc/platform/darwin/osx/storage/DarwinStorageProvider.cpp
@@ -340,23 +340,17 @@ bool CDarwinStorageProvider::Eject(const std::string& mountpath)
 
 bool CDarwinStorageProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 {
-  bool changed = !m_mountsToNotify.empty() || !m_unmountsToNotify.empty();
-
-  if (callback)
+  // Note: If we find a way to only notify kodi user initiated mounts/unmounts we
+  //       could do this here, but currently we can't distinguish this and popups
+  //       for system initiated mounts/unmounts (like done by Time Machine automatic
+  //       backups) are very confusing and annoying.
+  bool bChanged = !m_mountsToNotify.empty() || !m_unmountsToNotify.empty();
+  if (bChanged)
   {
-    for (const auto& mountToNotify : m_mountsToNotify)
-    {
-      callback->OnStorageAdded(mountToNotify.first, mountToNotify.second);
-    }
     m_mountsToNotify.clear();
-
-    for (const auto& unmountToNotify : m_unmountsToNotify)
-    {
-      callback->OnStorageSafelyRemoved(unmountToNotify.first);
-    }
     m_unmountsToNotify.clear();
   }
-  return changed;
+  return bChanged;
 }
 
 void CDarwinStorageProvider::VolumeMountNotification(const char* label, const char* mountpoint)

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -685,21 +685,6 @@ std::vector<std::string> CMediaManager::GetDiskUsage()
   return m_platformStorage->GetDiskUsage();
 }
 
-namespace
-{
-void ShowGUINotification(CGUIDialogKaiToast::eMessageType eType, const std::string& caption, const std::string& message)
-{
-  int activeWindow = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
-  if (activeWindow != WINDOW_FULLSCREEN_VIDEO &&
-      activeWindow != WINDOW_FULLSCREEN_GAME &&
-      activeWindow != WINDOW_VISUALISATION &&
-      activeWindow != WINDOW_SLIDESHOW)
-  {
-    CGUIDialogKaiToast::QueueNotification(eType, caption, message, TOAST_DISPLAY_TIME, false);
-  }
-}
-} // unnamed namespace
-
 void CMediaManager::OnStorageAdded(const std::string &label, const std::string &path)
 {
 #ifdef HAS_DVD_DRIVE
@@ -710,18 +695,18 @@ void CMediaManager::OnStorageAdded(const std::string &label, const std::string &
     else
       CJobManager::GetInstance().AddJob(new CAutorunMediaJob(label, path), this, CJob::PRIORITY_HIGH);
   else
-    ShowGUINotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label);
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label, TOAST_DISPLAY_TIME, false);
 #endif
 }
 
 void CMediaManager::OnStorageSafelyRemoved(const std::string &label)
 {
-  ShowGUINotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), label);
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), label, TOAST_DISPLAY_TIME, false);
 }
 
 void CMediaManager::OnStorageUnsafelyRemoved(const std::string &label)
 {
-  ShowGUINotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), label);
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), label);
 }
 
 CMediaManager::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)


### PR DESCRIPTION
Remove storage device mount/unmount popups as we cannot distinguish between Kodi user and System initiated mounts/unmounts and popups for System initiated mounts/unmounts are very confusing and annoying.

Reported in the forum: https://forum.kodi.tv/showthread.php?tid=337463&pid=2800834#pid2800834

@Memphiz mind doing a quick review?