### PR TITLE
[estuary] Fix visual glitch when PVR info dialog activated from PVR channels OSD.

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<visible>Player.Seeking | Player.DisplayAfterSeek | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | Player.ShowInfo | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(Player.SeekNumeric) | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
-	<visible>![Window.IsActive(sliderdialog) | Window.IsActive(pvrosdchannels)]</visible>
+	<visible>![Window.IsActive(sliderdialog) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrguideinfo)]</visible>
 	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
 	<include>Animation_BottomSlide</include>
 	<depth>DepthOSD</depth>


### PR DESCRIPTION
* Start plaback of a PVR channel
* (switch to fullscrenn)
* hit 'c' to bring up channel OSD
* hit 'i' to activate guide info dialog
=> garbage on screen.

![screenshot000](https://user-images.githubusercontent.com/3226626/52557701-7a5fa400-2df0-11e9-8a80-33109f75f422.png)

Seekbar should not be visible in this case, only the info dialog. 

@ronie good to go?