### PR TITLE
[Estuary] Music Track Info Fix

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -122,9 +122,13 @@
 		<value condition="String.IsEqual(listitem.dbtype,musicvideo) | String.IsEqual(listitem.dbtype,video)">$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Plot]</value>
 		<value condition="String.IsEqual(listitem.dbtype,artist)">$INFO[ListItem.Property(artist_description)]</value>
 		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
-		<value condition="String.IsEqual(listitem.dbtype,song)">$INFO[listitem.TrackNumber,[COLOR button_focus]$LOCALIZE[554]: [/COLOR]]. $INFO[ListItem.Title,,[CR]]$INFO[ListItem.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[listitem.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$INFO[ListItem.DiscNumber,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[ListItem.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Duration,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],[CR]]$INFO[ListItem.Playcount,[COLOR button_focus]$LOCALIZE[567]: [/COLOR],[CR]]</value>
+		<value condition="String.IsEqual(listitem.dbtype,song)">$VAR[MusicTrackInfo,[COLOR button_focus]$LOCALIZE[554]:[/COLOR],[CR]]$INFO[ListItem.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[listitem.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$INFO[ListItem.DiscNumber,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[ListItem.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Duration,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],[CR]]$INFO[ListItem.Playcount,[COLOR button_focus]$LOCALIZE[567]: [/COLOR],[CR]]</value>
 		<value>$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]</value>
 	</variable>
+	<variable name="MusicTrackInfo">
+		<value condition="String.IsEmpty(listitem.Title)">$INFO[listitem.TrackNumber, ]</value>
+		<value>$INFO[listitem.TrackNumber, ,.]$INFO[listitem.Title, ]</value>
+	</variable>	
 	<variable name="WidgetGenreIconVar">
 		<value condition="System.HasAddon(resource.images.moviegenreicons.transparent)">$INFO[ListItem.Label,resource://resource.images.moviegenreicons.transparent/,.png]</value>
 		<value>DefaultGenre.png</value>


### PR DESCRIPTION
## Description
Issue discovered with music track info I added in https://github.com/xbmc/xbmc/pull/14795

## Motivation and Context
Seems I did not fully test with all tagging scenarios for track number and track title tags for PR14795 . I discovered these issues when browsing a folder where I hadn't got round to checking the tags to make sure everything was present.

## How Has This Been Tested?
This is a Estuary skin only change and has been tested to cover all tagging scenarios for track number/track title tags as shown below.

## Screenshots (if appropriate):

**Scenario 1 - Track title only (no track number)**

**Before** 
The blue "Track" text is missing plus a leading fullstop in front of track title
![No Track Number - Track Title](https://user-images.githubusercontent.com/5781142/55290102-8e725b80-53c6-11e9-8dee-6569343001ef.JPG)

**After**
![No Track Number - Track Title - Fixed](https://user-images.githubusercontent.com/5781142/55290105-9500d300-53c6-11e9-938f-bbbd6591f95f.JPG)

**Scenario 2 - No track number or track title**

**Before** 
Misplaced full stop before blue "Artist" text
![No Track Number - No Track Title](https://user-images.githubusercontent.com/5781142/55290132-f6c13d00-53c6-11e9-811d-756e32c36216.JPG)

**After**
![No Track Number - No Track Title - Fixed](https://user-images.githubusercontent.com/5781142/55290136-fcb71e00-53c6-11e9-8e9f-7b610f50370d.JPG)

**Scenario 3 Track number only (no track title)**

**Before**
Carriage return missed in this scenario so Artist info does not begin on new line, also small comestic of full stop immediately after track number where it is not needed when there is no track title.
![Track Number -  No Track Title](https://user-images.githubusercontent.com/5781142/55290163-849d2800-53c7-11e9-8c44-d77b3e688ffa.JPG)

**After**
![Track Number -  No Track Title - Fixed](https://user-images.githubusercontent.com/5781142/55290169-89fa7280-53c7-11e9-8e2a-d665647460fe.JPG)

**Scenario 4 - track number and track title present**

**Before**
This was ok before as it was these types of song tracks I'd tested PR14795 against
![Track Number - Track Title](https://user-images.githubusercontent.com/5781142/55290201-1ad14e00-53c8-11e9-9971-509fc60ba9c5.JPG)

**After**
Confirmed no change and is still ok
![Track Number - Track Title - Fixed](https://user-images.githubusercontent.com/5781142/55290204-20c72f00-53c8-11e9-8c0e-c9ebad7d2186.JPG)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
