### PR TITLE
[Resolution] Check current mode if whitelist doesn't match

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -73,6 +73,8 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int heig
 void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution)
 {
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
+  CLog::Log(LOGNOTICE, "Whitelist search for: width: %d, height: %d, fps: %0.3f, 3D: %s",
+    width, height, fps, is3D ? "true" : "false");
 
   std::vector<CVariant> indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
   if (indexList.empty())
@@ -143,6 +145,16 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
 
   CLog::Log(LOGDEBUG, "No double refresh rate whitelisted resolution matched, trying current resolution");
 
+  if (width <= curr.iScreenWidth
+    && height <= curr.iScreenHeight
+    && (MathUtils::FloatEquals(curr.fRefreshRate, fps, 0.01f) || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2, 0.01f)))
+  {
+    CLog::Log(LOGDEBUG, "Matched current Resolution %s (%d)", curr.strMode.c_str(), resolution);
+    return;
+  }
+
+  CLog::Log(LOGDEBUG, "Current resolution doesn't match, trying default resolution");
+
   const RESOLUTION_INFO desktop_info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CDisplaySettings::GetInstance().GetCurrentResolution());
 
   for (const auto &mode : indexList)
@@ -161,7 +173,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     }
   }
 
-  CLog::Log(LOGDEBUG, "No larger whitelisted resolution matched, trying current resolution with double refreshrate");
+  CLog::Log(LOGDEBUG, "Default resolution doesn't provide reqired refreshrate, trying default resolution with double refreshrate");
 
   for (const auto &mode : indexList)
   {


### PR DESCRIPTION
## Description
Current whitelist search works in 4 steps:

1.) search stream resolution in whitelist / fps match
2.) search stream resolution in whitelist / double fps match
3.) search if default (GUI) resolution matches video fps and is in whitelist
4.) search if default (GUI) resolution matches double vide fps and is in whitelist

This PR adds a new criteria between 2 and 3: look if video resolution is <= current resolution and if video fps is half or full current Monitor frequency.

## Motivation and Context
Reduce resolution switch while zapping in Live-TV which contain SD and HD streams.

## How Has This Been Tested?
GUI: 1080p. Whitelist contains 720p, TV is not SD capable.
without PR:
- Select HD stream -> res switch to 720p
- select SD stream: res switch to 1080p (GUI default) because no SD in whitelist
- select HD stream: switch to 720p

with PR:
- Select HD stream -> res switch to 720p
- select SD stream: no res switch (SD fits into current 720p)
- select HD stream: no res switch

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
