### PR TITLE
revert 'hide episode thumb' option

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21769,12 +21769,6 @@ msgstr ""
 
 #. Label for "show information for unwatched items" setting option
 #: system/settings/settings.xml
-msgctxt "#39114"
-msgid "Episode thumb"
-msgstr ""
-
-#. Label for "show information for unwatched items" setting option
-#: system/settings/settings.xml
 msgctxt "#39115"
 msgid "Movie plot"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -972,12 +972,11 @@
         </setting>
         <setting id="videolibrary.showunwatchedplots" type="list[integer]" label="20369" help="36141">
           <level>0</level>
-          <default>0,1,2</default> <!-- Show plot for both -->
+          <default>0,1</default> <!-- Show plot for both -->
           <constraints>
             <options>
               <option label="39115">0</option> <!-- Show plot for unwatched movies only -->
               <option label="39116">1</option> <!-- Show plot for unwatched tv show episodes only -->
-              <option label="39114">2</option> <!-- Show thumb for unwatched tv show episodes only -->
             </options>
             <delimiter>,</delimiter>
           </constraints>

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -17,16 +17,13 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "settings/dialogs/GUIDialogLibExportSettings.h"
 #include "guilib/LocalizeStrings.h"
-#include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
 #include "music/MusicLibraryQueue.h"
 #include "messaging/helpers/DialogHelper.h"
-#include "ServiceBroker.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
 #include "threads/SingleLock.h"
-#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -341,15 +338,6 @@ void CMediaSettings::OnSettingAction(std::shared_ptr<const CSetting> setting)
       videodatabase.Close();
     }
   }
-}
-
-void CMediaSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
-{
-  if (setting == nullptr)
-    return;
-
-  if (setting->GetId() == CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnRefresh");
 }
 
 int CMediaSettings::GetWatchedMode(const std::string &content) const

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -39,7 +39,6 @@ public:
   bool Save(TiXmlNode *settings) const override;
 
   void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
-  void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
   void OnSettingsLoaded() override;
 
   const CVideoSettings& GetDefaultVideoSettings() const { return m_defaultVideoSettings; }

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -377,7 +377,6 @@ public:
   // values for SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES = 0;
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES = 1;
-  static const int VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE = 2;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -24,7 +24,6 @@
 #include "GUIUserMessages.h"
 #include "music/MusicDatabase.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "cores/VideoSettings.h"
@@ -348,27 +347,6 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
         artwork.insert(std::make_pair(type, art));
     }
     SetArt(*pItem, artwork);
-  }
-
-  // hide thumb if episode is unwatched 
-  std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(
-    CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
-  if (pItem->HasArt("thumb") && pItem->HasVideoInfoTag() &&
-      pItem->GetVideoInfoTag()->m_type == MediaTypeEpisode &&
-      pItem->GetVideoInfoTag()->GetPlayCount() == 0 &&
-      setting && 
-      !setting->FindIntInList(CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE)
-     )
-  {
-    // use fanart if available
-    if (pItem->HasArt("fanart"))
-    {
-      pItem->SetArt("thumb", pItem->GetArt("fanart"));
-    }
-    else
-    {
-      pItem->SetArt("thumb", "OverlaySpoiler.png");
-    }
   }
 
   m_videoDatabase->Close();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Because of the issues mentioned in #15296 which are a breaking change from my POV if users need to refresh the info to replace the current `OverlaySpoiler`and get the real thumbs, I would suggest to remove that option for v18 and probably give it a new try for v19.

The reason I removed string 39114 and did not changed the numberings for 39115 and 39116 is because of current existing translations. We could probably leave them as they are and might have a string left if we try to implement it for v19.

I happily change the help text as well, but I haven't touched it because of the translations which need to be done then. If we say, we should do that (because the help text is wrong then), I'll add it.

I also haven't removed the `OverlaySpoiler.png` file. If we need to do that, please advise me and I'll do that as well. 

Not sure if we need to remove the "OnRefresh" announcement as well as Daveblake already added something for JSON and it might not hurt to keep it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Fixes (if we could name it that way) #15296 

This option in its current state breaks user experience by scraping new tv shows and the real thumb never is shown even if the file has been marked as watched. I thought testing with dummy files (0-byte files) might be enough and for those the problem doesn't exist. The problem exists with real video files only and that's a no-go. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Compiled and tested on Ubuntu 16.04. Episode thumbs are shown correctly and the only options are to hide either the movie plot or the episode plot. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
