### PR TITLE
Add date to the log records

### DIFF
--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.cpp
@@ -83,13 +83,16 @@ void CPosixInterfaceForCLog::PrintDebugString(const std::string &debugString)
 #endif // _DEBUG
 }
 
-void CPosixInterfaceForCLog::GetCurrentLocalTime(int &hour, int &minute, int &second, double &milliseconds)
+void CPosixInterfaceForCLog::GetCurrentLocalTime(int& year, int& month, int& day, int &hour, int& minute, int& second, double& milliseconds)
 {
   struct tm localTime;
   struct timeval tv;
 
   if (gettimeofday(&tv, nullptr) != -1 && localtime_r(&tv.tv_sec, &localTime) != NULL)
   {
+    year   = localTime.tm_year + 1900;
+    month  = localTime.tm_mon + 1;
+    day    = localTime.tm_mday;
     hour   = localTime.tm_hour;
     minute = localTime.tm_min;
     second = localTime.tm_sec;
@@ -97,7 +100,7 @@ void CPosixInterfaceForCLog::GetCurrentLocalTime(int &hour, int &minute, int &se
   }
   else
   {
-    hour = minute = second = 0;
+    year = month = day = hour = minute = second = 0;
     milliseconds = 0.0;
   }
 }

--- a/xbmc/platform/posix/utils/PosixInterfaceForCLog.h
+++ b/xbmc/platform/posix/utils/PosixInterfaceForCLog.h
@@ -21,7 +21,7 @@ public:
   void CloseLogFile(void);
   bool WriteStringToLog(const std::string& logString);
   void PrintDebugString(const std::string& debugString);
-  static void GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond);
+  static void GetCurrentLocalTime(int& year, int& month, int& day, int& hour, int& minute, int& second, double& millisecond);
 private:
   FILEWRAP* m_file;
 };

--- a/xbmc/platform/win32/utils/Win32InterfaceForCLog.cpp
+++ b/xbmc/platform/win32/utils/Win32InterfaceForCLog.cpp
@@ -105,10 +105,13 @@ void CWin32InterfaceForCLog::PrintDebugString(const std::string& debugString)
 #endif // _DEBUG
 }
 
-void CWin32InterfaceForCLog::GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond)
+void CWin32InterfaceForCLog::GetCurrentLocalTime(int& year, int& month, int& day, int& hour, int& minute, int& second, double& millisecond)
 {
   SYSTEMTIME time;
   GetLocalTime(&time);
+  year = time.wYear;
+  month = time.wMonth;
+  day = time.wDay;
   hour = time.wHour;
   minute = time.wMinute;
   second = time.wSecond;

--- a/xbmc/platform/win32/utils/Win32InterfaceForCLog.h
+++ b/xbmc/platform/win32/utils/Win32InterfaceForCLog.h
@@ -21,7 +21,7 @@ public:
   void CloseLogFile(void);
   bool WriteStringToLog(const std::string& logString);
   void PrintDebugString(const std::string& debugString);
-  static void GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond);
+  static void GetCurrentLocalTime(int& year, int& month, int& day, int& hour, int& minute, int& second, double& millisecond);
 private:
   HANDLE m_hFile;
 };

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -188,17 +188,20 @@ void CLog::PrintDebugString(const std::string& line)
 
 bool CLog::WriteLogString(int logLevel, const std::string& logString)
 {
-  static const char* prefixFormat = "%02d:%02d:%02d.%03d T:%" PRIu64" %7s: ";
+  static const char* prefixFormat = "%02d-%02d-%02d %02d:%02d:%02d.%03d T:%" PRIu64" %7s: ";
 
   std::string strData(logString);
   /* fixup newline alignment, number of spaces should equal prefix length */
   StringUtils::Replace(strData, "\n", "\n                                            ");
 
-  int hour, minute, second;
+  int year, month, day, hour, minute, second;
   double millisecond;
-  g_logState.m_platform.GetCurrentLocalTime(hour, minute, second, millisecond);
+  g_logState.m_platform.GetCurrentLocalTime(year, month, day, hour, minute, second, millisecond);
 
   strData = StringUtils::Format(prefixFormat,
+                                  year,
+                                  month,
+                                  day,
                                   hour,
                                   minute,
                                   second,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This adds date to the existing timestamp in kodi logs. Its very usefull when using on 24/7 boxes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I always struggle to find correct logs quickly in troubleshooting X days back problems.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On my own boxes.
## Screenshots (if appropriate):
Before:
```
20:35:34.329 T:3887018864  NOTICE: thread end: video_thread
20:35:34.330 T:3878626160  NOTICE: deleting video codec
20:35:34.346 T:3878626160  NOTICE: Closing stream player 3
20:35:34.364 T:4087664656  NOTICE: VideoPlayer: finished waiting
```

After:
```
2019-02-07 12:17:45.687 T:4091854864  NOTICE: initialize done
2019-02-07 12:17:45.688 T:4091854864  NOTICE: Running the application...
2019-02-07 12:17:45.696 T:4091854864  NOTICE: starting zeroconf publishing
2019-02-07 12:17:45.696 T:4091854864  NOTICE: CWebServer[8080]: Started
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
