### PR TITLE
CFileItem::SetFromVideoInfoTag(): support PVR recordings

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -34,7 +34,9 @@
 #include "music/MusicDatabase.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/epg/Epg.h"
+#include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "video/Bookmark.h"
 #include "video/VideoInfoTag.h"
@@ -1627,10 +1629,22 @@ void CFileItem::SetFromVideoInfoTag(const CVideoInfoTag &video)
     m_bIsFolder = false;
   }
 
-  if (m_videoInfoTag)
-    *m_videoInfoTag = video;
+  if (!m_bIsFolder && URIUtils::IsPVRRecording(m_strPath))
+  {
+    delete m_videoInfoTag;
+    m_videoInfoTag = NULL;
+    CPVRRecordingsPtr recordings = CServiceBroker::GetPVRManager().Recordings();
+    if (recordings)
+      m_pvrRecordingInfoTag = recordings->GetByPath(m_strPath)->m_pvrRecordingInfoTag;
+    *GetVideoInfoTag() = video;
+  }
   else
-    m_videoInfoTag = new CVideoInfoTag(video);
+  {
+    if (m_videoInfoTag)
+      *m_videoInfoTag = video;
+    else
+      m_videoInfoTag = new CVideoInfoTag(video);
+  }
 
   if (video.m_iSeason == 0)
     SetProperty("isspecial", "true");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Create m_pvrRecordingInfoTag in CFileItem if a recording is set from CVideoInfoTag.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
PVR recordings added to the library don't play from the library section.

Fix for #15280 and #14791

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Linux build with VNSI client.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
