### PR TITLE
[guiinfo] Fix crash in CPlayerGUIInfo::GetContentRanges.

### DIFF
--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -625,7 +625,8 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
     for (const auto& range : ranges)
       values += StringUtils::Format("%.5f,%.5f,", range.first, range.second);
 
-    values.pop_back(); // remove trailing comma
+    if (!values.empty())
+      values.pop_back(); // remove trailing comma
   }
 
   return values;


### PR DESCRIPTION
Fixes a crash reported here: https://github.com/xbmc/xbmc/pull/15767#issuecomment-483897491 ff.

`std::string::pop_back()` has undefined behavior if called on an empty string. I tested on Mac and Android, where this worked fine, but Linux seems to crash. Fix is (obviously) to check for empty string before calling pop_back().

Fix confirmed working by @DaVukovic