### PR TITLE
[win32] don't react on DPI change event on Win10 >= FCU

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -278,6 +278,18 @@ void CApplication::HandlePortEvents()
             settings->SetInt(CSettings::SETTING_WINDOW_HEIGHT, newEvent.resize.h);
             settings->Save();
           }
+#ifdef TARGET_WINDOWS
+          else
+          {
+            // this may occurs when OS tries to resize application window 
+            //CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP, true);
+            //auto& gfxContext = CServiceBroker::GetWinSystem()->GetGfxContext();
+            //gfxContext.SetVideoResolution(gfxContext.GetVideoResolution(), true);
+            // try to resize window back to it's full screen size
+            auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+            CServiceBroker::GetWinSystem()->ResizeWindow(res_info.iScreenWidth, res_info.iScreenHeight, 0, 0);
+          }
+#endif
         }
         break;
       case XBMC_VIDEOMOVE:

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -739,11 +739,9 @@ void DX::DeviceResources::SetLogicalSize(float width, float height)
 // This method is called in the event handler for the DpiChanged event.
 void DX::DeviceResources::SetDpi(float dpi)
 {
+  dpi = std::max(dpi, DisplayMetrics::Dpi100);
   if (dpi != m_dpi)
-  {
     m_dpi = dpi;
-    CreateWindowSizeDependentResources();
-  }
 }
 
 // This method is called in the event handler for the DisplayContentsInvalidated event.

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -27,24 +27,6 @@ struct RESOLUTION_INFO;
 
 namespace DX
 {
-  namespace DisplayMetrics
-  {
-    // High resolution displays can require a lot of GPU and battery power to render.
-    // High resolution phones, for example, may suffer from poor battery life if
-    // games attempt to render at 60 frames per second at full fidelity.
-    // The decision to render at full fidelity across all platforms and form factors
-    // should be deliberate.
-    static const bool SupportHighResolutions = true;
-
-    // The default thresholds that define a "high resolution" display. If the thresholds
-    // are exceeded and SupportHighResolutions is false, the dimensions will be scaled
-    // by 50%.
-    static const float Dpi100 = 96.0f;    // 100% of standard desktop display.
-    static const float DpiThreshold = 192.0f;    // 200% of standard desktop display.
-    static const float WidthThreshold = 1920.0f;  // 1080p width.
-    static const float HeightThreshold = 1080.0f;  // 1080p height.
-  };
-
   interface IDeviceNotify
   {
     virtual void OnDXDeviceLost() = 0;

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -20,6 +20,24 @@ namespace DX
 #define RATIONAL_TO_FLOAT(rational) ((rational.Denominator != 0) ? \
   static_cast<float>(rational.Numerator) / static_cast<float>(rational.Denominator) : 0.0f)
 
+  namespace DisplayMetrics
+  {
+    // High resolution displays can require a lot of GPU and battery power to render.
+    // High resolution phones, for example, may suffer from poor battery life if
+    // games attempt to render at 60 frames per second at full fidelity.
+    // The decision to render at full fidelity across all platforms and form factors
+    // should be deliberate.
+    static const bool SupportHighResolutions = true;
+
+    // The default thresholds that define a "high resolution" display. If the thresholds
+    // are exceeded and SupportHighResolutions is false, the dimensions will be scaled
+    // by 50%.
+    static const float Dpi100 = 96.0f;    // 100% of standard desktop display.
+    static const float DpiThreshold = 192.0f;    // 200% of standard desktop display.
+    static const float WidthThreshold = 1920.0f;  // 1080p width.
+    static const float HeightThreshold = 1080.0f;  // 1080p height.
+  };
+
   inline void BreakIfFailed(HRESULT hr)
   {
     if (FAILED(hr))
@@ -32,18 +50,18 @@ namespace DX
     }
   }
 
-	// Converts a length in device-independent pixels (DIPs) to a length in physical pixels.
-	inline float ConvertDipsToPixels(float dips, float dpi)
-	{
-		static const float dipsPerInch = 96.0f;
-		return floorf(dips * dpi / dipsPerInch + 0.5f); // Round to nearest integer.
-	}
+  // Converts a length in device-independent pixels (DIPs) to a length in physical pixels.
+  inline float ConvertDipsToPixels(float dips, float dpi)
+  {
+	  static const float dipsPerInch = DisplayMetrics::Dpi100;
+	  return floorf(dips * dpi / dipsPerInch + 0.5f); // Round to nearest integer.
+  }
 
-	inline float ConvertPixelsToDips(float pixels, float dpi)
-	{
-		static const float dipsPerInch = 96.0f;
-		return floorf(pixels / (dpi / dipsPerInch) + 0.5f); // Round to nearest integer.
-	}
+  inline float ConvertPixelsToDips(float pixels, float dpi)
+  {
+	  static const float dipsPerInch = DisplayMetrics::Dpi100;
+	  return floorf(pixels / (dpi / dipsPerInch) + 0.5f); // Round to nearest integer.
+  }
 
   inline float RationalToFloat(DXGI_RATIONAL rational)
   {

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -556,7 +556,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       return(0);
     }
     case WM_DISPLAYCHANGE:
-      CLog::LogF(LOGDEBUG, "display change event");
+      CLog::LogFC(LOGDEBUG, LOGWINDOWING, "display change event");
       if (g_application.GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() && GET_X_LPARAM(lParam) > 0 && GET_Y_LPARAM(lParam) > 0)
       {
         DX::Windowing()->UpdateResolutions();

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -550,9 +550,10 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     // the new DPI.
     {
       // get the suggested size of the window on the new display with a different DPI
-      unsigned short  dpi = LOWORD(wParam);
-      RECT resizeRect = *reinterpret_cast<RECT*>(lParam);
-      DX::Windowing()->DPIChanged(dpi, resizeRect);
+      uint16_t  dpi = HIWORD(wParam);
+      RECT rc = *reinterpret_cast<RECT*>(lParam);
+      CLog::LogFC(LOGDEBUG, LOGWINDOWING, "dpi changed event -> %d (%d, %d, %d, %d)", dpi, rc.left, rc.top, rc.right, rc.bottom);
+      DX::Windowing()->DPIChanged(dpi, rc);
       return(0);
     }
     case WM_DISPLAYCHANGE:

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -566,22 +566,31 @@ bool CWinSystemWin32::DPIChanged(WORD dpi, RECT windowRect) const
   {
     MONITORINFOEX monitorInfo;
     monitorInfo.cbSize = sizeof(MONITORINFOEX);
-    GetMonitorInfo(hMon, &monitorInfo);
-    RECT wr = monitorInfo.rcWork;
-    long wrWidth = wr.right - wr.left;
-    long wrHeight = wr.bottom - wr.top;
-    long resizeWidth = resizeRect.right - resizeRect.left;
-    long resizeHeight = resizeRect.bottom - resizeRect.top;
+    GetMonitorInfoW(hMon, &monitorInfo);
 
-    if (resizeWidth > wrWidth)
+    if (m_state == WINDOW_STATE_FULLSCREEN_WINDOW ||
+        m_state == WINDOW_STATE_FULLSCREEN)
     {
-      resizeRect.right = resizeRect.left + wrWidth;
+      resizeRect = monitorInfo.rcMonitor; // the whole screen
     }
-
-    // make sure suggested windows size is not taller or wider than working area of new monitor (considers the toolbar)
-    if (resizeHeight > wrHeight)
+    else
     {
-      resizeRect.bottom = resizeRect.top + wrHeight;
+      RECT wr = monitorInfo.rcWork; // it excludes task bar
+      long wrWidth = wr.right - wr.left;
+      long wrHeight = wr.bottom - wr.top;
+      long resizeWidth = resizeRect.right - resizeRect.left;
+      long resizeHeight = resizeRect.bottom - resizeRect.top;
+
+      if (resizeWidth > wrWidth)
+      {
+        resizeRect.right = resizeRect.left + wrWidth;
+      }
+
+      // make sure suggested windows size is not taller or wider than working area of new monitor (considers the toolbar)
+      if (resizeHeight > wrHeight)
+      {
+        resizeRect.bottom = resizeRect.top + wrHeight;
+      }
     }
   }
 

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -14,6 +14,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
+#include "utils/SystemInfo.h"
 #include "windowing/GraphicContext.h"
 
 #include "system.h"
@@ -133,9 +134,13 @@ void CWinSystemWin32DX::OnMove(int x, int y)
 
 bool CWinSystemWin32DX::DPIChanged(WORD dpi, RECT windowRect) const
 {
+  // on Win10 FCU the OS keeps window size exactly the same size as it was
+  if (CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10_FCU))
+    return true;
+
   m_deviceResources->SetDpi(dpi);
   if (!IsAlteringWindow())
-    return CWinSystemWin32::DPIChanged(dpi, windowRect);
+    return __super::DPIChanged(dpi, windowRect);
 
   return true;
 }


### PR DESCRIPTION
and some cosmetics related to the fix

this also fixes issues with wrong rendering size after dpi changes and/or display switch off/on