### PR TITLE
[GLES] Check for GL_UNPACK_ROW_LENGTH by calling glGetInteger

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -202,6 +202,7 @@ protected:
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
   unsigned char* m_planeBuffer = nullptr;
+  bool m_unpackRowLengthSupported = false;
 
   // clear colour for "black" bars
   float m_clearColour{0.0f};


### PR DESCRIPTION
## Description
Enum value is the same for GL_UNPACK_ROW_LENGTH and GL_EXT_UNPACK_ROW_LENGTH, enum support can be validated by calling glGetIntegerv and checking glGetError return value. This allows to explicitly check for unpack_row_length support for both devices supporting it via extension and natively in GLES 3.0.

## Motivation and Context
Simplifies code a little bit. Motivation: wanted to use unpack_row_length with Mali-T820 via libhybris. Hybris reports GLES 2.0 and no unpack_row_length extension support whereas it is supported. 

## How Has This Been Tested?
LibreELEC on Amlogic S905 (Mali-450, no extension support) and S912 (Mali-T820, GLES 3.0).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
