### PR TITLE
 Add available artwork to the video 'Choose art type' dialog

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -848,6 +848,14 @@ public:
   bool GetTvShowSeasonArt(int mediaId, std::map<int, std::map<std::string, std::string> > &seasonArt);
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 
+  /*! \brief Fetch the distinct types of available-but-unassigned art held in the
+  database for a specific media item.
+  \param mediaId the id in the media table.
+  \param mediaType the type of media, which corresponds to the table the item resides in.
+  \return the types of art e.g. "thumb", "fanart", etc.
+  */
+  std::vector<std::string> GetAvailableArtTypesForItem(int mediaId, const MediaType& mediaType);
+
   int AddTag(const std::string &tag);
   void AddTagToItem(int idItem, int idTag, const std::string &type);
   void RemoveTagFromItem(int idItem, int idTag, const std::string &type);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -33,7 +33,6 @@ public:
   const CFileItemList& CurrentDirectory() const { return *m_castList; };
   bool HasListItems() const override { return true; };
 
-  static std::string ChooseArtType(const CFileItem &item, std::map<std::string, std::string> &currentArt);
   static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
 
   static int ManageVideoItem(const CFileItemPtr &item);
@@ -103,4 +102,7 @@ protected:
   bool m_hasUpdatedThumb = false;
   bool m_hasUpdatedUserrating = false;
   int m_startUserrating = -1;
+
+private:
+  static std::string ChooseArtType(const CFileItem& item);
 };


### PR DESCRIPTION
## Description
Add available but not assigned artwork types to the "Choose art type" dialog for the video library.

This is the video library counterpart to #15805.

## Motivation and Context
Don't hide artwork that is available.

## How Has This Been Tested?
Manually, by doctoring scraper results and viewing the list in the GUI.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
