### PR TITLE
[Android] rework intermediate stream start / flush

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -104,6 +104,7 @@ public:
 
   std::shared_ptr<CMediaCodec> GetMediaCodec();
   void ResetMediaCodec();
+  void ReleaseMediaCodecBuffers();
 
 private:
   CCriticalSection m_criticalSection;;
@@ -136,6 +137,8 @@ public:
 protected:
   void            Dispose();
   void            FlushInternal(void);
+  void            SignalEndOfStream();
+  void            InjectExtraData(AMediaFormat* mediaformat);
   bool            ConfigureMediaCodec(void);
   int             GetOutputPicture(void);
   void            ConfigureOutputFormat(AMediaFormat* mediaformat);


### PR DESCRIPTION
## Description
From experiences / user reports in the last couple of weeks https://github.com/xbmc/xbmc/pull/15455 lead to issues on some devices. Even we bumped SDK to >=26 after first issues appeared, still issues remained.

From reading below linked issue, it is quite sure that h.265 decoder at least on users device needs to be fed initially with an I-Frame. Because BitstreamConverter is already open for h.264 / h.265 streams because of annexb convertion, it does not cost too much searching for an IFrame on decoding start.

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=341201

## How Has This Been Tested?
Tested on several devices playing h.264 and h.265 streams.
Because the "decoder goes in broken mode" issue could not be reproduced from my side, the change is not fully self - tested (but user did)

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
