### PR TITLE
Allow speedadjust for half frame situations (e.g. 3:2 pullback)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -242,14 +242,14 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
 
   CSingleLock lock(m_speedsection);
 
-  double weight = rate / fps;
+  double weight = (rate * 2) / fps;
 
   //set the speed of the videoreferenceclock based on fps, refreshrate and maximum speed adjust set by user
   if (m_maxspeedadjust > 0.05)
   {
-    if (weight / MathUtils::round_int(weight) < 1.0 + m_maxspeedadjust / 100.0
-    &&  weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 100.0)
-      weight = MathUtils::round_int(weight);
+    if (weight / MathUtils::round_int(weight) < 1.0 + m_maxspeedadjust / 50.0
+    &&  weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 50.0)
+      weight = MathUtils::round_int(weight) * 0.5;
   }
   double speed = rate / (fps * weight);
   lock.Leave();


### PR DESCRIPTION
## Description
Playing 23.97fps on 60hz currently fails speed adjusting.
For this example expected behaviour is 3.2 pullback ( = 24fps adjust)

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=339822

## How Has This Been Tested?
Win x64 play 23.97fps stream on 60Hz display

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
