### PR TITLE
[PVR] Document implict call to CloseXXXStream() before OpenXXXStream()

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -413,6 +413,7 @@ extern "C"
    * @param channel The channel to stream.
    * @return True if the stream has been opened successfully, false otherwise.
    * @remarks Required if bHandlesInputStream or bHandlesDemuxing is set to true.
+   *          CloseLiveStream() will always be called by Kodi prior to calling this function.
    *          Return false if this add-on won't provide this function.
    */
   bool OpenLiveStream(const PVR_CHANNEL& channel);
@@ -523,6 +524,7 @@ extern "C"
    * @param recording The recording to open.
    * @return True if the stream has been opened successfully, false otherwise.
    * @remarks Optional, and only used if bSupportsRecordings is set to true.
+   *          CloseRecordedStream() will always be called by Kodi prior to calling this function.
    *          Return false if this add-on won't provide this function.
    */
   bool OpenRecordedStream(const PVR_RECORDING& recording);


### PR DESCRIPTION
## Description
The PVR API is implicitly calling CloseLiveStream() / CloseRecordedStream() before calling OpenLiveStream() / OpenRecordedStream().  I believe these implicit actions should not take place on behalf of the PVR Client addon.

## Motivation and Context
This is a problem if the PVR client is forced to open a stream prior to the actual call to OpenLiveStream() / OpenRecordedStream().  My specific example is that in order to properly support GetChannelStreamProperties() and GetRecordingStreamProperties(), I have to open the stream.  The backend I am working with (HDHomeRun DVR) does not expose the proper MIME type via metadata, and in the case of Recordings, I do not know if the stream will be real-time or not until it's been opened and I have examined the HTTP response headers.  (HDHomeRun DVR reports Recordings currently in-progress as real-time, for example).

Moving the point where GetXXXStreamProperties() is called so that it occurs after OpenXXXStream is prohibitive and unnecessary.  PVR addons can provide Kodi with the proper properties if they are unknown by opening the stream.

Which leads to why this change: Things fall apart because the stream that was opened in GetXXXStreamProperties() is implicitly closed by PVRClient.cpp, and is then opened again.  This is wasteful at best, but at worst the properties may be different on the subsequent open (this is unlikely, but possible).

I see no other instance in PVRClient.cpp where another PVR interface method is implicitly invoked by Kodi.  I also think that other addons may run into the same problem with Leia, not being able to properly report the MIME type and/or realtime flag unless they open and examine the stream -- and likely coming up with the same solution.

For now, I can reference count the calls to Open/Close as a workaround, but I would appreciate consideration of this PR for future Kodi 18.x releases as it's not technically 'breaking' in nature.  Thank you!

## How Has This Been Tested?
Tested on Kodi 18.0 Leia, both at the "18.0-Leia" tag commit as well as the current master branch commit at the time the PR was generated.  Windows 10, x86 and x64 (non-UWP/store).  I verified that CloseLiveStream()/CloseRecordedStream() was invoked the expected number of times (once).  I ran into no issues switching channels or changing from Live to Recorded and vice-versa.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
