### PR TITLE
[Android] Queue AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM buffer only >= API 26

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1054,7 +1054,7 @@ void CDVDVideoCodecAndroidMediaCodec::FlushInternal()
 {
   // invalidate any existing inflight buffers and create
   // new ones to match the number of output buffers
-  if (m_indexInputBuffer >=0)
+  if (m_indexInputBuffer >=0 && CJNIBase::GetSDKVersion() >= 26)
     AMediaCodec_queueInputBuffer(m_codec->codec(), m_indexInputBuffer, 0, 0, 0, AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM);
 
   m_OutputDuration = 0;


### PR DESCRIPTION
## Description
From user reports AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM lead to issues for older SDK's using 
AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM which is needed for Shield + mpeg2 playback.

Shield is currently running the 26 SDK API so the End-Of_Stream marker will still be sent.

## Motivation and Context
Issue comments here: https://github.com/xbmc/xbmc/pull/15455

## How Has This Been Tested?
Play mpeg2 and h.264 on shield / AFTV 2017 (AML) and AFTV2018 (MTK)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
