### PR TITLE
FFMPEG: Bump to 4.0.3-Leia-18.2

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.0.3-Leia-RC5
+VERSION=4.0.3-Leia-18.2
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz


### PR DESCRIPTION
Fixes: https://github.com/xbmc/xbmc/issues/15704

No other changes made to FFMPEG, only affects VAAPI on Linux.