### PR TITLE
Music library export empty artist folders

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20979,8 +20979,9 @@ msgctxt "#38042"
 msgid "[Missing]"
 msgstr ""
 
-#. Title album artists node
+#. Title album artists node, and music item to export output, see #38306
 #: system/library/music/musicroles/albumartists.xml
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#38043"
 msgid "Album artists"
 msgstr ""
@@ -21247,23 +21248,27 @@ msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#38309"
-msgid "Output only artwork, not NFO files"
+msgid "Output information to NFO files"
+msgstr ""
+
+#. See #38309 when NFO and art export disabled so only artist folders 
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+msgctxt "#38310"
+msgid "Output information to NFO files (currently exporting artist folders only)"
 msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
-msgctxt "#38310"
+msgctxt "#38311"
 msgid "Overwrite existing files"
 msgstr ""
 
-#empty string with id 38311
-
-#. Music item to export output, see #38093
+#. Music item to export output, see #38306
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#38312"
 msgid "Song artists"
 msgstr ""
 
-#. Music item to export output, see #38093
+#. Music item to export output, see #38306
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#38313"
 msgid "Other artists"
@@ -21295,7 +21300,37 @@ msgctxt "#38320"
 msgid "Do you have local artist information (NFO) and art files that you want to fetch? Set the location of these artist folders now"
 msgstr ""
 
-#empty strings from id 38321 to 38329
+#. Kind of export output, see #38304
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+msgctxt "#38321"
+msgid "Artist folders only"
+msgstr ""
+
+#. Explanation of what export to library folders means see #38303 when albums and artists selected
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+msgctxt "#38322"
+msgid "Artists exported to Artist Information Folder and albums to music folders"
+msgstr ""
+
+#. Explanation of what export to library folders means see #38303 when only albums selected
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+msgctxt "#38323"
+msgid "Albums exported to music folders"
+msgstr ""
+
+#. Explanation of what export to library folders means see #38303 when only artists selected
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+msgctxt "#38324"
+msgid "Artists exported to Artist Information Folder"
+msgstr ""
+
+#. Explanation of what export artist folders only means see #38304
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+msgctxt "#38325"
+msgid "Artist subfolders created in Artist Information Folder"
+msgstr ""
+
+#empty strings from id 38326 to 38329
 
 #. Dialog heading when editing default settings for fetching additional music information
 #: xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp

--- a/xbmc/settings/LibExportSettings.cpp
+++ b/xbmc/settings/LibExportSettings.cpp
@@ -51,6 +51,13 @@ bool CLibExportSettings::IsItemExported(ELIBEXPORTOPTIONS item) const
   return (m_itemstoexport & item);
 }
 
+bool CLibExportSettings::IsArtists() const
+{
+  return (m_itemstoexport & ELIBEXPORT_ALBUMARTISTS) ||
+         (m_itemstoexport & ELIBEXPORT_SONGARTISTS) ||
+         (m_itemstoexport & ELIBEXPORT_OTHERARTISTS);
+}
+
 std::vector<int> CLibExportSettings::GetExportItems() const
 {
   std::vector<int> values;
@@ -81,4 +88,9 @@ bool CLibExportSettings::IsSeparateFiles() const
 bool CLibExportSettings::IsToLibFolders() const
 {
   return (m_exporttype == ELIBEXPORT_TOLIBRARYFOLDER);
+}
+
+bool CLibExportSettings::IsArtistFoldersOnly() const
+{
+  return (m_exporttype == ELIBEXPORT_ARTISTFOLDERS);
 }

--- a/xbmc/settings/LibExportSettings.h
+++ b/xbmc/settings/LibExportSettings.h
@@ -29,7 +29,8 @@ enum ELIBEXPORTOPTIONS
   ELIBEXPORT_OTHERARTISTS = 0x0080,
   ELIBEXPORT_ARTWORK = 0x0100,
   ELIBEXPORT_NFOFILES = 0x0200,
-  ELIBEXPORT_ACTORTHUMBS = 0x0400
+  ELIBEXPORT_ACTORTHUMBS = 0x0400,
+  ELIBEXPORT_ARTISTFOLDERS = 0x0800
 };
 
 class CLibExportSettings
@@ -40,6 +41,7 @@ public:
 
   bool operator!=(const CLibExportSettings &right) const;
   bool IsItemExported(ELIBEXPORTOPTIONS item) const;
+  bool IsArtists() const;
   std::vector<int> GetExportItems() const;
   void ClearItems() { m_itemstoexport = 0; }
   void AddItem(ELIBEXPORTOPTIONS item) { m_itemstoexport += item; }
@@ -50,6 +52,7 @@ public:
   bool IsSingleFile() const;
   bool IsSeparateFiles() const;
   bool IsToLibFolders() const;
+  bool IsArtistFoldersOnly() const;
 
   std::string m_strPath;
   bool m_overwrite;

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.h
@@ -44,12 +44,17 @@ protected:
 
 private:
   void SetLabel2(const std::string &settingid, const std::string &label);
+  void SetLabel(const std::string &settingid, const std::string &label);
   void ToggleState(const std::string &settingid, bool enabled);
 
   using CGUIDialogSettingsManualBase::SetFocus;
   void SetFocus(const std::string &settingid);
   static int GetExportItemsFromSetting(SettingConstPtr setting);
+  void UpdateToggles();
+  void UpdateDescription();
 
   CLibExportSettings m_settings;
   bool m_destinationChecked = false;
+  std::shared_ptr<CSettingBool> m_settingNFO;
+  std::shared_ptr<CSettingBool> m_settingArt;
 };


### PR DESCRIPTION
Make the music library export GUI easier and clearer to use, and add facility to export artist folders only (no art or NFO files, just create correctly named folders in the Artist Information Folder).

It becme obvious from user feedback in wanting to use the new the Artist Information Folder facility for artist local art and NFO files that they needed a way to automatically create correctly named artist folders  without exporting nfo files or art. This fills that gap in the workflow.

![](https://i.imgur.com/3bCA249.png)

The GUI has also been simplified, and use clarified by showing a description of where exported files are going.

![Imgur](https://i.imgur.com/LCczAGv.png)

![Imgur](https://i.imgur.com/5Ol7vx9.png)
