### PR TITLE
AMLCodec: use a fallback rate for invalid fps hints

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2250,6 +2250,13 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
     SetVideoBrightness(brightness);
     m_brightness = brightness;
   }
+  // video rate adjustment.
+  unsigned int video_rate = GetDecoderVideoRate();
+  if (video_rate > 0 && video_rate != am_private->video_rate)
+  {
+    CLog::Log(LOGDEBUG, "CAMLCodec::SetVideoRect: decoder fps has changed, video_rate adjusted from %d to %d", am_private->video_rate, video_rate);
+    am_private->video_rate = video_rate;
+  }
 
   // video view mode
   int view_mode = m_processInfo.GetVideoSettings().m_ViewMode;
@@ -2394,4 +2401,11 @@ void CAMLCodec::SetVideoRate(int videoRate)
 {
   if (am_private)
     am_private->video_rate = videoRate;
+}
+
+unsigned int CAMLCodec::GetDecoderVideoRate()
+{
+  struct vdec_status vs;
+  m_dll->codec_get_vdec_state(&am_private->vcodec, &vs);
+  return static_cast<unsigned int>(0.5 + (static_cast<float>(UNIT_FREQ) / static_cast<float>(vs.fps)));
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -66,6 +66,7 @@ private:
   void          SetVfmMap(const std::string &name, const std::string &map);
   int           DequeueBuffer();
   float         GetTimeSize();
+  unsigned int  GetDecoderVideoRate();
 
   DllLibAmCodec   *m_dll;
   bool             m_opened;


### PR DESCRIPTION
## Description
Currently, the AMLCodec honours invalid ffmpeg fps hints such as 90,000 which leads to unwatchable playback.

This patch causes the AMLCodec to check the fps rate reported by the decoder api, and use this to update the video rate where this differs from the original rate calculated from the ffmpeg hints. This will also help playback of streams where the frame rate changes part way through.

## Motivation and Context
Invalid hints can be passed along in situations where ffmpeg has been unable to determine a correct framerate during FFMPEG analyze duration (e.g. for some tvheadend MPEGTS streams, with multiple streams included).

In such situations, kodi fails to read the framerate:

```
DEBUG: ffmpeg[DF8822F0]: [mpegts] Could not find codec parameters for stream 0 (Video: h264 ([27][0][0][0] / 0x001B), none): unspecified size
DEBUG: ffmpeg[DF8822F0]: [mpegts] Consider increasing the value for the 'analyzeduration' and 'probesize' options
DEBUG: Open - av_find_stream_info finished
INFO: ffmpeg[DF8822F0]: Input #0, mpegts, from '/mnt/mediapc/tvshows/Emmerdale_2019-02-07_sample.ts':
INFO: ffmpeg[DF8822F0]:   Duration: 00:01:00.42, start: 1.400000, bitrate: 7894 kb/s
INFO: ffmpeg[DF8822F0]:   Program 1
INFO: ffmpeg[DF8822F0]:     Metadata:
INFO: ffmpeg[DF8822F0]:       service_name    : Service01
INFO: ffmpeg[DF8822F0]:       service_provider: FFmpeg
INFO: ffmpeg[DF8822F0]:     Stream #0:0[0x100]: Video: h264 ([27][0][0][0] / 0x001B), none, 90k tbr, 90k tbn, 180k tbc
INFO: ffmpeg[DF8822F0]:     Stream #0:1[0x101](eng): Audio: ac3 ([129][0][0][0] / 0x0081), 48000 Hz, stereo, fltp, 192 kb/s
```

From my testing I found that if the analyze duration were increased (from 0.5 to 2 seconds), then the fps rate of the problematic files can be determined correctly. However, this idea was considered and rejected, as it would break other use cases: #15612 

I then found that my problematic files actually playback OK on other H/W decoders (e.g. VDPAU), so I did some debugging of the AMLCodec...

I found that when the frame rate fails to be determined, this causes a hint of 90,000fps to be passed along to the AMLCodec:

```
CAMLCodec::OpenDecoder hints.width(1920), hints.height(1080), hints.codec(27), hints.codec_tag(27)
CAMLCodec::OpenDecoder hints.fpsrate(90000), hints.fpsscale(1), video_rate(1), hints.bitsperpixel(8)
CAMLCodec::OpenDecoder hints.aspect(1.777778), video_ratio.num(1), video_ratio.den(1)
CAMLCodec::OpenDecoder hints.orientation(0), hints.forced_aspect(0), hints.extrasize(44)
```
i.e. fpsrate=90000 fpsscale=1

AMLCodec decoder then uses the following calculation:
am_private->video_rate = 0.5 + (float)UNIT_FREQ * hints.fpsscale / hints.fpsrate;

i.e.
0.5 + 96000 * 90000 / 1

This results in a video_rate of 1! which leads to an unwatchable file. The exact same is true for all the problematic tvheadend recordings which I’ve been keeping hold of (they all result in the decoder hint being set to 90000 fps).

## How Has This Been Tested?

With this patch in place I have played back several tvheadend recordings that I have kept hold of, which failed to playback correctly (symptoms described above). In each case, the files now play back correctly.

I also took the time to run through many of the sample clips at various frame rates from the [official samples page](https://kodi.wiki/view/Samples). In each case, comparing the results before and after the patch. I haven't seen any regressions (also running with the PlayerDebug info on-screen, to watch for any dropped or skipped frames).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
