### PR TITLE
[video] support <season>.<episode> file names for TV shows

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -254,15 +254,17 @@ void CAdvancedSettings::Initialize()
 
   m_tvshowEnumRegExps.clear();
   // foo.s01.e01, foo.s01_e01, S01E02 foo, S01 - E02, S01xE02
+  // 's'<season number>[separator]'e'<episode number [single-digit part number]>
+  // single-digit part number: letter or '.' digit
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"s([0-9]+)[ ._x-]*e([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
   // foo.ep01, foo.EP_01, foo.E01
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\._ -]()e(?:p[ ._-]?)?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
-  // foo.yyyy.mm.dd.* (byDate=true)
+  // foo.yyyy-mm-dd.* (byDate=true)
   m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})"));
   // foo.mm.dd.yyyy.* (byDate=true)
   m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{2})[\\.-]([0-9]{2})[\\.-]([0-9]{4})"));
-  // foo.1x09* or just /1x09*
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
+  // foo.1x09* or just /1x09*, also foo_1.09*
+  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ \\[\\(-]([0-9]+)[x.]([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
   // Part I, Pt.VI, Part 1
   m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\/._ -]p(?:ar)?t[_. -]()([ivx]+|[0-9]+)([._ -][^\\/]*)$"));
   // foo.103*, 103 foo

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -25,6 +25,8 @@ typedef struct
 static const TestEntry TestData[] = {
   //season+episode
   {"foo.S02E03.mkv",   2, {3} },
+  {"foo.2x03.mkv",      2, {3} },
+  {"foo.2.03.mkv",      2, {3} },
   {"foo.203.mkv",      2, {3} },
   //episode only
   {"foo.Ep03.mkv",     1, {3} },


### PR DESCRIPTION
## Description
The `TVShowRegexp()` regular expression for the `1x23` format, <season>x<episode>, is extended slightly to also support a period `.`, as in `1.23`, instead of the letter `x` as a separator, by changing `x` to `[x.]`.

## Motivation and Context
After having used the `1.23 foo` format for several years with a custom `AdvancedSettings.xml` without any problems encountered, I would like to see it supported by default, so others who favor this pattern do not have to fiddle with XML files and regular expressions themselves. The actual code change is trivial and should not interfere with the other default patterns, except perhaps in fringe situations where someone is using a period as a general word delimiter in media file names and has an episode or show title ending in a number followed by the episode number in absolute (single-season) or non-separated format:

* `I.am.Number.4.12.mp4` becomes season 4, episode 12 of "I am Number" instead of episode 12 (of the only season) of "I am Number 4".
* `I.am.Number.4.123.mp4` becomes season 4, episode 123 of "I am Number" instead of season 1, episode 23 of "I am Number 4".

## How Has This Been Tested?
I have been using a custom `AdvancedSettings.xml` with this regular expression for several years without any problems encountered ever.

NB: I considered to also add a format where absolute, season-less episode numbers are either preceded by a number sign `#12 foo` or succeeded by an ordinal period `12. foo`, but then decided that this should be a separate issue, because I have not used that myself yet.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, probably not Doxygen but defintely the [wiki](https://kodi.wiki/view/Advancedsettings.xml#tvshowmatching)
- [x] I have updated the documentation accordingly (only inline code documentation, but not the wiki yet)
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change (in `/video/test/TestVideoInfoScanner.cpp`, but only very basic)
- [x] All new and existing tests passed
