### PR TITLE
[docs] Minor fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -71,7 +71,7 @@ Used Operating system:
  - [ ] iOS
  - [ ] Linux
  - [ ] OSX
- - [ ] Raspberri-Pi
+ - [ ] Raspberry-Pi
  - [ ] Windows
  - [ ] Windows UWP
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -71,7 +71,7 @@ Used Operating system:
  - [ ] iOS
  - [ ] Linux
  - [ ] OSX
- - [ ] Raspberri-Pi
+ - [ ] Raspberry-Pi
  - [ ] Windows
  - [ ] Windows UWP
 

--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.h
@@ -325,15 +325,16 @@ namespace XBMCAddon
     /// @param content     string - content type (eg. movies)
     ///
     /// @par Available content strings
-    /// |          |          |          |          |
-    /// |:--------:|:--------:|:--------:|:--------:|
-    /// |  files   |  songs   | artists  | albums
-    /// | movies   | tvshows  | episodes | musicvideos
-    /// | videos   | images   |  games   |
+    /// |          |          |          |             |
+    /// |:--------:|:--------:|:--------:|:-----------:|
+    /// |  files   |  songs   | artists  | albums      |
+    /// | movies   | tvshows  | episodes | musicvideos |
+    /// | videos   | images   |  games   |     --      |
     ///
     /// @remark Use **videos** for all videos which do not apply to the
     /// more specific mentioned ones like "movies", "episodes" etc.
     /// A good example is youtube.
+    ///
     ///
     /// ------------------------------------------------------------------------
     /// @python_v18 Added new **games** content


### PR DESCRIPTION
## Description
Trivial fixes to docs:
- Typo in "Raspberry PI" for the issue template/bug report
- Layout is broken for `xbmcplugin.setContent`