### PR TITLE
[skins] addon settings - add help text

### DIFF
--- a/addons/skin.estouchy/xml/DialogAddonSettings.xml
+++ b/addons/skin.estouchy/xml/DialogAddonSettings.xml
@@ -4,15 +4,15 @@
 	<include>16x9_xPos_Relocation</include>
 	<include>Window_OpenClose_Animation_Zoom</include>
 	<coordinates>
-		<posx>140</posx>
-		<posy>80</posy>
+		<posx>15</posx>
+		<posy>30</posy>
 	</coordinates>
 	<controls>
 		<include>BehindDialogFadeOut</include>
 		<control type="image">
 			<posx>0</posx>
 			<posy>0</posy>
-			<width>1000</width>
+			<width>1250</width>
 			<height>60</height>
 			<texture border="5">dialog_header.png</texture>
 		</control>
@@ -21,19 +21,19 @@
 			<posx>20</posx>
 			<posy>0</posy>
 			<include>WindowTitleCommons</include>
-			<width>910</width>
+			<width>1160</width>
 			<label></label>
 		</control>
 		<control type="group">
-			<posx>930</posx>
+			<posx>1180</posx>
 			<posy>0</posy>
 			<include>DialogCloseButtonCommons</include>
 		</control>
 		<control type="image">
 			<posx>0</posx>
 			<posy>60</posy>
-			<width>1000</width>
-			<height>740</height>
+			<width>1250</width>
+			<height>840</height>
 			<texture>dialog_back.png</texture>
 		</control>
 		<control type="group">
@@ -53,7 +53,7 @@
 			</control>
 			<control type="button" id="11001">
 				<description>right Arrow</description>
-				<posx>920</posx>
+				<posx>1170</posx>
 				<posy>10</posy>
 				<width>24</width>
 				<height>40</height>
@@ -68,7 +68,7 @@
 			<description>button area</description>
 			<posx>60</posx>
 			<posy>70</posy>
-			<width>880</width>
+			<width>1130</width>
 			<height>60</height>
 			<itemgap>5</itemgap>
 			<align>center</align>
@@ -81,7 +81,7 @@
 		<control type="image">
 			<posx>0</posx>
 			<posy>140</posy>
-			<width>1000</width>
+			<width>1250</width>
 			<height>554</height>
 			<texture colordiffuse="40000000">panel.png</texture>
 		</control>
@@ -89,7 +89,7 @@
 			<description>control area</description>
 			<posx>0</posx>
 			<posy>140</posy>
-			<width>1000</width>
+			<width>1250</width>
 			<height>554</height>
 			<itemgap>-1</itemgap>
 			<pagecontrol>30</pagecontrol>
@@ -149,10 +149,21 @@
 			<height>70</height>
 			<font>font25</font>
 		</control>
+		<control type="textbox" id="6">
+			<description>description area</description>
+			<left>50</left>
+			<top>710</top>
+			<width>1150</width>
+			<height>100</height>
+			<font>font24</font>
+			<align>justify</align>
+			<textcolor>blue</textcolor>
+			<autoscroll time="3000" delay="5000" repeat="5000">true</autoscroll>
+		</control>
 		<control type="grouplist" id="9001">
 			<posx>20</posx>
-			<posy>730</posy>
-			<width>960</width>
+			<posy>830</posy>
+			<width>1210</width>
 			<height>60</height>
 			<itemgap>5</itemgap>
 			<align>center</align>

--- a/addons/skin.estuary/xml/DialogAddonSettings.xml
+++ b/addons/skin.estuary/xml/DialogAddonSettings.xml
@@ -4,13 +4,13 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">
-			<top>105</top>
+			<top>90</top>
 			<centerleft>50%</centerleft>
 			<width>1820</width>
 			<include>Animation_DialogPopupVisible</include>
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1820" />
-				<param name="height" value="870" />
+				<param name="height" value="900" />
 				<param name="header_label" value="" />
 				<param name="header_id" value="2" />
 			</include>
@@ -19,7 +19,7 @@
 				<left>29</left>
 				<top>80</top>
 				<width>400</width>
-				<height>750</height>
+				<height>685</height>
 				<itemgap>-25</itemgap>
 				<orientation>vertical</orientation>
 				<onleft>9000</onleft>
@@ -41,7 +41,7 @@
 				<left>410</left>
 				<top>80</top>
 				<width>1100</width>
-				<height>790</height>
+				<height>740</height>
 				<texture border="40">buttons/dialogbutton-nofo.png</texture>
 			</control>
 			<control type="grouplist" id="5">
@@ -49,11 +49,22 @@
 				<left>429</left>
 				<top>100</top>
 				<width>1060</width>
-				<height>750</height>
+				<height>700</height>
 				<onleft>3</onleft>
 				<onright>9000</onright>
 				<onup>5</onup>
 				<ondown>5</ondown>
+			</control>
+			<control type="textbox" id="6">
+				<description>description area</description>
+				<left>50</left>
+				<top>815</top>
+				<right>50</right>
+				<height>70</height>
+				<font>font12</font>
+				<align>justify</align>
+				<textcolor>button_focus</textcolor>
+				<autoscroll time="3000" delay="5000" repeat="5000">true</autoscroll>
 			</control>
 			<control type="button" id="7">
 				<description>Default Button</description>


### PR DESCRIPTION
since https://github.com/xbmc/xbmc/pull/12125 addons can now also add a help text for each setting.
our default skins where not updated to include this text though.

fixes https://github.com/xbmc/xbmc/issues/15793

![screenshot000](https://user-images.githubusercontent.com/687265/54791159-fc858880-4c38-11e9-9cfd-b67a072e5707.png)
