### PR TITLE
[PVR] Only trigger CPVRUpdateAddonsJob if the AddonEvent is a PVR client

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -233,7 +233,8 @@ void CPVRClients::OnAddonEvent(const AddonEvent& event)
       typeid(event) == typeid(AddonEvents::ReInstalled))
   {
     // update addons
-    CJobManager::GetInstance().AddJob(new CPVRUpdateAddonsJob(event.id), nullptr);
+    if (CServiceBroker::GetAddonMgr().HasType(event.id, ADDON_PVRDLL))
+      CJobManager::GetInstance().AddJob(new CPVRUpdateAddonsJob(event.id), nullptr);
   }
 }
 


### PR DESCRIPTION
## Description
Trigger only the PVRUpdateAddons job if the resulting event is in fact triggered by a PVR client event (addon: Enabled, Disabled, UnInstalled, ReInstalled).

## Motivation and Context
Found while debugging trough other issues.

## How Has This Been Tested?
Installed a video addon -> check the event was not triggered
Install pvr demo client -> check the event is triggered

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

