### PR TITLE
Fix absurd Announcement Manager locking

### DIFF
--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -42,7 +42,7 @@ void CAnnouncementManager::Deinitialize()
   m_bStop = true;
   m_queueEvent.Set();
   StopThread();
-  CSingleLock lock (m_critSection);
+  CSingleLock lock (m_announcersCritSection);
   m_announcers.clear();
 }
 
@@ -51,7 +51,7 @@ void CAnnouncementManager::AddAnnouncer(IAnnouncer *listener)
   if (!listener)
     return;
 
-  CSingleLock lock (m_critSection);
+  CSingleLock lock (m_announcersCritSection);
   m_announcers.push_back(listener);
 }
 
@@ -60,7 +60,7 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
   if (!listener)
     return;
 
-  CSingleLock lock (m_critSection);
+  CSingleLock lock (m_announcersCritSection);
   for (unsigned int i = 0; i < m_announcers.size(); i++)
   {
     if (m_announcers[i] == listener)
@@ -100,7 +100,7 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
     announcement.item = CFileItemPtr(new CFileItem(*item));
 
   {
-    CSingleLock lock (m_critSection);
+    CSingleLock lock (m_queueCritSection);
     m_announcementQueue.push_back(announcement);
   }
   m_queueEvent.Set();
@@ -110,9 +110,10 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender,
 {
   CLog::Log(LOGDEBUG, "CAnnouncementManager - Announcement: %s from %s", message, sender);
 
-  CSingleLock lock (m_critSection);
+  CSingleLock lock(m_announcersCritSection);
 
   // Make a copy of announcers. They may be removed or even remove themselves during execution of IAnnouncer::Announce()!
+
   std::vector<IAnnouncer *> announcers(m_announcers);
   for (unsigned int i = 0; i < announcers.size(); i++)
     announcers[i]->Announce(flag, sender, message, data);
@@ -271,19 +272,19 @@ void CAnnouncementManager::Process()
 
   while (!m_bStop)
   {
-    CSingleLock lock (m_critSection);
+    CSingleLock lock (m_queueCritSection);
     if (!m_announcementQueue.empty())
     {
       auto announcement = m_announcementQueue.front();
       m_announcementQueue.pop_front();
       {
-        CSingleExit ex(m_critSection);
+        CSingleExit ex(m_queueCritSection);
         DoAnnounce(announcement.flag, announcement.sender.c_str(), announcement.message.c_str(), announcement.item, announcement.data);
       }
     }
     else
     {
-      CSingleExit ex(m_critSection);
+      CSingleExit ex(m_queueCritSection);
       m_queueEvent.Wait();
     }
   }

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -61,7 +61,8 @@ namespace ANNOUNCEMENT
     CAnnouncementManager(const CAnnouncementManager&) = delete;
     CAnnouncementManager const& operator=(CAnnouncementManager const&) = delete;
 
-    CCriticalSection m_critSection;
+    CCriticalSection m_announcersCritSection;
+    CCriticalSection m_queueCritSection;
     std::vector<IAnnouncer *> m_announcers;
   };
 }


### PR DESCRIPTION
Announcement manager is using the same lock for both adding an event to the queue and when sending each event. This means that it is unable to add anything to the queue while it is sending something.  Surely a big mistake, as any delay in sending announcements prevents anything from being added to the announcement queue.

I believe this is what is causing the slow down of party mode initialisation when the `Allow remote control from applications on other systems` setting is enabled as reported here https://github.com/xbmc/xbmc/issues/15130, but may also improve a number of other performance issues such as filling current playlist (queue) with many songs.

The simple fix is to use separate sections for queue and listener list.

Win64 & OSX64 test builds exist (combined with other PR) on mirrors
http://mirrors.kodi.tv/test-builds/osx/x86_64/kodi-20190126-c49c7fb2-LockingFix-x86_64.dmg

@MilhouseVH could you add to a RPi build please
