### PR TITLE
Move libcurl symbols out of namespace

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1818,7 +1818,7 @@ std::string CCurlFile::GetRedirectURL()
 std::string CCurlFile::GetInfoString(int infoType)
 {
   char* info{};
-  CURLcode result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, static_cast<XCURL::CURLINFO> (infoType), &info);
+  CURLcode result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, static_cast<CURLINFO> (infoType), &info);
   if (result != CURLE_OK)
   {
     CLog::Log(LOGERROR, "Info string request for type {} failed with result code {}", infoType, result);
@@ -1894,9 +1894,9 @@ bool CCurlFile::GetContentType(const CURL &url, std::string &content, const std:
 bool CCurlFile::GetCookies(const CURL &url, std::string &cookies)
 {
   std::string cookiesStr;
-  struct curl_slist*     curlCookies;
-  XCURL::CURL_HANDLE*    easyHandle;
-  XCURL::CURLM*          multiHandle;
+  curl_slist* curlCookies;
+  CURL_HANDLE* easyHandle;
+  CURLM* multiHandle;
 
   // get the cookies list
   g_curlInterface.easy_acquire(url.GetProtocol().c_str(),
@@ -1905,7 +1905,7 @@ bool CCurlFile::GetCookies(const CURL &url, std::string &cookies)
   if (CURLE_OK == g_curlInterface.easy_getinfo(easyHandle, CURLINFO_COOKIELIST, &curlCookies))
   {
     // iterate over each cookie and format it into an RFC 2109 formatted Set-Cookie string
-    struct curl_slist* curlCookieIter = curlCookies;
+    curl_slist* curlCookieIter = curlCookies;
     while(curlCookieIter)
     {
       // tokenize the CURL cookie string

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -14,12 +14,9 @@
 #include <string>
 #include "utils/HttpHeader.h"
 
-namespace XCURL
-{
-  typedef void CURL_HANDLE;
-  typedef void CURLM;
-  struct curl_slist;
-}
+typedef void CURL_HANDLE;
+typedef void CURLM;
+struct curl_slist;
 
 namespace XFILE
 {
@@ -97,8 +94,8 @@ namespace XFILE
       public:
           CReadState();
           ~CReadState();
-          XCURL::CURL_HANDLE* m_easyHandle;
-          XCURL::CURLM* m_multiHandle;
+          CURL_HANDLE* m_easyHandle;
+          CURLM* m_multiHandle;
 
           CRingBuffer m_buffer; // our ringhold buffer
           unsigned int m_bufferSize;
@@ -121,8 +118,8 @@ namespace XFILE
           CHttpHeader m_httpheader;
           bool IsHeaderDone(void) { return m_httpheader.IsHeaderDone(); }
 
-          struct XCURL::curl_slist* m_curlHeaderList;
-          struct XCURL::curl_slist* m_curlAliasList;
+          curl_slist* m_curlHeaderList;
+          curl_slist* m_curlAliasList;
 
           size_t ReadCallback(char *buffer, size_t size, size_t nitems);
           size_t WriteCallback(char *buffer, size_t size, size_t nitems);

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -17,12 +17,12 @@
 #include <type_traits>
 #include <vector>
 
-/* put types of curl in namespace to avoid namespace pollution */
-namespace XCURL
-{
 #define CURL CURL_HANDLE
 #include <curl/curl.h>
 #undef CURL
+
+namespace XCURL
+{
 
 class DllLibCurl
 {
@@ -57,8 +57,8 @@ public:
   CURLMcode multi_timeout(CURLM* multi_handle, long* timeout);
   CURLMsg* multi_info_read(CURLM* multi_handle, int* msgs_in_queue);
   CURLMcode multi_cleanup(CURLM* handle);
-  struct curl_slist* slist_append(struct curl_slist* list, const char* to_append);
-  void slist_free_all(struct curl_slist* list);
+  curl_slist* slist_append(curl_slist* list, const char* to_append);
+  void slist_free_all(curl_slist* list);
   const char* easy_strerror(CURLcode code);
 };
 


### PR DESCRIPTION
Putting includes (that can in turn include all sorts of other stuff)
into namespaces is not really maintainable and finally broke the build
in Linux 5.1-rc1. Of course it was a good idea to not clutter the global
namespaces, but unfortunately it did not turn out to be possible with C
libraries.

See https://sourceware.org/ml/libc-help/2019-03/msg00014.html

Fixes #15775