### PR TITLE
Fix waiting for window close animation blocking JSON requests after SetFullScreen

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -318,7 +318,7 @@ public:
 
   bool SwitchToFullScreen(bool force = false);
 
-  bool GetRenderGUI() const { return m_renderGUI; };
+  bool GetRenderGUI() const override { return m_renderGUI; };
 
   bool SetLanguage(const std::string &strLanguage);
   bool LoadLanguage(bool reload);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1289,8 +1289,11 @@ CGUIWindow* CGUIWindowManager::GetWindow(int id) const
 
 bool CGUIWindowManager::ProcessRenderLoop(bool renderOnly)
 {
+  bool renderGui = true;
+
   if (g_application.IsCurrentThread() && m_pCallback)
   {
+    renderGui = m_pCallback->GetRenderGUI();
     m_iNested++;
     if (!renderOnly)
       m_pCallback->Process();
@@ -1298,7 +1301,7 @@ bool CGUIWindowManager::ProcessRenderLoop(bool renderOnly)
     m_pCallback->Render();
     m_iNested--;
   }
-  if (g_application.m_bStop)
+  if (g_application.m_bStop || !renderGui)
     return false;
   else
     return true;
@@ -1670,8 +1673,10 @@ void CGUIWindowManager::CloseWindowSync(CGUIWindow *window, int nextWindowID /*=
   }
 
   window->Close(false, nextWindowID);
-  while (window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
-    ProcessRenderLoop(true);
+
+  bool renderLoopProcessed = true;
+  while (window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE) && renderLoopProcessed)
+    renderLoopProcessed = ProcessRenderLoop(true);
 }
 
 #ifdef _DEBUG

--- a/xbmc/guilib/IWindowManagerCallback.h
+++ b/xbmc/guilib/IWindowManagerCallback.h
@@ -26,4 +26,5 @@ public:
   virtual void FrameMove(bool processEvents, bool processGUI = true) = 0;
   virtual void Render() = 0;
   virtual void Process() = 0;
+  virtual bool GetRenderGUI() const { return false; };
 };


### PR DESCRIPTION
To see the issue:
- Run Kodi in a window (not full screen), and play something, music or video it does not matter.
- During playback minimise Kodi onto task bar so still active but no longer displayed.
- Send JSON request to show Kodi full screen
```
{"id":1,"jsonrpc":"2.0","method":"GUI.SetFullscreen","params":{"fullscreen":true}}
```
But this does not get a reply, and afterwards other JSON requests either timeout or no longer work at all. For example  of a request that times out
```
 {"id":1,"jsonrpc":"2.0","method":"Player.GetActivePlayers"}
```

The cause is `CGUIWindow::Close_Internal` is waiting for close animation to finish before closing previous windows but since Kodi is minimised there's no rendering the so the close animation never finishes. Obviously there is no point in waiting for close animation when there is no GUI rendering,  and so the close can be instant.

Tested on Win64 and should be correct for other platforms where Kodi can be minimised