### PR TITLE
Quit instead of shutdown on signals

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4108,10 +4108,10 @@ void CApplication::ProcessSlow()
   }
 
 #if defined(TARGET_POSIX)
-  if (CPlatformPosix::TestShutdownFlag())
+  if (CPlatformPosix::TestQuitFlag())
   {
-    CLog::Log(LOGNOTICE, "Shutting down due to POSIX signal");
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
+    CLog::Log(LOGNOTICE, "Quitting due to POSIX signal");
+    CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
   }
 #endif
 

--- a/xbmc/platform/posix/PlatformPosix.cpp
+++ b/xbmc/platform/posix/PlatformPosix.cpp
@@ -16,13 +16,13 @@ void CPlatformPosix::Init()
   ms_signalFlag.test_and_set();
 }
 
-bool CPlatformPosix::TestShutdownFlag()
+bool CPlatformPosix::TestQuitFlag()
 {
   // Keep set, return true when it was cleared before
   return !ms_signalFlag.test_and_set();
 }
 
-void CPlatformPosix::RequestShutdown()
+void CPlatformPosix::RequestQuit()
 {
   ms_signalFlag.clear();
 }

--- a/xbmc/platform/posix/PlatformPosix.h
+++ b/xbmc/platform/posix/PlatformPosix.h
@@ -17,8 +17,8 @@ class CPlatformPosix : public CPlatform
 public:
   void Init() override;
 
-  static bool TestShutdownFlag();
-  static void RequestShutdown();
+  static bool TestQuitFlag();
+  static void RequestQuit();
 
 private:
   static std::atomic_flag ms_signalFlag;

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -44,7 +44,7 @@ void XBMC_POSIX_HandleSignal(int sig)
 {
   // Setting an atomic flag is one of the only useful things that is permitted by POSIX
   // in signal handlers
-  CPlatformPosix::RequestShutdown();
+  CPlatformPosix::RequestQuit();
 }
 
 }


### PR DESCRIPTION
TMSG_QUIT was indavertently changed to TMSG_SHUTDOWN when the signal
handling was modified. Change back to TMSG_QUIT - the application should
not cause the machine to power down upon receipt of SIGINT or SIGTERM
after all.

Slipped through in #15730 unfortunately