### PR TITLE
Improve detection of audio CDs using an infobool

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -793,7 +793,7 @@
 						<param name="button2_onclick" value="EjectTray()"/>
 						<param name="button3_label" value="$LOCALIZE[600]"/>
 						<param name="button3_onclick" value="RipCD"/>
-						<param name="visible_3" value="String.IsEqual(System.DVDLabel,Audio-CD)"/>
+						<param name="visible_3" value="System.HasMediaAudioCD"/>
 					</include>
 				</control>
 			</control>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1000,6 +1000,14 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///     @return **True** if there is a CD or DVD in the DVD-ROM drive.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`System.HasMediaAudioCD`</b>,
+///                  \anchor System_HasMediaAudioCD
+///                  _boolean_,
+///     @return **True** if there is an audio CD in the optical drive. **False** if no drive available\, empty drive or other medium.
+///   <p><hr>
+///   @skinning_v18 **[New Boolean Condition]** \link System_HasMediaAudioCD `System.HasMediaAudioCD` \endlink
+///   <p>
+///   }
 ///   \table_row3{   <b>`System.DVDReady`</b>,
 ///                  \anchor System_DVDReady
 ///                  _boolean_,
@@ -1581,6 +1589,7 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///   }
 const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACTIVE },
                                   { "hasmediadvd",      SYSTEM_MEDIA_DVD },
+                                  { "hasmediaaudiocd",  SYSTEM_MEDIA_AUDIO_CD },
                                   { "dvdready",         SYSTEM_DVDREADY },
                                   { "trayopen",         SYSTEM_TRAYOPEN },
                                   { "haslocks",         SYSTEM_HASLOCKS },

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -422,6 +422,7 @@
 #define SYSTEM_CAN_SUSPEND          751
 #define SYSTEM_CAN_HIBERNATE        752
 #define SYSTEM_CAN_REBOOT           753
+#define SYSTEM_MEDIA_AUDIO_CD       754
 
 #define SLIDESHOW_ISPAUSED          800
 #define SLIDESHOW_ISRANDOM          801

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -488,6 +488,19 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case SYSTEM_MEDIA_DVD:
       value = g_mediaManager.IsDiscInDrive();
       return true;
+    case SYSTEM_MEDIA_AUDIO_CD:
+    #ifdef HAS_DVD_DRIVE
+      if (g_mediaManager.IsDiscInDrive())
+      {
+        MEDIA_DETECT::CCdInfo *pCdInfo = g_mediaManager.GetCdInfo();
+        value = pCdInfo && (pCdInfo->IsAudio(1) || pCdInfo->IsCDExtra(1) || pCdInfo->IsMixedMode(1));
+      }
+      else
+    #endif
+      {
+        value = false;
+      }
+      return true;
 #ifdef HAS_DVD_DRIVE
     case SYSTEM_DVDREADY:
       value = g_mediaManager.GetDriveStatus() != DRIVE_NOT_READY;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

This change makes it possible to detect an audio CD using an infobool and make the "Rip CD" option at Estuary depend on that rather on the CD label which could be everything for an audio cd. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

As users report we have different ways to display the audio cd label ("audio cd" or "audio-cd") and for the reason we shouldn't depend on the label at all, it was suggested that it might be way better to check if there is an audio cd at the drive and using infobools for implementations at Estuary. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

This has been tested on Ubuntu 16.04 with some audio CDs (self-burned and original ones) and some DVDs and BRs to make sure, that option wouldn't show up on them.

I'm not sure if we need to check for something else or if `IsAudio()` might be enough. So I'm open for suggestions or pointers ;)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
   Doxygen is already included. I'll take care about the wiki myself. 
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
