### PR TITLE
Remove first check for EDL from PVR

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -89,7 +89,6 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFrameRa
    */
   const std::string strMovie = fileItem.GetDynPath();
   if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
-      !fileItem.IsPVRRecording() &&
       !URIUtils::IsInternetStream(strMovie))
   {
     CLog::Log(LOGDEBUG, "%s - Checking for edit decision lists (EDL) on local drive or remote share for: %s",


### PR DESCRIPTION
## Description
The April update to the EDL system changed the method of testing for a PVR file from inspecting the path for the PVR tags to checking the source of the request (in the object tags).  This check breaks PVR backends that use a TSTREAM to a network share (these were just detected as a network call before).

Removing the initial check (when it's checking for local/network file being accessed) fixes this and the test in the else statement still allows PVR backends that use RTSP to function correctly.

## Motivation and Context
The April rewrite broke MediaPortal EDL functions.

## How Has This Been Tested?
Tested on several Windows 10 setups and the recorded shows from Mediaportal backend now show the shortened time. The log has the following lines showing that the EDL was loaded correctly.

13:27:41.808 T:1564   DEBUG: CEdl::ReadEditDecisionLists - Checking for edit decision lists (EDL) on local drive or remote share for: smb://xxxxx/Recordings/Stargate SG-1/Stargate SG-1-S9E16-Ethon-2018-12-19.ts
13:27:41.819 T:18920   DEBUG: CPlayerGUIInfo::InitCurrentItem(pvr://recordings/tv/active/Stargate SG-1/Stargate%20SG-1%20-%20Ethon s09e16%20Ethon, TV%20(COMET), 20181218_160000, 26.pvr)
13:27:41.820 T:1564   DEBUG: CEdl::AddCut - Pushing new cut to back [00:00:00.033 - 00:00:13.980], 3
13:27:41.821 T:1564   DEBUG: CEdl::AddCut - Pushing new cut to back [00:03:41.021 - 00:06:16.109], 3
13:27:41.821 T:1564   DEBUG: CEdl::AddCut - Pushing new cut to back [00:14:39.379 - 00:18:49.963], 3
13:27:41.821 T:1564   DEBUG: CEdl::AddCut - Pushing new cut to back [00:26:14.140 - 00:28:24.604], 3
13:27:41.821 T:1564   DEBUG: CEdl::AddCut - Pushing new cut to back [00:34:11.451 - 00:37:11.398], 3
13:27:41.822 T:1564   DEBUG: CEdl::ReadComskip - Read 5 commercial breaks from Comskip file: smb://xxxxx/Recordings/Stargate SG-1/Stargate SG-1-S9E16-Ethon-2018-12-19.txt
13:27:41.822 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:00:00.033
13:27:41.822 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:00:13.980
13:27:41.822 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:03:41.021
13:27:41.822 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:06:16.109
13:27:41.823 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:14:39.379
13:27:41.823 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:18:49.963
13:27:41.823 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:26:14.140
13:27:41.823 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:28:24.604
13:27:41.823 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:34:11.451
13:27:41.823 T:1564   DEBUG: CEdl::AddSceneMarker - Inserting new scene marker: 00:37:11.398

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
