### PR TITLE
(Win32) Check the system capabilities to support sleep states S1/S2/S3/S4 before reporing them as available

### DIFF
--- a/xbmc/platform/win32/powermanagement/Win32PowerSyscall.cpp
+++ b/xbmc/platform/win32/powermanagement/Win32PowerSyscall.cpp
@@ -110,6 +110,7 @@ bool CWin32PowerStateWorker::PowerManagement(PowerState State)
 
 CWin32PowerSyscall::CWin32PowerSyscall()
 {
+  m_hascapabilities = GetPwrCapabilities(&m_capabilities);
   m_worker.Create();
 }
 
@@ -142,10 +143,14 @@ bool CWin32PowerSyscall::CanPowerdown()
 }
 bool CWin32PowerSyscall::CanSuspend()
 {
+  if (m_hascapabilities)
+    return (m_capabilities.SystemS1 == TRUE || m_capabilities.SystemS2 == TRUE || m_capabilities.SystemS3 == TRUE);
   return true;
 }
 bool CWin32PowerSyscall::CanHibernate()
 {
+  if (m_hascapabilities)
+    return (m_capabilities.SystemS4 == TRUE && m_capabilities.HiberFilePresent == TRUE);
   return true;
 }
 bool CWin32PowerSyscall::CanReboot()

--- a/xbmc/platform/win32/powermanagement/Win32PowerSyscall.h
+++ b/xbmc/platform/win32/powermanagement/Win32PowerSyscall.h
@@ -58,6 +58,8 @@ public:
   static bool IsSuspending() { return m_OnSuspend; }
 
 private:
+  BOOLEAN m_hascapabilities;
+  SYSTEM_POWER_CAPABILITIES m_capabilities;
   CWin32PowerStateWorker m_worker;
 
   static bool m_OnResume;


### PR DESCRIPTION
## Description
This change verifies that sleep states S1/S2/S3/S4 are available on a Win32-based system before reporting them as such

## Motivation and Context
Kodi will always report the "Suspend" (S1/S2/S3) and "Hibernate" (S4) states as available selections even if the underlying OS support is not present or disabled

## How Has This Been Tested?
This change was tested on Windows 10 (1809) Professional, x64 architecture.  Prior to the change Kodi would always list "Suspend" and "Hibernate" as valid options, regardless of the OS support.  After the change Kodi will correctly omit these options.
While most, if not all, supported Win32 systems support S1/S2/S3, S4 can easily be disabled by the user with the command "POWERCFG /H OFF".  I verified that if Hibernation (S4) is enabled the option still shows up, and if Hibernation (S4) is disabled the option no longer shows up.
I verified this in both the main Kodi "power button" functionality as well as in Settings/System/Power Saving/Shutdown Function.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
