### PR TITLE
[Android] Log kernel ThreadId instead pthread_self

### DIFF
--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -116,12 +116,20 @@ void CThread::SetThreadInfo()
 
 ThreadIdentifier CThread::GetCurrentThreadId()
 {
+#if defined(TARGET_ANDROID)
+  return gettid();
+#else
   return pthread_self();
+#endif
 }
 
 bool CThread::IsCurrentThread(const ThreadIdentifier tid)
 {
+#if defined(TARGET_ANDROID)
+  return gettid() == tid;
+#else
   return pthread_equal(pthread_self(), tid);
+#endif
 }
 
 int CThread::GetMinPriority(void)


### PR DESCRIPTION
## Description
Log kernel TID in log to make it compareable to android tools like top / systrace.

## Motivation and Context
Make debugging more transparent

## How Has This Been Tested?
AFTV4K, start kodi / read kodi.log

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)