### PR TITLE
[PVR] Initialize timer info tag with first available timer type from client

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -48,15 +48,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
   const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsTimers())
   {
-    // default to manual one-shot timer for given client
-    CPVRTimerTypePtr type(CPVRTimerType::CreateFromAttributes(
-      PVR_TIMER_TYPE_IS_MANUAL, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES, m_iClientId));
-
-    if (!type)
-    {
-      // last resort. default to first available type from any client.
-      type = CPVRTimerType::GetFirstAvailableType();
-    }
+    // default to first available type for given client
+    CPVRTimerTypePtr type = CPVRTimerType::GetFirstAvailableType(m_iClientId);
 
     if (type)
       SetTimerType(type);

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -26,10 +26,18 @@ const std::vector<CPVRTimerTypePtr> CPVRTimerType::GetAllTypes()
   return allTypes;
 }
 
-const CPVRTimerTypePtr CPVRTimerType::GetFirstAvailableType()
+const CPVRTimerTypePtr CPVRTimerType::GetFirstAvailableType(int iClientId)
 {
-  std::vector<CPVRTimerTypePtr> allTypes(GetAllTypes());
-  return allTypes.empty() ? CPVRTimerTypePtr() : *(allTypes.begin());
+  const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(iClientId);
+  if (client)
+  {
+    std::vector<CPVRTimerTypePtr> types;
+    if (client->GetTimerTypes(types) == PVR_ERROR_NO_ERROR && !types.empty())
+    {
+      return *(types.begin());
+    }
+  }
+  return {};
 }
 
 CPVRTimerTypePtr CPVRTimerType::CreateFromIds(unsigned int iTypeId, int iClientId)
@@ -49,7 +57,7 @@ CPVRTimerTypePtr CPVRTimerType::CreateFromIds(unsigned int iTypeId, int iClientI
   }
 
   CLog::LogF(LOGERROR, "Unable to resolve numeric timer type (%d, %d)", iTypeId, iClientId);
-  return CPVRTimerTypePtr();
+  return {};
 }
 
 CPVRTimerTypePtr CPVRTimerType::CreateFromAttributes(
@@ -71,7 +79,7 @@ CPVRTimerTypePtr CPVRTimerType::CreateFromAttributes(
   }
 
   CLog::LogF(LOGERROR, "Unable to resolve timer type (0x%x, 0x%x, %d)", iMustHaveAttr, iMustNotHaveAttr, iClientId);
-  return CPVRTimerTypePtr();
+  return {};
 }
 
 CPVRTimerType::CPVRTimerType() :

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -35,10 +35,11 @@ namespace PVR
     static const std::vector<CPVRTimerTypePtr> GetAllTypes();
 
     /*!
-     * @brief Return the first available timer type.
+     * @brief Return the first available timer type from given client id.
+     * @param iClientId the PVR client id.
      * @return A timer type or NULL if none available.
      */
-    static const CPVRTimerTypePtr GetFirstAvailableType();
+    static const CPVRTimerTypePtr GetFirstAvailableType(int iClientId);
 
     /*!
      * @brief Create a timer type from given timer type id and client id.


### PR DESCRIPTION
Initialize timer info tag with first timer type provided by the PVR client, when available, instead of arbitrarily trying to create a manual one-shot timer type which may not be supported and causes unnecessary errors in the log.

## Description
During construction, the CPVRTimerInfoTag class will attempt to default to a Manual One-Shot timer from the PVR client.  If creation fails, it will fall back to trying to create whatever the first available timer type from any PVR client happens to be.

If the PVR client does not support Manual One-Shot timers, the Kodi log will have a great deal of "PVR::CPVRTimerType::CreateFromAttributes: Unable to resolve timer type (0x1, 0xa, xxxxxxxx)" errors in it, one for every time a CPVRTimerInfoTag instance is created.

While there may have been a historic reason for defaulting to Manual One-Shot, it doesn't appear necessary any longer, making the error messages false-positive.  If Manual One-Shot isn't available, the code already falls back to a default type and continues without error.

The proposed change removes the arbitrary creation of a Manual One-Shot timer and instead, since the PVR client ID is known, retrieves the first available timer type for that client.  The CPVRTimerType::GetFirstAvailableType() method was modified to use the client ID instead of making a new method since this is the only place it's referenced.

## Motivation and Context
This change eliminates the plethora of false positive errors present in the Kodi logs if a PVR client does not support Manual One-Shot timers.  It should have no effect on the operation of the PVR subsystem since it was already falling back into similar code.  The original fallback didn't filter at all (for example PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES), the proposed change also does not.

## How Has This Been Tested?
Primary testing was on Windows 10, x64 and Win32 using my custom PVR (which does not support Manual One-Shot timers), with secondary testing on Android ARM64 (nVidia Shield).

I had set breakpoints on the offending error message and ran through unit testing of timers -- initial load, add/modify/delete.  All instances were generated from the CPVRTimerInfoTag constructor.  Ran the same unit testing after the modifications and ran into no issues with the same PVR timer operations (add/modify/delete), and verified that the message no longer appeared in the logs.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
