### PR TITLE
[skins] define textwidth for sliderex controls

### DIFF
--- a/addons/skin.estouchy/xml/DialogAddonSettings.xml
+++ b/addons/skin.estouchy/xml/DialogAddonSettings.xml
@@ -144,6 +144,7 @@
 			<description>Default Slider</description>
 			<height>70</height>
 			<font>font25</font>
+			<textwidth>550</textwidth>
 		</control>
 		<control type="edit" id="12">
 			<height>70</height>

--- a/addons/skin.estouchy/xml/DialogSettings.xml
+++ b/addons/skin.estouchy/xml/DialogSettings.xml
@@ -95,6 +95,7 @@
 		<control type="sliderex" id="13">
 			<height>70</height>
 			<font>font25</font>
+			<textwidth>300</textwidth>
 		</control>
 		<control type="label" id="14">
 			<posx>0</posx>

--- a/addons/skin.estuary/xml/DialogAddonSettings.xml
+++ b/addons/skin.estuary/xml/DialogAddonSettings.xml
@@ -78,6 +78,7 @@
 			<control type="sliderex" id="13">
 				<description>Default Slider</description>
 				<include>DefaultSettingButton</include>
+				<textwidth>700</textwidth>
 			</control>
 			<control type="label" id="14">
 				<description>Default Label</description>

--- a/addons/skin.estuary/xml/DialogSettings.xml
+++ b/addons/skin.estuary/xml/DialogSettings.xml
@@ -56,6 +56,7 @@
 			<control type="sliderex" id="13">
 				<description>Default Slider</description>
 				<include>DefaultSettingButton</include>
+				<textwidth>800</textwidth>
 			</control>
 			<control type="label" id="14">
 				<description>Default Label</description>


### PR DESCRIPTION
define a textwidth for sliderex controls to avoid possible text overlap.
ref: https://github.com/xbmc/xbmc/issues/15302