### PR TITLE
DVDDemuxFFmpeg: Do not discard stream indexes belonging to program

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1362,7 +1362,9 @@ void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
       // add streams from selected program
       for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
       {
-        AddStream(m_pFormatContext->programs[m_program]->stream_index[i]);
+        int streamIdx = m_pFormatContext->programs[m_program]->stream_index[i];
+        m_pFormatContext->streams[streamIdx]->discard = AVDISCARD_NONE;
+        AddStream(streamIdx);
       }
 
       // discard all unneeded streams


### PR DESCRIPTION
Fix: https://github.com/xbmc/xbmc/issues/15751