### PR TITLE
[curl] Accept all supported content encodings by default

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -206,7 +206,6 @@ bool CRepository::FetchChecksum(const std::string& url, std::string& checksum) n
 bool CRepository::FetchIndex(const DirInfo& repo, std::string const& digest, VECADDONS& addons) noexcept
 {
   XFILE::CCurlFile http;
-  http.SetAcceptEncoding("gzip");
 
   std::string response;
   if (!http.Get(repo.info, response))

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -425,6 +425,7 @@ CCurlFile::CCurlFile()
   m_httpresponse = -1;
   m_acceptCharset = "UTF-8,*;q=0.8"; /* prefer UTF-8 if available */
   m_allowRetry = true;
+  m_acceptencoding = "all"; /* Accept all supported encoding by default */
 }
 
 //Has to be called before Open()
@@ -579,7 +580,7 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
 
   // setup Accept-Encoding if requested
   if (m_acceptencoding.length() > 0)
-    g_curlInterface.easy_setopt(h, CURLOPT_ACCEPT_ENCODING, m_acceptencoding.c_str());
+    g_curlInterface.easy_setopt(h, CURLOPT_ACCEPT_ENCODING, m_acceptencoding == "all" ? "" : m_acceptencoding.c_str());
 
   if (!m_acceptCharset.empty())
     SetRequestHeader("Accept-Charset", m_acceptCharset);

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -185,9 +185,6 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
   http.SetReferer(scrURL.m_spoof);
   std::string strCachePath;
 
-  if (scrURL.m_isgz)
-    http.SetAcceptEncoding("gzip");
-
   if (!scrURL.m_cache.empty())
   {
     strCachePath = URIUtils::AddFileToFolder(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cachePath,


### PR DESCRIPTION
## Description
By setting CURLOPT_ACCEPT_ENCODING to "" by default, curl will request all
supported content encodings.
Users can still use the "Encoding" protocol option to override this
behavior; setting "Encoding" to "" will cause CURLOPT_ACCEPT_ENCODING
to not be set, resulting in curl not accepting any content encoding
(matching the default behavior before).

## Motivation and Context
I saw https://github.com/xbmc/xbmc/pull/15628 and wanted to improve upon that proposed solution.
This approach is basically what was suggested by @bol-van in the comment at https://github.com/xbmc/xbmc/pull/15628/#issuecomment-468284855

## How Has This Been Tested?
Compiled on Linux then used for an hour or so, mostly playing Youtube videos, looking at my security camera, and looking at pictures from my web server. I didn't notice any problems.

I setup my web server log the value of incoming request's `Accept-Encoding` header. With this PR, Kodi now sends `deflate, gzip, br` as is desired.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
