### PR TITLE
[Android] Don't flip GLES if window was destroyed

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -62,10 +62,7 @@ CWinSystemAndroid::CWinSystemAndroid()
 
 CWinSystemAndroid::~CWinSystemAndroid()
 {
-  if(m_nativeWindow)
-  {
-    m_nativeWindow = nullptr;
-  }
+  m_nativeWindow = nullptr;
   delete m_dispResetTimer, m_dispResetTimer = nullptr;
 }
 
@@ -134,6 +131,8 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
 
 bool CWinSystemAndroid::DestroyWindow()
 {
+  m_nativeWindow = nullptr;
+  m_bWindowCreated = false;
   return true;
 }
 

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -96,6 +96,12 @@ void CWinSystemAndroidGLESContext::SetVSyncImpl(bool enable)
 
 void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
 {
+  if (!m_nativeWindow)
+  {
+    usleep(10000);
+    return;
+  }
+
   // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
   // we can't actually do anything about it
   if (rendered && !m_pGLContext.TrySwapBuffers())


### PR DESCRIPTION
## Description
If window is destroyed (no surface to render GL available) we should avoid to render on it to avoid abort exceptions. This is what this PR is doing.

## Motivation and Context
Remove more ANR's / crashes

## How Has This Been Tested?
- Enable kill background tasks in android phone settings.
- Launch kodi
- Switch of screen from mobile.

Without PR you'll find a fatal abort in kodi.log

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
