### PR TITLE
GLContextEGL: Properly guard members

### DIFF
--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "GLContext.h"
+#include "threads/CriticalSection.h"
 #include "EGL/egl.h"
 #include "EGL/eglext.h"
 #include "EGL/eglextchromium.h"
@@ -47,6 +48,8 @@ protected:
     uint64_t msc2 = 0;
     uint64_t interval = 0;
   } m_sync;
+
+  CCriticalSection m_syncLock;
 
   bool m_usePB = false;
 };


### PR DESCRIPTION
Fix for concurrent access on members. Fixes: #15220