### PR TITLE
[PVR] Correct interface documentation for PVR API GetStreamProperties() function

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -497,7 +497,7 @@ extern "C"
    * Get the stream properties of the stream that's currently being read.
    * @param pProperties The properties of the currently playing stream.
    * @return PVR_ERROR_NO_ERROR if the properties have been fetched successfully.
-   * @remarks Required if bHandlesInputStream or bHandlesDemuxing is set to true.
+   * @remarks Required if bHandlesDemuxing is set to true.
    *          Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
   PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties);


### PR DESCRIPTION
## Description
The PVR interface documentation for GetStreamProperties() is incorrect.  This function is not called by Kodi if bHandlesInputStream is true.  It is only called when bHandlesDemuxing is true.

## Motivation and Context
While it would be great if this function was called when bHandlesInputStream is true as an alternative to GetChannelStreamProperties/GetRecordingStreamProperties, that is not the case.

## How Has This Been Tested?
No testing - interface documentation change only via code comments

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
