### PR TITLE
Fix party mode slowness on MySQL

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1376,7 +1376,20 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
     if (fetchAll)
       strSQL = PrepareSQL("SELECT * FROM artistview LEFT JOIN discography ON artistview.idArtist = discography.idArtist WHERE artistview.idArtist = %i", idArtist);
     else
-      strSQL = PrepareSQL("SELECT * FROM artistview WHERE artistview.idArtist = %i", idArtist);
+      // Same fields as artistview, but don't fetch dateadded when value not 
+      // needed. MySQL very slow for view with subquery column with aggregate
+      //! @todo replace with artistview once dateadded is column of artist table
+      strSQL = PrepareSQL("SELECT "
+        "idArtist, strArtist, strSortName, "
+        "strMusicBrainzArtistID, "
+        "strType, strGender, strDisambiguation, "
+        "strBorn, strFormed, strGenres,"
+        "strMoods, strStyles, strInstruments, "
+        "strBiography, strDied, strDisbanded, "
+        "strYearsActive, strImage, strFanart, "
+        "bScrapedMBID, lastScraped, "
+        "'' AS dateAdded "
+        "FROM artist WHERE idArtist = %i", idArtist);
 
     if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0)


### PR DESCRIPTION
The startup of party mode on MySQL can be crazy slow see issue https://github.com/xbmc/xbmc/issues/15130 where at one point it was taking 30s to start for that user! The more artists in the library the slower it gets.  Ironically party mode was introduced as was way to randomly play songs while avoiding the UI slowness related to the display of a large number of items (a fileitem list issue).

A small improvement to this was made by https://github.com/xbmc/xbmc/pull/15277, but party mode startup is still unacceptably slow.

The cause is a weakness in the MySQL optimiser that does not handle views with a column expressed as a subquery using aggregate functions (amongst other limitations see https://dev.mysql.com/doc/refman/5.7/en/derived-table-optimization.html). The `artistview` contains such a subquery for `dateadded`, and at the start of partymode it is queried 10 times, each triggers a full scan of the artist table only to fetch 1 record. 

For the future (v19) I think that `dateadded` can usefully be made a column of the artist table and set to the date when the artist record was added (not as it currently is the max file timestamp of the all the music files credited to that artist), but the entails a schema change which preferably is not done at this late stage in the dev cycle. That will avoid this issue.

However `dateadded` value is only used for sorting artists nodes, it is completely irrelevent other places where artist is fetched as a single record as it is for party mode startup. So I propose repacing use of the view with the artist table directly in that situation as a workaround for v18.

This has been tested by the MySQL user with the extreme case of slow party mode, it reduces the start time down to just 6s

 This can be superseded when `dateadded` is made a column of the artist table in a subsequent version of the schema.
