### PR TITLE
[videoplayer][pvr] Use audio stream to determine start time of programs with no video

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2078,6 +2078,21 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
         hasVideo = true;
       }
     }
+    // Workaround for live audio-only MPEG-TS streams: If there are no elementary video streams
+    // present attempt to set the start time from the first available elementary audio stream instead
+    if (!hasVideo && !m_startTime)
+    {
+      for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
+      {
+        int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+        st = m_pFormatContext->streams[idx];
+        if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+        {
+          m_startTime = static_cast<double>(av_rescale(st->cur_dts, st->time_base.num, st->time_base.den));
+          break;
+        }
+      }
+    }
   }
   else
   {
@@ -2093,6 +2108,20 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
           return true;
         }
         hasVideo = true;
+      }
+    }
+    // Workaround for live audio-only MPEG-TS streams: If there are no elementary video streams
+    // present attempt to set the start time from the first available elementary audio stream instead
+    if (!hasVideo && !m_startTime)
+    {
+      for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
+      {
+        st = m_pFormatContext->streams[i];
+        if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+        {
+          m_startTime = static_cast<double>(av_rescale(st->cur_dts, st->time_base.num, st->time_base.den));
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
This is an attempt to provide a minimally invasive solution to https://github.com/xbmc/xbmc/issues/15563.  When an MPEG-TS program with no video stream(s) is played live via a PVR client, the seek functionality fails to work properly.  The player UI also shows crazy invalid seek values (like -9 hours instead of +10s seconds when seeking forward).  I tracked this down to the DVDDemuxFFmpeg class never setting the start time member variable since there are no video streams.

I didn't want to muck around with the demuxer at all (I'd screw it up), so I'm attempting more of a workaround here as opposed to a true fix.  My opinion is that determination of the start time may be better served at a different point in the demuxer logic, the IsVideoReady() function doesn't seem like the ideal place to do this.

That said, what I did here to solve my immediate problem was to add code to IsVideoReady() that triggers if no video streams were found and the start time is still unknown.  In that case, check for an audio stream and use it to initialize the start time instead.  I didn't want to change the result of the function, so it will still return true/false based on examination of the video stream(s) only.

One immediate concern I have with my proposed change is if there should be a secondary check of the audio stream properties other than just it being an audio stream.  For example, when setting start time from a video stream, that stream must have a non-NULL codecpar->extradata.

Please let me know if a less hackish/workaroundish type of change will be proposed to better solve the issue, I can cancel this PR.  Thanks!

## Motivation and Context
This change, or something more comprehensive than this change, is required to allow proper seek functionality on live PVR MPEG-TS programs that do not have any associated video elementary streams.  Without setting the start time indicator properly, the seek calculations are incorrect and the PVR will be asked to seek to invalid locations.  Additionally this is causing a Player UI issue during seek, for example a +10 second seek attempt will show as a very large negative seek attempt, like -9 hours.

Related issue: https://github.com/xbmc/xbmc/issues/15563

## How Has This Been Tested?
I tested via the PVR functions to ensure that there was no impact to normal audio/video programs, both Live and Recorded.  Under all circumstances except audio-only MPEG-TS the start time was set at the existing point.  For audio-only MPEG-TS the start time was set at the added fallback point.

I also ran through as many different types of MPEG-based media I have to try and ensure there were no side effects.  MPEG, DVD, video-only MPEG, Blu-Ray, etc. While I found no problems I do not believe I have an exhaustive set of media available to test everything.

The target system was Windows 10, x64, using Kodi 18.1 built from the master branch.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
