### PR TITLE
Fix VAAPI post-processing of PAFF video

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1862,6 +1862,7 @@ bool COutput::Init()
   m_config.processInfo->SetDeinterlacingMethodDefault(EINTERLACEMETHOD::VS_INTERLACEMETHOD_VAAPI_BOB);
 
   m_vaError = false;
+  m_seenInterlaced = false;
 
   return true;
 }
@@ -1982,9 +1983,13 @@ void COutput::InitCycle()
 
   EINTERLACEMETHOD method = m_config.processInfo->GetVideoSettings().m_InterlaceMethod;
   bool interlaced = m_currentPicture.DVDPic.iFlags & DVP_FLAG_INTERLACED;
+  // Remember whether any interlaced frames were encountered already.
+  // If this is the case, the deinterlace method will never automatically be switched to NONE again in
+  // order to not change deint methods every few frames in PAFF streams.
+  m_seenInterlaced = m_seenInterlaced || interlaced;
 
   if (!(flags & DVD_CODEC_CTRL_NO_POSTPROC) &&
-      interlaced &&
+      m_seenInterlaced &&
       method != VS_INTERLACEMETHOD_NONE)
   {
     if (!m_config.processInfo->Supports(method))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -3152,19 +3152,8 @@ void CFFmpegPostproc::Flush()
 
 bool CFFmpegPostproc::UpdateDeintMethod(EINTERLACEMETHOD method)
 {
-  // switching between certain methods should be done without deinit/init
-  if (method != m_diMethod)
-    return false;
-
-  if (method == VS_INTERLACEMETHOD_DEINTERLACE)
-    return true;
-  else if (method == VS_INTERLACEMETHOD_RENDER_BOB)
-    return true;
-  else if (method == VS_INTERLACEMETHOD_NONE &&
-           !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(SETTING_VIDEOPLAYER_PREFERVAAPIRENDER))
-    return true;
-
-  return false;
+  /// \todo switching between certain methods could be done without deinit/init
+  return (m_diMethod == method);
 }
 
 bool CFFmpegPostproc::DoesSync()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -2626,6 +2626,7 @@ bool CVppPostproc::Filter(CVaapiProcessedPicture &outPic)
   pipelineParams->output_region = &outputRegion;
   pipelineParams->surface_region = &inputRegion;
   pipelineParams->output_background_color = 0xff000000;
+  pipelineParams->filter_flags = 0;
 
   VASurfaceID forwardRefs[32];
   VASurfaceID backwardRefs[32];
@@ -2663,11 +2664,6 @@ bool CVppPostproc::Filter(CVaapiProcessedPicture &outPic)
     {
       return false;
     }
-
-    if (m_vppMethod == VS_INTERLACEMETHOD_VAAPI_BOB)
-      pipelineParams->filter_flags = (flags & VA_DEINTERLACING_BOTTOM_FIELD) ? VA_BOTTOM_FIELD : VA_TOP_FIELD;
-    else
-      pipelineParams->filter_flags = 0;
 
     pipelineParams->filters = &m_filter;
     pipelineParams->num_filters = 1;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1547,16 +1547,8 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
 
           // set initial number of
           EnsureBufferPool();
-          if (!m_vaError)
-          {
-            m_state = O_TOP_CONFIGURED_IDLE;
-            msg->Reply(COutputControlProtocol::ACC);
-          }
-          else
-          {
-            m_state = O_TOP_ERROR;
-            msg->Reply(COutputControlProtocol::ERROR);
-          }
+          m_state = O_TOP_CONFIGURED_IDLE;
+          msg->Reply(COutputControlProtocol::ACC);
           return;
         default:
           break;
@@ -1747,11 +1739,6 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
               m_dataPort.SendInMessage(COutputDataProtocol::PICTURE, &outPic, sizeof(outPic));
             }
             m_config.stats->DecProcessed();
-            if (m_vaError)
-            {
-              m_state = O_TOP_ERROR;
-              return;
-            }
           }
           m_state = O_TOP_CONFIGURED_IDLE;
           m_extTimeout = 0;
@@ -1861,7 +1848,6 @@ bool COutput::Init()
   m_config.processInfo->UpdateDeinterlacingMethods(deintMethods);
   m_config.processInfo->SetDeinterlacingMethodDefault(EINTERLACEMETHOD::VS_INTERLACEMETHOD_VAAPI_BOB);
 
-  m_vaError = false;
   m_seenInterlaced = false;
 
   return true;
@@ -2217,17 +2203,6 @@ void COutput::ReadyForDisposal(CPostproc *pp)
       break;
     }
   }
-}
-
-bool COutput::CheckSuccess(VAStatus status, const std::string& function)
-{
-  if (status != VA_STATUS_SUCCESS)
-  {
-    CLog::Log(LOGERROR, "VAAPI/output {} error: {} ({})", function, vaErrorStr(status), status);
-    m_vaError = true;
-    return false;
-  }
-  return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -264,7 +264,7 @@ protected:
   void Flush();
   void EnsureBufferPool();
   void ReleaseBufferPool(bool precleanup = false);
-  bool CheckSuccess(VAStatus status);
+  bool CheckSuccess(VAStatus status, const std::string& function);
   void ReadyForDisposal(CPostproc *pp);
   CEvent m_outMsgEvent;
   CEvent *m_inMsgEvent;
@@ -330,7 +330,7 @@ private:
   bool CreateContext();
   void DestroyContext();
   void QueryCaps();
-  bool CheckSuccess(VAStatus status);
+  bool CheckSuccess(VAStatus status, const std::string& function);
   bool IsValidDecoder(CDecoder *decoder);
   void SetValidDRMVaDisplayFromRenderNode();
   static CVAAPIContext *m_context;
@@ -396,7 +396,7 @@ protected:
   void FiniVAAPIOutput();
   void ReturnRenderPicture(CVaapiRenderPicture *renderPic);
   long ReleasePicReference();
-  bool CheckSuccess(VAStatus status);
+  bool CheckSuccess(VAStatus status, const std::string& function);
 
   enum EDisplayState
   { VAAPI_OPEN
@@ -498,7 +498,7 @@ public:
   bool UseVideoSurface() override;
   void Discard(COutput *output, ReadyToDispose cb) override;
 protected:
-  bool CheckSuccess(VAStatus status);
+  bool CheckSuccess(VAStatus status, const std::string& function);
   void Dispose();
   void Advance();
   VAConfigID m_configId;
@@ -533,7 +533,7 @@ public:
   bool UseVideoSurface() override;
   void Discard(COutput *output, ReadyToDispose cb) override;
 protected:
-  bool CheckSuccess(VAStatus status);
+  bool CheckSuccess(VAStatus status, const std::string& function);
   void Close();
   DllLibSSE4 m_dllSSE4;
   uint8_t *m_cache;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -264,7 +264,6 @@ protected:
   void Flush();
   void EnsureBufferPool();
   void ReleaseBufferPool(bool precleanup = false);
-  bool CheckSuccess(VAStatus status, const std::string& function);
   void ReadyForDisposal(CPostproc *pp);
   CEvent m_outMsgEvent;
   CEvent *m_inMsgEvent;
@@ -274,7 +273,6 @@ protected:
 
   // extended state variables for state machine
   int m_extTimeout;
-  bool m_vaError;
   /// \brief Whether at least one interlaced frame was encountered in the video stream (indicating that more interlaced frames could potentially follow)
   bool m_seenInterlaced;
   CVaapiConfig m_config;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -275,6 +275,8 @@ protected:
   // extended state variables for state machine
   int m_extTimeout;
   bool m_vaError;
+  /// \brief Whether at least one interlaced frame was encountered in the video stream (indicating that more interlaced frames could potentially follow)
+  bool m_seenInterlaced;
   CVaapiConfig m_config;
   std::shared_ptr<CVaapiBufferPool> m_bufferPool;
   CVaapiDecodedPicture m_currentPicture;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -211,7 +211,6 @@ bool CRendererVAAPI::UploadTexture(int index)
   }
 
   m_vaapiTextures[index]->Map(pic);
-  m_buffers[index].m_srcTextureBits = m_vaapiTextures[index]->GetBits();
 
   YuvImage &im = buf.image;
   CYuvPlane (&planes)[3] = buf.fields[0];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -60,7 +60,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
   {
     case VA_FOURCC('N','V','1','2'):
     {
-      m_bits = 8;
       attrib = attribs;
       *attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
       *attrib++ = fourcc_code('R', '8', ' ', ' ');
@@ -109,8 +108,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
         return false;
       }
 
-      GLint format, type;
-
       glGenTextures(1, &m_textureY);
       glBindTexture(m_interop.textureTarget, m_textureY);
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -118,7 +115,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       m_interop.glEGLImageTargetTexture2DOES(m_interop.textureTarget, m_glSurface.eglImageY);
-      glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &format);
 
       glGenTextures(1, &m_textureVU);
       glBindTexture(m_interop.textureTarget, m_textureVU);
@@ -127,17 +123,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       m_interop.glEGLImageTargetTexture2DOES(m_interop.textureTarget, m_glSurface.eglImageVU);
-      glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &format);
-      glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &type);
-      if (type == GL_UNSIGNED_BYTE)
-        m_bits = 8;
-      else if (type == GL_UNSIGNED_SHORT)
-        m_bits = 16;
-      else
-      {
-        CLog::Log(LOGWARNING, "Did not expect texture type: %d", (int) type);
-        m_bits = 8;
-      }
 
       glBindTexture(m_interop.textureTarget, 0);
 
@@ -145,7 +130,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
     }
     case VA_FOURCC('P','0','1','0'):
     {
-      m_bits = 10;
       attrib = attribs;
       *attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
       *attrib++ = fourcc_code('R', '1', '6', ' ');
@@ -194,8 +178,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
         return false;
       }
 
-      GLint format, type;
-
       glGenTextures(1, &m_textureY);
       glBindTexture(m_interop.textureTarget, m_textureY);
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -203,7 +185,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       m_interop.glEGLImageTargetTexture2DOES(m_interop.textureTarget, m_glSurface.eglImageY);
-      glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &format);
 
       glGenTextures(1, &m_textureVU);
       glBindTexture(m_interop.textureTarget, m_textureVU);
@@ -212,17 +193,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(m_interop.textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       m_interop.glEGLImageTargetTexture2DOES(m_interop.textureTarget, m_glSurface.eglImageVU);
-      glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &format);
-      glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &type);
-      if (type == GL_UNSIGNED_BYTE)
-        m_bits = 8;
-      else if (type == GL_UNSIGNED_SHORT)
-        m_bits = 16;
-      else
-      {
-        CLog::Log(LOGWARNING, "Did not expect texture type: %d", (int) type);
-        m_bits = 8;
-      }
 
       glBindTexture(m_interop.textureTarget, 0);
 
@@ -230,7 +200,6 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
     }
     case VA_FOURCC('B','G','R','A'):
     {
-      m_bits = 8;
       attrib = attribs;
       *attrib++ = EGL_DRM_BUFFER_FORMAT_MESA;
       *attrib++ = EGL_DRM_BUFFER_FORMAT_ARGB32_MESA;
@@ -305,11 +274,6 @@ void CVaapi1Texture::Unmap()
 
   m_vaapiPic->Release();
   m_vaapiPic = nullptr;
-}
-
-int CVaapi1Texture::GetBits()
-{
-  return m_bits;
 }
 
 GLuint CVaapi1Texture::GetTextureY()
@@ -514,18 +478,6 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
 
   m_textureSize.Set(pic->DVDPic.iWidth, pic->DVDPic.iHeight);
 
-  GLint type;
-  glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &type);
-  if (type == GL_UNSIGNED_BYTE)
-    m_bits = 8;
-  else if (type == GL_UNSIGNED_SHORT)
-    m_bits = 16;
-  else
-  {
-    CLog::Log(LOGWARNING, "Did not expect texture type: %d", static_cast<int> (type));
-    m_bits = 8;
-  }
-
   for (uint32_t layerNo = 0; layerNo < surface.num_layers; layerNo++)
   {
     int plane = 0;
@@ -624,11 +576,6 @@ void CVaapi2Texture::Unmap()
 
   m_vaapiPic->Release();
   m_vaapiPic = nullptr;
-}
-
-int CVaapi2Texture::GetBits()
-{
-  return m_bits;
 }
 
 GLuint CVaapi2Texture::GetTextureY()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -49,7 +49,6 @@ public:
   virtual bool Map(CVaapiRenderPicture *pic) = 0;
   virtual void Unmap() = 0;
 
-  virtual int GetBits() = 0;
   virtual GLuint GetTextureY() = 0;
   virtual GLuint GetTextureVU() = 0;
   virtual CSizeInt GetTextureSize() = 0;
@@ -64,7 +63,6 @@ public:
   void Unmap() override;
   void Init(InteropInfo &interop) override;
 
-  int GetBits() override;
   GLuint GetTextureY() override;
   GLuint GetTextureVU() override;
   CSizeInt GetTextureSize() override;
@@ -76,7 +74,6 @@ public:
   GLuint m_textureVU = 0;
   int m_texWidth = 0;
   int m_texHeight = 0;
-  int m_bits = 0;
 
 protected:
   static bool TestInteropDeepColor(VADisplay vaDpy, EGLDisplay eglDisplay);
@@ -99,7 +96,6 @@ public:
   void Unmap() override;
   void Init(InteropInfo &interop) override;
 
-  int GetBits() override;
   GLuint GetTextureY() override;
   GLuint GetTextureVU() override;
   CSizeInt GetTextureSize() override;
@@ -120,7 +116,6 @@ private:
   CVaapiRenderPicture* m_vaapiPic{};
   bool m_hasPlaneModifiers{false};
   std::array<KODI::UTILS::POSIX::CFileHandle, 4> m_drmFDs;
-  int m_bits{0};
   MappedTexture m_y, m_vu;
   CSizeInt m_textureSize;
 };


### PR DESCRIPTION
Fix PAFF video deinterlacing by not automatically switching the post-processor to the `NONE` method when an interlaced frame has been encountered before.

@yasij Please test

Commits for dead code removal and more useful error messages included but separate.