### PR TITLE
[PVR] Fallback timer fields for EPG data

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -515,7 +515,14 @@ extern "C" {
     int             iGenreType;                                /*!< @brief (optional) genre type */
     int             iGenreSubType;                             /*!< @brief (optional) genre sub type */
     char            strSeriesLink[PVR_ADDON_URL_STRING_LENGTH]; /*!< @brief (optional) series link for this timer. If set for an epg-based timer rule, matching events will be found by checking strSeriesLink instead of strTitle (and bFullTextEpgSearch) */
-
+    char            strGenreDescription[PVR_ADDON_DESC_STRING_LENGTH]; /*!< @brief (optional) genre. Will be used only when iGenreType == EPG_GENRE_USE_STRING. Use EPG_STRING_TOKEN_SEPARATOR to separate different genres. */
+    char            strPlotOutline[PVR_ADDON_DESC_STRING_LENGTH];      /*!< @brief (optional) plot outline */
+    char            strPlot[PVR_ADDON_DESC_STRING_LENGTH];             /*!< @brief (optional) plot */
+    int             iYear;                                     /*!< @brief (optional) year */
+    int             iSeriesNumber;                             /*!< @brief (optional) series number */
+    int             iEpisodeNumber;                            /*!< @brief (optional) episode number */
+    int             iEpisodePartNumber;                        /*!< @brief (optional) episode part number */
+    
   } ATTRIBUTE_PACKED PVR_TIMER;
 
   /*!

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -371,6 +371,8 @@ namespace PVR
 
     std::string GetWeekdaysString() const;
     void UpdateEpgInfoTag(void);
+    bool HasFallbackEpgData() const;
+    CPVREpgInfoTagPtr CreateFallbackEpgInfoTag() const;
 
     static std::shared_ptr<CPVRTimerInfoTag> CreateFromEpg(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bCreateRule, bool bCreateReminder, bool bReadOnly);
     static std::shared_ptr<CPVRTimerInfoTag> CreateFromDate(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration, bool bCreateReminder, bool bReadOnly);
@@ -389,6 +391,16 @@ namespace PVR
     unsigned int m_iRadioChildTimersConflictNOK = 0;
     unsigned int m_iRadioChildTimersRecording = 0;
     unsigned int m_iRadioChildTimersErrors = 0;
+
+    int         m_iGenreType;          /*!< @brief (optional) genre type */
+    int         m_iGenreSubType;       /*!< @brief (optional) genre sub type */
+    std::string m_strGenreDescription; /*!< @brief (optional) genre. Will be used only when iGenreType == EPG_GENRE_USE_STRING. Use EPG_STRING_TOKEN_SEPARATOR to separate different genres. */
+    std::string m_strPlotOutline;      /*!< @brief (optional) plot outline */
+    std::string m_strPlot;             /*!< @brief (optional) plot */
+    int         m_iYear;               /*!< @brief (optional) year */
+    int         m_iSeriesNumber;       /*!< @brief (optional) series number */
+    int         m_iEpisodeNumber;      /*!< @brief (optional) episode number */
+    int         m_iEpisodePartNumber;  /*!< @brief (optional) episode part number */
 
     mutable CPVREpgInfoTagPtr m_epgTag; /*!< epg info tag matching m_iEpgUid. */
     mutable CPVRChannelPtr m_channel;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

For timers whose EPG info is not available in the EPG database provide fields that can be used as a fallback to populate in the timers UI

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

https://github.com/xbmc/xbmc/issues/15606

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested using pvr.vuplus, on windows and mac osx.

## Screenshots (if appropriate):

Timer that has an EPG entry:

![image](https://user-images.githubusercontent.com/4601187/55482338-35036a00-561c-11e9-9053-1afb7d7433cf.png)

Timer that previously had no epg entry:

![image](https://user-images.githubusercontent.com/4601187/55482369-4cdaee00-561c-11e9-8fb0-2a8c64b6e19c.png)

Timer that previously had no epg entry (programme info screen):

![image](https://user-images.githubusercontent.com/4601187/55482434-6f6d0700-561c-11e9-80a6-a04b0b1ad77a.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
