### PR TITLE
[tests] use correct storage size

### DIFF
--- a/xbmc/filesystem/test/TestFile.cpp
+++ b/xbmc/filesystem/test/TestFile.cpp
@@ -17,10 +17,10 @@
 TEST(TestFile, Read)
 {
   const std::string newLine = CXBMCTestUtils::Instance().getNewLineCharacters();
-  const int size = 1616;
-  const int lines = 25;
-  int addPerLine = newLine.length() - 1;
-  int realSize = size + lines * addPerLine;
+  const size_t size = 1616;
+  const size_t lines = 25;
+  size_t addPerLine = newLine.length() - 1;
+  size_t realSize = size + lines * addPerLine;
 
   const std::string firstBuf  = "About" + newLine + "-----" + newLine + "XBMC is ";
   const std::string secondBuf = "an award-winning fre";
@@ -32,7 +32,7 @@ TEST(TestFile, Read)
   char buf[23];
   memset(buf, 0, sizeof(buf));
 
-  int currentPos;
+  size_t currentPos;
   ASSERT_TRUE(file.Open(
     XBMC_REF_FILE_PATH("/xbmc/filesystem/test/reffile.txt")));
   EXPECT_EQ(0, file.GetPosition());

--- a/xbmc/filesystem/test/TestFileFactory.cpp
+++ b/xbmc/filesystem/test/TestFileFactory.cpp
@@ -52,7 +52,7 @@ TEST_F(TestFileFactory, Read)
 {
   XFILE::CFile file;
   std::string str;
-  unsigned int size, i;
+  ssize_t size, i;
   unsigned char buf[16];
   int64_t count = 0;
 
@@ -82,7 +82,7 @@ TEST_F(TestFileFactory, Read)
         str = StringUtils::Format("%02X ", buf[i]);
         std::cout << str;
       }
-      while (i++ < sizeof(buf))
+      while (i++ < static_cast<ssize_t> (sizeof(buf)))
         std::cout << "   ";
       std::cout << " [";
       for (i = 0; i < size; i++)
@@ -102,7 +102,7 @@ TEST_F(TestFileFactory, Write)
 {
   XFILE::CFile file, inputfile;
   std::string str;
-  unsigned int size, i;
+  size_t size, i;
   unsigned char buf[16];
   int64_t count = 0;
 

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -144,7 +144,7 @@ TEST_F(TestZipFile, CorruptedFile)
   memset(&buf, 0, sizeof(buf));
   std::string reffilepath, strpathinzip, str;
   CFileItemList itemlist;
-  unsigned int size, i;
+  ssize_t size, i;
   int64_t count = 0;
 
   reffilepath = XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt.zip");
@@ -192,7 +192,7 @@ TEST_F(TestZipFile, CorruptedFile)
       str = StringUtils::Format("%02X ", buf[i]);
       std::cout << str;
     }
-    while (i++ < sizeof(buf))
+    while (i++ < static_cast<ssize_t> (sizeof(buf)))
       std::cout << "   ";
     std::cout << " [";
     for (i = 0; i < size; i++)

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -134,7 +134,7 @@ XFILE::CFile *CXBMCTestUtils::CreateCorruptedFile(std::string const& strFileName
 {
   XFILE::CFile inputfile, *tmpfile = CreateTempFile(suffix);
   unsigned char buf[20], tmpchar;
-  unsigned int size, i;
+  ssize_t size, i;
 
   if (tmpfile && inputfile.Open(strFileName))
   {

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -137,7 +137,7 @@ TEST_F(TestRegExpLog, DumpOvector)
   CRegExp regex;
   std::string logfile, logstring;
   char buf[100];
-  unsigned int bytesread;
+  ssize_t bytesread;
   XFILE::CFile file;
 
   std::string appName = CCompileInfo::GetAppName();

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -329,7 +329,7 @@ TEST(TestStringUtils, RemoveCRLF)
 
 TEST(TestStringUtils, utf8_strlen)
 {
-  int ref, var;
+  size_t ref, var;
 
   ref = 9;
   var = StringUtils::utf8_strlen("ｔｅｓｔ＿ＵＴＦ８");
@@ -391,7 +391,7 @@ TEST(TestStringUtils, EmptyString)
 
 TEST(TestStringUtils, FindWords)
 {
-  int ref, var;
+  size_t ref, var;
 
   ref = 5;
   var = StringUtils::FindWords("test string", "string");
@@ -413,7 +413,7 @@ TEST(TestStringUtils, FindWords)
 
 TEST(TestStringUtils, FindWords_NonAscii)
 {
-  int ref, var;
+  size_t ref, var;
 
   ref = 6;
   var = StringUtils::FindWords("我的视频", "视频");

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -32,7 +32,7 @@ TEST_F(Testlog, Log)
 {
   std::string logfile, logstring;
   char buf[100];
-  unsigned int bytesread;
+  ssize_t bytesread;
   XFILE::CFile file;
   CRegExp regex;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
