### PR TITLE
Add addon settingslevel button

### DIFF
--- a/addons/skin.estouchy/xml/DialogAddonSettings.xml
+++ b/addons/skin.estouchy/xml/DialogAddonSettings.xml
@@ -190,6 +190,12 @@
 				<include>ButtonInfoDialogsCommonValues</include>
 				<label>409</label>
 			</control>
+			<control type="button" id="20">
+				<description>Level Button</description>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+				<onclick>SettingsLevelChange</onclick>
+			</control>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/DialogAddonSettings.xml
+++ b/addons/skin.estuary/xml/DialogAddonSettings.xml
@@ -19,13 +19,13 @@
 				<left>29</left>
 				<top>80</top>
 				<width>400</width>
-				<height>685</height>
+				<height>590</height>
 				<itemgap>-25</itemgap>
 				<orientation>vertical</orientation>
 				<onleft>9000</onleft>
 				<onright>5</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
+				<onup>20</onup>
+				<ondown>20</ondown>
 			</control>
 			<control type="button" id="10">
 				<description>Default Category Button</description>
@@ -116,6 +116,30 @@
 					<param name="id" value="30" />
 					<param name="label" value="" />
 				</include>
+			</control>
+			<control type="radiobutton" id="20">
+				<left>29</left>
+				<top>700</top>
+				<width>390</width>
+				<height>120</height>
+				<font>font25_title</font>
+				<aligny>center</aligny>
+				<onclick>SettingsLevelChange</onclick>
+				<textoffsetx>100</textoffsetx>
+				<textoffsety>0</textoffsety>
+				<texturenofocus />
+				<radioposx>40</radioposx>
+				<radioposy>0</radioposy>
+				<radiowidth>40</radiowidth>
+				<radioheight>40</radioheight>
+				<onleft>9000</onleft>
+				<onright>5</onright>
+				<onup>3</onup>
+				<ondown>3</ondown>
+				<textureradioonfocus>icons/settings.png</textureradioonfocus>
+				<textureradioonnofocus>icons/settings.png</textureradioonnofocus>
+				<textureradioofffocus>icons/settings.png</textureradioofffocus>
+				<textureradiooffnofocus>icons/settings.png</textureradiooffnofocus>
 			</control>
 		</control>
 	</controls>

--- a/xbmc/addons/settings/GUIDialogAddonSettings.h
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.h
@@ -19,6 +19,7 @@ public:
 
   // specializations of CGUIControl
   bool OnMessage(CGUIMessage &message) override;
+  bool OnAction(const CAction& action) override;
 
   static bool ShowForAddon(const ADDON::AddonPtr &addon, bool saveToDisk = true);
   static void SaveAndClose();


### PR DESCRIPTION
the settings level for addon setting was hardcoded to 'standard'.

this makes it user-configurable.


![screenshot000](https://user-images.githubusercontent.com/687265/54869550-813be800-4d9a-11e9-8fdd-ffa89a46e511.png)
