### PR TITLE
Fix aborts with -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_DEBUG

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -352,6 +352,11 @@ void CGUIFontTTFBase::End()
 
 void CGUIFontTTFBase::DrawTextInternal(float x, float y, const std::vector<UTILS::Color> &colors, const vecText &text, uint32_t alignment, float maxPixelWidth, bool scrolling)
 {
+  if (text.empty())
+  {
+    return;
+  }
+
   Begin();
 
   uint32_t rawAlignment = alignment;

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -23,6 +23,8 @@
 #endif
 #include "rendering/MatrixGL.h"
 
+#include <cassert>
+
 // stuff for freetype
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -280,6 +282,9 @@ void CGUIFontTTFGL::LastEnd()
 
 CVertexBuffer CGUIFontTTFGL::CreateVertexBuffer(const std::vector<SVertex> &vertices) const
 {
+  assert(!vertices.empty());
+  assert(vertices.size() % 4 == 0);
+
   // Generate a unique buffer object name and put it in bufferHandle
   GLuint bufferHandle;
   glGenBuffers(1, &bufferHandle);
@@ -288,7 +293,7 @@ CVertexBuffer CGUIFontTTFGL::CreateVertexBuffer(const std::vector<SVertex> &vert
   // Create a data store for the buffer object bound to the GL_ARRAY_BUFFER
   // binding point (i.e. our buffer object) and initialise it from the
   // specified client-side pointer
-  glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof (SVertex), &vertices[0], GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof (SVertex), vertices.data(), GL_STATIC_DRAW);
   // Unbind GL_ARRAY_BUFFER
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 


### PR DESCRIPTION
Fedora now seems to build with `-D_GLIBCXX_ASSERTIONS` on by default, leading to a (justified) abort when calling `DrawText` with an empty text value.

Another unrelated Wayland problem found with `-D_GLIBCXX_DEBUG` is also fixed here.

Should fix #15101