### PR TITLE
CRenderBufferPoolGBM: use DRM_FORMAT_ARGB1555 for AV_PIX_FMT_RGB555

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolGBM.cpp
@@ -45,6 +45,10 @@ bool CRenderBufferPoolGBM::ConfigureInternal()
       return true;
     }
     case AV_PIX_FMT_RGB555:
+    {
+      m_fourcc = DRM_FORMAT_ARGB1555;
+      return true;
+    }
     case AV_PIX_FMT_RGB565:
     {
       m_fourcc = DRM_FORMAT_RGB565;


### PR DESCRIPTION
This fixes an issue where the colors aren't displayed properly. We were rendering `AV_PIX_FMT_RGB555` as `DRM_FORMAT_RGB565` before (as I wanted to display something other than a black screen). This fixes the black screen and the color issue by using the correct format.