### PR TITLE
Deprecate MySQL < 5.6, MariaDB < 5.5

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -176,8 +176,22 @@ int MysqlDatabase::connect(bool create_new) {
       static bool showed_ver_info = false;
       if (!showed_ver_info)
       {
-        CLog::Log(LOGINFO, "MYSQL: Connected to version %s", mysql_get_server_info(conn));
+        std::string version_string = mysql_get_server_info(conn);
+        CLog::Log(LOGINFO, "MYSQL: Connected to version {}", version_string);
         showed_ver_info = true;
+        unsigned long version = mysql_get_server_version(conn);
+        // Minimum for MySQL: 5.6 (5.5 is EOL)
+        unsigned long min_version = 50600;
+        if (version_string.find("MariaDB") != std::string::npos)
+        {
+          // Minimum for MariaDB: 5.5 (still supported)
+          min_version = 50500;
+        }
+
+        if (version < min_version)
+        {
+          CLog::Log(LOGWARNING, "MYSQL: Your database server version {} is very old and might not be supported in future Kodi versions. Please consider upgrading to MySQL 5.7 or MariaDB 10.2.", version_string);
+        }
       }
 
       // disable mysql autocommit since we handle it

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -177,7 +177,7 @@ int MysqlDatabase::connect(bool create_new) {
       if (!showed_ver_info)
       {
         std::string version_string = mysql_get_server_info(conn);
-        CLog::Log(LOGINFO, "MYSQL: Connected to version {}", version_string);
+        CLog::Log(LOGNOTICE, "MYSQL: Connected to version {}", version_string);
         showed_ver_info = true;
         unsigned long version = mysql_get_server_version(conn);
         // Minimum for MySQL: 5.6 (5.5 is EOL)


### PR DESCRIPTION
We do not have the resources to maintain compatibility with all sorts of
ancient MySQL servers in the future (concerning both development
manpower and testing infrastructure). Therefore, deprecate very old
MySQL and MariaDB server versions so that we can remove support for them
when problems come up or we would have to go out of our way to keep them
happy.