### PR TITLE
TexturePacker: Fix memory / resource leak the ugly way

### DIFF
--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -58,6 +58,7 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
       }
     }
     frames.user = gifImage;
+    frames.destroyFN = &gifDestroyFN;
     return true;
   }
   else
@@ -75,6 +76,10 @@ void GIFDecoder::FreeDecodedFrames(DecodedFrames &frames)
   }
   delete (GifHelper *)frames.user;
   frames.clear();
+}
+void GIFDecoder::gifDestroyFN(void* user)
+{
+  delete (GifHelper *)user;
 }
 
 void GIFDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
@@ -33,4 +33,6 @@ class GIFDecoder : public IDecoder
     const char* GetDecoderName() override { return "libgif"; }
   protected:
     void FillSupportedExtensions() override;
+  private:
+    static void gifDestroyFN(void* user);
 };

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -46,12 +46,21 @@ class DecodedFrame
 class DecodedFrames
 {
   public:
-    DecodedFrames(): user(NULL) {}
+    DecodedFrames(): user(NULL), destroyFN(nullptr) {}
     std::vector<DecodedFrame> frameList;
     void     *user;         /* used internally*/
+    void (*destroyFN)(void *);
 
     void clear()
     {
+      for (auto f : frameList)
+      {
+        delete[] f.rgbaImage.pixels;
+      }
+      if (destroyFN)
+      {
+        destroyFN(user);
+      }
       frameList.clear();
       user = NULL;
     }


### PR DESCRIPTION
Feels really ugly. But the given design made the DecoderManager unaware of the decoders and let it just manage the DecodedFrames. Therefore there is no relationship between this manager and its Decoders.