### PR TITLE
[fix] installing binary addons from zip (and repo)

### DIFF
--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -163,11 +163,12 @@ bool CBinaryAddonManager::AddAddonBaseEntry(BINARY_ADDON_LIST_ENTRY& entry)
 
 void CBinaryAddonManager::OnEvent(const AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::Enabled))
+  if (typeid(event) == typeid(AddonEvents::Enabled)) // also called on install
   {
+    InstalledChangeEvent();
     EnableEvent(event.id);
   }
-  else if (typeid(event) == typeid(AddonEvents::Disabled))
+  else if (typeid(event) == typeid(AddonEvents::Disabled)) // not called on uninstall
   {
     DisableEvent(event.id);
   }


### PR DESCRIPTION
## Description
This fixes the installing process of binray addons from zip files (also including installing from a repository).

## Motivation and Context
Screensavers and visualisation addons weren't usable after the installation from zip. Only a black screen was shown and `CBinaryAddonManager::__FUNCTION__: Requested addon '<ADDON-ID>' unknown as binary` was logged.
One had to restart Kodi to get it working.
Edit: same for vfs addons, but for those `CBinaryAddonManager::__FUNCTION__: Requested addon '<ADDON-ID>' unknown as binary` wasn't logged

## How Has This Been Tested?
installed a screensaver and visualisation from zip and tested it without restarting Kodi

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
