### PR TITLE
FFmpeg: Bump to 4.0.3-Leia-RC5

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.0.3-Leia-Beta5
+VERSION=4.0.3-Leia-RC5
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz


### PR DESCRIPTION
This bumps ffmpeg version to our new rebased and released 4.0.3-Leia-RC5 version.