### PR TITLE
[guilib] GUISliderControl - don't scale if dimensions are zero

### DIFF
--- a/addons/skin.estuary/xml/Custom_1103_VolumeSlider.xml
+++ b/addons/skin.estuary/xml/Custom_1103_VolumeSlider.xml
@@ -44,27 +44,33 @@
 				<height>40</height>
 				<texturesliderbar></texturesliderbar>
 				<textureslidernib></textureslidernib>
-				<textureslidernibfocus colordiffuse="button_focus">colors/white.png</textureslidernibfocus>
+				<textureslidernibfocus></textureslidernibfocus>
 				<info>Player.Volume</info>
 				<action>Volume</action>
 			</control>
-			<control type="image">
+			<control type="button">
 				<left>0</left>
 				<top>65</top>
 				<width>28</width>
 				<height>28</height>
-				<texture flipx="true" colordiffuse="button_focus">overlays/arrowright.png</texture>
+				<texturefocus flipx="true" colordiffuse="button_focus">overlays/arrowright.png</texturefocus>
+				<texturenofocus flipx="true" colordiffuse="button_focus">overlays/arrowright.png</texturenofocus>
 				<animation effect="zoom" start="0,100" end="100,100" delay="500" center="auto" time="200">WindowOpen</animation>
 				<animation effect="zoom" start="100,100" end="0,100" center="auto" time="200">WindowClose</animation>
+				<hitrect x="-20" y="20" w="60" h="112" />
+				<onclick>Action(VolumeDown)</onclick>
 			</control>
-			<control type="image">
+			<control type="button">
 				<left>455</left>
 				<top>65</top>
 				<width>28</width>
 				<height>28</height>
-				<texture colordiffuse="button_focus">overlays/arrowright.png</texture>
+				<texturefocus colordiffuse="button_focus">overlays/arrowright.png</texturefocus>
+				<texturenofocus colordiffuse="button_focus">overlays/arrowright.png</texturenofocus>
 				<animation effect="zoom" start="0,100" end="100,100" delay="500" center="auto" time="200">WindowOpen</animation>
 				<animation effect="zoom" start="100,100" end="0,100" center="auto" time="200">WindowClose</animation>
+				<hitrect x="440" y="20" w="60" h="112" />
+				<onclick>Action(VolumeUp)</onclick>
 			</control>
 		</control>
 	</controls>

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -69,26 +69,28 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
       SetIntValue(val);
   }
 
-
   dirty |= m_guiBackground.SetHeight(m_height);
   dirty |= m_guiBackground.SetWidth(m_width);
   dirty |= m_guiBackground.Process(currentTime);
 
   CGUITexture &nibLower = (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
-  float fScale;
-  if (m_orientation == HORIZONTAL)
-    fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
-  else
-    fScale = m_width == 0 ? 1.0f : m_width / nibLower.GetTextureWidth();
 
+  float fScale = 1.0f;
+
+  if (m_orientation == HORIZONTAL && m_guiBackground.GetTextureHeight() != 0)
+    fScale = m_height / m_guiBackground.GetTextureHeight();
+  else if (m_width != 0 && nibLower.GetTextureWidth() != 0)
+    fScale = m_width / nibLower.GetTextureWidth();
   dirty |= ProcessSelector(nibLower, currentTime, fScale, RangeSelectorLower);
   if (m_rangeSelection)
   {
     CGUITexture &nibUpper = (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
-    if (m_orientation == HORIZONTAL)
-      fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
-    else
-      fScale = m_width == 0 ? 1.0f : m_width / nibUpper.GetTextureWidth();
+
+    if (m_orientation == HORIZONTAL && m_guiBackground.GetTextureHeight() != 0)
+      fScale = m_height / m_guiBackground.GetTextureHeight();
+    else if (m_width != 0 && nibUpper.GetTextureWidth() != 0)
+      fScale = m_width / nibUpper.GetTextureWidth();
+
     dirty |= ProcessSelector(nibUpper, currentTime, fScale, RangeSelectorUpper);
   }
 


### PR DESCRIPTION
## Description
This PR fixes https://github.com/xbmc/xbmc/issues/15255. The slidercontrol in estuary (using touchmode) does not define any textures for both `texturesliderbar` and `textureslidernib`. As the slidercontrol is tied to `Player.Volume`, when its value is updated Kodi will attempt to scale all control textures. The scaling factor is calculated using the width or height of the texture in a division. As the value is 0, the scalling factor will lead to +inf. Kodi will crash in rendering when attempting to round the values (assert in mathutils). The PR assumes a default scaling factor of 1 and only scales if the values of the divisor is not 0.
It also includes some changes to the estuary dialog (mostly provided by @ronie). Only additional change is the removal of the `textureslidernibfocus` as it will be rendered in between the background and the progress control (when the goal is to hide it).

Not sure who to ping for the cpp part, random.org assigned @fritsch :)

## Motivation and Context
Fix issues for Leia Final.

## How Has This Been Tested?
Compile and tested all estuary sliders

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
