### PR TITLE
Fix *All Albums item removed by Coverity fix

### DIFF
--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -67,7 +67,6 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
     //  All album related nodes
   case NODE_TYPE_ALBUM:
     if (directoryNode->GetType() == NODE_TYPE_OVERVIEW) return;
-    break;
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
   case NODE_TYPE_ALBUM_RECENTLY_ADDED:
   case NODE_TYPE_ALBUM_COMPILATIONS:


### PR DESCRIPTION
In the Coverity fixes of  https://github.com/xbmc/xbmc/pull/14273 the addition of ***All Albums**  item was broken for child nodes of `NODE_TYPE_ALBUM` type

When navigating the music library such as Genres > _[specific genre]_ > *All Artists, this PR restores the *All Albums item  to the resulting list of albums, providing "Show All Items" setting is enabled.