### PR TITLE
[GUI] refresh debug overlay if smartredraw is activated

### DIFF
--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -55,6 +55,9 @@ bool CGUIWindowDebugInfo::OnMessage(CGUIMessage &message)
     delete m_layout;
     m_layout = nullptr;
   }
+  else if (message.GetMessage() == GUI_MSG_REFRESH_TIMER)
+    MarkDirtyRegion();
+
   return CGUIDialog::OnMessage(message);
 }
 


### PR DESCRIPTION
## Description
Refresh debug overlay if smartredraw is activated

## Motivation and Context
When using smartredraw debugoverlay stops repainting at the mooment 2 frame intervals no values have changed. This does not work for debug overlay

## How Has This Been Tested?
- activate smartredraw in advancedsettings
- open debug overlay (settings/system/logging)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
