### PR TITLE
[Android] Yet another refreshrate switch enhancement

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -34,7 +34,7 @@ public:
   bool DestroyWindow() override;
   void UpdateResolutions() override;
 
-  void SetHDMIState(bool connected, uint32_t timeoutMs = 0);
+  void SetHDMIState(bool connected);
 
   bool HasCursor() override { return false; };
 


### PR DESCRIPTION
## Description
New logic:
- SetNativeResoluiton (==modechange) called
- Trigger android mode change (using window layout param)
- Wait for onDisplayChange callback invocation (max. 5 seconds)
- Trigger OnLostDisplay (max. runtime 2 seconds)
If during these 2 seconds a HDMI_AUDIOPLUG intent arrives, stop the timer, wait for HDMI on state.

## Motivation and Context
1.) Improve mode switch by not resetting Audio before android's new mode is triggered
2.) Allow mode changes on devices which don't switch HDMI on some modes (e.g. AFTV 2018, 59.94 -> 60 changes the mode, but does not lead to HDMI / TV switch)

## How Has This Been Tested?
AFTV 2017 / 2018 / Wetek HUB / ShieldTV. play various streams which force a mode switch.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
