### PR TITLE
Music lib export/import songs playback history on separate thread from GUI

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -564,6 +564,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
 #: xbmc/media/MediaTypes.cpp
+#: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#134"
 msgid "Songs"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2987,12 +2987,12 @@ msgctxt "#648"
 msgid "Import video library"
 msgstr ""
 
-#: xbmc/music/MusicDatabase.cpp
+#. unused?
 msgctxt "#649"
 msgid "Importing"
 msgstr ""
 
-#: xbmc/music/MusicDatabase.cpp
+#. unused?
 msgctxt "#650"
 msgid "Exporting"
 msgstr ""
@@ -12394,6 +12394,7 @@ msgctxt "#20196"
 msgid "Export music library"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 #: system/settings/settings.xml
 msgctxt "#20197"
 msgid "Import music library"
@@ -21393,7 +21394,39 @@ msgctxt "#38339"
 msgid "How to apply information provider settings"
 msgstr ""
 
-#empty strings from id 38340 to 38999
+#empty strings from id 38340 to 38349
+
+#. Progress statement when importing music library is processing song playback history data
+#: xbmc/music/MusicDatabase.cpp
+msgctxt "#38350"
+msgid "Importing song playback history"
+msgstr ""
+
+#. Progress statement when importing music library - data matching phase
+#: xbmc/music/MusicDatabase.cpp
+msgctxt "#38351"
+msgid "Matching data"
+msgstr ""
+
+#. Progress statement when importing music library - song history being updated
+#: xbmc/music/MusicDatabase.cpp
+msgctxt "#38352"
+msgid "Updating songs"
+msgstr ""
+
+#. Notification of import success "Importing song history - <number of songs matched> updated out of <total songs in xml> imported songs"
+#: xbmc/music/MusicDatabase.cpp
+msgctxt "#38353"
+msgid "Importing song history - {0:d} updated out of {0:d} imported songs"
+msgstr ""
+
+#. Message when reading the user specified XML for import to library fails
+#: xbmc/music/MusicDatabase.cpp
+msgctxt "#38354"
+msgid "Unable to read xml file"
+msgstr ""
+
+#empty strings from id 38355 to 38999
 
 #: system/settings/settings.xml
 msgctxt "#39000"

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -497,7 +497,8 @@ public:
   /////////////////////////////////////////////////
   // XML
   /////////////////////////////////////////////////
-  void ExportToXML(const CLibExportSettings& settings, CGUIDialogProgress* progressDialog = NULL);
+  void ExportToXML(const CLibExportSettings& settings, CGUIDialogProgress* progressDialog = nullptr);
+  bool ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* progressDialog = nullptr);
   void ImportFromXML(const std::string &xmlFile);
 
   /////////////////////////////////////////////////

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -499,7 +499,8 @@ public:
   /////////////////////////////////////////////////
   void ExportToXML(const CLibExportSettings& settings, CGUIDialogProgress* progressDialog = nullptr);
   bool ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* progressDialog = nullptr);
-  void ImportFromXML(const std::string &xmlFile);
+  void ImportFromXML(const std::string& xmlFile, CGUIDialogProgress* progressDialog = nullptr);
+  bool ImportSongHistory(const std::string& xmlFile, const int total, CGUIDialogProgress* progressDialog = nullptr);
 
   /////////////////////////////////////////////////
   // Properties

--- a/xbmc/music/MusicLibraryQueue.h
+++ b/xbmc/music/MusicLibraryQueue.h
@@ -44,6 +44,13 @@ public:
   void ExportLibrary(const CLibExportSettings& settings, bool showDialog = false);
 
   /*!
+  \brief Enqueue a music library import job.
+  \param[in] xmlFile    xml file to import
+  \param[in] showDialog Show a progress dialog while (asynchronously) exporting, otherwise export in synchronous
+  */
+  void ImportLibrary(const std::string& xmlFile, bool showDialog = false);
+
+  /*!
    \brief Enqueue a music library update job, scanning tags embedded in music files and optionally scraping additional data.
    \param[in] strDirectory Directory to scan or "" (empty string) for a global scan.
    \param[in] flags Flags for controlling the scanning process.  See xbmc/music/infoscanner/MusicInfoScanner.h for possible values.

--- a/xbmc/music/jobs/CMakeLists.txt
+++ b/xbmc/music/jobs/CMakeLists.txt
@@ -2,12 +2,14 @@ set(SOURCES MusicLibraryJob.cpp
             MusicLibraryProgressJob.cpp
             MusicLibraryCleaningJob.cpp
             MusicLibraryExportJob.cpp
+            MusicLibraryImportJob.cpp
             MusicLibraryScanningJob.cpp)
 
 set(HEADERS MusicLibraryJob.h
             MusicLibraryProgressJob.h
             MusicLibraryCleaningJob.h
             MusicLibraryExportJob.h
+            MusicLibraryImportJob.h
             MusicLibraryScanningJob.h)
 
 core_add_library(music_jobs)

--- a/xbmc/music/jobs/MusicLibraryImportJob.cpp
+++ b/xbmc/music/jobs/MusicLibraryImportJob.cpp
@@ -1,0 +1,41 @@
+/*
+*  Copyright (C) 2017-2018 Team Kodi
+*  This file is part of Kodi - https://kodi.tv
+*
+*  SPDX-License-Identifier: GPL-2.0-or-later
+*  See LICENSES/README.md for more information.
+*/
+
+#include "MusicLibraryImportJob.h"
+#include "dialogs/GUIDialogProgress.h"
+#include "music/MusicDatabase.h"
+
+CMusicLibraryImportJob::CMusicLibraryImportJob(const std::string& xmlFile, CGUIDialogProgress* progressDialog)
+  : CMusicLibraryProgressJob(nullptr)
+  ,  m_xmlFile(xmlFile)
+{
+  if (progressDialog)
+    SetProgressIndicators(nullptr, progressDialog);
+  SetAutoClose(true);
+}
+
+CMusicLibraryImportJob::~CMusicLibraryImportJob() = default;
+
+bool CMusicLibraryImportJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  const CMusicLibraryImportJob* importJob = dynamic_cast<const CMusicLibraryImportJob*>(job);
+  if (importJob == nullptr)
+    return false;
+
+  return !(m_xmlFile != importJob->m_xmlFile);
+}
+
+bool CMusicLibraryImportJob::Work(CMusicDatabase &db)
+{
+  db.ImportFromXML(m_xmlFile, GetProgressDialog());
+
+  return true;
+}

--- a/xbmc/music/jobs/MusicLibraryImportJob.h
+++ b/xbmc/music/jobs/MusicLibraryImportJob.h
@@ -1,0 +1,42 @@
+/*
+*  Copyright (C) 2017-2018 Team Kodi
+*  This file is part of Kodi - https://kodi.tv
+*
+*  SPDX-License-Identifier: GPL-2.0-or-later
+*  See LICENSES/README.md for more information.
+*/
+
+#pragma once
+
+#include "MusicLibraryProgressJob.h"
+
+class CGUIDialogProgress;
+
+/*!
+\brief Music library job implementation for importing data to the music library.
+*/
+class CMusicLibraryImportJob : public CMusicLibraryProgressJob
+{
+public:
+  /*!
+  \brief Creates a new music library import job for the given xml file.
+
+  \param[in] xmlFile       xml file to import
+  \param[in] progressDialog Progress dialog to be used to display the import progress
+  */
+  CMusicLibraryImportJob(const std::string &xmlFile, CGUIDialogProgress* progressDialog);
+
+  ~CMusicLibraryImportJob() override;
+
+  // specialization of CJob
+  const char *GetType() const override { return "MusicLibraryImportJob"; }
+  bool operator==(const CJob* job) const override;
+
+protected:
+  // implementation of CMusicLibraryJob
+  bool Work(CMusicDatabase &db) override;
+
+private:
+  std::string m_xmlFile;
+};
+

--- a/xbmc/settings/LibExportSettings.cpp
+++ b/xbmc/settings/LibExportSettings.cpp
@@ -71,7 +71,26 @@ std::vector<int> CLibExportSettings::GetExportItems() const
     values.emplace_back(ELIBEXPORT_OTHERARTISTS);
   if (IsItemExported(ELIBEXPORT_ACTORTHUMBS))
     values.emplace_back(ELIBEXPORT_ACTORTHUMBS);
+  if (IsItemExported(ELIBEXPORT_SONGS))
+    values.emplace_back(ELIBEXPORT_SONGS);
+  return values;
+}
 
+std::vector<int> CLibExportSettings::GetLimitedItems(int items) const
+{
+  std::vector<int> values;
+  if (IsItemExported(ELIBEXPORT_ALBUMS) && (items & ELIBEXPORT_ALBUMS))
+    values.emplace_back(ELIBEXPORT_ALBUMS);
+  if (IsItemExported(ELIBEXPORT_ALBUMARTISTS) && (items & ELIBEXPORT_ALBUMARTISTS))
+    values.emplace_back(ELIBEXPORT_ALBUMARTISTS);
+  if (IsItemExported(ELIBEXPORT_SONGARTISTS) && (items & ELIBEXPORT_SONGARTISTS))
+    values.emplace_back(ELIBEXPORT_SONGARTISTS);
+  if (IsItemExported(ELIBEXPORT_OTHERARTISTS) && (items & ELIBEXPORT_OTHERARTISTS))
+    values.emplace_back(ELIBEXPORT_OTHERARTISTS);
+  if (IsItemExported(ELIBEXPORT_ACTORTHUMBS) && (items & ELIBEXPORT_ACTORTHUMBS))
+    values.emplace_back(ELIBEXPORT_ACTORTHUMBS);
+  if (IsItemExported(ELIBEXPORT_SONGS) && (items & ELIBEXPORT_SONGS))
+    values.emplace_back(ELIBEXPORT_SONGS);
   return values;
 }
 

--- a/xbmc/settings/LibExportSettings.h
+++ b/xbmc/settings/LibExportSettings.h
@@ -30,7 +30,8 @@ enum ELIBEXPORTOPTIONS
   ELIBEXPORT_ARTWORK = 0x0100,
   ELIBEXPORT_NFOFILES = 0x0200,
   ELIBEXPORT_ACTORTHUMBS = 0x0400,
-  ELIBEXPORT_ARTISTFOLDERS = 0x0800
+  ELIBEXPORT_ARTISTFOLDERS = 0x0800,
+  ELIBEXPORT_SONGS = 0x1000
 };
 
 class CLibExportSettings
@@ -43,6 +44,7 @@ public:
   bool IsItemExported(ELIBEXPORTOPTIONS item) const;
   bool IsArtists() const;
   std::vector<int> GetExportItems() const;
+  std::vector<int> GetLimitedItems(int items) const;
   void ClearItems() { m_itemstoexport = 0; }
   void AddItem(ELIBEXPORTOPTIONS item) { m_itemstoexport += item; }
   unsigned int GetItemsToExport() { return m_itemstoexport; }

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -19,7 +19,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
-#include "music/MusicDatabase.h"
 #include "music/MusicLibraryQueue.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "ServiceBroker.h"
@@ -315,10 +314,8 @@ void CMediaSettings::OnSettingAction(std::shared_ptr<const CSetting> setting)
 
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "musicdb.xml", g_localizeStrings.Get(651) , path))
     {
-      CMusicDatabase musicdatabase;
-      musicdatabase.Open();
-      musicdatabase.ImportFromXML(path);
-      musicdatabase.Close();
+      // Import data to music library showing progress dialog
+      CMusicLibraryQueue::GetInstance().ImportLibrary(path, true);
     }
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_CLEANUP)

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -258,10 +258,6 @@ void CGUIDialogLibExportSettings::SetupView()
   SET_CONTROL_LABEL(CONTROL_SETTINGS_OKAY_BUTTON, 38319);
   SET_CONTROL_LABEL(CONTROL_SETTINGS_CANCEL_BUTTON, 222);
 
-  if (m_settings.IsSeparateFiles())
-    ToggleState(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, !m_settings.m_skipnfo);
-  else if (m_settings.IsToLibFolders())
-    ToggleState(CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, false);
   UpdateButtons();
   UpdateToggles();
   UpdateDescription();
@@ -360,31 +356,39 @@ void CGUIDialogLibExportSettings::InitializeSettings()
   entries.clear();
   if (!m_settings.IsArtistFoldersOnly())
     entries.push_back(std::make_pair(132, ELIBEXPORT_ALBUMS));  //ablums
+  if (m_settings.IsSingleFile())
+    entries.push_back(std::make_pair(134, ELIBEXPORT_SONGS));  //songs
   entries.push_back(std::make_pair(38043, ELIBEXPORT_ALBUMARTISTS)); //album artists
   entries.push_back(std::make_pair(38312, ELIBEXPORT_SONGARTISTS)); //song artists
   entries.push_back(std::make_pair(38313, ELIBEXPORT_OTHERARTISTS)); //other artists
+
+  std::vector<int> items;
   if (m_settings.IsArtistFoldersOnly())
   {
-    std::vector<int> artistitems; // Only artists, not albums
-    if (m_settings.IsItemExported(ELIBEXPORT_SONGARTISTS))
-      artistitems.emplace_back(ELIBEXPORT_SONGARTISTS);
-    if (m_settings.IsItemExported(ELIBEXPORT_OTHERARTISTS))
-      artistitems.emplace_back(ELIBEXPORT_OTHERARTISTS);
-    if (m_settings.IsItemExported(ELIBEXPORT_ALBUMARTISTS) || (artistitems.size() == 0))
-      artistitems.emplace_back(ELIBEXPORT_ALBUMARTISTS);
-    AddList(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS, 38306, SettingLevel::Basic, artistitems, entries, 133, 1);
+    // Only artists, not albums, at least album artists
+    items = m_settings.GetLimitedItems(ELIBEXPORT_ALBUMARTISTS + ELIBEXPORT_SONGARTISTS + ELIBEXPORT_OTHERARTISTS);
+    if (items.size() == 0)
+      items.emplace_back(ELIBEXPORT_ALBUMARTISTS);
+  }
+  else if (!m_settings.IsSingleFile())
+  {
+    // No songs unless single file export, at least album artists
+    items = m_settings.GetLimitedItems(ELIBEXPORT_ALBUMS + ELIBEXPORT_ALBUMARTISTS + ELIBEXPORT_SONGARTISTS + ELIBEXPORT_OTHERARTISTS);
+    if (items.size() == 0)
+      items.emplace_back(ELIBEXPORT_ALBUMARTISTS);
   }
   else
-  {
-    AddList(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS, 38306, SettingLevel::Basic, m_settings.GetExportItems(), entries, 133, 1);
+   items = m_settings.GetExportItems();
+  
+  AddList(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ITEMS, 38306, SettingLevel::Basic, items, entries, 133, 1);
 
-    if (!m_settings.IsSingleFile())
-    {
-      m_settingNFO = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, 38309, SettingLevel::Basic, !m_settings.m_skipnfo);
+  if (m_settings.IsToLibFolders() || m_settings.IsSeparateFiles())
+  {
+    m_settingNFO = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, 38309, SettingLevel::Basic, !m_settings.m_skipnfo);
+    if (m_settings.IsSeparateFiles())
       AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_UNSCRAPED, 38308, SettingLevel::Basic, m_settings.m_unscraped);
-      m_settingArt = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, 38307, SettingLevel::Basic, m_settings.m_artwork);
-      AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, 38311, SettingLevel::Basic, m_settings.m_overwrite);
-    }
+    m_settingArt = AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_ARTWORK, 38307, SettingLevel::Basic, m_settings.m_artwork);
+    AddToggle(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, 38311, SettingLevel::Basic, m_settings.m_overwrite);
   }
 }
 


### PR DESCRIPTION
Fix music import facility to work on separate thread from GUI, hence actually be able to cancel it in the way export works.

Add facility to backup the song playback history e.g. play count, lastplayed date,  rating, votes and userrating - all the dynamic data that can change during playback and is not held in the music file itself - to xml file. This means that if users need to remove music sources or move music files to new location they can subsequently restore their playback history, a facility that has been needed fo a long time.

Tested on both SQLite and MySQL music databases with a variety of music collections.

This is low risk and yet offers significant improvement so I would like to get it into v18.