### PR TITLE
[Android] send BUFFER_FLAG_END_OF_STREAM to MediaCodec if EOF was detected

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1085,7 +1085,8 @@ void CDVDVideoCodecAndroidMediaCodec::FlushInternal()
 
 void CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream()
 {
-  if (m_codec->codec() && m_state == MEDIACODEC_STATE_RUNNING)
+  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::%s: state: %d", __func__, m_state);
+  if (m_codec->codec() && (m_state == MEDIACODEC_STATE_RUNNING || m_state == MEDIACODEC_STATE_ENDOFSTREAM))
   {
     // Release all mediaodec output buffers to allow drain if we don't get inputbuffer early
     if (m_videoBufferPool)


### PR DESCRIPTION
## Description
Streams with still frames could be stated as EOF instead the normal case RUNNING in MediaCodec decoder. We have to send the BUFFER_FLAG_END_OF_STREAM in this situation, too.

Extends: https://github.com/xbmc/xbmc/pull/15622

## Motivation and Context
System freeze playing mpeg2 DVD so on nvidia shield

## How Has This Been Tested?
- Play DVD iso with still / very small first video sequence -> mpeg2 decoder freeze

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
