### PR TITLE
[Binary Addon] Provide instance version when creating AddonInstance

### DIFF
--- a/xbmc/DynamicDll.h
+++ b/xbmc/DynamicDll.h
@@ -125,7 +125,7 @@ public: \
   public: \
     virtual result name args override \
     { \
-      return m_##name args2; \
+      return m_##name ? m_##name args2 : (result) 0; \
     }
 
 #define DEFINE_METHOD_LINKAGE0(result, linkage, name) \
@@ -402,6 +402,10 @@ public: \
 #define RESOLVE_METHOD_RENAME(dllmethod, method) \
   if (!m_dll->ResolveExport( #dllmethod , & m_##method##_ptr )) \
     return false;
+
+#define RESOLVE_METHOD_RENAME_OPTIONAL(dllmethod, method) \
+  m_##method##_ptr = nullptr; \
+  m_dll->ResolveExport( #dllmethod , & m_##method##_ptr );
 
 #define RESOLVE_METHOD_RENAME_FP(dllmethod, method) \
   if (!m_dll->ResolveExport( #dllmethod , & method##_ptr )) \

--- a/xbmc/addons/binary-addons/DllAddon.h
+++ b/xbmc/addons/binary-addons/DllAddon.h
@@ -17,10 +17,12 @@ public:
   virtual ~DllAddonInterface() = default;
   virtual void GetAddon(void* pAddon) =0;
   virtual ADDON_STATUS Create(void *cb, void *info) =0;
+  virtual ADDON_STATUS CreateEx(void *cb, const char* globalApiVersion, void *info) = 0;
   virtual void Destroy() =0;
   virtual ADDON_STATUS GetStatus() =0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
   virtual const char* GetAddonTypeVersion(int type)=0;
+  virtual const char* GetAddonTypeMinVersion(int type) = 0;
 };
 
 class DllAddon : public DllDynamic, public DllAddonInterface
@@ -28,18 +30,24 @@ class DllAddon : public DllDynamic, public DllAddonInterface
 public:
   DECLARE_DLL_WRAPPER_TEMPLATE(DllAddon)
   DEFINE_METHOD2(ADDON_STATUS, Create, (void* p1, void* p2))
+  DEFINE_METHOD3(ADDON_STATUS, CreateEx, (void* p1, const char* p2, void* p3))
+  bool CreateEx_available() { return m_CreateEx != nullptr; }
   DEFINE_METHOD0(void, Destroy)
   DEFINE_METHOD0(ADDON_STATUS, GetStatus)
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (void* p1))
   DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
+  DEFINE_METHOD1(const char*, GetAddonTypeMinVersion, (int p1))
+  bool GetAddonTypeMinVersion_available() { return m_GetAddonTypeMinVersion != nullptr; }
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
+    RESOLVE_METHOD_RENAME_OPTIONAL(ADDON_CreateEx, CreateEx)
     RESOLVE_METHOD_RENAME(ADDON_Destroy, Destroy)
     RESOLVE_METHOD_RENAME(ADDON_GetStatus, GetStatus)
     RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetTypeVersion, GetAddonTypeVersion)
+    RESOLVE_METHOD_RENAME_OPTIONAL(ADDON_GetTypeMinVersion, GetAddonTypeMinVersion)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
@@ -15,12 +15,17 @@ extern "C" {
 #endif
 
   ADDON_STATUS __declspec(dllexport) ADDON_Create(void *callbacks, void* props);
+  ADDON_STATUS __declspec(dllexport) ADDON_CreateEx(void *callbacks, const char* globalApiVersion, void* props);
   void         __declspec(dllexport) ADDON_Destroy();
   ADDON_STATUS __declspec(dllexport) ADDON_GetStatus();
   ADDON_STATUS __declspec(dllexport) ADDON_SetSetting(const char *settingName, const void *settingValue);
   __declspec(dllexport) const char* ADDON_GetTypeVersion(int type)
   {
     return kodi::addon::GetTypeVersion(type);
+  }
+  __declspec(dllexport) const char* ADDON_GetTypeMinVersion(int type)
+  {
+    return kodi::addon::GetTypeMinVersion(type);
   }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description
[Binary Addon] Provide instance version when creating AddonInstance

This PR adds an optional CreateInstance overridable method which provides the interface version compiled inside kodi.  No adaption of existing addons necessary.

Beside this the current addon system is not downgrade capable for binary addons.
If for example inputstream binary has API verMin 1.0.0 and ver 1.0.9, but kodi is compiled with API verMin 1.0.0 and ver 1.0.8, addon is treated as incompatible, which shouldn't because addons min version is smaller as kodi version. This is fixed by retieving the API min version from compiled addon.

## Motivation and Context
For the binary addon inputstream.adaptive I need to know which API version is compiled in kodi to implement workarounds for the combination old(er) kodi + newer inputstream addon.

## How Has This Been Tested?
inputstream addon, with / without this PR combinations.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
