### PR TITLE
[cmake] fix policy CMP0053

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -199,7 +199,7 @@ macro (build_addon target prefix libs)
     endif()
 
     # TODO: remove this hack after v18
-    string(REPLACE "<platform>\@PLATFORM\@</platform>" "<platform>@PLATFORM_TAG@</platform>" addon_file "${addon_file}")
+    string(REPLACE "<platform>\@PLATFORM\@</platform>" "<platform>\@PLATFORM_TAG\@</platform>" addon_file "${addon_file}")
 
     string(CONFIGURE "${addon_file}" addon_file_conf @ONLY)
     file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${target}/addon.xml CONTENT "${addon_file_conf}")


### PR DESCRIPTION
## Description
The non escaped `@PLATFORM_TAG@` causes that the `@PLATFORM@` is not replaced with `@PLATFORM_TAG@`, but the actual value of that variable.
This replacement should (and with this change does) happen in `string(CONFIGURE ...)` the line below.

## Motivation and Context
Get rid of the following warning while building binary addons.
```
CMake Warning (dev) at build/build/depends/lib/kodi/AddonHelpers.cmake:202 (string):
  Policy CMP0053 is not set: Simplify variable reference and escape sequence
  evaluation.  Run "cmake --help-policy CMP0053" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  For input:

    '<platform>@PLATFORM_TAG@</platform>'

  the old evaluation rules produce:

    '<platform>osx-x86_64</platform>'

  but the new evaluation rules produce:

    '<platform>@PLATFORM_TAG@</platform>'

  Using the old result for compatibility since the policy is not set.
Call Stack (most recent call first):
  CMakeLists.txt:40 (build_addon)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## How Has This Been Tested?
build a binary addon and checked the generated addon.xml

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
