### PR TITLE
Redact URL in CUtil::ExcludeFileOrFolder

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -557,7 +557,7 @@ bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::v
     }
     if (regExExcludes.RegFind(strFileOrFolder) > -1)
     {
-      CLog::Log(LOGDEBUG, "%s: File '%s' excluded. (Matches exclude rule RegExp:'%s')", __FUNCTION__, strFileOrFolder.c_str(), regexp.c_str());
+      CLog::LogF(LOGDEBUG, "File '{}' excluded. (Matches exclude rule RegExp: '{}')", CURL::GetRedacted(strFileOrFolder), regexp);
       return true;
     }
   }


### PR DESCRIPTION
All URLs in debug output should be redacted. Use newer fmt features
while we're at it.

Fixes #15160.