### PR TITLE
[addons] add OpenGL support to the addon interface and allow GL usage via DirectX

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -11,6 +11,7 @@ xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance addons_kodi-addon-dev
 xbmc/addons/kodi-addon-dev-kit/include/kodi/gui addons_kodi-addon-dev-kit_include_kodi_gui
 xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls addons_kodi-addon-dev-kit_include_kodi_gui_controls
 xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs addons_kodi-addon-dev-kit_include_kodi_gui_dialogs
+xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl addons_kodi-addon-dev-kit_include_kodi_gui_gl
 xbmc/addons/kodi-addon-dev-kit/include/kodi/tools addons_kodi-addon-dev-kit_include_kodi_tools
 xbmc/addons/settings                            addons_settings
 xbmc/commons                                    commons

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -11,6 +11,7 @@
 #include <stdarg.h>     /* va_list, va_start, va_arg, va_end */
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -61,6 +62,7 @@
 
 namespace kodi { namespace addon { class CAddonBase; }}
 namespace kodi { namespace addon { class IAddonInstance; }}
+namespace kodi { namespace gui { struct IRenderHelper; }}
 
 extern "C" {
 
@@ -333,6 +335,9 @@ public:
   {
     return CreateInstance(instanceType, instanceID, instance, addonInstance);
   }
+
+  /* Background helper for GUI render systems, e.g. Screensaver or Visualization */
+  std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
 
   /* Global variables of class */
   static AddonGlobalInterface* m_interface; // Interface function table to hold addresses on add-on and from kodi

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "../AddonBase.h"
+#include "../gui/renderHelper.h"
 
 namespace kodi { namespace addon { class CInstanceScreensaver; }}
 
@@ -418,19 +419,35 @@ namespace addon
 
     inline static bool ADDON_Start(AddonInstance_Screensaver* instance)
     {
+      instance->toAddon.addonInstance->m_renderHelper = kodi::gui::GetRenderHelper();
       return instance->toAddon.addonInstance->Start();
     }
 
     inline static void ADDON_Stop(AddonInstance_Screensaver* instance)
     {
       instance->toAddon.addonInstance->Stop();
+      instance->toAddon.addonInstance->m_renderHelper = nullptr;
     }
 
     inline static void ADDON_Render(AddonInstance_Screensaver* instance)
     {
+      if (!instance->toAddon.addonInstance->m_renderHelper)
+        return;
+      instance->toAddon.addonInstance->m_renderHelper->Begin();
       instance->toAddon.addonInstance->Render();
+      instance->toAddon.addonInstance->m_renderHelper->End();
     }
 
+    /*
+     * Background render helper holds here and in addon base.
+     * In addon base also to have for the others, and stored here for the worst 
+     * case where this class is independent from base and base becomes closed
+     * before.
+     *
+     * This is on Kodi with GL unused and the calls to there are empty (no work)
+     * On Kodi with Direct X where angle is present becomes this used.
+     */
+    std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
     AddonInstance_Screensaver* m_instanceData;
   };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Visualization.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Visualization.h
@@ -14,6 +14,7 @@
  */
 
 #include "../AddonBase.h"
+#include "../gui/renderHelper.h"
 
 namespace kodi { namespace addon { class CInstanceVisualization; }}
 
@@ -665,12 +666,14 @@ namespace addon
 
     inline static bool ADDON_Start(const AddonInstance_Visualization* addon, int channels, int samplesPerSec, int bitsPerSample, const char* songName)
     {
+      addon->toAddon.addonInstance->m_renderHelper = kodi::gui::GetRenderHelper();
       return addon->toAddon.addonInstance->Start(channels, samplesPerSec, bitsPerSample, songName);
     }
 
     inline static void ADDON_Stop(const AddonInstance_Visualization* addon)
     {
       addon->toAddon.addonInstance->Stop();
+      addon->toAddon.addonInstance->m_renderHelper = nullptr;
     }
 
     inline static void ADDON_AudioData(const AddonInstance_Visualization* addon, const float* audioData, int audioDataLength, float *freqData, int freqDataLength)
@@ -685,7 +688,11 @@ namespace addon
 
     inline static void ADDON_Render(const AddonInstance_Visualization* addon)
     {
+      if (!addon->toAddon.addonInstance->m_renderHelper)
+        return;
+      addon->toAddon.addonInstance->m_renderHelper->Begin();
       addon->toAddon.addonInstance->Render();
+      addon->toAddon.addonInstance->m_renderHelper->End();
     }
 
     inline static void ADDON_GetInfo(const AddonInstance_Visualization* addon, VIS_INFO *info)
@@ -745,6 +752,7 @@ namespace addon
       return addon->toAddon.addonInstance->IsLocked();
     }
 
+    std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
     bool m_presetLockedByUser = false;
     AddonInstance_Visualization* m_instanceData;
   };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(HEADERS General.h
             ListItem.h
             Window.h
-            definitions.h)
+            definitions.h
+            renderHelper.h)
 
 if(NOT ENABLE_STATIC_LIBS)
   core_add_library(addons_kodi-addon-dev-kit_include_kodi_gui)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h
@@ -10,6 +10,7 @@
 
 #include "../../AddonBase.h"
 #include "../Window.h"
+#include "../renderHelper.h"
 
 namespace kodi
 {
@@ -179,17 +180,23 @@ namespace controls
      */
     static bool OnCreateCB(void* cbhdl, int x, int y, int w, int h, void* device)
     {
+      static_cast<CRendering*>(cbhdl)->m_renderHelper = kodi::gui::GetRenderHelper();
       return static_cast<CRendering*>(cbhdl)->Create(x, y, w, h, device);
     }
 
     static void OnRenderCB(void* cbhdl)
     {
+      if (!static_cast<CRendering*>(cbhdl)->m_renderHelper)
+        return;
+      static_cast<CRendering*>(cbhdl)->m_renderHelper->Begin();
       static_cast<CRendering*>(cbhdl)->Render();
+      static_cast<CRendering*>(cbhdl)->m_renderHelper->End();
     }
 
     static void OnStopCB(void* cbhdl)
     {
       static_cast<CRendering*>(cbhdl)->Stop();
+      static_cast<CRendering*>(cbhdl)->m_renderHelper = nullptr;
     }
 
     static bool OnDirtyCB(void* cbhdl)
@@ -197,6 +204,7 @@ namespace controls
       return static_cast<CRendering*>(cbhdl)->Dirty();
     }
 
+    std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
   };
 
 } /* namespace controls */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(HEADERS Shader.h)
+set(HEADERS GL.h
+            GLonDX.h
+            Shader.h)
 
 if(NOT ENABLE_STATIC_LIBS)
   core_add_library(addons_kodi-addon-dev-kit_include_kodi_gui_gl)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(HEADERS Shader.h)
+
+if(NOT ENABLE_STATIC_LIBS)
+  core_add_library(addons_kodi-addon-dev-kit_include_kodi_gui_gl)
+endif()

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/GL.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/GL.h
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2005-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+//==============================================================================
+///
+/// \defgroup cpp_kodi_gui_gl Kodi OpenGL helpers
+/// \ingroup cpp_kodi_gui
+/// \brief Auxiliary functions for Open GL
+///
+/// This group includes help for definitions, functions, and classes for
+/// OpenGL.
+///
+/// To use OpenGL for your system, add the \ref GL.h "#include <kodi/gui/gl/GL.h>".
+///
+///
+///-----------------------------------------------------------------------------
+///
+/// The \ref HAS_GL is declared if Open GL is required and \ref HAS_GLES if Open GL 
+/// Embedded Systems (ES) is required, with ES the version is additionally given
+/// in the definition, this can be "2" or "3".
+///
+///
+///-----------------------------------------------------------------------------
+///
+/// Following \ref GL_TYPE_STRING define can be used, for example, to manage 
+/// different folders for GL and GLES and make the selection easier.
+/// This are on OpenGL **"`GL`"** and on Open GL|ES **"`GLES`"**.
+/// **Example:**
+/// ~~~~~~~~~~~~~~~~~{.cpp}
+/// kodi::GetAddonPath("resources/shaders/" GL_TYPE_STRING "/frag.glsl");
+/// ~~~~~~~~~~~~~~~~~
+///
+///
+///----------------------------------------------------------------------------
+///
+/// In addition, \ref BUFFER_OFFSET is declared in it which can be used to give an 
+/// offset on the array to GL.
+/// **Example:**
+/// ~~~~~~~~~~~~~~~~~{.cpp}
+/// const struct PackedVertex {
+///   float position[3]; // Position x, y, z
+///   float color[4]; // Color r, g, b, a
+/// } vertices[3] = {
+///   { { -0.5f, -0.5f, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+///   { {  0.5f, -0.5f, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+///   { {  0.0f,  0.5f, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+/// };
+///
+/// glVertexAttribPointer(m_aPosition, 3, GL_FLOAT, GL_FALSE, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, position)));
+/// glEnableVertexAttribArray(m_aPosition);
+///
+/// glVertexAttribPointer(m_aColor, 4, GL_FLOAT, GL_FALSE, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, color)));
+/// glEnableVertexAttribArray(m_aColor);
+/// ~~~~~~~~~~~~~~~~~
+
+#if HAS_GL
+  #define GL_TYPE_STRING "GL"
+  // always define GL_GLEXT_PROTOTYPES before include gl headers
+  #if !defined(GL_GLEXT_PROTOTYPES)
+    #define GL_GLEXT_PROTOTYPES
+  #endif
+  #if defined(TARGET_LINUX)
+    #include <GL/gl.h>
+    #include <GL/glext.h>
+  #elif defined(TARGET_FREEBSD)
+    #include <GL/gl.h>
+  #elif defined(TARGET_DARWIN)
+    #include <OpenGL/gl3.h>
+    #include <OpenGL/gl3ext.h>
+  #elif defined(WIN32)
+    #error Use of GL under Windows is not possible
+  #endif
+#elif HAS_GLES >= 2
+  #define GL_TYPE_STRING "GLES"
+  #if defined(WIN32)
+    #if defined(HAS_ANGLE)
+      #include <angle_gl.h>
+    #else
+      #error Use of GLES only be available under Windows by the use of angle
+    #endif
+  #elif defined(TARGET_DARWIN)
+    #if HAS_GLES == 3
+      #include <OpenGLES/ES3/gl.h>
+      #include <OpenGLES/ES3/glext.h>
+    #else
+      #include <OpenGLES/ES2/gl.h>
+      #include <OpenGLES/ES2/glext.h>
+    #endif
+  #else
+    #if HAS_GLES == 3
+      #include <GLES3/gl3.h>
+      #include <GLES3/gl3ext.h>
+    #else
+      #include <GLES2/gl2.h>
+      #include <GLES2/gl2ext.h>
+    #endif
+  #endif
+#endif
+
+#ifndef BUFFER_OFFSET
+#define BUFFER_OFFSET(i) ((char *)nullptr + (i))
+#endif

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/GLonDX.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/GLonDX.h
@@ -1,0 +1,369 @@
+/*
+ *  Copyright (C) 2005-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <angle_gl.h>
+#include <d3d11.h>
+#include <d3dcompiler.h>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <kodi/AddonBase.h>
+#include <kodi/gui/General.h>
+#include <wrl/client.h>
+
+#pragma comment( lib, "d3dcompiler.lib" )
+#ifndef GL_CLIENT_VERSION
+#define GL_CLIENT_VERSION 3
+#endif
+
+namespace kodi
+{
+namespace gui
+{
+namespace gl
+{
+
+class CGLonDX : public kodi::gui::IRenderHelper
+{
+public:
+  explicit CGLonDX() : m_pContext(reinterpret_cast<ID3D11DeviceContext*>(kodi::gui::GetHWContext())) {}
+  ~CGLonDX() override { destruct(); }
+
+  bool Init() override
+  {
+    EGLint egl_display_attrs[] =
+    {
+      EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+      EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE, EGL_DONT_CARE,
+      EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE, EGL_DONT_CARE,
+      EGL_EXPERIMENTAL_PRESENT_PATH_ANGLE, EGL_EXPERIMENTAL_PRESENT_PATH_FAST_ANGLE,
+      EGL_NONE
+    };
+    EGLint egl_config_attrs[] =
+    {
+      EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8, EGL_ALPHA_SIZE, 8,
+      EGL_BIND_TO_TEXTURE_RGBA, EGL_TRUE,
+      EGL_RENDERABLE_TYPE, GL_CLIENT_VERSION == 3 ? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT,
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_NONE
+    };
+    EGLint egl_context_attrs[] =
+    {
+      EGL_CONTEXT_CLIENT_VERSION, GL_CLIENT_VERSION, EGL_NONE
+    };
+
+    m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, egl_display_attrs);
+    if (m_eglDisplay == EGL_NO_DISPLAY)
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to get EGL display (%s)", eglGetErrorString());
+      return false;
+    }
+
+    if (eglInitialize(m_eglDisplay, nullptr, nullptr) != EGL_TRUE)
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to init EGL display (%s)", eglGetErrorString());
+      return false;
+    }
+
+    EGLint numConfigs = 0;
+    if (eglChooseConfig(m_eglDisplay, egl_config_attrs, &m_eglConfig, 1, &numConfigs) != EGL_TRUE || numConfigs == 0)
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to get EGL config (%s)", eglGetErrorString());
+      return false;
+    }
+
+    m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig, nullptr, egl_context_attrs);
+    if (m_eglContext == EGL_NO_CONTEXT)
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to create EGL context (%s)", eglGetErrorString());
+      return false;
+    }
+
+    if (!createD3DResources())
+      return false;
+
+    if (eglMakeCurrent(m_eglDisplay, m_eglBuffer, m_eglBuffer, m_eglContext) != EGL_TRUE)
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to make current EGL (%s)", eglGetErrorString());
+      return false;
+    }
+    return true;
+  }
+
+  void CheckGL(ID3D11DeviceContext* device)
+  {
+    if (m_pContext != device)
+    {
+      m_pSRView = nullptr;
+      m_pVShader = nullptr;
+      m_pPShader = nullptr;
+      m_pContext = device;
+
+      if (m_eglBuffer != EGL_NO_SURFACE)
+      {
+        eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        eglDestroySurface(m_eglDisplay, m_eglBuffer);
+        m_eglBuffer = EGL_NO_SURFACE;
+      }
+
+      // create new resources
+      if (!createD3DResources())
+        return;
+
+      eglMakeCurrent(m_eglDisplay, m_eglBuffer, m_eglBuffer, m_eglContext);
+    }
+  }
+
+  void Begin() override
+  {
+    // confirm on begin D3D context is correct
+    CheckGL(reinterpret_cast<ID3D11DeviceContext*>(kodi::gui::GetHWContext()));
+
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+  }
+
+  void End() override
+  {
+    glFlush();
+
+    // set our primitive shaders
+    m_pContext->VSSetShader(m_pVShader.Get(), nullptr, 0);
+    m_pContext->PSSetShader(m_pPShader.Get(), nullptr, 0);
+    m_pContext->PSSetShaderResources(0, 1, m_pSRView.GetAddressOf());
+    // draw texture
+    m_pContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    m_pContext->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
+    m_pContext->IASetInputLayout(nullptr);
+    m_pContext->Draw(4, 0);
+    // unset shaders
+    m_pContext->PSSetShader(nullptr, nullptr, 0);
+    m_pContext->VSSetShader(nullptr, nullptr, 0);
+    // unbind our view
+    ID3D11ShaderResourceView* views[1] = {};
+    m_pContext->PSSetShaderResources(0, 1, views);
+  }
+
+private:
+  enum ShaderType
+  {
+    VERTEX_SHADER,
+    PIXEL_SHADER
+  };
+
+  bool createD3DResources()
+  {
+    HANDLE sharedHandle;
+    Microsoft::WRL::ComPtr<ID3D11Device> pDevice;
+    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> pRTView;
+    Microsoft::WRL::ComPtr<ID3D11Resource> pRTResource;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> pRTTexture;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> pOffScreenTexture;
+    Microsoft::WRL::ComPtr<IDXGIResource>  dxgiResource;
+
+    m_pContext->GetDevice(&pDevice);
+    m_pContext->OMGetRenderTargets(1, &pRTView, nullptr);
+    if (!pRTView)
+      return false;
+
+    pRTView->GetResource(&pRTResource);
+    if (FAILED(pRTResource.As(&pRTTexture)))
+      return false;
+
+    D3D11_TEXTURE2D_DESC texDesc;
+    pRTTexture->GetDesc(&texDesc);
+    texDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+    texDesc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+    if (FAILED(pDevice->CreateTexture2D(&texDesc, nullptr, &pOffScreenTexture)))
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to create intermediate texture");
+      return false;
+    }
+
+    CD3D11_SHADER_RESOURCE_VIEW_DESC srvDesc(pOffScreenTexture.Get(), D3D11_SRV_DIMENSION_TEXTURE2D);
+    if (FAILED(pDevice->CreateShaderResourceView(pOffScreenTexture.Get(), &srvDesc, &m_pSRView)))
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to create shader view");
+      return false;
+    }
+
+    if (FAILED(pOffScreenTexture.As(&dxgiResource)) ||
+        FAILED(dxgiResource->GetSharedHandle(&sharedHandle)))
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable get shared handle for texture");
+      return false;
+    }
+
+    // initiate simple shaders
+    if (FAILED(d3dCreateShader(VERTEX_SHADER, vs_out_shader_text, &m_pVShader)))
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to create vertex shader view");
+      return false;
+    }
+
+    if (FAILED(d3dCreateShader(PIXEL_SHADER, ps_out_shader_text, &m_pPShader)))
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to create pixel shader view");
+      return false;
+    }
+
+    // create EGL buffer from D3D shared texture
+    EGLint egl_buffer_attrs[] =
+    {
+      EGL_WIDTH, static_cast<EGLint>(texDesc.Width),
+      EGL_HEIGHT, static_cast<EGLint>(texDesc.Height),
+      EGL_TEXTURE_TARGET, EGL_TEXTURE_2D,
+      EGL_TEXTURE_FORMAT, EGL_TEXTURE_RGBA,
+      EGL_NONE
+    };
+
+    m_eglBuffer = eglCreatePbufferFromClientBuffer(m_eglDisplay,
+      EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE,
+      sharedHandle, m_eglConfig, egl_buffer_attrs);
+
+    if (m_eglBuffer == EGL_NO_SURFACE)
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to create EGL buffer (%s)", eglGetErrorString());
+      return false;
+    }
+    return true;
+  }
+
+  HRESULT d3dCreateShader(ShaderType shaderType, const std::string& source, IUnknown** ppShader) const
+  {
+    Microsoft::WRL::ComPtr<ID3DBlob> pBlob;
+    Microsoft::WRL::ComPtr<ID3DBlob> pErrors;
+
+    auto hr = D3DCompile(source.c_str(), source.length(), nullptr, nullptr, nullptr, "main",
+      shaderType == PIXEL_SHADER ? "ps_4_0" : "vs_4_0", 0, 0, &pBlob, &pErrors);
+
+    if (SUCCEEDED(hr))
+    {
+      Microsoft::WRL::ComPtr<ID3D11Device> pDevice;
+      m_pContext->GetDevice(&pDevice);
+
+      if (shaderType == PIXEL_SHADER)
+      {
+        hr = pDevice->CreatePixelShader(pBlob->GetBufferPointer(), pBlob->GetBufferSize(), nullptr,
+          reinterpret_cast<ID3D11PixelShader**>(ppShader));
+      }
+      else
+      {
+        hr = pDevice->CreateVertexShader(pBlob->GetBufferPointer(), pBlob->GetBufferSize(), nullptr,
+          reinterpret_cast<ID3D11VertexShader**>(ppShader));
+      }
+
+      if (FAILED(hr))
+      {
+        Log(ADDON_LOG_ERROR, "GLonDX: unable to create %s shader",
+          shaderType == PIXEL_SHADER ? "pixel" : "vertex");
+      }
+    }
+    else
+    {
+      Log(ADDON_LOG_ERROR, "GLonDX: unable to compile shader (%s)", pErrors->GetBufferPointer());
+    }
+    return hr;
+  }
+
+  static const char* eglGetErrorString()
+  {
+#define CASE_STR( value ) case value: return #value
+    switch (eglGetError())
+    {
+      CASE_STR(EGL_SUCCESS);
+      CASE_STR(EGL_NOT_INITIALIZED);
+      CASE_STR(EGL_BAD_ACCESS);
+      CASE_STR(EGL_BAD_ALLOC);
+      CASE_STR(EGL_BAD_ATTRIBUTE);
+      CASE_STR(EGL_BAD_CONTEXT);
+      CASE_STR(EGL_BAD_CONFIG);
+      CASE_STR(EGL_BAD_CURRENT_SURFACE);
+      CASE_STR(EGL_BAD_DISPLAY);
+      CASE_STR(EGL_BAD_SURFACE);
+      CASE_STR(EGL_BAD_MATCH);
+      CASE_STR(EGL_BAD_PARAMETER);
+      CASE_STR(EGL_BAD_NATIVE_PIXMAP);
+      CASE_STR(EGL_BAD_NATIVE_WINDOW);
+      CASE_STR(EGL_CONTEXT_LOST);
+    default:
+      return "Unknown";
+    }
+#undef CASE_STR
+  }
+
+  void destruct()
+  {
+    if (m_eglDisplay != EGL_NO_DISPLAY)
+    {
+      eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+      if (m_eglBuffer != EGL_NO_SURFACE)
+      {
+        eglDestroySurface(m_eglDisplay, m_eglBuffer);
+        m_eglBuffer = EGL_NO_SURFACE;
+      }
+
+      if (m_eglContext != EGL_NO_CONTEXT)
+      {
+        eglDestroyContext(m_eglDisplay, m_eglContext);
+        m_eglContext = EGL_NO_CONTEXT;
+      }
+
+      eglTerminate(m_eglDisplay);
+      m_eglDisplay = EGL_NO_DISPLAY;
+    }
+
+    m_pSRView = nullptr;
+    m_pVShader = nullptr;
+    m_pPShader = nullptr;
+    m_pContext = nullptr;
+  }
+
+  EGLConfig m_eglConfig = EGL_NO_CONFIG_KHR;
+  EGLDisplay m_eglDisplay = EGL_NO_DISPLAY;
+  EGLContext m_eglContext = EGL_NO_CONTEXT;
+  EGLSurface m_eglBuffer = EGL_NO_SURFACE;
+
+  ID3D11DeviceContext* m_pContext = nullptr; // don't hold context
+  Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_pSRView = nullptr;
+  Microsoft::WRL::ComPtr<ID3D11VertexShader> m_pVShader = nullptr;
+  Microsoft::WRL::ComPtr<ID3D11PixelShader> m_pPShader = nullptr;
+
+#define TO_STRING(...) #__VA_ARGS__
+  std::string vs_out_shader_text = TO_STRING(
+  void main(uint id : SV_VertexId, out float2 tex : TEXCOORD0, out float4 pos : SV_POSITION)
+  {
+    tex = float2(id % 2, (id % 4) >> 1);
+    pos = float4((tex.x - 0.5f) * 2, -(tex.y - 0.5f) * 2, 0, 1);
+  });
+
+  std::string ps_out_shader_text = TO_STRING(
+  Texture2D texMain : register(t0);
+  SamplerState Sampler
+  {
+    Filter = MIN_MAG_MIP_LINEAR;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    Comparison = NEVER;
+  };
+
+  float4 main(in float2 tex : TEXCOORD0) : SV_TARGET
+  {
+    return texMain.Sample(Sampler, tex);
+  });
+#undef TO_STRING
+}; /* class CGLonDX */
+
+} /* namespace gl */
+
+using CRenderHelper = gl::CGLonDX;
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/Shader.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/Shader.h
@@ -1,0 +1,353 @@
+/*
+ *  Copyright (C) 2005-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "GL.h"
+
+#include <stdio.h>
+#include <vector>
+#include <string>
+
+#include <kodi/AddonBase.h>
+#include <kodi/Filesystem.h>
+
+#define LOG_SIZE 1024
+#define GLchar char
+
+namespace kodi
+{
+namespace gui
+{
+namespace gl
+{
+
+//========================================================================
+/// CShader - base class
+class ATTRIBUTE_HIDDEN CShader
+{
+public:
+  CShader() = default;
+  virtual ~CShader() = default;
+  virtual bool Compile(const std::string& extraBegin = "",
+                       const std::string& extraEnd = "") = 0;
+  virtual void Free() = 0;
+  virtual GLuint Handle() = 0;
+
+  bool LoadSource(const std::string& file)
+  {
+    char buffer[16384];
+
+    kodi::vfs::CFile source;
+    if (!source.OpenFile(file))
+    {
+      kodi::Log(ADDON_LOG_ERROR, "CShader::%s: Failed to open file '%s'", __FUNCTION__, file.c_str());
+      return false;
+    }
+    size_t len = source.Read(buffer, sizeof(buffer));
+    m_source.assign(buffer);
+    m_source[len] = 0;
+    source.Close();
+    return true;
+  }
+
+  bool OK() const { return m_compiled; }
+
+protected:
+  std::string m_source;
+  std::string m_lastLog;
+  bool m_compiled = false;
+};
+//------------------------------------------------------------------------
+
+//========================================================================
+/// CVertexShader
+class ATTRIBUTE_HIDDEN CVertexShader : public CShader
+{
+public:
+  CVertexShader() = default;
+  ~CVertexShader() override { Free(); }
+
+  void Free() override
+  {
+    if (m_vertexShader)
+      glDeleteShader(m_vertexShader);
+    m_vertexShader = 0;
+  }
+
+  bool Compile(const std::string& extraBegin = "",
+               const std::string& extraEnd = "") override
+  {
+    GLint params[4];
+
+    Free();
+
+    m_vertexShader = glCreateShader(GL_VERTEX_SHADER);
+
+    GLsizei count = 0;
+    const char *sources[3];
+    if (!extraBegin.empty())
+      sources[count++] = extraBegin.c_str();
+    if (!m_source.empty())
+      sources[count++] = m_source.c_str();
+    if (!extraEnd.empty())
+      sources[count++] = extraEnd.c_str();
+
+    glShaderSource(m_vertexShader, count, sources, nullptr);
+    glCompileShader(m_vertexShader);
+    glGetShaderiv(m_vertexShader, GL_COMPILE_STATUS, params);
+    if (params[0] != GL_TRUE)
+    {
+      GLchar log[LOG_SIZE];
+      glGetShaderInfoLog(m_vertexShader, LOG_SIZE, nullptr, log);
+      kodi::Log(ADDON_LOG_ERROR, "CVertexShader::%s: %s", __FUNCTION__, log);
+      fprintf(stderr, "CVertexShader::%s: %s\n", __FUNCTION__, log);
+      m_lastLog = log;
+      m_compiled = false;
+    }
+    else
+    {
+      GLchar log[LOG_SIZE];
+      glGetShaderInfoLog(m_vertexShader, LOG_SIZE, nullptr, log);
+      m_lastLog = log;
+      m_compiled = true;
+    }
+    return m_compiled;
+  }
+
+  GLuint Handle() override { return m_vertexShader; }
+
+protected:
+  GLuint m_vertexShader = 0;
+};
+//------------------------------------------------------------------------
+
+//========================================================================
+/// CPixelShader
+class ATTRIBUTE_HIDDEN CPixelShader : public CShader
+{
+public:
+  CPixelShader() = default;
+  ~CPixelShader() { Free(); }
+  void Free() override
+  {
+    if (m_pixelShader)
+      glDeleteShader(m_pixelShader);
+    m_pixelShader = 0;
+  }
+
+  bool Compile(const std::string& extraBegin = "",
+               const std::string& extraEnd = "") override
+  {
+    GLint params[4];
+
+    Free();
+
+    m_pixelShader = glCreateShader(GL_FRAGMENT_SHADER);
+
+    GLsizei count = 0;
+    const char *sources[3];
+    if (!extraBegin.empty())
+      sources[count++] = extraBegin.c_str();
+    if (!m_source.empty())
+      sources[count++] = m_source.c_str();
+    if (!extraEnd.empty())
+      sources[count++] = extraEnd.c_str();
+
+    glShaderSource(m_pixelShader, count, sources, 0);
+    glCompileShader(m_pixelShader);
+    glGetShaderiv(m_pixelShader, GL_COMPILE_STATUS, params);
+    if (params[0] != GL_TRUE)
+    {
+      GLchar log[LOG_SIZE];
+      glGetShaderInfoLog(m_pixelShader, LOG_SIZE, nullptr, log);
+      kodi::Log(ADDON_LOG_ERROR, "CPixelShader::%s: %s", __FUNCTION__, log);
+      fprintf(stderr, "CPixelShader::%s: %s\n", __FUNCTION__, log);
+      m_lastLog = log;
+      m_compiled = false;
+    }
+    else
+    {
+      GLchar log[LOG_SIZE];
+      glGetShaderInfoLog(m_pixelShader, LOG_SIZE, nullptr, log);
+      m_lastLog = log;
+      m_compiled = true;
+    }
+    return m_compiled;
+  }
+
+  GLuint Handle() override { return m_pixelShader; }
+
+protected:
+  GLuint m_pixelShader = 0;
+};
+//------------------------------------------------------------------------
+
+//========================================================================
+/// CShaderProgram
+class ATTRIBUTE_HIDDEN CShaderProgram
+{
+public:
+  CShaderProgram() = default;
+  CShaderProgram(const std::string &vert, const std::string &frag)
+  {
+    LoadShaderFiles(vert, frag);
+  }
+
+  virtual ~CShaderProgram()
+  {
+    ShaderFree();
+  }
+
+  bool LoadShaderFiles(const std::string &vert, const std::string &frag)
+  {
+    if (!kodi::vfs::FileExists(vert) || !m_pVP.LoadSource(vert))
+    {
+      kodi::Log(ADDON_LOG_ERROR, "%s: Failed to load '%s'", __func__, vert.c_str());
+      return false;
+    }
+
+    if (!kodi::vfs::FileExists(frag) || !m_pFP.LoadSource(frag))
+    {
+      kodi::Log(ADDON_LOG_ERROR, "%s: Failed to load '%s'", __func__, frag.c_str());
+      return false;
+    }
+
+    return true;
+  }
+
+  bool CompileAndLink(const std::string& vertexExtraBegin = "",
+                      const std::string& vertexExtraEnd = "",
+                      const std::string& fragmentExtraBegin = "",
+                      const std::string& fragmentExtraEnd = "")
+  {
+    GLint params[4];
+
+    // free resources
+    ShaderFree();
+    m_ok = false;
+
+    // compiled vertex shader
+    if (!m_pVP.Compile(vertexExtraBegin, vertexExtraEnd))
+    {
+      kodi::Log(ADDON_LOG_ERROR, "GL: Error compiling vertex shader");
+      return false;
+    }
+
+    // compile pixel shader
+    if (!m_pFP.Compile(fragmentExtraBegin, fragmentExtraEnd))
+    {
+      m_pVP.Free();
+      kodi::Log(ADDON_LOG_ERROR, "GL: Error compiling fragment shader");
+      return false;
+    }
+
+    // create program object
+    m_shaderProgram = glCreateProgram();
+    if (!m_shaderProgram)
+    {
+      kodi::Log(ADDON_LOG_ERROR, "CShaderProgram::%s: Failed to create GL program", __FUNCTION__);
+      ShaderFree();
+      return false;
+    }
+
+    // attach the vertex shader
+    glAttachShader(m_shaderProgram, m_pVP.Handle());
+    glAttachShader(m_shaderProgram, m_pFP.Handle());
+
+    // link the program
+    glLinkProgram(m_shaderProgram);
+    glGetProgramiv(m_shaderProgram, GL_LINK_STATUS, params);
+    if (params[0] != GL_TRUE)
+    {
+      GLchar log[LOG_SIZE];
+      glGetProgramInfoLog(m_shaderProgram, LOG_SIZE, nullptr, log);
+      kodi::Log(ADDON_LOG_ERROR, "CShaderProgram::%s: %s", __FUNCTION__, log);
+      fprintf(stderr, "CShaderProgram::%s: %s\n", __FUNCTION__, log);
+      ShaderFree();
+      return false;
+    }
+
+    m_validated = false;
+    m_ok = true;
+    OnCompiledAndLinked();
+    return true;
+  }
+
+  bool EnableShader()
+  {
+    if (ShaderOK())
+    {
+      glUseProgram(m_shaderProgram);
+      if (OnEnabled())
+      {
+        if (!m_validated)
+        {
+          // validate the program
+          GLint params[4];
+          glValidateProgram(m_shaderProgram);
+          glGetProgramiv(m_shaderProgram, GL_VALIDATE_STATUS, params);
+          if (params[0] != GL_TRUE)
+          {
+            GLchar log[LOG_SIZE];
+            glGetProgramInfoLog(m_shaderProgram, LOG_SIZE, nullptr, log);
+            kodi::Log(ADDON_LOG_ERROR, "CShaderProgram::%s: %s", __FUNCTION__, log);
+            fprintf(stderr, "CShaderProgram::%s: %s\n", __FUNCTION__, log);
+          }
+          m_validated = true;
+        }
+        return true;
+      }
+      else
+      {
+        glUseProgram(0);
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  void DisableShader()
+  {
+    if (ShaderOK())
+    {
+      glUseProgram(0);
+      OnDisabled();
+    }
+  }
+
+  ATTRIBUTE_FORCEINLINE bool ShaderOK() const { return m_ok; }
+  ATTRIBUTE_FORCEINLINE CVertexShader& VertexShader() { return m_pVP; }
+  ATTRIBUTE_FORCEINLINE CPixelShader& PixelShader() { return m_pFP; }
+  ATTRIBUTE_FORCEINLINE GLuint ProgramHandle() { return m_shaderProgram; }
+
+  virtual void OnCompiledAndLinked() {};
+  virtual bool OnEnabled() { return false; };
+  virtual void OnDisabled() {};
+
+private:
+  void ShaderFree()
+  {
+    if (m_shaderProgram)
+      glDeleteProgram(m_shaderProgram);
+    m_shaderProgram = 0;
+    m_ok = false;
+  }
+
+  CVertexShader m_pVP;
+  CPixelShader m_pFP;
+  GLuint m_shaderProgram = 0;
+  bool m_ok = false;
+  bool m_validated = false;
+};
+//------------------------------------------------------------------------
+
+} /* namespace gl */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/renderHelper.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/renderHelper.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2005-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+struct IRenderHelper
+{
+  virtual ~IRenderHelper() = default;
+  virtual bool Init() = 0;
+  virtual void Begin() = 0;
+  virtual void End() = 0;
+}; /* class IRenderHelper */
+} /* namespace gui */
+} /* namespace kodi */
+
+#if defined(WIN32) && defined(HAS_ANGLE)
+#include "gl/GLonDX.h"
+#else
+/*
+ * Default background GUI render helper class
+ */
+namespace kodi
+{
+namespace gui
+{
+struct CRenderHelperStub : public IRenderHelper
+{
+  bool Init() override { return true; }
+  void Begin() override { }
+  void End() override { }
+}; /* class CRenderHelperStub */
+
+using CRenderHelper = CRenderHelperStub;
+} /* namespace gui */
+} /* namespace kodi */
+#endif
+
+namespace kodi
+{
+namespace gui
+{
+
+/*
+ * Create render background handler, e.g. becomes on "Windows" Angle used
+ * to emulate GL.
+ *
+ * This only be used internal and not from addon's direct.
+ *
+ * Function defines here and not in CAddonBase because of a hen and egg problem.
+ */
+inline std::shared_ptr<IRenderHelper> GetRenderHelper()
+{
+  using namespace ::kodi::addon;
+  if (CAddonBase::m_interface->addonBase->m_renderHelper)
+    return CAddonBase::m_interface->addonBase->m_renderHelper;
+
+  const std::shared_ptr<kodi::gui::IRenderHelper> renderHelper(new CRenderHelper());
+  if (!renderHelper->Init())
+    return nullptr;
+
+  CAddonBase::m_interface->addonBase->m_renderHelper = renderHelper; // Hold on base for other types
+  return renderHelper;
+}
+
+} /* namespace gui */
+} /* namespace kodi */


### PR DESCRIPTION
## Description
This is a request to facilitate GL usage on the addon and to allow GL under DirectX.

It is not yet final and since the addon special CMake stuff is needed, it still needs to be clarified how they are provided.

This are required:
 - [FindOpenGLES.cmake](https://github.com/xbmc/screensaver.matrixtrails/blob/94a572ec87830604a736ceb2e89907589fa36034/FindOpenGLES.cmake#L18)
- [./depends/windows/angle/*](https://github.com/xbmc/screensaver.matrixtrails/blob/94a572ec87830604a736ceb2e89907589fa36034/depends/windows/angle)

To test:
https://github.com/AlwinEsch/screensaver.example.windows.gles

My ideas:
1. In "./xbmc/addons/kodi-addon-dev-kit" add a "docs (?)" Folder and lay the necessary stuff there
    - ***PRO*** In devkit folder everything deposited together and not distributed between different places.
    - ***PRO*** One understands better why a `HAS_ANGLE` is in the addon headern
    - ***CONTRA*** The code is not used in the construction therefore errors can creep in.
2. Create a Hello World (Triangle) demo addon which is referenced
    - ***PRO*** Can be used to test the headers
    - ***PRO*** Would be a working example for external developers
    - ***CONTRA*** There is something in Kodi which needs CMake stuff from outside.

What ideas do you have or what would you prefer?

---------------------------------------
The main part is the GL.h, to have the integration of the necessary header
OS independently of the addon. Depending on the OS and CMake definition,
this will provide the necessary includes.

With "GLonDX.h" a background class is added which allows to use GL also
under Windows with DirectX.
This is meant for the case that an addon can not easily be converted to
DirectX. If CMake defines a HAS_ANGLE this will be used. In addition,
however, a special "depend" is needed and a customized "FindOpenGLES.cmake".
The support is included in screensaver, visualization and CRendering.

In addition, this adds helper classes to the addon interface to facilitate
OpenGL usage "Shader.h"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Why I would like that so at the addon headern is to have it independent at the addon OS and keep `# ifdef` away from the addon. So an addon would be usable everywhere without any changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
