### PR TITLE
[videoplayer] overlay: drop supporting crappy tab/sbs subtitles.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -231,21 +231,6 @@ CDVDOverlay* CDVDOverlayCodecFFmpeg::GetOverlay()
       }
     }
 
-    RENDER_STEREO_MODE render_stereo_mode = CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode();
-    if (render_stereo_mode != RENDER_STEREO_MODE_OFF)
-    {
-      if (rect.h > m_height / 2)
-      {
-        m_height /= 2;
-        rect.h /= 2;
-      }
-      else if (rect.w > m_width / 2)
-      {
-        m_width /= 2;
-        rect.w /= 2;
-      }
-    }
-
     CDVDOverlayImage* overlay = new CDVDOverlayImage();
 
     overlay->iPTSStartTime = m_StartTime;


### PR DESCRIPTION
this fixes regular subtitles with wide inscriptions is stereo mode.

I really don't understand why we support all this crappy sbs/tab subtitles then when Kodi can render regular subtitles well in stereo mode.