### PR TITLE
GL: fix HAS_FLOAT_TEXTURE usage

### DIFF
--- a/system/shaders/GL/1.2/gl_convolution-4x4.glsl
+++ b/system/shaders/GL/1.2/gl_convolution-4x4.glsl
@@ -35,7 +35,7 @@ uniform sampler1D kernelTex;
 
 half4 weight(float pos)
 {
-#if (HAS_FLOAT_TEXTURE)
+#if defined(HAS_FLOAT_TEXTURE)
   return texture1D(kernelTex, pos);
 #else
   return texture1D(kernelTex, pos) * 2.0 - 1.0;

--- a/system/shaders/GL/1.2/gl_convolution-6x6.glsl
+++ b/system/shaders/GL/1.2/gl_convolution-6x6.glsl
@@ -35,7 +35,7 @@ uniform sampler1D kernelTex;
 
 half3 weight(float pos)
 {
-#if (HAS_FLOAT_TEXTURE)
+#if defined(HAS_FLOAT_TEXTURE)
   return texture1D(kernelTex, pos).rgb;
 #else
   return texture1D(kernelTex, pos).rgb * 2.0 - 1.0;

--- a/system/shaders/GL/1.5/gl_convolution-4x4.glsl
+++ b/system/shaders/GL/1.5/gl_convolution-4x4.glsl
@@ -18,7 +18,7 @@ uniform sampler1D kernelTex;
 
 half4 weight(float pos)
 {
-#if (HAS_FLOAT_TEXTURE)
+#if defined(HAS_FLOAT_TEXTURE)
   return texture(kernelTex, pos);
 #else
   return texture(kernelTex, pos) * 2.0 - 1.0;

--- a/system/shaders/GL/1.5/gl_convolution-6x6.glsl
+++ b/system/shaders/GL/1.5/gl_convolution-6x6.glsl
@@ -18,7 +18,7 @@ uniform sampler1D kernelTex;
 
 half3 weight(float pos)
 {
-#if (HAS_FLOAT_TEXTURE)
+#if defined(HAS_FLOAT_TEXTURE)
   return texture(kernelTex, pos).rgb;
 #else
   return texture(kernelTex, pos).rgb * 2.0 - 1.0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -84,9 +84,7 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
   }
 
   if (m_floattex)
-    defines = "#define HAS_FLOAT_TEXTURE 1\n";
-  else
-    defines = "#define HAS_FLOAT_TEXTURE 0\n";
+    defines = "#define HAS_FLOAT_TEXTURE\n";
 
   //don't compile in stretch support when it's not needed
   if (stretch)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -99,12 +99,11 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
   if (m_floattex)
   {
     m_internalformat = GL_RGBA16F_EXT;
-    defines = "#define HAS_FLOAT_TEXTURE 1\n";
+    defines = "#define HAS_FLOAT_TEXTURE\n";
   }
   else
   {
     m_internalformat = GL_RGBA;
-    defines = "#define HAS_FLOAT_TEXTURE 0\n";
   }
 
   CLog::Log(LOGDEBUG, "GL: ConvolutionFilterShader: using %s defines:\n%s", shadername.c_str(), defines.c_str());


### PR DESCRIPTION
## Description
In GLES shaders `if defined(HAS_FLOAT_TEXTURE)` was always true as `HAS_FLOAT_TEXTURE` was always defined. Fix this by not defining `HAS_FLOAT_TEXTURE` when target does not support it and amend GL shaders to follow this behaviour.

## Motivation and Context
Found when browsing the code.

## How Has This Been Tested?
LibreELEC master + Kodi master on Amlogic-mainline.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
