### PR TITLE
xbmcclient.py doesn't allow non ascii characters

### DIFF
--- a/tools/EventClients/lib/python/xbmcclient.py
+++ b/tools/EventClients/lib/python/xbmcclient.py
@@ -101,7 +101,7 @@ ACTION_BUTTON      = 0x02
 
 def format_string(msg):
     """ """
-    return msg.encode() + b"\0"
+    return msg.encode('utf-8') + b"\0"
 
 def format_uint32(num):
     """ """


### PR DESCRIPTION
I want to show messages from an external program using xbmcclient.py, but as it is it doesn't allow me to send non ascii characters. With this modification I can do that. Tested with python 2 and python 3 using this code

```
# coding: utf-8
from xbmcclient import *
sock=socket(AF_INET,SOCK_DGRAM)
packet=PacketACTION(actionmessage=u"Notification(Test message, posición)", actiontype=ACTION_BUTTON)
packet.send(sock,('localhost',9777))
```


