### PR TITLE
Improve default keyboardlayout

### DIFF
--- a/system/keyboardlayouts/english.xml
+++ b/system/keyboardlayouts/english.xml
@@ -6,62 +6,80 @@ Default font lacks support for all characters
 <keyboardlayouts>
   <layout language="English" layout="QWERTY">
     <keyboard>
-      <row>1234567890</row>
-      <row>qwertyuiop</row>
-      <row>asdfghjkl:</row>
-      <row>zxcvbnm./@</row>
+      <row>1234567890-=`</row>
+      <row>qwertyuiop[]\</row>
+      <row>asdfghjkl:'</row>
+      <row>zxcvbnm,./</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>1234567890</row>
-      <row>QWERTYUIOP</row>
-      <row>ASDFGHJKL:</row>
-      <row>ZXCVBNM./@</row>
+      <row>!@#$%^&amp;*()_+~</row>
+      <row>QWERTYUIOP{}|</row>
+      <row>ASDFGHJKL:"</row>
+      <row>ZXCVBNM&lt;&gt;?</row>
     </keyboard>
-    <keyboard modifiers="symbol,shift+symbol">
-      <row>)!@#$%^&amp;*(</row>
-      <row>[]{}-_=+;:</row>
-      <row>'",.&lt;&gt;/?\|</row>
-      <row>`~</row>
+    <keyboard modifiers="symbol">
+      <row>£¥€§±µ¤«»·</row>
+      <row>áàâäãåæçéè</row>
+      <row>êëíìîïñóòô</row>
+      <row>öõøœßúùûü</row>
+    </keyboard>
+    <keyboard modifiers="shift+symbol">
+      <row>¼½¾¹²³°ªº¨</row>
+      <row>ÁÀÂÄÃÅÆÇÉÈ</row>
+      <row>ÊËÍÌÎÏÑÓÒÔ</row>
+      <row>ÖÕØŒẞÚÙÛÜ</row>
     </keyboard>
   </layout>
   <layout language="English" layout="AZERTY">
     <keyboard>
-      <row>1234567890</row>
-      <row>azertyuiop</row>
-      <row>qsdfghjklm</row>
-      <row>wxcvbn:./@</row>
+      <row>1234567890-=`</row>
+      <row>azertyuiop[]\</row>
+      <row>qsdfghjklm:'</row>
+      <row>wxcvbn,./</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>1234567890</row>
-      <row>AZERTYUIOP</row>
-      <row>QSDFGHJKLM</row>
-      <row>WXCVBN:./@</row>
+      <row>!@#$%^&amp;*()_+~</row>
+      <row>AZERTYUIOP{}|</row>
+      <row>QSDFGHJKLM:"</row>
+      <row>WXCVBN&lt;&gt;?</row>
     </keyboard>
-    <keyboard modifiers="symbol,shift+symbol">
-      <row>)!@#$%^&amp;*(</row>
-      <row>[]{}-_=+;:</row>
-      <row>'",.&lt;&gt;/?\|</row>
-      <row>`~éèçà</row>
+    <keyboard modifiers="symbol">
+      <row>£¥€§±µ¤«»·</row>
+      <row>áàâäãåæçéè</row>
+      <row>êëíìîïñóòô</row>
+      <row>öõøœßúùûü</row>
+    </keyboard>
+    <keyboard modifiers="shift+symbol">
+      <row>¼½¾¹²³°ªº¨</row>
+      <row>ÁÀÂÄÃÅÆÇÉÈ</row>
+      <row>ÊËÍÌÎÏÑÓÒÔ</row>
+      <row>ÖÕØŒẞÚÙÛÜ</row>
     </keyboard>
   </layout>
   <layout language="English" layout="ABC">
     <keyboard>
-      <row>0123456789</row>
-      <row>abcdefghij</row>
-      <row>klmnopqrst</row>
-      <row>uvwxyz:./@</row>
+      <row>1234567890-=`</row>
+      <row>abcdefghij[]\</row>
+      <row>klmnopqrst:'</row>
+      <row>uvwxyz,./</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>0123456789</row>
-      <row>ABCDEFGHIJ</row>
-      <row>KLMNOPQRST</row>
-      <row>UVWXYZ:./@</row>
+      <row>!@#$%^&amp;*()_+~</row>
+      <row>ABCDEFGHIJ{}|</row>
+      <row>KLMNOPQRST:"</row>
+      <row>UVWXYZ&lt;&gt;?</row>
     </keyboard>
-    <keyboard modifiers="symbol,shift+symbol">
-      <row>)!@#$%^&amp;*(</row>
-      <row>[]{}-_=+;:</row>
-      <row>'",.&lt;&gt;/?\|</row>
-      <row>`~</row>
-   </keyboard>
+    <keyboard modifiers="symbol">
+      <row>£¥€§±µ¤«»·</row>
+      <row>áàâäãåæçéè</row>
+      <row>êëíìîïñóòô</row>
+      <row>öõøœßúùûü</row>
+    </keyboard>
+    <keyboard modifiers="shift+symbol">
+      <row>¼½¾¹²³°ªº¨</row>
+      <row>ÁÀÂÄÃÅÆÇÉÈ</row>
+      <row>ÊËÍÌÎÏÑÓÒÔ</row>
+      <row>ÖÕØŒẞÚÙÛÜ</row>
+    </keyboard>
   </layout>
 </keyboardlayouts>


### PR DESCRIPTION
Since i couldn't figure out how to enter accented characters using the OSD keyboard (i don't think it's possible?) i decided to revise the default keyboard layout and add the most commonly used ones.
(https://practicaltypography.com/common-accented-characters.html)


normal:
![normal](https://user-images.githubusercontent.com/687265/53888475-e797db00-4024-11e9-8c0d-58c1900a7d48.jpg)

shift:
![normalshift](https://user-images.githubusercontent.com/687265/53888481-ea92cb80-4024-11e9-8a3f-9a015af98279.jpg)

symbol:
![symbol](https://user-images.githubusercontent.com/687265/53888485-ee265280-4024-11e9-923e-576783de040a.jpg)

shift+symbol:
![symbolshift](https://user-images.githubusercontent.com/687265/53888488-f1b9d980-4024-11e9-8a54-e18add20d481.jpg)

