### PR TITLE
[PVR] Speedup first open of Guide window.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -78,6 +78,7 @@ namespace PVR
     std::unique_ptr<CFileItemList> m_newTimeline;
 
     bool m_bChannelSelectionRestored;
+    std::atomic_bool m_bFirstOpen;
   };
 
   class CGUIWindowPVRTVGuide : public CGUIWindowPVRGuideBase


### PR DESCRIPTION
Obtaining tens of thousands of epg events at once on very first open of Guide window may take some time and the user sees a "blank" Guide window meanwhile. 20K of events take 1.5 secs on my Android Shield TV and we have users with far more data.

This PR will return all channels on first open, but without epg data. This takes almost zero time. The latter will be fetched asynchronously as soon as initial empty grid is ready. User will see all channels immediately. Channels will filling with EPG data asynchronously, then. Works well, nice user experience. ;-)

@Jalle19 good to go?