### PR TITLE
[Music]Fix collaboration album tag processing MBID matching

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -130,9 +130,9 @@ void CAlbum::SetArtistCredits(const std::vector<std::string>& names, const std::
                 if (albumartistHints.size() < i + 1)
                   albumartistHints.resize(i + 1);
                 if (artistmbids.size() == artisthints.size())
-                  albumartistHints[j] = artisthints[j];
+                  albumartistHints[i] = artisthints[j];
                 else
-                  albumartistHints[j] = artistnames[j];
+                  albumartistHints[i] = artistnames[j];
               }
             }
           }


### PR DESCRIPTION
Fix bug in album artist name and Musicbrainz id tag matching process for collaboration albums e.g. those with more than one album artist

Issue occurred when album has
- More than one album artist but Kodi can not separate the ALBUMARTIST tag into individual artists. For example ID3 v2.3 format tags (single frame) used with non-standard separator that has not been added to advancedsettings.xml e.g. ALBUMARTIST = "Simonetti - Pignatelli - Morante".
- MUSICBRAINZ ALBUM ARTIST ID tag provides mbid values all of the artists
- Values for ALBUMARTISTS tag is not provided (sadly not default Picard behaviour, but can do so)
- ARTISTS and MUSICBRAINZ ARTIST ID tags do provide matching name and mbid values, and they are the same artisits as the album artists, but the artists are credited in a different order e.g. "Simonetti / Morante / Pignatelli"

An example release with this tag combination is https://musicbrainz.org/release/1ad13756-05e9-4ab4-b6cc-b9ce782431f5 when tagged as ID3 v2.3 format by Picard default settings. Kindly reported by a user https://forum.kodi.tv/showthread.php?tid=341341. But it is an uncommon combination hence the processing flaw has only just shown up.

When unable to match up the album artist names and mbids, Kodi attempts to use the (song) artist names and mbid values as a fallback to sort out what individual album artists have been provided. The fix is simply to use the correct vector index when doing this.