### PR TITLE
[Fix]Stop playback when next from last item in current playlist

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3896,6 +3896,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
   case GUI_MSG_PLAYLISTPLAYER_STOPPED:
     m_itemCurrentFile->Reset();
     CServiceBroker::GetGUI()->GetInfoManager().ResetCurrentItem();
+    if (m_appPlayer.IsPlaying())
+      StopPlaying();
     PlaybackCleanup();
     return true;
 


### PR DESCRIPTION
When user does "next" during playback of the last item of the current playlist then playback should stop. This was not happening, play continues and yet the item is undefined so no metadata or art is displayed on GUI or returned to JSON requests about the currently playing item.  Once in this state "prev" does not goto the previous item in the playlist, instead play of that item restarts.

@ronie thanks for reporting here  https://forum.kodi.tv/showthread.php?tid=341168&pid=2825962#pid2825962

![image](https://i.imgur.com/vMSWdfk.jpg)

This is a regression introduced in the major app changes of March 2018.  Previously when the app processed `GUI_MSG_PLAYLISTPLAYER_STOPPED` messages it told the player to stop too, but app control of player and message sequences have changed significantly. 

In many situations the player has stopped before `GUI_MSG_PLAYLISTPLAYER_STOPPED` is sent, so the best fix IMO is to have the playlistplayer request the player stop in the two situations when it is the playlistplayer processing that want to abort playback. That is either 
- when user does next from last item in list, 
or 
- when in repeat one mode and single song is invalid.

This also avoids changes in CApplication message handling which is desirable since it is considered "fragile" by other team members.

