### PR TITLE
[Android] Check if ActiveAE is available if HEADSET_PLUG intent arrives

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1006,7 +1006,9 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     if (newstate != m_headsetPlugged)
     {
       m_headsetPlugged = newstate;
-      CServiceBroker::GetActiveAE()->DeviceChange();
+      IAE *iae = CServiceBroker::GetActiveAE();
+      if (iae)
+        iae->DeviceChange();
     }
   }
   else if (action == "android.media.action.HDMI_AUDIO_PLUG")


### PR DESCRIPTION
## Description
Segfault if HEADSET_PLUG arrives early (e.g. Lineage OS + attached BT Headset) and ActiveAE is not set up.

## Motivation and Context
https://github.com/xbmc/xbmc/issues/15616

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
