### PR TITLE
[python] xbmcvfs file.seek() - whence should be optional

### DIFF
--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -111,7 +111,7 @@ namespace XBMCAddon
       /// ~~~~~~~~~~~~~{.py}
       /// ..
       /// f = xbmcvfs.File(file)
-      /// b = f.read()
+      /// b = f.readBytes()
       /// f.close()
       /// ..
       /// ~~~~~~~~~~~~~

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -182,11 +182,12 @@ namespace XBMCAddon
       /// Seek to position in file.
       ///
       /// @param seekBytes          position in the file
-      /// @param iWhence            where in a file to seek from[0 beginning,
+      /// @param iWhence            [opt] where in a file to seek from[0 beginning,
       ///                           1 current , 2 end position]
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v19 Function changed. param **iWhence** is now optional.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -199,7 +200,7 @@ namespace XBMCAddon
       ///
       seek(...);
 #else
-      inline long long seek(long long seekBytes, int iWhence) { DelayedCallGuard dg(languageHook); return file->Seek(seekBytes,iWhence); }
+      inline long long seek(long long seekBytes, int iWhence = SEEK_SET) { DelayedCallGuard dg(languageHook); return file->Seek(seekBytes,iWhence); }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS


### PR DESCRIPTION
make our xbmcvfs file.seek() function compatible with the rest of the python world.

problem: it's currently often not possible to pass a xbmcvfs File object to an external python module which uses the seek() function on the file, as we require the whence parameter to be explicitly defined.

fix: make whence optional, as the rest of the python world expects it to be.
ref: https://python-reference.readthedocs.io/en/latest/docs/file/seek.html


additional: a cosmetic bonus commit