### PR TITLE
fix CID 1441972

### DIFF
--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -8,9 +8,9 @@
 
 #include "CompileInfo.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
-#include <algorithm>
 
 
 int CCompileInfo::GetMajor()
@@ -60,13 +60,13 @@ const char* CCompileInfo::GetCopyrightYears()
   return "@APP_COPYRIGHT_YEARS@";
 }
 
-const char* CCompileInfo::GetBuildDate()
+std::string CCompileInfo::GetBuildDate()
 {
   const std::string bdate = "@APP_BUILD_DATE@";
   if (!bdate.empty())
   {
     std::string datestamp = bdate.substr(0, 4) + "-" + bdate.substr(4, 2) + "-" + bdate.substr(6, 2);
-    return datestamp.c_str();
+    return datestamp;
   }
   return "1970-01-01";
 }

--- a/xbmc/CompileInfo.h
+++ b/xbmc/CompileInfo.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string>
+
 class CCompileInfo
 {
 public:
@@ -19,5 +21,5 @@ public:
   static const char *GetSuffix();  // Git "Tag", e.g. alpha1
   static const char* GetSCMID();   // Git Revision
   static const char* GetCopyrightYears();
-  static const char* GetBuildDate();
+  static std::string GetBuildDate();
 };


### PR DESCRIPTION
return a string instead of a dangling pointer

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The only consumer of this function is std::string anyway, so there is no really good reason to stick to char*

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
```
*** CID 1441972:  Memory - illegal accesses  (WRAPPER_ESCAPE)
/build/build/xbmc/CompileInfo.cpp: 69 in CCompileInfo::GetBuildDate()()
63     const char* CCompileInfo::GetBuildDate()
64     {
65       const std::string bdate = "20181225";
66       if (!bdate.empty())
67       {
68         std::string datestamp = bdate.substr(0, 4) + "-" + bdate.substr(4, 2) + "-" + bdate.substr(6, 2);
>>>     CID 1441972:  Memory - illegal accesses  (WRAPPER_ESCAPE)
>>>     The internal representation of local "datestamp" escapes, but is destroyed when it exits scope.
69         return datestamp.c_str();
70       }
71       return "1970-01-01";
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
built on ubuntu

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

