### PR TITLE
[Demux] VP9 does not provide extradata

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -480,6 +480,9 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       }
       m_mime = "video/x-vnd.on2.vp9";
       m_formatname = "amc-vp9";
+      free(m_hints.extradata);
+      m_hints.extradata = nullptr;
+      m_hints.extrasize = 0;
       break;
     case AV_CODEC_ID_AVS:
     case AV_CODEC_ID_CAVS:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -14,7 +14,6 @@
 
 #define FF_MAX_EXTRADATA_SIZE ((1 << 28) - AV_INPUT_BUFFER_PADDING_SIZE)
 
-
 class CDemuxStreamClientInternal
 {
 public:
@@ -122,7 +121,7 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
   if (st == nullptr)
     return change;
 
-  if (st->ExtraSize)
+  if (st->ExtraSize || !CodecHasExtraData(st->codec))
     return change;
 
   CDemuxStreamClientInternal* stream = dynamic_cast<CDemuxStreamClientInternal*>(st);
@@ -570,6 +569,7 @@ bool CDVDDemuxClient::IsVideoReady()
   {
     if (stream.first == m_videoStreamPlaying &&
         stream.second->type == STREAM_VIDEO &&
+        CodecHasExtraData(stream.second->codec) &&
         stream.second->ExtraData == nullptr)
       return false;
   }
@@ -604,6 +604,10 @@ std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
       strName = "h264";
     else if (stream->codec == AV_CODEC_ID_EAC3)
       strName = "eac3";
+    else if (stream->codec == AV_CODEC_ID_VP8)
+      strName = "vp8";
+    else if (stream->codec == AV_CODEC_ID_VP9)
+      strName = "vp9";
   }
   return strName;
 }
@@ -657,5 +661,16 @@ void CDVDDemuxClient::SetVideoResolution(int width, int height)
   if (m_IDemux)
   {
     m_IDemux->SetVideoResolution(width, height);
+  }
+}
+
+bool CDVDDemuxClient::CodecHasExtraData(AVCodecID id)
+{
+  switch (id)
+  {
+  case AV_CODEC_ID_VP9:
+      return false;
+    default:
+      return true;
   }
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -56,5 +56,8 @@ protected:
   double m_dtsAtDisplayTime;
   std::unique_ptr<DemuxPacket> m_packet;
   int m_videoStreamPlaying = -1;
+
+private:
+  static inline bool CodecHasExtraData(AVCodecID id);
 };
 


### PR DESCRIPTION
## Description
Playing VP9 streams using inputstream addon fail because codec extradata is not existant for this stream codec.
As a result Demuxer reads the whole stream to detect codec extradata using ffmpeg parser,

## Motivation and Context
During development of Webm / VP9 for 4K youtube this issue poped up and is solved here.

## How Has This Been Tested?
Play Youtube webm stream (changes in youtube addon necessary) in combination with inputstream.adaptive (development branch webm)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
