### PR TITLE
[skins] prefer poster over thumb to match design

### DIFF
--- a/addons/skin.estouchy/xml/DialogSelect.xml
+++ b/addons/skin.estouchy/xml/DialogSelect.xml
@@ -147,7 +147,7 @@
 					<posy>5</posy>
 					<width>110</width>
 					<height>110</height>
-					<texture>$INFO[Listitem.Icon]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 				</control>
 			</itemlayout>
 			<focusedlayout height="120" width="680">
@@ -184,7 +184,7 @@
 					<posy>5</posy>
 					<width>110</width>
 					<height>110</height>
-					<texture>$INFO[Listitem.Icon]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 				</control>
 			</focusedlayout>
 		</control>

--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -54,7 +54,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>270</height>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture background="true">$VAR[PosterThumb]</texture>
 						</control>
 						<control type="label">
 							<posx>10</posx>
@@ -85,7 +85,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>270</height>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture background="true">$VAR[PosterThumb]</texture>
 						</control>
 						<control type="label">
 							<posx>10</posx>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -52,7 +52,7 @@
 						<top>7</top>
 						<width>110</width>
 						<height>110</height>
-						<texture>$INFO[Listitem.Icon]</texture>
+						<texture>$VAR[InfoWallThumbVar]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -88,7 +88,7 @@
 						<top>7</top>
 						<width>110</width>
 						<height>110</height>
-						<texture>$INFO[Listitem.Icon]</texture>
+						<texture>$VAR[InfoWallThumbVar]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -55,6 +55,7 @@
 		<value>$INFO[Player.Icon]</value>
 	</variable>
 	<variable name="ShiftThumbVar">
+		<value condition="!String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
 		<value condition="ListItem.IsParentFolder">DefaultFolderBackSquare.png</value>
 		<value condition="String.IsEmpty(Listitem.Thumb) + [String.IsEqual(listitem.dbtype,album) | String.IsEqual(listitem.dbtype,artist)]">DefaultAudio.png</value>
 		<value condition="ListItem.IsFolder + String.IsEmpty(ListItem.Thumb)">DefaultFolderSquare.png</value>
@@ -67,12 +68,13 @@
 		<value>DefaultAudio.png</value>
 	</variable>
 	<variable name="InfoWallThumbVar">
-		<value condition="!String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
+		<value condition="!String.IsEqual(listitem.dbtype,musicvideo) + !String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="IconWallThumbVar">
 		<value condition="String.IsEqual(listitem.dbtype,genre) + System.HasAddon(resource.images.moviegenreicons.transparent)">$INFO[ListItem.Label,resource://resource.images.moviegenreicons.transparent/,.png]</value>
 		<value condition="String.IsEqual(listitem.dbtype,studio) + System.HasAddon(resource.images.studios.white)">$INFO[ListItem.Label,resource://resource.images.studios.white/,.png]</value>
+		<value condition="!String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
 		<value condition="!String.isempty(ListItem.Thumb)">$INFO[ListItem.Thumb]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>


### PR DESCRIPTION
## Description
When the image is designed for a poster (taller than wide), prefer a poster directly instead of using "Thumb" fallback to poster. Both Estuary and Estouchy updated.

## Motivation and Context
When the skin is designed to display a poster, display it even if there is also a thumbnail.

## How Has This Been Tested?
Quick run through the GUI, items with and without thumbnails and/or posters.

## Screenshots (if appropriate):
### before
![image](https://user-images.githubusercontent.com/260815/52917899-a2964980-32ad-11e9-9a13-b89c9d295d18.png)

### after
![image](https://user-images.githubusercontent.com/260815/52917884-724eab00-32ad-11e9-9dc3-3adfb35ef506.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
