### PR TITLE
Revert "FIX: [droid] translate to ascii for sorting"

### DIFF
--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -84,7 +84,6 @@ enum SpecialCharset
   SystemCharset,
   UserCharset /* locale.charset */,
   SubtitleCharset /* subtitles.charset */,
-  AsciiCharset
 };
 
 class CConverterType : public CCriticalSection
@@ -242,8 +241,6 @@ std::string CConverterType::ResolveSpecialCharset(enum SpecialCharset charset)
     return g_langInfo.GetGuiCharSet();
   case SubtitleCharset:
     return g_langInfo.GetSubtitleCharSet();
-  case AsciiCharset:
-    return "ASCII//TRANSLIT";
   case NotSpecialCharset:
   default:
     return "UTF-8"; /* dummy value */
@@ -269,8 +266,6 @@ enum StdConversionType /* Keep it in sync with CCharsetConverter::CInnerConverte
   Utf8ToSystem,
   SystemToUtf8,
   Ucs2CharsetToUtf8,
-  WtoAscii,
-  Utf8toAscii,
   NumberOfStdConversionTypes /* Dummy sentinel entry */
 };
 
@@ -314,9 +309,7 @@ CConverterType CCharsetConverter::CInnerConverter::m_stdConversion[NumberOfStdCo
   /* Utf8toW */             CConverterType(UTF8_SOURCE,     WCHAR_CHARSET),
   /* Utf8ToSystem */        CConverterType(UTF8_SOURCE,     SystemCharset),
   /* SystemToUtf8 */        CConverterType(SystemCharset,   UTF8_SOURCE),
-  /* Ucs2CharsetToUtf8 */   CConverterType("UCS-2LE",       "UTF-8", CCharsetConverter::m_Utf8CharMaxSize),
-  /* WtoAscii */            CConverterType(WCHAR_CHARSET,   AsciiCharset),
-  /* Utf8toAscii */         CConverterType(UTF8_SOURCE,     AsciiCharset),
+  /* Ucs2CharsetToUtf8 */   CConverterType("UCS-2LE",       "UTF-8", CCharsetConverter::m_Utf8CharMaxSize)
 };
 
 CCriticalSection CCharsetConverter::CInnerConverter::m_critSectionFriBiDi;
@@ -727,11 +720,6 @@ bool CCharsetConverter::utf8ToW(const std::string& utf8StringSrc, std::wstring& 
   return CInnerConverter::stdConvert(Utf8toW, utf8StringSrc, wStringDst, failOnBadChar);
 }
 
-bool CCharsetConverter::utf8ToASCII(const std::string& utf8StringSrc, std::string& asciiStringDst, bool failOnBadChar)
-{
-  return CInnerConverter::stdConvert(Utf8toAscii, utf8StringSrc, asciiStringDst, failOnBadChar);
-}
-
 bool CCharsetConverter::subtitleCharsetToUtf8(const std::string& stringSrc, std::string& utf8StringDst)
 {
   return CInnerConverter::stdConvert(SubtitleCharsetToUtf8, stringSrc, utf8StringDst, false);
@@ -812,11 +800,6 @@ bool CCharsetConverter::unknownToUTF8(const std::string& stringSrc, std::string&
 bool CCharsetConverter::wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar /*= false*/)
 {
   return CInnerConverter::stdConvert(WtoUtf8, wStringSrc, utf8StringDst, failOnBadChar);
-}
-
-bool CCharsetConverter::wToASCII(const std::wstring& wStringSrc, std::string& asciiStringDst, bool failOnBadChar)
-{
-  return CInnerConverter::stdConvert(WtoAscii, wStringSrc, asciiStringDst, failOnBadChar);
 }
 
 bool CCharsetConverter::utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst)

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -114,7 +114,6 @@ public:
   static bool utf8ToW(const std::string& utf8StringSrc, std::wstring& wStringDst,
                 bool bVisualBiDiFlip = true, bool forceLTRReadingOrder = false,
                 bool failOnBadChar = false);
-  static bool utf8ToASCII(const std::string& utf8StringSrc, std::string& asciiStringDst, bool failOnBadChar = false);
 
   static bool utf16LEtoW(const std::u16string& utf16String, std::wstring& wString);
 
@@ -133,7 +132,6 @@ public:
   static bool ToUtf8(const std::string& strSourceCharset, const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
 
   static bool wToUTF8(const std::wstring& wStringSrc, std::string& utf8StringDst, bool failOnBadChar = false);
-  static bool wToASCII(const std::wstring& wStringSrc, std::string& asciiStringDst, bool failOnBadChar = false);
   static bool utf16BEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   static bool utf16LEtoUTF8(const std::u16string& utf16StringSrc, std::string& utf8StringDst);
   static bool ucs2ToUTF8(const std::u16string& ucs2StringSrc, std::string& utf8StringDst);

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -13,7 +13,6 @@
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-#include "utils/log.h"
 
 #include <algorithm>
 
@@ -720,18 +719,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
         }
 
         std::wstring sortLabel;
-#ifdef TARGET_ANDROID
-        // Android does not support locale; Translate to ASCII
-        std::string dest;
-        g_charsetConverter.utf8ToASCII(preparator(attributes, *item), dest);
-        for (char c : dest)
-        {
-          if (::isalnum(c) || c == ' ')
-            sortLabel.push_back(c);
-        }
-#else
         g_charsetConverter.utf8ToW(preparator(attributes, *item), sortLabel, false);
-#endif
         item->insert(std::pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
       }
 
@@ -770,18 +758,7 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
         }
 
         std::wstring sortLabel;
-#ifdef TARGET_ANDROID
-        // Android does not support locale; Translate to ASCII
-        std::string dest;
-        g_charsetConverter.utf8ToASCII(preparator(attributes, **item), dest);
-        for (char c : dest)
-        {
-          if (::isalnum(c) || c == ' ')
-            sortLabel.push_back(c);
-        }
-#else
         g_charsetConverter.utf8ToW(preparator(attributes, **item), sortLabel, false);
-#endif
         (*item)->insert(std::pair<Field, CVariant>(FieldSort, CVariant(sortLabel)));
       }
 


### PR DESCRIPTION
This reverts commit 2d42c92c878f31df9396c1dcb7f35f2b4721de47.

The chosen approach is completely broken for all non-Latin languages,
so it cannot be shipped as part of v18.
A proper solution with location-aware sorting has to be implemented
in the future.

Fixes #15026, #14952.
