### PR TITLE
addon settings - inherit settings level

### DIFF
--- a/xbmc/addons/settings/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.cpp
@@ -19,6 +19,7 @@
 #include "settings/lib/SettingsManager.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "view/ViewStateSettings.h"
 
 using namespace KODI::MESSAGING;
 
@@ -171,7 +172,7 @@ std::string CGUIDialogAddonSettings::GetSettingsLabel(std::shared_ptr<ISetting> 
 
 int CGUIDialogAddonSettings::GetSettingLevel() const
 {
-  return static_cast<int>(SettingLevel::Standard);
+  return static_cast<int>(CViewStateSettings::GetInstance().GetSettingLevel());
 }
 
 std::shared_ptr<CSettingSection> CGUIDialogAddonSettings::GetSection()


### PR DESCRIPTION
Currently the settings level in the Addon Settings Dialog is harcoded to 'standard'.
The goal for v19 is to make it user-configurable by adding a settings level button to this dialog (https://github.com/xbmc/xbmc/pull/15796) 

meanwhile, for v18, we should simply inherit the level that's been set on the main Kodi settings windows.

@ksooo @phunkyfish 