### PR TITLE
[Estouchy] add missing 15th addon shortcut on homescreen

### DIFF
--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -523,6 +523,14 @@
 							<thumb></thumb>
 							<visible>!String.IsEmpty(Skin.String(HomeAddonButton14))</visible>
 						</item>
+						<item>
+							<label>$INFO[system.addontitle(Skin.String(HomeAddonButton15))]</label>
+							<label2></label2>
+							<onclick>RunAddon($INFO[Skin.String(HomeAddonButton15)])</onclick>
+							<icon>$INFO[system.addonicon(Skin.String(HomeAddonButton15))]</icon>
+							<thumb></thumb>
+							<visible>!String.IsEmpty(Skin.String(HomeAddonButton15))</visible>
+						</item>
 					</content>
 				</control>
 			</control>


### PR DESCRIPTION
in estouchy settings you can configure 15 addon shortcuts to appear on the homescreen,
but the code to display the 15th addon shortcut was missing.

fixes https://github.com/xbmc/xbmc/issues/15840

no brainer, save to merge into v18.