### PR TITLE
[keymaps] Specify that gamepad.xml is for EventServer "gamepads"

### DIFF
--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- This file contains the mapping of keys to actions within Kodi.                       -->
+<!-- This file contains the mapping of EventServer "gamepad" keys to actions within Kodi. -->
 <!--                                                                                      -->
 <!-- The format is:                                                                       -->
 <!--  <window>                                                                            -->


### PR DESCRIPTION
## Description
Having both a "joystick.xml" and "gamepad.xml", it is not clear which devices each XML file configures. I added a short description to gamepad.xml describing that it is only used for EventServer gamepads.

## Motivation and Context
Due to recent confusion mentioned on the forum: https://forum.kodi.tv/showthread.php?tid=338454

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
