### PR TITLE
[PVR] - Recording edit context menu visible when not supported

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -266,8 +266,9 @@ namespace PVR
     {
       const CPVRRecordingPtr recording(item.GetPVRRecordingInfoTag());
       if (recording && !recording->IsDeleted() && !recording->IsInProgress())
-        return true;
-
+      {
+        return CServiceBroker::GetPVRManager().GUIActions()->CanEditRecording(item);
+      }
       return false;
     }
 

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -916,6 +916,11 @@ namespace PVR
     return true;
   }
 
+  bool CPVRGUIActions::CanEditRecording(const CFileItem& item) const
+  {
+    return CGUIDialogPVRRecordingSettings::CanEditRecording(item);
+  }
+
   bool CPVRGUIActions::RenameRecording(const CFileItemPtr &item) const
   {
     const CPVRRecordingPtr recording(item->GetPVRRecordingInfoTag());

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -203,6 +203,13 @@ namespace PVR
     bool EditRecording(const CFileItemPtr &item) const;
 
     /*!
+     * @brief Check if any recording settings can be edited.
+     * @param item containing the recording to edit.
+     * @return true on success, false otherwise.
+     */
+    bool CanEditRecording(const CFileItem& item) const;
+
+    /*!
      * @brief Rename a recording, showing a text input dialog.
      * @param item containing a recording to rename.
      * @return true, if the recording was renamed successfully, false otherwise.

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -94,6 +94,23 @@ void CGUIDialogPVRRecordingSettings::InitializeSettings()
     setting = AddList(group, SETTING_RECORDING_LIFETIME, 19083, SettingLevel::Basic, m_iLifetime, LifetimesFiller, 19083);
 }
 
+bool CGUIDialogPVRRecordingSettings::CanEditRecording(const CFileItem& item)
+{
+  if (!item.HasPVRRecordingInfoTag())
+    return false;
+
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item.GetPVRRecordingInfoTag()->ClientID());
+
+  if (!client)
+    return false;
+
+  const CPVRClientCapabilities& capabilities = client->GetClientCapabilities();
+
+  return capabilities.SupportsRecordingsRename() ||
+         capabilities.SupportsRecordingsPlayCount() ||
+         capabilities.SupportsRecordingsLifetimeChange();
+}
+
 bool CGUIDialogPVRRecordingSettings::OnSettingChanging(std::shared_ptr<const CSetting> setting)
 {
   if (setting == nullptr)

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
@@ -26,6 +26,7 @@ namespace PVR
     CGUIDialogPVRRecordingSettings();
 
     void SetRecording(const CPVRRecordingPtr &recording);
+    static bool CanEditRecording(const CFileItem& item);
 
   protected:
     // implementation of ISettingCallback


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
PVR Recording edit context menu still visible when backend doesn't have recording editing capability.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes recording edit menu opening blank dialog when backend doesn't have recording editing capability.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->

Tested with pvr.dbvlink which doesn't have editing capability. Not tested with PVR with this capability.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
