### PR TITLE
[Estuary][PVR] PVRInfoPanel: Incorrect fallback icon

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -23,7 +23,7 @@
 				<width>461</width>
 				<height>461</height>
 				<aspectratio>keep</aspectratio>
-				<texture fallback="DefaultTVShows.png">$INFO[ListItem.Icon]</texture>
+				<texture fallback="DefaultTVShows.png">$VAR[ChannelListEPGIconVar]</texture>
 			</control>
 			<control type="group">
 				<top>230</top>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -450,6 +450,9 @@
 		<value>$LOCALIZE[20046]</value>
 	</variable>
 	<variable name="ChannelListEPGIconVar">
+		<value condition="String.IsEqual(ListItem.Icon,DefaultVideo.png)">DefaultTVShows.png</value>
+		<!-- to handle a deleted item this requires one additional image - DefaultTVShowsDeleted.png -->
+		<!-- <value condition="String.IsEqual(ListItem.Icon,DefaultVideoDeleted.png)">DefaultTVShowsDeleted.png</value> -->
 		<value condition="!String.IsEmpty(Listitem.EpgEventIcon)">$INFO[ListItem.EpgEventIcon]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Changed PVRInfoPanel fallback icon from DefaultVideo.png to DefaultTVShows.png

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Now shows correct fallback icon in PVRInfoPanel when no thumbnail is available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Compiled and tested - correct icon now visible when no thumbnail available.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
