### PR TITLE
[PluginDirectory] - ensure that Abort of ScriptObserver waits for thread exit - fix crash&burn

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -59,7 +59,8 @@ void CPluginDirectory::CScriptObserver::Process()
 
 void CPluginDirectory::CScriptObserver::Abort()
 {
-  m_bStop = true;
+  // will wait until thread exits
+  StopThread();
 }
 
 CPluginDirectory::CPluginDirectory()


### PR DESCRIPTION
This prevents bad access of already destroyed event object during a race condition.

Once of the Mac OS users was hit by that crash in a really reproducible manner. He also confirmed the fix.
Thx to @FernetMenta for the finding of the root cause.

This crash hits all platforms and might have happened whenever a plugin listing is opened or a movie is played via the plugin:// uri scheme 