### PR TITLE
CEGLImage: dump attributes if the import fails

### DIFF
--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -153,6 +153,11 @@ public:
     return m_attributes.data();
   }
 
+  int Size() const
+  {
+    return m_writePosition;
+  }
+
 private:
   std::array<EGLint, AttributeCount * 2 + 1> m_attributes;
   int m_writePosition{};


### PR DESCRIPTION
This has been really helpful for me to debug EGL image import failures.

example:
```
2019-04-08 19:34:03.775 T:140703923112320   DEBUG: CEGLImage::CreateImage - attributes:
                                            EGL_DMA_BUF_PLANE0_PITCH_EXT: 512
                                            EGL_DMA_BUF_PLANE0_OFFSET_EXT: 0
                                            EGL_DMA_BUF_PLANE0_FD_EXT: 57
                                            EGL_LINUX_DRM_FOURCC_EXT: 909199186
                                            EGL_HEIGHT: 240
                                            EGL_WIDTH: 256
```