### PR TITLE
[VideoPlayer] Flush streamplayers if abort is requested

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -742,6 +742,8 @@ bool CVideoPlayer::CloseFile(bool reopen)
   if(m_pInputStream)
     m_pInputStream->Abort();
 
+  m_renderManager.UnInit();
+
   CLog::Log(LOGNOTICE, "VideoPlayer: waiting for threads to exit");
 
   // wait for the main thread to finish up
@@ -758,7 +760,6 @@ bool CVideoPlayer::CloseFile(bool reopen)
   m_HasAudio = false;
 
   CLog::Log(LOGNOTICE, "VideoPlayer: finished waiting");
-  m_renderManager.UnInit();
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -90,6 +90,9 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
   {
     CSingleLock lock(m_statelock);
 
+    if (!m_bRenderGUI)
+      return true;
+
     if (m_width == picture.iWidth &&
         m_height == picture.iHeight &&
         m_dwidth == picture.iDisplayWidth &&
@@ -399,6 +402,7 @@ void CRenderManager::UnInit()
   m_renderState = STATE_UNCONFIGURED;
   m_width = 0;
   m_height = 0;
+  m_bRenderGUI = false;
   RemoveCaptures();
 
   m_initEvent.Set();


### PR DESCRIPTION
## Description
Flush VideoPlayer's (sub) players (video / audio / subtitle ...) when closing a stream.

## Motivation and Context
I ran regulary into the situation that stopping a video stream takes long time.
In one of my DVD iso's I have to wait for example ~ 15secs if I stop playback during legal notice.

In kodi log you see this: 
```
14:56:44.982 T:15216 WARNING: CRenderManager::WaitForBuffer - timeout waiting for buffer
14:56:54.210 T:11328 WARNING: Previous line repeats 175 times.
```

Reason is that sub-players are not notified that abort is requested, and e.g. VideoPlayer tries to render frames while VideoPlayer is waiting for finalization.

This PR notifies sub-players that abort is requested using Flush().

## How Has This Been Tested?
Very long wait for stream termination:
- Start this movie: http://www.archive.org/download/BigBuckBunny/big-buck-bunny-NTSC.iso
- Press X or stop while legal notice is displayed.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
