### PR TITLE
[libUPnP] Remove unused headers from Platinum/Source/Extras

### DIFF
--- a/lib/libUPnP/CMakeLists.txt
+++ b/lib/libUPnP/CMakeLists.txt
@@ -114,7 +114,6 @@ target_include_directories(upnp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                        Platinum/Source/Devices/MediaConnect
                                        Platinum/Source/Devices/MediaRenderer
                                        Platinum/Source/Devices/MediaServer
-                                       Platinum/Source/Extras
                                        Neptune/Source/Core
                                        Neptune/Source/System/Posix)
 if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)

--- a/lib/libUPnP/Platinum/Source/Platinum/Platinum.h
+++ b/lib/libUPnP/Platinum/Source/Platinum/Platinum.h
@@ -108,11 +108,4 @@ cross-platform logging system.
 #include "PltXbox360.h"
 #include "PltMediaConnect.h"
 
-#include "PltDownloader.h"
-#include "PltStreamPump.h"
-#include "PltFrameBuffer.h"
-#include "PltFrameServer.h"
-#include "PltFrameStream.h"
-#include "PltRingBufferStream.h"
-
 #endif /* _PLATINUM_H_ */

--- a/lib/libUPnP/patches/0048-libUPnP-Remove-unused-headers-from-Platinum-Source-E.patch
+++ b/lib/libUPnP/patches/0048-libUPnP-Remove-unused-headers-from-Platinum-Source-E.patch
@@ -1,0 +1,29 @@
+From: Olaf Hering <olaf@aepfle.de>
+Date: Thu, 28 Mar 2019 18:07:31 +0100
+Subject: [libUPnP] Remove unused headers from Platinum/Source/Extras
+
+No code from the Extras directory is compiled, so it is unlikely that
+any of the interfaces will be used. Remove the headers and remove
+Platinum/Source/Extras from the list of include directories.
+
+Signed-off-by: Olaf Hering <olaf@aepfle.de>
+---
+ lib/libUPnP/Platinum/Source/Platinum/Platinum.h | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Platinum/Platinum.h b/lib/libUPnP/Platinum/Source/Platinum/Platinum.h
+index a7f47a6241..970cb8bd95 100644
+--- a/lib/libUPnP/Platinum/Source/Platinum/Platinum.h
++++ b/lib/libUPnP/Platinum/Source/Platinum/Platinum.h
+@@ -108,11 +108,4 @@ cross-platform logging system.
+ #include "PltXbox360.h"
+ #include "PltMediaConnect.h"
+ 
+-#include "PltDownloader.h"
+-#include "PltStreamPump.h"
+-#include "PltFrameBuffer.h"
+-#include "PltFrameServer.h"
+-#include "PltFrameStream.h"
+-#include "PltRingBufferStream.h"
+-
+ #endif /* _PLATINUM_H_ */

--- a/xbmc/network/CMakeLists.txt
+++ b/xbmc/network/CMakeLists.txt
@@ -62,7 +62,6 @@ if(ENABLE_UPNP)
                                                      ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Devices/MediaConnect
                                                      ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Devices/MediaRenderer
                                                      ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Devices/MediaServer
-                                                     ${CMAKE_SOURCE_DIR}/lib/libUPnP/Platinum/Source/Extras
                                                      ${CMAKE_SOURCE_DIR}/lib/libUPnP/Neptune/Source/System/Posix
                                                      ${CMAKE_SOURCE_DIR}/lib/libUPnP/Neptune/Source/Core)
 endif()


### PR DESCRIPTION
No code from the Extras directory is compiled, so it is unlikely that
any of the interfaces will be used. Remove the headers and remove
Platinum/Source/Extras from the list of include directories.

Signed-off-by: Olaf Hering <olaf@aepfle.de>

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
