### PR TITLE
[Android] Fix monoscopic/2D viewrect calcuation

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -156,8 +156,10 @@ void CRendererMediaCodecSurface::RenderUpdate(int index, int index2, bool clear,
       m_surfDestRect.x2 *= 2.0;
       break;
     case RENDER_STEREO_MODE_MONO:
-      m_surfDestRect.y2 = m_surfDestRect.y2 * (m_surfDestRect.y2 / m_sourceRect.y2);
-      m_surfDestRect.x2 = m_surfDestRect.x2 * (m_surfDestRect.x2 / m_sourceRect.x2);
+      if (CONF_FLAGS_STEREO_MODE_MASK(m_iFlags) == CONF_FLAGS_STEREO_MODE_TAB)
+        m_surfDestRect.y2 = m_surfDestRect.y2 * 2.0;
+      else
+        m_surfDestRect.x2 = m_surfDestRect.x2 * 2.0;
       break;
     default:
       break;


### PR DESCRIPTION
## Description
[Android] Fix monoscopic/2D viewrect calcuation.

## Motivation and Context
Currently we scale 3D movies not correctly if we display them on screen resolutions other than stream resolution (e.g. 1080p 3D stream on 4K TV resolution.

http://trac.kodi.tv/ticket/17707#comment:7

## How Has This Been Tested?
AFTV 4K stick, set GUI resolution to Unlimited and TV to 4K, play a 3D HSBS stream, for example:
https://drive.google.com/file/d/0BwxFVkl63-lEX3RpYTNEMFZxcjA/view?usp=sharing

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
