### PR TITLE
[depends] binary-addons: fix libGL.so location

### DIFF
--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -106,8 +106,7 @@ linux-system-libs:
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/libdrm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/gl.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/glu.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/libGL.so ] || \
-          (ln -sf /usr/lib/$(HOST)/mesa $(ADDON_DEPS_DIR)/lib/mesa && ln -sf $(ADDON_DEPS_DIR)/lib/mesa/libGL.so $(ADDON_DEPS_DIR)/lib/libGL.so)
+	[ -f $(ADDON_DEPS_DIR)/lib/libGL.so ] || ln -sf /usr/lib/$(HOST)/libGL.so $(ADDON_DEPS_DIR)/lib/libGL.so
 	[ -L $(ADDON_DEPS_DIR)/include/GL ] || ln -sf /usr/include/GL $(ADDON_DEPS_DIR)/include/GL
 	[ -f $(ADDON_DEPS_DIR)/lib/libm.so ] || ln -sf /usr/lib/$(HOST)/libm.so $(ADDON_DEPS_DIR)/lib/
 


### PR DESCRIPTION
## Description
Instead of `/usr/lib/<HOST>/mesa/libGL.so` use Instead of `/usr/lib/<HOST>/libGL.so`.
`/usr/lib/<HOST>/mesa/libGL.so` only existed in Ubuntu Trusty (14.04) and Xenial (16.04). It doesn't exist any-more in Ubuntu Bionic (18.04) and also doesn't exist in any still supported Debian version.
`/usr/lib/<HOST>/libGL.so` exists in Ubuntu Xenial (16.04) so there is no need for a special case.

## Motivation and Context
I noticed that all screensavers fail to build for Linux on the Ubuntu Bionic (18.04) VM.

## How Has This Been Tested?
successfully compiled a screensaver on Debian

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
