### PR TITLE
[cleanup] remove include guards

### DIFF
--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -12,9 +12,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_NfoFile_H__641CCF68_6D2A_426E_9204_C0E4BEF12D00__INCLUDED_)
-#define AFX_NfoFile_H__641CCF68_6D2A_426E_9204_C0E4BEF12D00__INCLUDED_
-
 #include <string>
 
 #include "addons/Scraper.h"
@@ -62,5 +59,3 @@ private:
 
   int Load(const std::string&);
 };
-
-#endif // !defined(AFX_NfoFile_H__641CCF68_6D2A_426E_9204_C0E4BEF12D00__INCLUDED_)

--- a/xbmc/filesystem/FileFactory.h
+++ b/xbmc/filesystem/FileFactory.h
@@ -12,9 +12,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_FILEFACTORY1_H__068E3138_B7CB_4BEE_B5CE_8AA8CADAB233__INCLUDED_)
-#define AFX_FILEFACTORY1_H__068E3138_B7CB_4BEE_B5CE_8AA8CADAB233__INCLUDED_
-
 #include "IFile.h"
 #include <string>
 
@@ -29,4 +26,3 @@ public:
   static IFile* CreateLoader(const CURL& url);
 };
 }
-#endif // !defined(AFX_FILEFACTORY1_H__068E3138_B7CB_4BEE_B5CE_8AA8CADAB233__INCLUDED_)

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -14,9 +14,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_IFILE_H__7EE73AC7_36BC_4822_93FF_44F3B0C766F6__INCLUDED_)
-#define AFX_IFILE_H__7EE73AC7_36BC_4822_93FF_44F3B0C766F6__INCLUDED_
-
 #include "PlatformDefs.h" // for __stat64, ssize_t
 
 #include <stdio.h>
@@ -147,5 +144,3 @@ public:
 };
 
 }
-
-#endif // !defined(AFX_IFILE_H__7EE73AC7_36BC_4822_93FF_44F3B0C766F6__INCLUDED_)

--- a/xbmc/filesystem/ISOFile.h
+++ b/xbmc/filesystem/ISOFile.h
@@ -14,9 +14,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_FILEISO_H__C2FB9C6D_3319_4182_AB45_65E57EFAC8D1__INCLUDED_)
-#define AFX_FILEISO_H__C2FB9C6D_3319_4182_AB45_65E57EFAC8D1__INCLUDED_
-
 #include "IFile.h"
 #include "utils/RingBuffer.h"
 
@@ -42,5 +39,3 @@ protected:
   CRingBuffer m_cache;
 };
 }
-
-#endif // !defined(AFX_FILEISO_H__C2FB9C6D_3319_4182_AB45_65E57EFAC8D1__INCLUDED_)

--- a/xbmc/filesystem/PipeFile.h
+++ b/xbmc/filesystem/PipeFile.h
@@ -14,9 +14,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_FILEPIPE_H__DD2B0A9E_4971_4A29_B525_78CEFCDAF4A1__INCLUDED_)
-#define AFX_FILEPIPE_H__DD2B0A9E_4971_4A29_B525_78CEFCDAF4A1__INCLUDED_
-
 #include <string>
 #include <vector>
 
@@ -78,4 +75,3 @@ protected:
 };
 
 }
-#endif // !defined(AFX_FILEPIPE_H__DD2B0A9E_4971_4A29_B525_78CEFCDAF4A1__INCLUDED_)

--- a/xbmc/storage/IoSupport.h
+++ b/xbmc/storage/IoSupport.h
@@ -14,9 +14,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_IOSUPPORT_H__F084A488_BD6E_49D5_8CD3_0BE62149DB40__INCLUDED_)
-#define AFX_IOSUPPORT_H__F084A488_BD6E_49D5_8CD3_0BE62149DB40__INCLUDED_
-
 #include "PlatformDefs.h" // for Win32 types
 
 #define MODE1_DATA_SIZE    2048 // Mode1 sector has 2048 bytes of data
@@ -40,5 +37,3 @@ public:
 private:
   static void* m_rawXferBuffer;
 };
-
-#endif // !defined(AFX_IOSUPPORT_H__F084A488_BD6E_49D5_8CD3_0BE62149DB40__INCLUDED_)


### PR DESCRIPTION
## Description
remove explicit ifdef include guards
those files already contain `#pragma once`

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
