### PR TITLE
[sqlite] Use extended result codes

### DIFF
--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -620,7 +620,14 @@ void SqliteDataset::make_query(StringList &_sql) {
   char* err=NULL;
   Dataset::parse_sql(query);
   if (db->setErr(sqlite3_exec(this->handle(),query.c_str(),NULL,NULL,&err),query.c_str())!=SQLITE_OK) {
-    throw DbErrors(db->getErrorMsg());
+    std::string message = db->getErrorMsg();
+    if (err) {
+      message.append(" (");
+      message.append(err);
+      message.append(")");
+      sqlite3_free(err);
+    }
+    throw DbErrors("%s", message.c_str());
   }
   } // end of for
 
@@ -748,7 +755,10 @@ int SqliteDataset::exec(const std::string &sql) {
     return res;
   else
     {
-      throw DbErrors(db->getErrorMsg());
+      if (errmsg)
+        throw DbErrors("%s (%s)", db->getErrorMsg(), errmsg);
+      else
+        throw DbErrors("%s", db->getErrorMsg());
     }
 }
 

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -271,6 +271,8 @@ int SqliteDatabase::setErr(int err_code, const char * qry) {
   } else {
     ss << "Undefined SQLite error " << err_code;
   }
+  if (conn)
+    ss << " (" << sqlite3_errmsg(conn) << ")";
   ss << "\nQuery: " << qry;
   error = ss.str();
   return err_code;

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -309,7 +309,7 @@ int SqliteDatabase::connect(bool create) {
       char* err=NULL;
       if (setErr(sqlite3_exec(getHandle(),"PRAGMA empty_result_callbacks=ON",NULL,NULL,&err),"PRAGMA empty_result_callbacks=ON") != SQLITE_OK)
       {
-        throw DbErrors(getErrorMsg());
+        throw DbErrors("%s", getErrorMsg());
       }
       else if (sqlite3_db_readonly(conn, nullptr) == 1)
       {
@@ -783,7 +783,7 @@ bool SqliteDataset::query(const std::string &query) {
 
   sqlite3_stmt *stmt = NULL;
   if (db->setErr(sqlite3_prepare_v2(handle(),query.c_str(),-1,&stmt, NULL),query.c_str()) != SQLITE_OK)
-    throw DbErrors(db->getErrorMsg());
+    throw DbErrors("%s", db->getErrorMsg());
 
   // column headers
   const unsigned int numColumns = sqlite3_column_count(stmt);
@@ -831,7 +831,7 @@ bool SqliteDataset::query(const std::string &query) {
   }
   else
   {
-    throw DbErrors(db->getErrorMsg());
+    throw DbErrors("%s", db->getErrorMsg());
   }
 }
 


### PR DESCRIPTION
Extended result codes can give more information about what kind of error
occurred during an SQLite operation, which is desirable for improved
logging and debugging.

Should help with investigation of #15230

@MartijnKaijser not sure what to do with this, it's not a must for v18 but I don't know whether we can get more details on the Xbox issue without this being in the released store version.
Potential risks are that SQLite may now return different result codes in general from what was expected before. I checked the whole file and didn't find a problem, but something might have slipped through.