### PR TITLE
[PVR] Speedup close of Guide window.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -104,7 +104,7 @@ void CGUIWindowPVRGuideBase::OnDeinitWindow(int nextWindowID)
     {
       // speedup: save a copy of current items for reuse when re-opening the window
       m_newTimeline.reset(new CFileItemList);
-      m_newTimeline->Copy(*m_vecItems);
+      m_newTimeline->Assign(*m_vecItems);
     }
   }
 


### PR DESCRIPTION
Small code change with noticeable performance improvement effect when closing Guide windows containing lots of epg data. No need to create a deep copy of tens of thousands of items. ;-)

@Jalle19 good to go?