### PR TITLE
[Android] generate keypress for mediasession actions

### DIFF
--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
@@ -17,6 +17,9 @@
 #include "messaging/ApplicationMessenger.h"
 #include "input/Key.h"
 
+#include "AndroidKey.h"
+#include <androidjni/KeyEvent.h>
+
 using namespace jni;
 
 static std::string s_className = std::string(CCompileInfo::GetClass()) + "/XBMCMediaSession";
@@ -97,6 +100,12 @@ void CJNIXBMCMediaSession::updateIntent(const CJNIIntent& intent)
 
 void CJNIXBMCMediaSession::OnPlayRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_PLAY, XBMCK_MEDIA_PLAY_PAUSE, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (g_application.GetAppPlayer().IsPaused())
@@ -106,6 +115,12 @@ void CJNIXBMCMediaSession::OnPlayRequested()
 
 void CJNIXBMCMediaSession::OnPauseRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_PAUSE, XBMCK_MEDIA_PLAY_PAUSE, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (!g_application.GetAppPlayer().IsPaused())
@@ -115,18 +130,36 @@ void CJNIXBMCMediaSession::OnPauseRequested()
 
 void CJNIXBMCMediaSession::OnNextRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_NEXT, XBMCK_MEDIA_NEXT_TRACK, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
     KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_NEXT_ITEM)));
 }
 
 void CJNIXBMCMediaSession::OnPreviousRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_PREVIOUS, XBMCK_MEDIA_PREV_TRACK, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
     KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PREV_ITEM)));
 }
 
 void CJNIXBMCMediaSession::OnForwardRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_FAST_FORWARD, XBMCK_MEDIA_FASTFORWARD, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (!g_application.GetAppPlayer().IsPaused())
@@ -136,6 +169,12 @@ void CJNIXBMCMediaSession::OnForwardRequested()
 
 void CJNIXBMCMediaSession::OnRewindRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_REWIND, XBMCK_MEDIA_REWIND, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
   {
     if (!g_application.GetAppPlayer().IsPaused())
@@ -145,6 +184,12 @@ void CJNIXBMCMediaSession::OnRewindRequested()
 
 void CJNIXBMCMediaSession::OnStopRequested()
 {
+  if (CXBMCApp::HasFocus())
+  {
+    CAndroidKey::XBMC_Key(CJNIKeyEvent::KEYCODE_MEDIA_STOP, XBMCK_MEDIA_STOP, 0, 0, false);
+    return;
+  }
+
   if (g_application.GetAppPlayer().IsPlaying())
     KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
 }


### PR DESCRIPTION
## Description
If kodi has the focus, create normal keypress instead performing the mediasession actions

## Motivation and Context
fixes https://github.com/xbmc/xbmc/issues/15003
fixes https://github.com/xbmc/xbmc/issues/15189

## How Has This Been Tested?
Small test on AFTV 4K
- Press FFD and read log if it is handles as normal Keypress

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
