### PR TITLE
[GLES] Improve subtitle rendering

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -50,7 +50,6 @@ static void LoadTexture(GLenum target
   const GLvoid *pixelData = pixels;
 
 #ifdef HAS_GLES
-  /** OpenGL ES does not support BGR so use RGB and swap later **/
   GLenum internalFormat = alpha ? GL_ALPHA : GL_RGBA;
   GLenum externalFormat = alpha ? GL_ALPHA : GL_RGBA;
 #else
@@ -61,12 +60,30 @@ static void LoadTexture(GLenum target
   int bytesPerPixel = glFormatElementByteCount(externalFormat);
 
 #ifdef HAS_GLES
+  bool bgraSupported = false;
+  CRenderSystemGLES* renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
 
-  /** OpenGL ES does not support BGR **/
   if (!alpha)
   {
-    int bytesPerLine = bytesPerPixel * width;
+    if (renderSystem->IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
+        renderSystem->IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+    {
+      bgraSupported = true;
+      internalFormat = externalFormat = GL_BGRA_EXT;
+    }
+    else if (renderSystem->IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
+    {
+      // Apple's implementation does not conform to spec. Instead, they require
+      // differing format/internalformat, more like GL.
+      bgraSupported = true;
+      externalFormat = GL_BGRA_EXT;
+    }
+  }
 
+  int bytesPerLine = bytesPerPixel * width;
+
+  if (!alpha && !bgraSupported)
+  {
     pixelVector = (char *)malloc(bytesPerLine * height);
 
     const char *src = (const char*)pixels;
@@ -89,10 +106,8 @@ static void LoadTexture(GLenum target
     stride = width;
   }
   /** OpenGL ES does not support strided texture input. Make a copy without stride **/
-  else if (stride != width)
+  else if (stride != bytesPerLine)
   {
-    int bytesPerLine = bytesPerPixel * width;
-
     pixelVector = (char *)malloc(bytesPerLine * height);
 
     const char *src = (const char*)pixels;
@@ -105,7 +120,7 @@ static void LoadTexture(GLenum target
     }
 
     pixelData = pixelVector;
-    stride = width;
+    stride = bytesPerLine;
   }
 #else
   glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / bytesPerPixel);


### PR DESCRIPTION
## Description
Most GLES hardware support BGRA textures via an extension. If supported, use it to avoid doing malloc for convering textures.

## Motivation and Context
With some kind of subtitles there is a visible frame skip when subtitles are rendered. This is especially visible when subtitle is a 1920x1080 picture:
https://forum.kodi.tv/showthread.php?tid=315216
https://forum.libreelec.tv/thread/8100-bug-s905x-krypton-frame-skips-caused-by-burned-in-forced-subtitles/

## How Has This Been Tested?
LibreELEC on Amlogic S905 (GLES 2.0 with GL_EXT_texture_format_BGRA8888) and S912 (GLES 3.0 and GL_EXT_texture_format_BGRA8888)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
