### PR TITLE
[PVR][settings] Reintroduce setting "Close channel OSD after switchin…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10920,7 +10920,11 @@ msgctxt "#19302"
 msgid "Do you want to record the selected programme or to switch to the current programme?"
 msgstr ""
 
-#empty string with id 19303
+#. label for PVR settings close channel OSD after channel switch control
+#: system/settings/settings.xml
+msgctxt "#19303"
+msgid "Close channel OSD after switching channels"
+msgstr ""
 
 #. Label for context menu entry to open settings dialog for a timer rule (read-only)
 #: xbmc/pvr/PVRContextMenus.cpp
@@ -18641,7 +18645,10 @@ msgctxt "#36234"
 msgid "Duration of instant recordings when pressing the record button. This value will be taken into account if \"Instant recording action\" is set to \"Record for a fixed period of time\""
 msgstr ""
 
-#empty string with id 36235
+#: system/settings/settings.xml
+msgctxt "#36235"
+msgid "Close the on screen display controls after switching channels."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36236"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1294,6 +1294,11 @@
             <formatlabel>14045</formatlabel>
           </control>
         </setting>
+        <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19303" help="36235">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2" label="14302">
         <setting id="pvrmenu.iconpath" type="path" label="19018" help="36216">

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -15,6 +15,8 @@
 #include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
@@ -214,7 +216,9 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
 
   // Preserve the item before closing self, because this will clear m_vecItems
   const CFileItemPtr itemptr = m_vecItems->Get(item);
-  Close();
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH))
+    Close();
+
   CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(itemptr, true /* bCheckResume */);
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -201,6 +201,7 @@ const std::string CSettings::SETTING_PVRMANAGER_GROUPMANAGER = "pvrmanager.group
 const std::string CSettings::SETTING_PVRMANAGER_CHANNELSCAN = "pvrmanager.channelscan";
 const std::string CSettings::SETTING_PVRMANAGER_RESETDB = "pvrmanager.resetdb";
 const std::string CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO = "pvrmenu.displaychannelinfo";
+const std::string CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH = "pvrmenu.closechannelosdonswitch";
 const std::string CSettings::SETTING_PVRMENU_ICONPATH = "pvrmenu.iconpath";
 const std::string CSettings::SETTING_PVRMENU_SEARCHICONS = "pvrmenu.searchicons";
 const std::string CSettings::SETTING_EPG_PAST_DAYSTODISPLAY = "epg.pastdaystodisplay";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -161,6 +161,7 @@ public:
   static const std::string SETTING_PVRMANAGER_CHANNELSCAN;
   static const std::string SETTING_PVRMANAGER_RESETDB;
   static const std::string SETTING_PVRMENU_DISPLAYCHANNELINFO;
+  static const std::string SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH;
   static const std::string SETTING_PVRMENU_ICONPATH;
   static const std::string SETTING_PVRMENU_SEARCHICONS;
   static const std::string SETTING_EPG_PAST_DAYSTODISPLAY;


### PR DESCRIPTION
…g channels", which got accidentally removed for Leia 18.0

Discussed and requested in the forum: https://forum.kodi.tv/showthread.php?tid=336259&pid=2814566#pid2814566 ff

@Jalle19 good to go?