### PR TITLE
Add missing dirty region update in GUIFadeLabelControl

### DIFF
--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -87,12 +87,14 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &d
       m_scrollInfo.Reset();
       m_fadeAnim.ResetAnimation();
     }
+    MarkDirtyRegion();
   }
   if (m_currentLabel != m_lastLabel)
   { // new label - reset scrolling
     m_scrollInfo.Reset();
     m_fadeAnim.QueueAnimation(ANIM_PROCESS_REVERSE);
     m_lastLabel = m_currentLabel;
+    MarkDirtyRegion();
   }
 
   if (m_infoLabels.size() > 1 || !m_shortText)


### PR DESCRIPTION
When the label text is updated but there is only one text and it is so
short that it does not scroll, `MarkDirtyRegion()` is never called.
The old text will then stay there and not get updated.

Fixes #14583
