### PR TITLE
[GLES] memcpy instead multi glTexSubImage2D for planes with pitch

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -264,6 +264,8 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
 
   // OpenGL ES does not support strided texture input.
   GLint pixelStore = -1;
+  unsigned int pixelStoreKey = -1;
+
   if (stride != static_cast<int>(width * bps))
   {
 #if HAS_GLES >= 3
@@ -274,6 +276,15 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
     {
       glGetIntegerv(GL_UNPACK_ROW_LENGTH, &pixelStore);
       glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);
+      pixelStoreKey = GL_UNPACK_ROW_LENGTH;
+    }
+    else
+#elif defined (GL_UNPACK_ROW_LENGTH_EXT)
+    if (m_pRenderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
+    {
+      glGetIntegerv(GL_UNPACK_ROW_LENGTH_EXT, &pixelStore);
+      glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride);
+      pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
     }
     else
 #endif
@@ -290,7 +301,7 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
   glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
 
   if (pixelStore >= 0)
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, pixelStore);
+    glPixelStorei(pixelStoreKey, pixelStore);
 
   // check if we need to load any border pixels
   if (height < plane.texheight)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -267,17 +267,25 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
   if (stride != static_cast<int>(width * bps))
   {
 #if HAS_GLES >= 3
-    glGetIntegerv(GL_UNPACK_ROW_LENGTH, &pixelStore);
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);
-#else
-    unsigned char *src(static_cast<unsigned char*>(data)),
-                  *dst(m_planeBuffer);
+    unsigned int verMajor, verMinor;
+    m_renderSystem->GetRenderVersion(verMajor, verMinor);
 
-    for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
-      memcpy(dst, src, width * bpp);
-
-    pixelData = m_planeBuffer;
+    if (verMajor >= 3)
+    {
+      glGetIntegerv(GL_UNPACK_ROW_LENGTH, &pixelStore);
+      glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);
+    }
+    else
 #endif
+    {
+      unsigned char *src(static_cast<unsigned char*>(data)),
+                    *dst(m_planeBuffer);
+
+      for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
+        memcpy(dst, src, width * bpp);
+
+      pixelData = m_planeBuffer;
+    }
   }
   glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -201,6 +201,7 @@ protected:
   bool m_fullRange;
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
+  unsigned char* m_planeBuffer = nullptr;
 
   // clear colour for "black" bars
   float m_clearColour{0.0f};


### PR DESCRIPTION
## Description
For video streams which are s/w decoded using ffmpeg the resulting frames are padded to the ffmpeg internal  32 Byte alignment (e.g. 720 width line is aligned to 736)

Current LinuxrenderGLES implementation loads such padded frames line by line to GPU using glTexSubImage2D for every line. This slows down rendering un most devices enourmously.

This PR introduces following solution:

- If the device supports GLES >=3 we handle the pitch / stride using glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);

- for the other devices we copy the pitched lines into a temporary buffer (CPU memcpy) and provide the frame in one block to GPU.

## Motivation and Context
Discussion here: https://github.com/xbmc/xbmc/pull/15229

## How Has This Been Tested?
AFTV4K (2018):
- 5fps with current solution playing 720x568 test video
- 50fps for both solutions above

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
