### PR TITLE
[PVR] Inconsistencies in Guide/Channel/Recordings Info Dialogs

### DIFF
--- a/addons/skin.estouchy/xml/DialogPVRInfo.xml
+++ b/addons/skin.estouchy/xml/DialogPVRInfo.xml
@@ -180,23 +180,24 @@
 			<itemgap>10</itemgap>
 			<align>center</align>
 			<orientation>horizontal</orientation>
+			<defaultcontrol always="true">5</defaultcontrol>
 			<onleft>9000</onleft>
 			<onright>9000</onright>
 			<onup>50</onup>
 			<ondown>49</ondown>
-			<control type="button" id="4">
-				<description>Find similar</description>
-				<width>230</width>
-				<include>ButtonInfoDialogsCommonValues</include>
-				<label>19003</label>
-				<visible>Window.IsActive(PVRGuideInfo)</visible>
-			</control>
 			<control type="button" id="5">
-				<description>Switch Channel</description>
+				<description>Switch channel</description>
 				<width>230</width>
 				<include>ButtonInfoDialogsCommonValues</include>
 				<label>19165</label>
 				<visible>Window.IsActive(PVRGuideInfo)</visible>
+			</control>
+			<control type="button" id="8">
+				<description>Play recording</description>
+				<width>230</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+				<label>19687</label>
+				<visible>Window.IsActive(PVRRecordingInfo)</visible>
 			</control>
 			<control type="button" id="6">
 				<description>Record</description>
@@ -204,6 +205,13 @@
 				<include>ButtonInfoDialogsCommonValues</include>
 				<label></label>
 				<visible>Window.IsActive(PVRGuideInfo)</visible>
+			</control>
+			<control type="button" id="4">
+				<description>Find similar</description>
+				<width>230</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+				<label>19003</label>
+				<visible>Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo)</visible>
 			</control>
 			<control type="button" id="7">
 				<description>OK</description>

--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -60,7 +60,7 @@
 					<itemgap>10</itemgap>
 					<align>center</align>
 					<orientation>horizontal</orientation>
-					<defaultcontrol>5</defaultcontrol>
+					<defaultcontrol always="true">5</defaultcontrol>
 					<onleft>9000</onleft>
 					<onright>9000</onright>
 					<onup>61</onup>
@@ -104,7 +104,7 @@
 						<param name="id" value="4" />
 						<param name="icon" value="icons/infodialogs/similar.png" />
 						<param name="label" value="$LOCALIZE[19003]" />
-						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
+						<param name="visible" value="Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo)" />
 					</include>
 					<include content="InfoDialogButton">
 						<param name="width" value="275" />

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -18,6 +18,7 @@
 
 using namespace PVR;
 
+#define CONTROL_BTN_FIND 4
 #define CONTROL_BTN_OK  7
 #define CONTROL_BTN_PLAY_RECORDING  8
 
@@ -32,7 +33,9 @@ bool CGUIDialogPVRRecordingInfo::OnMessage(CGUIMessage& message)
   switch (message.GetMessage())
   {
     case GUI_MSG_CLICKED:
-      return OnClickButtonOK(message) || OnClickButtonPlay(message);
+      return OnClickButtonOK(message) ||
+             OnClickButtonPlay(message) ||
+             OnClickButtonFind(message);
   }
 
   return CGUIDialog::OnMessage(message);
@@ -61,6 +64,23 @@ bool CGUIDialogPVRRecordingInfo::OnClickButtonPlay(CGUIMessage &message)
 
     if (m_recordItem)
       CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(m_recordItem, true /* check resume */);
+
+    bReturn = true;
+  }
+
+  return bReturn;
+}
+
+bool CGUIDialogPVRRecordingInfo::OnClickButtonFind(CGUIMessage& message)
+{
+  bool bReturn = false;
+
+  if (message.GetSenderId() == CONTROL_BTN_FIND)
+  {
+    Close();
+
+    if (m_recordItem)
+      CServiceBroker::GetPVRManager().GUIActions()->FindSimilar(m_recordItem);
 
     bReturn = true;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -27,6 +27,7 @@ namespace PVR
     static void ShowFor(const CFileItemPtr& item);
 
   private:
+    bool OnClickButtonFind(CGUIMessage& message);
     bool OnClickButtonOK(CGUIMessage &message);
     bool OnClickButtonPlay(CGUIMessage &message);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Resolve inconsistencies in PVR Guide/Channel and Recordings Info Dialogs, particularly between Estuary and Estouchy Skins.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Creates a more consistent interface.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested both in Estuary and Estouchy Skins.

These are the proposed changes to the Estouchy and Estuary Skins for Recordings Info:

![1 recordings info](https://user-images.githubusercontent.com/25765532/53680725-4da7f980-3cd7-11e9-82f3-82de10569057.png)

These are the proposed changes to the Estouchy and Estuary Skins for Guide/Channel Info:

![2 guide info](https://user-images.githubusercontent.com/25765532/53680728-54367100-3cd7-11e9-8a04-875a652e5139.png)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
