### PR TITLE
Include user config and available artwork in music "Choose art type" dialog

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -10231,6 +10231,48 @@ bool CMusicDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
   return false;
 }
 
+std::vector<std::string> CMusicDatabase::GetAvailableArtTypesForItem(int mediaId,
+  const MediaType& mediaType)
+{
+  std::vector<std::string> result;
+  if (mediaType == MediaTypeArtist)
+  {
+    CArtist artist;
+    if (GetArtist(mediaId, artist))
+    {
+      //! @todo artwork: fanart stored separately, doesn't need to be
+      if (artist.fanart.GetNumFanarts())
+        result.push_back("fanart");
+
+      // all other images
+      for (const auto& urlEntry : artist.thumbURL.m_url)
+      {
+        std::string artType = urlEntry.m_aspect;
+        if (artType.empty())
+          artType = "thumb";
+        if (std::find(result.begin(), result.end(), artType) == result.end())
+          result.push_back(artType);
+      }
+    }
+  }
+  else if (mediaType == MediaTypeAlbum)
+  {
+    CAlbum album;
+    if (GetAlbum(mediaId, album))
+    {
+      for (const auto& urlEntry : album.thumbURL.m_url)
+      {
+        std::string artType = urlEntry.m_aspect;
+        if (artType.empty())
+          artType = "thumb";
+        if (std::find(result.begin(), result.end(), artType) == result.end())
+          result.push_back(artType);
+      }
+    }
+  }
+  return result;
+}
+
 bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription &sorting)
 {
   if (!musicUrl.IsValid())

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -596,6 +596,14 @@ public:
   */
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 
+  /*! \brief Fetch the distinct types of available-but-unassigned art held in the
+  database for a specific media item.
+  \param mediaId the id in the media (artist/album) table.
+  \param mediaType the type of media, which corresponds to the table the item resides in (artist/album).
+  \return the types of art e.g. "thumb", "fanart", etc.
+  */
+  std::vector<std::string> GetAvailableArtTypesForItem(int mediaId, const MediaType& mediaType);
+
   /////////////////////////////////////////////////
   // Tag Scan Version
   /////////////////////////////////////////////////

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -18,6 +18,9 @@
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/JobManager.h"
 
 using namespace MUSIC_INFO;
@@ -177,6 +180,63 @@ namespace MUSIC_UTILS
     CJobManager::GetInstance().AddJob(job, NULL);
   }
 
+  // Add art types required in Kodi
+  void AddHardCodedArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag)
+  {
+    artTypes.emplace_back("thumb");
+    if (tag.GetType() == MediaTypeArtist)
+    {
+      artTypes.emplace_back("fanart");
+    }
+  }
+
+  // Add art types configured by the user
+  void AddExtendedArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag)
+  {
+    for (const auto& artType : GetArtTypesToScan(tag.GetType()))
+    {
+      if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
+        artTypes.push_back(artType);
+    }
+  }
+
+  // Add art types currently assigned to to the media item
+  void AddCurrentArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
+    CMusicDatabase& db)
+  {
+    std::map<std::string, std::string> currentArt;
+    db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
+    for (const auto& art : currentArt)
+    {
+      if (!art.second.empty() && find(artTypes.begin(), artTypes.end(), art.first) == artTypes.end())
+        artTypes.push_back(art.first);
+    }
+  }
+
+  // Add art types that exist for other media items of the same type
+  void AddMediaTypeArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
+    CMusicDatabase& db)
+  {
+    std::vector<std::string> dbArtTypes;
+    db.GetArtTypes(tag.GetType(), dbArtTypes);
+    for (const auto& artType : dbArtTypes)
+    {
+      if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
+        artTypes.push_back(artType);
+    }
+  }
+
+  // Add art types from available but unassigned artwork for this media item
+  void AddAvailableArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
+    CMusicDatabase& db)
+  {
+    for (const auto& artType : db.GetAvailableArtTypesForItem(tag.GetDatabaseId(), tag.GetType()))
+    {
+      if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
+        artTypes.push_back(artType);
+    }
+  }
+
   bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist)
   {
     CMusicInfoTag &tag = *musicitem.GetMusicInfoTag();
@@ -186,33 +246,18 @@ namespace MUSIC_UTILS
       return false;
 
     artlist.Clear();
-    // Songs, albums and artists all  have thumbs by default
-    std::vector<std::string> artTypes = { "thumb" };
-    if (tag.GetType() == MediaTypeArtist)
-    {
-      artTypes.emplace_back("fanart");
-    }
 
     CMusicDatabase db;
     db.Open();
 
-    // Add in any stored art for this item that is non-empty.
-    std::map<std::string, std::string> currentArt;
-    db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
-    for (const auto art : currentArt)
-    {
-      if (!art.second.empty() && find(artTypes.begin(), artTypes.end(), art.first) == artTypes.end())
-        artTypes.push_back(art.first);
-    }
+    std::vector<std::string> artTypes;
 
-    // Add any art types that exist for other media items of the same type
-    std::vector<std::string> dbArtTypes;
-    db.GetArtTypes(tag.GetType(), dbArtTypes);
-    for (const auto it : dbArtTypes)
-    {
-      if (find(artTypes.begin(), artTypes.end(), it) == artTypes.end())
-        artTypes.push_back(it);
-    }
+    AddHardCodedArtTypes(artTypes, tag);
+    AddExtendedArtTypes(artTypes, tag);
+    AddCurrentArtTypes(artTypes, tag, db);
+    AddMediaTypeArtTypes(artTypes, tag, db);
+    AddAvailableArtTypes(artTypes, tag, db);
+
     db.Close();
 
     for (const auto type : artTypes)
@@ -304,5 +349,24 @@ namespace MUSIC_UTILS
     else
       job = new CSetSongRatingJob(pItem->GetPath(), userrating);
     CJobManager::GetInstance().AddJob(job, NULL);
+  }
+
+  std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType)
+  {
+    std::vector<std::string> arttypes;
+    // Get default types of art that are to be automatically fetched during scanning
+    if (mediaType == MediaTypeArtist)
+    {
+      arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistExtraArt;
+      arttypes.emplace_back("thumb");
+      arttypes.emplace_back("fanart");
+    }
+    else if (mediaType == MediaTypeAlbum)
+    {
+      arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt;
+      arttypes.emplace_back("thumb");
+    }
+
+    return arttypes;
   }
 }

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -56,4 +56,11 @@ namespace MUSIC_UTILS
 \param userrating the userrating 0 = no rating, 1 to 10
 */
   void UpdateSongRatingJob(const CFileItemPtr pItem, int userrating);
+
+  /*! \brief Get the types of art for an artist or album that are to be
+  automatically fetched from local files during scanning
+  \param mediaType [in] artist or album
+  \return vector of art types that are to be fetched during scanning
+  */
+  std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
 }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -35,6 +35,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
+#include "music/MusicUtils.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "MusicAlbumInfo.h"
@@ -1908,31 +1909,12 @@ void CMusicInfoScanner::ScannerWait(unsigned int milliseconds)
     XbmcThreads::ThreadSleep(milliseconds);
 }
 
-std::vector<std::string> CMusicInfoScanner::GetArtTypesToScan(const MediaType& mediaType)
-{
-  std::vector<std::string> arttypes;
-  // Get default types of art that are to be automatically fetched during scanning
-  if (mediaType == MediaTypeArtist)
-  {
-    arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistExtraArt;
-    arttypes.emplace_back("thumb");
-    arttypes.emplace_back("fanart");
-  }
-  else if (mediaType == MediaTypeAlbum)
-  {
-    arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt;
-    arttypes.emplace_back("thumb");
-  }
-
-  return arttypes;
-}
-
 std::vector<std::string> CMusicInfoScanner::GetMissingArtTypes(const MediaType& mediaType, const std::map<std::string, std::string>& art)
 {
   std::vector<std::string> missing;
   std::vector<std::string> arttypes;
   // Get default types of art that are automatically fetched during scanning
-  arttypes = GetArtTypesToScan(mediaType);
+  arttypes = MUSIC_UTILS::GetArtTypesToScan(mediaType);
 
   // Find the types which are missing from the given art
   if (art.empty())
@@ -2134,7 +2116,7 @@ void CMusicInfoScanner::SetDiscSetArtwork(CAlbum& album, const std::vector<std::
 
   // Get default types of art that are to be automatically fetched during scanning
   std::vector<std::string> arttypes;
-  arttypes = GetArtTypesToScan(MediaTypeAlbum);
+  arttypes = MUSIC_UTILS::GetArtTypesToScan(MediaTypeAlbum);
 
   // Check that there are art types other than thumb to process
   bool extratype = !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt.empty();

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -143,14 +143,6 @@ protected:
    */
   INFO_RET DownloadArtistInfo(const CArtist& artist, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, bool bUseScrapedMBID, CGUIDialogProgress* pDialog = NULL);
 
-
-  /*! \brief Get the types of art for an artist or album that are to be
-  automatically fetched from local files during scanning
-  \param mediaType [in] artist or album
-  \return vector of art types that are to be fetched during scanning
-  */
-  std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
-
   /*! \brief Get the types of art for an artist or album that can be
    automatically found during scanning, and are not in the provided set of art
    \param mediaType [in] artist or album


### PR DESCRIPTION
## Description
Add more artwork types to the "Choose art type" dialog for the music library.
1. Available but not assigned artwork types. Scrapers and NFO files can add more artwork than is assigned in the library, this includes these types in the dialog.
2. User configuration. This includes artwork types currently configured in AdvancedSettings.xml.

Only music library, but a separate PR for the video library is incoming. It has a completely separate implementation and I need to add a database function. It also already has the "user config" part.

## Motivation and Context
Don't hide artwork that is available. Don't make users enter any preferred artwork types twice (configuration and this dialog).

## How Has This Been Tested?
manually.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
