### PR TITLE
[PVR] Fix crash on channel switch when no pvr client is enabled.

### DIFF
--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1184,20 +1184,28 @@ namespace PVR
     switch (type)
     {
       case PlaybackTypeRadio:
+      {
         if (CServiceBroker::GetPVRManager().IsPlayingRadio())
           return true;
 
-        channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAllRadio()->GetLastPlayedChannel();
+        const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAllRadio();
+        if (allGroup)
+          channel = allGroup->GetLastPlayedChannel();
+
         bIsRadio = true;
         break;
-
+      }
       case PlaybackTypeTV:
+      {
         if (CServiceBroker::GetPVRManager().IsPlayingTV())
           return true;
 
-        channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAllTV()->GetLastPlayedChannel();
-        break;
+        const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAllTV();
+        if (allGroup)
+          channel = allGroup->GetLastPlayedChannel();
 
+        break;
+      }
       default:
         if (CServiceBroker::GetPVRManager().IsPlaying())
           return true;


### PR DESCRIPTION
Fixes #15548 

Runtime-tested on macOS with latest kodi master.

@Jalle19 for review?