### PR TITLE
Coverity fix to remove switch implicit fall through

### DIFF
--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -55,18 +55,23 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   if (items.GetObjectCount() <= 1)
     return;
 
-  switch (directoryNode->GetChildType())
+  auto nodeChildType = directoryNode->GetChildType();
+
+  // No need for "all" when overview node and child node albums or artists
+  if (directoryNode->GetType() == NODE_TYPE_OVERVIEW &&
+     (nodeChildType == NODE_TYPE_ARTIST || nodeChildType == NODE_TYPE_ALBUM))
+    return;
+
+  switch (nodeChildType)
   {
   case NODE_TYPE_ARTIST:
-    if (directoryNode->GetType() == NODE_TYPE_OVERVIEW) return;
     pItem.reset(new CFileItem(g_localizeStrings.Get(15103)));  // "All Artists"
     musicUrl.AppendPath("-1/");
     pItem->SetPath(musicUrl.ToString());
     break;
 
-    //  All album related nodes
+  //  All album related nodes
   case NODE_TYPE_ALBUM:
-    if (directoryNode->GetType() == NODE_TYPE_OVERVIEW) return;
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
   case NODE_TYPE_ALBUM_RECENTLY_ADDED:
   case NODE_TYPE_ALBUM_COMPILATIONS:


### PR DESCRIPTION
Follow up to https://github.com/xbmc/xbmc/pull/15155  - remove  implicit fall through from switch that Coverity doesn't like.

As promised @garbear @davilla @fritsch 