### PR TITLE
[PVR] Timer Rules no scheduled items misleading information

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -300,10 +300,12 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
   const CPVRTimerInfoTagPtr timer = item->GetPVRTimerInfoTag();
   if (timer)
   {
+    bool bRadio = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_RADIO_TIMER_RULES;
+
     switch (info.m_info)
     {
       case LISTITEM_DATE:
-        strValue = timer->Summary();
+        strValue = timer->Summary(bRadio);
         return true;
       case LISTITEM_STARTDATE:
         strValue = GetAsLocalizedDateString(timer->StartAsLocalTime(), true);
@@ -328,7 +330,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
         strValue = timer->Title();
         return true;
       case LISTITEM_COMMENT:
-        strValue = timer->GetStatus(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_RADIO_TIMER_RULES);
+        strValue = timer->GetStatus(bRadio);
         return true;
       case LISTITEM_TIMERTYPE:
         strValue = timer->GetTypeAsString();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -397,7 +397,8 @@ std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
       strReturn = g_localizeStrings.Get(257);   // "Error"
     else if ((m_bHasTVChildConflictNOK && !bRadio) || (m_bHasRadioChildConflictNOK && bRadio))
       strReturn = g_localizeStrings.Get(19276); // "Conflict error"
-    else if ((m_iActiveTVChildTimers > 0 && !bRadio) || (m_iActiveRadioChildTimers > 0 && bRadio))
+    else if ((m_iActiveTVChildTimers > 0 && !bRadio) || (m_iActiveRadioChildTimers > 0 && bRadio) ||
+            (IsTimerRule() && ((m_iActiveTVChildTimers == 0 && !bRadio) || (m_iActiveRadioChildTimers == 0 && bRadio))))
       strReturn = StringUtils::Format(g_localizeStrings.Get(19255).c_str(),
                                       bRadio ? m_iActiveRadioChildTimers : m_iActiveTVChildTimers); // "%d scheduled"
   }
@@ -1052,6 +1053,18 @@ const std::string& CPVRTimerInfoTag::Title(void) const
 const std::string& CPVRTimerInfoTag::Summary(void) const
 {
   return m_strSummary;
+}
+
+const std::string& CPVRTimerInfoTag::Summary(bool bRadio) const
+{
+  if (IsTimerRule() && ((m_iActiveTVChildTimers == 0 && !bRadio) || (m_iActiveRadioChildTimers == 0 && bRadio)))
+  {
+    return g_localizeStrings.Get(819); // "No matching events found"
+  }
+  else
+  {
+    return m_strSummary;
+  }
 }
 
 const std::string& CPVRTimerInfoTag::Path(void) const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -205,6 +205,7 @@ namespace PVR
 
     const std::string& Title(void) const;
     const std::string& Summary(void) const;
+    const std::string& Summary(bool bRadio) const;
     const std::string& Path(void) const;
 
     /*!


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Changes the display of information in the Timer Rules List when there are no scheduled items to something more meaningful.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When there are no scheduled items for a Timer Rule, which occurs when all Timers scheduled from the rule have been completed or new schedules are not yet available in the EPG, the rule displays "Enabled" and "01/01/1970 from anytime to 00.00" which is confusing.

All timer rules are enabled by default and cannot be disabled, only deleted, so showing this as enabled is misleading and it would be  better to show the number of schedules, which in this case is zero, similar to all the rest of the entries.

The entry "01/01/1970 from anytime to 00.00" is totally confusing and would be better with a simple message such as "No matching events found" or something similar.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
### **This is the current version:**

![1](https://user-images.githubusercontent.com/25765532/54107141-30a6b100-43d0-11e9-8195-a68df49e2091.png)

### **This is the proposed version:**

![2](https://user-images.githubusercontent.com/25765532/54107182-4caa5280-43d0-11e9-945a-905b4636a5f8.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
