### PR TITLE
CEGLImage: don't add modifiers if they are just linear

### DIFF
--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -83,7 +83,7 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
                    {eglDmabufPlanePitchAttr[i], imageAttrs.planes[i].pitch}});
 
 #if defined(EGL_EXT_image_dma_buf_import_modifiers)
-      if (imageAttrs.planes[i].modifier != DRM_FORMAT_MOD_INVALID)
+      if (imageAttrs.planes[i].modifier != DRM_FORMAT_MOD_INVALID && imageAttrs.planes[i].modifier != DRM_FORMAT_MOD_LINEAR)
         attribs.Add({{eglDmabufPlaneModifierLoAttr[i], static_cast<EGLint>(imageAttrs.planes[i].modifier & 0xFFFFFFFF)},
                      {eglDmabufPlaneModifierHiAttr[i], static_cast<EGLint>(imageAttrs.planes[i].modifier >> 32)}});
 #endif


### PR DESCRIPTION
Modifiers shouldn't be used to import the image if the modifier is `DRM_FORMAT_MOD_LINEAR` (0) so let's ignore that also.