### PR TITLE
[osx/WinEventsSDL] - ensure to enable gui rendering once the app gets focus

### DIFF
--- a/xbmc/windowing/osx/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/WinEventsSDL.cpp
@@ -50,6 +50,9 @@ bool CWinEventsSDL::MessagePump()
         else if (event.active.state & SDL_APPINPUTFOCUS)
         {
           g_application.m_AppFocused = event.active.gain != 0;
+          std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+          if (appPort)
+            appPort->SetRenderGUI(event.active.gain != 0);
           CServiceBroker::GetWinSystem()->NotifyAppFocusChange(g_application.m_AppFocused);
         }
         break;


### PR DESCRIPTION
SDL doesn't fire the proper SDL_APPACTIVE event once Kodi is unminimized again so we need to use the focus event instead.

This fixes ticket https://github.com/xbmc/xbmc/issues/14773

Issue was as follows:
1. On Kodi minimize we disable Gui rendering
2. On unminimize nobody re-enabled Gui rendering leaving Kodi in an unusable state.