### PR TITLE
[python] xbmcvfs - add file.tell() function

### DIFF
--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -205,6 +205,33 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_file
+      /// @brief \python_func{ tell() }
+      ///-----------------------------------------------------------------------
+      /// Get the current position in the file.
+      ///
+      /// @return                       The file position
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v19 New function added
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// f = xbmcvfs.File(file)
+      /// s = f.tell()
+      /// f.close()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      tell();
+#else
+      inline long long tell() { DelayedCallGuard dg(languageHook); return file->GetPosition(); }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_file
       /// @brief \python_func{ close() }
       ///-----------------------------------------------------------------------
       /// Close opened file.


### PR DESCRIPTION
add a tell() function to the xbmcvfs File class.

this will make it possible to pass a xbmcvfs File object to an external python module which uses tell() on the file.