### PR TITLE
[TexturePacker] update windows dirent implementation

### DIFF
--- a/tools/depends/native/TexturePacker/src/Win32/dirent.c
+++ b/tools/depends/native/TexturePacker/src/Win32/dirent.c
@@ -3,7 +3,7 @@
     Implementation of POSIX directory browsing functions and types for Win32.
 
     Author:  Kevlin Henney (kevlin@acm.org, kevlin@curbralan.com)
-    History: Created March 1997. Updated June 2003.
+    History: Created March 1997. Updated June 2003 and July 2012.
 
     Copyright Kevlin Henney, 1997, 2003. All rights reserved.
 
@@ -28,9 +28,11 @@ extern "C"
 {
 #endif
 
+typedef ptrdiff_t handle_type; /* C99's intptr_t not sufficiently portable */
+
 struct DIR
 {
-    long                handle; /* -1 for failed rewind */
+    handle_type         handle; /* -1 for failed rewind */
     struct _finddata_t  info;
     struct dirent       result; /* d_name null iff first time */
     char                *name;  /* null-terminated char string */
@@ -51,7 +53,7 @@ DIR *opendir(const char *name)
         {
             strcat(strcpy(dir->name, name), all);
 
-            if((dir->handle = (long) _findfirst(dir->name, &dir->info)) != -1)
+            if ((dir->handle = (handle_type)_findfirst(dir->name, &dir->info)) != -1)
             {
                 dir->result.d_name = 0;
                 dir->result.d_type = 0;
@@ -127,7 +129,7 @@ void rewinddir(DIR *dir)
     if(dir && dir->handle != -1)
     {
         _findclose(dir->handle);
-        dir->handle = (long) _findfirst(dir->name, &dir->info);
+        dir->handle = (handle_type)_findfirst(dir->name, &dir->info);
         dir->result.d_name = 0;
         dir->result.d_type = 0;
     }


### PR DESCRIPTION
## Description
update windows dirent implementation

## Motivation and Context
x86_64 TexturePacker crashes on windows

## How Has This Been Tested?
run x86_64 TexturePacker on windows

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
