### PR TITLE
X11: make make on vblank in SwapBuffers an advanced setting

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -568,6 +568,12 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "omxdecodestartwithvalidframe", m_omxDecodeStartWithValidFrame);
   }
 
+  pElement = pRootElement->FirstChildElement("x11");
+  if (pElement)
+  {
+    XMLUtils::GetBoolean(pElement, "omlsync", m_omlSync);
+  }
+
   pElement = pRootElement->FirstChildElement("video");
   if (pElement)
   {

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -135,6 +135,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     bool  m_omxDecodeStartWithValidFrame;
 
+    bool  m_omlSync = false;
+
     float m_videoSubsDelayRange;
     float m_videoAudioDelayRange;
     bool m_videoUseTimeSeeking;

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -34,4 +34,7 @@ public:
   std::string m_extensions;
 
   Display *m_dpy;
+
+protected:
+  bool m_omlSync = false;
 };

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -424,6 +424,7 @@ void CGLContextEGL::SwapBuffers()
   if ((msc1 - m_sync.msc1) > 2)
   {
     m_sync.cont = 0;
+    CLog::Log(LOGDEBUG, "CGLContextEGL::SwapBuffers: sync reset");
   }
 
   // we want to block in SwapBuffers
@@ -439,22 +440,29 @@ void CGLContextEGL::SwapBuffers()
     {
       m_sync.interval = (ust1 - m_sync.ust1) / (msc1 - m_sync.msc1);
       m_sync.cont++;
+      CLog::Log(LOGDEBUG, "CGLContextEGL::SwapBuffers: sync interval: %ld", m_sync.interval);
     }
   }
-  else if ((m_sync.cont == 5) && (msc2 == msc1))
+  else if (m_sync.cont == 5)
   {
-    // if no vertical retrace has occurred in eglSwapBuffers,
-    // sleep until next vertical retrace
-    uint64_t lastIncrement = (now / 1000 - ust2);
-    if (lastIncrement > m_sync.interval)
+    CLog::Log(LOGDEBUG, "CGLContextEGL::SwapBuffers: sync check blocking");
+
+    if (msc2 == msc1)
     {
-      lastIncrement = m_sync.interval;
-      CLog::Log(LOGWARNING, "CGLContextEGL::SwapBuffers: last msc time greater than interval");
+      // if no vertical retrace has occurred in eglSwapBuffers,
+      // sleep until next vertical retrace
+      uint64_t lastIncrement = (now / 1000 - ust2);
+      if (lastIncrement > m_sync.interval)
+      {
+        lastIncrement = m_sync.interval;
+        CLog::Log(LOGWARNING, "CGLContextEGL::SwapBuffers: last msc time greater than interval");
+      }
+      uint64_t sleeptime = m_sync.interval - lastIncrement;
+      usleep(sleeptime);
+      m_sync.cont++;
+      msc2++;
+      CLog::Log(LOGDEBUG, "CGLContextEGL::SwapBuffers: sync sleep: %ld", sleeptime);
     }
-    uint64_t sleeptime = m_sync.interval - lastIncrement;
-    usleep(sleeptime);
-    m_sync.cont++;
-    msc2++;
   }
   else if ((m_sync.cont > 5) && (msc2 == m_sync.msc2))
   {

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -18,6 +18,9 @@
 #include "GLContextEGL.h"
 #include "utils/log.h"
 #include <EGL/eglext.h>
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 
 #define EGL_NO_CONFIG (EGLConfig)0
 
@@ -30,6 +33,12 @@ CGLContextEGL::CGLContextEGL(Display *dpy) : CGLContext(dpy)
   m_eglConfig = EGL_NO_CONFIG;
 
   eglGetPlatformDisplayEXT = (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+
+  CSettingsComponent *settings = CServiceBroker::GetSettingsComponent();
+  if (settings)
+  {
+    m_omlSync = settings->GetAdvancedSettings()->m_omlSync;
+  }
 }
 
 CGLContextEGL::~CGLContextEGL()
@@ -443,7 +452,7 @@ void CGLContextEGL::SwapBuffers()
       CLog::Log(LOGDEBUG, "CGLContextEGL::SwapBuffers: sync interval: %ld", m_sync.interval);
     }
   }
-  else if (m_sync.cont == 5)
+  else if (m_sync.cont == 5 && m_omlSync)
   {
     CLog::Log(LOGDEBUG, "CGLContextEGL::SwapBuffers: sync check blocking");
 


### PR DESCRIPTION
Waiting on vblank in SwapBuffers turned out to be an issue on older hardware. This change disables it by default and allows enable via advanced settings. 
Not blocking in SwapBuffers is not ideal because then we don't know on what gl operation the app  will block instead. But this is better than stuttering video.