### PR TITLE
[GLES] Check for UNPACK_ROW_LENGTH support on renderer instantiation

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -39,6 +39,23 @@ CLinuxRendererGLES::CLinuxRendererGLES()
   m_fullRange = !CServiceBroker::GetWinSystem()->UseLimitedColor();
 
   m_renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+
+#if HAS_GLES >= 3
+  unsigned int verMajor, verMinor;
+  m_renderSystem->GetRenderVersion(verMajor, verMinor);
+
+  if (verMajor >= 3)
+  {
+    m_pixelStoreKey = GL_UNPACK_ROW_LENGTH;
+  }
+#endif
+
+#if defined (GL_UNPACK_ROW_LENGTH_EXT)
+  if (m_renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
+  {
+    m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
+  }
+#endif
 }
 
 CLinuxRendererGLES::~CLinuxRendererGLES()
@@ -262,46 +279,24 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
 
   glBindTexture(m_textureTarget, plane.id);
 
-  // OpenGL ES does not support strided texture input.
-  GLint pixelStore = -1;
-  unsigned int pixelStoreKey = -1;
-
-  if (stride != static_cast<int>(width * bps))
+  if (m_pixelStoreKey > 0)
   {
-#if HAS_GLES >= 3
-    unsigned int verMajor, verMinor;
-    m_renderSystem->GetRenderVersion(verMajor, verMinor);
+    glPixelStorei(m_pixelStoreKey, stride);
+  }
+  else if (stride != static_cast<int>(width * bps))
+  {
+    unsigned char *src(static_cast<unsigned char*>(data)),
+                  *dst(m_planeBuffer);
 
-    if (verMajor >= 3)
-    {
-      glGetIntegerv(GL_UNPACK_ROW_LENGTH, &pixelStore);
-      glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);
-      pixelStoreKey = GL_UNPACK_ROW_LENGTH;
-    }
-    else
-#elif defined (GL_UNPACK_ROW_LENGTH_EXT)
-    if (m_renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
-    {
-      glGetIntegerv(GL_UNPACK_ROW_LENGTH_EXT, &pixelStore);
-      glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride);
-      pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
-    }
-    else
-#endif
-    {
-      unsigned char *src(static_cast<unsigned char*>(data)),
-                    *dst(m_planeBuffer);
+    for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
+      memcpy(dst, src, width * bpp);
 
-      for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
-        memcpy(dst, src, width * bpp);
-
-      pixelData = m_planeBuffer;
-    }
+    pixelData = m_planeBuffer;
   }
   glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
 
-  if (pixelStore >= 0)
-    glPixelStorei(pixelStoreKey, pixelStore);
+  if (m_pixelStoreKey > 0)
+    glPixelStorei(m_pixelStoreKey, 0);
 
   // check if we need to load any border pixels
   if (height < plane.texheight)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -148,6 +148,7 @@ protected:
   int m_currentField{FIELD_FULL};
   int m_reloadShaders{0};
   CRenderSystemGLES *m_renderSystem{nullptr};
+  GLenum m_pixelStoreKey{0};
 
   struct CYuvPlane
   {


### PR DESCRIPTION
## Description
Check for UNPACK_ROW_LENGTH support on renderer instantiation not on every LoadPlane call. Additionally check for `GL_EXT_unpack_subimage` extension even if headers define `HAS_GLES == 3`, e.g. Android <s>or Mali-450 running mainline Linux + Lima</s>.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
LibreELEC running on Amlogic S905 and S912.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
