### PR TITLE
Initialize color_primaries to AVCOL_PRI_UNSPECIFIED if unspecified

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -191,7 +191,7 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
     pVideoPicture->iFlags = 0;
     pVideoPicture->chroma_position = 0;
     pVideoPicture->colorBits = 8;
-    pVideoPicture->color_primaries = 0;
+    pVideoPicture->color_primaries = AVColorPrimaries::AVCOL_PRI_UNSPECIFIED;
     pVideoPicture->color_range = 0;
     pVideoPicture->color_space = AVCOL_SPC_UNSPECIFIED;
     pVideoPicture->color_transfer = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -39,7 +39,7 @@ void VideoPicture::Reset()
   color_space = AVCOL_SPC_UNSPECIFIED;
   color_range = 0;
   chroma_position = 0;
-  color_primaries = 0;
+  color_primaries = AVColorPrimaries::AVCOL_PRI_UNSPECIFIED;
   color_transfer = 0;
   colorBits = 8;
   stereoMode.clear();


### PR DESCRIPTION
## Description
0 is AVCOL_PRI_RESERVED0 and will trigger color conversion in renderer which is unnecessary.

If initialized to AVCOL_PRI_UNSPECIFIED, renderer will try to guess color primaries and in most cases will not enable color coversion.

## Motivation and Context
Improve inputstream.adaptive rendering performance. This PR reduces load on GPU when playing HD content.

## How Has This Been Tested?
LibreELEC 8 on Amlogic S905 device. Confirmed that color conversion is not applied for 720p Netflix.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
