### PR TITLE
[Android] Prevent HDMI_AUDIO_PLUG intent on TV

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -229,6 +229,7 @@ private:
   static bool m_headsetPlugged;
   static bool m_hdmiPlugged;
   static bool m_hdmiReportedState;
+  static bool m_hdmiSource;
   static IInputDeviceCallbacks* m_inputDeviceCallbacks;
   static IInputDeviceEventHandler* m_inputDeviceEventHandler;
   static bool m_hasReqVisible;


### PR DESCRIPTION
## Description
We use the HDMI_AUDIO_PLUG intent for pausing video playback during resolution / refreshrate switching.
This works well on kodi boxes which are HDMI source, but is not correct if kodi runs on TV and connected HDMI input (like AVR) changes. In that case kodi went into playback pause even android system manages audio playback internally right.

## Motivation and Context
@da-anda 's request in slack (turn AVR off == Kodi stream stall

fixes https://github.com/xbmc/xbmc/issues/15650

## How Has This Been Tested?
I only tested, if kodi still works on TV box (ro.hdmi.device_type = 4)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
