### PR TITLE
[pyton] update docs for artwork functions

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -761,7 +761,7 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ setAvailableFanart(images) }
       ///-----------------------------------------------------------------------
-      /// @brief Set available images (needed for scrapers)
+      /// @brief Set available images (needed for video scrapers)
       ///
       /// @param images            list of dictionaries (see below for relevant keys)
       ///
@@ -794,7 +794,7 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ addAvailableArtwork(images) }
       ///-----------------------------------------------------------------------
-      /// @brief Add an image to available artworks (needed for scrapers)
+      /// @brief Add an image to available artworks (needed for video scrapers)
       ///
       /// @param url            string (image path url)
       /// @param art_type       string (image type)


### PR DESCRIPTION
the setAvailableFanart() / addAvailableArtwork() will only work for video scrapers.

if you're writing an album or artist scraper, setArt() / setProperty() have to be used instead.
