### PR TITLE
[guiinfo] Fix Player.Duration / Musicplayer.Duration time format para…

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -250,7 +250,10 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         int iDuration = tag->GetDuration();
         if (iDuration > 0)
         {
-          value = StringUtils::SecondsToTimeString(iDuration, static_cast<TIME_FORMAT>(info.GetData4()));
+          value = StringUtils::SecondsToTimeString(iDuration,
+                                                   static_cast<TIME_FORMAT>(info.m_info == LISTITEM_DURATION
+                                                                            ? info.GetData4()
+                                                                            : info.GetData1()));
           return true;
         }
         break;


### PR DESCRIPTION
Fix Player.Duration / Musicplayer.Duration time format parameter handling. Fixes #15181.

... listitems have the format info in param 4, player and musicplayer in param 1. ;-)

@ronie good to go?