### PR TITLE
[modernize] use std:: instead of using namespace std

### DIFF
--- a/tools/depends/native/JsonSchemaBuilder/src/JsonSchemaBuilder.cpp
+++ b/tools/depends/native/JsonSchemaBuilder/src/JsonSchemaBuilder.cpp
@@ -24,26 +24,24 @@
 #include <string>
 #include <regex>
 
-using namespace std;
-
-void print_version(ifstream &in, ofstream &out)
+void print_version(std::ifstream &in, std::ofstream &out)
 {
-  string line;
+  std::string line;
   if (getline(in, line))
-    out << regex_replace(line, regex("(\\s+)?JSONRPC_VERSION\\s+|(\\s+)?#.*"), "");
+    out << std::regex_replace(line, std::regex("(\\s+)?JSONRPC_VERSION\\s+|(\\s+)?#.*"), "");
 }
 
-void print_license(ifstream &in, ofstream &out)
+void print_license(std::ifstream &in, std::ofstream &out)
 {
-  string line;
+  std::string line;
 
   while (getline(in, line, '\n'))
-    out << line << endl;
+    out << line << std::endl;
 }
 
-void print_json(ifstream &in, ofstream &out)
+void print_json(std::ifstream &in, std::ofstream &out)
 {
-  string line;
+  std::string line;
   unsigned int count = 0;
   bool closing = false;
 
@@ -52,18 +50,18 @@ void print_json(ifstream &in, ofstream &out)
     // No need to handle the last line
     if (line == "}")
     {
-      out << endl;
+      out << std::endl;
       continue;
     }
 
     // If we just closed a whole object we need to print the separator
     if (closing)
-      out << "," << endl;
+      out << "," << std::endl;
 
     out << "  ";
     bool started = false;
     closing = false;
-    for (string::iterator itr = line.begin(); itr != line.end(); itr++)
+    for (std::string::iterator itr = line.begin(); itr != line.end(); itr++)
     {
       // Skip \r characters
       if (*itr == '\r') {
@@ -114,13 +112,13 @@ void print_json(ifstream &in, ofstream &out)
 
     // Only print a newline if we haven't just closed a whole object
     if (!closing)
-      out << endl;
+      out << std::endl;
   }
 }
 
 void print_usage(const char *application)
 {
-  cout << application << " version.txt license.txt methods.json types.json notifications.json" << endl;
+  std::cout << application << " version.txt license.txt methods.json types.json notifications.json" << std::endl;
 }
 
 int main(int argc, char* argv[])
@@ -131,48 +129,48 @@ int main(int argc, char* argv[])
     return -1;
   }
 
-  ofstream out ("ServiceDescription.h", ofstream::binary);
+  std::ofstream out ("ServiceDescription.h", std::ofstream::binary);
 
-  ifstream version(argv[1], ios_base::in);
-  ifstream license(argv[2], ios_base::in);
-  ifstream methods(argv[3], ios_base::in);
-  ifstream types(argv[4], ios_base::in);
-  ifstream notifications(argv[5], ios_base::in);
+  std::ifstream version(argv[1], std::ios_base::in);
+  std::ifstream license(argv[2], std::ios_base::in);
+  std::ifstream methods(argv[3], std::ios_base::in);
+  std::ifstream types(argv[4], std::ios_base::in);
+  std::ifstream notifications(argv[5], std::ios_base::in);
 
   if (!(version && license && methods && types && notifications))
   {
-    cout << "Failed to find one or more of version.txt, license.txt, methods.json, types.json or notifications.json" << endl;
+    std::cout << "Failed to find one or more of version.txt, license.txt, methods.json, types.json or notifications.json" << std::endl;
     return -1;
   }
 
-  out << "#pragma once" << endl;
+  out << "#pragma once" << std::endl;
 
   print_license(license, out);
 
-  out << endl;
+  out << std::endl;
 
-  out << "namespace JSONRPC" << endl;
-  out << "{" << endl;
-  out << "  const char* const JSONRPC_SERVICE_ID          = \"http://xbmc.org/jsonrpc/ServiceDescription.json\";" << endl;
-  out << "  const char* const JSONRPC_SERVICE_VERSION     = \""; print_version(version, out); out << "\";" << endl;
-  out << "  const char* const JSONRPC_SERVICE_DESCRIPTION = \"JSON-RPC API of XBMC\";" << endl;
-  out << endl;
+  out << "namespace JSONRPC" << std::endl;
+  out << "{" << std::endl;
+  out << "  const char* const JSONRPC_SERVICE_ID          = \"http://xbmc.org/jsonrpc/ServiceDescription.json\";" << std::endl;
+  out << "  const char* const JSONRPC_SERVICE_VERSION     = \""; print_version(version, out); out << "\";" << std::endl;
+  out << "  const char* const JSONRPC_SERVICE_DESCRIPTION = \"JSON-RPC API of XBMC\";" << std::endl;
+  out << std::endl;
 
   out << "  const char* const JSONRPC_SERVICE_TYPES[] = {";
   print_json(types, out);
-  out << "  };" << endl;
-  out << endl;
+  out << "  };" << std::endl;
+  out << std::endl;
 
   out << "  const char* const JSONRPC_SERVICE_METHODS[] = {";
   print_json(methods, out);
-  out << "  };" << endl;
-  out << endl;
+  out << "  };" << std::endl;
+  out << std::endl;
 
   out << "  const char* const JSONRPC_SERVICE_NOTIFICATIONS[] = {";
   print_json(notifications, out);
-  out << "  };" << endl;
+  out << "  };" << std::endl;
 
-  out << "}" << endl;
+  out << "}" << std::endl;
 
   return 0;
 }

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -47,8 +47,6 @@
 #include <lzo/lzo1x.h>
 #include <sys/stat.h>
 
-using namespace std;
-
 #define FLAGS_USE_LZO     1
 
 #define DIR_SEPARATOR "/"
@@ -223,8 +221,8 @@ void Usage()
 }
 
 static bool checkDupe(struct MD5Context* ctx,
-                      map<string,unsigned int>& hashes,
-                      vector<unsigned int>& dupes, unsigned int pos)
+                      std::map<std::string, unsigned int>& hashes,
+                      std::vector<unsigned int>& dupes, unsigned int pos)
 {
   unsigned char digest[17];
   MD5Final(digest,ctx);
@@ -236,14 +234,14 @@ static bool checkDupe(struct MD5Context* ctx,
       digest[9], digest[10], digest[11], digest[12], digest[13], digest[14],
       digest[15]);
   hex[32] = 0;
-  map<string,unsigned int>::iterator it = hashes.find(hex);
+  std::map<std::string, unsigned int>::iterator it = hashes.find(hex);
   if (it != hashes.end())
   {
     dupes[pos] = it->second;
     return true;
   }
 
-  hashes.insert(make_pair(hex,pos));
+  hashes.insert(std::make_pair(hex,pos));
   dupes[pos] = pos;
 
   return false;
@@ -258,8 +256,8 @@ int createBundle(const std::string& InputDir, const std::string& OutputFile, dou
     return 1;
   }
 
-  map<string,unsigned int> hashes;
-  vector<unsigned int> dupes;
+  std::map<std::string, unsigned int> hashes;
+  std::vector<unsigned int> dupes;
   CreateSkeletonHeader(writer, InputDir);
 
   std::vector<CXBTFFile> files = writer.GetFiles();


### PR DESCRIPTION
## Motivation and Context
This was forgotten at #7912

## How Has This Been Tested?
compiled

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
