### PR TITLE
[wayland] fix compilation with C++17

### DIFF
--- a/xbmc/windowing/wayland/Util.h
+++ b/xbmc/windowing/wayland/Util.h
@@ -22,7 +22,7 @@ namespace WAYLAND
 
 struct WaylandCPtrCompare
 {
-  bool operator()(wayland::proxy_t const& p1, wayland::proxy_t const& p2)
+  bool operator()(wayland::proxy_t const& p1, wayland::proxy_t const& p2) const
   {
     return p1.c_ptr() < p2.c_ptr();
   }


### PR DESCRIPTION
Compilation for Wayland/gles fails with --std=c++17 because it has
stricter checks:

error: static assertion failed: comparison object must be invocable as const

Fix this error by declaring the result as const.

Fixes #15788

Signed-off-by: Olaf Hering <olaf@aepfle.de>

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
