### PR TITLE
[Fix]Avoid attempt to load music info for smartplaylists

### DIFF
--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -147,7 +147,10 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
 bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
 {
   if ((pItem->m_bIsFolder && !pItem->IsAudio()) ||
-       pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+      pItem->IsPlayList() || pItem->IsSmartPlayList() ||
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") ||
+      pItem->IsNFO() || pItem->IsInternetStream())
     return false;
 
   // Get thumb for item
@@ -161,8 +164,11 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if ((pItem->m_bIsFolder && !pItem->IsAudio()) || pItem->IsPlayList() ||
-       pItem->IsNFO() || pItem->IsInternetStream())
+  if ((pItem->m_bIsFolder && !pItem->IsAudio()) || 
+      pItem->IsPlayList() || pItem->IsSmartPlayList() ||
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") ||
+      pItem->IsNFO() || pItem->IsInternetStream())
     return false;
 
   if (!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded())


### PR DESCRIPTION
Avoid trying to load music info for smartplaylists and "newplaylist" and "newsmartplaylist" menu items - they are not songs do not have related artists etc. 

Before displaying the Playlists node,  especially if the music library was large or there were a number of playlists,  a dialog box "Scanning Media Information" 
````
Loading media information from files
playlistmusic://
````
was appearing. This was because the items (.xsp files) were being treated as songs, whereas previously they were skipped as they are flagged as folders. The addition of audiobook support in  #11147 exposed the "accident" as `IsAudio()` returns true (they do have `CMusicInfoTag`).

Solution is to check if item `IsSmartPlaylist()` and skip loading. 
Thanks @notspiff  for help
