### PR TITLE
Inhibit screensaver in a later initialization stage

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -652,7 +652,6 @@ bool CApplication::CreateGUI()
     // If OS has no screen saver, use Kodi one by default
     screensaverModeSetting->SetDefault("screensaver.xbmc.builtin.dim");
   }
-  CheckOSScreenSaverInhibitionSetting();
 
   if (sav_res)
     CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP, true);
@@ -862,6 +861,7 @@ bool CApplication::Initialize()
 
   CLog::Log(LOGNOTICE, "initialize done");
 
+  CheckOSScreenSaverInhibitionSetting();
   // reset our screensaver (starts timers etc.)
   ResetScreenSaver();
 


### PR DESCRIPTION
When the OS screensaver is already inhibited in InitializeGUI, e.g. the
language is not loaded yet, which has led to problems on GNOME because
the screensaver inhibition requires a translated "reason" string.

Moving the inhibition to a later stage solves this.