### PR TITLE
[osx] fix multi monitor when monitors have same name

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -423,6 +423,12 @@ NSString* screenNameForDisplay(CGDirectDisplayID displayID)
   {
     screenName = [[NSString alloc] initWithFormat:@"%i", displayID];
   }
+  else
+  {
+    // ensure screen name is unique by appending displayid
+    screenName = [[screenName stringByAppendingFormat:@" (%@)", [@(displayID) stringValue]] retain];
+  }
+
   return [screenName autorelease];
 }
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1346,9 +1346,6 @@ void CWinSystemOSX::FillInVideoModes()
 
   for (int disp = 0; disp < numDisplays; disp++)
   {
-    if (disp != dispIdx)
-      continue;
-
     Boolean stretched;
     Boolean interlaced;
     Boolean safeForHardware;
@@ -1391,27 +1388,32 @@ void CWinSystemOSX::FillInVideoModes()
         }
         CLog::Log(LOGNOTICE, "Found possible resolution for display %d with %d x %d @ %f Hz\n", disp, w, h, refreshrate);
 
-        if (dispName != nil)
+        // only add the resolution if it belongs to "our" screen
+        // all others are only logged above...
+        if (disp == dispIdx)
         {
-          res.strOutput = [dispName UTF8String];
+          if (dispName != nil)
+          {
+            res.strOutput = [dispName UTF8String];
+          }
+
+          UpdateDesktopResolution(res, w, h, refreshrate, 0);
+
+          // overwrite the mode str because  UpdateDesktopResolution adds a
+          // "Full Screen". Since the current resolution is there twice
+          // this would lead to 2 identical resolution entrys in the guisettings.xml.
+          // That would cause problems with saving screen overscan calibration
+          // because the wrong entry is picked on load.
+          // So we just use UpdateDesktopResolutions for the current DESKTOP_RESOLUTIONS
+          // in UpdateResolutions. And on all other resolutions make a unique
+          // mode str by doing it without appending "Full Screen".
+          // this is what linux does - though it feels that there shouldn't be
+          // the same resolution twice... - thats why i add a FIXME here.
+          res.strMode = StringUtils::Format("%dx%d @ %.2f", w, h, refreshrate);
+
+          CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
+          CDisplaySettings::GetInstance().AddResolutionInfo(res);
         }
-
-        UpdateDesktopResolution(res, w, h, refreshrate, 0);
-
-        // overwrite the mode str because  UpdateDesktopResolution adds a
-        // "Full Screen". Since the current resolution is there twice
-        // this would lead to 2 identical resolution entrys in the guisettings.xml.
-        // That would cause problems with saving screen overscan calibration
-        // because the wrong entry is picked on load.
-        // So we just use UpdateDesktopResolutions for the current DESKTOP_RESOLUTIONS
-        // in UpdateResolutions. And on all other resolutions make a unique
-        // mode str by doing it without appending "Full Screen".
-        // this is what linux does - though it feels that there shouldn't be
-        // the same resolution twice... - thats why i add a FIXME here.
-        res.strMode = StringUtils::Format("%dx%d @ %.2f", w, h, refreshrate);
-
-        CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
-        CDisplaySettings::GetInstance().AddResolutionInfo(res);
       }
     }
     CFRelease(displayModes);


### PR DESCRIPTION
WinSystemOSX finds screens by name. When having t identical monitors connected it can't distinguish between those and will always take the first with the name in the list.

This PR makes the names unique by appending the display id. It also ensures that all found displays and resolutions are logged (like we had It in Kodi 17) which was changed during some screen handle refactoring from f. iirc.

That second commit looks a bit messy - but its just an indentation change of code.