### PR TITLE
fixed: do no add cache=no option to zip urls unless zip:// protocol

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -74,7 +74,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
 
   // special case for zips - ignore caching
   CURL url(url2);
-  if (URIUtils::IsInZIP(url.Get()) || URIUtils::IsInAPK(url.Get()))
+  if (StringUtils::StartsWith(url.Get(), "zip://") || URIUtils::IsInAPK(url.Get()))
     url.SetOptions("?cache=no");
   if (file.Open(url.Get(), READ_TRUNCATED | READ_CHUNKED))
   {


### PR DESCRIPTION
fixes zip files handled using vfs.libarchive (archive:// protocol)

## Description
Do not append the zip protocol specific cache=no option for zip files handled by libarchive.

## Motivation and Context
See https://forum.kodi.tv/showthread.php?tid=323321 for context.