### PR TITLE
RetroPlayer: Move rendering calls to initialize/deinitialize methods

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -68,6 +68,8 @@ void CRPRenderManager::Deinitialize()
     buffer->Release();
   m_pendingBuffers.clear();
 
+  for (const auto &renderer : m_renderers)
+    renderer->Deinitialize();
   m_renderers.clear();
 
   m_state = RENDER_STATE::UNCONFIGURED;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -63,6 +63,11 @@ bool CRPBaseRenderer::Configure(AVPixelFormat format)
   return m_bConfigured;
 }
 
+void CRPBaseRenderer::Deinitialize()
+{
+  void DeinitializeInternal();
+}
+
 void CRPBaseRenderer::FrameMove()
 {
   m_renderFrameCount++;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -41,6 +41,7 @@ namespace RETRO
 
     // Player functions
     bool Configure(AVPixelFormat format);
+    void Deinitialize();
     void FrameMove();
     /*!
      * \brief Performs whatever necessary before rendering the frame
@@ -70,6 +71,7 @@ namespace RETRO
   protected:
     // Protected renderer interface
     virtual bool ConfigureInternal() { return true; }
+    virtual void DeinitializeInternal() { }
     virtual void RenderInternal(bool clear, uint8_t alpha) = 0;
     virtual void FlushInternal() { }
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -41,7 +41,12 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings &renderSettings, CRen
 {
   // Initialize CRPRendererOpenGL
   m_clearColour = m_context.UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+}
 
+CRPRendererOpenGL::~CRPRendererOpenGL() = default;
+
+bool CRPRendererOpenGL::ConfigureInternal()
+{
   // Set up main screen VAO/VBOs
   glGenVertexArrays(1, &m_mainVAO);
   glBindVertexArray(m_mainVAO);
@@ -79,9 +84,11 @@ CRPRendererOpenGL::CRPRendererOpenGL(const CRenderSettings &renderSettings, CRen
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  return true;
 }
 
-CRPRendererOpenGL::~CRPRendererOpenGL()
+void CRPRendererOpenGL::DeinitializeInternal()
 {
   glDeleteBuffers(1, &m_mainIndexVBO);
   glDeleteBuffers(1, &m_mainVertexVBO);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -56,6 +56,8 @@ namespace RETRO
     };
     
     // implementation of CRPBaseRenderer
+    bool ConfigureInternal() override;
+    void DeinitializeInternal() override;
     void RenderInternal(bool clear, uint8_t alpha) override;
     void FlushInternal() override;
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -44,12 +44,20 @@ RenderBufferPoolVector CRendererFactoryOpenGLES::CreateBufferPools(CRenderContex
 CRPRendererOpenGLES::CRPRendererOpenGLES(const CRenderSettings &renderSettings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) :
   CRPBaseRenderer(renderSettings, context, std::move(bufferPool))
 {
+}
+
+CRPRendererOpenGLES::~CRPRendererOpenGLES() = default;
+
+bool CRPRendererOpenGLES::ConfigureInternal()
+{
   glGenBuffers(1, &m_mainIndexVBO);
   glGenBuffers(1, &m_mainVertexVBO);
   glGenBuffers(1, &m_blackbarsVertexVBO);
+
+  return true;
 }
 
-CRPRendererOpenGLES::~CRPRendererOpenGLES()
+void CRPRendererOpenGLES::DeinitializeInternal()
 {
   glDeleteBuffers(1, &m_mainIndexVBO);
   glDeleteBuffers(1, &m_mainVertexVBO);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -49,6 +49,8 @@ namespace RETRO
 
   protected:
     // implementation of CRPBaseRenderer
+    bool ConfigureInternal() override;
+    void DeinitializeInternal() override;
     void RenderInternal(bool clear, uint8_t alpha) override;
     void FlushInternal() override;
 


### PR DESCRIPTION
## Description
This PR refactors some rendering code to fix the issue that appeared in https://github.com/xbmc/xbmc/pull/14522. I haven't verified that it fixes the problem on GLES platforms, but the change is an improvement nonetheless.

## How Has This Been Tested?
Tested on macOS, games render successfully (though they weren't broken on macOS before).

Needs testing on RPi.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
