### PR TITLE
Assign video library NFO thumb without aspect as poster

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1504,8 +1504,8 @@ namespace VIDEO
         continue;
       std::string aspect = url.m_aspect;
       if (aspect.empty())
-        // temporary support for XML music video scrapers that share music album scraper bits
-        aspect = content == CONTENT_MUSICVIDEOS ? "poster" : "thumb";
+        // Backward compatibility with Kodi 11 Eden NFO files
+        aspect = ContentToMediaType(content, pItem->m_bIsFolder) == MediaTypeEpisode ? "thumb" : "poster";
       if (find(artTypes.begin(), artTypes.end(), aspect) == artTypes.end() || art.find(aspect) != art.end())
         continue;
       std::string image = GetImage(url, pItem->GetPath());


### PR DESCRIPTION
## Description
Small adjustment to #12612 to keep backward-compatibility with video library NFOs for Kodi 11 Eden or exported from Kodi 11 Eden scrapers. Kodi only supported a single non-fanart image so thumbs didn't have an `aspect` attribute, but before #12612 it was mapped to "poster" for all media types except episodes, and this returns that behavior.

## Motivation and Context
NFOs can be somewhat long lived, and keeping this behavior is simple enough at this point. Resolves #15514.

## How Has This Been Tested?
Manually, scanning a few movies, TV shows, and episodes with and without the 'aspect' tag.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
