### PR TITLE
[music] format album rating

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -9966,7 +9966,7 @@ void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album
   item.SetProperty("album_genre_array", album.genre);
   item.SetProperty("album_title", album.strAlbum);
   if (album.fRating > 0)
-    item.SetProperty("album_rating", album.fRating);
+    item.SetProperty("album_rating", StringUtils::FormatNumber(album.fRating));
   if (album.iUserrating > 0)
     item.SetProperty("album_userrating", album.iUserrating);
   if (album.iVotes > 0)


### PR DESCRIPTION
currently $INFO[ListItem.Property(Album_Rating)] is returned as a float `8.000000` instead of a number `8.0`.

this commit changes it to use the same format as we use for $INFO[ListItem.Rating]