### PR TITLE
[Windowing] Build complete strmode for RES_DESKTOP

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -553,16 +553,19 @@ void CDisplaySettings::UpdateCalibrations()
 {
   CSingleLock lock(m_critical);
 
+  if (m_resolutions.size() <= RES_DESKTOP)
+    return;
+
   // Add new (unique) resolutions
-  for (ResolutionInfos::const_iterator res(m_resolutions.cbegin() + RES_DESKTOP + 1); res != m_resolutions.cend(); ++res)
+  for (ResolutionInfos::const_iterator res(m_resolutions.cbegin() + RES_CUSTOM); res != m_resolutions.cend(); ++res)
     if (std::find_if(m_calibrations.cbegin(), m_calibrations.cend(),
       [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(res->strMode, info.strMode); }) == m_calibrations.cend())
         m_calibrations.push_back(*res);
 
   for (auto &cal : m_calibrations)
   {
-    ResolutionInfos::const_iterator res(std::find_if(m_resolutions.cbegin()+ RES_DESKTOP, m_resolutions.cend(),
-      [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(cal.strMode, info.strMode); }));
+    ResolutionInfos::const_iterator res(std::find_if(m_resolutions.cbegin() + RES_DESKTOP, m_resolutions.cend(),
+    [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(cal.strMode, info.strMode); }));
 
     if (res != m_resolutions.cend())
     {

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -42,7 +42,7 @@ bool CWinSystemBase::DestroyWindowSystem()
   return false;
 }
 
-void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, int width, int height, float refreshRate, uint32_t dwFlags)
+void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags)
 {
   newRes.Overscan.left = 0;
   newRes.Overscan.top = 0;
@@ -57,15 +57,16 @@ void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, int width,
   newRes.iHeight = height;
   newRes.iScreenWidth = width;
   newRes.iScreenHeight = height;
-  newRes.strMode = StringUtils::Format("%dx%d", width, height);
+  newRes.strMode = StringUtils::Format("%s: %dx%d", output.c_str(), width, height);
   if (refreshRate > 1)
-    newRes.strMode += StringUtils::Format("@ %.2f", refreshRate);
+    newRes.strMode += StringUtils::Format(" @ %.2fHz", refreshRate);
   if (dwFlags & D3DPRESENTFLAG_INTERLACED)
     newRes.strMode += "i";
   if (dwFlags & D3DPRESENTFLAG_MODE3DTB)
     newRes.strMode += "tab";
   if (dwFlags & D3DPRESENTFLAG_MODE3DSBS)
     newRes.strMode += "sbs";
+  newRes.strOutput = output;
 }
 
 void CWinSystemBase::UpdateResolutions()

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -140,7 +140,7 @@ public:
   CGraphicContext& GetGfxContext();
 
 protected:
-  void UpdateDesktopResolution(RESOLUTION_INFO& newRes, int width, int height, float refreshRate, uint32_t dwFlags);
+  void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);
   virtual std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() { return nullptr; }
 
   int m_nWidth = 0;

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -340,11 +340,10 @@ void CWinSystemX11::UpdateResolutions()
       mode = g_xrandr.GetPreferredMode(m_userOutput);
     m_bIsRotated = out->isRotated;
     if (!m_bIsRotated)
-      UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), mode.w, mode.h, mode.hz, 0);
+      UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), out->name, mode.w, mode.h, mode.hz, 0);
     else
-      UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), mode.h, mode.w, mode.hz, 0);
+      UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), out->name, mode.h, mode.w, mode.hz, 0);
     CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP).strId = mode.id;
-    CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP).strOutput = m_userOutput;
   }
   else
   {
@@ -352,7 +351,7 @@ void CWinSystemX11::UpdateResolutions()
     m_screen = DefaultScreen(m_dpy);
     int w = DisplayWidth(m_dpy, m_screen);
     int h = DisplayHeight(m_dpy, m_screen);
-    UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), w, h, 0.0, 0);
+    UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), m_userOutput, w, h, 0.0, 0);
   }
 
   // erase previous stored modes

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -261,10 +261,7 @@ void CWinSystemIOS::UpdateResolutions()
 
   //first screen goes into the current desktop mode
   if(GetScreenResolution(&w, &h, &fps, screenIdx))
-  {
-    UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), w, h, fps, 0);
-    CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP).strOutput = screenIdx == 0 ? CONST_TOUCHSCREEN : CONST_EXTERNAL;
-  }
+    UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), screenIdx == 0 ? CONST_TOUCHSCREEN : CONST_EXTERNAL, w, h, fps, 0);
 
   CDisplaySettings::GetInstance().ClearCustomResolutions();
 
@@ -291,16 +288,7 @@ void CWinSystemIOS::FillInVideoModes(int screenIdx)
     w = mode.size.width;
     h = mode.size.height;
 
-    if (screenIdx == 0)
-    {
-      res.strOutput = CONST_TOUCHSCREEN;
-    }
-    else
-    {
-      res.strOutput = CONST_EXTERNAL;
-    }
-
-    UpdateDesktopResolution(res, w, h, refreshrate, 0);
+    UpdateDesktopResolution(res, screenIdx == 0 ? CONST_TOUCHSCREEN : CONST_EXTERNAL, w, h, refreshrate, 0);
     CLog::Log(LOGNOTICE, "Found possible resolution for display %d with %d x %d\n", screenIdx, w, h);
 
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1115,10 +1115,8 @@ void CWinSystemOSX::UpdateResolutions()
 
   int dispIdx = GetDisplayIndex(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
   GetScreenResolution(&w, &h, &fps, dispIdx);
-  UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), w, h, fps, 0);
-  NSString *dispName = screenNameForDisplay(GetDisplayID(dispIdx));
-
-  CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP).strOutput = [dispName UTF8String];
+  NSString *dispName = screenNameForDisplay(GetDisplayID(dispIdx));  
+  UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), [dispName UTF8String], w, h, fps, 0);
 
   CDisplaySettings::GetInstance().ClearCustomResolutions();
 
@@ -1395,25 +1393,7 @@ void CWinSystemOSX::FillInVideoModes()
         // all others are only logged above...
         if (disp == dispIdx)
         {
-          if (dispName != nil)
-          {
-            res.strOutput = [dispName UTF8String];
-          }
-
-          UpdateDesktopResolution(res, w, h, refreshrate, 0);
-
-          // overwrite the mode str because  UpdateDesktopResolution adds a
-          // "Full Screen". Since the current resolution is there twice
-          // this would lead to 2 identical resolution entrys in the guisettings.xml.
-          // That would cause problems with saving screen overscan calibration
-          // because the wrong entry is picked on load.
-          // So we just use UpdateDesktopResolutions for the current DESKTOP_RESOLUTIONS
-          // in UpdateResolutions. And on all other resolutions make a unique
-          // mode str by doing it without appending "Full Screen".
-          // this is what linux does - though it feels that there shouldn't be
-          // the same resolution twice... - thats why i add a FIXME here.
-          res.strMode = StringUtils::Format("%dx%d @ %.2f", w, h, refreshrate);
-
+          UpdateDesktopResolution(res, (dispName != nil) ? [dispName UTF8String] : "Unknown", w, h, refreshrate, 0);
           CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
           CDisplaySettings::GetInstance().AddResolutionInfo(res);
         }

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -347,7 +347,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
   ApplyWindowGeometry();
 
   // Update resolution with real size as it could have changed due to configure()
-  UpdateDesktopResolution(res, m_bufferSize.Width(), m_bufferSize.Height(), res.fRefreshRate, 0);
+  UpdateDesktopResolution(res, res.strOutput, m_bufferSize.Width(), m_bufferSize.Height(), res.fRefreshRate, 0);
   res.bFullScreen = fullScreen;
 
   m_seatInputProcessing.reset(new CSeatInputProcessing(m_surface, *this));
@@ -475,8 +475,7 @@ void CWinSystemWayland::UpdateResolutions()
     CLog::LogF(LOGINFO, "- %dx%d @%.3f Hz pixel ratio %.3f%s", mode.size.Width(), mode.size.Height(), mode.refreshMilliHz / 1000.0f, pixelRatio, isCurrent ? " current" : "");
 
     RESOLUTION_INFO res;
-    UpdateDesktopResolution(res, mode.size.Width(), mode.size.Height(), mode.GetRefreshInHz(), 0);
-    res.strOutput = outputName;
+    UpdateDesktopResolution(res, outputName, mode.size.Width(), mode.size.Height(), mode.GetRefreshInHz(), 0);
     res.fPixelRatio = pixelRatio;
 
     if (isCurrent)
@@ -889,8 +888,8 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
       {
         // Add new resolution if none found
         RESOLUTION_INFO newResInfo;
-        UpdateDesktopResolution(newResInfo, sizes.bufferSize.Width(), sizes.bufferSize.Height(), refreshRate, 0);
-        newResInfo.strOutput = CDisplaySettings::GetInstance().GetCurrentResolutionInfo().strOutput; // we just assume the compositor put us on the right output
+        // we just assume the compositor put us on the right output
+        UpdateDesktopResolution(newResInfo, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().strOutput, sizes.bufferSize.Width(), sizes.bufferSize.Height(), refreshRate, 0);
         CDisplaySettings::GetInstance().AddResolutionInfo(newResInfo);
         CDisplaySettings::GetInstance().ApplyCalibrations();
         res = static_cast<RESOLUTION> (CDisplaySettings::GetInstance().ResolutionInfoSize() - 1);

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -380,7 +380,7 @@ void CWinSystemWin10::UpdateResolutions()
     refreshRate = static_cast<float>(details->RefreshRate);
 
   RESOLUTION_INFO& primary_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
-  UpdateDesktopResolution(primary_info, w, h, refreshRate, dwFlags);
+  UpdateDesktopResolution(primary_info, "Default", w, h, refreshRate, dwFlags);
   CLog::Log(LOGNOTICE, "Primary mode: %s", primary_info.strMode.c_str());
 
   // erase previous stored modes

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -886,19 +886,20 @@ void CWinSystemWin32::UpdateResolutions()
     refreshRate = static_cast<float>(details->RefreshRate + 1) / 1.001f;
   else
     refreshRate = static_cast<float>(details->RefreshRate);
-  std::string strOuput = FromW(details->DeviceNameW);
+
+  std::string strOutput = FromW(details->DeviceNameW);
+  std::string monitorName = FromW(details->MonitorNameW);
 
   uint32_t dwFlags = details->Interlaced ? D3DPRESENTFLAG_INTERLACED : 0;
 
   RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
-  UpdateDesktopResolution(info, w, h, refreshRate, dwFlags);
-  info.strOutput = strOuput;
+  UpdateDesktopResolution(info, monitorName, w, h, refreshRate, dwFlags);
+  info.strOutput = strOutput;
 
   CLog::Log(LOGNOTICE, "Primary mode: %s", info.strMode.c_str());
 
   // erase previous stored modes
   CDisplaySettings::GetInstance().ClearCustomResolutions();
-  std::string monitorName = FromW(details->MonitorNameW);
 
   for(int mode = 0;; mode++)
   {
@@ -929,7 +930,7 @@ void CWinSystemWin32::UpdateResolutions()
     res.strMode = StringUtils::Format("%s: %dx%d @ %.2fHz", monitorName.c_str(), res.iWidth,
                                       res.iHeight, res.fRefreshRate);
     GetGfxContext().ResetOverscan(res);
-    res.strOutput = strOuput;
+    res.strOutput = strOutput;
 
     if (AddResolution(res))
       CLog::Log(LOGNOTICE, "Additional mode: %s", res.strMode.c_str());


### PR DESCRIPTION
## Description
Build complete strmode for RES_DESKTOP

## Motivation and Context
Calibration changes are currently not applied to the resolution after kodi termination because of non-matching strMode in RES_DESKTOP.

https://github.com/xbmc/xbmc/issues/15165
https://github.com/xbmc/xbmc/pull/15508

## How Has This Been Tested?
Win10, change sub position in settings::display::calibrations, restart kodi

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

@afedchin ping....