### PR TITLE
[Android] Fix invalid PTS decoder value

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -718,7 +718,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   if (!ConfigureMediaCodec())
     goto FAIL;
 
-  if (m_codecname.find("OMX", 0, 3) == 0)
+  if (m_codecname.find("OMX.NVidia", 0, 10) == 0)
     m_invalidPTSValue = AV_NOPTS_VALUE;
   else
     m_invalidPTSValue = 0;


### PR DESCRIPTION
## Description
Some video codecs do not provide PTS (e.g. P-Frame for mpeg2 streams)
While AML / MTK use 0 as "non existent PTS) NVIDIA's value is AV_NOPTS_VALUE

## Motivation and Context
Stutter because of not correct Invalid PTS marker

## How Has This Been Tested?
WETEK Hub / AFTV (MTK and AML) / NVIDIA Shield:
Play movie with Video Component logging enabled and verify decoded PTS values

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
