### PR TITLE
[Application] - register Stereoscopicmanager for message target

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1316,6 +1316,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(this);
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&CServiceBroker::GetPlaylistPlayer());
   CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&g_fontManager);
+  CServiceBroker::GetGUI()->GetWindowManager().AddMsgTarget(&CServiceBroker::GetGUI()->GetStereoscopicsManager());
   CServiceBroker::GetGUI()->GetWindowManager().SetCallback(*this);
   //@todo should be done by GUIComponents
   CServiceBroker::GetGUI()->GetWindowManager().Initialize();


### PR DESCRIPTION
workaround for #13878 for Leia.

I consider this an acceptable fix for Leia for the stereoscopic regression which is a long standing bug.

This should go into Leia only and be merged after Leia was branched off.

The real fix for 19.x will be developed here https://github.com/xbmc/xbmc/pull/15825