### PR TITLE
Android: Properly overwrite ProcessInfo and use Deinterlace Half

### DIFF
--- a/cmake/treedata/android/subdirs.txt
+++ b/cmake/treedata/android/subdirs.txt
@@ -15,3 +15,4 @@ xbmc/platform/android/network           platform/android/network
 xbmc/platform/android/peripherals       platform/android/peripherals
 xbmc/platform/android/powermanagement   platform/android/powermanagement
 xbmc/platform/android/storage           platform/android/storage
+xbmc/cores/VideoPlayer/Process/android/ cores/VideoPlayer/Process/android/

--- a/xbmc/cores/VideoPlayer/Process/android/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Process/android/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES ProcessInfoAndroid.cpp)
+
+set(HEADERS ProcessInfoAndroid.h)
+
+core_add_library(processAndroid)

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ProcessInfoAndroid.h"
+
+using namespace VIDEOPLAYER;
+
+CProcessInfo* CProcessInfoAndroid::Create()
+{
+  return new CProcessInfoAndroid();
+}
+
+CProcessInfoAndroid::CProcessInfoAndroid()
+{
+}
+
+void CProcessInfoAndroid::Register()
+{
+  CProcessInfo::RegisterProcessControl("android", CProcessInfoAndroid::Create);
+}
+
+EINTERLACEMETHOD CProcessInfoAndroid::GetFallbackDeintMethod()
+{
+  return EINTERLACEMETHOD::VS_INTERLACEMETHOD_DEINTERLACE_HALF;
+}

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/IPlayer.h"
+#include "cores/VideoPlayer/Process/ProcessInfo.h"
+
+namespace VIDEOPLAYER
+{
+  class CProcessInfoAndroid : public CProcessInfo
+  {
+  public:
+    CProcessInfoAndroid();
+    static CProcessInfo* Create();
+    static void Register();
+    EINTERLACEMETHOD GetFallbackDeintMethod() override;
+
+  //protected:
+  };
+}

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -29,6 +29,7 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h"
+#include "cores/VideoPlayer/Process/android/ProcessInfoAndroid.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h"
 #include "platform/android/powermanagement/AndroidPowerSyscall.h"
 #include "addons/interfaces/platform/android/System.h"
@@ -84,6 +85,7 @@ bool CWinSystemAndroid::InitWindowSystem()
   CRendererMediaCodecSurface::Register();
   ADDON::Interface_Android::Register();
   DRM::CMediaDrmCryptoSession::Register();
+  VIDEOPLAYER::CProcessInfoAndroid::Register();
   return CWinSystemBase::InitWindowSystem();
 }
 


### PR DESCRIPTION
YADIF Full is too much for most devices. Use a less CPU hungry default.

This is only used when SW Decoding is active, e.g. für DVD stills and so on.