### PR TITLE
When the player starts to play a file, the dialog busy is no more displ…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3788,9 +3788,13 @@ bool CApplication::OnMessage(CGUIMessage& message)
       // we don't want a busy dialog when switching channels
       if (!m_itemCurrentFile->IsLiveTV())
       {
-        CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
-        if (dialog && !dialog->IsDialogRunning())
-          dialog->WaitOnEvent(m_playerEvent);
+        // and we don't want a busy dialog if show_dialog_busy property is false
+        if (!m_itemCurrentFile->HasProperty("show_dialog_busy") || m_itemCurrentFile->GetProperty("show_dialog_busy").asBoolean())
+        {
+          CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
+          if (dialog && !dialog->IsDialogRunning())
+            dialog->WaitOnEvent(m_playerEvent);
+        }
       }
 
       return true;


### PR DESCRIPTION
…ayed if the listitem  to play has the property "show_dialog_busy" set to "false".

## Description
Add a new condition to display the dialog busy when the player starts to play an item.
If the item has the property "show_dialog_busy" set to "false", then dialog busy will NOT be displayed.
If the item has the property "show_dialog_busy" set to "true", then the dialog busy will be displayed.
If the item doesn't have the property "show_dialog_busy", then the dialog busy will be displayed (as before).

## Motivation and Context
In a script addon with a WindowXML (or WindowXMLDialog), when the player starts to play a file, it displays the dialog busy during several seconds. During this delay, the WindowXML (or WindowXMLDialog) can't receive user inputs (keyboard, ...).

## How Has This Been Tested?
Try to play an item without the property "show_dialog_busy" => dialog busy is displayed
Try to play an item with the property "show_dialog_busy" set to "true" play_item.setProperty("show_dialog_busy", "true") => dialog busy is displayed
Try to play an item with the property "show_dialog_busy" set to "false" play_item.setProperty("show_dialog_busy", "false") => dialog busy is NOT displayed


## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
