### PR TITLE
[cmake] replace patch file with actual commands in add_addon_depends

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -88,16 +88,12 @@ function(add_addon_depends addon searchpath)
           message(${BUILD_ARGS})
         endif()
 
-        # prepare patchfile. ensure we have a clean file after reconfiguring
-        set(PATCH_FILE ${BUILD_DIR}/${id}/tmp/patch.cmake)
-        file(REMOVE ${PATCH_FILE})
+        set(PATCH_COMMAND)
 
         # if there's a CMakeLists.txt use it to prepare the build
         if(EXISTS ${dir}/CMakeLists.txt)
           set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${dir}/CMakeLists.txt)
-          file(APPEND ${PATCH_FILE}
-               "file(COPY ${dir}/CMakeLists.txt
-                     DESTINATION ${BUILD_DIR}/${id}/src/${id})\n")
+          list(APPEND PATCH_COMMAND COMMAND ${CMAKE_COMMAND} -E copy_if_different ${dir}/CMakeLists.txt ${BUILD_DIR}/${id}/src/${id})
         endif()
 
         # check if we have patches to apply
@@ -124,14 +120,13 @@ function(add_addon_depends addon searchpath)
               file(READ ${patch} patch_content_hex HEX)
               # Force handle LF-only line endings
               if(NOT patch_content_hex MATCHES "0d0a")
-                set(PATCH_PROGRAM "\"${PATCH_PROGRAM}\" --binary")
+                list(APPEND PATCH_PROGRAM --binary)
               endif()
             endif()
           endif()
 
           set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${patch})
-          file(APPEND ${PATCH_FILE}
-               "execute_process(COMMAND ${PATCH_PROGRAM} -p1 -i \"${patch}\")\n")
+          list(APPEND PATCH_COMMAND COMMAND ${PATCH_PROGRAM} -p1 -i ${patch})
         endforeach()
 
 
@@ -168,16 +163,9 @@ function(add_addon_depends addon searchpath)
         if(CROSS_AUTOCONF AND AUTOCONF_FILES)
           foreach(afile ${AUTOCONF_FILES})
             set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${afile})
-            file(APPEND ${PATCH_FILE}
-                 "message(STATUS \"AUTOCONF: copying ${afile} to ${BUILD_DIR}/${id}/src/${id}\")\n
-                 file(COPY ${afile} DESTINATION ${BUILD_DIR}/${id}/src/${id})\n")
+            list(APPEND PATCH_COMMAND COMMAND ${CMAKE_COMMAND} -E echo "AUTOCONF: copying ${afile} to ${BUILD_DIR}/${id}/src/${id}")
+            list(APPEND PATCH_COMMAND COMMAND ${CMAKE_COMMAND} -E copy_if_different ${afile} ${BUILD_DIR}/${id}/src/${id})
           endforeach()
-        endif()
-
-        # if the patch file exists we need to set the PATCH_COMMAND
-        set(PATCH_COMMAND "")
-        if(EXISTS ${PATCH_FILE})
-          set(PATCH_COMMAND ${CMAKE_COMMAND} -P ${PATCH_FILE})
         endif()
 
         # prepare the setup of the call to externalproject_add()


### PR DESCRIPTION
## Motivation and Context
With explicitly writing a patch file and then executing it, the patch step doesn't fail if a command (e.g. patch apply) from the patch file fails.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
