### PR TITLE
Fix localised "various arists" missing from some artist lists

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -10484,13 +10484,6 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     }
     // remove the null string
     filter.AppendWhere("artistview.strArtist != ''");
-
-    // and the various artist entry if applicable
-    if (!albumArtistsOnly)
-    {
-      std::string strVariousArtists = g_localizeStrings.Get(340);
-      filter.AppendWhere(PrepareSQL("artistview.strArtist <> '%s'", strVariousArtists.c_str()));
-    }
   }
   else if (type == "albums")
   {


### PR DESCRIPTION
Any artist with a name that matches the current localised string for "Various artists" was being excluded from lists of artists when both song and album artists were being fetched. This was a mistake, left over from original query building when this artist name was used to filter compilations, and there is no reason to exclude it.

Issue reported by user https://forum.kodi.tv/showthread.php?tid=341496
