### PR TITLE
[feature] add option for show/hide names of unwatched episodes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21614,3 +21614,9 @@ msgstr ""
 msgctxt "#39116"
 msgid "Episode plot"
 msgstr ""
+
+#. Label for "show information for unwatched items" setting option
+#: system/settings/settings.xml
+msgctxt "#39117"
+msgid "Episode name"
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -970,12 +970,13 @@
         </setting>
         <setting id="videolibrary.showunwatchedplots" type="list[integer]" label="20369" help="36141">
           <level>0</level>
-          <default>0,1,2</default> <!-- Show plot for both -->
+          <default>0,1,2,3</default> <!-- Show plot for both -->
           <constraints>
             <options>
               <option label="39115">0</option> <!-- Show plot for unwatched movies only -->
               <option label="39116">1</option> <!-- Show plot for unwatched tv show episodes only -->
               <option label="39114">2</option> <!-- Show thumb for unwatched tv show episodes only -->
+              <option label="39117">3</option> <!-- Show name for unwatched tv show episodes only -->
             </options>
             <delimiter>,</delimiter>
           </constraints>

--- a/xbmc/guilib/guiinfo/CMakeLists.txt
+++ b/xbmc/guilib/guiinfo/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES GUIInfo.cpp
             PlayerGUIInfo.cpp
             SkinGUIInfo.cpp
             SystemGUIInfo.cpp
+            UnwatchedGUIInfo.cpp
             VideoGUIInfo.cpp
             VisualisationGUIInfo.cpp
             WeatherGUIInfo.cpp)
@@ -35,6 +36,7 @@ set(HEADERS GUIInfo.h
             PlayerGUIInfo.h
             SkinGUIInfo.h
             SystemGUIInfo.h
+            UnwatchedGUIInfo.h
             VideoGUIInfo.h
             VisualisationGUIInfo.h
             WeatherGUIInfo.h)

--- a/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
@@ -16,6 +16,7 @@ using namespace KODI::GUILIB::GUIINFO;
 CGUIInfoProviders::CGUIInfoProviders()
 {
   RegisterProvider(&m_guiControlsGUIInfo);
+  RegisterProvider(&m_unwatchedGUIInfo);
   RegisterProvider(&m_videoGUIInfo); // Note: video info provider must be registered before music info provider,
                                      // because of music videos having both a video info tag and a music info tag
                                      // and video info tag always has to be evaluated first.
@@ -44,6 +45,7 @@ CGUIInfoProviders::~CGUIInfoProviders()
   UnregisterProvider(&m_picturesGUIInfo);
   UnregisterProvider(&m_musicGUIInfo);
   UnregisterProvider(&m_videoGUIInfo);
+  UnregisterProvider(&m_unwatchedGUIInfo);
   UnregisterProvider(&m_guiControlsGUIInfo);
 }
 

--- a/xbmc/guilib/guiinfo/GUIInfoProviders.h
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.h
@@ -20,6 +20,7 @@
 #include "guilib/guiinfo/PlayerGUIInfo.h"
 #include "guilib/guiinfo/SkinGUIInfo.h"
 #include "guilib/guiinfo/SystemGUIInfo.h"
+#include "guilib/guiinfo/UnwatchedGUIInfo.h"
 #include "guilib/guiinfo/VideoGUIInfo.h"
 #include "guilib/guiinfo/VisualisationGUIInfo.h"
 #include "guilib/guiinfo/WeatherGUIInfo.h"
@@ -147,6 +148,7 @@ private:
   CPlayerGUIInfo m_playerGUIInfo;
   CSkinGUIInfo m_skinGUIInfo;
   CSystemGUIInfo m_systemGUIInfo;
+  CUnwatchedGUIInfo m_unwatchedGUIInfo;
   CVideoGUIInfo m_videoGUIInfo;
   CVisualisationGUIInfo m_visualisationGUIInfo;
   CWeatherGUIInfo m_weatherGUIInfo;

--- a/xbmc/guilib/guiinfo/UnwatchedGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/UnwatchedGUIInfo.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/guiinfo/UnwatchedGUIInfo.h"
+
+#include "FileItem.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/lib/Setting.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+#include "video/VideoInfoTag.h"
+
+#include "guilib/guiinfo/GUIInfo.h"
+#include "guilib/guiinfo/GUIInfoHelper.h"
+#include "guilib/guiinfo/GUIInfoLabels.h"
+
+using namespace KODI::GUILIB;
+using namespace KODI::GUILIB::GUIINFO;
+
+bool CUnwatchedGUIInfo::InitCurrentItem(CFileItem *item)
+{
+  return false;
+}
+
+bool CUnwatchedGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
+{
+  if (!item->HasVideoInfoTag())
+    return false;
+  
+  const CVideoInfoTag* tag = item->GetVideoInfoTag();
+  
+  if (tag->GetPlayCount() > 0)
+    return false;
+  
+  if (tag->m_type != MediaTypeMovie && tag->m_type != MediaTypeEpisode)
+    return false;
+  
+  std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(
+    CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
+  
+  if (!setting)
+    return false;
+  
+  switch (info.m_info)
+  {
+    case PLAYER_TITLE:
+    case VIDEOPLAYER_TITLE:
+    case LISTITEM_LABEL:
+    case LISTITEM_TITLE:
+    case VIDEOPLAYER_ORIGINALTITLE:
+    case LISTITEM_ORIGINALTITLE:
+      if (tag->m_type == MediaTypeEpisode && !setting->FindIntInList(CSettings::VIDEOLIBRARY_NAMES_SHOW_UNWATCHED_EPISODE))
+      {
+        std::string label = item->GetLabel();
+        value = label.substr(0, label.find('.'));
+        return true;
+      }
+      break;
+    case LISTITEM_PLOT:
+      if ((tag->m_type == MediaTypeMovie && !setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES))
+        || (tag->m_type == MediaTypeEpisode && !setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES))
+      )
+      {
+        value = g_localizeStrings.Get(20370);
+        return true;
+      }
+      break;
+  }
+  
+  return false;
+}
+
+bool CUnwatchedGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
+{
+  return false;
+}
+
+bool CUnwatchedGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
+{
+  return false;
+}

--- a/xbmc/guilib/guiinfo/UnwatchedGUIInfo.h
+++ b/xbmc/guilib/guiinfo/UnwatchedGUIInfo.h
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "guilib/guiinfo/GUIInfoProvider.h"
+
+class CVideoInfoTag;
+
+namespace KODI
+{
+namespace GUILIB
+{
+namespace GUIINFO
+{
+
+class CGUIInfo;
+
+class CUnwatchedGUIInfo : public CGUIInfoProvider
+{
+public:
+  CUnwatchedGUIInfo() = default;
+  ~CUnwatchedGUIInfo() override = default;
+
+  // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
+  bool InitCurrentItem(CFileItem *item) override;
+  bool GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const override;
+  bool GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
+  bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
+};
+
+} // namespace GUIINFO
+} // namespace GUILIB
+} // namespace KODI

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -331,27 +331,8 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         }
         break;
       case LISTITEM_PLOT:
-        {
-          std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>( 
-            CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
-          if (tag->m_type != MediaTypeTvShow &&
-              tag->m_type != MediaTypeVideoCollection &&
-              tag->GetPlayCount() == 0 &&
-              setting &&
-              (
-               (tag->m_type == MediaTypeMovie && (!setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES))) ||  
-               (tag->m_type == MediaTypeEpisode && (!setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES)))
-              )
-             ) 
-          {
-            value = g_localizeStrings.Get(20370);
-          }
-          else
-          {
-            value = tag->m_strPlot;
-          }
-          return true;
-        }
+        value = tag->m_strPlot;
+        return true;
       case LISTITEM_STATUS:
         value = tag->m_strStatus;
         return true;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -377,6 +377,7 @@ public:
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES = 0;
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES = 1;
   static const int VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE = 2;
+  static const int VIDEOLIBRARY_NAMES_SHOW_UNWATCHED_EPISODE = 3;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.


### PR DESCRIPTION
## Description
Add "Episode name" element to setting "Media" -> "Videos" -> "Show information for unwatched items".
The name is replaced by the episode number depending on the context (for example, 1x01 or 01).

The processing is performed in a new UnwatchedGuiInfo file (which extends GUIInfoProvider) that is added to the providers of the CGUIInfoProviders class. Incorporating this processing in "VideoGuiInfo" would have increased the complexity too much.

The code that hides the plot of unwatched episodes or movies has been moved to the new provider for the sake of keeping the code simple, clear and clean.

New localized text has been created (39117, "Episode name").

## Motivation and Context
It was already possible to hide the plots and thumbs of the unwatched episodes. The name may also contain spoilers. It was therefore necessary to be able to hide it.

## How Has This Been Tested?
Tested with Windows 10 x64
Tested with skins Estuary, Rapier and Xperience1080
The previous options (plot and thumb) continue to work despite moving some of the code.

## Screenshots (if appropriate):
![home](https://user-images.githubusercontent.com/46631671/51432123-c6c12500-1c32-11e9-8471-e922ac9bfda1.png)
![option](https://user-images.githubusercontent.com/46631671/51432051-c3796980-1c31-11e9-84f7-01f82e7d91cc.png)
![season1](https://user-images.githubusercontent.com/46631671/51432052-c3796980-1c31-11e9-90ff-4880d3884442.png)
![seasonall](https://user-images.githubusercontent.com/46631671/51432053-c3796980-1c31-11e9-9d73-bee95a2432f6.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (non-breaking change which improves existing functionality)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
