### PR TITLE
Add READ_EXTERNAL_STORAGE permission, to fix script.kodi.android.update

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -9,6 +9,7 @@
         android:minSdkVersion="21"
         android:targetSdkVersion="26" />
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -137,7 +137,7 @@ public class Splash extends Activity
           mSplash.mTextView.setText("Asking for permissions...");
           mSplash.mProgress.setVisibility(View.INVISIBLE);
 
-          requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+          requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE},
                     PERMISSION_RESULT_CODE);
           break;
         case CheckingPermissionsDone:


### PR DESCRIPTION
## Description
This should allow the app to be granted both READ_EXTERNAL_STORAGE *and* WRITE_EXTERNAL_STORAGE permissions, hopefully solving the issue of Kodi not being able to install other *.apk* files, like in the official Kodi Android Installer add-on.

## Motivation and Context
I don't believe there are any open issues regarding this, but as of Nov 2018, the script.kodi.android.update add-on stopped working (first mention of the crash [here](https://forum.kodi.tv/showthread.php?tid=322783&pid=2786299#pid2786299), I believe), and was simply ["impaired due to an Android API change"](https://github.com/xbmc/repo-scripts/commit/b3a61b7904dc2b3831e34a4d0995388184e2d7ef). This "API change" came in late 2018, when Google Play began enforcing `targetSdkVersion="26"` across new apps (more details on that [here](https://www.androidpolice.com/2017/12/19/play-store-require-new-updated-apps-target-recent-api-levels-distribute-native-apps-64-bit-support/)), and when Oreo (Android 8.0) updates started hitting devices, which made them need to request the proper permissions at runtime.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
