### PR TITLE
[PVR] Fixes for broken timer handling

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -363,7 +363,7 @@ namespace PVR
     bool ToggleTimerState::IsVisible(const CFileItem &item) const
     {
       const CPVRTimerInfoTagPtr timer(item.GetPVRTimerInfoTag());
-      if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+      if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER) || timer->IsBroken())
         return false;
 
       const CPVRTimerTypePtr timerType(timer->GetTimerType());

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1125,7 +1125,7 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string &condit
   }
 
   /* Always enable enable/disable, if supported by the timer type. */
-  if (pThis->m_timerType->SupportsEnableDisable())
+  if (pThis->m_timerType->SupportsEnableDisable() && !pThis->m_timerInfoTag->IsBroken())
   {
     if (cond == SETTING_TMR_ACTIVE)
       return true;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -412,7 +412,7 @@ std::vector<CFileItemPtr> CPVRTimers::GetActiveTimers(void) const
     for (VecTimerInfoTag::const_iterator timerIt = it->second.begin(); timerIt != it->second.end(); ++timerIt)
     {
       CPVRTimerInfoTagPtr current = *timerIt;
-      if (current->IsActive() && !current->IsTimerRule())
+      if (current->IsActive() && !current->IsTimerRule() && !current->IsBroken())
       {
         CFileItemPtr fileItem(new CFileItem(current));
         tags.push_back(fileItem);
@@ -434,7 +434,8 @@ int CPVRTimers::AmountActiveTimers(const TimerKind &eKind) const
     {
       if (KindMatchesTag(eKind, timersEntry) &&
           timersEntry->IsActive() &&
-          !timersEntry->IsTimerRule())
+          !timersEntry->IsTimerRule() &&
+          !timersEntry->IsBroken())
         ++iReturn;
     }
   }
@@ -468,7 +469,8 @@ std::vector<CFileItemPtr> CPVRTimers::GetActiveRecordings(const TimerKind &eKind
     {
       if (KindMatchesTag(eKind, timersEntry) &&
           timersEntry->IsRecording() &&
-          !timersEntry->IsTimerRule())
+          !timersEntry->IsTimerRule() &&
+          !timersEntry->IsBroken())
       {
         CFileItemPtr fileItem(new CFileItem(timersEntry));
         tags.push_back(fileItem);
@@ -505,7 +507,8 @@ int CPVRTimers::AmountActiveRecordings(const TimerKind &eKind) const
     {
       if (KindMatchesTag(eKind, timersEntry) &&
           timersEntry->IsRecording() &&
-          !timersEntry->IsTimerRule())
+          !timersEntry->IsTimerRule() &&
+          !timersEntry->IsBroken())
         ++iReturn;
     }
   }
@@ -533,7 +536,7 @@ bool CPVRTimers::HasActiveTimers(void) const
   CSingleLock lock(m_critSection);
   for (MapTags::const_iterator it = m_tags.begin(); it != m_tags.end(); ++it)
     for (VecTimerInfoTag::const_iterator timerIt = it->second.begin(); timerIt != it->second.end(); ++timerIt)
-      if ((*timerIt)->IsActive() && !(*timerIt)->IsTimerRule())
+      if ((*timerIt)->IsActive() && !(*timerIt)->IsTimerRule() && !(*timerIt)->IsBroken())
         return true;
 
   return false;
@@ -795,6 +798,7 @@ CPVRTimerInfoTagPtr CPVRTimers::GetRecordingTimerForRecording(const CPVRRecordin
     {
       if (timersEntry->IsRecording() &&
           !timersEntry->IsTimerRule() &&
+          !timersEntry->IsBroken() &&
           timersEntry->m_iClientId == recording.ClientID() &&
           timersEntry->m_iClientChannelUid == recording.ChannelUid())
       {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

- Don't display Activate/Deactivate in timer context menu if timer state is PVR_TIMER_STATE_ERROR
- Don't display enabled toggle in timer settings dialog if timer state is PVR_TIMER_STATE_ERROR
- Don't include timer in active or recording lists if timer state is PVR_TIMER_STATE_ERROR

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Deactivating doesn't make sense when a timer is in this state.

Fixes #15682

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Built kodi, on OSX with just pvr.vuplus to test.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
