### PR TITLE
ApplicationMessenger separate queue and target locking

### DIFF
--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -421,6 +421,7 @@ private:
   std::queue<ThreadMessage*> m_vecWindowMessages; /*!< queue for UI messages */
   std::map<int, IMessageTarget*> m_mapTargets; /*!< a map of registered receivers indexed on the message mask*/
   CCriticalSection m_critSection;
+  CCriticalSection m_targetCritSection;
   ThreadIdentifier m_guiThreadId{0};
   bool m_bStop{ false };
 };


### PR DESCRIPTION
Optimize locking in ApplicationMessenger by using separate locks for queue from that for protecting targets.

Edit: "optimise" was a bad choice of word, it implied far more than I intended
