### PR TITLE
Game add-ons: Fall back to system path if profile path is empty

### DIFF
--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -136,9 +136,17 @@ const char** CGameClientProperties::GetResourceDirectories(void)
       CDirectory::Create(addonProfile);
     }
 
-    char* addonProfileDir = new char[addonProfile.length() + 1];
-    std::strcpy(addonProfileDir, addonProfile.c_str());
-    m_resourceDirectories.push_back(addonProfileDir);
+    // Only add user profile directory if non-empty
+    CFileItemList items;
+    if (CDirectory::GetDirectory(addonProfile, items, "", DIR_FLAG_DEFAULTS))
+    {
+      if (!items.IsEmpty())
+      {
+        char* addonProfileDir = new char[addonProfile.length() + 1];
+        std::strcpy(addonProfileDir, addonProfile.c_str());
+        m_resourceDirectories.push_back(addonProfileDir);
+      }
+    }
 
     char* addonPathDir = new char[addonPath.length() + 1];
     std::strcpy(addonPathDir, addonPath.c_str());


### PR DESCRIPTION
Currently, libretro core assets, like BIOSes and game databases, must be in a `system` folder in the add-on's userdata profile. This PR checks if the userdata profile is empty, and falls back to the system add-on profile when looking for core assets.

## Motivation and Context
Inspiration: https://github.com/kodi-game/game.libretro.fsuae/pull/2

## How Has This Been Tested?
Tested in https://github.com/kodi-game/game.libretro.fsuae/pull/2. The following states successfully find the system asset:

* Game add-on installed via zip to userdata
* Game add-on preinstalled to system level

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
