### PR TITLE
[python] fix usage of line-breaks in ok dialog

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -173,7 +173,10 @@ namespace XBMCAddon
                     const String& line3)
     {
       DelayedCallGuard dcguard(languageHook);
-      return HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{line1}, CVariant{line2}, CVariant{line3});
+      if (line2.empty() && line3.empty())
+        return HELPERS::ShowOKDialogText(CVariant{heading}, CVariant{line1});
+      else
+        return HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{line1}, CVariant{line2}, CVariant{line3});
     }
 
     void Dialog::textviewer(const String& heading, const String& text, bool usemono)


### PR DESCRIPTION
fix the usage of line-breaks in a python ok dialog.
when a single line of text is passed to the dialog, the ShowOKDialogText helper should be used.

the fixes issue https://github.com/xbmc/xbmc/issues/14824

issue was introduced by PR https://github.com/xbmc/xbmc/pull/10893