### PR TITLE
Clear focus-history when leaving window with focus on parent folder item (Fixes #15608)

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1286,6 +1286,8 @@ void CGUIMediaWindow::SaveSelectedItemInHistory()
     CFileItemPtr pItem = m_vecItems->Get(iItem);
     if (!pItem->IsParentFolder())
       GetDirectoryHistoryString(pItem.get(), strSelectedItem);
+    else
+      m_history.RemoveSelectedItem(m_vecItems->GetPath());
   }
 
   m_history.SetSelectedItem(strSelectedItem, m_vecItems->GetPath());

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1284,10 +1284,7 @@ void CGUIMediaWindow::SaveSelectedItemInHistory()
   if (iItem >= 0 && iItem < m_vecItems->Size())
   {
     CFileItemPtr pItem = m_vecItems->Get(iItem);
-    if (!pItem->IsParentFolder())
-      GetDirectoryHistoryString(pItem.get(), strSelectedItem);
-    else
-      m_history.RemoveSelectedItem(m_vecItems->GetPath());
+    GetDirectoryHistoryString(pItem.get(), strSelectedItem);
   }
 
   m_history.SetSelectedItem(strSelectedItem, m_vecItems->GetPath());


### PR DESCRIPTION
## Description
Clear focus-history when leaving window with focus on parent folder item (Fixes #15608)

## Motivation and Context
Fixes #15608

## How Has This Been Tested?
Compiled/tested on Linux within LibreELEC builds (LE 8.2 (Kodi 17.6), LE 9.1 (KODI 18 master))

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue) [as far as i can assess]
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
