### PR TITLE
[Docs] Add xrefitems for v19 (python and skinning engine)

### DIFF
--- a/docs/doxygen/Doxyfile.doxy
+++ b/docs/doxygen/Doxyfile.doxy
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Kodi Documentation"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 18.0
+PROJECT_NUMBER         = 19.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -257,13 +257,15 @@ ALIASES                = "table_start=<table width=\"100%\" style=\"border\" bgc
                          "python_v16=\xrefitem python_v16 \"v16 Python API changes\" \"\"" \
                          "python_v17=\xrefitem python_v17 \"v17 Python API changes\" \"\"" \
                          "python_v18=\xrefitem python_v18 \"v18 Python API changes\" \"\"" \
+                         "python_v19=\xrefitem python_v19 \"v19 Python API changes\" \"\"" \
                          "skinning_v12=\xrefitem skinning_v12 \"v12 Skinning engine changes\" \"\"" \
                          "skinning_v13=\xrefitem skinning_v13 \"v13 Skinning engine changes\" \"\"" \
                          "skinning_v14=\xrefitem skinning_v14 \"v14 Skinning engine changes\" \"\"" \
                          "skinning_v15=\xrefitem skinning_v15 \"v15 Skinning engine changes\" \"\"" \
                          "skinning_v16=\xrefitem skinning_v16 \"v16 Skinning engine changes\" \"\"" \
                          "skinning_v17=\xrefitem skinning_v17 \"v17 Skinning engine changes\" \"\"" \
-                         "skinning_v18=\xrefitem skinning_v18 \"v18 Skinning engine changes\" \"\""
+                         "skinning_v18=\xrefitem skinning_v18 \"v18 Skinning engine changes\" \"\"" \
+                         "skinning_v19=\xrefitem skinning_v19 \"v19 Skinning engine changes\" \"\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -147,6 +147,9 @@ web applications or frameworks for the Python programming language.
 */
 
 /*!
+@page python_v19 Python API v19
+*/
+/*!
 @page python_v18 Python API v18
 */
 /*!
@@ -192,6 +195,7 @@ web applications or frameworks for the Python programming language.
 @page python_revisions Python API Changes
 @brief Overview of changes on Python API for Kodi
 
+- @subpage python_v19
 - @subpage python_v18
 - @subpage python_v17
 - @subpage python_v16

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Skin/skin.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Skin/skin.dox
@@ -25,6 +25,9 @@ or two by adding a button, or altering the textures or layout.
 */
 
 /*!
+@page skinning_v19 Skinning engine v19
+*/
+/*!
 @page skinning_v18 Skinning engine v18
 */
 /*!
@@ -50,6 +53,7 @@ or two by adding a button, or altering the textures or layout.
 @page skinning_revisions Skinning engine changes
 @brief Overview of changes on Skinning engine for Kodi
 
+- @subpage skinning_v19
 - @subpage skinning_v18
 - @subpage skinning_v17
 - @subpage skinning_v16


### PR DESCRIPTION
## Description
This little change provides doxygen xrefitems for v19 so devs can annotate docs in the python API and skinning engine using `@python_v19` and `@skinning_v19` respectively.

## Motivation and Context
There are already some PR's targeting v19 that touch those areas so make sure we have doxygen tags merged once v19 is branched so we can request such annotations to be added when something is changed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
