### PR TITLE
 Do not crash when not getting GL_EXTENSIONS

### DIFF
--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -48,21 +48,25 @@ bool CRenderSystemGL::InitRenderSystem()
   if (m_RenderVersionMajor > 3 ||
       (m_RenderVersionMajor == 3 && m_RenderVersionMinor >= 2))
   {
-    GLint n;
+    GLint n = 0;
     glGetIntegerv(GL_NUM_EXTENSIONS, &n);
     if (n > 0)
     {
       GLint i;
       for (i = 0; i < n; i++)
       {
-        m_RenderExtensions += (const char*)glGetStringi(GL_EXTENSIONS, i);
+        m_RenderExtensions += (const char*) glGetStringi(GL_EXTENSIONS, i);
         m_RenderExtensions += " ";
       }
     }
   }
   else
   {
-    m_RenderExtensions += (const char*) glGetString(GL_EXTENSIONS);
+    auto extensions = (const char*) glGetString(GL_EXTENSIONS);
+    if (extensions)
+    {
+      m_RenderExtensions += extensions;
+    }
   }
   m_RenderExtensions += " ";
 


### PR DESCRIPTION
All glGetString results except for the extensions are checked for NULL.
Also check those in hope of fixing
https://retrace.fedoraproject.org/faf/reports/2389135/