### PR TITLE
DisplaySettings: Fix off by 1 iterator start in UpdateCalibrations()

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -554,7 +554,7 @@ void CDisplaySettings::UpdateCalibrations()
   CSingleLock lock(m_critical);
 
   // Add new (unique) resolutions
-  for (ResolutionInfos::const_iterator res(m_resolutions.cbegin() + RES_DESKTOP + 1); res != m_resolutions.cend(); ++res)
+  for (ResolutionInfos::const_iterator res(m_resolutions.cbegin() + RES_DESKTOP); res != m_resolutions.cend(); ++res)
     if (std::find_if(m_calibrations.cbegin(), m_calibrations.cend(),
       [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(res->strMode, info.strMode); }) == m_calibrations.cend())
         m_calibrations.push_back(*res);


### PR DESCRIPTION
## Description
Trying to fix "Video calibration settings changes are lost after Kodi restart"

Fixes what looks like an off-by 1 the iterator start position in DisplaySettings;:UpdateCalibrations().  It looked off when I went through the diff that caused the above bug here:
https://github.com/xbmc/xbmc/commit/e8c158606000f19fef478184e20898f8ff8bd5c4

## Motivation and Context
Video Calibration settings does not persist without this.

https://github.com/xbmc/xbmc/issues/15165

## How Has This Been Tested?
Just calibrated video and rebooted, verified that my overscan settings came up again.

I am extremely new to this project, so take my conclusions with a grain of salt until the author of the diff causing the bug has had a chance to go over it :+1: 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
