### PR TITLE
[PVR] Fix absent calls to SetRecordingLastPlayedPosition

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2509,7 +2509,7 @@ void CVideoPlayer::OnExit()
   CBookmark bookmark;
   bookmark.totalTimeInSeconds = 0;
   bookmark.timeInSeconds = 0;
-  if (m_State.startTime == 0)
+  if (m_State.startTime != 0)
   {
     bookmark.totalTimeInSeconds = m_State.timeMax / 1000;
     bookmark.timeInSeconds = m_State.time / 1000;
@@ -2578,7 +2578,7 @@ void CVideoPlayer::HandleMessages()
       CBookmark bookmark;
       bookmark.totalTimeInSeconds = 0;
       bookmark.timeInSeconds = 0;
-      if (m_State.startTime == 0)
+      if (m_State.startTime != 0)
       {
         bookmark.totalTimeInSeconds = m_State.timeMax / 1000;
         bookmark.timeInSeconds = m_State.time / 1000;


### PR DESCRIPTION
## Description
Leia is not calling the PVR API function SetRecordingLastPlayedPosition when a Recorded TV stream is stopped as expected.

## Motivation and Context
I was informed of this limitation/defect by a user of my third-party PVR client (zuki.pvr.hdhomerundvr), and confirmed it as a defect in Kodi 18.0 final as well as the latest RC1 commit(s) available on 2019.02.12.  I believe the defect was introduced on 2018.08.19 via commit: https://github.com/xbmc/xbmc/commit/4e7b05678fec9b32ad51219851b5ae06b88d63a6.  Since the start time of a PVR recorded stream is known (m_State.startTime != 0), that commit will bypass the necessary code to set the state of the bookmark, and bypass the call into the PVR addon to persist it.  This seems to be a logic error using the operator (==) as opposed to operator (!=) when checking m_State.startTime for validity.

I suggest review by the VideoPlayer core maintainer as well as the PVR maintainer to ensure there are no unintended side-effects; my view of this defect is somewhat myopic and is based on the perspective of PVR addons alone.

## How Has This Been Tested?
Tested on Windows x86 and x64 (non-store).  Prior to the change the PVR API function SetRecordingLastPlayedPosition was never called.  After the change it was called as expected and the functionality was restored.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
