### PR TITLE
[py-docs] fix version info for getDbId

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -63,7 +63,7 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
-      /// @python_v17 New function added.
+      /// @python_v18 New function added.
       ///
       getDbId();
 #else

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -704,10 +704,10 @@ namespace XBMCAddon
       /// @python_v15 **duration** has to be set in seconds.
       /// @python_v16 Added new label **mediatype**.
       /// @python_v17
-      /// Added labels **setid**, **set**, **imdbnumber**, **code**, **dbid**, **path** and **userrating**.
+      /// Added labels **setid**, **set**, **imdbnumber**, **code**, **dbid** (video), **path** and **userrating**.
       /// Expanded the possible infoLabels for the option **mediatype**.
       /// @python_v18 Added new **game** type and associated infolabels.
-      /// Added labels **setoverview**, **tag**, **sortepisode**, **sortseason**, **episodeguide**, **showlink**.
+      /// Added labels **dbid** (music), **setoverview**, **tag**, **sortepisode**, **sortseason**, **episodeguide**, **showlink**.
       /// Extended labels **genre**, **country**, **director**, **studio**, **writer**, **tag**, **credits** to also use a list of strings.
       ///
       /// **Example:**


### PR DESCRIPTION
cosmetics.

the getDbId() python function for music was added in Leia, not Krypton.
(https://github.com/xbmc/xbmc/pull/10858)