### PR TITLE
Scroll GUIListLabel on focus only when enabled

### DIFF
--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -27,11 +27,6 @@ CGUIListLabel::CGUIListLabel(int parentID, int controlID, float posX, float posY
 
 CGUIListLabel::~CGUIListLabel(void) = default;
 
-void CGUIListLabel::SetScrolling(bool scrolling)
-{
-  m_label.SetScrolling(scrolling);
-}
-
 void CGUIListLabel::SetSelected(bool selected)
 {
   if(m_label.SetColor(selected ? CGUILabel::COLOR_SELECTED : CGUILabel::COLOR_TEXT))
@@ -41,7 +36,10 @@ void CGUIListLabel::SetSelected(bool selected)
 void CGUIListLabel::SetFocus(bool focus)
 {
   CGUIControl::SetFocus(focus);
-  SetScrolling(focus);
+  if (m_scroll == CGUIControl::FOCUS)
+  {
+    m_label.SetScrolling(focus);
+  }
 }
 
 CRect CGUIListLabel::CalcRenderRegion() const

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -40,7 +40,6 @@ public:
 
   void SetLabel(const std::string &label);
   void SetSelected(bool selected);
-  void SetScrolling(bool scrolling);
 
   static void CheckAndCorrectOverlap(CGUIListLabel &label1, CGUIListLabel &label2)
   {


### PR DESCRIPTION
Behavior changed as part of #12213, but the value of `m_scroll` (which
can be use to inhibit scrolling on focus or always enable it) was not
checked any more, which is clearly in error.

Supersedes #15117

@HitcherUK I think this more closely resembles the intended behavior (I hope). Can you check if it works as intended?
@peak3d Why did you remove the check?