### PR TITLE
[Python] Add listitem.setSubtitlesEnabled(bool) function

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -836,6 +836,12 @@ namespace XBMCAddon
       }
     }
 
+    void ListItem::setSubtitlesEnabled(bool enable)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      item->SetProperty("enabledsubtitles", enable);
+    }
+
     xbmc::InfoTagVideo* ListItem::getVideoInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -1076,6 +1076,34 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setSubtitlesEnabled(bool) }
+      ///-----------------------------------------------------------------------
+      /// Set subtitles enabled/disabled.
+      ///
+      /// @param bool True/False - enable or disable the subtitles.
+      /// @note If a user changes the subtitle enable condition after the playback
+      /// has started, Kodi will store and reuse the setting the next time the item
+      /// is played.
+      ///
+      ///-----------------------------------------------------------------------
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// listitem.setSubtitlesEnabled(False)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///-----------------------------------------------------------------------
+      /// @python_v19 New function added.
+      ///
+      setSubtitlesEnabled(...);
+#else
+      void setSubtitlesEnabled(bool enable);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getdescription() }
       ///-----------------------------------------------------------------------
       /// @python_v17 Deprecated.


### PR DESCRIPTION
## Description
This PR adds a new function to the Python API: `listitem.setSubtitlesEnabled(bool)`. I opted for a property to avoid increasing the number of member variables already in `CFileItem`.

## Motivation and Context
Mainly https://github.com/xbmc/repo-plugins/pull/2203#discussion_r243897809. We often recommend plugin developers to avoid using the `xbmc.Player()` class since plugins are simple vfs listings. The player interface is more directed towards scripts, when you want to have full control over the player. In plugins, Kodi should handle the listitem once the url is confirmed resolved through `xbmcplugin.setResolvedUrl`. Right now there is no way to add subtitles to the item without this resulting on the automatic enabling (and display) of subtitles. Addon developers have to instantiate a player object, wait for playback to start and disable the subtitles via the player interface afterwards. Developers may want to add subtitle streams to a video stream but still have them disabled, delegating the option to the user.
Furthermore, currently even if you specifically disable subtitles in the Kodi core, they are always enabled due to the call to `SetSubtitleVisibleInternal`.

@FernetMenta can you please take a look at the changes since this touches videoplayer? Also, I'm not used to work with pointers so feedback on my approach in the `CVideoPlayer::OpenDefaultStreams(bool reset)` method is also appreciated (high probability of rubbish code :) ).

Requires https://github.com/xbmc/xbmc/pull/15133.

## How Has This Been Tested?

Via a plugin:
```python
@plugin.route('/play/<mode>')
def play_video(mode):
    liz = ListItem("My video")
    liz.setPath("/Users/enen/Desktop/samplevideos/Sintel_DivXPlus_6500kbps.mkv")
    liz.setSubtitles(
        [
            '/Users/enen/Desktop/samplevideos/Sintel_(2010).spa.srt',
            '/Users/enen/Desktop/samplevideos/Sintel_(2010).fre.srt'])
    liz.setSubtitlesEnabled(False)
    setResolvedUrl(plugin.handle, True, liz)
```

Also confirmed the behaviour is retained in my video library.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
