### PR TITLE
[Applicaion/GuiComponent] - don't call init/deinit of subcomponents of guicomponent from application

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1376,7 +1376,7 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
   else if (!m_saveSkinOnUnloading)
     m_saveSkinOnUnloading = true;
 
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui)
   {
     gui->GetAudioManager().Enable(false);
@@ -1830,7 +1830,7 @@ bool CApplication::OnAction(const CAction &action)
       if (!m_appPlayer.IsPaused() && m_appPlayer.GetPlaySpeed() != 1)
         m_appPlayer.SetPlaySpeed(1);
 
-      CGUIComponent *gui = CServiceBroker::GetGUI();
+      IGUIComponent *gui = CServiceBroker::GetGUI();
       if (gui)
         gui->GetAudioManager().Enable(m_appPlayer.IsPaused());
       return true;
@@ -1893,7 +1893,7 @@ bool CApplication::OnAction(const CAction &action)
         // unpause, and set the playspeed back to normal
         m_appPlayer.Pause();
 
-        CGUIComponent *gui = CServiceBroker::GetGUI();
+        IGUIComponent *gui = CServiceBroker::GetGUI();
         if (gui)
           gui->GetAudioManager().Enable(m_appPlayer.IsPaused());
 
@@ -2626,7 +2626,7 @@ void CApplication::Stop(int exitCode)
     UnregisterActionListener(&m_appPlayer.GetSeekHandler());
     UnregisterActionListener(&CPlayerController::GetInstance());
 
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetAudioManager().DeInitialize();
 
@@ -2965,7 +2965,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   m_appPlayer.SetMute(m_muted);
 
 #if !defined(TARGET_POSIX)
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().Enable(false);
 #endif
@@ -2980,7 +2980,7 @@ void CApplication::PlaybackCleanup()
 {
   if (!m_appPlayer.IsPlaying())
   {
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui)
       CServiceBroker::GetGUI()->GetAudioManager().Enable(true);
     m_appPlayer.OpenNext(m_ServiceManager->GetPlayerCoreFactory());
@@ -3315,7 +3315,7 @@ bool CApplication::IsFullScreen()
 
 void CApplication::StopPlaying()
 {
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
 
   if (gui)
   {
@@ -4762,7 +4762,7 @@ void CApplication::SetRenderGUI(bool renderGUI)
 {
   if (renderGUI && ! m_renderGUI)
   {
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui)
       CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -671,6 +671,7 @@ bool CApplication::CreateGUI()
 
   m_pGUI = std::make_shared<CGUIComponent>();
   m_pGUI->Init();
+  CServiceBroker::RegisterGUI(m_pGUI);
   m_pGUI->AddMsgTarget(this);
   m_pGUI->AddMsgTarget(&g_fontManager);
 
@@ -2487,6 +2488,7 @@ bool CApplication::Cleanup()
 
     if (m_pGUI)
     {
+      CServiceBroker::UnregisterGUI();
       m_pGUI->Deinit();
       m_pGUI.reset();
     }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -669,7 +669,7 @@ bool CApplication::CreateGUI()
   if (sav_res)
     CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP, true);
 
-  m_pGUI.reset(new CGUIComponent());
+  m_pGUI = std::make_shared<CGUIComponent>();
   m_pGUI->Init();
   m_pGUI->AddMsgTarget(this);
   m_pGUI->AddMsgTarget(&g_fontManager);
@@ -1376,7 +1376,7 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
   else if (!m_saveSkinOnUnloading)
     m_saveSkinOnUnloading = true;
 
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
   {
     gui->GetAudioManager().Enable(false);
@@ -1830,7 +1830,7 @@ bool CApplication::OnAction(const CAction &action)
       if (!m_appPlayer.IsPaused() && m_appPlayer.GetPlaySpeed() != 1)
         m_appPlayer.SetPlaySpeed(1);
 
-      IGUIComponent *gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui)
         gui->GetAudioManager().Enable(m_appPlayer.IsPaused());
       return true;
@@ -1893,7 +1893,7 @@ bool CApplication::OnAction(const CAction &action)
         // unpause, and set the playspeed back to normal
         m_appPlayer.Pause();
 
-        IGUIComponent *gui = CServiceBroker::GetGUI();
+        auto gui = CServiceBroker::GetGUI();
         if (gui)
           gui->GetAudioManager().Enable(m_appPlayer.IsPaused());
 
@@ -2626,7 +2626,7 @@ void CApplication::Stop(int exitCode)
     UnregisterActionListener(&m_appPlayer.GetSeekHandler());
     UnregisterActionListener(&CPlayerController::GetInstance());
 
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetAudioManager().DeInitialize();
 
@@ -2965,7 +2965,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   m_appPlayer.SetMute(m_muted);
 
 #if !defined(TARGET_POSIX)
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().Enable(false);
 #endif
@@ -2980,7 +2980,7 @@ void CApplication::PlaybackCleanup()
 {
   if (!m_appPlayer.IsPlaying())
   {
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
       CServiceBroker::GetGUI()->GetAudioManager().Enable(true);
     m_appPlayer.OpenNext(m_ServiceManager->GetPlayerCoreFactory());
@@ -3315,7 +3315,7 @@ bool CApplication::IsFullScreen()
 
 void CApplication::StopPlaying()
 {
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
 
   if (gui)
   {
@@ -4762,7 +4762,7 @@ void CApplication::SetRenderGUI(bool renderGUI)
 {
   if (renderGUI && ! m_renderGUI)
   {
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
       CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1316,7 +1316,6 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(this);
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&CServiceBroker::GetPlaylistPlayer());
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&g_fontManager);
-  CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&CServiceBroker::GetGUI()->GetStereoscopicsManager());
   CServiceBroker::GetGUI()->GetWindowManager().SetCallback(*this);
   //@todo should be done by GUIComponents
   CServiceBroker::GetGUI()->GetWindowManager().Initialize();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -671,6 +671,8 @@ bool CApplication::CreateGUI()
 
   m_pGUI.reset(new CGUIComponent());
   m_pGUI->Init();
+  m_pGUI->AddMsgTarget(this);
+  m_pGUI->AddMsgTarget(&g_fontManager);
 
   // Splash requires gui component!!
   CServiceBroker::GetRenderSystem()->ShowSplash("");
@@ -1313,9 +1315,6 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CLog::Log(LOGDEBUG,"Load Skin XML: %.2fms", 1000.f * (end - start) / freq);
 
   CLog::Log(LOGINFO, "  initialize new skin...");
-  CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(this);
-  CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&CServiceBroker::GetPlaylistPlayer());
-  CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&g_fontManager);
   CServiceBroker::GetGUI()->GetWindowManager().SetCallback(*this);
   //@todo should be done by GUIComponents
   CServiceBroker::GetGUI()->GetWindowManager().Initialize();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -52,7 +52,7 @@ class DPMSSupport;
 class CSplash;
 class CBookmark;
 class IActionListener;
-class IGUIComponent;
+class CGUIComponent;
 class CAppInboundProtocol;
 class CSettingsComponent;
 
@@ -377,7 +377,7 @@ protected:
 
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   std::unique_ptr<CSettingsComponent> m_pSettingsComponent;
-  std::unique_ptr<IGUIComponent> m_pGUI;
+  std::unique_ptr<CGUIComponent> m_pGUI;
   std::unique_ptr<CWinSystemBase> m_pWinSystem;
   std::unique_ptr<ActiveAE::CActiveAE> m_pActiveAE;
   std::shared_ptr<CAppInboundProtocol> m_pAppPort;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -52,7 +52,7 @@ class DPMSSupport;
 class CSplash;
 class CBookmark;
 class IActionListener;
-class CGUIComponent;
+class IGUIComponent;
 class CAppInboundProtocol;
 class CSettingsComponent;
 
@@ -377,7 +377,7 @@ protected:
 
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   std::unique_ptr<CSettingsComponent> m_pSettingsComponent;
-  std::unique_ptr<CGUIComponent> m_pGUI;
+  std::unique_ptr<IGUIComponent> m_pGUI;
   std::unique_ptr<CWinSystemBase> m_pWinSystem;
   std::unique_ptr<ActiveAE::CActiveAE> m_pActiveAE;
   std::shared_ptr<CAppInboundProtocol> m_pAppPort;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -377,7 +377,7 @@ protected:
 
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   std::unique_ptr<CSettingsComponent> m_pSettingsComponent;
-  std::unique_ptr<CGUIComponent> m_pGUI;
+  std::shared_ptr<CGUIComponent> m_pGUI;
   std::unique_ptr<CWinSystemBase> m_pWinSystem;
   std::unique_ptr<ActiveAE::CActiveAE> m_pActiveAE;
   std::shared_ptr<CAppInboundProtocol> m_pAppPort;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -479,6 +479,11 @@ private:
   CApplicationPlayer m_appPlayer;
   CEvent m_playerEvent;
   CApplicationStackHelper m_stackHelper;
+  
+  void InitGuiComponent();
+  void DeinitGuiComponent();
+  void ActivateGuiComponent();
+  void DeactivateGuiComponent();
 };
 
 XBMC_GLOBAL_REF(CApplication,g_application);

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -46,6 +46,10 @@ CPlayListPlayer::CPlayListPlayer(void)
     repeatState = REPEAT_NONE;
   m_iFailedSongs = 0;
   m_failedSongsStart = 0;
+
+  CGUIComponent *pGUI = CServiceBroker::GetGUI();
+  if (pGUI)
+    pGUI->AddMsgTarget(this);
 }
 
 CPlayListPlayer::~CPlayListPlayer(void)

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -47,7 +47,7 @@ CPlayListPlayer::CPlayListPlayer(void)
   m_iFailedSongs = 0;
   m_failedSongsStart = 0;
 
-  CGUIComponent *pGUI = CServiceBroker::GetGUI();
+  IGUIComponent *pGUI = CServiceBroker::GetGUI();
   if (pGUI)
     pGUI->AddMsgTarget(this);
 }

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -47,9 +47,9 @@ CPlayListPlayer::CPlayListPlayer(void)
   m_iFailedSongs = 0;
   m_failedSongsStart = 0;
 
-  IGUIComponent *pGUI = CServiceBroker::GetGUI();
-  if (pGUI)
-    pGUI->AddMsgTarget(this);
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->AddMsgTarget(this);
 }
 
 CPlayListPlayer::~CPlayListPlayer(void)

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -205,21 +205,20 @@ CEventLog& CServiceBroker::GetEventLog()
   return m_pSettingsComponent->GetProfileManager()->GetEventLog();
 }
 
-IGUIComponent* CServiceBroker::m_pGUI = nullptr;
-
-IGUIComponent* CServiceBroker::GetGUI()
+std::shared_ptr<IGUIComponent> CServiceBroker::m_pGUI;
+std::shared_ptr<IGUIComponent> CServiceBroker::GetGUI()
 {
   return m_pGUI;
 }
 
-void CServiceBroker::RegisterGUI(IGUIComponent *gui)
+void CServiceBroker::RegisterGUI(std::shared_ptr<IGUIComponent> gui)
 {
   m_pGUI = gui;
 }
 
 void CServiceBroker::UnregisterGUI()
 {
-  m_pGUI = nullptr;
+  m_pGUI.reset();
 }
 
 // audio

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -205,14 +205,14 @@ CEventLog& CServiceBroker::GetEventLog()
   return m_pSettingsComponent->GetProfileManager()->GetEventLog();
 }
 
-CGUIComponent* CServiceBroker::m_pGUI = nullptr;
+IGUIComponent* CServiceBroker::m_pGUI = nullptr;
 
-CGUIComponent* CServiceBroker::GetGUI()
+IGUIComponent* CServiceBroker::GetGUI()
 {
   return m_pGUI;
 }
 
-void CServiceBroker::RegisterGUI(CGUIComponent *gui)
+void CServiceBroker::RegisterGUI(IGUIComponent *gui)
 {
   m_pGUI = gui;
 }

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -49,7 +49,7 @@ class CWeatherManager;
 class CPlayerCoreFactory;
 class CDatabaseManager;
 class CEventLog;
-class CGUIComponent;
+class IGUIComponent;
 class CAppInboundProtocol;
 class CSettingsComponent;
 class CDecoderFilterManager;
@@ -107,8 +107,8 @@ public:
   static CDatabaseManager &GetDatabaseManager();
   static CEventLog &GetEventLog();
 
-  static CGUIComponent* GetGUI();
-  static void RegisterGUI(CGUIComponent *gui);
+  static IGUIComponent* GetGUI();
+  static void RegisterGUI(IGUIComponent *gui);
   static void UnregisterGUI();
 
   static void RegisterSettingsComponent(CSettingsComponent *settings);
@@ -133,7 +133,7 @@ public:
 
 private:
   static std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
-  static CGUIComponent* m_pGUI;
+  static IGUIComponent* m_pGUI;
   static CWinSystemBase* m_pWinSystem;
   static IAE* m_pActiveAE;
   static std::shared_ptr<CAppInboundProtocol> m_pAppPort;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -107,8 +107,8 @@ public:
   static CDatabaseManager &GetDatabaseManager();
   static CEventLog &GetEventLog();
 
-  static IGUIComponent* GetGUI();
-  static void RegisterGUI(IGUIComponent *gui);
+  static std::shared_ptr<IGUIComponent> GetGUI();
+  static void RegisterGUI(std::shared_ptr<IGUIComponent> gui);
   static void UnregisterGUI();
 
   static void RegisterSettingsComponent(CSettingsComponent *settings);
@@ -133,7 +133,7 @@ public:
 
 private:
   static std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
-  static IGUIComponent* m_pGUI;
+  static std::shared_ptr<IGUIComponent> m_pGUI;
   static CWinSystemBase* m_pWinSystem;
   static IAE* m_pActiveAE;
   static std::shared_ptr<CAppInboundProtocol> m_pAppPort;

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -22,6 +22,7 @@
 #include "games/GameUtils.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogHelper.h"

--- a/xbmc/addons/UISoundsResource.cpp
+++ b/xbmc/addons/UISoundsResource.cpp
@@ -30,7 +30,7 @@ bool CUISoundsResource::IsInUse() const
 
 void CUISoundsResource::OnPostInstall(bool update, bool modal)
 {
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
   if (IsInUse() && gui)
     gui->GetAudioManager().Load();
 }

--- a/xbmc/addons/UISoundsResource.cpp
+++ b/xbmc/addons/UISoundsResource.cpp
@@ -30,7 +30,7 @@ bool CUISoundsResource::IsInUse() const
 
 void CUISoundsResource::OnPostInstall(bool update, bool modal)
 {
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (IsInUse() && gui)
     gui->GetAudioManager().Load();
 }

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -498,10 +498,14 @@ bool CAddonDll::CheckAPIVersion(int type)
 
 bool CAddonDll::UpdateSettingInActiveDialog(const char* id, const std::string& value)
 {
-  if (!CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_DIALOG_ADDON_SETTINGS))
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
     return false;
 
-  CGUIDialogAddonSettings* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogAddonSettings>(WINDOW_DIALOG_ADDON_SETTINGS);
+  if (!gui->GetWindowManager().IsWindowActive(WINDOW_DIALOG_ADDON_SETTINGS))
+    return false;
+
+  CGUIDialogAddonSettings* dialog = gui->GetWindowManager().GetWindow<CGUIDialogAddonSettings>(WINDOW_DIALOG_ADDON_SETTINGS);
   if (dialog->GetCurrentAddonID() != m_addonInfo.ID())
     return false;
 
@@ -510,7 +514,7 @@ bool CAddonDll::UpdateSettingInActiveDialog(const char* id, const std::string& v
   params.push_back(id);
   params.push_back(value);
   message.SetStringParams(params);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message, WINDOW_DIALOG_ADDON_SETTINGS);
+  gui->GetWindowManager().SendThreadMessage(message, WINDOW_DIALOG_ADDON_SETTINGS);
 
   return true;
 }

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -401,7 +401,7 @@ bool CAddonCallbacksGUI::Window_Show(void *addonData, GUIHANDLE handle)
     return false;
 
   if (pAddonWindow->m_iOldWindowId != pAddonWindow->m_iWindowId && pAddonWindow->m_iWindowId != gui->GetWindowManager().GetActiveWindow())
-    pAddonWindow->m_iOldWindowId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
+    pAddonWindow->m_iOldWindowId = gui->GetWindowManager().GetActiveWindow();
 
   Lock();
   if (pAddonWindow->IsDialog())
@@ -613,7 +613,7 @@ void CAddonCallbacksGUI::Window_SetPropertyInt(void *addonData, GUIHANDLE handle
   }
 
   CGUIAddonWindow *pAddonWindow = static_cast<CGUIAddonWindow*>(handle);
-  CGUIWindow      *pWindow      = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(pAddonWindow->m_iWindowId);
+  CGUIWindow      *pWindow      = gui->GetWindowManager().GetWindow(pAddonWindow->m_iWindowId);
   if (!pWindow)
     return;
 

--- a/xbmc/addons/interfaces/GUI/controls/FadeLabel.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/FadeLabel.cpp
@@ -12,6 +12,7 @@
 #include "addons/binary-addons/AddonDll.h"
 #include "guilib/GUIFadeLabelControl.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "utils/log.h"
 
 extern "C"

--- a/xbmc/addons/interfaces/GUI/controls/Label.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Label.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
 

--- a/xbmc/addons/interfaces/GUI/controls/Label.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Label.cpp
@@ -63,7 +63,9 @@ void Interface_GUIControlLabel::set_label(void* kodiBase, void* handle, const ch
 
   CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
   msg.SetLabel(label);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 char* Interface_GUIControlLabel::get_label(void* kodiBase, void* handle)

--- a/xbmc/addons/interfaces/GUI/controls/SettingsSlider.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/SettingsSlider.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUISettingsSliderControl.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
 

--- a/xbmc/addons/interfaces/GUI/controls/SettingsSlider.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/SettingsSlider.cpp
@@ -92,7 +92,9 @@ void Interface_GUIControlSettingsSlider::set_text(void* kodiBase, void* handle, 
 
   CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
   msg.SetLabel(text);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 void Interface_GUIControlSettingsSlider::reset(void* kodiBase, void* handle)
@@ -107,7 +109,9 @@ void Interface_GUIControlSettingsSlider::reset(void* kodiBase, void* handle)
   }
 
   CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 void Interface_GUIControlSettingsSlider::set_int_range(void* kodiBase, void* handle, int start, int end)

--- a/xbmc/addons/interfaces/GUI/controls/Slider.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Slider.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
 

--- a/xbmc/addons/interfaces/GUI/controls/Slider.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Slider.cpp
@@ -91,7 +91,9 @@ void Interface_GUIControlSlider::reset(void* kodiBase, void* handle)
   }
 
   CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 char* Interface_GUIControlSlider::get_description(void* kodiBase, void* handle)

--- a/xbmc/addons/interfaces/GUI/controls/Spin.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Spin.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
 

--- a/xbmc/addons/interfaces/GUI/controls/Spin.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Spin.cpp
@@ -94,7 +94,9 @@ void Interface_GUIControlSpin::set_text(void* kodiBase, void* handle, const char
 
   CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
   msg.SetLabel(text);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 void Interface_GUIControlSpin::reset(void* kodiBase, void* handle)
@@ -109,7 +111,9 @@ void Interface_GUIControlSpin::reset(void* kodiBase, void* handle)
   }
 
   CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 void Interface_GUIControlSpin::set_type(void* kodiBase, void* handle, int type)

--- a/xbmc/addons/interfaces/GUI/controls/TextBox.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/TextBox.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUITextBox.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "utils/log.h"
 #include "ServiceBroker.h"
 

--- a/xbmc/addons/interfaces/GUI/controls/TextBox.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/TextBox.cpp
@@ -65,7 +65,9 @@ void Interface_GUIControlTextBox::reset(void* kodiBase, void* handle)
   }
 
   CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 void Interface_GUIControlTextBox::set_text(void* kodiBase, void* handle, const char* text)
@@ -81,7 +83,9 @@ void Interface_GUIControlTextBox::set_text(void* kodiBase, void* handle, const c
 
   CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
   msg.SetLabel(text);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg, control->GetParentID());
 }
 
 char* Interface_GUIControlTextBox::get_text(void* kodiBase, void* handle)

--- a/xbmc/addons/interfaces/GUI/dialogs/ContextMenu.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/ContextMenu.cpp
@@ -42,7 +42,11 @@ int Interface_GUIDialogContextMenu::open(void* kodiBase, const char *heading, co
     return -1;
   }
 
-  CGUIDialogContextMenu* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogContextMenu>(WINDOW_DIALOG_CONTEXT_MENU);
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return -1;
+  
+  CGUIDialogContextMenu* dialog = gui->GetWindowManager().GetWindow<CGUIDialogContextMenu>(WINDOW_DIALOG_CONTEXT_MENU);
   if (!heading || !entries || !dialog)
   {
     CLog::Log(LOGERROR,

--- a/xbmc/addons/interfaces/GUI/dialogs/ExtendedProgressBar.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/ExtendedProgressBar.cpp
@@ -53,7 +53,11 @@ void* Interface_GUIDialogExtendedProgress::new_dialog(void* kodiBase, const char
   }
 
   // setup the progress dialog
-  CGUIDialogExtendedProgressBar* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return nullptr;
+
+  CGUIDialogExtendedProgressBar* dialog = gui->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
   if (!title || !dialog)
   {
     CLog::Log(LOGERROR,

--- a/xbmc/addons/interfaces/GUI/dialogs/Progress.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/Progress.cpp
@@ -55,7 +55,11 @@ void* Interface_GUIDialogProgress::new_dialog(void* kodiBase)
     return nullptr;
   }
 
-  CGUIDialogProgress *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return nullptr;
+  
+  CGUIDialogProgress *dialog = gui->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
   if (!dialog)
   {
     CLog::Log(LOGERROR,

--- a/xbmc/addons/interfaces/GUI/dialogs/Select.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/Select.cpp
@@ -44,7 +44,11 @@ int Interface_GUIDialogSelect::open(void* kodiBase, const char *heading, const c
     return -1;
   }
 
-  CGUIDialogSelect* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return -1;
+  
+  CGUIDialogSelect* dialog = gui->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   if (!heading || !entries || !dialog)
   {
     CLog::Log(LOGERROR,
@@ -81,7 +85,11 @@ bool Interface_GUIDialogSelect::open_multi_select(void* kodiBase, const char *he
     return false;
   }
 
-  CGUIDialogSelect* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return false;
+  
+  CGUIDialogSelect* dialog = gui->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   if (!heading || !entryIDs || !entryNames || !entriesSelected || !dialog)
   {
     CLog::Log(LOGERROR,

--- a/xbmc/addons/interfaces/GUI/dialogs/TextViewer.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/TextViewer.cpp
@@ -42,7 +42,11 @@ void Interface_GUIDialogTextViewer::open(void* kodiBase, const char *heading, co
     return;
   }
 
-  CGUIDialogTextViewer* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogTextViewer>(WINDOW_DIALOG_TEXT_VIEWER);
+  auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return;
+  
+  CGUIDialogTextViewer* dialog = gui->GetWindowManager().GetWindow<CGUIDialogTextViewer>(WINDOW_DIALOG_TEXT_VIEWER);
   if (!heading || !text || !dialog)
   {
     CLog::Log(LOGERROR,

--- a/xbmc/cores/RetroPlayer/guiplayback/GUIPlaybackControl.cpp
+++ b/xbmc/cores/RetroPlayer/guiplayback/GUIPlaybackControl.cpp
@@ -24,7 +24,7 @@ CGUIPlaybackControl::~CGUIPlaybackControl() = default;
 
 void CGUIPlaybackControl::FrameMove()
 {
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui == nullptr)
     return;
 

--- a/xbmc/cores/RetroPlayer/guiplayback/GUIPlaybackControl.cpp
+++ b/xbmc/cores/RetroPlayer/guiplayback/GUIPlaybackControl.cpp
@@ -24,7 +24,7 @@ CGUIPlaybackControl::~CGUIPlaybackControl() = default;
 
 void CGUIPlaybackControl::FrameMove()
 {
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui == nullptr)
     return;
 

--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
@@ -16,6 +16,7 @@
 #include "guilib/GUIDialog.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h" //! @todo Remove me
 #include "guilib/WindowIDs.h"
 #include "input/actions/Action.h"

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3729,7 +3729,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
 
   if (hint.stereo_mode.empty())
   {
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui != nullptr)
     {
       const CStereoscopicsManager &stereoscopicsManager = gui->GetStereoscopicsManager();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3729,7 +3729,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
 
   if (hint.stereo_mode.empty())
   {
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui != nullptr)
     {
       const CStereoscopicsManager &stereoscopicsManager = gui->GetStereoscopicsManager();

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -293,7 +293,7 @@ bool CGUIDialogGamepad::ShowAndVerifyInput(std::string& strToVerify, const std::
   else
     pDialog->SetLine(2, CVariant{atoi(dlgLine2.c_str())});
 
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().Enable(false); // don't do sounds during pwd input
 

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -293,7 +293,7 @@ bool CGUIDialogGamepad::ShowAndVerifyInput(std::string& strToVerify, const std::
   else
     pDialog->SetLine(2, CVariant{atoi(dlgLine2.c_str())});
 
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().Enable(false); // don't do sounds during pwd input
 

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -14,6 +14,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "input/XBMC_vkeys.h"
 #include "utils/Digest.h"
 #include "utils/StringUtils.h"

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -9,6 +9,7 @@
 #include "GUIDialogPlayEject.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
 #include "utils/Variant.h"

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -10,6 +10,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "ServiceBroker.h"

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -20,6 +20,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "profiles/ProfileManager.h"
 #include "settings/Settings.h"

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
 #include "utils/LabelFormatter.h"

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -9,6 +9,7 @@
 #include "GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "ServiceBroker.h"

--- a/xbmc/favourites/GUIDialogFavourites.cpp
+++ b/xbmc/favourites/GUIDialogFavourites.cpp
@@ -15,6 +15,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -140,7 +140,7 @@ TiXmlElement *CLibraryDirectory::LoadXML(const std::string &xmlFile)
 
   // check the condition
   std::string condition = XMLUtils::GetAttribute(xml, "visible");
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
   if (condition.empty() || (gui && gui->GetInfoManager().EvaluateBool(condition)))
     return xml;
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -140,7 +140,7 @@ TiXmlElement *CLibraryDirectory::LoadXML(const std::string &xmlFile)
 
   // check the condition
   std::string condition = XMLUtils::GetAttribute(xml, "visible");
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (condition.empty() || (gui && gui->GetInfoManager().EvaluateBool(condition)))
     return xml;
 

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -32,7 +32,7 @@ CControllerInstaller::CControllerInstaller() :
 
 void CControllerInstaller::Process()
 {
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui == nullptr)
     return;
 

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -32,7 +32,7 @@ CControllerInstaller::CControllerInstaller() :
 
 void CControllerInstaller::Process()
 {
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui == nullptr)
     return;
 

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -134,9 +134,11 @@ set(HEADERS DDSImage.h
             GUIWrappingListContainer.h
             IAudioDeviceChangedCallback.h
             IDirtyRegionSolver.h
+            IGUIComponent.h
             IGUIContainer.h
             iimage.h
             imagefactory.h
+            IMsgHandler.h
             IMsgTargetCallback.h
             IRenderingCallback.h
             ISliderCallback.h

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -12,6 +12,7 @@
 #include "GUIInfoManager.h"
 #include "GUIComponent.h"
 #include "ServiceBroker.h"
+#include "GUIMessage.h"
 
 CGUIAction::CGUIAction(int controlID)
 {

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -15,12 +15,13 @@
 #include "ServiceBroker.h"
 #include "StereoscopicsManager.h"
 #include "TextureManager.h"
+#include "GUIMessage.h"
 #include "URL.h"
 #include "dialogs/GUIDialogYesNo.h"
 
 CGUIComponent::CGUIComponent()
 {
-  m_pWindowManager.reset(new CGUIWindowManager());
+  m_pWindowManager.reset(new CGUIWindowManager(this));
   m_pTextureManager.reset(new CGUITextureManager());
   m_pLargeTextureManager.reset(new CGUILargeTextureManager());
   m_stereoscopicsManager.reset(new CStereoscopicsManager());
@@ -40,8 +41,7 @@ void CGUIComponent::Init()
   m_stereoscopicsManager->Initialize();
   m_guiInfoManager->Initialize();
 
-  //! @todo This is something we need to change
-  m_pWindowManager->AddMsgTarget(m_stereoscopicsManager.get());
+  AddMsgTarget(m_stereoscopicsManager.get());
 
   CServiceBroker::RegisterGUI(this);
 }
@@ -102,4 +102,22 @@ bool CGUIComponent::ConfirmDelete(std::string path)
       return true;
   }
   return false;
+}
+
+void CGUIComponent::AddMsgTarget(IMsgTargetCallback* pMsgTarget)
+{
+  if (std::find(m_msgTargets.begin(), m_msgTargets.end(), pMsgTarget) == m_msgTargets.end())
+    m_msgTargets.emplace_back(pMsgTarget);
+}
+
+bool CGUIComponent::ProcessMsgHooks(CGUIMessage& message)
+{
+  bool handled = false;
+
+  for (const auto& target : m_msgTargets)
+  {
+    if (target->OnMessage(message))
+      handled = true;
+  }
+  return handled;
 }

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -43,7 +43,7 @@ void CGUIComponent::Init()
 
   AddMsgTarget(m_stereoscopicsManager.get());
 
-  CServiceBroker::RegisterGUI(this);
+  CServiceBroker::RegisterGUI(std::shared_ptr<IGUIComponent>(this));
 }
 
 void CGUIComponent::Deinit()

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -42,14 +42,10 @@ void CGUIComponent::Init()
   m_guiInfoManager->Initialize();
 
   AddMsgTarget(m_stereoscopicsManager.get());
-
-  CServiceBroker::RegisterGUI(std::shared_ptr<IGUIComponent>(this));
 }
 
 void CGUIComponent::Deinit()
 {
-  CServiceBroker::UnregisterGUI();
-
   m_pWindowManager->DeInitialize();
 }
 

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 class CGUIWindowManager;
 class CGUITextureManager;
@@ -18,9 +19,12 @@ class CStereoscopicsManager;
 class CGUIInfoManager;
 class CGUIColorManager;
 class CGUIAudioManager;
+class IMsgTargetCallback;
+class CGUIMessage;
 
 class CGUIComponent
 {
+  friend CGUIWindowManager;
 public:
   CGUIComponent();
   virtual ~CGUIComponent();
@@ -37,7 +41,11 @@ public:
 
   bool ConfirmDelete(std::string path);
 
+  void AddMsgTarget(IMsgTargetCallback* pMsgTarget);
+
 protected:
+  bool ProcessMsgHooks(CGUIMessage& message);
+
   // members are pointers in order to avoid includes
   std::unique_ptr<CGUIWindowManager> m_pWindowManager;
   std::unique_ptr<CGUITextureManager> m_pTextureManager;
@@ -46,4 +54,6 @@ protected:
   std::unique_ptr<CGUIInfoManager> m_guiInfoManager;
   std::unique_ptr<CGUIColorManager> m_guiColorManager;
   std::unique_ptr<CGUIAudioManager> m_guiAudioManager;
+
+  std::vector<IMsgTargetCallback*> m_msgTargets;
 };

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -29,8 +29,8 @@ class CGUIComponent : public IMsgHandler, public IGUIComponent
 public:
   CGUIComponent();
   virtual ~CGUIComponent();
-  void Init() override;
-  void Deinit() override;
+  void Init();
+  void Deinit();
 
   CGUIWindowManager& GetWindowManager() override;
   CGUITextureManager& GetTextureManager() override;

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "IMsgHandler.h"
 
 class CGUIWindowManager;
 class CGUITextureManager;
@@ -22,9 +23,8 @@ class CGUIAudioManager;
 class IMsgTargetCallback;
 class CGUIMessage;
 
-class CGUIComponent
+class CGUIComponent : public IMsgHandler
 {
-  friend CGUIWindowManager;
 public:
   CGUIComponent();
   virtual ~CGUIComponent();
@@ -42,9 +42,10 @@ public:
   bool ConfirmDelete(std::string path);
 
   void AddMsgTarget(IMsgTargetCallback* pMsgTarget);
-
+  
+  bool ProcessMsgHooks(CGUIMessage& message) override;
+  
 protected:
-  bool ProcessMsgHooks(CGUIMessage& message);
 
   // members are pointers in order to avoid includes
   std::unique_ptr<CGUIWindowManager> m_pWindowManager;

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 #include "IMsgHandler.h"
+#include "IGUIComponent.h"
 
 class CGUIWindowManager;
 class CGUITextureManager;
@@ -23,25 +24,25 @@ class CGUIAudioManager;
 class IMsgTargetCallback;
 class CGUIMessage;
 
-class CGUIComponent : public IMsgHandler
+class CGUIComponent : public IMsgHandler, public IGUIComponent
 {
 public:
   CGUIComponent();
   virtual ~CGUIComponent();
-  void Init();
-  void Deinit();
+  void Init() override;
+  void Deinit() override;
 
-  CGUIWindowManager& GetWindowManager();
-  CGUITextureManager& GetTextureManager();
-  CGUILargeTextureManager& GetLargeTextureManager();
-  CStereoscopicsManager &GetStereoscopicsManager();
-  CGUIInfoManager &GetInfoManager();
-  CGUIColorManager &GetColorManager();
-  CGUIAudioManager &GetAudioManager();
+  CGUIWindowManager& GetWindowManager() override;
+  CGUITextureManager& GetTextureManager() override;
+  CGUILargeTextureManager& GetLargeTextureManager() override;
+  CStereoscopicsManager &GetStereoscopicsManager() override;
+  CGUIInfoManager &GetInfoManager() override;
+  CGUIColorManager &GetColorManager() override;
+  CGUIAudioManager &GetAudioManager() override;
 
-  bool ConfirmDelete(std::string path);
+  bool ConfirmDelete(std::string path) override;
 
-  void AddMsgTarget(IMsgTargetCallback* pMsgTarget);
+  void AddMsgTarget(IMsgTargetCallback* pMsgTarget) override;
   
   bool ProcessMsgHooks(CGUIMessage& message) override;
   

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -14,6 +14,7 @@
 #include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "GUIMessage.h"
 #include "GUIWindowManager.h"
 
 static const SliderAction actions[] = {

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -24,6 +24,7 @@
 #include "input/Key.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "IMsgHandler.h"
 
 #include "windows/GUIWindowHome.h"
 #include "events/windows/GUIWindowEventLog.h"
@@ -150,7 +151,7 @@ using namespace PVR;
 using namespace PERIPHERALS;
 using namespace MESSAGING;
 
-CGUIWindowManager::CGUIWindowManager(CGUIComponent *gui) : m_pGUI(gui)
+CGUIWindowManager::CGUIWindowManager(IMsgHandler *gui) : m_pGUI(gui)
 {
   m_pCallback = nullptr;
   m_iNested = 0;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -150,7 +150,7 @@ using namespace PVR;
 using namespace PERIPHERALS;
 using namespace MESSAGING;
 
-CGUIWindowManager::CGUIWindowManager()
+CGUIWindowManager::CGUIWindowManager(CGUIComponent *gui) : m_pGUI(gui)
 {
   m_pCallback = nullptr;
   m_iNested = 0;
@@ -465,20 +465,13 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
 {
   bool handled = false;
 //  CLog::Log(LOGDEBUG,"SendMessage: mess=%d send=%d control=%d param1=%d", message.GetMessage(), message.GetSenderId(), message.GetControlId(), message.GetParam1());
-  // Send the message to all none window targets
-  for (int i = 0; i < int(m_vecMsgTargets.size()); i++)
-  {
-    IMsgTargetCallback* pMsgTarget = m_vecMsgTargets[i];
 
-    if (pMsgTarget)
-    {
-      if (pMsgTarget->OnMessage( message )) handled = true;
-    }
-  }
+  // Send the message to all none window targets
+  handled = m_pGUI->ProcessMsgHooks(message);
 
   //  A GUI_MSG_NOTIFY_ALL is send to any active modal dialog
   //  and all windows whether they are active or not
-  if (message.GetMessage()==GUI_MSG_NOTIFY_ALL)
+  if (message.GetMessage() == GUI_MSG_NOTIFY_ALL)
   {
     CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
@@ -554,8 +547,8 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
 bool CGUIWindowManager::SendMessage(CGUIMessage& message, int window)
 {
   if (window == 0)
-    // send to no specified windows.
     return SendMessage(message);
+
   CGUIWindow* pWindow = GetWindow(window);
   if(pWindow)
     return pWindow->OnMessage(message);
@@ -1331,8 +1324,6 @@ void CGUIWindowManager::DeInitialize()
   }
   UnloadNotOnDemandWindows();
 
-  m_vecMsgTargets.erase( m_vecMsgTargets.begin(), m_vecMsgTargets.end() );
-
   // destroy our custom windows...
   for (int i = 0; i < int(m_vecCustomWindows.size()); i++)
   {
@@ -1478,11 +1469,6 @@ int CGUIWindowManager::RemoveThreadMessageByMessageIds(int *pMessageIDList)
     }
   }
   return removedMsgCount;
-}
-
-void CGUIWindowManager::AddMsgTarget(IMsgTargetCallback* pMsgTarget)
-{
-  m_vecMsgTargets.emplace_back(pMsgTarget);
 }
 
 int CGUIWindowManager::GetActiveWindow() const

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -21,7 +21,7 @@
 
 class CGUIDialog;
 class CGUIMediaWindow;
-class CGUIComponent;
+class IMsgHandler;
 
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(push, 8)
@@ -50,7 +50,7 @@ class CGUIWindowManager : public KODI::MESSAGING::IMessageTarget
   friend CGUIDialog;
   friend CGUIMediaWindow;
 public:
-  CGUIWindowManager(CGUIComponent *gui);
+  CGUIWindowManager(IMsgHandler *gui);
   ~CGUIWindowManager() override;
   bool SendMessage(CGUIMessage& message);
   bool SendMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
@@ -247,7 +247,7 @@ private:
 
   bool HandleAction(const CAction &action) const;
 
-  CGUIComponent *m_pGUI = nullptr;
+  IMsgHandler *m_pGUI = nullptr;
   std::unordered_map<int, CGUIWindow*> m_mapWindows;
   std::vector<CGUIWindow*> m_vecCustomWindows;
   std::vector<CGUIWindow*> m_activeDialogs;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -16,12 +16,12 @@
 #include "DirtyRegionTracker.h"
 #include "guilib/WindowIDs.h"
 #include "GUIWindow.h"
-#include "IMsgTargetCallback.h"
 #include "IWindowManagerCallback.h"
 #include "messaging/IMessageTarget.h"
 
 class CGUIDialog;
 class CGUIMediaWindow;
+class CGUIComponent;
 
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(push, 8)
@@ -50,7 +50,7 @@ class CGUIWindowManager : public KODI::MESSAGING::IMessageTarget
   friend CGUIDialog;
   friend CGUIMediaWindow;
 public:
-  CGUIWindowManager();
+  CGUIWindowManager(CGUIComponent *gui);
   ~CGUIWindowManager() override;
   bool SendMessage(CGUIMessage& message);
   bool SendMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
@@ -185,7 +185,6 @@ public:
   // method to removed queued messages with message id in the requested message id list.
   // pMessageIDList: point to first integer of a 0 ends integer array.
   int RemoveThreadMessageByMessageIds(int *pMessageIDList);
-  void AddMsgTarget( IMsgTargetCallback* pMsgTarget );
   int GetActiveWindow() const;
   int GetActiveWindowOrDialog() const;
   bool HasModalDialog(bool ignoreClosing) const;
@@ -248,6 +247,7 @@ private:
 
   bool HandleAction(const CAction &action) const;
 
+  CGUIComponent *m_pGUI = nullptr;
   std::unordered_map<int, CGUIWindow*> m_mapWindows;
   std::vector<CGUIWindow*> m_vecCustomWindows;
   std::vector<CGUIWindow*> m_activeDialogs;
@@ -258,7 +258,6 @@ private:
   IWindowManagerCallback* m_pCallback;
   std::list< std::pair<CGUIMessage*,int> > m_vecThreadMessages;
   CCriticalSection m_critSection;
-  std::vector<IMsgTargetCallback*> m_vecMsgTargets;
 
   int  m_iNested;
   bool m_initialized;

--- a/xbmc/guilib/IGUIComponent.h
+++ b/xbmc/guilib/IGUIComponent.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class CGUIWindowManager;
+class CGUITextureManager;
+class CGUILargeTextureManager;
+class CStereoscopicsManager;
+class CGUIInfoManager;
+class CGUIColorManager;
+class CGUIAudioManager;
+class IMsgTargetCallback;
+
+class IGUIComponent
+{
+public:
+
+  virtual void Init() = 0;
+  virtual void Deinit() = 0;
+
+  virtual CGUIWindowManager& GetWindowManager() = 0;
+  virtual CGUITextureManager& GetTextureManager() = 0;
+  virtual CGUILargeTextureManager& GetLargeTextureManager() = 0;
+  virtual CStereoscopicsManager &GetStereoscopicsManager() = 0;
+  virtual CGUIInfoManager &GetInfoManager() = 0;
+  virtual CGUIColorManager &GetColorManager() = 0;
+  virtual CGUIAudioManager &GetAudioManager() = 0;
+
+  virtual bool ConfirmDelete(std::string path) = 0;
+  
+  virtual void AddMsgTarget(IMsgTargetCallback* pMsgTarget) = 0;
+
+  virtual ~IGUIComponent() = default;
+};

--- a/xbmc/guilib/IGUIComponent.h
+++ b/xbmc/guilib/IGUIComponent.h
@@ -23,9 +23,6 @@ class IGUIComponent
 {
 public:
 
-  virtual void Init() = 0;
-  virtual void Deinit() = 0;
-
   virtual CGUIWindowManager& GetWindowManager() = 0;
   virtual CGUITextureManager& GetTextureManager() = 0;
   virtual CGUILargeTextureManager& GetLargeTextureManager() = 0;

--- a/xbmc/guilib/IMsgHandler.h
+++ b/xbmc/guilib/IMsgHandler.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "GUIMessage.h"
+
+class IMsgHandler
+{
+public:
+  virtual bool ProcessMsgHooks(CGUIMessage& message) = 0;
+  virtual ~IMsgHandler() = default;
+};

--- a/xbmc/guilib/IMsgTargetCallback.h
+++ b/xbmc/guilib/IMsgTargetCallback.h
@@ -8,17 +8,8 @@
 
 #pragma once
 
-/*!
-\file IMsgTargetCallback.h
-\brief
-*/
-
 #include "GUIMessage.h"
 
-/*!
- \ingroup winman
- \brief
- */
 class IMsgTargetCallback
 {
 public:

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -679,7 +679,7 @@ bool CInputManager::AlwaysProcess(const CAction& action)
 bool CInputManager::ExecuteInputAction(const CAction &action)
 {
   bool bResult = false;
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
 
   // play sound before the action unless the button is held,
   // where we execute after the action as held actions aren't fired every time.

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -679,7 +679,7 @@ bool CInputManager::AlwaysProcess(const CAction& action)
 bool CInputManager::ExecuteInputAction(const CAction &action)
 {
   bool bResult = false;
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
 
   // play sound before the action unless the button is held,
   // where we execute after the action as held actions aren't fired every time.

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -99,7 +99,7 @@ void CJoystickEasterEgg::OnFinish(void)
   gameSettings.ToggleGames();
 
   WINDOW_SOUND sound = gameSettings.GamesEnabled() ? SOUND_INIT : SOUND_DEINIT;
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().PlayWindowSound(WINDOW_DIALOG_KAI_TOAST, sound);
 

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -99,7 +99,7 @@ void CJoystickEasterEgg::OnFinish(void)
   gameSettings.ToggleGames();
 
   WINDOW_SOUND sound = gameSettings.GamesEnabled() ? SOUND_INIT : SOUND_DEINIT;
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetAudioManager().PlayWindowSound(WINDOW_DIALOG_KAI_TOAST, sound);
 

--- a/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
@@ -10,6 +10,7 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "input/WindowTranslator.h"
 #include "utils/StringUtils.h"
 

--- a/xbmc/interfaces/builtins/WeatherBuiltins.cpp
+++ b/xbmc/interfaces/builtins/WeatherBuiltins.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 
 /*! \brief Switch to a given weather location.
  *  \param params The parameters.

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -37,7 +37,7 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
   if(!wakeScreensaver || !handleScreenSaver())
   {
     g_application.ResetSystemIdleTimer();
-    IGUIComponent* gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetAudioManager().PlayActionSound(actionID);
 

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -37,7 +37,7 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
   if(!wakeScreensaver || !handleScreenSaver())
   {
     g_application.ResetSystemIdleTimer();
-    CGUIComponent* gui = CServiceBroker::GetGUI();
+    IGUIComponent* gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetAudioManager().PlayActionSound(actionID);
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -329,7 +329,7 @@ namespace XBMCAddon
       if (!filename)
         return;
 
-      CGUIComponent* gui = CServiceBroker::GetGUI();
+      IGUIComponent* gui = CServiceBroker::GetGUI();
       if (XFILE::CFile::Exists(filename) && gui)
       {
         gui->GetAudioManager().PlayPythonSound(filename,useCached);
@@ -340,7 +340,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       DelayedCallGuard dg;
-      CGUIComponent* gui = CServiceBroker::GetGUI();
+      IGUIComponent* gui = CServiceBroker::GetGUI();
       if (gui)
         gui->GetAudioManager().Stop();
     }
@@ -348,7 +348,7 @@ namespace XBMCAddon
     void enableNavSounds(bool yesNo)
     {
       XBMC_TRACE;
-      CGUIComponent* gui = CServiceBroker::GetGUI();
+      IGUIComponent* gui = CServiceBroker::GetGUI();
       if (gui)
         gui->GetAudioManager().Enable(yesNo);
     }

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -329,7 +329,7 @@ namespace XBMCAddon
       if (!filename)
         return;
 
-      IGUIComponent* gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (XFILE::CFile::Exists(filename) && gui)
       {
         gui->GetAudioManager().PlayPythonSound(filename,useCached);
@@ -340,7 +340,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       DelayedCallGuard dg;
-      IGUIComponent* gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui)
         gui->GetAudioManager().Stop();
     }
@@ -348,7 +348,7 @@ namespace XBMCAddon
     void enableNavSounds(bool yesNo)
     {
       XBMC_TRACE;
-      IGUIComponent* gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui)
         gui->GetAudioManager().Enable(yesNo);
     }

--- a/xbmc/interfaces/legacy/WindowDialog.cpp
+++ b/xbmc/interfaces/legacy/WindowDialog.cpp
@@ -12,6 +12,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "WindowInterceptor.h"
 
 namespace XBMCAddon

--- a/xbmc/interfaces/legacy/WindowDialogMixin.cpp
+++ b/xbmc/interfaces/legacy/WindowDialogMixin.cpp
@@ -13,6 +13,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 
 using namespace KODI::MESSAGING;
 

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/TextureManager.h"
+#include "guilib/GUIMessage.h"
 #include "addons/Skin.h"
 #include "filesystem/File.h"
 #include "utils/URIUtils.h"

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -9220,7 +9220,7 @@ bool CMusicDatabase::CommitTransaction()
 {
   if (CDatabase::CommitTransaction())
   { // number of items in the db has likely changed, so reset the infomanager cache
-    IGUIComponent* gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
     {
       gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
@@ -10005,7 +10005,7 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
       if (!ImportSongHistory(xmlFile, songtotal, progressDialog))
         return;
 
-    IGUIComponent* gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().ResetLibraryBools();
   }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -9220,7 +9220,7 @@ bool CMusicDatabase::CommitTransaction()
 {
   if (CDatabase::CommitTransaction())
   { // number of items in the db has likely changed, so reset the infomanager cache
-    CGUIComponent* gui = CServiceBroker::GetGUI();
+    IGUIComponent* gui = CServiceBroker::GetGUI();
     if (gui)
     {
       gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
@@ -10005,7 +10005,7 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
       if (!ImportSongHistory(xmlFile, songtotal, progressDialog))
         return;
 
-    CGUIComponent* gui = CServiceBroker::GetGUI();
+    IGUIComponent* gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().ResetLibraryBools();
   }

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -26,6 +26,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "interfaces/builtins/Builtins.h"
 #include "ServiceBroker.h"
 #include "settings/lib/Setting.h"

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -799,7 +799,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     if (item->IsPlayList() || item->IsSmartPlayList())
     {
       item->m_bIsFolder = false;
-      IGUIComponent *gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui && gui->ConfirmDelete(item->GetPath()))
         CFileUtils::DeleteItem(item);
     }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -799,7 +799,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     if (item->IsPlayList() || item->IsSmartPlayList())
     {
       item->m_bIsFolder = false;
-      CGUIComponent *gui = CServiceBroker::GetGUI();
+      IGUIComponent *gui = CServiceBroker::GetGUI();
       if (gui && gui->ConfirmDelete(item->GetPath()))
         CFileUtils::DeleteItem(item);
     }

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -337,7 +337,7 @@ bool CEventServer::ExecuteNextAction()
           unsigned int actionID;
           CActionTranslator::TranslateString(actionEvent.actionName, actionID);
           CAction action(actionID, 1.0f, 0.0f, actionEvent.actionName);
-          CGUIComponent* gui = CServiceBroker::GetGUI();
+          IGUIComponent* gui = CServiceBroker::GetGUI();
           if (gui)
             gui->GetAudioManager().PlayActionSound(action);
 

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -337,7 +337,7 @@ bool CEventServer::ExecuteNextAction()
           unsigned int actionID;
           CActionTranslator::TranslateString(actionEvent.actionName, actionID);
           CAction action(actionID, 1.0f, 0.0f, actionEvent.actionName);
-          IGUIComponent* gui = CServiceBroker::GetGUI();
+          auto gui = CServiceBroker::GetGUI();
           if (gui)
             gui->GetAudioManager().PlayActionSound(action);
 

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -21,6 +21,7 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "settings/lib/Setting.h"
 #include "settings/windows/GUIControlSettings.h"
 #include "URL.h"

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -271,7 +271,7 @@ public:
   {
     if (g_application.IsCurrentThread())
     {
-      CGUIComponent *gui = CServiceBroker::GetGUI();
+      IGUIComponent *gui = CServiceBroker::GetGUI();
       if (gui)
         m_dialog = gui->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
     }

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -271,7 +271,7 @@ public:
   {
     if (g_application.IsCurrentThread())
     {
-      IGUIComponent *gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui)
         m_dialog = gui->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
     }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -11,6 +11,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "guilib/GUIMessage.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "messaging/ApplicationMessenger.h"
 #include "peripherals/Peripherals.h"

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -10,6 +10,7 @@
 #include "GUIInfoManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "input/Key.h"

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -324,7 +324,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   CServiceBroker::GetInputManager().SetMouseEnabled(settings->GetBool(CSettings::SETTING_INPUT_ENABLEMOUSE));
 
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
   {
     CGUIInfoManager& infoMgr = gui->GetInfoManager();
@@ -499,7 +499,7 @@ bool CProfileManager::DeleteProfile(unsigned int index)
   item->m_bIsFolder = true;
   item->Select(true);
 
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui && gui->ConfirmDelete(item->GetPath()))
     CFileUtils::DeleteItem(item);
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -324,7 +324,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   CServiceBroker::GetInputManager().SetMouseEnabled(settings->GetBool(CSettings::SETTING_INPUT_ENABLEMOUSE));
 
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
   {
     CGUIInfoManager& infoMgr = gui->GetInfoManager();
@@ -499,7 +499,7 @@ bool CProfileManager::DeleteProfile(unsigned int index)
   item->m_bIsFolder = true;
   item->Select(true);
 
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui && gui->ConfirmDelete(item->GetPath()))
     CFileUtils::DeleteItem(item);
 

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingSection.h"
 #include "settings/windows/GUIControlSettings.h"

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -19,6 +19,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "GUIPassword.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "profiles/ProfileManager.h"

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -14,6 +14,7 @@
 #include "dialogs/GUIDialogMediaSource.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/GUIMessage.h"
 #include "FileItem.h"
 #include "settings/MediaSourceSettings.h"
 #include "input/Key.h"

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -112,7 +112,7 @@ void CPVRGUIInfo::Stop(void)
   StopThread();
   CServiceBroker::GetPVRManager().UnregisterObserver(this);
 
-  IGUIComponent* gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
   {
     gui->GetInfoManager().UnregisterInfoProvider(this);
@@ -142,7 +142,7 @@ void CPVRGUIInfo::Process(void)
   {
     if (!m_bRegistered)
     {
-      IGUIComponent* gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui)
       {
         gui->GetInfoManager().RegisterInfoProvider(this);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -112,7 +112,7 @@ void CPVRGUIInfo::Stop(void)
   StopThread();
   CServiceBroker::GetPVRManager().UnregisterObserver(this);
 
-  CGUIComponent* gui = CServiceBroker::GetGUI();
+  IGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
   {
     gui->GetInfoManager().UnregisterInfoProvider(this);
@@ -142,7 +142,7 @@ void CPVRGUIInfo::Process(void)
   {
     if (!m_bRegistered)
     {
-      CGUIComponent* gui = CServiceBroker::GetGUI();
+      IGUIComponent* gui = CServiceBroker::GetGUI();
       if (gui)
       {
         gui->GetInfoManager().RegisterInfoProvider(this);

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -23,6 +23,7 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfileManager.h"

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -36,7 +36,9 @@ CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD()
 
 CGUIDialogPVRChannelsOSD::~CGUIDialogPVRChannelsOSD()
 {
-  CServiceBroker::GetGUI()->GetInfoManager().UnregisterObserver(this);
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetInfoManager().UnregisterObserver(this);
   CServiceBroker::GetPVRManager().EpgContainer().UnregisterObserver(this);
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -16,6 +16,7 @@
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "messaging/helpers//DialogOKHelper.h"
 #include "utils/StringUtils.h"

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -14,6 +14,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "settings/SettingUtils.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -44,7 +44,9 @@ CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio, int id, const 
 
 CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase()
 {
-  CServiceBroker::GetGUI()->GetInfoManager().UnregisterObserver(this);
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetInfoManager().UnregisterObserver(this);
   CServiceBroker::GetPVRManager().EpgContainer().UnregisterObserver(this);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -42,7 +42,9 @@ CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio, int id, co
 
 CGUIWindowPVRRecordingsBase::~CGUIWindowPVRRecordingsBase()
 {
-  CServiceBroker::GetGUI()->GetInfoManager().UnregisterObserver(this);
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetInfoManager().UnregisterObserver(this);
 }
 
 void CGUIWindowPVRRecordingsBase::OnWindowLoaded()

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -13,6 +13,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "threads/IRunnable.h"

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -36,7 +36,9 @@ CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std:
 
 CGUIWindowPVRTimersBase::~CGUIWindowPVRTimersBase()
 {
-  CServiceBroker::GetGUI()->GetInfoManager().UnregisterObserver(this);
+  auto gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetInfoManager().UnregisterObserver(this);
 }
 
 bool CGUIWindowPVRTimersBase::OnAction(const CAction &action)

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -791,7 +791,7 @@ void CDisplaySettings::SettingOptionsDispModeFiller(SettingConstPtr setting, std
 
 void CDisplaySettings::SettingOptionsStereoscopicModesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui != nullptr)
   {
     const CStereoscopicsManager &stereoscopicsManager = gui->GetStereoscopicsManager();

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -791,7 +791,7 @@ void CDisplaySettings::SettingOptionsDispModeFiller(SettingConstPtr setting, std
 
 void CDisplaySettings::SettingOptionsStereoscopicModesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui != nullptr)
   {
     const CStereoscopicsManager &stereoscopicsManager = gui->GetStereoscopicsManager();

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -23,6 +23,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/lib/Setting.h"

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -19,6 +19,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GUIMessage.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "ServiceBroker.h"

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -282,7 +282,7 @@ void CMediaManager::AddAutoSource(const CMediaSource &share, bool bAutorun)
   CMediaSourceSettings::GetInstance().AddShare("music", share);
   CMediaSourceSettings::GetInstance().AddShare("programs", share);
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetWindowManager().SendThreadMessage( msg );
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -282,7 +282,7 @@ void CMediaManager::AddAutoSource(const CMediaSource &share, bool bAutorun)
   CMediaSourceSettings::GetInstance().AddShare("music", share);
   CMediaSourceSettings::GetInstance().AddShare("programs", share);
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
     gui->GetWindowManager().SendThreadMessage( msg );
 

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -14,6 +14,7 @@
 #include "addons/Skin.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "filesystem/Directory.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "profiles/ProfileManager.h"
 #include "settings/Settings.h"

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1470,7 +1470,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
       if (item->IsStack())
         item->m_bIsFolder = true;
 
-      IGUIComponent *gui = CServiceBroker::GetGUI();
+      auto gui = CServiceBroker::GetGUI();
       if (gui && gui->ConfirmDelete(item->GetPath()))
         CFileUtils::DeleteItem(item);
     }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1470,7 +1470,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
       if (item->IsStack())
         item->m_bIsFolder = true;
 
-      CGUIComponent *gui = CServiceBroker::GetGUI();
+      IGUIComponent *gui = CServiceBroker::GetGUI();
       if (gui && gui->ConfirmDelete(item->GetPath()))
         CFileUtils::DeleteItem(item);
     }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1164,7 +1164,7 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
        m_vecItems->IsPath("special://videoplaylists/")) &&
       CUtil::SupportsWriteFileOperations(item->GetPath()))
   {
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui && gui->ConfirmDelete(item->GetPath()))
       CFileUtils::DeleteItem(item);
   }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1164,7 +1164,7 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
        m_vecItems->IsPath("special://videoplaylists/")) &&
       CUtil::SupportsWriteFileOperations(item->GetPath()))
   {
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui && gui->ConfirmDelete(item->GetPath()))
       CFileUtils::DeleteItem(item);
   }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -864,7 +864,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
            m_vecItems->IsPath("special://videoplaylists/"))
   {
     pItem->m_bIsFolder = false;
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui && gui->ConfirmDelete(pItem->GetPath()))
       CFileUtils::DeleteItem(pItem);
   }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -864,7 +864,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
            m_vecItems->IsPath("special://videoplaylists/"))
   {
     pItem->m_bIsFolder = false;
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui && gui->ConfirmDelete(pItem->GetPath()))
       CFileUtils::DeleteItem(pItem);
   }

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -18,6 +18,7 @@
 #include "guilib/IGUIContainer.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "guilib/GUIMessage.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -457,7 +457,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
     // update anyone that relies on sizing information
     CServiceBroker::GetInputManager().SetMouseResolution(info_org.iWidth, info_org.iHeight, 1, 1);
 
-    CGUIComponent *gui = CServiceBroker::GetGUI();
+    IGUIComponent *gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetWindowManager().SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
   }

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -457,7 +457,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
     // update anyone that relies on sizing information
     CServiceBroker::GetInputManager().SetMouseResolution(info_org.iWidth, info_org.iHeight, 1, 1);
 
-    IGUIComponent *gui = CServiceBroker::GetGUI();
+    auto gui = CServiceBroker::GetGUI();
     if (gui)
       gui->GetWindowManager().SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
   }

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -133,7 +133,7 @@ void CWinSystemRpiGLESContext::SetVSyncImpl(bool enable)
 
 void CWinSystemRpiGLESContext::PresentRenderImpl(bool rendered)
 {
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui)
     CWinSystemRpi::SetVisible(gui->GetWindowManager().HasVisibleControls() || g_application.GetAppPlayer().IsRenderingGuiLayer());
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1611,7 +1611,7 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
       return;
   }
 
-  IGUIComponent *gui = CServiceBroker::GetGUI();
+  auto gui = CServiceBroker::GetGUI();
   if (gui && gui->ConfirmDelete(item->GetPath()))
   {
     if (!CFileUtils::DeleteItem(item))

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1611,7 +1611,7 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
       return;
   }
 
-  CGUIComponent *gui = CServiceBroker::GetGUI();
+  IGUIComponent *gui = CServiceBroker::GetGUI();
   if (gui && gui->ConfirmDelete(item->GetPath()))
   {
     if (!CFileUtils::DeleteItem(item))

--- a/xbmc/windows/GUIWindowStartup.cpp
+++ b/xbmc/windows/GUIWindowStartup.cpp
@@ -12,6 +12,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "guilib/GUIMessage.h"
 
 CGUIWindowStartup::CGUIWindowStartup(void)
     : CGUIWindow(WINDOW_STARTUP_ANIM, "Startup.xml")


### PR DESCRIPTION
 Instead refactor init/deinit of guicomponent to do the righthing - fixes #15561

This might be the proper fix instead of #13878
It ensures that loadskin/unloadskin calls init/deinit of guicomponent instead of the subcomponent (windowmanager). To make it work the init/deinit of guicomponent was altered to not deregister from servicebroker during deinit - but only in the dtor.
Also the application cleanup now only calls reset on the gui because the dtor already does the deinit (would have been a double deinit before which is a nop).

With this the stereoscopic mode selection works properly again (and it turns off 3d mode after playback if setting is configured that way)
