### PR TITLE
[GUIControllerWindow] Update controller list after controller addon installation

### DIFF
--- a/xbmc/games/controllers/windows/GUIControllerWindow.h
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.h
@@ -42,8 +42,8 @@ namespace GAME
     void OnControllerSelected(unsigned int controllerIndex);
     void OnFeatureFocused(unsigned int featureIndex);
     void OnFeatureSelected(unsigned int featureIndex);
-    void OnEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event);
     void UpdateButtons(void);
+    void UpdateControllerList(void);
 
     // Action for the available button
     void GetMoreControllers(void);
@@ -51,6 +51,10 @@ namespace GAME
     void ResetController(void);
     void ShowHelp(void);
     void ShowButtonCaptureDialog(void);
+
+    // Callbacks for events
+    void OnEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event);
+    void OnEvent(const ADDON::AddonEvent& event);
 
     IControllerList* m_controllerList = nullptr;
     IFeatureList* m_featureList = nullptr;


### PR DESCRIPTION
## Description
When installing a new controller through the ControllerWindow the list of installed controller addons is not updated. We have to close the dialog and open it again to configure the new installed controller. This PR makes the window subscribe to addon events via the addon manager reacting accordingly to the received event.

## Motivation and Context
Better user experience.

## How Has This Been Tested?
Installed a new controller addon and check if the list was updated.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
