### PR TITLE
Fixes a crash when a file's embedded art is invalid

### DIFF
--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -40,10 +40,10 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
                                                  std::vector<EmbeddedArt>*)
 {
   CNfoFile nfoReader;
-  CInfoScanner::INFO_TYPE result;
-  if (m_info->Content() == CONTENT_TVSHOWS && !m_item.m_bIsFolder)
+  CInfoScanner::INFO_TYPE result = CInfoScanner::NO_NFO;
+  if (m_info && m_info->Content() == CONTENT_TVSHOWS && !m_item.m_bIsFolder)
     result = nfoReader.Create(m_path, m_info, m_item.GetVideoInfoTag()->m_iEpisode);
-  else
+  else if (m_info)
     result = nfoReader.Create(m_path, m_info);
 
   if (result == CInfoScanner::FULL_NFO || result == CInfoScanner::COMBINED_NFO)


### PR DESCRIPTION
## Description
If a file's metadata contains embedded art and that art is not valid, kodi will crash when a user tries to edit the thumbnail from the Context Menu -> Information -> Choose Art -> Thumbnail. This patch checks to see that the m_info object is not null to prevent a crash.

## Motivation and Context
This change is required to fix a crash when editing the thumbnail of a movie/episode that has invalid embedded art.

## How Has This Been Tested?
Tested on MacOS with an mkv that has invalid embedded art and scanned to the library as a movie. Then from the movie library and the movie's context menu Information -> Choose Art -> Thumbnail was selected. This would previously cause the crash. With the patch, there is no longer a crash.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
