### PR TITLE
Several Joystick keymap changes related to the B button and back buttons.

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -49,6 +49,7 @@
       <x>ContextMenu</x>
       <y>FullScreen</y>
       <start>ActivateWindow(PlayerControls)</start>
+      <back>ActivateWindow(Home)</back>
       <guide>ActivateWindow(Home)</guide>
       <up>Up</up>
       <down>Down</down>
@@ -91,12 +92,12 @@
   <FullscreenVideo>
     <joystick profile="game.controller.default">
       <a>Pause</a>
-      <b>Fullscreen</b>
-      <b holdtime="500">Stop</b>
+      <b>Stop</b>
+      <b holdtime="500">FullScreen</b>
       <x>OSD</x>
       <y>FullScreen</y>
       <start>Info</start>
-      <back>OSD</back>
+      <back>FullScreen</back>
       <guide>OSD</guide>
       <up>ChapterOrBigStepForward</up>
       <down>ChapterOrBigStepBack</down>


### PR DESCRIPTION
## Description
Added <back>ActivateWindow(Home)</back> as a global keypress for the back button, it was not assigned any action before.
Changed the B button back to the original action of Stop and changed the long press action to Fullscreen.
Changed the back button to the Fullscreen action. It doesn't toggle, instead it sends you back to the home screen after pressing it a second time because of the global action, which kind of makes sense for the View (on xbox one, previously back) button.

## Motivation and Context
Adds a quick way to go back to the Home screen via the back/view button.

Also reverts the change of the B button not being assigned the Stop action during video playback. (which is also included in https://github.com/xbmc/xbmc/pull/15267 , but this has more radical changes)

## How Has This Been Tested?
Tested myself on my own Kodi install and Xbox controller.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
