### PR TITLE
Fix Top 100 Albums regression

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4293,7 +4293,7 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
     sorting = sortDescription;
     if (limitedInSQL && sortDescription.sortBy == SortByRandom)
       sorting.sortBy = SortByNone;
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeSong, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeArtist, m_pDS, results))
       return false;
     
     // get data from returned rows
@@ -4467,7 +4467,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
     sorting = sortDescription;
     if (limitedInSQL && sortDescription.sortBy == SortByRandom)
       sorting.sortBy = SortByNone;
-    if (!SortUtils::SortFromDataset(sorting, MediaTypeSong, m_pDS, results))
+    if (!SortUtils::SortFromDataset(sorting, MediaTypeAlbum, m_pDS, results))
       return false;
 
     // get data from returned rows


### PR DESCRIPTION
Fix a gremlin crept in with https://github.com/xbmc/xbmc/pull/15340 (a copy 'n' paste error)

User reported odd results in Top 100 Albums, but any artists or albums smart playlists or custom nodes with limits defined would not be able to correctly sort before applying limit.

