### PR TITLE
DialogVideoInfo: do not reset the current listitem before play

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -627,27 +627,24 @@ void CGUIDialogVideoInfo::Play(bool resume)
   {
     std::string strPath = StringUtils::Format("videodb://movies/sets/%i/?setid=%i",m_movieItem->GetVideoInfoTag()->m_iDbId,m_movieItem->GetVideoInfoTag()->m_iDbId);
     Close();
-    CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VIDEO_NAV,strPath);
+    CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VIDEO_NAV, strPath);
     return;
   }
 
-  CFileItem movie(*m_movieItem->GetVideoInfoTag());
-  if (m_movieItem->GetVideoInfoTag()->m_strFileNameAndPath.empty())
-    movie.SetPath(m_movieItem->GetPath());
   CGUIWindowVideoNav* pWindow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowVideoNav>(WINDOW_VIDEO_NAV);
   if (pWindow)
   {
     // close our dialog
     Close(true);
     if (resume)
-      movie.m_lStartOffset = STARTOFFSET_RESUME;
-    else if (!CGUIWindowVideoBase::ShowResumeMenu(movie))
+      m_movieItem->m_lStartOffset = STARTOFFSET_RESUME;
+    else if (!CGUIWindowVideoBase::ShowResumeMenu(*m_movieItem))
     {
       // The Resume dialog was closed without any choice
       Open();
       return;
     }
-    pWindow->PlayMovie(&movie);
+    pWindow->PlayMovie(m_movieItem.get());
   }
 }
 


### PR DESCRIPTION
## Description
When listitems are played via the VideoInfo dialog the current ListItem is reset and a new `CFileItem` is created using the previous ListItem `VideoInfoTag`. In case the previous item did not have an infotag, the new `CFileItem` path is set to the older listitem path while the remaining listitem information is lost/recreated. The option to play from beginning or resume the playback for an item takes into account the fact of the item being a folder (`m_bisFolder`) which by default is set to true. Resume options only are displayed if the item is not a folder.

When adding plugin directories we have the option to specify if the listitem is a folder. Playable items are added by defining the `isPlayable` property to true and setting `isFolder` to false. Since the `isFolder` info is lost when we play from the video info dialog, the video is always played from the beginning. Different behaviour happens when playing from the the regular plugin window containing the item list.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/15581

## How Has This Been Tested?
Played several items from the video info dialog:
- movies
- tvshow episodes
- plugins
- movies or episodes in playlists

Checked the old behaviour was retained for all the items but for plugins we now get the option to resume playback.

## Screenshots (if appropriate):
![alt text](https://i.imgur.com/Z0EpfnW.png "Logo Title Text 1")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

