### PR TITLE
Amlogic fixes from community builds

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -435,7 +435,8 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
   {
     // probe demux for sequence_header_code NAL and
     // decode aspect ratio and frame rate.
-    if (CBitstreamConverter::mpeg2_sequence_header(pData, iSize, m_mpeg2_sequence))
+    if (CBitstreamConverter::mpeg2_sequence_header(pData, iSize, m_mpeg2_sequence) &&
+       (m_mpeg2_sequence->fps_rate > 0) && (m_mpeg2_sequence->fps_scale > 0))
     {
       m_mpeg2_sequence_pts = pts;
       if (m_mpeg2_sequence_pts == DVD_NOPTS_VALUE)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -107,14 +107,14 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
     return false;
   }
 
-  m_opened = false;
-
   // allow only 1 instance here
   if (m_InstanceGuard.exchange(true))
   {
     CLog::Log(LOGERROR, "CDVDVideoCodecAmlogic::Open - InstanceGuard locked\n");
     return false;
   }
+
+  m_opened = false;
 
   m_hints = hints;
 
@@ -283,7 +283,6 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
   CLog::Log(LOGINFO, "%s: Opened Amlogic Codec", __MODULE_NAME__);
   return true;
 FAIL:
-  m_InstanceGuard.exchange(false);
   Dispose();
   return false;
 }
@@ -294,9 +293,6 @@ void CDVDVideoCodecAmlogic::Dispose(void)
 
   if (m_Codec)
     m_Codec->CloseDecoder(), m_Codec = nullptr;
-
-  if (m_opened)
-    m_InstanceGuard.exchange(false);
 
   m_videobuffer.iFlags = 0;
 
@@ -310,6 +306,7 @@ void CDVDVideoCodecAmlogic::Dispose(void)
     delete m_bitparser, m_bitparser = NULL;
 
   m_opened = false;
+  m_InstanceGuard.exchange(false);
 }
 
 bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -532,8 +532,8 @@ bool aml_get_preferred_resolution(RESOLUTION_INFO *res)
   // check display/mode, it gets defaulted at boot
   if (!aml_get_native_resolution(res))
   {
-    // punt to 720p if we get nothing
-    aml_mode_to_resolution("720p", res);
+    // punt to 1080p if we get nothing
+    aml_mode_to_resolution("1080p", res);
   }
 
   return true;

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -474,6 +474,7 @@ bool aml_set_native_resolution(const RESOLUTION_INFO &res, std::string framebuff
 {
   bool result = false;
 
+  aml_handle_display_stereo_mode(RENDER_STEREO_MODE_OFF);
   result = aml_set_display_resolution(res, framebuffer_name);
 
   aml_handle_scale(res);

--- a/xbmc/windowing/amlogic/VideoSyncAML.cpp
+++ b/xbmc/windowing/amlogic/VideoSyncAML.cpp
@@ -49,6 +49,9 @@ void CVideoSyncAML::Run(CEvent& stopEvent)
   unsigned int waittime (3000 / m_fps);
   uint64_t numVBlanks (0);
 
+  /* This shouldn't be very busy and timing is important so increase priority */
+  CThread::GetCurrentThread()->SetPriority(CThread::GetCurrentThread()->GetPriority() + 1);
+
   while (!stopEvent.Signaled() && !m_abort)
   {
     int countVSyncs(1);


### PR DESCRIPTION
## Description, motivation and Context
This PR consists of a few commits that have been used in OSMC and community LibreELEC and CoreELEC builds for a long time that I don't consider "hacks" or "ugly workarounds".

The PR consists of:
- fixing a crash when switching resolution in 3D mode
- changing default resolution to 1080p since most TVs are at least 1080p nowadays
- fix for HW decoding stop working for no reason
- fix for very long playback PTS overflow
- fix for a rare situation when fpsrate/fpsscale is 0 in mpeg2 frame rate tracking

I hope I got all commit authors correct.

I collected these in a single PR as all commits touch Amlogic-only code and have been in use for a long time, proven working.

## How Has This Been Tested?
OSMC, CoreELEC and LibreELEC builds for Amlogic S905, S905X and S912 devices running for many months, confirming the issues were solved.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
