### PR TITLE
CDRMUtils: rework modifiers flag selection

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -109,10 +109,13 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
   memset(offsets, 0, 16);
 #endif
 
-  if (modifiers[0] == DRM_FORMAT_MOD_INVALID)
-    modifiers[0] = DRM_FORMAT_MOD_LINEAR;
+  uint32_t flags = 0;
 
-  CLog::Log(LOGDEBUG, "CDRMUtils::%s - using modifier: %lli", __FUNCTION__, modifiers[0]);
+  if (modifiers[0] && modifiers[0] != DRM_FORMAT_MOD_INVALID)
+  {
+    flags |= DRM_MODE_FB_MODIFIERS;
+    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using modifier: {:#x}", __FUNCTION__, modifiers[0]);
+  }
 
   auto ret = drmModeAddFB2WithModifiers(m_fd,
                                         width,
@@ -123,7 +126,7 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
                                         offsets,
                                         modifiers,
                                         &fb->fb_id,
-                                        (modifiers[0] > 0) ? DRM_MODE_FB_MODIFIERS : 0);
+                                        flags);
 
   if(ret)
   {


### PR DESCRIPTION
This makes the `drmModeAddFB2WithModifiers` call more similar to the one use in `CVideoLayerBridgeDRMPRIME`. This also only logs the modifier used if one is actually present.

This also logs the modifier as a hex value as there is no easy way to get a string for the modifier name. The modifier then refers to the format found in `drm/drm_fourcc.h`

for example:
`0x100000000000005` refers to 
```
#define DRM_FORMAT_MOD_VENDOR_INTEL   0x01
```
and
```
#define I915_FORMAT_MOD_Yf_TILED_CCS    fourcc_mod_code(INTEL, 5)
```

EDIT:
IMO this is better then the alternative which is hardcoding all the modifiers like libdrm does for the `modetest` utility -> https://gitlab.freedesktop.org/mesa/drm/blob/master/tests/modetest/modetest.c#L253-299