### PR TITLE
[wayland] Fix raw pointer comparison

### DIFF
--- a/xbmc/windowing/wayland/Util.h
+++ b/xbmc/windowing/wayland/Util.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <wayland-client.hpp>
@@ -24,7 +25,7 @@ struct WaylandCPtrCompare
 {
   bool operator()(wayland::proxy_t const& p1, wayland::proxy_t const& p2) const
   {
-    return p1.c_ptr() < p2.c_ptr();
+    return reinterpret_cast<std::uintptr_t>(p1.c_ptr()) < reinterpret_cast<std::uintptr_t>(p2.c_ptr());
   }
 };
 


### PR DESCRIPTION
Comparing pointers that do not point into the same array
is unspecified in C++