### PR TITLE
Add missing POP to return to the calling directory after error

### DIFF
--- a/tools/buildsteps/windows/download-dependencies.bat
+++ b/tools/buildsteps/windows/download-dependencies.bat
@@ -53,6 +53,12 @@ IF NOT EXIST %FORMED_OK_FLAG% (
   ECHO   C:\^> SET KODI_MIRROR=http://example.com/pub/xbmc/
   ECHO.
   ECHO Then, rerun this script.
+  
+  REM Restore the previous current directory
+  POPD
+
+  ENDLOCAL
+  
   EXIT /B 101
 )
 


### PR DESCRIPTION
While setting up my environment, `make-mingwlibs.bat` kept hanging, until I discovered issue #14664 where I saw this [reply](https://github.com/xbmc/xbmc/issues/14664#issuecomment-452486260). 
Essentially, after the `download-dependencies.bat` fails, it doesn't return to the calling directory (x64 in my case) and stays in the `windows` directory. 
If you run the `download-dependencies.bat` again, you'll run the one in the `windows` directory, rather than the one in the directory you were before. This change fixes that issue.
