### PR TITLE
[PVR] Guide window: On first open, trigger immediate fetching of real data, not delayed.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -224,7 +224,7 @@ bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFile
 
   // never call DoRefresh with locked mutex!
   if (m_bSyncRefreshTimelineItems)
-    m_refreshTimelineItemsThread->DoRefresh();
+    m_refreshTimelineItemsThread->DoRefresh(true);
 
   {
     CSingleLock lock(m_critSection);
@@ -632,6 +632,7 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
 
         // next, fetch actual data.
         m_bRefreshTimelineItems = true;
+        m_refreshTimelineItemsThread->DoRefresh(false);
       }
       else
       {
@@ -766,11 +767,15 @@ void CPVRRefreshTimelineItemsThread::Stop()
   m_ready.Set(); // wake up the worker thread to let it exit
 }
 
-void CPVRRefreshTimelineItemsThread::DoRefresh()
+void CPVRRefreshTimelineItemsThread::DoRefresh(bool bWait)
 {
   m_ready.Set(); // wake up the worker thread
-  m_done.Reset();
-  CGUIDialogBusy::WaitOnEvent(m_done, 100, false);
+
+  if (bWait)
+  {
+    m_done.Reset();
+    CGUIDialogBusy::WaitOnEvent(m_done, 100, false);
+  }
 }
 
 void CPVRRefreshTimelineItemsThread::Process()

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -101,7 +101,7 @@ namespace PVR
 
     void Process() override;
 
-    void DoRefresh();
+    void DoRefresh(bool bWait);
     void Stop();
 
   private:


### PR DESCRIPTION
Motivation: https://github.com/xbmc/xbmc/commit/35974005423894fc554dbc9b212988ab4768486a#commitcomment-32700197 ff.
