### PR TITLE
Allow for disabling caching of slow video and music library items

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -708,6 +708,7 @@ public:
   void SetCacheToDisc(CACHE_TYPE cacheToDisc) { m_cacheToDisc = cacheToDisc; }
   bool CacheToDiscAlways() const { return m_cacheToDisc == CACHE_ALWAYS; }
   bool CacheToDiscIfSlow() const { return m_cacheToDisc == CACHE_IF_SLOW; }
+  bool CacheToDiscNever() const { return m_cacheToDisc == CACHE_NEVER; }
   /*! \brief remove a previously cached CFileItemList from the cache
 
    The file list may be cached based on which window we're viewing in, as different

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -34,6 +34,7 @@
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "profiles/ProfileManager.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -407,6 +408,12 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
 {
   if (strDirectory.empty())
     AddSearchFolder();
+
+  // check if caching of slow queries is disabled; the initial value is CACHE_IF_SLOW.
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bMusicLibraryCacheSlowQueries)
+  {
+    items.SetCacheToDisc(CFileItemList::CACHE_NEVER);
+  }
 
   bool bResult = CGUIWindowMusicBase::GetDirectory(strDirectory, items);
   if (bResult)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -293,6 +293,7 @@ void CAdvancedSettings::Initialize()
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryCleanOnUpdate = false;
   m_bMusicLibraryArtistSortOnUpdate = false;
+  m_bMusicLibraryCacheSlowQueries = true;
   m_iMusicLibraryRecentlyAddedItems = 25;
   m_strMusicLibraryAlbumFormat = "";
   m_prioritiseAPEv2tags = false;
@@ -307,6 +308,7 @@ void CAdvancedSettings::Initialize()
   m_bVideoLibraryUseFastHash = true;
   m_bVideoLibraryExportAutoThumbs = false;
   m_bVideoLibraryImportWatchedState = false;
+  m_bVideoLibraryCacheSlowQueries = true;
   m_bVideoLibraryImportResumePoint = false;
   m_bVideoScannerIgnoreErrors = false;
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
@@ -776,6 +778,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "allitemsonbottom", m_bMusicLibraryAllItemsOnBottom);
     XMLUtils::GetBoolean(pElement, "cleanonupdate", m_bMusicLibraryCleanOnUpdate);
     XMLUtils::GetBoolean(pElement, "artistsortonupdate", m_bMusicLibraryArtistSortOnUpdate);
+    XMLUtils::GetBoolean(pElement, "cacheslowqueries", m_bMusicLibraryCacheSlowQueries);
     XMLUtils::GetString(pElement, "albumformat", m_strMusicLibraryAlbumFormat);
     XMLUtils::GetString(pElement, "itemseparator", m_musicItemSeparator);
     XMLUtils::GetInt(pElement, "dateadded", m_iMusicLibraryDateAdded);
@@ -807,6 +810,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pElement, "itemseparator", m_videoItemSeparator);
     XMLUtils::GetBoolean(pElement, "exportautothumbs", m_bVideoLibraryExportAutoThumbs);
     XMLUtils::GetBoolean(pElement, "importwatchedstate", m_bVideoLibraryImportWatchedState);
+    XMLUtils::GetBoolean(pElement, "cacheslowqueries", m_bVideoLibraryCacheSlowQueries);
     XMLUtils::GetBoolean(pElement, "importresumepoint", m_bVideoLibraryImportResumePoint);
     XMLUtils::GetInt(pElement, "dateadded", m_iVideoLibraryDateAdded);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -251,6 +251,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bMusicLibraryAllItemsOnBottom;
     bool m_bMusicLibraryCleanOnUpdate;
     bool m_bMusicLibraryArtistSortOnUpdate;
+    bool m_bMusicLibraryCacheSlowQueries;
     std::string m_strMusicLibraryAlbumFormat;
     bool m_prioritiseAPEv2tags;
     std::string m_musicItemSeparator;
@@ -264,6 +265,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bVideoLibraryUseFastHash;
     bool m_bVideoLibraryExportAutoThumbs;
     bool m_bVideoLibraryImportWatchedState;
+    bool m_bVideoLibraryCacheSlowQueries;
     bool m_bVideoLibraryImportResumePoint;
     std::vector<std::string> m_videoEpisodeExtraArt;
     std::vector<std::string> m_videoTvShowExtraArt;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -358,6 +358,12 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
   items.ClearArt();
   items.ClearProperties();
 
+  // check if caching of slow queries is disabled; the initial value is CACHE_IF_SLOW.
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVideoLibraryCacheSlowQueries)
+  {
+    items.SetCacheToDisc(CFileItemList::CACHE_NEVER);
+  }
+
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
   if (bResult)
   {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -723,7 +723,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
 
   // see if we can load a previously cached folder
   CFileItemList cachedItems(strDirectory);
-  if (!strDirectory.empty() && cachedItems.Load(GetID()))
+  if (!items.CacheToDiscNever() && !strDirectory.empty() && cachedItems.Load(GetID()))
   {
     items.Assign(cachedItems);
   }


### PR DESCRIPTION
## Description
This change provides a way to prevent `fileitem` caching. The flag is named `cacheslowqueries`, is `true` by default to honor the existing behavior, and is read from `videolibrary` and `musiclibrary` from `advancedsettings.xml`.

```xml
<advancedsettings>
    <videolibrary>
        <cacheslowqueries>false</cacheslowqueries>
     </videolibrary>
    <musiclibrary>
        <cacheslowqueries>false</cacheslowqueries>
     </musiclibrary>
</advancedsettings>
```


## Motivation and Context
Kodi caches `fileitem` data that take longer that 1000ms to get fetched. Loading video and music library items from a local SQLite database often doesn't take that long but fetching data from a remote MySQL database, especially if the database is not minuscule, is almost guarantied to get cached; not because MySQL queries are slow but because of the huge amount of data that has to travel over the network.

Jarvis and prior versions had a flaw and failed to cache anything irrespective of how long it took to fetch the data; this flaw was fixed with Krypton. Starting with Krypton, having a large database meant not being able to
1. watch an episode and see the correct watched-flag when the episode ended or the correct watched-count on the season or tvshow listing
2. refresh a movie from the info dialog and see it in the list or have the ability to watch it until by some magic the cache-file gets deleted

With random movies, 200 items in the `videolibrary` were enough to trigger caching all the time. One simple way to allow users like me to have control over whether Kodi caches their data or not, was to add a setting in `advancedsettings.xml`.

https://trac.kodi.tv/ticket/17336
https://trac.kodi.tv/ticket/17536

## How Has This Been Tested?
The code was built on Windows 10 x64 and tested without the setting, with the setting set to true, and with the setting set to false. The first two behaved just like Krypton+ while setting to false didn't create the cache files and forced refetching of the data on navigation; this allowed for (1) displaying of correct watched-status and watched-counts for episodes, seasons, and tvshows, and (2) showing correct movie info upon manually refreshing its info and playing it.

The code changes (a) introduce the new settings, and (b) disable caching within `CGUIWindowVideoNav` and `CGUIWindowMusicNav`. For b, I chose not to do it in `CGUIMediaWindow` in order to limit the blast radius.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
