### PR TITLE
VideoPlayerVideo: Invert stereo flags from codec when option is enabled

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -795,11 +795,9 @@ CDVDVideoCodec::VCReturn CMMALVideo::GetPicture(VideoPicture* picture)
   if (ret == CDVDVideoCodec::VC_PICTURE)
   {
     assert(buffer && buffer->mmal_buffer);
-    if (picture->videoBuffer)
-      picture->videoBuffer->Release();
+    picture->Reset();
     picture->videoBuffer = dynamic_cast<CVideoBuffer*>(buffer);
     assert(picture->videoBuffer);
-    picture->color_range  = 0;
     picture->iWidth = buffer->Width() ? buffer->Width() : m_decoded_width;
     picture->iHeight = buffer->Height() ? buffer->Height() : m_decoded_height;
     picture->iDisplayWidth  = picture->iWidth;
@@ -819,8 +817,6 @@ CDVDVideoCodec::VCReturn CMMALVideo::GetPicture(VideoPicture* picture)
     // timestamp is in microseconds
     picture->dts = buffer->mmal_buffer->dts == MMAL_TIME_UNKNOWN ? DVD_NOPTS_VALUE : buffer->mmal_buffer->dts;
     picture->pts = buffer->mmal_buffer->pts == MMAL_TIME_UNKNOWN ? DVD_NOPTS_VALUE : buffer->mmal_buffer->pts;
-    picture->iRepeatPicture = 0;
-    picture->iFlags  = 0;
     if (buffer->mmal_buffer->flags & MMAL_BUFFER_HEADER_FLAG_USER3)
       picture->iFlags |= DVP_FLAG_DROPPED;
     CLog::Log(LOGINFO, LOGVIDEO,

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -17,6 +17,7 @@
 #include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
 #include "cores/VideoPlayer/Interface/Addon/DemuxPacket.h"
 #include "cores/VideoPlayer/Interface/Addon/TimingConstants.h"
+#include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "windowing/GraphicContext.h"
 #include <sstream>
 #include <iomanip>
@@ -697,6 +698,8 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
           break;
         default:
           stereoMode = m_hints.stereo_mode;
+          if (m_processInfo.GetVideoSettings().m_StereoInvert)
+            stereoMode = InvertStereoMode(stereoMode);
           break;
       }
       if (!stereoMode.empty() && stereoMode != "mono")

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderFlags.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderFlags.cpp
@@ -86,3 +86,28 @@ unsigned int GetFlagsStereoMode(const std::string& mode)
   return convert[mode];
 }
 
+std::string InvertStereoMode(const std::string& mode)
+{
+  static std::map<std::string, std::string> convert;
+  if(convert.empty())
+  {
+    convert[""]                       = "";
+    convert["left_right"]             = "right_left";
+    convert["bottom_top"]             = "top_bottom";
+    convert["top_bottom"]             = "bottom_top";
+    convert["checkerboard_rl"]        = "checkerboard_lr";
+    convert["checkerboard_lr"]        = "checkerboard_rl";
+    convert["row_interleaved_rl"]     = "row_interleaved_lr";
+    convert["row_interleaved_lr"]     = "row_interleaved_rl";
+    convert["col_interleaved_rl"]     = "col_interleaved_lr";
+    convert["col_interleaved_lr"]     = "col_interleaved_rl";
+    convert["right_left"]             = "left_right";
+    convert["block_lr"]               = "block_rl";
+    convert["block_rl"]               = "block_lr";
+  }
+  // if the format is not known then leave it as it is
+  if (convert.count(mode) == 0)
+    return mode;
+  return convert[mode];
+}
+

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderFlags.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderFlags.h
@@ -66,3 +66,4 @@ unsigned int GetFlagsColorMatrix(unsigned int color_matrix, unsigned width, unsi
 unsigned int GetFlagsChromaPosition(unsigned int chroma_position);
 unsigned int GetFlagsColorPrimaries(unsigned int color_primaries);
 unsigned int GetFlagsStereoMode(const std::string& mode);
+std::string InvertStereoMode(const std::string& mode);

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -264,6 +264,8 @@ std::string OMXPlayerVideo::GetStereoMode()
       break;
     default:
       stereoMode = m_hints.stereo_mode;
+      if (m_processInfo.GetVideoSettings().m_StereoInvert)
+        stereoMode = InvertStereoMode(stereoMode);
       break;
   }
   return stereoMode;


### PR DESCRIPTION
## Description
We were ignoring the gui invert eyes flag when playing stereoscopic videos, when stereomode is set to auto.

Also MMAL had a bug where the stereoMode for pictures wasn't reset each frame resulting in a stale value (which wouldn't get updated when gui option changed).

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/15474

## How Has This Been Tested?
Reported fixed in milhouse nightly build

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
