### PR TITLE
[Music]Show artist disambiguation text when picking which one to scrape

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -646,6 +646,12 @@ CMusicArtistInfo FromFileItem<CMusicArtistInfo>(const CFileItem &item)
   if (item.HasProperty("artist.genre"))
     info.GetArtist().genre = StringUtils::Split(item.GetProperty("artist.genre").asString(),
                                                 CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+  if (item.HasProperty("artist.disambiguation"))
+    info.GetArtist().strDisambiguation = item.GetProperty("artist.disambiguation").asString();
+  if (item.HasProperty("artist.type"))
+    info.GetArtist().strType = item.GetProperty("artist.type").asString();
+  if (item.HasProperty("artist.gender"))
+    info.GetArtist().strGender = item.GetProperty("artist.gender").asString();
   if (item.HasProperty("artist.born"))
     info.GetArtist().strBorn = item.GetProperty("artist.born").asString();
 
@@ -768,6 +774,9 @@ void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
 {
   artist.strArtist = item.GetLabel();
   artist.strMusicBrainzArtistID = FromString(item, "artist.musicbrainzid");
+  artist.strDisambiguation = FromString(item, "artist.disambiguation");
+  artist.strType = FromString(item, "artist.type");
+  artist.strGender = FromString(item, "artist.gender");
   artist.genre = FromArray(item, "artist.genre", 0);
   artist.styles = FromArray(item, "artist.styles", 0);
   artist.moods = FromArray(item, "artist.moods", 0);
@@ -1112,6 +1121,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::
   //   <title>...</title>
   //   <year>...</year>
   //   <genre>...</genre>
+  //   <disambiguation>...</disambiguation>
   //   <url>...</url> (with the usual CScraperUrl decorations like post or spoof)
   //  </entity>
   //  ...
@@ -1152,6 +1162,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::
         if (!genre.empty())
           ari.GetArtist().genre =
               StringUtils::Split(genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);
+        XMLUtils::GetString(pxeArtist, "disambiguation", ari.GetArtist().strDisambiguation);
         XMLUtils::GetString(pxeArtist, "year", ari.GetArtist().strBorn);
 
         vcari.push_back(ari);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1794,9 +1794,11 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
           {
             // set the label to artist
             CFileItem item(scraper.GetArtist(i).GetArtist());
-            std::string strTemp=scraper.GetArtist(i).GetArtist().strArtist;
+            std::string strTemp = scraper.GetArtist(i).GetArtist().strArtist;
             if (!scraper.GetArtist(i).GetArtist().strBorn.empty())
               strTemp += " ("+scraper.GetArtist(i).GetArtist().strBorn+")";
+            if (!scraper.GetArtist(i).GetArtist().strDisambiguation.empty())
+              strTemp += " - " + scraper.GetArtist(i).GetArtist().strDisambiguation;
             if (!scraper.GetArtist(i).GetArtist().genre.empty())
             {
               std::string genres = StringUtils::Join(scraper.GetArtist(i).GetArtist().genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator);


### PR DESCRIPTION
When refreshing the artist information for an artist, if MusicbrainzID is unknown and the name is not unique then the user is presented with a list of artists to choose from. This is usually just a list of names, many the same, and is pretty useless leaving the user to find the right artist by trail and error.

Here is a screenshot for artist called Darius (93 to choose from)
![Imgur](https://i.imgur.com/CWjr92E.png?1)

Musicbrainz returns disambiguation text which is idea information to help the user identify the right artist, and this fix ensures this information gets displayed. See example of Darius after this change
![Imgur](https://i.imgur.com/idPCXP8.png)

This use of disambiguation text value should have been added when use of this Musicbrainz data was added elsewhere by https://github.com/xbmc/xbmc/pull/12963 but was accidentally omitted.  It was also always intended for this dialog to have more information to help the user choose e.g. year, genre, but neither get returned to the by the scraper request to Musicbrainz to find artist by name.

Well tested and a low risk localised change, hope another team member will approve for 18.2