### PR TITLE
Fix debug log statement in Windows NotificationClient

### DIFF
--- a/xbmc/platform/win32/IMMNotificationClient.h
+++ b/xbmc/platform/win32/IMMNotificationClient.h
@@ -146,7 +146,7 @@ public:
 
   HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR pwstrDeviceId, const PROPERTYKEY key)
   {
-    CLog::Log(LOGDEBUG, "%s: Changed device property of %s is {{%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x}}#%d",
+    CLog::Log(LOGDEBUG, "%s: Changed device property of %s is (%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x)#%d",
               __FUNCTION__, FromW(pwstrDeviceId), key.fmtid.Data1, key.fmtid.Data2, key.fmtid.Data3,
                                            key.fmtid.Data4[0], key.fmtid.Data4[1],
                                            key.fmtid.Data4[2], key.fmtid.Data4[3],


### PR DESCRIPTION
Debug log had lines where the format statement was not being parsed e.g.
```
DEBUG: %s: Changed device property of %s is {%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x}#%d
```
The issue was the `{{` and `}}` in the format statements - obviously an unsuccessful attempt to escape `{` and `}` since the change to use fmt https://github.com/xbmc/xbmc/pull/13452

The extra bracket is removed by fmt but makes the test in `Format()` below fail and so the statement is not passed to sprintf
  https://github.com/xbmc/xbmc/blob/a836e71009bec53778d276780057d358ae1fff81/xbmc/utils/StringUtils.h#L79-L86

Fix is to replace with simple brackets, then at least the log contains actual data.

