### PR TITLE
Fix artist discography for MySQL

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -290,7 +290,7 @@ public:
 
   int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName, bool bScrapedMBID = false);
   int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, bool bScrapedMBID = false);
-  bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = true);
+  bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = false);
   bool GetArtistExists(int idArtist);
   int GetLastArtist();
   int  UpdateArtist(int idArtist,


### PR DESCRIPTION
Some music db fixes found while looking into MySQL slowness:

- With  MySQL scraped discography entries were not showing on artist info dialog
- Since Gotham we have been unnecessarily fetching discography data for every `GetArtist()` by default due to an accidental mismatch between header and code comment in body
- Use artist ID when have it to fetch artist props for fileitem

Tested on both SQLite and MySQL databases.

This does give a small speed improvement to the slowness of starting party mode with a MySQL music database discussed in https://github.com/xbmc/xbmc/issues/15130 but does not fix that issue completely.