### PR TITLE
[PVR] Ignore very first 'server not reachable' notification.

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -596,6 +596,13 @@ void CPVRClients::ConnectionStateChange(
   {
     case PVR_CONNECTION_STATE_SERVER_UNREACHABLE:
       iMsg = 35505; // Server is unreachable
+      if (client->GetPreviousConnectionState() == PVR_CONNECTION_STATE_UNKNOWN ||
+          client->GetPreviousConnectionState() == PVR_CONNECTION_STATE_CONNECTING)
+      {
+        // Make our users happy. There were so many complaints about this notification because their TV backend
+        // was not up quick enough after Kodi start. So, ignore the very first 'server not reachable' notification.
+        bNotify = false;
+      }
       break;
     case PVR_CONNECTION_STATE_SERVER_MISMATCH:
       iMsg = 35506; // Server does not respond properly


### PR DESCRIPTION
Fixes user complaints about "server not reachable" notification on Kodi startup due to their TV server not always online by intention or not starting up fast enough when launched together with Kodi. 

Examples: https://forum.kodi.tv/showthread.php?tid=340331 and https://forum.kodi.tv/showthread.php?tid=338069

I hesitated a long time to implement this, but at the end I decided to make those users happy. We still write an event log entry in this situation - so information is not lost. 

Re-introduction of the silly "suppress connection loss notifications" setting is a nogo, btw. Wont happen.

@Jalle19 good to go?