### PR TITLE
Fix refclock calculation

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -247,11 +247,11 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
   //set the speed of the videoreferenceclock based on fps, refreshrate and maximum speed adjust set by user
   if (m_maxspeedadjust > 0.05)
   {
-    if (weight / MathUtils::round_int(weight) < 1.0 + m_maxspeedadjust / 50.0
-    &&  weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 50.0)
-      weight = MathUtils::round_int(weight) * 0.5;
+    if (weight / MathUtils::round_int(weight) < 1.0 + m_maxspeedadjust / 200.0
+    &&  weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 200.0)
+      weight = MathUtils::round_int(weight);
   }
-  double speed = rate / (fps * weight);
+  double speed = (rate * 2.0 ) / (fps * weight);
   lock.Leave();
 
   m_videoRefClock->SetSpeed(speed);

--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
@@ -204,7 +204,7 @@ void CVideoReferenceClock::SetSpeed(double Speed)
     if (Speed != m_ClockSpeed)
     {
       m_ClockSpeed = Speed;
-      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Clock speed %f%%", m_ClockSpeed * 100.0);
+      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Clock speed %0.2f %%", m_ClockSpeed * 100.0);
     }
   }
 }


### PR DESCRIPTION
## Description
Fix calculation error introduced in: https://github.com/xbmc/xbmc/pull/15586

## Motivation and Context
https://github.com/xbmc/xbmc/issues/15617

## How Has This Been Tested?
Win64, 25 / 50 / 23.97 on 60 hz

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
