### PR TITLE
[PVR] Fix duplicate channel numbers

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -188,6 +188,7 @@ void CPVRClient::Destroy(void)
 void CPVRClient::Stop()
 {
   m_bBlockAddonCalls = true;
+  m_bPriorityFetched = false;
 }
 
 void CPVRClient::Continue()

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -476,7 +476,11 @@ bool CPVRClients::GetTimers(CPVRTimersContainer *timers, std::vector<int> &faile
 PVR_ERROR CPVRClients::GetTimerTypes(CPVRTimerTypes& results) const
 {
   return ForCreatedClients(__FUNCTION__, [&results](const CPVRClientPtr &client) {
-    return client->GetTimerTypes(results);
+    CPVRTimerTypes types;
+    PVR_ERROR ret = client->GetTimerTypes(types);
+    if (ret == PVR_ERROR_NO_ERROR)
+      results.insert(results.end(), types.begin(), types.end());
+    return ret;
   });
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -846,7 +846,9 @@ bool CPVRChannelGroup::Renumber(void)
       (*it).channelNumber = currentChannelNumber;
     }
 
-    (*it).channel->SetChannelNumber((*it).channelNumber);
+    //! @todo This is a quick fix for v18. Whole channel number handling should be reworked - code is imo unmaintainable.
+    if (IsInternalGroup())
+      (*it).channel->SetChannelNumber((*it).channelNumber);
   }
 
   SortByChannelNumber();


### PR DESCRIPTION
First commit fixes a nasty problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=339539

The other two commits fix other bugs in multi-client setups I found along the way while debugging the original issue.

@Jalle19 mind taking a look. Commit 1 is a quick fix that should not have negative side-effects, nevertheless the whole channel number handling code needs to be reworks. It is unmaintainable - at least for me.