### PR TITLE
[PVR] Add 'Find similar' for epg-based timer rules

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -197,8 +197,10 @@ namespace PVR
         return true;
 
       const CPVRTimerInfoTagPtr timer(item.GetPVRTimerInfoTag());
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return timer->GetEpgInfoTag().get() != nullptr;
+      if (timer && ((!URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER) &&
+          timer->GetEpgInfoTag().get() != nullptr) ||
+          timer->GetTimerType()->IsEpgBased()))
+        return true;
 
       const CPVRRecordingPtr recording(item.GetPVRRecordingInfoTag());
       if (recording)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -1023,6 +1023,11 @@ const std::string& CPVRTimerInfoTag::Title(void) const
   return m_strTitle;
 }
 
+const std::string& CPVRTimerInfoTag::EpgSearchString() const
+{
+  return m_strEpgSearchString;
+}
+
 const std::string& CPVRTimerInfoTag::Summary(void) const
 {
   return m_strSummary;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -210,6 +210,7 @@ namespace PVR
     std::string GetDeletedNotificationText() const;
 
     const std::string& Title(void) const;
+    const std::string& EpgSearchString() const;
     const std::string& Summary(void) const;
     const std::string& Path(void) const;
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -27,6 +27,7 @@
 #include "pvr/dialogs/GUIDialogPVRGuideSearch.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgSearchFilter.h"
+#include "pvr/timers/PVRTimerInfoTag.h"
 
 using namespace PVR;
 using namespace KODI::MESSAGING;
@@ -121,6 +122,10 @@ void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItemPtr &item)
     const CPVREpgInfoTagPtr epgTag(CPVRItem(item).GetEpgInfoTag());
     if (epgTag && !CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
       m_searchfilter->SetSearchPhrase(epgTag->Title());
+
+    const CPVRTimerInfoTagPtr timer(CPVRItem(item).GetTimerInfoTag());
+    if (timer && timer->GetTimerType()->IsEpgBased())
+      m_searchfilter->SetSearchPhrase(timer->EpgSearchString().empty() ? timer->Title() : timer->EpgSearchString());
   }
 
   m_bSearchConfirmed = true;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Add 'Find similar' to timer rules context menu to allow searching for similar items for epg-based timer rules. 

Allows searching from 'Record Series' and 'Repeating Keyword' timers for similar epg listings based on either Title or EPG Search String.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adds a useful feature to the timer rules.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
