### PR TITLE
GL: Don't use SM_TEXTURE_LIM for GLSL < 1.5

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -514,7 +514,14 @@ void COverlayTextureGL::Render(SRenderState& state)
 
 #if defined(HAS_GL)
   CRenderSystemGL* renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
-  renderSystem->EnableShader(SM_TEXTURE_LIM);
+
+  int glslMajor, glslMinor;
+  renderSystem->GetGLSLVersion(glslMajor, glslMinor);
+  if (glslMajor >= 2 || (glslMajor == 1 && glslMinor >= 50))
+    renderSystem->EnableShader(SM_TEXTURE_LIM);
+  else
+    renderSystem->EnableShader(SM_TEXTURE);
+
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();
   GLint uniColLoc = renderSystem->ShaderGetUniCol();


### PR DESCRIPTION
## Description
SM_TEXTURE_LIM is not available for GLSL < 1.5, we should use SM_TEXTURE instead.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/15723

## How Has This Been Tested?
Both users who reported the issue confirmed a fix.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
