### PR TITLE
X11: fix usage of required configuration values

### DIFF
--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -129,25 +129,18 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
     return false;
   }
 
-  if (!IsSuitableVisual(vInfo))
-  {
-    CLog::Log(LOGWARNING, "Visual 0x%x of the window is not suitable", (unsigned) vInfo->visualid);
-    XFree(vInfo);
-    Destroy();
-    return false;
-  }
-
-  CLog::Log(LOGNOTICE, "Using visual 0x%x", (unsigned) vInfo->visualid);
-
+  unsigned int visualid = static_cast<unsigned int>(vInfo->visualid);
   m_eglConfig = GetEGLConfig(m_eglDisplay, vInfo);
   XFree(vInfo);
 
   if (m_eglConfig == EGL_NO_CONFIG)
   {
-    CLog::Log(LOGERROR, "failed to get eglconfig for visual id");
+    CLog::Log(LOGERROR, "failed to get suitable eglconfig for visual 0x%x", visualid);
     Destroy();
     return false;
   }
+
+  CLog::Log(LOGNOTICE, "Using visual 0x%x", visualid);
 
   m_eglSurface = eglCreateWindowSurface(m_eglDisplay, m_eglConfig, glWindow, NULL);
   if (m_eglSurface == EGL_NO_SURFACE)
@@ -330,12 +323,6 @@ void CGLContextEGL::Detach()
     eglDestroySurface(m_eglDisplay, m_eglSurface);
     m_eglSurface = EGL_NO_SURFACE;
   }
-}
-
-bool CGLContextEGL::IsSuitableVisual(XVisualInfo *vInfo)
-{
-  EGLConfig config = GetEGLConfig(m_eglDisplay, vInfo);
-  return config != EGL_NO_CONFIG;
 }
 
 bool CGLContextEGL::SuitableCheck(EGLDisplay eglDisplay, EGLConfig config)

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -34,7 +34,6 @@ public:
   EGLContext m_eglContext;
   EGLConfig m_eglConfig;
 protected:
-  bool IsSuitableVisual(XVisualInfo *vInfo);
   bool SuitableCheck(EGLDisplay eglDisplay, EGLConfig config);
   EGLConfig GetEGLConfig(EGLDisplay eglDisplay, XVisualInfo *vInfo);
   PFNEGLGETSYNCVALUESCHROMIUMPROC eglGetSyncValuesCHROMIUM = nullptr;

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -35,6 +35,7 @@ public:
   EGLConfig m_eglConfig;
 protected:
   bool IsSuitableVisual(XVisualInfo *vInfo);
+  bool SuitableCheck(EGLDisplay eglDisplay, EGLConfig config);
   EGLConfig GetEGLConfig(EGLDisplay eglDisplay, XVisualInfo *vInfo);
   PFNEGLGETSYNCVALUESCHROMIUMPROC eglGetSyncValuesCHROMIUM = nullptr;
   PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT = nullptr;


### PR DESCRIPTION
## Description
Before has Kodi checked only the **EGL_NATIVE_VISUAL_ID** and ignored
others. With this was e.g. on some addons the needed **EGL_DEPTH_SIZE**
not available.

This separates a part of `IsSuitableVisual(...)` into a separate function
(`SuitableCheck(...)`) which is checked by `GetEGLConfig(...)` and takes the
necessary configuration from the list.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
Sit for a while because the addons which use GL to switch to the 4.0 version so that they work again and was almost senseless.

Thought all the time to have done something wrong in the rework and now found that the error lies in Kodi.

In addition, I found in the end that it was with the override `KODI_GL_INTERFACE=GLX ./Kodi-x11` went and finally found that the error lies in Kodi itself.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
