### PR TITLE
[LinuxRendererGLES] Fix pixelstore usage

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -279,23 +279,28 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
 
   glBindTexture(m_textureTarget, plane.id);
 
-  if (m_pixelStoreKey > 0)
+  bool pixelStoreChanged = false;
+  if (stride != static_cast<int>(width * bps))
   {
-    glPixelStorei(m_pixelStoreKey, stride);
-  }
-  else if (stride != static_cast<int>(width * bps))
-  {
-    unsigned char *src(static_cast<unsigned char*>(data)),
-                  *dst(m_planeBuffer);
+    if (m_pixelStoreKey > 0)
+    {
+      pixelStoreChanged = true;
+      glPixelStorei(m_pixelStoreKey, stride);
+    }
+    else
+    {
+      unsigned char *src(static_cast<unsigned char*>(data)),
+                    *dst(m_planeBuffer);
 
-    for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
-      memcpy(dst, src, width * bpp);
+      for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
+        memcpy(dst, src, width * bpp);
 
-    pixelData = m_planeBuffer;
+      pixelData = m_planeBuffer;
+    }
   }
   glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
 
-  if (m_pixelStoreKey > 0)
+  if (m_pixelStoreKey > 0 && pixelStoreChanged)
     glPixelStorei(m_pixelStoreKey, 0);
 
   // check if we need to load any border pixels


### PR DESCRIPTION
## Description
Don't call glPixelStorei if not necessary.

## Motivation and Context
Should solve discussion here: https://github.com/xbmc/xbmc/pull/15684

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
