### PR TITLE
[Android] implement MediaSession::onMediaButtonEvent

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
@@ -33,6 +33,8 @@ public class XBMCMediaSession
 
   native void _onSeekRequested(long pos);
 
+  native boolean _onMediaButtonEvent(Intent intent);
+
   private static final String TAG = "XBMCMediaSession";
 
   private class XBMCMediaSessionCallback extends MediaSession.Callback
@@ -100,6 +102,15 @@ public class XBMCMediaSession
       Log.d(TAG, "onSeekTo: ");
       super.onSeekTo(pos);
       _onSeekRequested(pos);
+    }
+
+    @Override
+    public boolean onMediaButtonEvent(Intent intent)
+    {
+      Log.d(TAG, "onMediaButtonEvent: ");
+      if (!_onMediaButtonEvent(intent))
+        return super.onMediaButtonEvent(intent);
+      return true;
     }
   }
 

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.h
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.h
@@ -40,7 +40,7 @@ public:
   void OnRewindRequested();
   void OnStopRequested();
   void OnSeekRequested(int64_t pos);
-
+  bool OnMediaButtonEvent(CJNIIntent intent);
   bool isActive() const;
 
 protected:
@@ -52,6 +52,7 @@ protected:
   static void _onRewindRequested(JNIEnv* env, jobject thiz);
   static void _onStopRequested(JNIEnv* env, jobject thiz);
   static void _onSeekRequested(JNIEnv* env, jobject thiz, jlong pos);
+  static bool _onMediaButtonEvent(JNIEnv* env, jobject thiz, jobject intent);
 
   bool m_isActive;
 };


### PR DESCRIPTION
## Description
This replaces the logic of translating MediaSession events to keypresses introduced here:
https://github.com/xbmc/xbmc/pull/15654

Android provides the possibility to override the MediaKey keypresses before they are handled in MediaSession. This is required to get up / down state and timings between these two states.

## Motivation and Context
Issues reported here: https://github.com/xbmc/xbmc/issues/15003

## How Has This Been Tested?
- Play a movie
- Press a MediaKey on remote (e.g.fast forward / rewind).

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
