### PR TITLE
[videoplayer] Increase analyzeduration to fix playback of DVB-T2 stre…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -439,7 +439,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   bool isBluray = pInput->IsStreamType(DVDSTREAM_TYPE_BLURAY);
   if (iformat && (strcmp(iformat->name, "mpegts") == 0) && !fileinfo && !isBluray)
   {
-    av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
+    av_opt_set_int(m_pFormatContext, "analyzeduration", 2000000, 0);
     m_checkvideo = true;
     skipCreateStreams = true;
   }


### PR DESCRIPTION
…ams with aac_lapm audio streams

## Description
Increase the FFMPEG analyze duration for MPEGTS streams. This is needed to make streaming from DVB-T2 with multiple aac_latm streams working. With the old value only one audio streams will be recognized. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This fixes the bug desribed in this bug report :  http://trac.kodi.tv/ticket/17927

## How Has This Been Tested?
Tested it with several recordings from DVB-T2, the ones with aac_lapm are working now, the ones with eac3 are still working. I haven't encountered any regression

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
