### PR TITLE
[PVR] Fix deadlock while obtaining recordings from PVR client.

### DIFF
--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -22,6 +22,7 @@ class CFileItemList;
 
 namespace PVR
 {
+  struct PVRRecordingsEvent;
   class CEpgUpdateRequest;
   class CEpgTagStateChange;
 
@@ -75,6 +76,12 @@ namespace PVR
      * @return True on success, false otherwise.
      */
     bool DeleteEpg(const CPVREpgPtr &epg, bool bDeleteFromDatabase = false);
+
+    /*!
+     * @brief Process an event.
+     * @param event The event.
+     */
+    void OnPVRRecordingsEvent(const PVRRecordingsEvent& event);
 
     /*!
      * @brief Process a notification from an observable.

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -22,7 +22,6 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
-#include "pvr/epg/EpgContainer.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
 
@@ -220,22 +219,7 @@ bool CPVRRecording::Delete(void)
   if (!client || client->DeleteRecording(*this) != PVR_ERROR_NO_ERROR)
     return false;
 
-  OnDelete();
   return true;
-}
-
-void CPVRRecording::OnDelete(void)
-{
-  if (m_iEpgEventId != EPG_TAG_INVALID_UID)
-  {
-    const CPVRChannelPtr channel(Channel());
-    if (channel)
-    {
-      const CPVREpgInfoTagPtr epgTag(CServiceBroker::GetPVRManager().EpgContainer().GetTagById(channel, m_iEpgEventId));
-      if (epgTag)
-        epgTag->ClearRecording();
-    }
-  }
 }
 
 bool CPVRRecording::Undelete(void)
@@ -409,9 +393,6 @@ void CPVRRecording::Update(const CPVRRecording &tag)
     strEpisode.erase(0, pos + 2);
     m_strShowTitle = strEpisode;
   }
-
-  if (m_bIsDeleted)
-    OnDelete();
 
   UpdatePath();
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -95,11 +95,6 @@ namespace PVR
     bool Delete(void);
 
     /*!
-     * @brief Called when this recording has been deleted
-     */
-    void OnDelete(void);
-
-    /*!
      * @brief Undelete this recording on the client (if supported).
      * @return True if it was undeleted successfully, false otherwise.
      */

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "FileItem.h"
+#include "utils/EventStream.h"
 #include "video/VideoDatabase.h"
 
 #include "pvr/PVRTypes.h"
@@ -21,10 +22,27 @@ namespace PVR
 {
   class CPVRRecordingsPath;
 
+  struct PVRRecordingsEvent
+  {
+    static const int RecordingUpdated = 0;
+    static const int RecordingRemoved = 1;
+
+    PVRRecordingsEvent(int _id, const std::shared_ptr<CPVRRecording>& _recording)
+    : id(_id), recording(_recording) {}
+
+    int id;
+    std::shared_ptr<CPVRRecording> recording;
+  };
+
   class CPVRRecordings
   {
   public:
     virtual ~CPVRRecordings(void);
+
+    /*!
+     * @brief Query the events available for CEventStream
+     */
+    CEventStream<PVRRecordingsEvent>& Events() { return m_events; }
 
     /**
      * @brief (re)load the recordings from the clients.
@@ -97,6 +115,8 @@ namespace PVR
     bool m_bDeletedRadioRecordings = false;
     unsigned int m_iTVRecordings = 0;
     unsigned int m_iRadioRecordings = 0;
+
+    CEventSource<PVRRecordingsEvent> m_events;
 
     void UpdateFromClients(void);
     std::string TrimSlashes(const std::string &strOrig) const;


### PR DESCRIPTION
This fixes #14794 

Details, root cause and fix alternatives were discussed in the issue.

This PR implements fix approach 2:

> 2. Have clear responsibility on who updates the relations between Recordings and EPG. Either Recordings always update EPG items (any update in EPG would need to notify asynchronously Recordings to make update), or EPG update Recordings (same principle - any update in Recordings would need to notify EPG that relations/counts need to be refreshed).

Thanks to @oldium for the idea and the initial code for the fix.

@Jalle19 mind doing the code review?