### PR TITLE
playlist threading

### DIFF
--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -57,6 +57,8 @@ public:
   const CGUIViewState *GetViewState() const;
   virtual bool UseFileDirectories() { return true; }
 
+  int PlaylistPosition = 0;
+
 protected:
   // specializations of CGUIControlGroup
   CGUIControl *GetFirstFocusableControl(int id) override;
@@ -155,6 +157,12 @@ protected:
   virtual void LoadPlayList(const std::string& strFileName) {}
   virtual bool OnPlayMedia(int iItem, const std::string &player = "");
   virtual bool OnPlayAndQueueMedia(const CFileItemPtr &item, std::string player = "");
+
+
+  static void* callPlaylistAddAsync(void *arg) { return ((CGUIMediaWindow*)arg)->PlaylistAddAsync(); }
+  void*         PlaylistAddAsync(void);
+
+
   void UpdateFileList();
   virtual void OnDeleteItem(int iItem);
   void OnRenameItem(int iItem);


### PR DESCRIPTION
Hello
I uploaded a snippet of code and maybe some of the devs can have a look at it.
The goal is to fix some design based performance problems in case using large (e.g. music) collections.
The current problem is, e.g. playlist creation can take on highend hardware minutes, on lowend hardware half an hour.
Imagine, you have a playlist with around 50.000 songs. The current approach creates the whole playlist before continuing with anything else, for example start playing the first song.
My snippet will now generate the actual playlist in a separate thread to get rid of this performance lag.

Actually in the end, all list-generations should be modified to a threading approach.

As I'm not a professional c-programmer and not familiar complete kodi code, the snippets just shows a functional version of the playlist threading.
Maybe the devs can check it and give a feedback if this approach is total crap and triggers issues in other modules of kodi or they can give it a shot.

Also as mentioned, I'm not an C expert. I program my own projects in different languages, so I'm not sure  if e.g. using "pthread.h" for threading is the best for generating threads in kodi etc.
Maybe such things can be also checked by the devs to rule out conceptional problems. 
Don't actually pull it yet into the kodi sources!