### PR TITLE
[PVR] Rework PVR component inter-dependencies

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9094,7 +9094,7 @@ msgid "Find similar"
 msgstr ""
 
 #. label for epg import progress control
-#: xbmc/epg/EpgContainer.cpp
+#: xbmc/pvr/epg/EpgContainer.cpp
 msgctxt "#19004"
 msgid "Importing guide from clients"
 msgstr ""
@@ -9443,7 +9443,7 @@ msgstr ""
 #: addons/skin.estuary/xml/MyPics.xml
 #: addons/skin.estuary/xml/MyVideoNav.xml
 #: addons/skin.estuary/xml/View_50_List.xml
-#: xbmc/epg/EpgInfoTag.cpp
+#: xbmc/pvr/epg/EpgInfoTag.cpp
 #: xbmc/FileItem.cpp
 #: xbmc/GUIInfoManager.cpp
 #: xbmc/pvr/PVRManager.cpp
@@ -10608,7 +10608,7 @@ msgid "Filter channels"
 msgstr ""
 
 #. label 'loading epg data from database' for progress dialog text
-#: xbmc/epg/EpgContainer.cpp
+#: xbmc/pvr/epg/EpgContainer.cpp
 msgctxt "#19250"
 msgid "Loading guide from database"
 msgstr ""
@@ -10702,7 +10702,7 @@ msgid "The entered PIN was incorrect."
 msgstr ""
 
 #. label to use for epg tag title instead of actual event title if the respective channel is parental locked
-#: xbmc/epg/EpgInfoTag.cpp
+#: xbmc/pvr/PVRGUIActions.cpp
 msgctxt "#19266"
 msgid "Parental locked"
 msgstr ""
@@ -10935,63 +10935,63 @@ msgstr ""
 #empty strings from id 19305 to 19498
 
 #. label for epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19499"
 msgid "Other / Unknown"
 msgstr ""
 
 #. label for epg "movie/drama" genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19500"
 msgid "Movie / Drama"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19501"
 msgid "Detective / Thriller"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19502"
 msgid "Adventure / Western / War"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19503"
 msgid "Science fiction / Fantasy / Horror"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19504"
 msgid "Comedy"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19505"
 msgid "Soap / Melodrama / Folkloric"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19506"
 msgid "Romance"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19507"
 msgid "Serious / Classical / Religious / Historical movie / drama"
 msgstr ""
 
 #. label for epg "movie/drama" subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19508"
 msgid "Adult movie / drama"
 msgstr ""
@@ -10999,32 +10999,32 @@ msgstr ""
 #empty strings from id 19509 to 19515
 
 #. label for "news/current affairs" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19516"
 msgid "News / Current affairs"
 msgstr ""
 
 #. label for "news/current affairs" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19517"
 msgid "News / Weather report"
 msgstr ""
 
 #. label for "news/current affairs" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19518"
 msgid "News magazine"
 msgstr ""
 
 #. label for "news/current affairs" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19519"
 msgid "Documentary"
 msgstr ""
 
 #. label for "news/current affairs" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19520"
 msgid "Discussion / Interview / Debate"
 msgstr ""
@@ -11032,26 +11032,26 @@ msgstr ""
 #empty strings from id 19521 to 19531
 
 #. label for "show/game show" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19532"
 msgid "Show / Game show"
 msgstr ""
 
 #. label for "show/game show" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19533"
 msgid "Game show / Quiz / Contest"
 msgstr ""
 
 #. label for "show/game show" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19534"
 msgid "Variety show"
 msgstr ""
 
 #. label for "show/game show" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19535"
 msgid "Talk show"
 msgstr ""
@@ -11059,74 +11059,74 @@ msgstr ""
 #empty strings from id 19536 to 19547
 
 #. label for "sports" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19548"
 msgid "Sports"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19549"
 msgid "Special event"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19550"
 msgid "Sport magazine"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19551"
 msgid "Football"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19552"
 msgid "Tennis / Squash"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19553"
 msgid "Team sports"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19554"
 msgid "Athletics"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19555"
 msgid "Motor sport"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19556"
 msgid "Water sport"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19557"
 msgid "Winter sports"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19558"
 msgid "Equestrian"
 msgstr ""
 
 #. label for "sports" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19559"
 msgid "Martial sports"
 msgstr ""
@@ -11134,38 +11134,38 @@ msgstr ""
 #empty strings from id 19560 to 19563
 
 #. label for "children's/youth programmes" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19564"
 msgid "Children's / Youth programmes"
 msgstr ""
 
 #. label for "children's/youth programmes" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19565"
 msgid "Pre-school children's programmes"
 msgstr ""
 
 #. label for "children's/youth programmes" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19566"
 msgid "Entertainment programmes for 6 to 14"
 msgstr ""
 
 #. label for "children's/youth programmes" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19567"
 msgid "Entertainment programmes for 10 to 16"
 msgstr ""
 
 #. label for "children's/youth programmes" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19568"
 msgid "Informational / Educational / School programme"
 msgstr ""
 
 #. label for "children's/youth programmes" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19569"
 msgid "Cartoons / Puppets"
 msgstr ""
@@ -11173,38 +11173,38 @@ msgstr ""
 #empty strings from id 19570 to 19579
 
 #. label for "music/ballet/dance" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19580"
 msgid "Music / Ballet / Dance"
 msgstr ""
 
 #. label for "music/ballet/dance" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19581"
 msgid "Rock / Pop"
 msgstr ""
 
 #. label for "music/ballet/dance" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19582"
 msgid "Serious / Classical music"
 msgstr ""
 
 #. label for "music/ballet/dance" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19583"
 msgid "Folk / Traditional music"
 msgstr ""
 
 #. label for "music/ballet/dance" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19584"
 msgid "Musical / Opera"
 msgstr ""
 
 #. label for "music/ballet/dance" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19585"
 msgid "Ballet"
 msgstr ""
@@ -11212,74 +11212,74 @@ msgstr ""
 #empty strings from id 19586 to 19595
 
 #. label for "arts/culture" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19596"
 msgid "Arts / Culture"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19597"
 msgid "Performing arts"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19598"
 msgid "Fine arts"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19599"
 msgid "Religion"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19600"
 msgid "Popular culture / Traditional arts"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19601"
 msgid "Literature"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19602"
 msgid "Film / Cinema"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19603"
 msgid "Experimental film / video"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19604"
 msgid "Broadcasting / Press"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19605"
 msgid "New media"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19606"
 msgid "Arts / Culture magazines"
 msgstr ""
 
 #. label for "arts/culture" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19607"
 msgid "Fashion"
 msgstr ""
@@ -11287,26 +11287,26 @@ msgstr ""
 #empty strings from id 19608 to 19611
 
 #. label for "social/political/economics" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19612"
 msgid "Social / Political / Economics"
 msgstr ""
 
 #. label for "social/political/economics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19613"
 msgid "Magazines / Reports / Documentary"
 msgstr ""
 
 #. label for "social/political/economics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19614"
 msgid "Economics / Social advisory"
 msgstr ""
 
 #. label for "social/political/economics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19615"
 msgid "Remarkable people"
 msgstr ""
@@ -11314,50 +11314,50 @@ msgstr ""
 #empty strings from id 19616 to 19627
 
 #. label for "education/science/factual" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19628"
 msgid "Education / Science / Factual"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19629"
 msgid "Nature / Animals / Environment"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19630"
 msgid "Technology / Natural sciences"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19631"
 msgid "Medicine / Physiology / Psychology"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19632"
 msgid "Foreign countries / Expeditions"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19633"
 msgid "Social / Spiritual sciences"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19634"
 msgid "Further education"
 msgstr ""
 
 #. label for "education/science/factual" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19635"
 msgid "Languages"
 msgstr ""
@@ -11365,50 +11365,50 @@ msgstr ""
 #empty strings from id 19636 to 19643
 
 #. label for "leisure/hobbies" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19644"
 msgid "Leisure / Hobbies"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19645"
 msgid "Tourism / Travel"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19646"
 msgid "Handicraft"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19647"
 msgid "Motoring"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19648"
 msgid "Fitness & health"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19649"
 msgid "Cooking"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19650"
 msgid "Advertisement / Shopping"
 msgstr ""
 
 #. label for "leisure/hobbies" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19651"
 msgid "Gardening"
 msgstr ""
@@ -11416,32 +11416,32 @@ msgstr ""
 #empty strings from id 19652 to 19659
 
 #. label for "special characteristics" epg genre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
 msgctxt "#19660"
 msgid "Special characteristics"
 msgstr ""
 
 #. label for "special characteristics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19661"
 msgid "Original language"
 msgstr ""
 
 #. label for "special characteristics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19662"
 msgid "Black & white"
 msgstr ""
 
 #. label for "special characteristics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19663"
 msgid "Unpublished"
 msgstr ""
 
 #. label for "special characteristics" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19664"
 msgid "Live broadcast"
 msgstr ""
@@ -11449,55 +11449,55 @@ msgstr ""
 #empty strings from id 19665 to 19675
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19676"
 msgid "Drama"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19677"
 msgid "Detective / Thriller"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19678"
 msgid "Adventure / Western / War"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19679"
 msgid "Science fiction / Fantasy / Horror"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19680"
 msgid "Comedy"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19681"
 msgid "Soap / Melodrama / Folkloric"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19682"
 msgid "Romance"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19683"
 msgid "Serious / Classical / Religion / Historical"
 msgstr ""
 
 #. label for "user defined" epg subgenre value
-#: xbmc/epg/Epg.cpp
+#: xbmc/pvr/epg/Epg.cpp
 msgctxt "#19684"
 msgid "Adult"
 msgstr ""

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -35,6 +35,7 @@ extern "C" {
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
+#include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecordings.h"
@@ -609,11 +610,25 @@ PVR_ERROR CPVRClient::RenameChannel(const CPVRChannelPtr &channel)
   }, m_clientCapabilities.SupportsChannelSettings());
 }
 
-PVR_ERROR CPVRClient::GetEPGForChannel(const CPVRChannelPtr &channel, CPVREpg *epg, time_t start /* = 0 */, time_t end /* = 0 */, bool bSaveInDb /* = false*/)
+PVR_ERROR CPVRClient::GetEPGForChannel(const std::shared_ptr<CPVREpgChannelData>& channelData,
+                                       CPVREpg* epg,
+                                       time_t start /* = 0 */,
+                                       time_t end /* = 0 */,
+                                       bool bSaveInDb /* = false */)
 {
-  return DoAddonCall(__FUNCTION__, [this, channel, epg, start, end, bSaveInDb](const AddonInstance* addon) {
-    PVR_CHANNEL addonChannel;
-    WriteClientChannelInfo(channel, addonChannel);
+  return DoAddonCall(__FUNCTION__, [this, channelData, epg, start, end, bSaveInDb](const AddonInstance* addon) {
+
+    //! @todo PVR Addon API Change: Change GetEPGForChannel param from 'PVR_CHANNEL channel' to 'int iUniqueId'.
+    PVR_CHANNEL addonChannel = {0};
+
+    // mandatory
+    addonChannel.iUniqueId = channelData->UniqueClientChannelId();
+    addonChannel.bIsRadio = channelData->IsRadio();
+
+    // optional
+    strncpy(addonChannel.strChannelName, channelData->ChannelName().c_str(), sizeof(addonChannel.strChannelName) - 1);
+    strncpy(addonChannel.strIconPath, channelData->IconPath().c_str(), sizeof(addonChannel.strIconPath) - 1);
+    addonChannel.bIsHidden = channelData->IsHidden();
 
     ADDON_HANDLE_STRUCT handle;
     handle.callerAddress  = this;
@@ -647,15 +662,15 @@ class CAddonEpgTag : public EPG_TAG
 public:
   CAddonEpgTag() = delete;
   explicit CAddonEpgTag(const CConstPVREpgInfoTagPtr kodiTag) :
-    m_strTitle(kodiTag->Title(true)),
-    m_strPlotOutline(kodiTag->PlotOutline(true)),
-    m_strPlot(kodiTag->Plot(true)),
-    m_strOriginalTitle(kodiTag->OriginalTitle(true)),
+    m_strTitle(kodiTag->Title()),
+    m_strPlotOutline(kodiTag->PlotOutline()),
+    m_strPlot(kodiTag->Plot()),
+    m_strOriginalTitle(kodiTag->OriginalTitle()),
     m_strCast(kodiTag->DeTokenize(kodiTag->Cast())),
     m_strDirector(kodiTag->DeTokenize(kodiTag->Directors())),
     m_strWriter(kodiTag->DeTokenize(kodiTag->Writers())),
     m_strIMDBNumber(kodiTag->IMDBNumber()),
-    m_strEpisodeName(kodiTag->EpisodeName(true)),
+    m_strEpisodeName(kodiTag->EpisodeName()),
     m_strIconPath(kodiTag->Icon()),
     m_strSeriesLink(kodiTag->SeriesLink()),
     m_strGenreDescription(kodiTag->GetGenresLabel())
@@ -1664,7 +1679,6 @@ void CPVRClient::cb_trigger_channel_groups_update(void *kodiInstance)
 
 void CPVRClient::cb_trigger_epg_update(void *kodiInstance, unsigned int iChannelUid)
 {
-  // get the client
   CPVRClient *client = static_cast<CPVRClient*>(kodiInstance);
   if (!client)
   {
@@ -1718,7 +1732,9 @@ void CPVRClient::cb_epg_event_state_change(void* kodiInstance, EPG_TAG* tag, EPG
     return;
   }
 
-  CServiceBroker::GetPVRManager().EpgContainer().UpdateFromClient(std::make_shared<CPVREpgInfoTag>(*tag, client->GetID()), newState);
+  // Note: channel data and epg id may not yet be available. Tag will be fully initialized later.
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = std::make_shared<CPVREpgInfoTag>(*tag, client->GetID(), nullptr, -1);
+  CServiceBroker::GetPVRManager().EpgContainer().UpdateFromClient(epgTag, newState);
 }
 
 class CCodecIds

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1499,7 +1499,7 @@ void CPVRClient::cb_transfer_channel_group(void *kodiInstance, const ADDON_HANDL
   }
 
   /* transfer this entry to the groups container */
-  CPVRChannelGroup transferGroup(*group);
+  CPVRChannelGroup transferGroup(*group, kodiGroups->GetGroupAll());
   kodiGroups->UpdateFromClient(transferGroup);
 }
 

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -22,6 +22,7 @@
 namespace PVR
 {
   class CPVRChannelGroups;
+  class CPVREpgChannelData;
   class CPVRTimersContainer;
   class CPVRClientMenuHook;
   class CPVRClientMenuHooks;
@@ -400,14 +401,14 @@ namespace PVR
 
     /*!
      * @brief Request an EPG table for a channel from the client.
-     * @param channel The channel to get the EPG table for.
+     * @param channelData The data for the channel to get the EPG table for.
      * @param epg The table to write the data to.
      * @param start The start time to use.
      * @param end The end time to use.
      * @param bSaveInDb If true, tell the callback method to save any new entry in the database or not. see CAddonCallbacksPVR::PVRTransferEpgEntry()
      * @return PVR_ERROR_NO_ERROR if the table has been fetched successfully.
      */
-    PVR_ERROR GetEPGForChannel(const CPVRChannelPtr &channel, CPVREpg *epg, time_t start = 0, time_t end = 0, bool bSaveInDb = false);
+    PVR_ERROR GetEPGForChannel(const std::shared_ptr<CPVREpgChannelData>& channelData, CPVREpg* epg, time_t start = 0, time_t end = 0, bool bSaveInDb = false);
 
     /*!
      * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -575,7 +575,7 @@ bool CEdl::ReadPvr(const CFileItem &fileItem)
   }
   else if (fileItem.HasEPGInfoTag())
   {
-    CLog::Log(LOGDEBUG, "%s - Reading Edl for EPG: %s", __FUNCTION__, fileItem.GetEPGInfoTag()->Title(true).c_str());
+    CLog::Log(LOGDEBUG, "%s - Reading Edl for EPG: %s", __FUNCTION__, fileItem.GetEPGInfoTag()->Title().c_str());
     edl = fileItem.GetEPGInfoTag()->GetEdl();
   }
   else

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -211,13 +211,14 @@ JSONRPC_STATUS CPVROperations::Record(const std::string &method, ITransportLayer
     return FailedToExecute;
 
   CVariant record = parameterObject["record"];
+  bool bIsRecording = CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*pChannel);
   bool toggle = true;
-  if (record.isBoolean() && record.asBoolean() == pChannel->IsRecording())
+  if (record.isBoolean() && record.asBoolean() == bIsRecording)
     toggle = false;
 
   if (toggle)
   {
-    if (!CServiceBroker::GetPVRManager().GUIActions()->SetRecordingOnChannel(pChannel, !pChannel->IsRecording()))
+    if (!CServiceBroker::GetPVRManager().GUIActions()->SetRecordingOnChannel(pChannel, !bIsRecording))
       return FailedToExecute;
   }
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -326,7 +326,7 @@ JSONRPC_STATUS CPVROperations::AddTimer(const std::string &method, ITransportLay
   if (!epgTag)
     return InvalidParams;
 
-  if (epgTag->HasTimer())
+  if (CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag))
     return InvalidParams;
 
   CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, parameterObject["timerrule"].asBoolean(false));
@@ -370,7 +370,7 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
 
   bool timerrule = parameterObject["timerrule"].asBoolean(false);
   bool sentOkay = false;
-  CPVRTimerInfoTagPtr timer(epgTag->Timer());
+  std::shared_ptr<CPVRTimerInfoTag> timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag);
   if (timer)
   {
     if (timerrule)

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -157,7 +157,12 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
     return InternalError;
 
   CFileItemList programFull;
-  channelEpg->Get(programFull);
+
+  const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags = channelEpg->GetTags();
+  for (const auto& tag : tags)
+  {
+    programFull.Add(std::make_shared<CFileItem>(tag));
+  }
 
   HandleFileItemList("broadcastid", false, "broadcasts", programFull, parameterObject, result, programFull.Size(), true);
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -169,7 +169,8 @@ JSONRPC_STATUS CPVROperations::GetBroadcastDetails(const std::string &method, IT
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const CPVREpgInfoTagPtr epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(CPVRChannelPtr(), parameterObject["broadcastid"].asUnsignedInteger());
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(std::shared_ptr<CPVREpg>(),
+                                                                                                           parameterObject["broadcastid"].asUnsignedInteger());
 
   if (!epgTag)
     return InvalidParams;
@@ -321,7 +322,8 @@ JSONRPC_STATUS CPVROperations::AddTimer(const std::string &method, ITransportLay
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const CPVREpgInfoTagPtr epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(CPVRChannelPtr(), parameterObject["broadcastid"].asUnsignedInteger());
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(std::shared_ptr<CPVREpg>(),
+                                                                                                           parameterObject["broadcastid"].asUnsignedInteger());
 
   if (!epgTag)
     return InvalidParams;
@@ -363,7 +365,8 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const CPVREpgInfoTagPtr epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(CPVRChannelPtr(), parameterObject["broadcastid"].asUnsignedInteger());
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(std::shared_ptr<CPVREpg>(),
+                                                                                                           parameterObject["broadcastid"].asUnsignedInteger());
 
   if (!epgTag)
     return InvalidParams;

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -174,7 +174,7 @@ JSONRPC_STATUS CPVROperations::GetBroadcastDetails(const std::string &method, IT
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(std::shared_ptr<CPVREpg>(),
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(nullptr,
                                                                                                            parameterObject["broadcastid"].asUnsignedInteger());
 
   if (!epgTag)
@@ -328,7 +328,7 @@ JSONRPC_STATUS CPVROperations::AddTimer(const std::string &method, ITransportLay
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(std::shared_ptr<CPVREpg>(),
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(nullptr,
                                                                                                            parameterObject["broadcastid"].asUnsignedInteger());
 
   if (!epgTag)
@@ -371,7 +371,7 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(std::shared_ptr<CPVREpg>(),
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(nullptr,
                                                                                                            parameterObject["broadcastid"].asUnsignedInteger());
 
   if (!epgTag)

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -221,7 +221,6 @@ namespace PVR
       const CPVREpgInfoTagPtr epg = item.GetEPGInfoTag();
       if (epg &&
           !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg) &&
-          epg->Channel() &&
           epg->IsRecordable())
         return client && client->GetClientCapabilities().SupportsTimers();
 
@@ -380,9 +379,7 @@ namespace PVR
     bool AddTimerRule::IsVisible(const CFileItem &item) const
     {
       const CPVREpgInfoTagPtr epg = item.GetEPGInfoTag();
-      if (epg &&
-          epg->Channel() &&
-          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg))
+      if (epg && !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg))
       {
         const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(item);
         return client && client->GetClientCapabilities().SupportsTimers();

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -20,6 +20,7 @@
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
 
@@ -115,12 +116,7 @@ namespace PVR
 
     bool PlayRecording::IsVisible(const CFileItem &item) const
     {
-      CPVRRecordingPtr recording;
-
-      const CPVREpgInfoTagPtr epg(item.GetEPGInfoTag());
-      if (epg)
-        recording = epg->Recording();
-
+      const std::shared_ptr<CPVRRecording> recording = CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(item.GetEPGInfoTag());
       if (recording)
         return !recording->IsDeleted();
 

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -86,7 +86,7 @@ namespace PVR
 
       const CPVREpgInfoTagPtr epg(item.GetEPGInfoTag());
       if (epg)
-        timer = epg->Timer();
+        timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
 
       if (!timer)
         timer = item.GetPVRTimerInfoTag();
@@ -219,7 +219,10 @@ namespace PVR
         return !channel->IsRecording() && client && client->GetClientCapabilities().SupportsTimers();
 
       const CPVREpgInfoTagPtr epg = item.GetEPGInfoTag();
-      if (epg && !epg->Timer() && epg->Channel() && epg->IsRecordable())
+      if (epg &&
+          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg) &&
+          epg->Channel() &&
+          epg->IsRecordable())
         return client && client->GetClientCapabilities().SupportsTimers();
 
       return false;
@@ -377,7 +380,9 @@ namespace PVR
     bool AddTimerRule::IsVisible(const CFileItem &item) const
     {
       const CPVREpgInfoTagPtr epg = item.GetEPGInfoTag();
-      if (epg && epg->Channel() && !epg->Timer())
+      if (epg &&
+          epg->Channel() &&
+          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg))
       {
         const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(item);
         return client && client->GetClientCapabilities().SupportsTimers();

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -23,6 +23,7 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 namespace PVR
 {

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -216,7 +216,8 @@ namespace PVR
 
       const CPVRChannelPtr channel = item.GetPVRChannelInfoTag();
       if (channel)
-        return !channel->IsRecording() && client && client->GetClientCapabilities().SupportsTimers();
+        return client && client->GetClientCapabilities().SupportsTimers() &&
+               !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
 
       const CPVREpgInfoTagPtr epg = item.GetEPGInfoTag();
       if (epg &&
@@ -243,7 +244,7 @@ namespace PVR
 
       const CPVRChannelPtr channel(item.GetPVRChannelInfoTag());
       if (channel)
-        return channel->IsRecording();
+        return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
 
       const CPVRTimerInfoTagPtr timer(GetTimerInfoTagFromItem(item));
       if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -521,7 +521,7 @@ bool CPVRDatabase::Get(CPVRChannelGroups &results)
     {
       while (!m_pDS->eof())
       {
-        CPVRChannelGroup data(m_pDS->fv("bIsRadio").get_asBool(), m_pDS->fv("idGroup").get_asInt(), m_pDS->fv("sName").get_asString());
+        CPVRChannelGroup data(m_pDS->fv("bIsRadio").get_asBool(), m_pDS->fv("idGroup").get_asInt(), m_pDS->fv("sName").get_asString(), results.GetGroupAll());
         data.SetGroupType(m_pDS->fv("iGroupType").get_asInt());
         data.SetLastWatched(static_cast<time_t>(m_pDS->fv("iLastWatched").get_asInt()));
         data.SetHidden(m_pDS->fv("bIsHidden").get_asBool());

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -755,7 +755,7 @@ namespace PVR
     CPVRTimerInfoTagPtr timer;
     const CPVRRecordingPtr recording(CPVRItem(item).GetRecording());
     if (recording)
-      timer = CServiceBroker::GetPVRManager().Timers()->GetRecordingTimerForRecording(*recording);
+      timer = recording->GetRecordingTimer();
 
     if (!timer)
       timer = CPVRItem(item).GetTimerInfoTag();

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -483,7 +483,7 @@ namespace PVR
   {
     const CPVRChannelPtr channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
     if (channel && channel->CanRecord())
-      return SetRecordingOnChannel(channel, !channel->IsRecording());
+      return SetRecordingOnChannel(channel, !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel));
 
     return false;
   }
@@ -502,7 +502,7 @@ namespace PVR
     if (client && client->GetClientCapabilities().SupportsTimers())
     {
       /* timers are supported on this channel */
-      if (bOnOff && !channel->IsRecording())
+      if (bOnOff && !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel))
       {
         CPVREpgInfoTagPtr epgTag;
         int iDuration = m_settings.GetIntValue(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
@@ -613,7 +613,7 @@ namespace PVR
         if (!bReturn)
           HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19164}); // "Error", "Could not start recording. Check the log for more information about this message."
       }
-      else if (!bOnOff && channel->IsRecording())
+      else if (!bOnOff && CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel))
       {
         /* delete active timers */
         bReturn = CServiceBroker::GetPVRManager().Timers()->DeleteTimersOnChannel(channel, true, true);

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -308,7 +308,7 @@ namespace PVR
       return false;
     }
 
-    CPVRTimerInfoTagPtr timer(bCreateRule || !epgTag ? nullptr : epgTag->Timer());
+    CPVRTimerInfoTagPtr timer(bCreateRule || !epgTag ? nullptr : CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag));
     CPVRTimerInfoTagPtr rule (bCreateRule ? CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer) : nullptr);
     if (timer || rule)
     {

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -537,15 +537,19 @@ namespace PVR
             epgTag = channel->GetEPGNow();
             if (epgTag)
             {
+              bool bLocked = CServiceBroker::GetPVRManager().IsParentalLocked(epgTag);
+
               // "now"
-              selector.AddAction(RECORD_CURRENT_SHOW, epgTag->Title());
+              const std::string currentTitle = bLocked ? g_localizeStrings.Get(19266) /* Parental locked */ : epgTag->Title();
+              selector.AddAction(RECORD_CURRENT_SHOW, currentTitle);
               ePreselect = RECORD_CURRENT_SHOW;
 
               // "next"
               epgTagNext = channel->GetEPGNext();
               if (epgTagNext)
               {
-                selector.AddAction(RECORD_NEXT_SHOW, epgTagNext->Title());
+                const std::string nextTitle = bLocked ? g_localizeStrings.Get(19266) /* Parental locked */ : epgTagNext->Title();
+                selector.AddAction(RECORD_NEXT_SHOW, nextTitle);
 
                 // be smart. if current show is almost over, preselect next show.
                 if (epgTag->ProgressPercentage() > 90.0f)

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1699,12 +1699,12 @@ namespace PVR
   bool CPVRGUIActions::AllLocalBackendsIdle(CPVRTimerInfoTagPtr& causingEvent) const
   {
     // active recording on local backend?
-    const std::vector<CFileItemPtr> activeRecordings = CServiceBroker::GetPVRManager().Timers()->GetActiveRecordings();
+    const std::vector<std::shared_ptr<CPVRTimerInfoTag>> activeRecordings = CServiceBroker::GetPVRManager().Timers()->GetActiveRecordings();
     for (const auto& timer : activeRecordings)
     {
-      if (EventOccursOnLocalBackend(timer))
+      if (EventOccursOnLocalBackend(std::make_shared<CFileItem>(timer)))
       {
-        causingEvent = timer->GetPVRTimerInfoTag();
+        causingEvent = timer;
         return false;
       }
     }
@@ -1712,17 +1712,17 @@ namespace PVR
     // soon recording on local backend?
     if (IsNextEventWithinBackendIdleTime())
     {
-      const CFileItemPtr item = CServiceBroker::GetPVRManager().Timers()->GetNextActiveTimer();
-      if (!item)
+      const std::shared_ptr<CPVRTimerInfoTag> timer = CServiceBroker::GetPVRManager().Timers()->GetNextActiveTimer();
+      if (!timer)
       {
         // Next event is due to automatic daily wakeup of PVR!
         causingEvent.reset();
         return false;
       }
 
-      if (EventOccursOnLocalBackend(item))
+      if (EventOccursOnLocalBackend(std::make_shared<CFileItem>(timer)))
       {
-        causingEvent = item->GetPVRTimerInfoTag();
+        causingEvent = timer;
         return false;
       }
     }

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1178,7 +1178,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
-          bValue = epgTag->HasRecording();
+          bValue = !!CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(epgTag);
         return true;
       }
       break;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1133,7 +1133,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
-          bValue = epgTag->HasTimer();
+          bValue = !!CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag);
         return true;
       }
       break;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1110,7 +1110,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
     case LISTITEM_ISRECORDING:
       if (item->IsPVRChannel())
       {
-        bValue = item->GetPVRChannelInfoTag()->IsRecording();
+        bValue = CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*item->GetPVRChannelInfoTag());
         return true;
       }
       else if (item->IsEPG() || item->IsPVRTimer())

--- a/xbmc/pvr/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/PVRGUITimerInfo.cpp
@@ -87,10 +87,10 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
   /* safe to fetch these unlocked, since they're updated from the same thread as this one */
   if (m_iRecordingTimerAmount > 0)
   {
-    std::vector<CFileItemPtr> activeTags = GetActiveRecordings();
-    if (m_iTimerInfoToggleCurrent < activeTags.size() && activeTags.at(m_iTimerInfoToggleCurrent)->HasPVRTimerInfoTag())
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> activeTags = GetActiveRecordings();
+    if (m_iTimerInfoToggleCurrent < activeTags.size())
     {
-      CPVRTimerInfoTagPtr tag = activeTags.at(m_iTimerInfoToggleCurrent)->GetPVRTimerInfoTag();
+      const std::shared_ptr<CPVRTimerInfoTag> tag = activeTags.at(m_iTimerInfoToggleCurrent);
       strActiveTimerTitle = StringUtils::Format("%s", tag->Title().c_str());
       strActiveTimerChannelName = StringUtils::Format("%s", tag->ChannelName().c_str());
       strActiveTimerChannelIcon = StringUtils::Format("%s", tag->ChannelIcon().c_str());
@@ -128,10 +128,9 @@ void CPVRGUITimerInfo::UpdateNextTimer()
   std::string strNextRecordingTime;
   std::string strNextTimerInfo;
 
-  CFileItemPtr tag = GetNextActiveTimer();
-  if (tag && tag->HasPVRTimerInfoTag())
+  const std::shared_ptr<CPVRTimerInfoTag> timer = GetNextActiveTimer();
+  if (timer)
   {
-    CPVRTimerInfoTagPtr timer = tag->GetPVRTimerInfoTag();
     strNextRecordingTitle = StringUtils::Format("%s", timer->Title().c_str());
     strNextRecordingChannelName = StringUtils::Format("%s", timer->ChannelName().c_str());
     strNextRecordingChannelIcon = StringUtils::Format("%s", timer->ChannelIcon().c_str());
@@ -216,12 +215,12 @@ int CPVRGUIAnyTimerInfo::AmountActiveRecordings()
   return CServiceBroker::GetPVRManager().Timers()->AmountActiveRecordings();
 }
 
-std::vector<CFileItemPtr> CPVRGUIAnyTimerInfo::GetActiveRecordings()
+std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRGUIAnyTimerInfo::GetActiveRecordings()
 {
   return CServiceBroker::GetPVRManager().Timers()->GetActiveRecordings();
 }
 
-CFileItemPtr CPVRGUIAnyTimerInfo::GetNextActiveTimer()
+std::shared_ptr<CPVRTimerInfoTag> CPVRGUIAnyTimerInfo::GetNextActiveTimer()
 {
   return CServiceBroker::GetPVRManager().Timers()->GetNextActiveTimer();
 }
@@ -236,12 +235,12 @@ int CPVRGUITVTimerInfo::AmountActiveRecordings()
   return CServiceBroker::GetPVRManager().Timers()->AmountActiveTVRecordings();
 }
 
-std::vector<CFileItemPtr> CPVRGUITVTimerInfo::GetActiveRecordings()
+std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRGUITVTimerInfo::GetActiveRecordings()
 {
   return CServiceBroker::GetPVRManager().Timers()->GetActiveTVRecordings();
 }
 
-CFileItemPtr CPVRGUITVTimerInfo::GetNextActiveTimer()
+std::shared_ptr<CPVRTimerInfoTag> CPVRGUITVTimerInfo::GetNextActiveTimer()
 {
   return CServiceBroker::GetPVRManager().Timers()->GetNextActiveTVTimer();
 }
@@ -256,12 +255,12 @@ int CPVRGUIRadioTimerInfo::AmountActiveRecordings()
   return CServiceBroker::GetPVRManager().Timers()->AmountActiveRadioRecordings();
 }
 
-std::vector<CFileItemPtr> CPVRGUIRadioTimerInfo::GetActiveRecordings()
+std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRGUIRadioTimerInfo::GetActiveRecordings()
 {
   return CServiceBroker::GetPVRManager().Timers()->GetActiveRadioRecordings();
 }
 
-CFileItemPtr CPVRGUIRadioTimerInfo::GetNextActiveTimer()
+std::shared_ptr<CPVRTimerInfoTag> CPVRGUIRadioTimerInfo::GetNextActiveTimer()
 {
   return CServiceBroker::GetPVRManager().Timers()->GetNextActiveRadioTimer();
 }

--- a/xbmc/pvr/PVRGUITimerInfo.h
+++ b/xbmc/pvr/PVRGUITimerInfo.h
@@ -14,11 +14,10 @@
 
 #include "threads/CriticalSection.h"
 
-class CFileItem;
-typedef std::shared_ptr<CFileItem> CFileItemPtr;
-
 namespace PVR
 {
+  class CPVRTimerInfoTag;
+
   class CPVRGUITimerInfo
   {
   public:
@@ -50,8 +49,8 @@ namespace PVR
 
     virtual int AmountActiveTimers() = 0;
     virtual int AmountActiveRecordings() = 0;
-    virtual std::vector<CFileItemPtr> GetActiveRecordings() = 0;
-    virtual CFileItemPtr GetNextActiveTimer() = 0;
+    virtual std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings() = 0;
+    virtual std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer() = 0;
 
     unsigned int m_iTimerAmount;
     unsigned int m_iRecordingTimerAmount;
@@ -80,8 +79,8 @@ namespace PVR
   private:
     int AmountActiveTimers() override;
     int AmountActiveRecordings() override;
-    std::vector<CFileItemPtr> GetActiveRecordings() override;
-    CFileItemPtr GetNextActiveTimer() override;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings() override;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer() override;
   };
 
   class CPVRGUITVTimerInfo : public CPVRGUITimerInfo
@@ -92,8 +91,8 @@ namespace PVR
   private:
     int AmountActiveTimers() override;
     int AmountActiveRecordings() override;
-    std::vector<CFileItemPtr> GetActiveRecordings() override;
-    CFileItemPtr GetNextActiveTimer() override;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings() override;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer() override;
   };
 
   class CPVRGUIRadioTimerInfo : public CPVRGUITimerInfo
@@ -104,8 +103,8 @@ namespace PVR
   private:
     int AmountActiveTimers() override;
     int AmountActiveRecordings() override;
-    std::vector<CFileItemPtr> GetActiveRecordings() override;
-    CFileItemPtr GetNextActiveTimer() override;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings() override;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer() override;
   };
 
 } // namespace PVR

--- a/xbmc/pvr/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/PVRGUITimesInfo.cpp
@@ -19,6 +19,7 @@
 #include "utils/StringUtils.h"
 
 #include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 
 using namespace PVR;
 
@@ -56,9 +57,11 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
     if (currentChannel && !currentTag)
       currentTag = currentChannel->GetEPGNow();
 
+    const std::shared_ptr<CPVRChannelGroupsContainer> groups = CServiceBroker::GetPVRManager().ChannelGroups();
+
     CSingleLock lock(m_critSection);
 
-    const CPVRChannelPtr playingChannel = m_playingEpgTag ? m_playingEpgTag->Channel() : nullptr;
+    const std::shared_ptr<CPVRChannel> playingChannel = m_playingEpgTag ? groups->GetChannelForEpgTag(m_playingEpgTag) : nullptr;
     if (!m_playingEpgTag || !m_playingEpgTag->IsActive() ||
         !playingChannel || !currentChannel || *playingChannel != *currentChannel)
     {

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -97,19 +97,11 @@ namespace PVR
     }
     else if (m_item->IsEPG())
     {
-      return m_item->GetEPGInfoTag()->Timer();
+      return CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_item->GetEPGInfoTag());
     }
     else if (m_item->IsPVRChannel())
     {
-      CPVRTimerInfoTagPtr timer;
-      const CPVREpgInfoTagPtr epgTag(m_item->GetPVRChannelInfoTag()->GetEPGNow());
-      if (epgTag)
-        timer = epgTag->Timer(); // cheap method, but not reliable as timers get set at epg tags asynchronously
-
-      if (timer)
-        return timer;
-
-      return CServiceBroker::GetPVRManager().Timers()->GetActiveTimerForChannel(m_item->GetPVRChannelInfoTag()); // more expensive, but reliable and works even for channels with no epg data
+      return CServiceBroker::GetPVRManager().Timers()->GetActiveTimerForChannel(m_item->GetPVRChannelInfoTag());
     }
     else
     {

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -16,6 +16,7 @@
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
 
@@ -125,7 +126,7 @@ namespace PVR
     }
     else if (m_item->IsEPG())
     {
-      return m_item->GetEPGInfoTag()->Recording();
+      return CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(m_item->GetEPGInfoTag());
     }
     else
     {

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -14,6 +14,7 @@
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
@@ -47,7 +48,7 @@ namespace PVR
   {
     if (m_item->IsEPG())
     {
-      const CPVRChannelPtr channel = m_item->GetEPGInfoTag()->Channel();
+      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(m_item->GetEPGInfoTag());
       if (channel)
         return channel->GetEPGNext();
     }
@@ -76,7 +77,7 @@ namespace PVR
     }
     else if (m_item->IsEPG())
     {
-      return m_item->GetEPGInfoTag()->Channel();
+      return CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(m_item->GetEPGInfoTag());
     }
     else if (m_item->IsPVRTimer())
     {
@@ -135,8 +136,7 @@ namespace PVR
     }
     else if (m_item->IsEPG())
     {
-      const CPVRChannelPtr channel(m_item->GetEPGInfoTag()->Channel());
-      return (channel && channel->IsRadio());
+      return m_item->GetEPGInfoTag()->IsRadio();
     }
     else if (m_item->IsPVRRecording())
     {

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -686,7 +686,7 @@ int CPVRManager::GetPlayingClientID(void) const
 bool CPVRManager::IsRecordingOnPlayingChannel(void) const
 {
   const CPVRChannelPtr currentChannel = GetPlayingChannel();
-  return currentChannel && currentChannel->IsRecording();
+  return currentChannel && CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*currentChannel);
 }
 
 bool CPVRManager::CanRecordOnPlayingChannel(void) const

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -650,6 +650,14 @@ bool CPVRManager::IsPlayingEpgTag(const CPVREpgInfoTagPtr &epgTag) const
   return bReturn;
 }
 
+bool CPVRManager::MatchPlayingChannel(int iClientID, int iUniqueChannelID) const
+{
+  if (m_playingChannel)
+    return m_playingChannel->ClientID() == iClientID && m_playingChannel->UniqueID() == iUniqueChannelID;
+
+  return false;
+}
+
 CPVRChannelPtr CPVRManager::GetPlayingChannel(void) const
 {
   return m_playingChannel;
@@ -693,19 +701,33 @@ void CPVRManager::RestartParentalTimer()
     m_parentalTimer->StartZero();
 }
 
-bool CPVRManager::IsParentalLocked(const CPVRChannelPtr &channel)
+bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
-  bool bReturn(false);
-  if (!IsStarted())
-    return bReturn;
-  CPVRChannelPtr currentChannel(GetPlayingChannel());
+  return m_channelGroups &&
+         epgTag &&
+         IsCurrentlyParentalLocked(m_channelGroups->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID()),
+                                   epgTag->IsParentalLocked());
+}
 
-  if (// different channel
+bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const
+{
+  return channel &&
+         IsCurrentlyParentalLocked(channel, channel->IsLocked());
+}
+
+bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel, bool bGenerallyLocked) const
+{
+  bool bReturn = false;
+
+  if (!channel || !bGenerallyLocked)
+    return bReturn;
+
+  const std::shared_ptr<CPVRChannel> currentChannel = GetPlayingChannel();
+
+  if (// if channel in question is currently playing it must be currently unlocked.
       (!currentChannel || channel != currentChannel) &&
       // parental control enabled
-      m_settings.GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED) &&
-      // channel is locked
-      channel && channel->IsLocked())
+      m_settings.GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED))
   {
     float parentalDurationMs = m_settings.GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION) * 1000.0f;
     bReturn = m_parentalTimer &&

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -240,6 +240,14 @@ namespace PVR
     }
 
     /*!
+     * @brief Check whether playing channel matches given uids.
+     * @param iClientID The client id.
+     * @param iUniqueChannelID The channel uid.
+     * @return True on match, false if there is no match or no channel is playing.
+     */
+    bool MatchPlayingChannel(int iClientID, int iUniqueChannelID) const;
+
+    /*!
      * @brief Return the channel that is currently playing.
      * @return The channel or NULL if none is playing.
      */
@@ -403,10 +411,17 @@ namespace PVR
 
     /*!
      * @brief Check if parental lock is overridden at the given moment.
-     * @param channel The channel to open.
+     * @param channel The channel to check.
      * @return True if parental lock is overridden, false otherwise.
      */
-    bool IsParentalLocked(const CPVRChannelPtr &channel);
+    bool IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const;
+
+    /*!
+     * @brief Check if parental lock is overridden at the given moment.
+     * @param epgTag The epg tag to check.
+     * @return True if parental lock is overridden, false otherwise.
+     */
+    bool IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
 
     /*!
      * @brief Restart the parental timer.
@@ -508,6 +523,8 @@ namespace PVR
      * @param state the new state.
      */
     void SetState(ManagerState state);
+
+    bool IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel, bool bGenerallyLocked) const;
 
     /** @name containers */
     //@{

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -22,7 +22,6 @@
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
-#include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
 
@@ -114,7 +113,7 @@ void CPVRChannel::Serialize(CVariant& value) const
   if (epg)
     epg->Serialize(value["broadcastnext"]);
 
-  value["isrecording"] = IsRecording();
+  value["isrecording"] = false; // compat
 }
 
 /********** XBMC related channel methods **********/
@@ -299,11 +298,6 @@ void CPVRChannel::SetRadioRDSInfoTag(const std::shared_ptr<CPVRRadioRDSInfoTag>&
 {
   CSingleLock lock(m_critSection);
   m_rdsTag = tag;
-}
-
-bool CPVRChannel::IsRecording(void) const
-{
-  return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*this);
 }
 
 bool CPVRChannel::SetIconPath(const std::string &strIconPath, bool bIsUserSetIcon /* = false */)

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -527,16 +527,16 @@ void CPVRChannel::UpdateEncryptionName(void)
 
 /********** EPG methods **********/
 
-int CPVRChannel::GetEPG(CFileItemList &results) const
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEpgTags() const
 {
   const CPVREpgPtr epg = GetEPG();
   if (!epg)
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "Cannot get EPG for channel '%s'", m_strChannelName.c_str());
-    return -1;
+    return std::vector<std::shared_ptr<CPVREpgInfoTag>>();
   }
 
-  return epg->Get(results);
+  return epg->GetTags();
 }
 
 bool CPVRChannel::ClearEPG() const

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -19,7 +19,6 @@
 
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
-#include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
 
@@ -398,17 +397,14 @@ bool CPVRChannel::SetClientID(int iClientId)
   return false;
 }
 
-void CPVRChannel::UpdatePath(CPVRChannelGroupInternal* group)
+void CPVRChannel::UpdatePath(const std::string& groupPath)
 {
-  if (!group)
-    return;
-
   const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client)
   {
     CSingleLock lock(m_critSection);
     const std::string strFileNameAndPath = StringUtils::Format("%s%s_%d.pvr",
-                                                               group->GetPath(),
+                                                               groupPath,
                                                                client->ID().c_str(),
                                                                m_iUniqueId);
     if (m_strFileNameAndPath != strFileNameAndPath)

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -292,18 +292,6 @@ bool CPVRChannel::IsRecording(void) const
   return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*this);
 }
 
-CPVRRecordingPtr CPVRChannel::GetRecording(void) const
-{
-  const CPVREpgInfoTagPtr epgTag = GetEPGNow();
-  return (epgTag && epgTag->HasRecording()) ? epgTag->Recording() : CPVRRecordingPtr();
-}
-
-bool CPVRChannel::HasRecording(void) const
-{
-  const CPVREpgInfoTagPtr epgTag = GetEPGNow();
-  return epgTag && epgTag->HasRecording();
-}
-
 bool CPVRChannel::SetIconPath(const std::string &strIconPath, bool bIsUserSetIcon /* = false */)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -143,7 +143,7 @@ CPVREpgPtr CPVRChannel::GetEPG(void) const
   if (!m_bIsHidden && m_bEPGEnabled)
     return m_epg;
 
-  return std::shared_ptr<CPVREpg>();
+  return {};
 }
 
 bool CPVRChannel::CreateEPG()
@@ -533,7 +533,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEpgTags() const
   if (!epg)
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "Cannot get EPG for channel '%s'", m_strChannelName.c_str());
-    return std::vector<std::shared_ptr<CPVREpgInfoTag>>();
+    return {};
   }
 
   return epg->GetTags();

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -145,11 +145,6 @@ namespace PVR
     bool IsRecording(void) const;
 
     /*!
-     * @return If recording, gets the recording if the add-on provides the epg id in recordings
-     */
-    CPVRRecordingPtr GetRecording(void) const;
-
-    /*!
      * @brief Obtain the Radio RDS data for this channel, if available.
      * @return The Radio RDS data or nullptr.
      */
@@ -160,11 +155,6 @@ namespace PVR
      * @param tag The RDS data.
      */
     void SetRadioRDSInfoTag(const std::shared_ptr<CPVRRadioRDSInfoTag>& tag);
-
-    /*!
-     * @return True if this channel has a corresponding recording, false otherwise
-     */
-    bool HasRecording(void) const;
 
     /*!
      * @return The path to the icon for this channel.

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -140,11 +140,6 @@ namespace PVR
     bool SetLocked(bool bIsLocked);
 
     /*!
-     * @return True if a recording is currently running on this channel. False if not.
-     */
-    bool IsRecording(void) const;
-
-    /*!
      * @brief Obtain the Radio RDS data for this channel, if available.
      * @return The Radio RDS data or nullptr.
      */

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "threads/CriticalSection.h"
@@ -22,7 +23,6 @@
 #include "pvr/PVRTypes.h"
 
 class CVariant;
-class CFileItemList;
 
 namespace PVR
 {
@@ -340,11 +340,10 @@ namespace PVR
     CPVREpgPtr GetEPG(void) const;
 
     /*!
-     * @brief Get the EPG table for this channel.
-     * @param results The file list to store the results in.
-     * @return The number of tables that were added.
+     * @brief Get the EPG tags for this channel.
+     * @return The tags.
      */
-    int GetEPG(CFileItemList &results) const;
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTags() const;
 
     /*!
      * @brief Clear the EPG for this channel.

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -26,7 +26,6 @@ class CFileItemList;
 
 namespace PVR
 {
-  class CPVRChannelGroupInternal;
   class CPVREpg;
   class CPVRRadioRDSInfoTag;
 
@@ -277,10 +276,10 @@ namespace PVR
     void ToSortable(SortItem& sortable, Field field) const override;
 
     /*!
-     * @brief Update the path this channel got added to the internal group
-     * @param group The internal group that contains this channel
+     * @brief Update the channel path
+     * @param groupPath The new path of the group this channel belongs to
      */
-    void UpdatePath(CPVRChannelGroupInternal* group);
+    void UpdatePath(const std::string& groupPath);
 
     /*!
      * @return Storage id for this channel in CPVRChannelGroup

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -27,6 +27,7 @@ class CFileItemList;
 namespace PVR
 {
   class CPVRChannelGroupInternal;
+  class CPVREpg;
   class CPVRRadioRDSInfoTag;
 
   /** PVR Channel class */
@@ -334,10 +335,9 @@ namespace PVR
 
     /*!
      * @brief Create the EPG for this channel, if it does not yet exist
-     * @param bForce to create a new EPG, even if it already exists.
      * @return true if a new epg was created, false otherwise.
      */
-    bool CreateEPG(bool bForce);
+    bool CreateEPG();
 
     /*!
      * @brief Get the EPG table for this channel.
@@ -453,9 +453,9 @@ namespace PVR
      */
     //@{
     int              m_iEpgId;                  /*!< the id of the EPG for this channel */
-    bool             m_bEPGCreated;             /*!< true if an EPG has been created for this channel */
     bool             m_bEPGEnabled;             /*!< don't use an EPG for this channel if set to false */
     std::string      m_strEPGScraper;           /*!< the name of the scraper to be used for this channel */
+    std::shared_ptr<CPVREpg> m_epg;
     //@}
 
     /*! @name Client related channel data

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -32,8 +32,7 @@ namespace PVR
   /** PVR Channel class */
   class CPVRChannel : public Observable,
                       public ISerializable,
-                      public ISortable,
-                      public std::enable_shared_from_this<CPVRChannel>
+                      public ISortable
   {
     friend class CPVRDatabase;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -29,7 +29,6 @@
 #include "pvr/PVRGUIProgressHandler.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
-#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
 
@@ -40,18 +39,24 @@ CPVRChannelGroup::CPVRChannelGroup(void)
   OnInit();
 }
 
-CPVRChannelGroup::CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std::string &strGroupName) :
+CPVRChannelGroup::CPVRChannelGroup(bool bRadio,
+                                   unsigned int iGroupId,
+                                   const std::string& strGroupName,
+                                   const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup) :
     m_bRadio(bRadio),
     m_iGroupId(iGroupId),
-    m_strGroupName(strGroupName)
+    m_strGroupName(strGroupName),
+    m_allChannelsGroup(allChannelsGroup)
 {
   OnInit();
 }
 
-CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP &group) :
+CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
+                                   const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup) :
     m_bRadio(group.bIsRadio),
     m_strGroupName(group.strGroupName),
-    m_iPosition(group.iPosition)
+    m_iPosition(group.iPosition),
+    m_allChannelsGroup(allChannelsGroup)
 {
   OnInit();
 }
@@ -74,6 +79,8 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup &group) :
   m_iPosition                   = group.m_iPosition;
   m_failedClientsForChannels    = group.m_failedClientsForChannels;
   m_failedClientsForChannelGroupMembers = group.m_failedClientsForChannelGroupMembers;
+  m_allChannelsGroup = group.m_allChannelsGroup;
+
   OnInit();
 }
 
@@ -107,7 +114,7 @@ void CPVRChannelGroup::OnInit(void)
   });
 }
 
-bool CPVRChannelGroup::Load(void)
+bool CPVRChannelGroup::Load(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove)
 {
   /* make sure this container is empty before loading */
   Unload();
@@ -119,7 +126,7 @@ bool CPVRChannelGroup::Load(void)
   int iChannelCount = m_iGroupId > 0 ? LoadFromDb() : 0;
   CLog::LogFC(LOGDEBUG, LOGPVR, "%d channels loaded from the database for group '%s'", iChannelCount, m_strGroupName.c_str());
 
-  if (!Update())
+  if (!Update(channelsToRemove))
   {
     CLog::LogF(LOGERROR, "Failed to update channels for group '%s', m_strGroupName.c_str()");
     return false;
@@ -147,17 +154,17 @@ void CPVRChannelGroup::Unload(void)
   m_failedClientsForChannelGroupMembers.clear();
 }
 
-bool CPVRChannelGroup::Update(void)
+bool CPVRChannelGroup::Update(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove)
 {
   if (GroupType() == PVR_GROUP_TYPE_USER_DEFINED ||
       !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMANAGER_SYNCCHANNELGROUPS))
     return true;
 
-  CPVRChannelGroup PVRChannels_tmp(m_bRadio, m_iGroupId, m_strGroupName);
+  CPVRChannelGroup PVRChannels_tmp(m_bRadio, m_iGroupId, m_strGroupName, m_allChannelsGroup);
   PVRChannels_tmp.SetPreventSortAndRenumber();
   PVRChannels_tmp.LoadFromClients();
   m_failedClientsForChannelGroupMembers = PVRChannels_tmp.m_failedClientsForChannelGroupMembers;
-  return UpdateGroupEntries(PVRChannels_tmp);
+  return UpdateGroupEntries(PVRChannels_tmp, channelsToRemove);
 }
 
 std::string CPVRChannelGroup::GetPath() const
@@ -523,18 +530,6 @@ void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumber
     channelNumbers.emplace_back(member.channelNumber.FormattedChannelNumber());
 }
 
-CPVRChannelGroupPtr CPVRChannelGroup::GetNextGroup(void) const
-{
-  return CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bRadio)->GetNextGroup(*this);
-}
-
-CPVRChannelGroupPtr CPVRChannelGroup::GetPreviousGroup(void) const
-{
-  return CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bRadio)->GetPreviousGroup(*this);
-}
-
-/********** private methods **********/
-
 int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
 {
   const CPVRDatabasePtr database(CServiceBroker::GetPVRManager().GetTVDatabase());
@@ -543,11 +538,7 @@ int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
 
   int iChannelCount = Size();
 
-  const CPVRChannelGroupPtr allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(IsRadio());
-  if (!allGroup)
-    return -1;
-
-  database->Get(*this, *allGroup);
+  database->Get(*this, *m_allChannelsGroup);
 
   return Size() - iChannelCount;
 }
@@ -561,14 +552,13 @@ bool CPVRChannelGroup::LoadFromClients(void)
 bool CPVRChannelGroup::AddAndUpdateChannels(const CPVRChannelGroup &channels, bool bUseBackendChannelNumbers)
 {
   bool bReturn(false);
-  const CPVRChannelGroupPtr groupAll(CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bRadio));
 
   /* go through the channel list and check for new channels.
      channels will only by updated in CPVRChannelGroupInternal to prevent dupe updates */
   for (PVR_CHANNEL_GROUP_MEMBERS::const_iterator it = channels.m_members.begin(); it != channels.m_members.end(); ++it)
   {
     /* check whether this channel is known in the internal group */
-    const PVRChannelGroupMember& existingChannel(groupAll->GetByUniqueID(it->first));
+    const PVRChannelGroupMember& existingChannel(m_allChannelsGroup->GetByUniqueID(it->first));
     if (!existingChannel.channel)
       continue;
 
@@ -634,7 +624,7 @@ std::vector<CPVRChannelPtr> CPVRChannelGroup::RemoveDeletedChannels(const CPVRCh
   return removedChannels;
 }
 
-bool CPVRChannelGroup::UpdateGroupEntries(const CPVRChannelGroup &channels)
+bool CPVRChannelGroup::UpdateGroupEntries(const CPVRChannelGroup& channels, std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove)
 {
   bool bReturn(false);
   bool bChanged(false);
@@ -645,7 +635,8 @@ bool CPVRChannelGroup::UpdateGroupEntries(const CPVRChannelGroup &channels)
   bool bUseBackendChannelNumbers(m_members.empty() || m_bUsingBackendChannelOrder);
 
   SetPreventSortAndRenumber(true);
-  bRemoved = !RemoveDeletedChannels(channels).empty();
+  channelsToRemove = RemoveDeletedChannels(channels);
+  bRemoved = !channelsToRemove.empty();
   bChanged = AddAndUpdateChannels(channels, bUseBackendChannelNumbers) || bRemoved;
   SetPreventSortAndRenumber(false);
 
@@ -704,14 +695,13 @@ bool CPVRChannelGroup::RemoveFromGroup(const CPVRChannelPtr &channel)
 bool CPVRChannelGroup::AddToGroup(const CPVRChannelPtr &channel, const CPVRChannelNumber &channelNumber, bool bUseBackendChannelNumbers)
 {
   bool bReturn(false);
-  const CPVRChannelGroupPtr groupAll(CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bRadio));
   CSingleLock lock(m_critSection);
 
   if (!CPVRChannelGroup::IsGroupMember(channel))
   {
     const PVRChannelGroupMember& realChannel(IsInternalGroup() ?
         GetByUniqueID(channel->StorageId()) :
-        groupAll->GetByUniqueID(channel->StorageId()));
+        m_allChannelsGroup->GetByUniqueID(channel->StorageId()));
 
     if (realChannel.channel)
     {
@@ -815,9 +805,6 @@ bool CPVRChannelGroup::Renumber(void)
   unsigned int iChannelNumber(0);
   bool bUseBackendChannelNumbers(CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMANAGER_USEBACKENDCHANNELNUMBERS) &&
                                  CServiceBroker::GetPVRManager().Clients()->EnabledClientAmount() == 1);
-  CPVRChannelGroupPtr groupAll;
-  if (!bUseBackendChannelNumbers && !IsInternalGroup())
-    groupAll = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bRadio);
 
   CSingleLock lock(m_critSection);
 
@@ -837,7 +824,7 @@ bool CPVRChannelGroup::Renumber(void)
       if (IsInternalGroup())
         currentChannelNumber = CPVRChannelNumber(++iChannelNumber, 0);
       else
-        currentChannelNumber = groupAll->GetChannelNumber((*it).channel);
+        currentChannelNumber = m_allChannelsGroup->GetChannelNumber((*it).channel);
     }
 
     if ((*it).channelNumber != currentChannelNumber)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -30,6 +30,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
+#include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
 
 using namespace PVR;
@@ -941,16 +942,16 @@ int CPVRChannelGroup::GetEPGAll(CFileItemList &results, bool bIncludeChannelsWit
 
       CPVREpgPtr epg = channel->GetEPG();
       if (epg)
-      {
-        // XXX channel pointers aren't set in some occasions. this works around the issue, but is not very nice
-        epg->SetChannel(channel);
         iAdded = epg->Get(results);
-      }
 
       if (bIncludeChannelsWithoutEPG && iAdded == 0)
       {
         // Add dummy EPG tag associated with this channel
-        epgTag = std::make_shared<CPVREpgInfoTag>(channel);
+        if (epg)
+          epgTag = std::make_shared<CPVREpgInfoTag>(epg->GetChannelData(), epg->EpgID());
+        else
+          epgTag = std::make_shared<CPVREpgInfoTag>(std::make_shared<CPVREpgChannelData>(*channel), -1);
+
         results.Add(std::make_shared<CFileItem>(epgTag));
       }
     }

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -22,6 +22,8 @@
 class CFileItem;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
 
+class CFileItemList;
+
 namespace PVR
 {
 #define PVR_GROUP_TYPE_DEFAULT      0
@@ -374,12 +376,11 @@ namespace PVR
     virtual bool CreateChannelEpgs(bool bForce = false);
 
     /*!
-     * @brief Get all EPG tables.
-     * @param results The fileitem list to store the results in.
+     * @brief Get all EPG tags for all channels in this group.
      * @param bIncludeChannelsWithoutEPG, for channels without EPG data, put an empty EPG tag associated with the channel into results
-     * @return The amount of entries that were added.
+     * @return The tags.
      */
-    int GetEPGAll(CFileItemList &results, bool bIncludeChannelsWithoutEPG = false) const;
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGAll(bool bIncludeChannelsWithoutEPG = false) const;
 
     /*!
      * @brief Get the start time of the first entry.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -64,14 +64,16 @@ namespace PVR
      * @param bRadio True if this group holds radio channels.
      * @param iGroupId The database ID of this group.
      * @param strGroupName The name of this group.
+     * @param allChannelsGroup The channel group containing all TV or radio channels.
      */
-    CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std::string &strGroupName);
+    CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std::string& strGroupName, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
 
     /*!
      * @brief Create a new channel group instance from a channel group provided by an add-on.
      * @param group The channel group provided by the add-on.
+     * @param allChannelsGroup The channel group containing all TV or radio channels.
      */
-    explicit CPVRChannelGroup(const PVR_CHANNEL_GROUP &group);
+    CPVRChannelGroup(const PVR_CHANNEL_GROUP& group, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
 
     /*!
      * @brief Copy constructor
@@ -91,9 +93,10 @@ namespace PVR
 
     /*!
      * @brief Load the channels from the database.
+     * @param channelsToRemove Returns the channels to be removed from all groups, if any
      * @return True when loaded successfully, false otherwise.
      */
-    virtual bool Load(void);
+    virtual bool Load(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove);
 
     /*!
      * @return The amount of group members
@@ -102,8 +105,9 @@ namespace PVR
 
     /*!
      * @brief Refresh the channel list from the clients.
+     * @param channelsToRemove Returns the channels to be removed from all groups, if any
      */
-    virtual bool Update(void);
+    virtual bool Update(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove);
 
     /*!
      * @brief Get the path of this group.
@@ -336,16 +340,6 @@ namespace PVR
     void GetChannelNumbers(std::vector<std::string>& channelNumbers) const;
 
     /*!
-     * @return The next channel group.
-     */
-    CPVRChannelGroupPtr GetNextGroup(void) const;
-
-    /*!
-     * @return The previous channel group.
-     */
-    CPVRChannelGroupPtr GetPreviousGroup(void) const;
-
-    /*!
      * @brief The amount of hidden channels in this container.
      * @return The amount of hidden channels in this container.
      */
@@ -457,9 +451,10 @@ namespace PVR
      * Only the new channels will be present in the passed list after this call.
      *
      * @param channels The channels to use to update this list.
+     * @param channelsToRemove Returns the channels to be removed from all groups, if any
      * @return True if everything went well, false otherwise.
      */
-    virtual bool UpdateGroupEntries(const CPVRChannelGroup &channels);
+    virtual bool UpdateGroupEntries(const CPVRChannelGroup& channels, std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove);
 
     /*!
      * @brief Add new channels to this group; updtae data.
@@ -522,5 +517,7 @@ namespace PVR
 
   private:
     CDateTime GetEPGDate(EpgDateType epgDateType) const;
+
+    std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
   };
 }

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -307,10 +307,10 @@ bool CPVRChannelGroupInternal::UpdateGroupEntries(const CPVRChannelGroup &channe
   return bReturn;
 }
 
-void CPVRChannelGroupInternal::CreateChannelEpg(const CPVRChannelPtr &channel, bool bForce /* = false */)
+void CPVRChannelGroupInternal::CreateChannelEpg(const std::shared_ptr<CPVRChannel>& channel)
 {
   if (channel)
-    channel->CreateEPG(bForce);
+    channel->CreateEPG();
 }
 
 bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -24,7 +24,6 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
-#include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
 using namespace KODI::MESSAGING;
@@ -298,7 +297,6 @@ bool CPVRChannelGroupInternal::UpdateGroupEntries(const CPVRChannelGroup &channe
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRChannelIconsAutoScan)
       SearchAndSetChannelIcons();
 
-    CServiceBroker::GetPVRManager().Timers()->UpdateChannels();
     Persist();
 
     bReturn = true;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -83,7 +83,7 @@ void CPVRChannelGroupInternal::UpdateChannelPaths(void)
     if (it->second.channel->IsHidden())
       ++m_iHiddenChannels;
     else
-      it->second.channel->UpdatePath(this);
+      it->second.channel->UpdatePath(GetPath());
   }
 }
 
@@ -103,7 +103,7 @@ CPVRChannelPtr CPVRChannelGroupInternal::UpdateFromClient(const CPVRChannelPtr &
       iChannelNumber = static_cast<int>(m_sortedMembers.size()) + 1;
 
     PVRChannelGroupMember newMember(channel, CPVRChannelNumber(iChannelNumber, channelNumber.GetSubChannelNumber()), 0);
-    channel->UpdatePath(this);
+    channel->UpdatePath(GetPath());
     m_sortedMembers.push_back(newMember);
     m_members.insert(std::make_pair(channel->StorageId(), newMember));
     m_bChanged = true;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -95,9 +95,10 @@ namespace PVR
      * Only the new channels will be present in the passed list after this call.
      *
      * @param channels The channels to use to update this list.
+     * @param channelsToRemove Returns the channels to be removed from all groups, if any
      * @return True if everything went well, false otherwise.
      */
-    bool UpdateGroupEntries(const CPVRChannelGroup &channels) override;
+    bool UpdateGroupEntries(const CPVRChannelGroup& channels, std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove) override;
 
     /*!
      * @brief Add new channels to this group; updtae data.
@@ -116,8 +117,9 @@ namespace PVR
 
     /*!
      * @brief Refresh the channel list from the clients.
+     * @param channelsToRemove Returns the channels to be removed from all groups, if any
      */
-    bool Update(void) override;
+    bool Update(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove) override;
 
     /*!
      * @brief Load the channels from the database.
@@ -125,9 +127,10 @@ namespace PVR
      * Load the channels from the database.
      * If no channels are stored in the database, then the channels will be loaded from the clients.
      *
+     * @param channelsToRemove Returns the channels to be removed from all groups, if any
      * @return True when loaded successfully, false otherwise.
      */
-    bool Load(void) override;
+    bool Load(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove) override;
 
     /*!
      * @brief Update the vfs paths of all channels.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -134,7 +134,7 @@ namespace PVR
      */
     void UpdateChannelPaths(void);
 
-    void CreateChannelEpg(const CPVRChannelPtr &channel, bool bForce = false);
+    void CreateChannelEpg(const std::shared_ptr<CPVRChannel>& channel);
 
     size_t m_iHiddenChannels; /*!< the amount of hidden channels in this container */
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -546,7 +546,7 @@ bool CPVRChannelGroups::CreateChannelEpgs(void)
   CSingleLock lock(m_critSection);
   for (std::vector<CPVRChannelGroupPtr>::iterator it = m_groups.begin(); it != m_groups.end(); ++it)
   {
-    /* Only create EPGs for the internatl groups */
+    /* Only create EPGs for the internal groups */
     if ((*it)->IsInternalGroup())
       bReturn = (*it)->CreateChannelEpgs();
   }

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -76,7 +76,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup &group, bool bUpdateFromCl
     {
       // create a new group if none was found. Copy the properties immediately
       // so the group doesn't get flagged as "changed" further down.
-      updateGroup = CPVRChannelGroupPtr(new CPVRChannelGroup(group.IsRadio(), group.GroupID(), group.GroupName()));
+      updateGroup.reset(new CPVRChannelGroup(group.IsRadio(), group.GroupID(), group.GroupName(), GetGroupAll()));
       m_groups.push_back(updateGroup);
     }
 
@@ -189,6 +189,15 @@ CPVRChannelGroupPtr CPVRChannelGroups::GetByName(const std::string &strName) con
   return empty;
 }
 
+void CPVRChannelGroups::RemoveFromAllGroups(const std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove)
+{
+  for (const auto& channel : channelsToRemove)
+  {
+    /* remove this channel from all non-system groups */
+    RemoveFromAllGroups(channel);
+  }
+}
+
 void CPVRChannelGroups::RemoveFromAllGroups(const CPVRChannelPtr &channel)
 {
   CSingleLock lock(m_critSection);
@@ -221,7 +230,11 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
   for (const auto &group : groups)
   {
     if (bUpdateAllGroups || group->IsInternalGroup())
-      bReturn = group->Update() && bReturn;
+    {
+      std::vector<std::shared_ptr<CPVRChannel>> channelsToRemove;
+      bReturn = group->Update(channelsToRemove) && bReturn;
+      RemoveFromAllGroups(channelsToRemove);
+    }
   }
 
   // persist changes
@@ -252,11 +265,14 @@ bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
     // load only user defined groups, as internal group is already loaded
     if (!(*it)->IsInternalGroup())
     {
-      if (!(*it)->Load())
+      std::vector<std::shared_ptr<CPVRChannel>> channelsToRemove;
+      if (!(*it)->Load(channelsToRemove))
       {
         CLog::LogFC(LOGDEBUG, LOGPVR, "Failed to load user defined channel group '%s'", (*it)->GroupName().c_str());
         return false;
       }
+
+      RemoveFromAllGroups(channelsToRemove);
 
       // remove empty groups when sync with backend is enabled
       if (bSyncWithBackends && (*it)->Size() == 0)
@@ -296,11 +312,14 @@ bool CPVRChannelGroups::Load(void)
   CLog::LogFC(LOGDEBUG, LOGPVR, "%d %s groups fetched from the database", m_groups.size(), m_bRadio ? "radio" : "TV");
 
   // load channels of internal group
-  if (!internalGroup->Load())
+  std::vector<std::shared_ptr<CPVRChannel>> channelsToRemove;
+  if (!internalGroup->Load(channelsToRemove))
   {
     CLog::LogF(LOGERROR, "Failed to load 'all channels' group");
     return false;
   }
+
+  RemoveFromAllGroups(channelsToRemove);
 
   // load the other groups from the database
   if (!LoadUserDefinedChannelGroups())
@@ -528,7 +547,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
   }
 
   if (playingGroup)
-    CServiceBroker::GetPVRManager().SetPlayingGroup(playingGroup);
+    SetSelectedGroup(playingGroup);
 
   if (group.GroupID() > 0)
   {

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -193,7 +193,7 @@ void CPVRChannelGroups::RemoveFromAllGroups(const std::vector<std::shared_ptr<CP
 {
   for (const auto& channel : channelsToRemove)
   {
-    /* remove this channel from all non-system groups */
+    // remove this channel from all non-system groups
     RemoveFromAllGroups(channel);
   }
 }

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -179,12 +179,6 @@ namespace PVR
     bool CreateChannelEpgs(void);
 
     /*!
-     * @brief Remove a channel from all non-system groups.
-     * @param channel The channel to remove.
-     */
-    void RemoveFromAllGroups(const CPVRChannelPtr &channel);
-
-    /*!
      * @brief Persist all changes in channel groups.
      * @return True if everything was persisted, false otherwise.
      */
@@ -206,6 +200,18 @@ namespace PVR
     bool LoadUserDefinedChannelGroups(void);
     bool GetGroupsFromClients(void);
     void SortGroups(void);
+
+    /*!
+     * @brief Remove the given channels from all non-system groups.
+     * @param channel The channels to remove.
+     */
+    void RemoveFromAllGroups(const std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove);
+
+    /*!
+     * @brief Remove a channel from all non-system groups.
+     * @param channel The channel to remove.
+     */
+    void RemoveFromAllGroups(const std::shared_ptr<CPVRChannel>& channel);
 
     bool                             m_bRadio;         /*!< true if this is a container for radio channels, false if it is for tv channels */
     CPVRChannelGroupPtr              m_selectedGroup;  /*!< the group that's currently selected in the UI */

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -109,7 +109,7 @@ CPVRChannelPtr CPVRChannelGroupsContainer::GetChannelByEpgId(int iEpgId) const
 std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
   if (!epgTag)
-    return std::shared_ptr<CPVRChannel>();
+    return {};
 
   const CPVRChannelGroups* groups = epgTag->IsRadio() ? m_groupsRadio : m_groupsTV;
   return groups->GetGroupAll()->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID());

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -15,6 +15,7 @@
 #include "utils/log.h"
 
 #include "pvr/PVRManager.h"
+#include "pvr/epg/EpgInfoTag.h"
 
 using namespace PVR;
 
@@ -103,6 +104,15 @@ CPVRChannelPtr CPVRChannelGroupsContainer::GetChannelByEpgId(int iEpgId) const
     channel = m_groupsRadio->GetGroupAll()->GetByChannelEpgID(iEpgId);
 
   return channel;
+}
+
+std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+{
+  if (!epgTag)
+    return std::shared_ptr<CPVRChannel>();
+
+  const CPVRChannelGroups* groups = epgTag->IsRadio() ? m_groupsRadio : m_groupsTV;
+  return groups->GetGroupAll()->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID());
 }
 
 bool CPVRChannelGroupsContainer::GetGroupsDirectory(CFileItemList *results, bool bRadio) const

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -113,6 +113,13 @@ namespace PVR
     CPVRChannelPtr GetChannelByEpgId(int iEpgId) const;
 
     /*!
+     * @brief Get the channel for the given epg tag.
+     * @param epgTag The epg tag.
+     * @return The channel.
+     */
+    std::shared_ptr<CPVRChannel> GetChannelForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+
+    /*!
      * @brief Get the groups list for a directory.
      * @param strBase The directory path.
      * @param results The file list to store the results in.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
@@ -42,7 +42,12 @@ void CGUIDialogPVRChannelGuide::OnInitWindow()
 
   Init();
 
-  m_channel->GetEPG(*m_vecItems);
+  const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags = m_channel->GetEpgTags();
+  for (const auto& tag : tags)
+  {
+    m_vecItems->Add(std::make_shared<CFileItem>(tag));
+  }
+
   m_viewControl.SetItems(*m_vecItems);
 
   CGUIDialogPVRItemsViewBase::OnInitWindow();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -21,6 +21,7 @@
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
 
 using namespace PVR;
@@ -113,7 +114,10 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction &action)
       SaveControlStates();
 
       // switch to next or previous group
-      const CPVRChannelGroupPtr nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP ? m_group->GetNextGroup() : m_group->GetPreviousGroup();
+      const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_group->IsRadio());
+      const std::shared_ptr<CPVRChannelGroup> nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP
+                                                        ? groups->GetNextGroup(*m_group)
+                                                        : groups->GetPreviousGroup(*m_group);
       CServiceBroker::GetPVRManager().SetPlayingGroup(nextGroup);
       m_group = nextGroup;
       Init();

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -69,14 +69,6 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
   {
     bReturn = true;
 
-    if (!m_progItem || !m_progItem->HasChannel())
-    {
-      /* invalid channel */
-      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19067});
-      Close();
-      return bReturn;
-    }
-
     const std::shared_ptr<CPVRTimerInfoTag> timerTag = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_progItem);
     if (timerTag)
     {
@@ -216,7 +208,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
       bHideRecord = false;
     }
   }
-  else if (m_progItem->Channel() && m_progItem->IsRecordable())
+  else if (m_progItem->IsRecordable())
   {
     const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_progItem->ClientID());
     if (client && client->GetClientCapabilities().SupportsTimers())

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -27,6 +27,7 @@
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
+#include "pvr/timers/PVRTimers.h"
 #include "pvr/windows/GUIWindowPVRSearch.h"
 
 using namespace PVR;
@@ -76,7 +77,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
       return bReturn;
     }
 
-    const CPVRTimerInfoTagPtr timerTag(m_progItem->Timer());
+    const std::shared_ptr<CPVRTimerInfoTag> timerTag = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_progItem);
     if (timerTag)
     {
       const CFileItemPtr item(new CFileItem(timerTag));
@@ -104,7 +105,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonAddTimer(CGUIMessage &message)
 
   if (message.GetSenderId() == CONTROL_BTN_ADD_TIMER)
   {
-    if (m_progItem && !m_progItem->Timer())
+    if (m_progItem && !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_progItem))
     {
       const CFileItemPtr item(new CFileItem(m_progItem));
       bReturn = CServiceBroker::GetPVRManager().GUIActions()->AddTimerRule(item, true);
@@ -201,14 +202,15 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
   bool bHideRecord(true);
   bool bHideAddTimer(true);
 
-  if (m_progItem->HasTimer())
+  const std::shared_ptr<CPVRTimerInfoTag> timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_progItem);
+  if (timer)
   {
-    if (m_progItem->Timer()->IsRecording())
+    if (timer->IsRecording())
     {
       SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 19059); /* Stop recording */
       bHideRecord = false;
     }
-    else if (m_progItem->Timer()->HasTimerType() && !m_progItem->Timer()->GetTimerType()->IsReadOnly())
+    else if (timer->HasTimerType() && !timer->GetTimerType()->IsReadOnly())
     {
       SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 19060); /* Delete timer */
       bHideRecord = false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -25,6 +25,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/windows/GUIWindowPVRSearch.h"
 
@@ -191,7 +192,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
     return;
   }
 
-  if (!m_progItem->HasRecording())
+  if (!CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(m_progItem))
   {
     /* not recording. hide the play recording button */
     SET_CONTROL_HIDDEN(CONTROL_BTN_PLAY_RECORDING);

--- a/xbmc/pvr/epg/CMakeLists.txt
+++ b/xbmc/pvr/epg/CMakeLists.txt
@@ -2,12 +2,14 @@ set(SOURCES EpgContainer.cpp
             Epg.cpp
             EpgDatabase.cpp
             EpgInfoTag.cpp
-            EpgSearchFilter.cpp)
+            EpgSearchFilter.cpp
+            EpgChannelData.cpp)
 
 set(HEADERS Epg.h
             EpgContainer.h
             EpgDatabase.h
             EpgInfoTag.h
-            EpgSearchFilter.h)
+            EpgSearchFilter.h
+            EpgChannelData.h)
 
 core_add_library(pvr_epg)

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -481,32 +481,29 @@ bool CPVREpg::Update(const time_t start, const time_t end, int iUpdateTime, bool
   return bGrabSuccess;
 }
 
-int CPVREpg::Get(CFileItemList &results) const
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags() const
 {
-  int iInitialSize = results.Size();
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
 
   CSingleLock lock(m_critSection);
   for (const auto& tag : m_tags)
-    results.Add(std::make_shared<CFileItem>(tag.second));
+    tags.emplace_back(tag.second);
 
-  return results.Size() - iInitialSize;
+  return tags;
 }
 
-int CPVREpg::Get(CFileItemList &results, const CPVREpgSearchFilter &filter) const
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags(const CPVREpgSearchFilter& filter) const
 {
-  int iInitialSize = results.Size();
-
-  if (!HasValidEntries())
-    return -1;
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
 
   CSingleLock lock(m_critSection);
   for (const auto& tag : m_tags)
   {
     if (filter.FilterEntry(tag.second))
-      results.Add(std::make_shared<CFileItem>(tag.second));
+      tags.emplace_back(tag.second);
   }
 
-  return results.Size() - iInitialSize;
+  return tags;
 }
 
 bool CPVREpg::Persist(void)

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -506,12 +506,11 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags(const CPVREpgSearc
   return tags;
 }
 
-bool CPVREpg::Persist(void)
+bool CPVREpg::Persist(const std::shared_ptr<CPVREpgDatabase>& database)
 {
   if (CServiceBroker::GetPVRManager().EpgContainer().IgnoreDB() || !NeedsSave())
     return true;
 
-  const CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
   if (!database)
   {
     CLog::LogF(LOGERROR, "Could not open the EPG database");
@@ -537,7 +536,7 @@ bool CPVREpg::Persist(void)
       database->Delete(*tag.second);
 
     for (const auto& tag : m_changedTags)
-      tag.second->Persist(false);
+      tag.second->Persist(database, false);
 
     if (m_bUpdateLastScanTime)
       database->PersistLastEpgScanTime(m_iEpgID, true);

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -22,7 +22,6 @@
 #include "utils/log.h"
 
 #include "pvr/PVRManager.h"
-#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
@@ -91,7 +90,6 @@ void CPVREpg::Cleanup(const CDateTime &time)
         m_nowActiveStart.SetValid(false);
 
       it->second->ClearTimer();
-      it->second->ClearRecording();
       it = m_tags.erase(it);
     }
     else
@@ -297,7 +295,6 @@ void CPVREpg::AddEntry(const CPVREpgInfoTag &tag)
     newTag->SetChannel(channel);
     newTag->SetEpg(this);
     newTag->SetTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(newTag));
-    newTag->SetRecording(CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(newTag));
   }
 }
 
@@ -415,7 +412,6 @@ bool CPVREpg::UpdateEntry(const CPVREpgInfoTagPtr &tag, bool bUpdateDatabase)
   }
 
   infoTag->SetTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(infoTag));
-  infoTag->SetRecording(CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(infoTag));
 
   return true;
 }
@@ -454,7 +450,6 @@ bool CPVREpg::UpdateEntry(const CPVREpgInfoTagPtr &tag, EPG_EVENT_STATE newState
           m_deletedTags.insert(std::make_pair(it->second->UniqueBroadcastID(), it->second));
 
         it->second->ClearTimer();
-        it->second->ClearRecording();
         m_tags.erase(it);
       }
       else
@@ -643,7 +638,6 @@ bool CPVREpg::FixOverlappingEvents(bool bUpdateDb /* = false */)
         m_nowActiveStart.SetValid(false);
 
       it->second->ClearTimer();
-      it->second->ClearRecording();
       m_tags.erase(it++);
     }
     else if (previousTag->EndAsUTC() > currentTag->StartAsUTC())

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -478,20 +478,6 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags() const
   return tags;
 }
 
-std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags(const CPVREpgSearchFilter& filter) const
-{
-  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
-
-  CSingleLock lock(m_critSection);
-  for (const auto& tag : m_tags)
-  {
-    if (filter.FilterEntry(tag.second))
-      tags.emplace_back(tag.second);
-  }
-
-  return tags;
-}
-
 bool CPVREpg::Persist(const std::shared_ptr<CPVREpgDatabase>& database)
 {
   if (!database)

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -17,13 +17,14 @@
 #include "utils/Observer.h"
 
 #include "pvr/PVRTypes.h"
-#include "pvr/channels/PVRChannel.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/epg/EpgSearchFilter.h"
 
 /** EPG container for CPVREpgInfoTag instances */
 namespace PVR
 {
+  class CPVREpgChannelData;
+
   class CPVREpg : public Observable
   {
     friend class CPVREpgDatabase;
@@ -34,15 +35,17 @@ namespace PVR
      * @param iEpgID The ID of this table or <= 0 to create a new ID.
      * @param strName The name of this table.
      * @param strScraperName The name of the scraper to use.
-     * @param bLoadedFromDb True if this table was loaded from the database, false otherwise.
      */
-    CPVREpg(int iEpgID, const std::string &strName, const std::string &strScraperName, bool bLoadedFromDb);
+    CPVREpg(int iEpgID, const std::string& strName, const std::string& strScraperName);
 
     /*!
-     * @brief Create a new EPG instance for a channel.
-     * @param channel The channel to create the EPG for.
+     * @brief Create a new EPG instance.
+     * @param iEpgID The ID of this table or <= 0 to create a new ID.
+     * @param strName The name of this table.
+     * @param strScraperName The name of the scraper to use.
+     * @param channelData The channel data.
      */
-    CPVREpg(const CPVRChannelPtr &channel);
+    CPVREpg(int iEpgID, const std::string& strName, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData);
 
     /*!
      * @brief Destroy this EPG instance.
@@ -56,22 +59,22 @@ namespace PVR
     bool Load(void);
 
     /*!
-     * @brief The channel this EPG belongs to.
-     * @return The channel this EPG belongs to
+     * @brief Get data for the channel associated with this EPG.
+     * @return The data.
      */
-    CPVRChannelPtr Channel(void) const;
+    std::shared_ptr<CPVREpgChannelData> GetChannelData() const;
 
     /*!
-     * @brief The id of the channel this EPG belongs to.
-     * @return The channel id or -1 if no channel
+     * @brief Set data for the channel associated with this EPG.
+     * @param data The data.
+     */
+    void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
+
+    /*!
+     * @brief The id of the channel associated with this EPG.
+     * @return The channel id or -1 if no channel is associated
      */
     int ChannelID(void) const;
-
-    /*!
-     * @brief Channel the channel tag linked to this EPG table.
-     * @param channel The new channel tag.
-     */
-    void SetChannel(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Get the name of the scraper to use for this table.
@@ -317,12 +320,10 @@ namespace PVR
     std::string                         m_strName;         /*!< the name of this table */
     std::string                         m_strScraperName;  /*!< the name of the scraper to use */
     mutable CDateTime                   m_nowActiveStart;  /*!< the start time of the tag that is currently active */
-
     CDateTime                           m_lastScanTime;    /*!< the last time the EPG has been updated */
-
-    CPVRChannelPtr                      m_pvrChannel;      /*!< the channel this EPG belongs to */
-
     mutable CCriticalSection            m_critSection;     /*!< critical section for changes in this table */
     bool                                m_bUpdateLastScanTime = false;
+
+    std::shared_ptr<CPVREpgChannelData> m_channelData;
   };
 }

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -17,7 +17,6 @@
 
 #include "pvr/PVRTypes.h"
 #include "pvr/epg/EpgInfoTag.h"
-#include "pvr/epg/EpgSearchFilter.h"
 
 /** EPG container for CPVREpgInfoTag instances */
 namespace PVR
@@ -199,13 +198,6 @@ namespace PVR
      * @return The tags.
      */
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags() const;
-
-    /*!
-     * @brief Get all EPG tags matching the given filter.
-     * @param filter The filter to apply.
-     * @return The matching tags.
-     */
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags(const CPVREpgSearchFilter& filter) const;
 
     /*!
      * @brief Persist this table in the given database

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -154,14 +154,6 @@ namespace PVR
     CPVREpgInfoTagPtr GetTagBetween(const CDateTime &beginTime, const CDateTime &endTime, bool bUpdateFromClient = false);
 
     /*!
-     * @brief Get all events occurring between the given begin and end time.
-     * @param beginTime Minimum start time in UTC of the event.
-     * @param endTime Maximum end time in UTC of the event.
-     * @return The tags found or an empty vector if none was found.
-     */
-    std::vector<CPVREpgInfoTagPtr> GetTagsBetween(const CDateTime &beginTime, const CDateTime &endTime) const;
-
-    /*!
      * @brief Get the event matching the given unique broadcast id
      * @param iUniqueBroadcastId The uid to look up
      * @return The matching event or NULL if it wasn't found.

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "FileItem.h"
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
@@ -200,19 +199,17 @@ namespace PVR
     bool Update(const time_t start, const time_t end, int iUpdateTime, bool bForceUpdate = false);
 
     /*!
-     * @brief Get all EPG entries.
-     * @param results The file list to store the results in.
-     * @return The amount of entries that were added.
+     * @brief Get all EPG tags.
+     * @return The tags.
      */
-    int Get(CFileItemList &results) const;
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags() const;
 
     /*!
-     * @brief Get all EPG entries that and apply a filter.
-     * @param results The file list to store the results in.
+     * @brief Get all EPG tags matching the given filter.
      * @param filter The filter to apply.
-     * @return The amount of entries that were added.
+     * @return The matching tags.
      */
-    int Get(CFileItemList &results, const CPVREpgSearchFilter &filter) const;
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags(const CPVREpgSearchFilter& filter) const;
 
     /*!
      * @brief Persist this table in the database.

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -52,10 +52,11 @@ namespace PVR
     ~CPVREpg(void) override;
 
     /*!
-     * @brief Load all entries for this table from the database.
+     * @brief Load all entries for this table from the given database.
+     * @param database The database.
      * @return True if any entries were loaded, false otherwise.
      */
-    bool Load(void);
+    bool Load(const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
      * @brief Get data for the channel associated with this EPG.
@@ -111,17 +112,10 @@ namespace PVR
     bool HasValidEntries(void) const;
 
     /*!
-     * @brief Remove all entries from this EPG that finished before the given time
-     *        and that have no timers set.
+     * @brief Remove all entries from this EPG that finished before the given time.
      * @param time Delete entries with an end time before this time in UTC.
      */
     void Cleanup(const CDateTime &time);
-
-    /*!
-     * @brief Remove all entries from this EPG that finished before the given time
-     *        and that have no timers set.
-     */
-    void Cleanup(void);
 
     /*!
      * @brief Remove all entries from this EPG.
@@ -193,10 +187,12 @@ namespace PVR
      * @param start The start time.
      * @param end The end time.
      * @param iUpdateTime Update the table after the given amount of time has passed.
+     * @param iPastDays Amount of past days from now on, for which past entries are to be kept.
+     * @param database If given, the database to store the data.
      * @param bForceUpdate Force update from client even if it's not the time to
      * @return True if the update was successful, false otherwise.
      */
-    bool Update(const time_t start, const time_t end, int iUpdateTime, bool bForceUpdate = false);
+    bool Update(time_t start, time_t end, int iUpdateTime, int iPastDays, const std::shared_ptr<CPVREpgDatabase>& database, bool bForceUpdate = false);
 
     /*!
      * @brief Get all EPG tags.
@@ -229,12 +225,6 @@ namespace PVR
      * @return The last date in UTC.
      */
     CDateTime GetLastDate(void) const;
-
-    /*!
-     * @brief Get the time the EPG data were last updated.
-     * @return The last time this table was scanned.
-     */
-    CDateTime GetLastScanTime(void);
 
     /*!
      * @brief Notify observers when the currently active tag changed.
@@ -306,6 +296,12 @@ namespace PVR
      * @return True if the update was successful, false otherwise.
      */
     bool UpdateEntries(const CPVREpg &epg, bool bStoreInDb = true);
+
+    /*!
+     * @brief Remove all entries from this EPG that finished before the given amount of days.
+     * @param iPastDays Delete entries with an end time before the given amount of days from now on.
+     */
+    void Cleanup(int iPastDays);
 
     std::map<CDateTime, CPVREpgInfoTagPtr> m_tags;
     std::map<int, CPVREpgInfoTagPtr>       m_changedTags;

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -212,10 +212,11 @@ namespace PVR
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags(const CPVREpgSearchFilter& filter) const;
 
     /*!
-     * @brief Persist this table in the database.
+     * @brief Persist this table in the given database
+     * @param database The database.
      * @return True if the table was persisted, false otherwise.
      */
-    bool Persist(void);
+    bool Persist(const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
      * @brief Get the start time of the first entry in this table.

--- a/xbmc/pvr/epg/EpgChannelData.cpp
+++ b/xbmc/pvr/epg/EpgChannelData.cpp
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpgChannelData.h"
+
+#include "XBDateTime.h"
+
+#include "pvr/channels/PVRChannel.h"
+
+using namespace PVR;
+
+CPVREpgChannelData::CPVREpgChannelData(int iClientId, int iUniqueClientChannelId)
+: m_iClientId(iClientId),
+  m_iUniqueClientChannelId(iUniqueClientChannelId)
+{
+}
+
+CPVREpgChannelData::CPVREpgChannelData(const CPVRChannel& channel)
+: m_bIsRadio(channel.IsRadio()),
+  m_iClientId(channel.ClientID()),
+  m_iUniqueClientChannelId(channel.UniqueID()),
+  m_bIsHidden(channel.IsHidden()),
+  m_bIsLocked(channel.IsLocked()),
+  m_bIsEPGEnabled(channel.EPGEnabled()),
+  m_iChannelId(channel.ChannelID()),
+  m_strIconPath(channel.IconPath()),
+  m_strChannelName(channel.ChannelName()),
+  m_strSortableChannelNumber(channel.ChannelNumber().SortableChannelNumber())
+{
+  SetLastWatched(channel.LastWatched());
+}
+
+bool CPVREpgChannelData::IsRadio() const
+{
+  return m_bIsRadio;
+}
+
+int CPVREpgChannelData::ClientId() const
+{
+  return m_iClientId;
+}
+
+int CPVREpgChannelData::UniqueClientChannelId() const
+{
+  return m_iUniqueClientChannelId;
+}
+
+bool CPVREpgChannelData::IsHidden() const
+{
+  return m_bIsHidden;
+}
+
+void CPVREpgChannelData::SetHidden(bool bIsHidden)
+{
+  m_bIsHidden = bIsHidden;
+}
+
+bool CPVREpgChannelData::IsLocked() const
+{
+  return m_bIsLocked;
+}
+
+void CPVREpgChannelData::SetLocked(bool bIsLocked)
+{
+  m_bIsLocked = bIsLocked;
+}
+
+bool CPVREpgChannelData::IsEPGEnabled() const
+{
+  return m_bIsEPGEnabled;
+}
+
+void CPVREpgChannelData::SetEPGEnabled(bool bIsEPGEnabled)
+{
+  m_bIsEPGEnabled = bIsEPGEnabled;
+}
+
+int CPVREpgChannelData::ChannelId() const
+{
+  return m_iChannelId;
+}
+
+void CPVREpgChannelData::SetChannelId(int iChannelId)
+{
+  m_iChannelId = iChannelId;
+}
+
+const std::string& CPVREpgChannelData::IconPath() const
+{
+  return m_strIconPath;
+}
+
+void CPVREpgChannelData::SetIconPath(const std::string& strIconPath)
+{
+  m_strIconPath = strIconPath;
+}
+
+const std::string& CPVREpgChannelData::ChannelName() const
+{
+  return m_strChannelName;
+}
+
+void CPVREpgChannelData::SetChannelName(const std::string& strChannelName)
+{
+  m_strChannelName = strChannelName;
+}
+
+const std::string& CPVREpgChannelData::SortableChannelNumber() const
+{
+  return m_strSortableChannelNumber;
+}
+
+void CPVREpgChannelData::SetSortableChannelNumber(const std::string& strSortableChannelNumber)
+{
+  m_strSortableChannelNumber = strSortableChannelNumber;
+}
+
+const std::string& CPVREpgChannelData::LastWatched() const
+{
+  return m_strLastWatched;
+}
+
+void CPVREpgChannelData::SetLastWatched(time_t iLastWatched)
+{
+  const CDateTime lastWatched(iLastWatched);
+  if (lastWatched.IsValid())
+    m_strLastWatched = lastWatched.GetAsDBDateTime();
+  else
+    m_strLastWatched.clear();
+}

--- a/xbmc/pvr/epg/EpgChannelData.h
+++ b/xbmc/pvr/epg/EpgChannelData.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <ctime>
+#include <string>
+
+namespace PVR
+{
+  class CPVRChannel;
+
+  class CPVREpgChannelData
+  {
+  public:
+    CPVREpgChannelData() = default;
+    CPVREpgChannelData(int iClientId, int iUniqueClientChannelId);
+    explicit CPVREpgChannelData(const CPVRChannel& channel);
+
+    int ClientId() const;
+    int UniqueClientChannelId() const;
+    bool IsRadio() const;
+
+    bool IsHidden() const;
+    void SetHidden(bool bIsHidden);
+
+    bool IsLocked() const;
+    void SetLocked(bool bIsLocked);
+
+    bool IsEPGEnabled() const;
+    void SetEPGEnabled(bool bIsEPGEnabled);
+
+    int ChannelId() const;
+    void SetChannelId(int iChannelId);
+
+    const std::string& IconPath() const;
+    void SetIconPath(const std::string& strIconPath);
+
+    const std::string& ChannelName() const;
+    void SetChannelName(const std::string& strChannelName);
+
+    const std::string& SortableChannelNumber() const;
+    void SetSortableChannelNumber(const std::string& strSortableChannelNumber);
+
+    const std::string& LastWatched() const;
+    void SetLastWatched(time_t iLastWatched);
+
+  private:
+    const bool m_bIsRadio = false;
+    const int m_iClientId = -1;
+    const int m_iUniqueClientChannelId = -1;
+
+    bool m_bIsHidden = false;
+    bool m_bIsLocked = false;
+    bool m_bIsEPGEnabled = true;
+    int m_iChannelId = -1;
+    std::string m_strIconPath;
+    std::string m_strChannelName;
+    std::string m_strSortableChannelNumber;
+    std::string m_strLastWatched;
+  };
+}

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -457,7 +457,7 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::GetByChannelUid(int iClientId, int iC
     return epg;
 
   CSingleLock lock(m_critSection);
-  const auto &epgEntry = m_channelUidToEpgMap.find(std::pair<int, int>(iClientId, iChannelUid));
+  const auto& epgEntry = m_channelUidToEpgMap.find(std::pair<int, int>(iClientId, iChannelUid));
   if (epgEntry != m_channelUidToEpgMap.end())
     epg = epgEntry->second;
 
@@ -477,7 +477,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagById(const std::shared_p
   }
   else
   {
-    for (const auto &epgEntry : m_epgIdToEpgMap)
+    for (const auto& epgEntry : m_epgIdToEpgMap)
     {
       retval = epgEntry.second->GetTagByBroadcastId(iBroadcastId);
       if (retval)
@@ -519,7 +519,7 @@ void CPVREpgContainer::InsertFromDB(const CPVREpgPtr &newEpg)
   {
     // create a new epg table
     epg = newEpg;
-    m_epgIdToEpgMap.insert(std::make_pair(epg->EpgID(), epg));
+    m_epgIdToEpgMap.insert({epg->EpgID(), epg});
     SetChanged();
     epg->RegisterObserver(this);
   }
@@ -543,15 +543,15 @@ CPVREpgPtr CPVREpgContainer::CreateChannelEpg(int iEpgId, const std::string& str
     epg.reset(new CPVREpg(iEpgId, channelData->ChannelName(), strScraperName, channelData));
 
     CSingleLock lock(m_critSection);
-    m_epgIdToEpgMap.insert(std::make_pair(iEpgId, epg));
-    m_channelUidToEpgMap.insert(std::make_pair(std::make_pair(channelData->ClientId(), channelData->UniqueClientChannelId()), epg));
+    m_epgIdToEpgMap.insert({iEpgId, epg});
+    m_channelUidToEpgMap.insert({{channelData->ClientId(), channelData->UniqueClientChannelId()}, epg});
     SetChanged();
     epg->RegisterObserver(this);
   }
   else if (epg->ChannelID() == -1)
   {
     CSingleLock lock(m_critSection);
-    m_channelUidToEpgMap.insert(std::make_pair(std::make_pair(channelData->ClientId(), channelData->UniqueClientChannelId()), epg));
+    m_channelUidToEpgMap.insert({{channelData->ClientId(), channelData->UniqueClientChannelId()}, epg});
     epg->SetChannelData(channelData);
   }
 
@@ -572,7 +572,7 @@ bool CPVREpgContainer::RemoveOldEntries(void)
   const CDateTime cleanupTime(CDateTime::GetUTCDateTime() - CDateTimeSpan(GetPastDaysToDisplay(), 0, 0, 0));
 
   /* call Cleanup() on all known EPG tables */
-  for (const auto &epgEntry : m_epgIdToEpgMap)
+  for (const auto& epgEntry : m_epgIdToEpgMap)
     epgEntry.second->Cleanup(cleanupTime);
 
   /* remove the old entries from the database */
@@ -592,7 +592,7 @@ bool CPVREpgContainer::DeleteEpg(const CPVREpgPtr &epg, bool bDeleteFromDatabase
 
   CSingleLock lock(m_critSection);
 
-  const auto &epgEntry = m_epgIdToEpgMap.find(epg->EpgID());
+  const auto& epgEntry = m_epgIdToEpgMap.find(epg->EpgID());
   if (epgEntry == m_epgIdToEpgMap.end())
     return false;
 
@@ -674,7 +674,7 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   /* load or update all EPG tables */
   unsigned int iCounter = 0;
   const std::shared_ptr<CPVREpgDatabase> database = IgnoreDB() ? nullptr : GetEpgDatabase();
-  for (const auto &epgEntry : m_epgIdToEpgMap)
+  for (const auto& epgEntry : m_epgIdToEpgMap)
   {
     if (InterruptUpdate())
     {
@@ -793,7 +793,7 @@ bool CPVREpgContainer::CheckPlayingEvents(void)
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
   if (iNow >= iNextEpgActiveTagCheck)
   {
-    for (const auto &epgEntry : m_epgIdToEpgMap)
+    for (const auto& epgEntry : m_epgIdToEpgMap)
       bFoundChanges = epgEntry.second->CheckPlayingEvent() || bFoundChanges;
 
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNextEpgActiveTagCheck);

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -8,8 +8,6 @@
 
 #include "EpgContainer.h"
 
-#include <utility>
-
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
@@ -22,8 +20,8 @@
 
 #include "pvr/PVRManager.h"
 #include "pvr/PVRGUIProgressHandler.h"
-#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
+#include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgSearchFilter.h"
 
 namespace PVR
@@ -33,29 +31,22 @@ class CEpgUpdateRequest
 {
 public:
   CEpgUpdateRequest() : CEpgUpdateRequest(-1, PVR_CHANNEL_INVALID_UID) {}
-  CEpgUpdateRequest(int iClientID, unsigned int iUniqueChannelID) : m_iClientID(iClientID), m_iUniqueChannelID(iUniqueChannelID) {}
+  CEpgUpdateRequest(int iClientID, int iUniqueChannelID) : m_iClientID(iClientID), m_iUniqueChannelID(iUniqueChannelID) {}
 
   void Deliver();
 
 private:
   int m_iClientID;
-  unsigned int m_iUniqueChannelID;
+  int m_iUniqueChannelID;
 };
 
 void CEpgUpdateRequest::Deliver()
 {
-  const CPVRChannelPtr channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetByUniqueID(m_iUniqueChannelID, m_iClientID);
-  if (!channel)
-  {
-    CLog::LogF(LOGERROR, "Invalid channel (%d)! Unable to deliver the epg update!", m_iUniqueChannelID);
-    return;
-  }
-
-  const CPVREpgPtr epg = channel->GetEPG();
+  const std::shared_ptr<CPVREpg> epg = CServiceBroker::GetPVRManager().EpgContainer().GetByChannelUid(m_iClientID, m_iUniqueChannelID);
   if (!epg)
   {
-    CLog::LogF(LOGERROR, "Channel '%s' does not have an EPG! Unable to deliver the epg update!", 
-               channel->ChannelName().c_str());
+    CLog::LogF(LOGERROR, "Unable to obtain EPG for client %d and channel %d! Unable to deliver the epg update request!",
+               m_iClientID, m_iUniqueChannelID);
     return;
   }
 
@@ -77,25 +68,27 @@ private:
 
 void CEpgTagStateChange::Deliver()
 {
-  const CPVRChannelPtr channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetByUniqueID(m_epgtag->UniqueChannelID(), m_epgtag->ClientID());
-  if (!channel)
+  const std::shared_ptr<CPVREpg> epg = CServiceBroker::GetPVRManager().EpgContainer().GetByChannelUid(m_epgtag->ClientID(), m_epgtag->UniqueChannelID());
+  if (!epg)
   {
-    CLog::LogF(LOGERROR, "Invalid channel (%d)! Unable to deliver state change for tag '%d'!",
-               m_epgtag->UniqueChannelID(), m_epgtag->UniqueBroadcastID());
+    CLog::LogF(LOGERROR, "Unable to obtain EPG for client %d and channel %d! Unable to deliver state change for tag '%d'!",
+               m_epgtag->ClientID(), m_epgtag->UniqueChannelID(), m_epgtag->UniqueBroadcastID());
     return;
   }
 
-  const CPVREpgPtr epg = channel->GetEPG();
-  if (!epg)
+  if (m_epgtag->EpgID() < 0)
   {
-    CLog::LogF(LOGERROR, "Channel '%s' does not have an EPG! Unable to deliver state change for tag '%d'!",
-                channel->ChannelName().c_str(), m_epgtag->UniqueBroadcastID());
-    return;
+    // now that we have the epg instance, fully initialize the tag
+    m_epgtag->SetEpgID(epg->EpgID());
+    m_epgtag->SetChannelData(epg->GetChannelData());
   }
 
   // update
   if (!epg->UpdateEntry(m_epgtag, m_state, false))
-    CLog::LogF(LOGERROR, "Update failed for epgtag change for channel '%s'", channel->ChannelName().c_str());
+    CLog::LogF(LOGWARNING, "State update failed for epgtag (%s | %s | %s | %s | %s)",
+               m_state == EPG_EVENT_DELETED ? "DELETED" : m_state == EPG_EVENT_UPDATED ? "UPDTAED" : m_state == EPG_EVENT_CREATED ? "CREATED" : "UNKNOWN",
+               epg->GetChannelData()->ChannelName().c_str(), m_epgtag->StartAsLocalTime().GetAsDBDateTime(), m_epgtag->EndAsLocalTime().GetAsDBDateTime(),
+               m_epgtag->Title().c_str());
 }
 
 CPVREpgContainer::CPVREpgContainer(void) :
@@ -134,7 +127,7 @@ bool CPVREpgContainer::IsStarted(void) const
   return m_bStarted;
 }
 
-unsigned int CPVREpgContainer::NextEpgId(void)
+int CPVREpgContainer::NextEpgId(void)
 {
   CSingleLock lock(m_critSection);
   return ++m_iNextEpgId;
@@ -150,10 +143,11 @@ void CPVREpgContainer::Clear()
   {
     CSingleLock lock(m_critSection);
     /* clear all epg tables and remove pointers to epg tables on channels */
-    for (const auto &epgEntry : m_epgs)
+    for (const auto &epgEntry : m_epgIdToEpgMap)
       epgEntry.second->UnregisterObserver(this);
 
-    m_epgs.clear();
+    m_epgIdToEpgMap.clear();
+    m_channelUidToEpgMap.clear();
     m_iNextEpgUpdate  = 0;
     m_bStarted = false;
     m_bIsInitialising = true;
@@ -280,12 +274,12 @@ void CPVREpgContainer::LoadFromDB(void)
   for (const auto& entry : result)
     InsertFromDB(entry);
 
-  for (const auto &epgEntry : m_epgs)
+  for (const auto &epgEntry : m_epgIdToEpgMap)
   {
     if (m_bStop)
       break;
 
-    progressHandler->UpdateProgress(epgEntry.second->Name(), ++iCounter, m_epgs.size());
+    progressHandler->UpdateProgress(epgEntry.second->Name(), ++iCounter, m_epgIdToEpgMap.size());
 
     lock.Leave();
     epgEntry.second->Load();
@@ -302,7 +296,7 @@ bool CPVREpgContainer::PersistAll(void)
   bool bReturn = true;
 
   m_critSection.lock();
-  const auto epgs = m_epgs;
+  const auto epgs = m_epgIdToEpgMap;
   m_critSection.unlock();
 
   for (const auto& epg : epgs)
@@ -438,29 +432,42 @@ CPVREpgPtr CPVREpgContainer::GetById(int iEpgId) const
     return retval;
 
   CSingleLock lock(m_critSection);
-  const auto &epgEntry = m_epgs.find(static_cast<unsigned int>(iEpgId));
-  if (epgEntry != m_epgs.end())
+  const auto &epgEntry = m_epgIdToEpgMap.find(iEpgId);
+  if (epgEntry != m_epgIdToEpgMap.end())
     retval = epgEntry->second;
 
   return retval;
 }
 
-CPVREpgInfoTagPtr CPVREpgContainer::GetTagById(const CPVRChannelPtr &channel, unsigned int iBroadcastId) const
+std::shared_ptr<CPVREpg> CPVREpgContainer::GetByChannelUid(int iClientId, int iChannelUid) const
+{
+  std::shared_ptr<CPVREpg> epg;
+
+  if (iClientId < 0 || iChannelUid < 0)
+    return epg;
+
+  CSingleLock lock(m_critSection);
+  const auto &epgEntry = m_channelUidToEpgMap.find(std::pair<int, int>(iClientId, iChannelUid));
+  if (epgEntry != m_channelUidToEpgMap.end())
+    epg = epgEntry->second;
+
+  return epg;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagById(const std::shared_ptr<CPVREpg>& epg, unsigned int iBroadcastId) const
 {
   CPVREpgInfoTagPtr retval;
 
   if (iBroadcastId == EPG_TAG_INVALID_UID)
     return retval;
 
-  if (channel)
+  if (epg)
   {
-    const CPVREpgPtr epg = channel->GetEPG();
-    if (epg)
-      retval = epg->GetTagByBroadcastId(iBroadcastId);
+    retval = epg->GetTagByBroadcastId(iBroadcastId);
   }
   else
   {
-    for (const auto &epgEntry : m_epgs)
+    for (const auto &epgEntry : m_epgIdToEpgMap)
     {
       retval = epgEntry.second->GetTagByBroadcastId(iBroadcastId);
       if (retval)
@@ -488,38 +495,41 @@ void CPVREpgContainer::InsertFromDB(const CPVREpgPtr &newEpg)
   {
     // create a new epg table
     epg = newEpg;
-    m_epgs.insert(std::make_pair(epg->EpgID(), epg));
+    m_epgIdToEpgMap.insert(std::make_pair(epg->EpgID(), epg));
     SetChanged();
     epg->RegisterObserver(this);
   }
 }
 
-CPVREpgPtr CPVREpgContainer::CreateChannelEpg(const CPVRChannelPtr &channel)
+CPVREpgPtr CPVREpgContainer::CreateChannelEpg(int iEpgId, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData)
 {
   CPVREpgPtr epg;
-  if (!channel)
-    return epg;
 
   WaitForUpdateFinish();
   LoadFromDB();
 
-  if (channel->EpgID() > 0)
-    epg = GetById(channel->EpgID());
+  if (iEpgId > 0)
+    epg = GetById(iEpgId);
 
   if (!epg)
   {
-    if (channel->EpgID() <= 0)
-      channel->SetEpgID(NextEpgId());
+    if (iEpgId <= 0)
+      iEpgId = NextEpgId();
 
-    epg.reset(new CPVREpg(channel));
+    epg.reset(new CPVREpg(iEpgId, channelData->ChannelName(), strScraperName, channelData));
 
     CSingleLock lock(m_critSection);
-    m_epgs.insert(std::make_pair(static_cast<unsigned int>(epg->EpgID()), epg));
+    m_epgIdToEpgMap.insert(std::make_pair(iEpgId, epg));
+    m_channelUidToEpgMap.insert(std::make_pair(std::make_pair(channelData->ClientId(), channelData->UniqueClientChannelId()), epg));
     SetChanged();
     epg->RegisterObserver(this);
   }
-
-  epg->SetChannel(channel);
+  else if (epg->ChannelID() == -1)
+  {
+    CSingleLock lock(m_critSection);
+    m_channelUidToEpgMap.insert(std::make_pair(std::make_pair(channelData->ClientId(), channelData->UniqueClientChannelId()), epg));
+    epg->SetChannelData(channelData);
+  }
 
   {
     CSingleLock lock(m_critSection);
@@ -538,7 +548,7 @@ bool CPVREpgContainer::RemoveOldEntries(void)
   const CDateTime cleanupTime(CDateTime::GetUTCDateTime() - CDateTimeSpan(GetPastDaysToDisplay(), 0, 0, 0));
 
   /* call Cleanup() on all known EPG tables */
-  for (const auto &epgEntry : m_epgs)
+  for (const auto &epgEntry : m_epgIdToEpgMap)
     epgEntry.second->Cleanup(cleanupTime);
 
   /* remove the old entries from the database */
@@ -558,16 +568,21 @@ bool CPVREpgContainer::DeleteEpg(const CPVREpgPtr &epg, bool bDeleteFromDatabase
 
   CSingleLock lock(m_critSection);
 
-  const auto &epgEntry = m_epgs.find(static_cast<unsigned int>(epg->EpgID()));
-  if (epgEntry == m_epgs.end())
+  const auto &epgEntry = m_epgIdToEpgMap.find(epg->EpgID());
+  if (epgEntry == m_epgIdToEpgMap.end())
     return false;
+
+  const auto& epgEntry1 = m_channelUidToEpgMap.find(std::make_pair(epg->GetChannelData()->ClientId(),
+                                                                   epg->GetChannelData()->UniqueClientChannelId()));
+  if (epgEntry1 != m_channelUidToEpgMap.end())
+    m_channelUidToEpgMap.erase(epgEntry1);
 
   CLog::LogFC(LOGDEBUG, LOGEPG, "Deleting EPG table %s (%d)", epg->Name().c_str(), epg->EpgID());
   if (bDeleteFromDatabase && !IgnoreDB())
     m_database->Delete(*epgEntry->second);
 
   epgEntry->second->UnregisterObserver(this);
-  m_epgs.erase(epgEntry);
+  m_epgIdToEpgMap.erase(epgEntry);
 
   return true;
 }
@@ -634,7 +649,7 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
 
   /* load or update all EPG tables */
   unsigned int iCounter = 0;
-  for (const auto &epgEntry : m_epgs)
+  for (const auto &epgEntry : m_epgIdToEpgMap)
   {
     if (InterruptUpdate())
     {
@@ -647,19 +662,7 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
       continue;
 
     if (bShowProgress && !bOnlyPending)
-      progressHandler->UpdateProgress(epg->Name(), ++iCounter, m_epgs.size());
-
-    // we currently only support update via pvr add-ons. skip update when the pvr manager isn't started
-    if (!CServiceBroker::GetPVRManager().IsStarted())
-      continue;
-
-    // check the pvr manager when the channel pointer isn't set
-    if (!epg->Channel())
-    {
-      const CPVRChannelPtr channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelByEpgId(epg->EpgID());
-      if (channel)
-        epg->SetChannel(channel);
-    }
+      progressHandler->UpdateProgress(epg->Name(), ++iCounter, m_epgIdToEpgMap.size());
 
     if ((!bOnlyPending || epg->UpdatePending()) &&
         epg->Update(start, end, m_settings.GetIntValue(CSettings::SETTING_EPG_EPGUPDATE) * 60, bOnlyPending))
@@ -714,7 +717,7 @@ const CDateTime CPVREpgContainer::GetFirstEPGDate(void)
   CDateTime returnValue;
 
   m_critSection.lock();
-  const auto epgs = m_epgs;
+  const auto epgs = m_epgIdToEpgMap;
   m_critSection.unlock();
 
   for (const auto &epgEntry : epgs)
@@ -732,7 +735,7 @@ const CDateTime CPVREpgContainer::GetLastEPGDate(void)
   CDateTime returnValue;
 
   m_critSection.lock();
-  const auto epgs = m_epgs;
+  const auto epgs = m_epgIdToEpgMap;
   m_critSection.unlock();
 
   for (const auto &epgEntry : epgs)
@@ -752,7 +755,7 @@ int CPVREpgContainer::GetEPGSearch(CFileItemList &results, const CPVREpgSearchFi
   /* get filtered results from all tables */
   {
     CSingleLock lock(m_critSection);
-    for (const auto &epgEntry : m_epgs)
+    for (const auto &epgEntry : m_epgIdToEpgMap)
       epgEntry.second->Get(results, filter);
   }
 
@@ -778,7 +781,7 @@ bool CPVREpgContainer::CheckPlayingEvents(void)
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
   if (iNow >= iNextEpgActiveTagCheck)
   {
-    for (const auto &epgEntry : m_epgs)
+    for (const auto &epgEntry : m_epgIdToEpgMap)
       bFoundChanges = epgEntry.second->CheckPlayingEvent() || bFoundChanges;
 
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNextEpgActiveTagCheck);
@@ -815,7 +818,7 @@ void CPVREpgContainer::SetHasPendingUpdates(bool bHasPendingUpdates /* = true */
     m_pendingUpdates = 0;
 }
 
-void CPVREpgContainer::UpdateRequest(int iClientID, unsigned int iUniqueChannelID)
+void CPVREpgContainer::UpdateRequest(int iClientID, int iUniqueChannelID)
 {
   CSingleLock lock(m_updateRequestsLock);
   m_updateRequests.emplace_back(CEpgUpdateRequest(iClientID, iUniqueChannelID));

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -748,22 +748,23 @@ const CDateTime CPVREpgContainer::GetLastEPGDate(void)
   return returnValue;
 }
 
-int CPVREpgContainer::GetEPGSearch(CFileItemList &results, const CPVREpgSearchFilter &filter)
+const std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetEPGSearch(const CPVREpgSearchFilter &filter)
 {
-  int iInitialSize = results.Size();
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
 
-  /* get filtered results from all tables */
   {
     CSingleLock lock(m_critSection);
     for (const auto &epgEntry : m_epgIdToEpgMap)
-      epgEntry.second->Get(results, filter);
+    {
+      const std::vector<std::shared_ptr<CPVREpgInfoTag>> epgTags = epgEntry.second->GetTags(filter);
+      tags.insert(tags.end(), epgTags.begin(), epgTags.end());
+    }
   }
 
-  /* remove duplicate entries */
   if (filter.ShouldRemoveDuplicates())
-    filter.RemoveDuplicates(results);
+    filter.RemoveDuplicates(tags);
 
-  return results.Size() - iInitialSize;
+  return tags;
 }
 
 bool CPVREpgContainer::CheckPlayingEvents(void)

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -302,7 +302,7 @@ bool CPVREpgContainer::PersistAll(void)
   for (const auto& epg : epgs)
   {
     if (epg.second && epg.second->NeedsSave())
-      bReturn &= epg.second->Persist();
+      bReturn &= epg.second->Persist(GetEpgDatabase());
   }
 
   return bReturn;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -273,7 +273,7 @@ void CPVREpgContainer::LoadFromDB(void)
   m_database->Lock();
   m_iNextEpgId = m_database->GetLastEPGId();
   m_database->DeleteEpgEntries(cleanupTime);
-  const std::vector<CPVREpgPtr> result = m_database->Get(*this);
+  const std::vector<std::shared_ptr<CPVREpg>> result = m_database->GetAll();
   m_database->Unlock();
 
   for (const auto& entry : result)

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -25,7 +25,6 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgSearchFilter.h"
-#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 
 namespace PVR

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -25,7 +25,6 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgSearchFilter.h"
-#include "pvr/timers/PVRTimerInfoTag.h"
 
 namespace PVR
 {
@@ -470,22 +469,6 @@ CPVREpgInfoTagPtr CPVREpgContainer::GetTagById(const CPVRChannelPtr &channel, un
   }
 
   return retval;
-}
-
-std::vector<CPVREpgInfoTagPtr> CPVREpgContainer::GetEpgTagsForTimer(const CPVRTimerInfoTagPtr &timer) const
-{
-  CPVRChannelPtr channel = timer->Channel();
-
-  if (!channel)
-    channel = timer->UpdateChannel();
-
-  if (channel)
-  {
-    const CPVREpgPtr epg = channel->GetEPG();
-    if (epg)
-      return epg->GetTagsBetween(timer->StartAsUTC(), timer->EndAsUTC());
-  }
-  return std::vector<CPVREpgInfoTagPtr>();
 }
 
 void CPVREpgContainer::InsertFromDB(const CPVREpgPtr &newEpg)

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -488,6 +488,20 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagById(const std::shared_p
   return retval;
 }
 
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetAllTags() const
+{
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> allTags;
+
+  CSingleLock lock(m_critSection);
+  for (const auto& epgEntry : m_epgIdToEpgMap)
+  {
+    const std::vector<std::shared_ptr<CPVREpgInfoTag>> epgTags = epgEntry.second->GetTags();
+    allTags.insert(allTags.end(), epgTags.begin(), epgTags.end());
+  }
+
+  return allTags;
+}
+
 void CPVREpgContainer::InsertFromDB(const CPVREpgPtr &newEpg)
 {
   // table might already have been created when pvr channels were loaded
@@ -762,25 +776,6 @@ const CDateTime CPVREpgContainer::GetLastEPGDate(void)
   }
 
   return returnValue;
-}
-
-const std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetEPGSearch(const CPVREpgSearchFilter &filter)
-{
-  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
-
-  {
-    CSingleLock lock(m_critSection);
-    for (const auto &epgEntry : m_epgIdToEpgMap)
-    {
-      const std::vector<std::shared_ptr<CPVREpgInfoTag>> epgTags = epgEntry.second->GetTags(filter);
-      tags.insert(tags.end(), epgTags.begin(), epgTags.end());
-    }
-  }
-
-  if (filter.ShouldRemoveDuplicates())
-    filter.RemoveDuplicates(tags);
-
-  return tags;
 }
 
 bool CPVREpgContainer::CheckPlayingEvents(void)

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -99,13 +99,6 @@ namespace PVR
     std::shared_ptr<CPVREpg> CreateChannelEpg(int iEpgId, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData);
 
     /*!
-     * @brief Get all EPG tags matching the given filter.
-     * @param filter The filter to apply.
-     * @return The matching tags.
-     */
-    const std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGSearch(const CPVREpgSearchFilter &filter);
-
-    /*!
      * @brief Get the start time of the first entry.
      * @return The start time.
      */
@@ -139,6 +132,12 @@ namespace PVR
      * @return The requested event, or an empty tag when not found
      */
     std::shared_ptr<CPVREpgInfoTag> GetTagById(const std::shared_ptr<CPVREpg>& epg, unsigned int iBroadcastId) const;
+
+    /*!
+     * @brief Get all EPG tags.
+     * @return The tags.
+     */
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllTags() const;
 
     /*!
      * @brief Check whether data should be persisted to the EPG database.

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -10,6 +10,7 @@
 
 #include <list>
 #include <map>
+#include <memory>
 #include <utility>
 
 #include "XBDateTime.h"
@@ -22,7 +23,7 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgDatabase.h"
 
-class CFileItemList;
+class CFileItem;
 
 namespace PVR
 {
@@ -98,12 +99,11 @@ namespace PVR
     std::shared_ptr<CPVREpg> CreateChannelEpg(int iEpgId, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData);
 
     /*!
-     * @brief Get all EPG tables and apply a filter.
-     * @param results The fileitem list to store the results in.
+     * @brief Get all EPG tags matching the given filter.
      * @param filter The filter to apply.
-     * @return The amount of entries that were added.
+     * @return The matching tags.
      */
-    int GetEPGSearch(CFileItemList &results, const CPVREpgSearchFilter &filter);
+    const std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGSearch(const CPVREpgSearchFilter &filter);
 
     /*!
      * @brief Get the start time of the first entry.
@@ -182,13 +182,13 @@ namespace PVR
      * @brief Inform the epg container that playback of an item just started.
      * @param item The item that started to play.
      */
-    void OnPlaybackStarted(const CFileItemPtr &item);
+    void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
 
     /*!
      * @brief Inform the epg container that playback of an item was stopped due to user interaction.
      * @param item The item that stopped to play.
      */
-    void OnPlaybackStopped(const CFileItemPtr &item);
+    void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
 
   private:
     /*!

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -126,13 +126,6 @@ namespace PVR
     CPVREpgInfoTagPtr GetTagById(const CPVRChannelPtr &channel, unsigned int iBroadcastId) const;
 
     /*!
-     * @brief Get the EPG events matching the given timer
-     * @param timer The timer to get the matching events for.
-     * @return The matching events, or an empty vector when no matching tag was found
-     */
-    std::vector<CPVREpgInfoTagPtr> GetEpgTagsForTimer(const CPVRTimerInfoTagPtr &timer) const;
-
-    /*!
      * @brief Check whether data should be persisted to the EPG database.
      * @return True if data should not be persisted to the EPG database, false otherwise.
      */

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -213,7 +213,7 @@ std::vector<CPVREpgPtr> CPVREpgDatabase::Get(const CPVREpgContainer &container)
         std::string strName        = m_pDS->fv("sName").get_asString().c_str();
         std::string strScraperName = m_pDS->fv("sScraperName").get_asString().c_str();
 
-        result.emplace_back(new CPVREpg(iEpgID, strName, strScraperName, true));
+        result.emplace_back(new CPVREpg(iEpgID, strName, strScraperName));
         m_pDS->next();
       }
       m_pDS->close();
@@ -359,7 +359,7 @@ int CPVREpgDatabase::Persist(const CPVREpgInfoTag &tag, bool bSingleUpdate /* = 
 
   if (tag.EpgID() <= 0)
   {
-    CLog::LogF(LOGERROR, "Tag '%s' does not have a valid table", tag.Title(true).c_str());
+    CLog::LogF(LOGERROR, "Tag '%s' does not have a valid table", tag.Title().c_str());
     return iReturn;
   }
 
@@ -384,12 +384,12 @@ int CPVREpgDatabase::Persist(const CPVREpgInfoTag &tag, bool bSingleUpdate /* = 
         "iEpisodeId, iEpisodePart, sEpisodeName, iFlags, sSeriesLink, iBroadcastUid) "
         "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, '%s', %i);",
         tag.EpgID(), static_cast<unsigned int>(iStartTime), static_cast<unsigned int>(iEndTime),
-        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(),
-        tag.OriginalTitle(true).c_str(), tag.DeTokenize(tag.Cast()).c_str(), tag.DeTokenize(tag.Directors()).c_str(),
+        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(),
+        tag.OriginalTitle().c_str(), tag.DeTokenize(tag.Cast()).c_str(), tag.DeTokenize(tag.Directors()).c_str(),
         tag.DeTokenize(tag.Writers()).c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         static_cast<unsigned int>(iFirstAired), tag.ParentalRating(), tag.StarRating(), tag.Notify(),
-        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName(true).c_str(), tag.Flags(), tag.SeriesLink().c_str(),
+        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(), tag.Flags(), tag.SeriesLink().c_str(),
         tag.UniqueBroadcastID());
   }
   else
@@ -400,12 +400,12 @@ int CPVREpgDatabase::Persist(const CPVREpgInfoTag &tag, bool bSingleUpdate /* = 
         "iEpisodeId, iEpisodePart, sEpisodeName, iFlags, sSeriesLink, iBroadcastUid, idBroadcast) "
         "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i, %i, %i, %i, '%s', %i, '%s', %i, %i);",
         tag.EpgID(), static_cast<unsigned int>(iStartTime), static_cast<unsigned int>(iEndTime),
-        tag.Title(true).c_str(), tag.PlotOutline(true).c_str(), tag.Plot(true).c_str(),
-        tag.OriginalTitle(true).c_str(), tag.DeTokenize(tag.Cast()).c_str(), tag.DeTokenize(tag.Directors()).c_str(),
+        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(),
+        tag.OriginalTitle().c_str(), tag.DeTokenize(tag.Cast()).c_str(), tag.DeTokenize(tag.Directors()).c_str(),
         tag.DeTokenize(tag.Writers()).c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         static_cast<unsigned int>(iFirstAired), tag.ParentalRating(), tag.StarRating(), tag.Notify(),
-        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName(true).c_str(), tag.Flags(), tag.SeriesLink().c_str(),
+        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(), tag.Flags(), tag.SeriesLink().c_str(),
         tag.UniqueBroadcastID(), iBroadcastId);
   }
 

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -317,11 +317,11 @@ bool CPVREpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime *lastScan)
   return bReturn;
 }
 
-bool CPVREpgDatabase::PersistLastEpgScanTime(int iEpgId /* = 0 */, bool bQueueWrite /* = false */)
+bool CPVREpgDatabase::PersistLastEpgScanTime(int iEpgId, const CDateTime& lastScanTime, bool bQueueWrite /* = false */)
 {
   CSingleLock lock(m_critSection);
   std::string strQuery = PrepareSQL("REPLACE INTO lastepgscan(idEpg, sLastScan) VALUES (%u, '%s');",
-      iEpgId, CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsDBDateTime().c_str());
+      iEpgId, lastScanTime.GetAsDBDateTime().c_str());
 
   return bQueueWrite ? QueueInsertQuery(strQuery) : ExecuteQuery(strQuery);
 }

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -8,16 +8,15 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "dbwrappers/Database.h"
 #include "threads/CriticalSection.h"
 
-#include "pvr/epg/Epg.h"
+class CDateTime;
 
 namespace PVR
 {
+  class CPVREpg;
   class CPVREpgInfoTag;
-  class CPVREpgContainer;
 
   /** The EPG database */
 
@@ -99,17 +98,16 @@ namespace PVR
 
     /*!
      * @brief Get all EPG tables from the database. Does not get the EPG tables' entries.
-     * @param container The container to get the EPG tables for.
      * @return The entries.
      */
-    std::vector<CPVREpgPtr> Get(const CPVREpgContainer &container);
+    std::vector<std::shared_ptr<CPVREpg>> GetAll();
 
     /*!
      * @brief Get all EPG entries for a table.
      * @param epg The EPG table to get the entries for.
      * @return The entries.
      */
-    std::vector<CPVREpgInfoTagPtr> Get(const CPVREpg &epg);
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> Get(const CPVREpg &epg);
 
     /*!
      * @brief Get the last stored EPG scan time.

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -121,11 +121,12 @@ namespace PVR
 
     /*!
      * @brief Update the last scan time.
-     * @param iEpgId The table to update the time for. Use 0 for a global value.
+     * @param iEpgId The table to update the time for.
+     * @param lastScanTime The time to write to the database.
      * @param bQueueWrite Don't execute the query immediately but queue it if true.
      * @return True if it was updated successfully, false otherwise.
      */
-    bool PersistLastEpgScanTime(int iEpgId = 0, bool bQueueWrite = false);
+    bool PersistLastEpgScanTime(int iEpgId, const CDateTime& lastScanTime, bool bQueueWrite = false);
 
     /*!
      * @brief Persist an EPG table. It's entries are not persisted.

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -24,7 +24,6 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgDatabase.h"
-#include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
 
@@ -160,8 +159,8 @@ void CPVREpgInfoTag::Serialize(CVariant &value) const
   value["episodename"] = m_strEpisodeName;
   value["episodenum"] = m_iEpisodeNumber;
   value["episodepart"] = m_iEpisodePart;
-  value["hastimer"] = HasTimer();
-  value["hastimerrule"] = HasTimerRule();
+  value["hastimer"] = false; // compat
+  value["hastimerrule"] = false; // compat
   value["hasrecording"] = false; // compat
   value["recording"] = ""; // compat
   value["isactive"] = IsActive();
@@ -524,24 +523,6 @@ std::string CPVREpgInfoTag::Path(void) const
   return m_strFileNameAndPath;
 }
 
-bool CPVREpgInfoTag::HasTimer(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_timer != nullptr;
-}
-
-bool CPVREpgInfoTag::HasTimerRule(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_timer && (m_timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT);
-}
-
-CPVRTimerInfoTagPtr CPVREpgInfoTag::Timer(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_timer;
-}
-
 void CPVREpgInfoTag::SetChannel(const CPVRChannelPtr &channel)
 {
   CSingleLock lock(m_critSection);
@@ -704,24 +685,6 @@ void CPVREpgInfoTag::UpdatePath(void)
 int CPVREpgInfoTag::EpgID(void) const
 {
   return m_epg ? m_epg->EpgID() : -1;
-}
-
-void CPVREpgInfoTag::SetTimer(const CPVRTimerInfoTagPtr &timer)
-{
-  CSingleLock lock(m_critSection);
-  m_timer = timer;
-}
-
-void CPVREpgInfoTag::ClearTimer(void)
-{
-  CPVRTimerInfoTagPtr previousTag;
-  {
-    CSingleLock lock(m_critSection);
-    previousTag = std::move(m_timer);
-  }
-
-  if (previousTag)
-    previousTag->ClearEpgTag();
 }
 
 bool CPVREpgInfoTag::IsRecordable(void) const

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -136,8 +136,6 @@ bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
 
 void CPVREpgInfoTag::Serialize(CVariant &value) const
 {
-  const CPVRRecordingPtr recording = Recording();
-
   value["broadcastid"] = m_iUniqueBroadcastID;
   value["channeluid"] = m_iUniqueChannelID;
   value["parentalrating"] = m_iParentalRating;
@@ -164,8 +162,8 @@ void CPVREpgInfoTag::Serialize(CVariant &value) const
   value["episodepart"] = m_iEpisodePart;
   value["hastimer"] = HasTimer();
   value["hastimerrule"] = HasTimerRule();
-  value["hasrecording"] = HasRecording();
-  value["recording"] = recording ? recording->m_strFileNameAndPath : "";
+  value["hasrecording"] = false; // compat
+  value["recording"] = ""; // compat
   value["isactive"] = IsActive();
   value["wasactive"] = WasActive();
   value["isseries"] = IsSeries();
@@ -724,30 +722,6 @@ void CPVREpgInfoTag::ClearTimer(void)
 
   if (previousTag)
     previousTag->ClearEpgTag();
-}
-
-void CPVREpgInfoTag::SetRecording(const CPVRRecordingPtr &recording)
-{
-  CSingleLock lock(m_critSection);
-  m_recording = recording;
-}
-
-void CPVREpgInfoTag::ClearRecording(void)
-{
-  CSingleLock lock(m_critSection);
-  m_recording.reset();
-}
-
-bool CPVREpgInfoTag::HasRecording(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_recording != nullptr;
-}
-
-CPVRRecordingPtr CPVREpgInfoTag::Recording(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_recording;
 }
 
 bool CPVREpgInfoTag::IsRecordable(void) const

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -12,9 +12,7 @@
 #include "addons/PVRClient.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "cores/DataCacheCore.h"
-#include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -22,37 +20,60 @@
 
 #include "pvr/PVRManager.h"
 #include "pvr/epg/Epg.h"
+#include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgDatabase.h"
 
 using namespace PVR;
 
-CPVREpgInfoTag::CPVREpgInfoTag(const CPVRChannelPtr &channel, CPVREpg *epg /* = nullptr */, const std::string &strTableName /* = "" */)
-: m_iClientId(channel ? channel->ClientID() : -1),
-  m_iUniqueChannelID(channel ? channel->UniqueID() : PVR_CHANNEL_INVALID_UID),
-  m_strIconPath(channel ? channel->IconPath() : ""),
-  m_epg(epg),
-  m_channel(channel)
+CPVREpgInfoTag::CPVREpgInfoTag()
+: m_channelData(new CPVREpgChannelData)
 {
+}
+
+CPVREpgInfoTag::CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData, int iEpgID)
+: m_iEpgID(iEpgID)
+{
+  if (channelData)
+    m_channelData = channelData;
+  else
+    m_channelData = std::make_shared<CPVREpgChannelData>();
+
   UpdatePath();
 }
 
-CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG &data, int iClientId)
+CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data, int iClientId, const std::shared_ptr<CPVREpgChannelData>& channelData, int iEpgID)
 : m_bNotify(data.bNotify),
-  m_iClientId(iClientId),
   m_iParentalRating(data.iParentalRating),
   m_iStarRating(data.iStarRating),
   m_iSeriesNumber(data.iSeriesNumber),
   m_iEpisodeNumber(data.iEpisodeNumber),
   m_iEpisodePart(data.iEpisodePartNumber),
   m_iUniqueBroadcastID(data.iUniqueBroadcastId),
-  m_iUniqueChannelID(data.iUniqueChannelId),
   m_iYear(data.iYear),
   m_startTime(data.startTime + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
   m_endTime(data.endTime + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
   m_firstAired(data.firstAired + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection),
-  m_iFlags(data.iFlags)
+  m_iFlags(data.iFlags),
+  m_iEpgID(iEpgID)
 {
+  if (channelData)
+  {
+    m_channelData = channelData;
+
+    if (m_channelData->ClientId() != iClientId)
+      CLog::LogF(LOGERROR, "Client id mismatch (channel: %d, epg: %d)!",
+                 m_channelData->ClientId(), iClientId);
+    if (m_channelData->UniqueClientChannelId() != static_cast<int>(data.iUniqueChannelId))
+      CLog::LogF(LOGERROR, "Channel uid mismatch (channel: %d, epg: %d)!",
+                 m_channelData->UniqueClientChannelId(), data.iUniqueChannelId);
+  }
+  else
+  {
+    // provide minimalistic channel data until we get fully initialized later
+    m_channelData = std::make_shared<CPVREpgChannelData>(iClientId, data.iUniqueChannelId);
+  }
+
   SetGenre(data.iGenreType, data.iGenreSubType, data.strGenreDescription);
 
   // explicit NULL check, because there is no implicit NULL constructor for std::string
@@ -82,19 +103,21 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG &data, int iClientId)
   UpdatePath();
 }
 
+void CPVREpgInfoTag::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
+{
+  CSingleLock lock(m_critSection);
+  if (data)
+    m_channelData = data;
+  else
+    m_channelData.reset(new CPVREpgChannelData);
+}
+
 bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
 {
   if (this == &right)
     return true;
 
-  bool bChannelMatch = false;
-  {
-    CSingleLock lock(m_critSection);
-    bChannelMatch = (m_channel == right.m_channel);
-  }
-  return (bChannelMatch &&
-          m_bNotify            == right.m_bNotify &&
-          m_iClientId          == right.m_iClientId &&
+  return (m_bNotify            == right.m_bNotify &&
           m_iDatabaseID        == right.m_iDatabaseID &&
           m_iGenreType         == right.m_iGenreType &&
           m_iGenreSubType      == right.m_iGenreSubType &&
@@ -105,7 +128,6 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
           m_iEpisodeNumber     == right.m_iEpisodeNumber &&
           m_iEpisodePart       == right.m_iEpisodePart &&
           m_iUniqueBroadcastID == right.m_iUniqueBroadcastID &&
-          m_iUniqueChannelID   == right.m_iUniqueChannelID &&
           m_strTitle           == right.m_strTitle &&
           m_strPlotOutline     == right.m_strPlotOutline &&
           m_strPlot            == right.m_strPlot &&
@@ -117,12 +139,14 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
           m_strIMDBNumber      == right.m_strIMDBNumber &&
           m_genre              == right.m_genre &&
           m_strEpisodeName     == right.m_strEpisodeName &&
+          m_iEpgID             == right.m_iEpgID &&
           m_strIconPath        == right.m_strIconPath &&
           m_strFileNameAndPath == right.m_strFileNameAndPath &&
           m_startTime          == right.m_startTime &&
           m_endTime            == right.m_endTime &&
           m_iFlags             == right.m_iFlags &&
-          m_strSeriesLink      == right.m_strSeriesLink);
+          m_strSeriesLink      == right.m_strSeriesLink &&
+          m_channelData        == right.m_channelData);
 }
 
 bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
@@ -136,7 +160,7 @@ bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
 void CPVREpgInfoTag::Serialize(CVariant &value) const
 {
   value["broadcastid"] = m_iUniqueBroadcastID;
-  value["channeluid"] = m_iUniqueChannelID;
+  value["channeluid"] = m_channelData->UniqueClientChannelId();
   value["parentalrating"] = m_iParentalRating;
   value["rating"] = m_iStarRating;
   value["title"] = m_strTitle;
@@ -169,27 +193,26 @@ void CPVREpgInfoTag::Serialize(CVariant &value) const
   value["serieslink"] = m_strSeriesLink;
 }
 
+int CPVREpgInfoTag::ClientID() const
+{
+  return m_channelData->ClientId();
+}
+
 void CPVREpgInfoTag::ToSortable(SortItem& sortable, Field field) const
 {
   CSingleLock lock(m_critSection);
 
-  if (!m_channel)
-    return;
-
   switch (field)
   {
     case FieldChannelName:
-      sortable[FieldChannelName] = m_channel->ChannelName();
+      sortable[FieldChannelName] = m_channelData->ChannelName();
       break;
     case FieldChannelNumber:
-      sortable[FieldChannelNumber] = m_channel->ChannelNumber().SortableChannelNumber();
+      sortable[FieldChannelNumber] = m_channelData->SortableChannelNumber();
       break;
     case FieldLastPlayed:
-    {
-      const CDateTime lastWatched(m_channel->LastWatched());
-      sortable[FieldLastPlayed] = lastWatched.IsValid() ? lastWatched.GetAsDBDateTime() : StringUtils::Empty;
+      sortable[FieldLastPlayed] = m_channelData->LastWatched();
       break;
-    }
     default:
       break;
   }
@@ -197,7 +220,7 @@ void CPVREpgInfoTag::ToSortable(SortItem& sortable, Field field) const
 
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
 {
-  if (CServiceBroker::GetPVRManager().GetPlayingChannel() == Channel())
+  if (CServiceBroker::GetPVRManager().MatchPlayingChannel(ClientID(), UniqueChannelID()))
   {
     // start time valid?
     time_t startTime = CServiceBroker::GetDataCacheCore().GetStartTime();
@@ -274,9 +297,9 @@ int CPVREpgInfoTag::DatabaseID(void) const
   return m_iDatabaseID;
 }
 
-unsigned int CPVREpgInfoTag::UniqueChannelID(void) const
+int CPVREpgInfoTag::UniqueChannelID(void) const
 {
-  return m_iUniqueChannelID;
+  return m_channelData->UniqueClientChannelId();
 }
 
 CDateTime CPVREpgInfoTag::StartAsUTC(void) const
@@ -316,59 +339,24 @@ int CPVREpgInfoTag::GetDuration(void) const
   return end - start > 0 ? end - start : 3600;
 }
 
-bool CPVREpgInfoTag::IsParentalLocked() const
+std::string CPVREpgInfoTag::Title() const
 {
-  CPVRChannelPtr channel;
-  {
-    CSingleLock lock(m_critSection);
-    channel = m_channel;
-  }
-
-  return channel && CServiceBroker::GetPVRManager().IsParentalLocked(channel);
+  return m_strTitle;
 }
 
-std::string CPVREpgInfoTag::Title(bool bOverrideParental /* = false */) const
+std::string CPVREpgInfoTag::PlotOutline() const
 {
-  std::string strTitle;
-
-  if (!bOverrideParental && IsParentalLocked())
-    strTitle = g_localizeStrings.Get(19266); // parental locked
-  else if (m_strTitle.empty() && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-    strTitle = g_localizeStrings.Get(19055); // no information available
-  else
-    strTitle = m_strTitle;
-
-  return strTitle;
+  return m_strPlotOutline;
 }
 
-std::string CPVREpgInfoTag::PlotOutline(bool bOverrideParental /* = false */) const
+std::string CPVREpgInfoTag::Plot() const
 {
-  std::string retVal;
-
-  if (bOverrideParental || !IsParentalLocked())
-    retVal = m_strPlotOutline;
-
-  return retVal;
+  return m_strPlot;
 }
 
-std::string CPVREpgInfoTag::Plot(bool bOverrideParental /* = false */) const
+std::string CPVREpgInfoTag::OriginalTitle() const
 {
-  std::string retVal;
-
-  if (bOverrideParental || !IsParentalLocked())
-    retVal = m_strPlot;
-
-  return retVal;
-}
-
-std::string CPVREpgInfoTag::OriginalTitle(bool bOverrideParental /* = false */) const
-{
-  std::string retVal;
-
-  if (bOverrideParental || !IsParentalLocked())
-    retVal = m_strOriginalTitle;
-
-  return retVal;
+  return m_strOriginalTitle;
 }
 
 const std::vector<std::string> CPVREpgInfoTag::Cast(void) const
@@ -503,14 +491,9 @@ int CPVREpgInfoTag::EpisodePart(void) const
   return m_iEpisodePart;
 }
 
-std::string CPVREpgInfoTag::EpisodeName(bool bOverrideParental /* = false */) const
+std::string CPVREpgInfoTag::EpisodeName() const
 {
-  std::string retVal;
-
-  if (bOverrideParental || !IsParentalLocked())
-    retVal = m_strEpisodeName;
-
-  return retVal;
+  return m_strEpisodeName;
 }
 
 std::string CPVREpgInfoTag::Icon(void) const
@@ -523,120 +506,87 @@ std::string CPVREpgInfoTag::Path(void) const
   return m_strFileNameAndPath;
 }
 
-void CPVREpgInfoTag::SetChannel(const CPVRChannelPtr &channel)
-{
-  CSingleLock lock(m_critSection);
-  m_channel = channel;
-  m_iClientId = m_channel ? m_channel->ClientID() : -1;
-  m_iUniqueChannelID = m_channel ? m_channel->UniqueID() : PVR_CHANNEL_INVALID_UID;
-}
-
-bool CPVREpgInfoTag::HasChannel(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_channel != nullptr;
-}
-
-const CPVRChannelPtr CPVREpgInfoTag::Channel() const
-{
-  CSingleLock lock(m_critSection);
-  return m_channel;
-}
-
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /* = true */)
 {
-  bool bChanged = false;
-  {
-    CSingleLock lock(m_critSection);
-    bChanged = (m_channel != tag.m_channel);
-  }
+  bool bChanged = (
+      m_strTitle           != tag.m_strTitle ||
+      m_strPlotOutline     != tag.m_strPlotOutline ||
+      m_strPlot            != tag.m_strPlot ||
+      m_strOriginalTitle   != tag.m_strOriginalTitle ||
+      m_cast               != tag.m_cast ||
+      m_directors          != tag.m_directors ||
+      m_writers            != tag.m_writers ||
+      m_iYear              != tag.m_iYear ||
+      m_strIMDBNumber      != tag.m_strIMDBNumber ||
+      m_startTime          != tag.m_startTime ||
+      m_endTime            != tag.m_endTime ||
+      m_iGenreType         != tag.m_iGenreType ||
+      m_iGenreSubType      != tag.m_iGenreSubType ||
+      m_firstAired         != tag.m_firstAired ||
+      m_iParentalRating    != tag.m_iParentalRating ||
+      m_iStarRating        != tag.m_iStarRating ||
+      m_bNotify            != tag.m_bNotify ||
+      m_iEpisodeNumber     != tag.m_iEpisodeNumber ||
+      m_iEpisodePart       != tag.m_iEpisodePart ||
+      m_iSeriesNumber      != tag.m_iSeriesNumber ||
+      m_strEpisodeName     != tag.m_strEpisodeName ||
+      m_iUniqueBroadcastID != tag.m_iUniqueBroadcastID ||
+      m_iEpgID             != tag.m_iEpgID ||
+      m_genre              != tag.m_genre ||
+      m_strIconPath        != tag.m_strIconPath ||
+      m_iFlags             != tag.m_iFlags ||
+      m_strSeriesLink      != tag.m_strSeriesLink ||
+      m_channelData        != tag.m_channelData
+  );
 
+  if (bUpdateBroadcastId)
+    bChanged |= (m_iDatabaseID != tag.m_iDatabaseID);
+
+  if (bChanged)
   {
-    bChanged |= (
-        m_iClientId          != tag.m_iClientId ||
-        m_strTitle           != tag.m_strTitle ||
-        m_strPlotOutline     != tag.m_strPlotOutline ||
-        m_strPlot            != tag.m_strPlot ||
-        m_strOriginalTitle   != tag.m_strOriginalTitle ||
-        m_cast               != tag.m_cast ||
-        m_directors          != tag.m_directors ||
-        m_writers            != tag.m_writers ||
-        m_iYear              != tag.m_iYear ||
-        m_strIMDBNumber      != tag.m_strIMDBNumber ||
-        m_startTime          != tag.m_startTime ||
-        m_endTime            != tag.m_endTime ||
-        m_iGenreType         != tag.m_iGenreType ||
-        m_iGenreSubType      != tag.m_iGenreSubType ||
-        m_firstAired         != tag.m_firstAired ||
-        m_iParentalRating    != tag.m_iParentalRating ||
-        m_iStarRating        != tag.m_iStarRating ||
-        m_bNotify            != tag.m_bNotify ||
-        m_iEpisodeNumber     != tag.m_iEpisodeNumber ||
-        m_iEpisodePart       != tag.m_iEpisodePart ||
-        m_iSeriesNumber      != tag.m_iSeriesNumber ||
-        m_strEpisodeName     != tag.m_strEpisodeName ||
-        m_iUniqueBroadcastID != tag.m_iUniqueBroadcastID ||
-        m_iUniqueChannelID   != tag.m_iUniqueChannelID ||
-        EpgID()              != tag.EpgID() ||
-        m_genre              != tag.m_genre ||
-        m_strIconPath        != tag.m_strIconPath ||
-        m_iFlags             != tag.m_iFlags ||
-        m_strSeriesLink      != tag.m_strSeriesLink
-    );
     if (bUpdateBroadcastId)
-      bChanged |= (m_iDatabaseID != tag.m_iDatabaseID);
+      m_iDatabaseID      = tag.m_iDatabaseID;
 
-    if (bChanged)
+    m_strTitle           = tag.m_strTitle;
+    m_strPlotOutline     = tag.m_strPlotOutline;
+    m_strPlot            = tag.m_strPlot;
+    m_strOriginalTitle   = tag.m_strOriginalTitle;
+    m_cast               = tag.m_cast;
+    m_directors          = tag.m_directors;
+    m_writers            = tag.m_writers;
+    m_iYear              = tag.m_iYear;
+    m_strIMDBNumber      = tag.m_strIMDBNumber;
+    m_startTime          = tag.m_startTime;
+    m_endTime            = tag.m_endTime;
+    m_iGenreType         = tag.m_iGenreType;
+    m_iGenreSubType      = tag.m_iGenreSubType;
+    m_iEpgID             = tag.m_iEpgID;
+    m_iFlags             = tag.m_iFlags;
+    m_strSeriesLink      = tag.m_strSeriesLink;
+
+    if (m_iGenreType == EPG_GENRE_USE_STRING)
     {
-      if (bUpdateBroadcastId)
-        m_iDatabaseID      = tag.m_iDatabaseID;
-
-      m_iClientId          = tag.m_iClientId;
-      m_strTitle           = tag.m_strTitle;
-      m_strPlotOutline     = tag.m_strPlotOutline;
-      m_strPlot            = tag.m_strPlot;
-      m_strOriginalTitle   = tag.m_strOriginalTitle;
-      m_cast               = tag.m_cast;
-      m_directors          = tag.m_directors;
-      m_writers            = tag.m_writers;
-      m_iYear              = tag.m_iYear;
-      m_strIMDBNumber      = tag.m_strIMDBNumber;
-      m_startTime          = tag.m_startTime;
-      m_endTime            = tag.m_endTime;
-      m_iGenreType         = tag.m_iGenreType;
-      m_iGenreSubType      = tag.m_iGenreSubType;
-      m_epg                = tag.m_epg;
-      m_iFlags             = tag.m_iFlags;
-      m_strSeriesLink      = tag.m_strSeriesLink;
-
-      {
-        CSingleLock lock(m_critSection);
-        m_channel          = tag.m_channel;
-      }
-
-      if (m_iGenreType == EPG_GENRE_USE_STRING)
-      {
-        /* No type/subtype. Use the provided description */
-        m_genre            = tag.m_genre;
-      }
-      else
-      {
-        /* Determine genre description by type/subtype */
-        m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
-      }
-      m_firstAired         = tag.m_firstAired;
-      m_iParentalRating    = tag.m_iParentalRating;
-      m_iStarRating        = tag.m_iStarRating;
-      m_bNotify            = tag.m_bNotify;
-      m_iEpisodeNumber     = tag.m_iEpisodeNumber;
-      m_iEpisodePart       = tag.m_iEpisodePart;
-      m_iSeriesNumber      = tag.m_iSeriesNumber;
-      m_strEpisodeName     = tag.m_strEpisodeName;
-      m_iUniqueBroadcastID = tag.m_iUniqueBroadcastID;
-      m_iUniqueChannelID   = tag.m_iUniqueChannelID;
-      m_strIconPath        = tag.m_strIconPath;
+      /* No type/subtype. Use the provided description */
+      m_genre            = tag.m_genre;
     }
+    else
+    {
+      /* Determine genre description by type/subtype */
+      m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(tag.m_iGenreType, tag.m_iGenreSubType), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+    }
+    m_firstAired         = tag.m_firstAired;
+    m_iParentalRating    = tag.m_iParentalRating;
+    m_iStarRating        = tag.m_iStarRating;
+    m_bNotify            = tag.m_bNotify;
+    m_iEpisodeNumber     = tag.m_iEpisodeNumber;
+    m_iEpisodePart       = tag.m_iEpisodePart;
+    m_iSeriesNumber      = tag.m_iSeriesNumber;
+    m_strEpisodeName     = tag.m_strEpisodeName;
+    m_iUniqueBroadcastID = tag.m_iUniqueBroadcastID;
+    m_strIconPath        = tag.m_strIconPath;
+    m_channelData        = tag.m_channelData;
   }
+
   if (bChanged)
     UpdatePath();
 
@@ -669,7 +619,7 @@ bool CPVREpgInfoTag::Persist(bool bSingleUpdate /* = true */)
 std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
 {
   std::vector<PVR_EDL_ENTRY> edls;
-  const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
 
   if (client && client->GetClientCapabilities().SupportsEpgTagEdl())
     client->GetEpgTagEdl(shared_from_this(), edls);
@@ -684,13 +634,19 @@ void CPVREpgInfoTag::UpdatePath(void)
 
 int CPVREpgInfoTag::EpgID(void) const
 {
-  return m_epg ? m_epg->EpgID() : -1;
+  return m_iEpgID;
+}
+
+void CPVREpgInfoTag::SetEpgID(int iEpgID)
+{
+  m_iEpgID = iEpgID;
+  UpdatePath(); // Note: path contains epg id.
 }
 
 bool CPVREpgInfoTag::IsRecordable(void) const
 {
   bool bIsRecordable = false;
-  const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
   {
     // event end time based fallback
@@ -702,7 +658,7 @@ bool CPVREpgInfoTag::IsRecordable(void) const
 bool CPVREpgInfoTag::IsPlayable(void) const
 {
   bool bIsPlayable = false;
-  const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {
     // fallback
@@ -711,18 +667,22 @@ bool CPVREpgInfoTag::IsPlayable(void) const
   return bIsPlayable;
 }
 
-void CPVREpgInfoTag::SetEpg(CPVREpg *epg)
-{
-  m_epg = epg;
-  UpdatePath(); // Note: path contains epg id.
-}
-
 bool CPVREpgInfoTag::IsSeries(void) const
 {
   if ((m_iFlags & EPG_TAG_FLAG_IS_SERIES) > 0 || SeriesNumber() > 0 || EpisodeNumber() > 0 || EpisodePart() > 0)
     return true;
   else
     return false;
+}
+
+bool CPVREpgInfoTag::IsRadio() const
+{
+  return m_channelData->IsRadio();
+}
+
+bool CPVREpgInfoTag::IsParentalLocked() const
+{
+  return m_channelData->IsLocked();
 }
 
 const std::vector<std::string> CPVREpgInfoTag::Tokenize(const std::string &str)

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -115,6 +115,7 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
   if (this == &right)
     return true;
 
+  CSingleLock lock(m_critSection);
   return (m_bNotify            == right.m_bNotify &&
           m_iDatabaseID        == right.m_iDatabaseID &&
           m_iGenreType         == right.m_iGenreType &&
@@ -157,6 +158,7 @@ bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
 
 void CPVREpgInfoTag::Serialize(CVariant &value) const
 {
+  CSingleLock lock(m_critSection);
   value["broadcastid"] = m_iUniqueBroadcastID;
   value["channeluid"] = m_channelData->UniqueClientChannelId();
   value["parentalrating"] = m_iParentalRating;
@@ -193,6 +195,7 @@ void CPVREpgInfoTag::Serialize(CVariant &value) const
 
 int CPVREpgInfoTag::ClientID() const
 {
+  CSingleLock lock(m_critSection);
   return m_channelData->ClientId();
 }
 
@@ -297,6 +300,7 @@ int CPVREpgInfoTag::DatabaseID(void) const
 
 int CPVREpgInfoTag::UniqueChannelID(void) const
 {
+  CSingleLock lock(m_critSection);
   return m_channelData->UniqueClientChannelId();
 }
 
@@ -506,6 +510,7 @@ std::string CPVREpgInfoTag::Path(void) const
 
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /* = true */)
 {
+  CSingleLock lock(m_critSection);
   bool bChanged = (
       m_strTitle           != tag.m_strTitle ||
       m_strPlotOutline     != tag.m_strPlotOutline ||
@@ -616,6 +621,8 @@ bool CPVREpgInfoTag::Persist(const std::shared_ptr<CPVREpgDatabase>& database, b
 std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
 {
   std::vector<PVR_EDL_ENTRY> edls;
+
+  CSingleLock lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
 
   if (client && client->GetClientCapabilities().SupportsEpgTagEdl())
@@ -643,6 +650,8 @@ void CPVREpgInfoTag::SetEpgID(int iEpgID)
 bool CPVREpgInfoTag::IsRecordable(void) const
 {
   bool bIsRecordable = false;
+
+  CSingleLock lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
   {
@@ -655,6 +664,8 @@ bool CPVREpgInfoTag::IsRecordable(void) const
 bool CPVREpgInfoTag::IsPlayable(void) const
 {
   bool bIsPlayable = false;
+
+  CSingleLock lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {
@@ -674,11 +685,13 @@ bool CPVREpgInfoTag::IsSeries(void) const
 
 bool CPVREpgInfoTag::IsRadio() const
 {
+  CSingleLock lock(m_critSection);
   return m_channelData->IsRadio();
 }
 
 bool CPVREpgInfoTag::IsParentalLocked() const
 {
+  CSingleLock lock(m_critSection);
   return m_channelData->IsLocked();
 }
 

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -19,9 +19,7 @@
 #include "utils/log.h"
 
 #include "pvr/PVRManager.h"
-#include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
-#include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgDatabase.h"
 
 using namespace PVR;
@@ -593,11 +591,10 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /
   return bChanged;
 }
 
-bool CPVREpgInfoTag::Persist(bool bSingleUpdate /* = true */)
+bool CPVREpgInfoTag::Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bSingleUpdate /* = true */)
 {
   bool bReturn = false;
 
-  const CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
   if (!database)
   {
     CLog::LogF(LOGERROR, "Could not open the EPG database");

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -352,11 +352,12 @@ namespace PVR
     bool IsPlayable(void) const;
 
     /*!
-     * @brief Persist this tag in the database.
+     * @brief Persist this tag in the given database.
+     * @param database The database.
      * @param bSingleUpdate True if this is a single update, false if more updates will follow.
      * @return True if the tag was persisted correctly, false otherwise.
      */
-    bool Persist(bool bSingleUpdate = true);
+    bool Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bSingleUpdate = true);
 
     /*!
      * @brief Update the information in this tag with the info in the given tag.

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -19,7 +19,6 @@
 
 #include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/timers/PVRTimerInfoTag.h"
 
 class CVariant;
 
@@ -339,35 +338,6 @@ namespace PVR
     std::string Path(void) const;
 
     /*!
-     * @brief Set a timer for this event.
-     * @param timer The timer.
-     */
-    void SetTimer(const CPVRTimerInfoTagPtr &timer);
-
-    /*!
-     * @brief Clear the timer for this event.
-     */
-    void ClearTimer(void);
-
-    /*!
-     * @brief Check whether this event has a timer tag.
-     * @return True if it has a timer tag, false if not.
-     */
-    bool HasTimer(void) const;
-
-    /*!
-     * @brief Check whether this event has a timer rule.
-     * @return True if it has a timer rule, false if not.
-     */
-    bool HasTimerRule(void) const;
-
-    /*!
-     * @brief Get the timer for this event, if any.
-     * @return The timer or nullptr if there is none.
-     */
-    CPVRTimerInfoTagPtr Timer(void) const;
-
-    /*!
      * @brief Check if this event can be recorded.
      * @return True if it can be recorded, false otherwise.
      */
@@ -508,6 +478,5 @@ namespace PVR
     mutable CCriticalSection m_critSection;
     CPVREpg *m_epg = nullptr;
     CPVRChannelPtr m_channel;
-    CPVRTimerInfoTagPtr m_timer;
   };
 }

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -19,7 +19,6 @@
 
 #include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/recordings/PVRRecording.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 
 class CVariant;
@@ -369,29 +368,6 @@ namespace PVR
     CPVRTimerInfoTagPtr Timer(void) const;
 
     /*!
-     * @brief Set a recording for this event.
-     * @param recording The recording.
-     */
-    void SetRecording(const CPVRRecordingPtr &recording);
-
-    /*!
-     * @brief Clear a recording for this event.
-     */
-    void ClearRecording(void);
-
-    /*!
-     * @brief Check whether this event has a recording.
-     * @return True if it has a recording, false if not.
-     */
-    bool HasRecording(void) const;
-
-    /*!
-     * @brief Get the recording for this event, if any.
-     * @return The pointer or nullptr if there is none.
-     */
-    CPVRRecordingPtr Recording(void) const;
-
-    /*!
      * @brief Check if this event can be recorded.
      * @return True if it can be recorded, false otherwise.
      */
@@ -533,6 +509,5 @@ namespace PVR
     CPVREpg *m_epg = nullptr;
     CPVRChannelPtr m_channel;
     CPVRTimerInfoTagPtr m_timer;
-    CPVRRecordingPtr m_recording;
   };
 }

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -198,15 +198,13 @@ bool CPVREpgSearchFilter::MatchChannelGroup(const CPVREpgInfoTagPtr &tag) const
 
 bool CPVREpgSearchFilter::MatchFreeToAir(const CPVREpgInfoTagPtr &tag) const
 {
-  bool bReturn(true);
-
   if (m_bFreeToAirOnly)
   {
     const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
-    bReturn = (channel && !channel->IsEncrypted());
+    return channel && !channel->IsEncrypted();
   }
 
-  return bReturn;
+  return true;
 }
 
 bool CPVREpgSearchFilter::MatchTimers(const CPVREpgInfoTagPtr &tag) const

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -144,38 +144,21 @@ bool CPVREpgSearchFilter::FilterEntry(const CPVREpgInfoTagPtr &tag) const
       MatchFreeToAir(tag);
 }
 
-int CPVREpgSearchFilter::RemoveDuplicates(CFileItemList &results)
+void CPVREpgSearchFilter::RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgInfoTag>>& results)
 {
-  unsigned int iSize = results.Size();
-
-  for (unsigned int iResultPtr = 0; iResultPtr < iSize; iResultPtr++)
+  for (auto it = results.begin(); it != results.end();)
   {
-    const CPVREpgInfoTagPtr epgentry_1(results.Get(iResultPtr)->GetEPGInfoTag());
-    if (!epgentry_1)
-      continue;
-
-    for (unsigned int iTagPtr = 0; iTagPtr < iSize; iTagPtr++)
-    {
-      if (iResultPtr == iTagPtr)
-        continue;
-
-      const CPVREpgInfoTagPtr epgentry_2(results.Get(iTagPtr)->GetEPGInfoTag());
-      if (!epgentry_2)
-        continue;
-
-      if (epgentry_1->Title()       != epgentry_2->Title() ||
-          epgentry_1->Plot()        != epgentry_2->Plot() ||
-          epgentry_1->PlotOutline() != epgentry_2->PlotOutline())
-        continue;
-
-      results.Remove(iTagPtr);
-      iResultPtr--;
-      iTagPtr--;
-      iSize--;
-    }
+    it = results.erase(std::remove_if(results.begin(),
+                                      results.end(),
+                                      [&it](const std::shared_ptr<CPVREpgInfoTag>& entry)
+                                      {
+                                         return *it != entry &&
+                                                (*it)->Title() == entry->Title() &&
+                                                (*it)->Plot() == entry->Plot() &&
+                                                (*it)->PlotOutline() == entry->PlotOutline();
+                                      }),
+                       results.end());
   }
-
-  return iSize;
 }
 
 bool CPVREpgSearchFilter::MatchChannelType(const CPVREpgInfoTagPtr &tag) const

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "XBDateTime.h"
 
 #include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRChannelNumber.h"
-
-class CFileItemList;
 
 namespace PVR
 {
@@ -46,10 +48,9 @@ namespace PVR
 
     /*!
      * @brief remove duplicates from a list of epg tags.
-     * @param results the list of epg tags.
-     * @return the number of items in the list after removing duplicates.
+     * @param results The list of epg tags.
      */
-    static int RemoveDuplicates(CFileItemList &results);
+    static void RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgInfoTag>>& results);
 
     /*!
      * @brief Get the type of channels to search.

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -217,25 +217,7 @@ void CPVRRecording::Reset(void)
 bool CPVRRecording::Delete(void)
 {
   CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
-  if (!client || client->DeleteRecording(*this) != PVR_ERROR_NO_ERROR)
-    return false;
-
-  OnDelete();
-  return true;
-}
-
-void CPVRRecording::OnDelete(void)
-{
-  if (m_iEpgEventId != EPG_TAG_INVALID_UID)
-  {
-    const CPVRChannelPtr channel(Channel());
-    if (channel)
-    {
-      const CPVREpgInfoTagPtr epgTag(CServiceBroker::GetPVRManager().EpgContainer().GetTagById(channel, m_iEpgEventId));
-      if (epgTag)
-        epgTag->ClearRecording();
-    }
-  }
+  return client && (client->DeleteRecording(*this) == PVR_ERROR_NO_ERROR);
 }
 
 bool CPVRRecording::Undelete(void)
@@ -409,9 +391,6 @@ void CPVRRecording::Update(const CPVRRecording &tag)
     strEpisode.erase(0, pos + 2);
     m_strShowTitle = strEpisode;
   }
-
-  if (m_bIsDeleted)
-    OnDelete();
 
   UpdatePath();
 }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -484,7 +484,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRRecording::GetRecordingTimer() const
         return timer;
     }
   }
-  return std::shared_ptr<CPVRTimerInfoTag>();
+  return {};
 }
 
 bool CPVRRecording::IsInProgress() const

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -95,11 +95,6 @@ namespace PVR
     bool Delete(void);
 
     /*!
-     * @brief Called when this recording has been deleted
-     */
-    void OnDelete(void);
-
-    /*!
      * @brief Undelete this recording on the client (if supported).
      * @return True if it was undeleted successfully, false otherwise.
      */

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -276,6 +276,12 @@ namespace PVR
     bool IsInProgress() const;
 
     /*!
+     * @brief return the timer for an in-progress recording, if any
+     * @return the timer if the recording is in progress, nullptr otherwise
+     */
+    std::shared_ptr<CPVRTimerInfoTag> GetRecordingTimer() const;
+
+    /*!
     * @brief set the genre for this recording.
     * @param iGenreType The genre type ID. If set to EPG_GENRE_USE_STRING, set genre to the value provided with strGenre. Otherwise, compile the genre string from the values given by iGenreType and iGenreSubType
     * @param iGenreSubType The genre subtype ID

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -395,16 +395,6 @@ void CPVRRecordings::UpdateFromClient(const CPVRRecordingPtr &tag)
   {
     newTag = CPVRRecordingPtr(new CPVRRecording);
     newTag->Update(*tag);
-    if (newTag->BroadcastUid() != EPG_TAG_INVALID_UID)
-    {
-      const CPVRChannelPtr channel(newTag->Channel());
-      if (channel)
-      {
-        const CPVREpgInfoTagPtr epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(channel, newTag->BroadcastUid());
-        if (epgTag)
-          epgTag->SetRecording(newTag);
-      }
-    }
     newTag->m_iRecordingId = ++m_iLastId;
     m_recordings.insert(std::make_pair(CPVRRecordingUid(newTag->m_iClientId, newTag->m_strRecordingId), newTag));
     if (newTag->IsRadio())
@@ -416,6 +406,9 @@ void CPVRRecordings::UpdateFromClient(const CPVRRecordingPtr &tag)
 
 CPVRRecordingPtr CPVRRecordings::GetRecordingForEpgTag(const CPVREpgInfoTagPtr &epgTag) const
 {
+  if (!epgTag)
+    return std::shared_ptr<CPVRRecording>();
+
   CSingleLock lock(m_critSection);
 
   for (const auto recording : m_recordings)
@@ -423,25 +416,21 @@ CPVRRecordingPtr CPVRRecordings::GetRecordingForEpgTag(const CPVREpgInfoTagPtr &
     if (recording.second->IsDeleted())
       continue;
 
+    if (recording.second->ClientID() != epgTag->ClientID())
+      continue;
+
+    if (recording.second->ChannelUid() != epgTag->UniqueChannelID())
+      continue;
+
     unsigned int iEpgEvent = recording.second->BroadcastUid();
     if (iEpgEvent != EPG_TAG_INVALID_UID)
     {
       if (iEpgEvent == epgTag->UniqueBroadcastID())
-      {
-        // uid matches. perfect.
         return recording.second;
-      }
     }
     else
     {
-      // uid is optional, so check other relevant data.
-
-      // note: don't use recording.second->Channel() for comparing channels here as this can lead
-      //       to deadlocks. compare client ids and channel ids instead, this has the same effect.
-      if (epgTag->Channel() &&
-          recording.second->ClientID() == epgTag->Channel()->ClientID() &&
-          recording.second->ChannelUid() == epgTag->Channel()->UniqueID() &&
-          recording.second->RecordingTimeAsUTC() <= epgTag->StartAsUTC() &&
+      if (recording.second->RecordingTimeAsUTC() <= epgTag->StartAsUTC() &&
           recording.second->EndTimeAsUTC() >= epgTag->EndAsUTC())
         return recording.second;
     }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -407,7 +407,7 @@ void CPVRRecordings::UpdateFromClient(const CPVRRecordingPtr &tag)
 CPVRRecordingPtr CPVRRecordings::GetRecordingForEpgTag(const CPVREpgInfoTagPtr &epgTag) const
 {
   if (!epgTag)
-    return std::shared_ptr<CPVRRecording>();
+    return {};
 
   CSingleLock lock(m_critSection);
 

--- a/xbmc/pvr/timers/CMakeLists.txt
+++ b/xbmc/pvr/timers/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES PVRTimerInfoTag.cpp
             PVRTimers.cpp
+            PVRTimersPath.cpp
             PVRTimerType.cpp)
 
 set(HEADERS PVRTimerInfoTag.h
             PVRTimers.h
+            PVRTimersPath.h
             PVRTimerType.h)
 
 core_add_library(pvr_timers)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -23,7 +23,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
-#include "pvr/timers/PVRTimers.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 using namespace PVR;
 
@@ -974,7 +974,7 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
           }
         }
 
-        if (!m_epgTag && m_epTagRefetchTimeout.IsTimePast())
+        if (!IsTimerRule() && !m_epgTag && m_epTagRefetchTimeout.IsTimePast())
         {
           m_epTagRefetchTimeout.Set(30000); // try to fetch missing epg tag from backend at most every 30 secs
 
@@ -988,26 +988,9 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
           if (startTime > 0 && endTime > 0)
           {
             // try to fetch missing epg tag from backend
-            const CPVREpgInfoTagPtr epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0), true);
-            if (epgTag)
-            {
-              bool bTagMatches = !IsTimerRule();
-              if (!bTagMatches)
-              {
-                // Check whether the tag actually is an event that belongs to a child of this timer rule
-                const std::shared_ptr<CPVRTimerInfoTag> timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag);
-                if (timer && (timer->GetTimerRuleId() == m_iClientIndex))
-                {
-                  bTagMatches = true;
-                }
-              }
-
-              if (bTagMatches)
-              {
-                m_epgTag = epgTag;
-                m_iEpgUid = m_epgTag->UniqueBroadcastID();
-              }
-            }
+            m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0), true);
+            if (m_epgTag)
+              m_iEpgUid = m_epgTag->UniqueBroadcastID();
           }
         }
       }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -986,7 +986,7 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
               if (!bTagMatches)
               {
                 // Check whether the tag actually is an event that belongs to a child of this timer rule
-                const CPVRTimerInfoTagPtr timer = epgTag->Timer();
+                const std::shared_ptr<CPVRTimerInfoTag> timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epgTag);
                 if (timer && (timer->GetTimerRuleId() == m_iClientIndex))
                 {
                   bTagMatches = true;
@@ -1009,20 +1009,8 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
 
 void CPVRTimerInfoTag::SetEpgTag(const CPVREpgInfoTagPtr &tag)
 {
-  CPVREpgInfoTagPtr previousTag;
-  {
-    CSingleLock lock(m_critSection);
-    previousTag = m_epgTag;
-    m_epgTag = tag;
-  }
-
-  if (previousTag)
-    previousTag->ClearTimer();
-}
-
-void CPVRTimerInfoTag::ClearEpgTag(void)
-{
-  SetEpgTag(CPVREpgInfoTagPtr());
+  CSingleLock lock(m_critSection);
+  m_epgTag = tag;
 }
 
 bool CPVRTimerInfoTag::HasChannel() const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -742,7 +742,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CPVREpgInfoTagPtr &tag
   CPVRTimerInfoTagPtr newTag(new CPVRTimerInfoTag());
 
   /* check if a valid channel is set */
-  CPVRChannelPtr channel = tag->Channel();
+  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
   if (!channel)
   {
     CLog::LogF(LOGERROR, "EPG tag has no channel");
@@ -754,7 +754,10 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CPVREpgInfoTagPtr &tag
   CDateTime newEnd = tag->EndAsUTC();
   newTag->m_iClientIndex       = PVR_TIMER_NO_CLIENT_INDEX;
   newTag->m_iParentClientIndex = PVR_TIMER_NO_PARENT;
-  newTag->m_strTitle           = tag->Title().empty() ? channel->ChannelName() : tag->Title();
+  if (!CServiceBroker::GetPVRManager().IsParentalLocked(tag))
+    newTag->m_strTitle = tag->Title();
+  if (newTag->m_strTitle.empty())
+    newTag->m_strTitle = channel->ChannelName();
   newTag->m_iClientChannelUid  = channel->UniqueID();
   newTag->m_iClientId          = channel->ClientID();
   newTag->m_bIsRadio           = channel->IsRadio();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -295,13 +295,6 @@ void CPVRTimerInfoTag::Serialize(CVariant &value) const
   value["serieslink"]        = m_strSeriesLink;
 }
 
-void CPVRTimerInfoTag::UpdateEpgInfoTag(void)
-{
-  CSingleLock lock(m_critSection);
-  m_epgTag.reset();
-  GetEpgInfoTag();
-}
-
 void CPVRTimerInfoTag::UpdateSummary(void)
 {
   CSingleLock lock(m_critSection);
@@ -713,7 +706,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateInstantTimerTag(const CPVRChannelPtr
     newTimer->SetTimerType(timerType);
 
     if (epgTag)
-      newTimer->SetEpgTag(epgTag);
+      newTimer->SetEpgInfoTag(epgTag);
     else
       newTimer->UpdateEpgInfoTag();
   }
@@ -820,7 +813,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CPVREpgInfoTagPtr &tag
 
   newTag->SetTimerType(timerType);
   newTag->UpdateSummary();
-  newTag->SetEpgTag(tag);
+  newTag->SetEpgInfoTag(tag);
 
   /* unused only for reference */
   newTag->m_strFileNameAndPath = CPVRTimersPath::PATH_NEW;
@@ -938,6 +931,19 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
   return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(stringID).c_str(), m_strTitle.c_str());
 }
 
+void CPVRTimerInfoTag::SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag)
+{
+  CSingleLock lock(m_critSection);
+  m_epgTag = tag;
+}
+
+void CPVRTimerInfoTag::UpdateEpgInfoTag()
+{
+  CSingleLock lock(m_critSection);
+  m_epgTag.reset();
+  GetEpgInfoTag();
+}
+
 CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) const
 {
   if (!m_epgTag && bCreate)
@@ -1005,12 +1011,6 @@ CPVREpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) con
     }
   }
   return m_epgTag;
-}
-
-void CPVRTimerInfoTag::SetEpgTag(const CPVREpgInfoTagPtr &tag)
-{
-  CSingleLock lock(m_critSection);
-  m_epgTag = tag;
 }
 
 bool CPVRTimerInfoTag::HasChannel() const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -253,11 +253,6 @@ namespace PVR
     void SetEpgTag(const CPVREpgInfoTagPtr &tag);
 
     /*!
-     * @brief Clear the epg tag associated with this timer; before, clear this timer at associated epg tag, if any.
-     */
-    void ClearEpgTag(void);
-
-    /*!
      * @brief Update the channel associated with this timer.
      * @return the channel for the timer. Can be empty for epg based repeating timers (e.g. "match any channel" rules)
      */

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -77,6 +77,12 @@ namespace PVR
     static CPVRTimerInfoTagPtr CreateFromEpg(const CPVREpgInfoTagPtr &tag, bool bCreateRule = false);
 
     /*!
+     * @brief Associate the given epg tag with this timer.
+     * @param tag The epg tag to assign.
+     */
+    void SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag);
+
+    /*!
      * @brief get the epg info tag associated with this timer, if any
      * @param bCreate if true, try to find the epg tag if not yet set (lazy evaluation)
      * @return the epg info tag associated with this timer or null if there is no tag
@@ -245,12 +251,6 @@ namespace PVR
      * @return True on success, false otherwise.
      */
     bool UpdateOnClient();
-
-    /*!
-     * @brief Associate the given epg tag with this timer; before, clear old timer at associated epg tag, if any.
-     * @param tag The epg tag to assign.
-     */
-    void SetEpgTag(const CPVREpgInfoTagPtr &tag);
 
     /*!
      * @brief Update the channel associated with this timer.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -724,43 +724,6 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CPVREpgInfoTagPtr &epgTa
   return CPVRTimerInfoTagPtr();
 }
 
-bool CPVRTimers::HasRecordingTimerForRecording(const CPVRRecording &recording) const
-{
-  return GetRecordingTimerForRecording(recording) != nullptr;
-}
-
-CPVRTimerInfoTagPtr CPVRTimers::GetRecordingTimerForRecording(const CPVRRecording &recording) const
-{
-  CSingleLock lock(m_critSection);
-
-  for (const auto &tagsEntry : m_tags)
-  {
-    for (const auto &timersEntry : tagsEntry.second)
-    {
-      if (timersEntry->IsRecording() &&
-          !timersEntry->IsTimerRule() &&
-          !timersEntry->IsBroken() &&
-          timersEntry->m_iClientId == recording.ClientID() &&
-          timersEntry->m_iClientChannelUid == recording.ChannelUid())
-      {
-        // first, match epg event uids, if available
-        if (timersEntry->UniqueBroadcastID() == recording.BroadcastUid() &&
-            timersEntry->UniqueBroadcastID() != EPG_TAG_INVALID_UID)
-          return timersEntry;
-
-        // alternatively, match start and end times
-        const CDateTime timerStart = timersEntry->StartAsUTC() - CDateTimeSpan(0, 0, timersEntry->m_iMarginStart, 0);
-        const CDateTime timerEnd = timersEntry->EndAsUTC() + CDateTimeSpan(0, 0, timersEntry->m_iMarginEnd, 0);
-        if (timerStart <= recording.RecordingTimeAsUTC() &&
-            timerEnd >= recording.EndTimeAsUTC())
-          return timersEntry;
-      }
-    }
-  }
-
-  return CPVRTimerInfoTagPtr();
-}
-
 CPVRTimerInfoTagPtr CPVRTimers::GetTimerRule(const CPVRTimerInfoTagPtr &timer) const
 {
   if (timer)

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -8,7 +8,6 @@
 
 #include "PVRTimers.h"
 
-#include <cstdlib>
 #include <utility>
 
 #include "FileItem.h"
@@ -17,8 +16,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
-#include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include "pvr/PVRJobs.h"
@@ -26,6 +23,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 using namespace PVR;
 
@@ -852,74 +850,4 @@ CPVRTimerInfoTagPtr CPVRTimers::GetById(unsigned int iTimerId) const
     }
   }
   return item;
-}
-
-
-//= CPVRTimersPath ============================================================
-
-const std::string CPVRTimersPath::PATH_ADDTIMER = "pvr://timers/addtimer/";
-const std::string CPVRTimersPath::PATH_NEW      = "pvr://timers/new/";
-
-CPVRTimersPath::CPVRTimersPath(const std::string &strPath)
-{
-  Init(strPath);
-}
-
-CPVRTimersPath::CPVRTimersPath(const std::string &strPath, int iClientId, unsigned int iParentId)
-{
-  if (Init(strPath))
-  {
-    /* set/replace client and parent id. */
-    m_path = StringUtils::Format("pvr://timers/%s/%s/%d/%d",
-                                 m_bRadio      ? "radio" : "tv",
-                                 m_bTimerRules ? "rules" : "timers",
-                                 iClientId,
-                                 iParentId);
-    m_iClientId = iClientId;
-    m_iParentId = iParentId;
-    m_bRoot = false;
-  }
-}
-
-CPVRTimersPath::CPVRTimersPath(bool bRadio, bool bTimerRules) :
-  m_path(StringUtils::Format(
-    "pvr://timers/%s/%s", bRadio ? "radio" : "tv", bTimerRules ? "rules" : "timers")),
-  m_bValid(true),
-  m_bRoot(true),
-  m_bRadio(bRadio),
-  m_bTimerRules(bTimerRules),
-  m_iClientId(-1),
-  m_iParentId(0)
-{
-}
-
-bool CPVRTimersPath::Init(const std::string &strPath)
-{
-  std::string strVarPath(strPath);
-  URIUtils::RemoveSlashAtEnd(strVarPath);
-
-  m_path = strVarPath;
-  const std::vector<std::string> segments = URIUtils::SplitPath(m_path);
-
-  m_bValid   = (((segments.size() == 4) || (segments.size() == 6)) &&
-                (segments.at(1) == "timers") &&
-                ((segments.at(2) == "radio") || (segments.at(2) == "tv"))&&
-                ((segments.at(3) == "rules") || (segments.at(3) == "timers")));
-  m_bRoot    = (m_bValid && (segments.size() == 4));
-  m_bRadio   = (m_bValid && (segments.at(2) == "radio"));
-  m_bTimerRules = (m_bValid && (segments.at(3) == "rules"));
-
-  if (!m_bValid || m_bRoot)
-  {
-    m_iClientId = -1;
-    m_iParentId = 0;
-  }
-  else
-  {
-    char *end;
-    m_iClientId = std::strtol (segments.at(4).c_str(), &end, 10);
-    m_iParentId = std::strtoul(segments.at(5).c_str(), &end, 10);
-  }
-
-  return m_bValid;
 }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -290,36 +290,4 @@ namespace PVR
     bool m_bIsUpdating = false;
     CPVRSettings m_settings;
   };
-
-  class CPVRTimersPath
-  {
-  public:
-    static const std::string PATH_ADDTIMER;
-    static const std::string PATH_NEW;
-
-    explicit CPVRTimersPath(const std::string &strPath);
-    CPVRTimersPath(const std::string &strPath, int iClientId, unsigned int iParentId);
-    CPVRTimersPath(bool bRadio, bool bTimerRules);
-
-    bool IsValid() const { return m_bValid; }
-
-    const std::string &GetPath() const     { return m_path; }
-    bool              IsTimersRoot() const { return m_bRoot; }
-    bool              IsTimerRule() const  { return !IsTimersRoot(); }
-    bool              IsRadio() const      { return m_bRadio; }
-    bool              IsRules() const      { return m_bTimerRules; }
-    int               GetClientId() const  { return m_iClientId; }
-    unsigned int      GetParentId() const  { return m_iParentId; }
-
-  private:
-    bool Init(const std::string &strPath);
-
-    std::string  m_path;
-    bool         m_bValid;
-    bool         m_bRoot;
-    bool         m_bRadio;
-    bool         m_bTimerRules;
-    int          m_iClientId;
-    unsigned int m_iParentId;
-  };
 }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -26,7 +26,6 @@ typedef std::shared_ptr<CFileItem> CFileItemPtr;
 
 namespace PVR
 {
-  class CPVRRecording;
   class CPVRTimersPath;
 
   class CPVRTimersContainer
@@ -240,20 +239,6 @@ namespace PVR
      * @return The requested timer tag, or nullptr if none was found.
      */
     CPVRTimerInfoTagPtr GetTimerForEpgTag(const CPVREpgInfoTagPtr &epgTag) const;
-
-    /*!
-     * @brief Check whether there is a timer currently recording the given recording.
-     * @param recording The recording to check.
-     * @return true if there is a timer currently recording the given recording, false otherwise.
-     */
-    bool HasRecordingTimerForRecording(const CPVRRecording &recording) const;
-
-    /*!
-     * @brief Get the timer currently recording the given recording, if any.
-     * @param recording The recording to check.
-     * @return The requested timer tag, or an null if none was found.
-     */
-    CPVRTimerInfoTagPtr GetRecordingTimerForRecording(const CPVRRecording &recording) const;
 
     /*!
      * Get the timer rule for a given timer tag

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -287,8 +287,6 @@ namespace PVR
     bool UpdateEntries(const CPVRTimersContainer &timers, const std::vector<int> &failedClients);
     bool GetRootDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
     bool GetSubDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
-    bool SetEpgTagTimer(const CPVRTimerInfoTagPtr &timer);
-    bool ClearEpgTagTimer(const CPVRTimerInfoTagPtr &timer);
 
     enum TimerKind
     {

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -87,24 +87,24 @@ namespace PVR
     bool Update(void);
 
     /*!
-     * @return The tv or radio timer that will be active next (state scheduled), or an empty fileitemptr if none.
+     * @return The tv or radio timer that will be active next (state scheduled), or nullptr if none.
      */
-    CFileItemPtr GetNextActiveTimer(void) const;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer(void) const;
 
     /*!
-     * @return The tv timer that will be active next (state scheduled), or an empty fileitemptr if none.
+     * @return The tv timer that will be active next (state scheduled), or nullptr if none.
      */
-    CFileItemPtr GetNextActiveTVTimer(void) const;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTVTimer(void) const;
 
     /*!
-     * @return The radio timer that will be active next (state scheduled), or an empty fileitemptr if none.
+     * @return The radio timer that will be active next (state scheduled), or nullptr if none.
      */
-    CFileItemPtr GetNextActiveRadioTimer(void) const;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveRadioTimer(void) const;
 
     /*!
      * @return All timers that are active (states scheduled or recording)
      */
-    std::vector<CFileItemPtr> GetActiveTimers(void) const;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveTimers(void) const;
 
     /*!
      * Get all timers
@@ -135,17 +135,17 @@ namespace PVR
     /*!
      * @return All tv and radio timers that are recording
      */
-    std::vector<CFileItemPtr> GetActiveRecordings(void) const;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings() const;
 
     /*!
      * @return All tv timers that are recording
      */
-    std::vector<CFileItemPtr> GetActiveTVRecordings(void) const;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveTVRecordings() const;
 
     /*!
      * @return All radio timers that are recording
      */
-    std::vector<CFileItemPtr> GetActiveRadioRecordings(void) const;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRadioRecordings() const;
 
     /*!
      * @return True when recording, false otherwise.
@@ -237,7 +237,7 @@ namespace PVR
     /*!
      * @brief Get the timer tag that matches the given epg tag.
      * @param epgTag The epg tag.
-     * @return The requested timer tag, or an empty fileitemptr if none was found.
+     * @return The requested timer tag, or nullptr if none was found.
      */
     CPVRTimerInfoTagPtr GetTimerForEpgTag(const CPVREpgInfoTagPtr &epgTag) const;
 
@@ -258,7 +258,7 @@ namespace PVR
     /*!
      * Get the timer rule for a given timer tag
      * @param timer The timer to query the timer rule for
-     * @return The timer rule, or null if none was found.
+     * @return The timer rule, or nullptr if none was found.
      */
     CPVRTimerInfoTagPtr GetTimerRule(const CPVRTimerInfoTagPtr &timer) const;
 
@@ -297,9 +297,9 @@ namespace PVR
 
     bool KindMatchesTag(const TimerKind &eKind, const CPVRTimerInfoTagPtr &tag) const;
 
-    CFileItemPtr GetNextActiveTimer(const TimerKind &eKind) const;
+    std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer(const TimerKind& eKind) const;
     int AmountActiveTimers(const TimerKind &eKind) const;
-    std::vector<CFileItemPtr> GetActiveRecordings(const TimerKind &eKind) const;
+    std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings(const TimerKind& eKind) const;
     int AmountActiveRecordings(const TimerKind &eKind) const;
 
     bool m_bIsUpdating = false;

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRTimersPath.h"
+
+#include <cstdlib>
+#include <vector>
+
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+using namespace PVR;
+
+const std::string CPVRTimersPath::PATH_ADDTIMER = "pvr://timers/addtimer/";
+const std::string CPVRTimersPath::PATH_NEW      = "pvr://timers/new/";
+
+CPVRTimersPath::CPVRTimersPath(const std::string& strPath)
+{
+  Init(strPath);
+}
+
+CPVRTimersPath::CPVRTimersPath(const std::string& strPath, int iClientId, unsigned int iParentId)
+{
+  if (Init(strPath))
+  {
+    /* set/replace client and parent id. */
+    m_path = StringUtils::Format("pvr://timers/%s/%s/%d/%d",
+                                 m_bRadio      ? "radio" : "tv",
+                                 m_bTimerRules ? "rules" : "timers",
+                                 iClientId,
+                                 iParentId);
+    m_iClientId = iClientId;
+    m_iParentId = iParentId;
+    m_bRoot = false;
+  }
+}
+
+CPVRTimersPath::CPVRTimersPath(bool bRadio, bool bTimerRules) :
+  m_path(StringUtils::Format(
+    "pvr://timers/%s/%s", bRadio ? "radio" : "tv", bTimerRules ? "rules" : "timers")),
+  m_bValid(true),
+  m_bRoot(true),
+  m_bRadio(bRadio),
+  m_bTimerRules(bTimerRules),
+  m_iClientId(-1),
+  m_iParentId(0)
+{
+}
+
+bool CPVRTimersPath::Init(const std::string& strPath)
+{
+  std::string strVarPath(strPath);
+  URIUtils::RemoveSlashAtEnd(strVarPath);
+
+  m_path = strVarPath;
+  const std::vector<std::string> segments = URIUtils::SplitPath(m_path);
+
+  m_bValid   = (((segments.size() == 4) || (segments.size() == 6)) &&
+                (segments.at(1) == "timers") &&
+                ((segments.at(2) == "radio") || (segments.at(2) == "tv"))&&
+                ((segments.at(3) == "rules") || (segments.at(3) == "timers")));
+  m_bRoot    = (m_bValid && (segments.size() == 4));
+  m_bRadio   = (m_bValid && (segments.at(2) == "radio"));
+  m_bTimerRules = (m_bValid && (segments.at(3) == "rules"));
+
+  if (!m_bValid || m_bRoot)
+  {
+    m_iClientId = -1;
+    m_iParentId = 0;
+  }
+  else
+  {
+    char *end;
+    m_iClientId = std::strtol (segments.at(4).c_str(), &end, 10);
+    m_iParentId = std::strtoul(segments.at(5).c_str(), &end, 10);
+  }
+
+  return m_bValid;
+}

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -28,7 +28,7 @@ CPVRTimersPath::CPVRTimersPath(const std::string& strPath, int iClientId, unsign
 {
   if (Init(strPath))
   {
-    /* set/replace client and parent id. */
+    // set/replace client and parent id.
     m_path = StringUtils::Format("pvr://timers/%s/%s/%d/%d",
                                  m_bRadio      ? "radio" : "tv",
                                  m_bTimerRules ? "rules" : "timers",
@@ -75,9 +75,8 @@ bool CPVRTimersPath::Init(const std::string& strPath)
   }
   else
   {
-    char *end;
-    m_iClientId = std::strtol (segments.at(4).c_str(), &end, 10);
-    m_iParentId = std::strtoul(segments.at(5).c_str(), &end, 10);
+    m_iClientId = std::stoi(segments.at(4));
+    m_iParentId = std::stoul(segments.at(5));
   }
 
   return m_bValid;

--- a/xbmc/pvr/timers/PVRTimersPath.h
+++ b/xbmc/pvr/timers/PVRTimersPath.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace PVR
+{
+  class CPVRTimersPath
+  {
+  public:
+    static const std::string PATH_ADDTIMER;
+    static const std::string PATH_NEW;
+
+    explicit CPVRTimersPath(const std::string& strPath);
+    CPVRTimersPath(const std::string& strPath, int iClientId, unsigned int iParentId);
+    CPVRTimersPath(bool bRadio, bool bTimerRules);
+
+    bool IsValid() const { return m_bValid; }
+
+    const std::string& GetPath() const { return m_path; }
+    bool IsTimersRoot() const { return m_bRoot; }
+    bool IsTimerRule() const { return !IsTimersRoot(); }
+    bool IsRadio() const { return m_bRadio; }
+    bool IsRules() const { return m_bTimerRules; }
+    int GetClientId() const { return m_iClientId; }
+    unsigned int GetParentId() const { return m_iParentId; }
+
+  private:
+    bool Init(const std::string &strPath);
+
+    std::string m_path;
+    bool m_bValid = false;
+    bool m_bRoot = false;
+    bool m_bRadio = false;
+    bool m_bTimerRules = false;
+    int m_iClientId = -1;
+    unsigned int m_iParentId = 0;
+  };
+}

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -23,7 +23,7 @@
 #include "utils/Variant.h"
 
 #include "pvr/channels/PVRChannel.h"
-#include "pvr/epg/Epg.h"
+#include "pvr/epg/EpgInfoTag.h"
 #include "pvr/windows/GUIEPGGridContainerModel.h"
 
 using namespace PVR;
@@ -692,17 +692,14 @@ void CGUIEPGGridContainer::UpdateItems()
         newBlockIndex = m_gridModel->GetFirstEventBlock(prevSelectedEpgTag) + eventOffset;
       }
 
-      const CPVRChannelPtr channel(prevSelectedEpgTag->Channel());
-      if (channel)
-        channelUid = channel->UniqueID();
-
+      channelUid = prevSelectedEpgTag->UniqueChannelID();
       broadcastUid = prevSelectedEpgTag->UniqueBroadcastID();
     }
     else // "gap" tag selected
     {
       const GridItem *currItem(GetItem(m_channelCursor));
       if (currItem)
-        channelUid = currItem->item->GetEPGInfoTag()->Channel()->UniqueID();
+        channelUid = currItem->item->GetEPGInfoTag()->UniqueChannelID();
 
       const GridItem *prevItem(GetPrevItem(m_channelCursor));
       if (prevItem)
@@ -768,7 +765,8 @@ void CGUIEPGGridContainer::UpdateItems()
         newChannelIndex = iChannelIndex;
       }
       else if (newChannelIndex >= m_gridModel->ChannelItemsSize() ||
-               m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->Channel() != prevSelectedEpgTag->Channel())
+               (m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->UniqueChannelID() != prevSelectedEpgTag->UniqueChannelID() &&
+                m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->ClientID() != prevSelectedEpgTag->ClientID()))
       {
         // default to first channel
         newChannelIndex = 0;

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.h
@@ -84,6 +84,7 @@ namespace PVR
 
   private:
     void FreeItemsMemory();
+    std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
 
     struct ItemsPtr
     {

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -15,7 +15,7 @@
 #include "view/ViewStateSettings.h"
 
 #include "pvr/recordings/PVRRecordingsPath.h"
-#include "pvr/timers/PVRTimers.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 using namespace PVR;
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -179,9 +179,11 @@ bool CGUIWindowPVRBase::OnAction(const CAction &action)
     case ACTION_NEXT_CHANNELGROUP:
     {
       // switch to next or previous group
-      if (const CPVRChannelGroupPtr channelGroup = GetChannelGroup())
+      const std::shared_ptr<CPVRChannelGroup> channelGroup = GetChannelGroup();
+      if (channelGroup)
       {
-        SetChannelGroup(action.GetID() == ACTION_NEXT_CHANNELGROUP ? channelGroup->GetNextGroup() : channelGroup->GetPreviousGroup());
+        const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio());
+        SetChannelGroup(action.GetID() == ACTION_NEXT_CHANNELGROUP ? groups->GetNextGroup(*channelGroup) : groups->GetPreviousGroup(*channelGroup));
       }
       return true;
     }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -27,6 +27,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/windows/GUIEPGGridContainer.h"
 
 using namespace KODI::MESSAGING;
@@ -453,7 +454,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                     else
                     {
                       // past event
-                      if (tag->HasRecording())
+                      if (CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(tag))
                         CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(pItem, true);
                       else if (tag->IsPlayable())
                         CServiceBroker::GetPVRManager().GUIActions()->PlayEpgTag(pItem);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -642,7 +642,11 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       else
       {
         // can be very expensive. never call with lock acquired.
-        group->GetEPGAll(*timeline, true);
+        const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags = group->GetEPGAll(true);
+        for (const auto& tag : tags)
+        {
+          timeline->Add(std::make_shared<CFileItem>(tag));
+        }
       }
 
       CDateTime startDate(group->GetFirstEPGDate());

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -28,6 +28,7 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/recordings/PVRRecordings.h"
+#include "pvr/timers/PVRTimers.h"
 #include "pvr/windows/GUIEPGGridContainer.h"
 
 using namespace KODI::MESSAGING;
@@ -436,7 +437,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                     else if (now < start)
                     {
                       // future event
-                      if (tag->HasTimer())
+                      if (CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(tag))
                         CServiceBroker::GetPVRManager().GUIActions()->EditTimer(pItem);
                       else
                       {

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -96,7 +96,7 @@ void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItemPtr &item)
   else
   {
     const CPVREpgInfoTagPtr epgTag(CPVRItem(item).GetEpgInfoTag());
-    if (epgTag)
+    if (epgTag && !CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
       m_searchfilter->SetSearchPhrase(epgTag->Title());
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -23,6 +23,7 @@
 #include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRGuideSearch.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgSearchFilter.h"
@@ -55,7 +56,11 @@ namespace
 
   void AsyncSearchAction::Run()
   {
-    CServiceBroker::GetPVRManager().EpgContainer().GetEPGSearch(*m_items, *m_filter);
+    const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags = CServiceBroker::GetPVRManager().EpgContainer().GetEPGSearch(*m_filter);
+    for (const auto& tag : tags)
+    {
+      m_items->Add(std::make_shared<CFileItem>(tag));
+    }
   }
 } // unnamed namespace
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -20,7 +20,7 @@ namespace PVR
   {
   public:
     CGUIWindowPVRSearchBase(bool bRadio, int id, const std::string &xmlFile);
-    ~CGUIWindowPVRSearchBase() override = default;
+    ~CGUIWindowPVRSearchBase() override;
 
     bool OnMessage(CGUIMessage& message)  override;
     void GetContextButtons(int itemNumber, CContextButtons &buttons) override;

--- a/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
@@ -11,7 +11,7 @@
 #include "FileItem.h"
 #include "utils/URIUtils.h"
 
-#include "pvr/timers/PVRTimers.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 using namespace PVR;
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -11,7 +11,7 @@
 #include "FileItem.h"
 #include "utils/URIUtils.h"
 
-#include "pvr/timers/PVRTimers.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 using namespace PVR;
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -22,7 +22,8 @@
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
-#include "pvr/timers/PVRTimers.h"
+#include "pvr/timers/PVRTimerInfoTag.h"
+#include "pvr/timers/PVRTimersPath.h"
 
 using namespace PVR;
 using namespace KODI::MESSAGING;

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -24,6 +24,7 @@ typedef enum
   ObservableMessageEpgContainer,
   ObservableMessageEpgActiveItem,
   ObservableMessageEpgItemUpdate,
+  ObservableMessageEpgUpdatePending,
   ObservableMessageChannelGroup,
   ObservableMessageChannelGroupReset,
   ObservableMessageTimers,


### PR DESCRIPTION
"Inspired" by the large amount of rare but varying deadlocks among PVR components I finally moved my ass and I defined a dependency graph for the PVR components and their subcomponents.

Before, every PVR component called into every other PVR component. Even the subcomponents called each other in any order. It was all a big mess (and I was part of building this mess, yes).

Now, we have a clear picture:

<img width="850" alt="pvr-component-deps" src="https://user-images.githubusercontent.com/3226626/54072771-c979e700-427f-11e9-9434-f8f13606bdb7.png">

This PR strictly implements this dependency tree. No more, no less. No functional restrictions due to the refactoring, no new features, but massive reduction in deadlock risk.

I tried to slice this PR down into reviewable pieces. Each commit removes exactly one wrong dependency.

I have tested this for quite some time now on Android and macOS. Works without any issues.

@Jalle19 I really would appreciate your feedback on the code.