### PR TITLE
[osx/WinEventsSDL] - don't disable gui rendering when losing focus

### DIFF
--- a/xbmc/windowing/osx/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/WinEventsSDL.cpp
@@ -51,8 +51,8 @@ bool CWinEventsSDL::MessagePump()
         {
           g_application.m_AppFocused = event.active.gain != 0;
           std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
-          if (appPort)
-            appPort->SetRenderGUI(event.active.gain != 0);
+          if (appPort && g_application.m_AppFocused)
+            appPort->SetRenderGUI(g_application.m_AppFocused);
           CServiceBroker::GetWinSystem()->NotifyAppFocusChange(g_application.m_AppFocused);
         }
         break;


### PR DESCRIPTION
this fixes regression inroduced in #15105 pointed out by our testing user base.

mea culpa

@MartijnKaijser no idea who I should mark for review here now. But I ensured that the original bug is still fixed and the regression too :)