### PR TITLE
Input: Fix ignoring custom joystick.xml

### DIFF
--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -37,6 +37,14 @@ void CJoystickMapper::MapActions(int windowID, const TiXmlNode *pDevice)
   if (controllerId.empty())
     return;
 
+  // Update Controller IDs
+  if (std::find(m_controllerIds.begin(), m_controllerIds.end(), controllerId) == m_controllerIds.end())
+    m_controllerIds.emplace_back(controllerId);
+
+  // Create/overwrite keymap
+  auto &keymap = m_joystickKeymaps[controllerId];
+  keymap.reset(new CWindowKeymap(controllerId));
+
   const TiXmlElement *pButton = pDevice->FirstChildElement();
   while (pButton != nullptr)
   {
@@ -47,15 +55,6 @@ void CJoystickMapper::MapActions(int windowID, const TiXmlNode *pDevice)
     std::string actionString;
     if (DeserializeButton(pButton, feature, dir, holdtimeMs, hotkeys, actionString))
     {
-      // Update Controller IDs
-      if (std::find(m_controllerIds.begin(), m_controllerIds.end(), controllerId) == m_controllerIds.end())
-        m_controllerIds.emplace_back(controllerId);
-
-      // Find/create keymap
-      auto &keymap = m_joystickKeymaps[controllerId];
-      if (!keymap)
-        keymap.reset(new CWindowKeymap(controllerId));
-
       // Update keymap
       unsigned int actionId = ACTION_NONE;
       if (CActionTranslator::TranslateString(actionString, actionId))


### PR DESCRIPTION
Currently, custom joystick.xml is loaded last, and its buttons are appended to the existing keymap. However, the keymapper uses the first action in the keymap, so appended actions may be ignored.

The fix is to clear the keymap for a window/joystick combination when a new node is discovered in a later keymap XML.

Fixes https://github.com/xbmc/xbmc/issues/15316.

## How Has This Been Tested?
Unfortunately, no access to controllers to test atm. @Wintermute0110 are you able to test?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
