### PR TITLE
[PVR] Guide window: Fix gap tags information.

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -275,6 +275,25 @@ bool CPVRGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contex
          GetRadioRDSLabel(item, info, value);
 }
 
+namespace
+{
+  std::string GetAsLocalizedDateString(const CDateTime& datetime, bool bLongDate)
+  {
+    return datetime.IsValid() ? datetime.GetAsLocalizedDate(bLongDate) : "";
+  }
+
+  std::string GetAsLocalizedTimeString(const CDateTime& datetime)
+  {
+    return datetime.IsValid() ? datetime.GetAsLocalizedTime("", false) : "";
+  }
+
+  std::string GetAsLocalizedDateTimeString(const CDateTime& datetime)
+  {
+    return datetime.IsValid() ? datetime.GetAsLocalizedDateTime(false, false) : "";
+  }
+
+} // unnamed namespace
+
 bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInfo &info, std::string &strValue) const
 {
   const CPVRTimerInfoTagPtr timer = item->GetPVRTimerInfoTag();
@@ -286,16 +305,16 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
         strValue = timer->Summary();
         return true;
       case LISTITEM_STARTDATE:
-        strValue = timer->StartAsLocalTime().GetAsLocalizedDate(true);
+        strValue = GetAsLocalizedDateString(timer->StartAsLocalTime(), true);
         return true;
       case LISTITEM_STARTTIME:
-        strValue = timer->StartAsLocalTime().GetAsLocalizedTime("", false);
+        strValue = GetAsLocalizedTimeString(timer->StartAsLocalTime());
         return true;
       case LISTITEM_ENDDATE:
-        strValue = timer->EndAsLocalTime().GetAsLocalizedDate(true);
+        strValue = GetAsLocalizedDateString(timer->EndAsLocalTime(), true);
         return true;
       case LISTITEM_ENDTIME:
-        strValue = timer->EndAsLocalTime().GetAsLocalizedTime("", false);
+        strValue = GetAsLocalizedTimeString(timer->EndAsLocalTime());
         return true;
       case LISTITEM_DURATION:
         if (timer->GetDuration() > 0)
@@ -343,33 +362,33 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
     switch (info.m_info)
     {
       case LISTITEM_DATE:
-        strValue = recording->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(false, false);
+        strValue = GetAsLocalizedDateTimeString(recording->RecordingTimeAsLocalTime());
         return true;
       case LISTITEM_STARTDATE:
-        strValue = recording->RecordingTimeAsLocalTime().GetAsLocalizedDate(true);
+        strValue = GetAsLocalizedDateString(recording->RecordingTimeAsLocalTime(), true);
         return true;
       case VIDEOPLAYER_STARTTIME:
       case LISTITEM_STARTTIME:
-        strValue = recording->RecordingTimeAsLocalTime().GetAsLocalizedTime("", false);
+        strValue = GetAsLocalizedTimeString(recording->RecordingTimeAsLocalTime());
         return true;
       case LISTITEM_ENDDATE:
-        strValue = recording->EndTimeAsLocalTime().GetAsLocalizedDate(true);
+        strValue = GetAsLocalizedDateString(recording->EndTimeAsLocalTime(), true);
         return true;
       case VIDEOPLAYER_ENDTIME:
       case LISTITEM_ENDTIME:
-        strValue = recording->EndTimeAsLocalTime().GetAsLocalizedTime("", false);
+        strValue = GetAsLocalizedTimeString(recording->EndTimeAsLocalTime());
         return true;
       case LISTITEM_EXPIRATION_DATE:
         if (recording->HasExpirationTime())
         {
-          strValue = recording->ExpirationTimeAsLocalTime().GetAsLocalizedDate(false);
+          strValue = GetAsLocalizedDateString(recording->ExpirationTimeAsLocalTime(), false);
           return true;
         }
         break;
       case LISTITEM_EXPIRATION_TIME:
         if (recording->HasExpirationTime())
         {
-          strValue = recording->ExpirationTimeAsLocalTime().GetAsLocalizedTime("", false);;
+          strValue = GetAsLocalizedTimeString(recording->ExpirationTimeAsLocalTime());;
           return true;
         }
         break;
@@ -478,27 +497,27 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
         strValue = epgTag->PlotOutline();
         return true;
       case LISTITEM_DATE:
-        strValue = epgTag->StartAsLocalTime().GetAsLocalizedDateTime(false, false);
+        strValue = GetAsLocalizedDateTimeString(epgTag->StartAsLocalTime());
         return true;
       case LISTITEM_STARTDATE:
       case LISTITEM_NEXT_STARTDATE:
-        strValue = epgTag->StartAsLocalTime().GetAsLocalizedDate(true);
+        strValue = GetAsLocalizedDateString(epgTag->StartAsLocalTime(), true);
         return true;
       case VIDEOPLAYER_STARTTIME:
       case VIDEOPLAYER_NEXT_STARTTIME:
       case LISTITEM_STARTTIME:
       case LISTITEM_NEXT_STARTTIME:
-        strValue = epgTag->StartAsLocalTime().GetAsLocalizedTime("", false);
+        strValue = GetAsLocalizedTimeString(epgTag->StartAsLocalTime());
         return true;
       case LISTITEM_ENDDATE:
       case LISTITEM_NEXT_ENDDATE:
-        strValue = epgTag->EndAsLocalTime().GetAsLocalizedDate(true);
+        strValue = GetAsLocalizedDateString(epgTag->EndAsLocalTime(), true);
         return true;
       case VIDEOPLAYER_ENDTIME:
       case VIDEOPLAYER_NEXT_ENDTIME:
       case LISTITEM_ENDTIME:
       case LISTITEM_NEXT_ENDTIME:
-        strValue = epgTag->EndAsLocalTime().GetAsLocalizedTime("", false);
+        strValue = GetAsLocalizedTimeString(epgTag->EndAsLocalTime());
         return true;
       // note: for some reason, there is no VIDEOPLAYER_DURATION
       case LISTITEM_DURATION:

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -1314,13 +1314,13 @@ int CGUIEPGGridContainer::GetSelectedItem() const
   return m_gridModel->GetGridItemIndex(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 }
 
-CFileItemPtr CGUIEPGGridContainer::GetSelectedChannelItem() const
+CFileItemPtr CGUIEPGGridContainer::GetSelectedGridItem(int offset /*= 0*/) const
 {
   CFileItemPtr item;
 
   if (m_gridModel->HasGridItems() &&
       m_gridModel->ChannelItemsSize() > 0 &&
-      m_channelCursor + m_channelOffset < m_gridModel->ChannelItemsSize() &&
+      m_channelCursor + m_channelOffset + offset < m_gridModel->ChannelItemsSize() &&
       m_blockCursor + m_blockOffset < m_gridModel->GetBlockCount())
     item = m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 

--- a/xbmc/pvr/windows/GUIEPGGridContainer.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.h
@@ -58,7 +58,7 @@ namespace PVR
     CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const override;
     std::string GetLabel(int info) const override;
 
-    CFileItemPtr GetSelectedChannelItem() const;
+    CFileItemPtr GetSelectedGridItem(int offset = 0) const;
     PVR::CPVRChannelPtr GetSelectedChannel() const;
     CDateTime GetSelectedDate() const;
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -250,6 +250,19 @@ void CGUIWindowPVRGuideBase::FormatAndSort(CFileItemList &items)
   CGUIWindowPVRBase::FormatAndSort(items);
 }
 
+CFileItemPtr CGUIWindowPVRGuideBase::GetCurrentListItem(int offset /*= 0*/)
+{
+  CFileItemPtr item = CGUIWindowPVRBase::GetCurrentListItem(offset);
+  if (!item)
+  {
+    // EPG "gap" item selected?
+    CGUIEPGGridContainer* epgGridContainer = GetGridControl();
+    if (epgGridContainer)
+      item = epgGridContainer->GetSelectedGridItem(offset);
+  }
+  return item;
+}
+
 bool CGUIWindowPVRGuideBase::ShouldNavigateToGridContainer(int iAction)
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
@@ -488,7 +501,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
               CGUIEPGGridContainer *epgGridContainer = GetGridControl();
               if (epgGridContainer)
               {
-                const CFileItemPtr item(epgGridContainer->GetSelectedChannelItem());
+                const CFileItemPtr item(epgGridContainer->GetSelectedGridItem());
                 if (item)
                 {
                   CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, true);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -50,6 +50,7 @@ namespace PVR
     std::string GetDirectoryPath(void) override { return ""; }
     bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
     void FormatAndSort(CFileItemList &items) override;
+    CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
     void ClearData() override;
 


### PR DESCRIPTION
This fixes a long standing bug. Guide window displayed wrong information if selected item has no epg data ("gap" tags).

Before:
![screenshot000](https://user-images.githubusercontent.com/3226626/53965937-6870d880-40f2-11e9-941d-8d9cfdfe4411.png)

After:

![screenshot001](https://user-images.githubusercontent.com/3226626/53965942-6d358c80-40f2-11e9-8d82-463b0bc82a7a.png)

Second commit fixes pvr datetime gui info labels to return empty string if respective CDateTime is invalid. Popped up while fixing the main issue.

@Jalle mind taking a look at the code changes.