### PR TITLE
[Music]Prompt skip artist or album nfo files and refresh from remote sites

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5338,6 +5338,7 @@ msgid "Now playing - Videos"
 msgstr ""
 
 #: xbmc/music/ContextMenus.h
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#10523"
 msgid "Album information"
 msgstr ""
@@ -13258,6 +13259,9 @@ msgctxt "#20445"
 msgid "Fanart"
 msgstr ""
 
+#. Ask user when refreshing music or video info if they want to use data from NFO file
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
+#: xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
 msgctxt "#20446"
 msgid "Locally stored information found. Ignore and refresh from Internet?"
 msgstr ""
@@ -14390,6 +14394,7 @@ msgid "Select artist"
 msgstr ""
 
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 #: xbmc/music/ContextMenus.h
 msgctxt "#21891"
 msgid "Artist information"

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -18,6 +18,7 @@
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "events/EventLog.h"
 #include "events/MediaLibraryEvent.h"
 #include "FileItem.h"
@@ -1439,6 +1440,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
   }
 
   // handle nfo files
+  bool existsNFO = false;
   std::string path = album.strPath;
   if (path.empty())
     m_musicDatabase.GetAlbumPath(album.idAlbum, path);
@@ -1446,7 +1448,14 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
   std::string strNfo = URIUtils::AddFileToFolder(path, "album.nfo");
   CInfoScanner::INFO_TYPE result = CInfoScanner::NO_NFO;
   CNfoFile nfoReader;
-  if (XFILE::CFile::Exists(strNfo))
+  existsNFO = XFILE::CFile::Exists(strNfo);
+  // When on GUI ask user if they want to ignore nfo and refresh from Internet  
+  if (existsNFO && pDialog && CGUIDialogYesNo::ShowAndGetInput(10523, 20446))
+  {
+    existsNFO = false;
+    CLog::Log(LOGDEBUG, "Ignoring nfo file: %s", CURL::GetRedacted(strNfo).c_str());
+  }
+  if (existsNFO)
   {
     CLog::Log(LOGDEBUG,"Found matching nfo file: %s", CURL::GetRedacted(strNfo).c_str());
     result = nfoReader.Create(strNfo, info);
@@ -1725,6 +1734,13 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
     }
     else
       CLog::Log(LOGDEBUG, "%s not have path, nfo file not possible", artist.strArtist.c_str());
+  }
+
+  // When on GUI ask user if they want to ignore nfo and refresh from Internet  
+  if (existsNFO && pDialog && CGUIDialogYesNo::ShowAndGetInput(21891, 20446))
+  {
+    existsNFO = false;
+    CLog::Log(LOGDEBUG, "Ignoring nfo file: %s", CURL::GetRedacted(strNfo).c_str());
   }
 
   if (existsNFO)


### PR DESCRIPTION
Make refresh of artist or album additional information and artwork from music info dialog more consistent with video info dialog behaviour by allowing user to skip existing nfo files. 

Currently, if an nfo file is found that is  always applied so user has to notice this happened, and go and delete the nfo if they want to fetch new remote data to replace it.  This PR adds the display of the following prompt when an nfo file is found (matches the video equivalent).
![Imgur](https://i.imgur.com/8bwyAeb.png)

@KarellenX sorry this took so long for me to get around to, should make the manual management of additional music data a bit easier.

Tested for artists and albums both with and without nfo files, and that it does _not_ impact  automated scraping. Fixing an inconsistency in bejaviour and an improvement so would like to get into v18.2