### PR TITLE
Add missing zlib dependency to taglib

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -119,6 +119,7 @@ waylandpp: wayland $(WAYLANDPP_DEPS)
 dbus: expat
 libinput: mtdev libevdev
 libevdev: libudev
+taglib: $(ZLIB)
 
 .installed-$(PLATFORM): $(DEPENDS)
 	touch $@


### PR DESCRIPTION
zlib is an optional dependency of taglib (for reading compressed tags)
and it was missing, so it might have only worked by chance if at all.

(discovered during discussion of #15090 which came to the surface due to apparently missing zlib compression support on Windows)

@Rechi I think we should also enable zlib for taglib on the Windows side.