### PR TITLE
[CryptThreading] Support CRYPTO_THREADID_set_callback() of OpenSSL 1.0.x

### DIFF
--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -12,7 +12,10 @@
 
 #include <openssl/crypto.h>
 
+//! @todo Remove support for OpenSSL <1.0 in v19
+
 #define KODI_OPENSSL_NEEDS_LOCK_CALLBACK (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#define KODI_OPENSSL_USE_THREADID (OPENSSL_VERSION_NUMBER >= 0x10000000L)
 
 #if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
 namespace
@@ -31,11 +34,19 @@ void lock_callback(int mode, int type, const char* file, int line)
     getlock(type)->unlock();
 }
 
+#if KODI_OPENSSL_USE_THREADID
+void thread_id(CRYPTO_THREADID* tid)
+{
+  // C-style cast required due to vastly differing native ID return types
+  CRYPTO_THREADID_set_numeric(tid, (unsigned long)CThread::GetCurrentThreadId());
+}
+#else
 unsigned long thread_id()
 {
   // C-style cast required due to vastly differing native ID return types
   return (unsigned long)CThread::GetCurrentThreadId();
 }
+#endif
 
 }
 #endif
@@ -46,7 +57,11 @@ CryptThreadingInitializer::CryptThreadingInitializer()
   // OpenSSL < 1.1 needs integration code to support multi-threading
   // This is absolutely required for libcurl if it uses the OpenSSL backend
   m_locks.resize(CRYPTO_num_locks());
+#if KODI_OPENSSL_USE_THREADID
+  CRYPTO_THREADID_set_callback(thread_id);
+#else
   CRYPTO_set_id_callback(thread_id);
+#endif
   CRYPTO_set_locking_callback(lock_callback);
 #endif
 }
@@ -55,7 +70,9 @@ CryptThreadingInitializer::~CryptThreadingInitializer()
 {
 #if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
   CSingleLock l(m_locksLock);
+#if !KODI_OPENSSL_USE_THREADID
   CRYPTO_set_id_callback(nullptr);
+#endif
   CRYPTO_set_locking_callback(nullptr);
   m_locks.clear();
 #endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Deprecated function CRYPTO_set_id_callback() is replaced with CRYPTO_THREADID_set_callback() when building with OpenSSL 1.0.x 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Kodi's (with CRYPTO_set_id_callback()) installed call back function may be overwritten by other components using and initializing OpenSSL, i.e. binary plugins. In worst case Kodi is crashing after plugin unload.

When using CRYPTO_THREADID_set_callback() the first installed call back function is locked preventing any change.

To reproduce the crash:
- Install Milhouse LibreELEC test build
- Enable vfs.sftp
- Restart Kodi to have the default initialization order
- Stop Kodi. The crash occur in exit handlers: http://ix.io/1ylh


## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Checked call order in debugger. No crash any more on my LibreELEC Generic build. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
