### PR TITLE
[PVR] guiinfo times: reset timeshift offset and timeshift play time after channel change. fixes #15175

### DIFF
--- a/xbmc/pvr/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/PVRGUITimesInfo.cpp
@@ -43,6 +43,7 @@ void CPVRGUITimesInfo::Reset()
   m_iTimeshiftProgressDuration = 0;
 
   m_playingEpgTag.reset();
+  m_playingChannel.reset();
 }
 
 void CPVRGUITimesInfo::UpdatePlayingTag()
@@ -52,7 +53,7 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
 
   if (currentChannel || currentTag)
   {
-    if (!currentTag)
+    if (currentChannel && !currentTag)
       currentTag = currentChannel->GetEPGNow();
 
     CSingleLock lock(m_critSection);
@@ -104,8 +105,17 @@ void CPVRGUITimesInfo::UpdateTimeshiftData()
   int64_t iPlayTime, iMinTime, iMaxTime;
   CServiceBroker::GetDataCacheCore().GetPlayTimes(iStartTime, iPlayTime, iMinTime, iMaxTime);
   bool bPlaying = CServiceBroker::GetDataCacheCore().GetSpeed() == 1.0;
+  const CPVRChannelPtr playingChannel = CServiceBroker::GetPVRManager().GetPlayingChannel();
 
   CSingleLock lock(m_critSection);
+
+  if (playingChannel != m_playingChannel)
+  {
+    // playing channel changed. we need to reset offset and playtime.
+    m_iTimeshiftOffset = 0;
+    m_iTimeshiftPlayTime = 0;
+    m_playingChannel = playingChannel;
+  }
 
   if (!iStartTime)
   {

--- a/xbmc/pvr/PVRGUITimesInfo.h
+++ b/xbmc/pvr/PVRGUITimesInfo.h
@@ -67,6 +67,7 @@ namespace PVR
     mutable CCriticalSection m_critSection;
 
     CPVREpgInfoTagPtr m_playingEpgTag;
+    CPVRChannelPtr m_playingChannel;
 
     time_t m_iStartTime;
     unsigned int m_iDuration;


### PR DESCRIPTION
Fixes #15175 

@Jalle19 good to go?