### PR TITLE
Controller dialog: Update controllers after controller addon installation

### DIFF
--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -146,7 +146,9 @@ void CGUIControllerList::ResetController(void)
 
 void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
 {
-  if (typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||  // also called on install,
+      typeid(event) == typeid(ADDON::AddonEvents::Disabled) || // not called on uninstall
+      typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
       typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
     using namespace MESSAGING;

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -75,7 +75,7 @@ void CGUIControllerList::Deinitialize(void)
   m_controllerButton = nullptr;
 }
 
-bool CGUIControllerList::Refresh(const std::string &controllerId)
+bool CGUIControllerList::Refresh(const std::string& controllerId)
 {
   // Focus specified controller after refresh
   std::string focusController = controllerId;

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -59,7 +59,7 @@ bool CGUIControllerList::Initialize(void)
     m_controllerButton->SetVisible(false);
 
   CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CGUIControllerList::OnEvent);
-  Refresh();
+  Refresh("");
 
   return m_controllerList != nullptr &&
          m_controllerButton != nullptr;
@@ -75,8 +75,17 @@ void CGUIControllerList::Deinitialize(void)
   m_controllerButton = nullptr;
 }
 
-bool CGUIControllerList::Refresh(void)
+bool CGUIControllerList::Refresh(const std::string &controllerId)
 {
+  // Focus specified controller after refresh
+  std::string focusController = controllerId;
+
+  if (focusController.empty() && m_focusedController >= 0)
+  {
+    // If controller ID wasn't provided, focus current controller
+    focusController = m_controllers[m_focusedController]->ID();
+  }
+
   if (!RefreshControllers())
     return false;
 
@@ -91,6 +100,12 @@ bool CGUIControllerList::Refresh(void)
 
       CGUIButtonControl* pButton = new CGUIControllerButton(*m_controllerButton, controller->Layout().Label(), buttonId++);
       m_controllerList->AddControl(pButton);
+
+      if (!focusController.empty() && controller->ID() == focusController)
+      {
+        CGUIMessage msg(GUI_MSG_SETFOCUS, m_guiWindow->GetID(), pButton->GetID());
+        m_guiWindow->OnMessage(msg);
+      }
 
       // Just in case
       if (buttonId >= MAX_CONTROLLER_COUNT)
@@ -153,6 +168,12 @@ void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
   {
     using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);
+
+    // Focus installed add-on
+    if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
+        typeid(event) == typeid(ADDON::AddonEvents::ReInstalled))
+      msg.SetStringParam(event.id);
+
     CApplicationMessenger::GetInstance().SendGUIMessage(msg, m_guiWindow->GetID());
   }
 }

--- a/xbmc/games/controllers/windows/GUIControllerList.h
+++ b/xbmc/games/controllers/windows/GUIControllerList.h
@@ -35,7 +35,7 @@ namespace GAME
     // implementation of IControllerList
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
-    virtual bool Refresh(void) override;
+    virtual bool Refresh(const std::string &controllerId) override;
     virtual void OnFocus(unsigned int controllerIndex) override;
     virtual void OnSelect(unsigned int controllerIndex) override;
     virtual int GetFocusedController() const override { return m_focusedController; }

--- a/xbmc/games/controllers/windows/GUIControllerList.h
+++ b/xbmc/games/controllers/windows/GUIControllerList.h
@@ -35,7 +35,7 @@ namespace GAME
     // implementation of IControllerList
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
-    virtual bool Refresh(const std::string &controllerId) override;
+    virtual bool Refresh(const std::string& controllerId) override;
     virtual void OnFocus(unsigned int controllerIndex) override;
     virtual void OnSelect(unsigned int controllerIndex) override;
     virtual int GetFocusedController() const override { return m_focusedController; }

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -165,7 +165,8 @@ bool CGUIControllerWindow::OnMessage(CGUIMessage& message)
 
       if (controlId == CONTROL_CONTROLLER_LIST)
       {
-        if (m_controllerList && m_controllerList->Refresh())
+        const std::string controllerId = message.GetStringParam();
+        if (m_controllerList && m_controllerList->Refresh(controllerId))
         {
           CGUIDialog::OnMessage(message);
           bHandled = true;

--- a/xbmc/games/controllers/windows/IConfigurationWindow.h
+++ b/xbmc/games/controllers/windows/IConfigurationWindow.h
@@ -67,7 +67,7 @@ namespace GAME
      * \param controllerId The controller to focus, or empty to leave focus unchanged
      * \return True if the list was changed
      */
-    virtual bool Refresh(const std::string &controllerId) = 0;
+    virtual bool Refresh(const std::string& controllerId) = 0;
 
     /*
      * \brief  The specified controller has been focused

--- a/xbmc/games/controllers/windows/IConfigurationWindow.h
+++ b/xbmc/games/controllers/windows/IConfigurationWindow.h
@@ -64,9 +64,10 @@ namespace GAME
 
     /*!
      * \brief Refresh the contents of the list
+     * \param controllerId The controller to focus, or empty to leave focus unchanged
      * \return True if the list was changed
      */
-    virtual bool Refresh(void) = 0;
+    virtual bool Refresh(const std::string &controllerId) = 0;
 
     /*
      * \brief  The specified controller has been focused


### PR DESCRIPTION
## Description

This PR is a continuation of the UX fix in https://github.com/xbmc/xbmc/pull/15754.

The first commit adds the missing add-on events that caused the list to not refresh when an add-on is installed.

However, this led to the following problem:

![Screen Shot 2019-03-16 at 5 18 30 PM](https://user-images.githubusercontent.com/531482/54494449-90e99700-4897-11e9-8552-61e9ab617a83.png)

The SNES controller was selected, but installing a 3DO controller updated the controller list indices and caused the wrong one to be highlighted. To fix this, I made the controller dialog focus the newly installed controller.

## How Has This Been Tested?
Installed a controller and observed it being focused.

Clicked "Get all", and controllers were updated as they were installed. Unfortunately, the image is blocked by the modal dialog. I would like to make it a toast, but then how would the user cancel? Closing the dialog?

![Screen Shot 2019-03-17 at 9 40 06 AM](https://user-images.githubusercontent.com/531482/54494564-ea05fa80-4898-11e9-9837-b55448b34784.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
