### PR TITLE
PVRClient: Do not overwrite arbitrary memory fixes #15157

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -497,7 +497,7 @@ bool CPVRClient::GetAddonProperties(void)
                 : 821; // "One time (guide-based)
           }
           std::string descr(g_localizeStrings.Get(id));
-          strncpy(types_array[i].strDescription, descr.c_str(), descr.size());
+          strncpy(types_array[i].strDescription, descr.c_str(), sizeof(types_array[i].strDescription) - 1);
         }
         timerTypes.emplace_back(CPVRTimerTypePtr(new CPVRTimerType(types_array[i], m_iClientId)));
       }


### PR DESCRIPTION
strncpy was not properly guarded. Max size in bytes is 64 bytes. Means: 63 chars + \0 speaking of c_str()

Fixes: #15157