### PR TITLE
[Android] Fix "Unable to create AudioTrack" when we jump from one audio format to another

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -23,6 +23,9 @@
 
 #include "utils/AMLUtils.h"
 
+#include <chrono>
+#include <thread>
+
 // This is an alternative to the linear weighted delay smoothing
 // advantages: only one history value needs to be stored
 // in tests the linear weighted average smoother yield better results
@@ -591,6 +594,10 @@ void CAESinkAUDIOTRACK::Deinitialize()
 
   delete m_at_jni;
   m_at_jni = NULL;
+  
+  // We wait a bit for the device to be fully released or the next call to CreateAudioTrack
+  // will fail if it is done right after here (At least on the Nvidia Shield)
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
 }
 
 bool CAESinkAUDIOTRACK::IsInitialized()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
There are many problems with the audio output on the Nvidia Shield when we change from one audio format to another and we have active passthrough. The problem is that the playback runs out of audio output and finally after several seconds the image also it freezes. The problem reproduces easily, fails approximately 90% of the time. The error that the log shows is **ERROR: AESinkAUDIOTRACK - Unable to create AudioTrack**.

After investigating the bug, adding many debug messages to try and even force certain commands in the code thinking they were wrong, I realized that the code was perfectly and I discovered that the only difference between the few times it works and the ones that the problem occurs, is that in those that work there is a little more time between the call to **CAESinkAUDIOTRACK :: Deinitialize** and the call to **CAESinkAUDIOTRACK :: Initialize**.

Assuming it is a problem / limitation of Android, Nvidia Firmware or directly Hardware I have found that putting a little wait at the end of **CAESinkAUDIOTRACK :: Deinitialize** so that the device is fully released, solves the problem. The wait is 50 milliseconds, I have tried less but failed sometimes.

Put a wait is not the best way to try to make a first contribution as a programmer to this project but solves the problem, it is a simple change that does not affect the rest of things or break anything.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This bug affects:

- If during the reproduction of a file (for example with audio ac3) we launch the playback of another file without stopping the first one and this new file has a different audio format (for example dts), the failure occurs .

- If we play a DVD or blu-ray with menus and the audio format during the menu is different from the movie later, at the beginning of the movie (or select a chapter from the menu) the fault occurs.

- It may affect other parts (perhaps the change of channels in pvr or with some addon), although I have not checked it since I do not use / have any of that.

This PR resolves https://github.com/xbmc/xbmc/issues/15504 and https://github.com/xbmc/xbmc/issues/15523

It has been commented here https://forum.kodi.tv/showthread.php?tid=327486&pid=2824295#pid2824295 and here https://forum.kodi.tv/showthread.php?tid=339983&pid=2820782#pid2820782 at least.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

It has been tested by me on my Nvidia Shield TV with the apk compiled by myself with the changes described, jumping from a file with AC3 audio to a file with DTS audio twenty times and also playing a DVD with menus in AC3 and movie in DTS passing from the menu to the movie and going back to the menu many times, perfectly working the output audio passthrough listening to it and checking the format on my avr.

With the current official version (18.1) it fails 90% of the time, usually at the first attempt and sometimes at the second attempt.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
