### PR TITLE
[Android] Don't signal END_OF_STREAM if dropping packets

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1061,11 +1061,6 @@ void CDVDVideoCodecAndroidMediaCodec::SetCodecControl(int flags)
   {
     CLog::Log(LOGDEBUG, LOGVIDEO, "CDVDVideoCodecAndroidMediaCodec::%s %x->%x",  __func__, m_codecControlFlags, flags);
     m_codecControlFlags = flags;
-
-    if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
-      m_videobuffer.iFlags |= DVP_FLAG_DROPPED;
-    else
-      m_videobuffer.iFlags &= ~DVP_FLAG_DROPPED;
   }
 }
 
@@ -1227,8 +1222,9 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
 
     if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
     {
+      m_noPictureLoop = 0;
       AMediaCodec_releaseOutputBuffer(m_codec->codec(), index, false);
-      return -1;
+      return -2;
     }
 
     if (bufferInfo.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM)


### PR DESCRIPTION
## Description
When seeking for resume point after seek we currently flush too often what leads to playback start on non-I-Frame. This not only looks ugly, it also kills some h/w decoder.

## Motivation and Context
Conversation with NVIDIA regarding seek issues.

## How Has This Been Tested?
Most visible using webm VP9 streams because we don't provide bitstream parser for this.
e.g.: https://mango.blender.org/download/ the 1080p webm stream (VP8)

- start stream
- seek to 5 minutes
- stop stream
- resume

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
