### PR TITLE
[GBM] CRendererDRMPRIMEGLES improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -153,28 +153,44 @@ bool CRendererDRMPRIMEGLES::RenderHook(int index)
   {
     float x, y, z;
     float u1, v1;
-  } vertex[4];
+  };
+
+  std::array<PackedVertex, 4> vertex;
 
   GLint vertLoc = renderSystem->GUIShaderGetPos();
   GLint loc = renderSystem->GUIShaderGetCoord0();
 
-  for (unsigned int i = 0; i < 4; i++)
-  {
-    // Setup vertex position values
-    vertex[i].x = m_rotatedDestCoords[i].x;
-    vertex[i].y = m_rotatedDestCoords[i].y;
-    vertex[i].z = 0.0f;
-  }
+  // top left
+  vertex[0].x = m_rotatedDestCoords[0].x;
+  vertex[0].y = m_rotatedDestCoords[0].y;
+  vertex[0].z = 0.0f;
+  vertex[0].u1 = plane.rect.x1;
+  vertex[0].v1 = plane.rect.y1;
 
-  // Setup texture coordinates
-  vertex[0].u1 = vertex[3].u1 = plane.rect.x1;
-  vertex[0].v1 = vertex[1].v1 = plane.rect.y1;
-  vertex[1].u1 = vertex[2].u1 = plane.rect.x2;
-  vertex[2].v1 = vertex[3].v1 = plane.rect.y2;
+  // top right
+  vertex[1].x = m_rotatedDestCoords[1].x;
+  vertex[1].y = m_rotatedDestCoords[1].y;
+  vertex[1].z = 0.0f;
+  vertex[1].u1 = plane.rect.x2;
+  vertex[1].v1 = plane.rect.y1;
+
+  // bottom right
+  vertex[2].x = m_rotatedDestCoords[2].x;
+  vertex[2].y = m_rotatedDestCoords[2].y;
+  vertex[2].z = 0.0f;
+  vertex[2].u1 = plane.rect.x2;
+  vertex[2].v1 = plane.rect.y2;
+
+  // bottom left
+  vertex[3].x = m_rotatedDestCoords[3].x;
+  vertex[3].y = m_rotatedDestCoords[3].y;
+  vertex[3].z = 0.0f;
+  vertex[3].u1 = plane.rect.x1;
+  vertex[3].v1 = plane.rect.y2;;
 
   glGenBuffers(1, &vertexVBO);
   glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * vertex.size(), vertex.data(), GL_STATIC_DRAW);
 
   glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
   glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
@@ -184,7 +200,7 @@ bool CRendererDRMPRIMEGLES::RenderHook(int index)
 
   glGenBuffers(1, &indexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -223,3 +223,29 @@ void CRendererDRMPRIMEGLES::AfterRenderHook(int index)
 {
   m_fences[index]->CreateFence();
 }
+
+bool CRendererDRMPRIMEGLES::Supports(ERENDERFEATURE feature)
+{
+  switch (feature)
+  {
+  case RENDERFEATURE_STRETCH:
+  case RENDERFEATURE_ZOOM:
+  case RENDERFEATURE_VERTICAL_SHIFT:
+  case RENDERFEATURE_PIXEL_RATIO:
+  case RENDERFEATURE_ROTATION:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool CRendererDRMPRIMEGLES::Supports(ESCALINGMETHOD method)
+{
+  switch (method)
+  {
+  case VS_SCALINGMETHOD_LINEAR:
+    return true;
+  default:
+    return false;
+  }
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -40,6 +40,9 @@ public:
   void ReleaseBuffer(int index) override;
   bool NeedBuffer(int index) override;
 
+  bool Supports(ERENDERFEATURE feature) override;
+  bool Supports(ESCALINGMETHOD method) override;
+
 protected:
   // CLinuxRendererGLES overrides
   bool LoadShadersHook() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -11,6 +11,20 @@
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "DRMPRIMEEGL.h"
 
+#include <array>
+#include <memory>
+
+namespace KODI
+{
+namespace UTILS
+{
+namespace EGL
+{
+class CEGLFence;
+}
+}
+}
+
 class CRendererDRMPRIMEGLES : public CLinuxRendererGLES
 {
 public:
@@ -24,14 +38,17 @@ public:
   // CLinuxRendererGLES overrides
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
   void ReleaseBuffer(int index) override;
+  bool NeedBuffer(int index) override;
 
 protected:
   // CLinuxRendererGLES overrides
   bool LoadShadersHook() override;
   bool RenderHook(int index) override;
+  void AfterRenderHook(int index) override;
   bool UploadTexture(int index) override;
   void DeleteTexture(int index) override;
   bool CreateTexture(int index) override;
 
+  std::array<std::unique_ptr<KODI::UTILS::EGL::CEGLFence>, NUM_BUFFERS> m_fences;
   CDRMPRIMETexture m_DRMPRIMETextures[NUM_BUFFERS];
 };

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -169,8 +169,10 @@ if(XSLT_FOUND)
   list(APPEND HEADERS XSLTUtils.h)
 endif()
 if(EGL_FOUND)
-  list(APPEND SOURCES EGLUtils.cpp)
-  list(APPEND HEADERS EGLUtils.h)
+  list(APPEND SOURCES EGLUtils.cpp
+                      EGLFence.cpp)
+  list(APPEND HEADERS EGLUtils.h
+                      EGLFence.h)
 endif()
 
 # The large map trips the clang optimizer

--- a/xbmc/utils/EGLFence.cpp
+++ b/xbmc/utils/EGLFence.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EGLFence.h"
+
+#include "EGLUtils.h"
+
+using namespace KODI::UTILS::EGL;
+
+CEGLFence::CEGLFence(EGLDisplay display) :
+  m_display(display)
+{
+  m_eglCreateSyncKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLCREATESYNCKHRPROC>("eglCreateSyncKHR");
+  m_eglDestroySyncKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLDESTROYSYNCKHRPROC>("eglDestroySyncKHR");
+  m_eglGetSyncAttribKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLGETSYNCATTRIBKHRPROC>("eglGetSyncAttribKHR");
+}
+
+void CEGLFence::CreateFence()
+{
+  m_fence = m_eglCreateSyncKHR(m_display, EGL_SYNC_FENCE_KHR, nullptr);
+  if (m_fence == EGL_NO_SYNC_KHR)
+  {
+    CEGLUtils::LogError("failed to create egl sync fence");
+    throw std::runtime_error("failed to create egl sync fence");
+  }
+}
+
+void CEGLFence::DestroyFence()
+{
+  if (m_fence == EGL_NO_SYNC_KHR)
+  {
+    return;
+  }
+
+  if (m_eglDestroySyncKHR(m_display, m_fence) != EGL_TRUE)
+  {
+    CEGLUtils::LogError("failed to destroy egl sync fence");
+  }
+
+  m_fence = EGL_NO_SYNC_KHR;
+}
+
+bool CEGLFence::IsSignaled()
+{
+  // fence has been destroyed so return true immediately so buffer can be used
+  if (m_fence == EGL_NO_SYNC_KHR)
+  {
+    return true;
+  }
+
+  EGLint status = EGL_UNSIGNALED_KHR;
+  if (m_eglGetSyncAttribKHR(m_display, m_fence, EGL_SYNC_STATUS_KHR, &status) != EGL_TRUE)
+  {
+    CEGLUtils::LogError("failed to query egl sync fence");
+    return false;
+  }
+
+  if (status == EGL_SIGNALED_KHR)
+  {
+    return true;
+  }
+
+  return false;
+}

--- a/xbmc/utils/EGLFence.h
+++ b/xbmc/utils/EGLFence.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+namespace KODI
+{
+namespace UTILS
+{
+namespace EGL
+{
+
+class CEGLFence
+{
+public:
+  explicit CEGLFence(EGLDisplay display);
+  CEGLFence(CEGLFence const& other) = delete;
+  CEGLFence& operator=(CEGLFence const& other) = delete;
+
+  void CreateFence();
+  void DestroyFence();
+  bool IsSignaled();
+
+private:
+  EGLDisplay m_display{nullptr};
+  EGLSyncKHR m_fence{nullptr};
+
+  PFNEGLCREATESYNCKHRPROC m_eglCreateSyncKHR{nullptr};
+  PFNEGLDESTROYSYNCKHRPROC m_eglDestroySyncKHR{nullptr};
+  PFNEGLGETSYNCATTRIBKHRPROC m_eglGetSyncAttribKHR{nullptr};
+};
+
+}
+}
+}


### PR DESCRIPTION
This PR adds a new class `CEGLFence` which has been designed to help using EGL sync objects. This works by inserting a sync object into the command stream and then signaling that sync object when it has been rendered. This allows us to check the signaled status so we can decide if we can reuse the buffer or not. For more information please see [1].

This also updates the VBO's to the more standardized format used in other renderers.

The last commit adds proper override methods for the renderer to properly expose the features and scalers that are able to be use with this renderer.

references:
 1) https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_fence_sync.txt
