### PR TITLE
Revert "[DetectDVDType]: fix Crash due to non-checked error state"

### DIFF
--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -328,11 +328,6 @@ DWORD CDetectDVDMedia::GetTrayState()
     }
     laststatus = status;
     m_cdio->cdio_destroy(cdio);
-    
-    if (status == DRIVER_OP_UNSUPPORTED)
-    {
-      return DRIVE_NONE;
-    }
   }
   else
     return DRIVE_NOT_READY;


### PR DESCRIPTION
Reverts xbmc/xbmc#14842

I have to revert that fix. The problem is that getting the tray state on some Macs results in "operation unsupported". This now results in the fact that no media is detected. Without the fix it will work because of the default initialization of the tray state to "closed with media".

The original crash that was fixed here happened due to the fact that the user uses an Toshiba usb hdd which presents itself as an virtual cd drive (which holds the usb hdd manual and crap like that). libcdio choked and crashed on that virtual drive.

I'd rather support real cd/dvd drives then supporting a single users with broken HDDs. So here is my revert.