### PR TITLE
Fix path for looking up external subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -813,7 +813,7 @@ bool CVideoPlayer::OpenInputStream()
   {
     // find any available external subtitles
     std::vector<std::string> filenames;
-    CUtil::ScanForExternalSubtitles(m_item.GetPath(), filenames);
+    CUtil::ScanForExternalSubtitles(m_item.GetDynPath(), filenames);
 
     // load any subtitles from file item
     std::string key("subtitle:1");


### PR DESCRIPTION
`GetPath()` may point to a videodb location where it is not possible to
find external files. Use `GetDynPath()` instead which always contains
an actual file path.

Fix suggested by @FernetMenta.

Fixes #14947.