### PR TITLE
[Scraper] prevent sending Range Header

### DIFF
--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -206,6 +206,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
 
   std::string strHTML1(strHTML);
 
+  url.SetProtocolOption("seekable", "0");
   if (scrURL.m_post)
   {
     std::string strOptions = url.GetOptions();


### PR DESCRIPTION
## Description
By forcing the URL to not seekable, we prevent sending the Range: bytes 0- Header.
Sending this Header seems to lead to 206 partitial contnt even the full content is provided (cloudfare)

My assumption is, that requests with Range and without Range are 2 different requests for CF cache and this would lead to double space they require for their cache. 

What should be discussed is if it makes possibly sense to set seekable = false by default in libCURL.
Modules which need seekable content must specify seekable=1 if they really need it.

https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/CurlFile.cpp#L311-L313 (6 years old)
https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/CurlFile.cpp#L1003


## Motivation and Context
Discussions with themoviedb.org regarding many 206 response / cache misses

## How Has This Been Tested?
Scrape a movie with libCURL component debugging enabled, search for 206 in kodi log

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
