### PR TITLE
[Android] Prevent modeswitch when native_window is invalid

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -127,11 +127,21 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
     return true;
   }
 
+  if (m_dispResetState != RESET_NOTWAITING)
+  {
+    CLog::Log(LOGINFO, "CWinSystemAndroid::CreateNewWindow: cannot create window while resetting");
+    return false;
+  }
+
   m_stereo_mode = stereo_mode;
   m_bFullScreen = fullScreen;
 
   m_nativeWindow = CXBMCApp::GetNativeWindow(2000);
-
+  if (!m_nativeWindow)
+  {
+    CLog::Log(LOGERROR, "CWinSystemAndroid::CreateNewWindow: failed");
+    return false;
+  }
   m_android->SetNativeResolution(res);
 
   return true;


### PR DESCRIPTION
## Description
If kodi is in paused state of a video which was started with display mode switch, screen changes (like automatic screen off / changes regarding HDMI port) can lead to segfaults.

Reason is that Android does not provide a native_window but kodi tries to perform a mode switch on it.

Example call stack:

```
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil: backtrace:
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #00 pc 0000d458  /system/lib/libandroid.so (ANativeWindow_setBuffersGeometry+39)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #01 pc 014e5a20  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN13CAndroidUtils19SetNativeResolutionERK15RESOLUTION_INFO+272)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #02 pc 014e2fd0  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN17CWinSystemAndroid15CreateNewWindowERKNSt6__ndk112basic_stringIc
NS0_11char_traitsIcEENS0_9allocatorIcEEEEbR15RESOLUTION_INFO+320)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #03 pc 014e76b4  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN28CWinSystemAndroidGLESContext15CreateNewWindowERKNSt6__ndk112bas
ic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEbR15RESOLUTION_INFO+52)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #04 pc 014e774c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN28CWinSystemAndroidGLESContext13SetFullScreenEbR15RESOLUTION_INFO
b+76)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #05 pc 00c27b3c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN15CGraphicContext26SetVideoResolutionInternalE10RESOLUTIONb+612)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #06 pc 00c27690  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN15CGraphicContext18SetFullScreenVideoEb+532)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #07 pc 00af14e4  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN20CGUIWindowFullScreen9OnMessageER11CGUIMessage+468)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #08 pc 00e05cd8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN10CGUIWindow14Close_InternalEbib+320)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #09 pc 00e0be4c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN17CGUIWindowManager15CloseWindowSyncEP10CGUIWindowi+260)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #10 pc 00e0ba0c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN17CGUIWindowManager14PreviousWindowEv+448)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #11 pc 00fa84b0  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN12CApplication11StopPlayingEv+120)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #12 pc 00f9d800  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN12CApplication8OnActionERK7CAction+2488)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #13 pc 00e0d1f4  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN17CGUIWindowManager20OnApplicationMessageEPN4KODI9MESSAGING13Thre
adMessageE+456)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #14 pc 00d48d7c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN4KODI9MESSAGING21CApplicationMessenger14ProcessMessageEPNS0_13Thr
eadMessageE+268)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #15 pc 00d4a038  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN4KODI9MESSAGING21CApplicationMessenger15ProcessMessagesEv+164)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #16 pc 00fb429c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN12CApplication7ProcessEv+592)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #17 pc 00e0e8b8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN17CGUIWindowManager17ProcessRenderLoopEb+120)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #18 pc 00dc0e34  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN10CGUIDialog13Open_InternalEbRKNSt6__ndk112basic_stringIcNS0_11ch
ar_traitsIcEENS0_9allocatorIcEEEE+332)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #19 pc 00af0ce0  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN20CGUIWindowFullScreen9ToggleOSDEv+140)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #20 pc 00af0960  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN20CGUIWindowFullScreen8OnActionERK7CAction+668)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #21 pc 00e0d950  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZNK17CGUIWindowManager12HandleActionERK7CAction+308)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #22 pc 00e0d794  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZNK17CGUIWindowManager8OnActionERK7CAction+124)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #23 pc 00f9cfd8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN12CApplication8OnActionERK7CAction+400)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #24 pc 00d6f460  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN13CInputManager9HandleKeyERK4CKey+764)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #25 pc 00d6f0ec  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN13CInputManager7OnKeyUpERK4CKey+136)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #26 pc 00d6ebc4  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (_ZN13CInputManager7OnEventER10XBMC_Event+476)
04-07 21:08:25.997  3455 32439 V CrashDescriptorUtil:     #27 pc 00f9c8cc  /data/app/

```

## Motivation and Context
Fix more segfaults

## How Has This Been Tested?
AFTV 2017:
- Start a video which produces a refreshrate switch
- Pause the video
- Wait until AFTV goes into Screen Off mode

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
