### PR TITLE
[cmake] enable using ccache with xcode

### DIFF
--- a/cmake/modules/FindCCache.cmake
+++ b/cmake/modules/FindCCache.cmake
@@ -12,7 +12,16 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CCache REQUIRED_VARS CCACHE_PROGRAM)
 
 if(CCACHE_FOUND)
-  # Supports Unix Makefiles and Ninja
+  # Supports Unix Makefiles, Ninja and Xcode
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
+
+  file(WRITE "${CMAKE_BINARY_DIR}/launch-c" "exec \"${CCACHE_PROGRAM}\" \"${CMAKE_C_COMPILER}\" \"$@\"\n")
+  file(WRITE "${CMAKE_BINARY_DIR}/launch-cxx" "exec \"${CCACHE_PROGRAM}\" \"${CMAKE_CXX_COMPILER}\" \"$@\"\n")
+  execute_process(COMMAND chmod +x "${CMAKE_BINARY_DIR}/launch-c" "${CMAKE_BINARY_DIR}/launch-cxx")
+
+  set(CMAKE_XCODE_ATTRIBUTE_CC "${CMAKE_BINARY_DIR}/launch-c" PARENT_SCOPE)
+  set(CMAKE_XCODE_ATTRIBUTE_CXX "${CMAKE_BINARY_DIR}/launch-cxx" PARENT_SCOPE)
+  set(CMAKE_XCODE_ATTRIBUTE_LD "${CMAKE_BINARY_DIR}/launch-c" PARENT_SCOPE)
+  set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx" PARENT_SCOPE)
 endif()


### PR DESCRIPTION
## Motivation and Context
speed up build process for xcode users

## How Has This Been Tested?
- zeroed ccache statistics counters
- generated xcode project
- build kodi
- checked ccache statistics summary
- touched all cpp and mm files in lib/libUPnP and xbmc
- zeroed ccache statistics counters
- build kodi
- checked ccache statistics summary

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
