### PR TITLE
Fix unchecked reinterpret_cast of ID3v2 UFID frame

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -397,8 +397,8 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
       // Loop through any UFID frames and set them
       for (ID3v2::FrameList::ConstIterator ut = it->second.begin(); ut != it->second.end(); ++ut)
       {
-        auto ufid = reinterpret_cast<ID3v2::UniqueFileIdentifierFrame*> (*ut);
-        if (ufid->owner() == "http://musicbrainz.org")
+        auto ufid = dynamic_cast<ID3v2::UniqueFileIdentifierFrame*> (*ut);
+        if (ufid && ufid->owner() == "http://musicbrainz.org")
         {
           // MusicBrainz pads with a \0, but the spec requires binary, be cautious
           char cUfid[64];


### PR DESCRIPTION
Unlike all other ID3v2 frame types handled in TagLoaderTagLib, the UFID
tag is reinterpret_cast to the target type. However, tag loading might
fail (e.g. in case the tag is compressed and taglib is compiled without
zlib support), which makes the tag dynamic type an ID3v2::UnknownFrame,
so the successive access to the owner() function after the cast will
trigger a crash. Fix by using dynamic_cast like everywhere else.

Fixes #15090.

Thanks @DaveTBlake for the crash analysis