### PR TITLE
[video] Use dynpath for discs

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1059,6 +1059,9 @@ bool CFileItem::IsNFO() const
 
 bool CFileItem::IsDiscImage() const
 {
+  if (!m_strDynPath.empty())
+    return URIUtils::HasExtension(m_strDynPath, ".img|.iso|.nrg|.udf");
+
   return URIUtils::HasExtension(m_strPath, ".img|.iso|.nrg|.udf");
 }
 
@@ -1241,7 +1244,7 @@ bool CFileItem::IsMusicDb() const
 
 bool CFileItem::IsVideoDb() const
 {
-  return URIUtils::IsVideoDb(m_strPath);
+  return URIUtils::IsVideoDb(m_strPath) || URIUtils::IsVideoDb(m_strDynPath);
 }
 
 bool CFileItem::IsVirtualDirectoryRoot() const

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -298,7 +298,11 @@ bool CPlayListPlayer::Play(int iSong, std::string player, bool bAutoPlay /* = fa
   m_iCurrentSong = iSong;
   CFileItemPtr item = playlist[m_iCurrentSong];
   if (item->IsVideoDb() && !item->HasVideoInfoTag())
-    *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetPath()));
+  {
+    *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetDynPath()));
+    item->SetProperty("original_listitem_url", item->GetDynPath());
+    item->SetDynPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
+  }
 
   playlist.SetPlayed(true);
 

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -52,15 +52,9 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
 
-  std::string path;
-  if (item.IsVideoDb())
-    path = item.GetVideoInfoTag()->m_strFileNameAndPath;
-  else
-    path = item.GetPath();
-
   if (item.IsBDFile())
   {
-    std::string root = URIUtils::GetParentPath(path);
+    std::string root = URIUtils::GetParentPath(item.GetDynPath());
     URIUtils::RemoveSlashAtEnd(root);
     if (URIUtils::GetFileName(root) == "BDMV")
     {
@@ -74,7 +68,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
   if (item.IsDiscImage())
   {
     CURL url2("udf://");
-    url2.SetHostName(item.GetPath());
+    url2.SetHostName(item.GetDynPath());
     url2.SetFileName("BDMV/index.bdmv");
     if (XFILE::CFile::Exists(url2.Get()))
     {
@@ -122,9 +116,9 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
       break;
     }
 
-    if (item_new->m_bIsFolder == false)
+    if (!item_new->m_bIsFolder)
     {
-      std::string original_path = item.GetPath();
+      std::string original_path = item.GetDynPath();
       item.Reset();
       item = *item_new;
       item.SetProperty("original_listitem_url", original_path);
@@ -132,7 +126,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
     }
 
     items.Clear();
-    if (!GetDirectoryItems(item_new->GetPath(), items, XFILE::CDirectory::CHints()) || items.IsEmpty())
+    if (!GetDirectoryItems(item_new->GetDynPath(), items, XFILE::CDirectory::CHints()) || items.IsEmpty())
     {
       CLog::Log(LOGERROR, "CGUIWindowVideoBase::ShowPlaySelection - Failed to get any items %s", item_new->GetPath().c_str());
       break;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1097,11 +1097,6 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
 
   CFileItem item(*pItem);
-  if (pItem->IsVideoDb())
-  {
-    item.SetPath(pItem->GetVideoInfoTag()->m_strFileNameAndPath);
-    item.SetProperty("original_listitem_url", pItem->GetPath());
-  }
   CLog::Log(LOGDEBUG, "%s %s", __FUNCTION__, CURL::GetRedacted(item.GetPath()).c_str());
 
   PlayMovie(&item, player);


### PR DESCRIPTION
## Description
This PR makes kodi use `dynpath` instead of `path` also for discs (bluray and dvds). In the current state, if play next video automatically is enabled for movies, kodi will create a playlist. At some point during the playlist creation, the unique path of the item (that should never change) is replaced by its dynpath: `item.SetPath(pItem->GetVideoInfoTag()->m_strFileNameAndPath);` which is wrong. This explains the differences between playing the ISO from a playlist and from the library.

I just have one BR ISO so this might need additional testing. @DaVukovic mind giving it a go with your library? I haven't tested the BD-J menus too (only the simplified menu). Pinging @ace20022 for review.

## Motivation and Context
Fix https://github.com/xbmc/xbmc/issues/15519. Might also fix https://github.com/xbmc/xbmc/issues/15414.

## How Has This Been Tested?
Compile and runtime tested in OSX

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
