### PR TITLE
[PVR][Addon][API] Add PVR_RECORDING.RecordingState as optional value

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -181,6 +181,11 @@ extern "C" {
   const int PVR_CHANNEL_INVALID_UID = -1; /*!< @brief denotes that no channel uid is available. */
 
   /*!
+   * @brief special PVR_RECORDING.iRecordingState value to indicate that no recording state is available.
+   */
+  const int PVR_RECORDED_TV_ITEM_STATE_INVALID = -1; /*!< @brief denotes that no recording state is available. */
+
+  /*!
    * @brief special PVR_DESCRAMBLE_INFO value to indicate that a struct member's value is not available.
    */
   const int PVR_DESCRAMBLE_INFO_NOT_AVAILABLE = -1;
@@ -248,6 +253,17 @@ extern "C" {
     PVR_CONNECTION_STATE_DISCONNECTED       = 6,  /*!< @brief no connection to backend server (e.g. due to network errors or client initiated disconnect)*/
     PVR_CONNECTION_STATE_CONNECTING         = 7,  /*!< @brief connecting to backend */
   } PVR_CONNECTION_STATE;
+
+   /*!
+   * @brief PVR recorded TV item state types
+   */
+  typedef enum
+  {
+    PVR_RECORDED_TV_ITEM_STATE_IN_PROGRESS          = 0,  /*!< @brief recording is in progress */
+    PVR_RECORDED_TV_ITEM_STATE_ERROR                = 1,  /*!< @brief recording not started because of error */
+    PVR_RECORDED_TV_ITEM_STATE_FORCED_TO_COMPLETION = 2,  /*!< @brief recording was forced to completion, but may miss a certain part at the end because it was cancelled by user */
+    PVR_RECORDED_TV_ITEM_STATE_COMPLETED            = 3,  /*!< @brief recording completed successfully */
+  } PVR_RECORDED_TV_ITEM_STATE;
 
   /*!
    * @brief PVR recording channel types
@@ -546,6 +562,7 @@ extern "C" {
     bool   bIsDeleted;                                    /*!< @brief (optional) shows this recording is deleted and can be undelete */
     unsigned int iEpgEventId;                             /*!< @brief (optional) EPG event id associated with this recording. Valid ids must be greater than EPG_TAG_INVALID_UID. */
     int    iChannelUid;                                   /*!< @brief (optional) unique identifier of the channel for this recording. PVR_CHANNEL_INVALID_UID denotes that channel uid is not available. */
+    int    iRecordingState;                               /*!< @brief (optional) the recording state of the recorded TV item. PVR_RECORDED_TV_ITEM_STATE_INVALID denotes that the recording state is not available */
     PVR_RECORDING_CHANNEL_TYPE channelType;               /*!< @brief (optional) channel type. Set to PVR_RECORDING_CHANNEL_TYPE_UNKNOWN if the type cannot be determined. */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -91,6 +91,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_bIsDeleted                     = recording.bIsDeleted;
   m_iEpgEventId                    = recording.iEpgEventId;
   m_iChannelUid                    = recording.iChannelUid;
+  m_iRecordingState                = recording.iRecordingState;
 
   SetGenre(recording.iGenreType, recording.iGenreSubType, recording.strGenreDescription);
   CVideoInfoTag::SetPlayCount(recording.iPlayCount);
@@ -208,6 +209,7 @@ void CPVRRecording::Reset(void)
   m_iSeason            = -1;
   m_iEpisode           = -1;
   m_iChannelUid        = PVR_CHANNEL_INVALID_UID;
+  m_iRecordingState    = PVR_RECORDED_TV_ITEM_STATE_INVALID;
   m_bRadio             = false;
 
   m_recordingTime.Reset();
@@ -376,6 +378,7 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   m_bIsDeleted        = tag.m_bIsDeleted;
   m_iEpgEventId       = tag.m_iEpgEventId;
   m_iChannelUid       = tag.m_iChannelUid;
+  m_iRecordingState   = tag.m_iRecordingState;
   m_bRadio            = tag.m_bRadio;
 
   CVideoInfoTag::SetPlayCount(tag.GetLocalPlayCount());
@@ -478,6 +481,11 @@ int CPVRRecording::ChannelUid(void) const
   return m_iChannelUid;
 }
 
+int CPVRRecording::RecordingState(void) const
+{
+  return m_iRecordingState;
+}
+
 int CPVRRecording::ClientID(void) const
 {
   return m_iClientId;
@@ -489,8 +497,24 @@ bool CPVRRecording::IsInProgress() const
   //       Only the state of the related timer is a safe indicator that the backend
   //       actually is recording this.
 
-  return CServiceBroker::GetPVRManager().Timers()->HasRecordingTimerForRecording(*this);
+  if (m_iChannelUid != PVR_CHANNEL_INVALID_UID && m_iRecordingState != PVR_RECORDED_TV_ITEM_STATE_INVALID)
+  {
+    return (m_iRecordingState == PVR_RECORDED_TV_ITEM_STATE_IN_PROGRESS);
+  }
+  else
+  {
+    return CServiceBroker::GetPVRManager().Timers()->HasRecordingTimerForRecording(*this);
+  }
 }
+
+/* Or with 'ChannelUid' and 'RecordingState' mandatory it becomes:
+
+bool CPVRRecording::IsInProgress() const
+{
+  return (m_iRecordingState == PVR_RECORDED_TV_ITEM_STATE_IN_PROGRESS);
+}
+
+*/
 
 void CPVRRecording::SetGenre(int iGenreType, int iGenreSubType, const std::string &strGenre)
 {

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -263,6 +263,12 @@ namespace PVR
     int ChannelUid(void) const;
 
     /*!
+     * @brief Get the recording state of the channel on which this recording is/was running
+     * @return the recording state of the channel on which this recording is/was running
+     */
+    int RecordingState(void) const;
+
+    /*!
      * @brief the identifier of the client that serves this recording
      * @return the client identifier
      */
@@ -313,12 +319,13 @@ namespace PVR
    const std::string GetGenresLabel() const;
 
   private:
-    CDateTime    m_recordingTime; /*!< start time of the recording */
+    CDateTime    m_recordingTime;     /*!< start time of the recording */
     bool         m_bGotMetaData;
-    bool         m_bIsDeleted;    /*!< set if entry is a deleted recording which can be undelete */
-    unsigned int m_iEpgEventId;   /*!< epg broadcast id associated with this recording */
-    int          m_iChannelUid;   /*!< channel uid associated with this recording */
-    bool         m_bRadio;        /*!< radio or tv recording */
+    bool         m_bIsDeleted;        /*!< set if entry is a deleted recording which can be undelete */
+    unsigned int m_iEpgEventId;       /*!< epg broadcast id associated with this recording */
+    int          m_iChannelUid;       /*!< channel uid associated with this recording */
+    int          m_iRecordingState;   /*!< recording state associated with this recording */
+    bool         m_bRadio;            /*!< radio or tv recording */
     int          m_iGenreType = 0;    /*!< genre type */
     int          m_iGenreSubType = 0; /*!< genre subtype */
     mutable XbmcThreads::EndTime m_resumePointRefetchTimeout;


### PR DESCRIPTION
Add PVR_RECORDING.RecordingState as an optional value to the PVR addon API to remove reliance on time and epg data for matching recording to it's associated timer.

Then for Kodi 19.0 consider making PVR_RECORDING.RecordingState, PVR_RECORDING.ChannelUid and PVR_TIMER.channeluid mandatory.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Add PVR_RECORDING.RecordingState as an optional value to the PVR addon API to remove reliance on time and epg data for matching recording to it's associated timer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Removes reliance on time and epg data for matching recording to it's associated timer which, currently, is not foolproof. If recording the same program in separate segments (stop recording then restart recording) then they all show as recording when only the last segment is actually recording.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Compiled and tested with modified pvr.dbvlink addon  providing RecordingState values.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
