### PR TITLE
[DllLoader] No warning if resolve fails for optional dependencies

### DIFF
--- a/xbmc/DynamicDll.h
+++ b/xbmc/DynamicDll.h
@@ -381,11 +381,11 @@ public: \
 
 #define RESOLVE_METHOD_OPTIONAL(method) \
    m_##method##_ptr = nullptr; \
-   m_dll->ResolveExport( #method , & m_##method##_ptr );
+   m_dll->ResolveExport( #method , & m_##method##_ptr, false );
 
 #define RESOLVE_METHOD_OPTIONAL_FP(method) \
    method##_ptr = NULL; \
-   m_dll->ResolveExport( #method , & method##_ptr );
+   m_dll->ResolveExport( #method , & method##_ptr, false );
 
 
 
@@ -405,7 +405,7 @@ public: \
 
 #define RESOLVE_METHOD_RENAME_OPTIONAL(dllmethod, method) \
   m_##method##_ptr = nullptr; \
-  m_dll->ResolveExport( #dllmethod , & m_##method##_ptr );
+  m_dll->ResolveExport( #dllmethod , & m_##method##_ptr, false );
 
 #define RESOLVE_METHOD_RENAME_FP(dllmethod, method) \
   if (!m_dll->ResolveExport( #dllmethod , & method##_ptr )) \


### PR DESCRIPTION
## Description
Binary addon binding supports optional linkage. We should not warn, if resolve fails for this category:
WARNING: Unable to resolve: XXX.so ADDON_CreateEx, reason: undefined symbol: ADDON_CreateEx

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
