### PR TITLE
CUtil::ValidatePath fix double (back)slash check

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1013,7 +1013,7 @@ std::string CUtil::ValidatePath(const std::string &path, bool bFixDoubleSlashes 
       for (size_t x = 1; x < result.size() - 1; x++)
       {
         if (result[x] == '\\' && result[x+1] == '\\')
-          result.erase(x);
+          result.erase(x, 1);
       }
     }
   }
@@ -1031,7 +1031,7 @@ std::string CUtil::ValidatePath(const std::string &path, bool bFixDoubleSlashes 
       for (size_t x = 2; x < result.size() - 1; x++)
       {
         if ( result[x] == '/' && result[x + 1] == '/' && !(result[x - 1] == ':' || (result[x - 1] == '/' && result[x - 2] == ':')) )
-          result.erase(x);
+          result.erase(x, 1);
       }
     }
   }

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -102,3 +102,27 @@ TEST(TestUtil, MakeShortenPath)
   EXPECT_EQ(true, CUtil::MakeShortenPath("//test//string/is/long/and/very//much/so", result, 30));
   EXPECT_EQ("/../../../../../so", result);
 }
+
+TEST(TestUtil, ValidatePath)
+{
+  std::string path;
+#ifdef TARGET_WINDOWS
+  path = "C:/foo/bar/";
+  EXPECT_EQ(CUtil::ValidatePath(path), "C:\\foo\\bar\\");
+  path = "C:\\\\foo\\\\bar\\";
+  EXPECT_EQ(CUtil::ValidatePath(path, true), "C:\\foo\\bar\\");
+  path = "\\\\foo\\\\bar\\";
+  EXPECT_EQ(CUtil::ValidatePath(path, true), "\\\\foo\\bar\\");
+#else
+  path = "\\foo\\bar\\";
+  EXPECT_EQ(CUtil::ValidatePath(path), "/foo/bar/");
+  path = "/foo//bar/";
+  EXPECT_EQ(CUtil::ValidatePath(path, true), "/foo/bar/");
+#endif
+  path = "smb://foo/bar/";
+  EXPECT_EQ(CUtil::ValidatePath(path), "smb://foo/bar/");
+  path = "smb://foo//bar/";
+  EXPECT_EQ(CUtil::ValidatePath(path, true), "smb://foo/bar/");
+  path = "smb:\\\\foo\\\\bar\\";
+  EXPECT_EQ(CUtil::ValidatePath(path, true), "smb://foo/bar/");
+}


### PR DESCRIPTION
Very simple patch for correct double (back)slash path validation. This is only used by the function called from Python (xbmc.validatePath), all others in code assume false and skip this section. That is probably why this has been unnoticed for such a long time, but an user of my add-on tried to validate a path like this against it: nfs://1.2.3.4//video/Test/test.avi. The current situation returns 'nfs://1.2.3.4' instead of the full path with only the doubles removed. Of course it seems unnecessary to use the function at all, but it's nice to have it fixed anyway (or it should be removed if obsolete).

When we're looking at the previous commit, already 5 years ago, it seems clear that .Delete(x) has been replaced by .erase(x). However that Delete function used to call erase(x, length) with a default value of 1 for length. So that's when this bug got introduced. Simply adding a length of 1 to the erase() function will fix this.

This is my first PR on this repo, so hopefully I've done nothing wrong ;-) Otherwise, please forgive me.