### PR TITLE
[VideoPlayer] Ensure video queue is not in intermediate state when flushing

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -462,6 +462,7 @@ void CVideoPlayerVideo::Process()
       }
 
       m_renderManager.DiscardBuffer();
+      FlushMessages();
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
@@ -776,7 +777,6 @@ void CVideoPlayerVideo::Flush(bool sync)
   /* flush using message as this get's called from VideoPlayer thread */
   /* and any demux packet that has been taken out of queue need to */
   /* be disposed of before we flush */
-  FlushMessages();
   SendMessage(new CDVDMsgBool(CDVDMsg::GENERAL_FLUSH, sync), 1);
   m_bAbortOutput = true;
 }


### PR DESCRIPTION
## Description
If VPV receives a Flush() command from VP thread, it is possible that VPV thread has a video packet in process which will be stacked back (decoder resetted / not ready to receive input data after reset)

VP and VPV thread are not synchronized regarding completeness of the msgqueue, and especially after seek the packet with the old PTS value leads to long pause until VP has synced audio and video again.

This PR ensures that all packets are in VPV messagequeue and will be flushed by the VPV::FlushMessages call.

Kodi log snippet:

```
2019-03-09 23:54:23.297 T:20238   DEBUG: CVideoPlayer::FlushBuffers - flushing buffers
2019-03-09 23:54:23.301 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::AddData dts:354542000.00 pts:354542000.00 sz:9785 indexBuffer:-1 current state (3)
2019-03-09 23:54:23.301 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream: state: 3
2019-03-09 23:54:23.301 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream: ReleaseMediaCodecBuffers
2019-03-09 23:54:23.302 T:20248   DEBUG: CMediaCodecVideoBuffer::ReleaseOutputBuffer index(5), render(0), time:0, offset:0
2019-03-09 23:54:23.302 T:20248   DEBUG: CMediaCodecVideoBuffer::ReleaseOutputBuffer index(12), render(0), time:0, offset:0
2019-03-09 23:54:23.303 T:20248   DEBUG: CMediaCodecVideoBuffer::ReleaseOutputBuffer index(4), render(0), time:0, offset:0
2019-03-09 23:54:23.303 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream: BUFFER_FLAG_END_OF_STREAM send
2019-03-09 23:54:23.303 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::Reset Current state (3)
2019-03-09 23:54:23.309 T:19495   DEBUG: CAnnouncementManager - Announcement: OnSeek from xbmc
2019-03-09 23:54:23.309 T:19495   DEBUG: GOT ANNOUNCEMENT, type: 1, from xbmc, message OnSeek
2019-03-09 23:54:23.310 T:20249   DEBUG: CDVDAudio::Pause - pausing audio stream
2019-03-09 23:54:23.357 T:20249   DEBUG: CDVDAudio::Flush - flush audio stream
2019-03-09 23:54:23.357 T:20249   DEBUG: CDVDAudio::Pause - pausing audio stream
2019-03-09 23:54:23.357 T:20249   DEBUG: CVideoPlayerAudio - CDVDMsg::GENERAL_SYNCHRONIZE
2019-03-09 23:54:23.358 T:20248   DEBUG: CVideoPlayerVideo - CDVDMsg::GENERAL_SYNCHRONIZE
2019-03-09 23:54:23.358 T:20248    INFO: CVideoPlayerVideo - Stillframe left, switching to normal playback
2019-03-09 23:54:23.358 T:20248   DEBUG: CVideoPlayerVideo::CalcDropRequirement - hurry: 0
2019-03-09 23:54:23.358 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::SetCodecControl 0->4000000
2019-03-09 23:54:23.358 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::AddData dts:354542000.00 pts:354542000.00 sz:9785 indexBuffer:-1 current state (2)
2019-03-09 23:54:23.370 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::GetPicture VC_BUFFER
2019-03-09 23:54:23.370 T:20248   DEBUG: CVideoPlayerVideo::CalcDropRequirement - hurry: 0
2019-03-09 23:54:23.370 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::AddData dts:354542000.00 pts:354542000.00 sz:9785 indexBuffer:0 current state (2)
2019-03-09 23:54:23.372 T:20248   DEBUG: CDVDVideoCodecAndroidMediaCodec::GetPicture index: 1, pts:354542000.0000
2019-03-09 23:54:23.379 T:20238   DEBUG: CVideoPlayer::HandleMessages - player started 2
2019-03-09 23:54:23.382 T:19491   DEBUG: CMediaCodecVideoBuffer::ReleaseOutputBuffer index(1), render(1), time:46004559865300, offset:20135350
2019-03-09 23:54:23.383 T:20238   DEBUG: CVideoPlayer::HandleMessages - player started 1
2019-03-09 23:54:23.384 T:20238   DEBUG: CVideoPlayer::SetCaching - caching state 3
2019-03-09 23:54:23.384 T:20227   DEBUG: OnAVChange: CApplication::OnAVChange
2019-03-09 23:54:23.384 T:20238   DEBUG: CDVDClock::SetSpeedAdjust - adjusted:0.000000
2019-03-09 23:54:23.385 T:20238   DEBUG: CVideoPlayer::SetCaching - caching state 0
2019-03-09 23:54:23.385 T:20238   DEBUG: CDVDClock::SetSpeedAdjust - adjusted:0.000000
2019-03-09 23:54:23.385 T:20238   DEBUG: VideoPlayer::Sync - Audio - pts: 385703000.000000, cache: 303728.974831, totalcache: 664166.688919
2019-03-09 23:54:23.385 T:20238   DEBUG: VideoPlayer::Sync - Video - pts: 354542000.000000, cache: 50000.000000, totalcache: 100000.000000
```
## Motivation and Context
Often stalls when seeking Video streams

## How Has This Been Tested?
Android, play any stream and seek around some times

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
