### PR TITLE
[cleanup] remove outated iOS version checks

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.cpp
@@ -15,7 +15,6 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/VTB.h"
 #include "settings/MediaSettings.h"
 #include "windowing/ios/WinSystemIOS.h"
-#include "platform/darwin/DarwinUtils.h"
 #include <CoreVideo/CVBuffer.h>
 #include <CoreVideo/CVPixelBuffer.h>
 #include <OpenGLES/ES2/glext.h>
@@ -93,16 +92,9 @@ EShaderFormat CRendererVTB::GetShaderFormat()
 
 bool CRendererVTB::LoadShadersHook()
 {
-  float ios_version = CDarwinUtils::GetIOSVersion();
   CLog::Log(LOGNOTICE, "GL: Using CVBREF render method");
   m_textureTarget = GL_TEXTURE_2D;
   m_renderMethod = RENDER_CUSTOM;
-
-  if (ios_version < 5.0)
-  {
-    CLog::Log(LOGNOTICE, "GL: ios version < 5 is not supported");
-    return false;
-  }
 
   if (!m_textureCache)
   {

--- a/xbmc/platform/darwin/DarwinUtils.h
+++ b/xbmc/platform/darwin/DarwinUtils.h
@@ -22,7 +22,6 @@ public:
   static bool        DeviceHasRetina(double &scale);
   static const char *GetOSReleaseString(void);
   static const char *GetOSVersionString(void);
-  static float       GetIOSVersion(void);
   static const char *GetIOSVersionString(void);
   static const char *GetOSXVersionString(void);
   static int         GetFrameworkPath(bool forPython, char* path, size_t *pathsize);

--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -283,19 +283,6 @@ const char *CDarwinUtils::GetOSVersionString(void)
   return [[[NSProcessInfo processInfo] operatingSystemVersionString] UTF8String];
 }
 
-float CDarwinUtils::GetIOSVersion(void)
-{
-  CCocoaAutoPool pool;
-  float version;
-#if defined(TARGET_DARWIN_IOS)
-  version = [[[UIDevice currentDevice] systemVersion] floatValue];
-#else
-  version = 0.0f;
-#endif
-
-  return(version);
-}
-
 const char *CDarwinUtils::GetIOSVersionString(void)
 {
 #if defined(TARGET_DARWIN_IOS)

--- a/xbmc/platform/darwin/ios/IOSKeyboardView.mm
+++ b/xbmc/platform/darwin/ios/IOSKeyboardView.mm
@@ -9,7 +9,6 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "threads/Event.h"
 #include "Application.h"
-#include "platform/darwin/DarwinUtils.h"
 
 #import "IOSKeyboardView.h"
 #import "IOSScreenManager.h"
@@ -118,14 +117,8 @@ static CEvent keyboardFinishedEvent;
     CGSize headingSize = [_heading.text sizeWithAttributes: @{NSFontAttributeName: [UIFont systemFontOfSize:[UIFont systemFontSize]]}];
     headingW = MIN(self.bounds.size.width/2, headingSize.width+30);
   }
-  CGFloat kbHeight = _kbRect.size.height;
 
-  CGFloat y = kbHeight <= 0 ?
-    _textField.frame.origin.y :
-    MIN(self.bounds.size.height - kbHeight, self.bounds.size.height/5*3) - INPUT_BOX_HEIGHT - SPACE_BETWEEN_INPUT_AND_KEYBOARD;
-
-  if (CDarwinUtils::GetIOSVersion() >= 8.0)
-    y = _kbRect.origin.y - INPUT_BOX_HEIGHT - SPACE_BETWEEN_INPUT_AND_KEYBOARD;
+  CGFloat y = _kbRect.origin.y - INPUT_BOX_HEIGHT - SPACE_BETWEEN_INPUT_AND_KEYBOARD;
 
   _heading.frame = CGRectMake(0, y, headingW, INPUT_BOX_HEIGHT);
   _textField.frame = CGRectMake(headingW, y, self.bounds.size.width-headingW, INPUT_BOX_HEIGHT);

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -32,7 +32,6 @@
 #include "TextureCache.h"
 #undef id
 #include <math.h>
-#include "platform/darwin/DarwinUtils.h"
 
 using namespace KODI::MESSAGING;
 
@@ -567,22 +566,19 @@ XBMCController *g_xbmcController;
 - (void)loadView
 {
   [super loadView];
-  if (CDarwinUtils::GetIOSVersion() >= 8.0)
-  {
-    self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.view.autoresizesSubviews = YES;
+  self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  self.view.autoresizesSubviews = YES;
 
-    m_glView = [[IOSEAGLView alloc] initWithFrame:self.view.bounds withScreen:[UIScreen mainScreen]];
-    [[IOSScreenManager sharedInstance] setView:m_glView];
-    [m_glView setMultipleTouchEnabled:YES];
+  m_glView = [[IOSEAGLView alloc] initWithFrame:self.view.bounds withScreen:[UIScreen mainScreen]];
+  [[IOSScreenManager sharedInstance] setView:m_glView];
+  [m_glView setMultipleTouchEnabled:YES];
 
-    /* Check if screen is Retina */
-    screenScale = [m_glView getScreenScale:[UIScreen mainScreen]];
+  /* Check if screen is Retina */
+  screenScale = [m_glView getScreenScale:[UIScreen mainScreen]];
 
-    [self.view addSubview: m_glView];
+  [self.view addSubview: m_glView];
 
-    [self createGestureRecognizers];
-  }
+  [self createGestureRecognizers];
 }
 //--------------------------------------------------------------
 -(void)viewDidLoad

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -27,9 +27,6 @@
 #if defined(TARGET_DARWIN_OSX)
 #include "platform/darwin/osx/XBMCHelper.h"
 #endif // defined(TARGET_DARWIN_OSX)
-#if defined(TARGET_DARWIN)
-#include "platform/darwin/DarwinUtils.h"
-#endif
 #if defined(TARGET_DARWIN_IOS)
 #include "SettingAddon.h"
 #endif
@@ -608,15 +605,12 @@ void CSettings::InitializeControls()
 void CSettings::InitializeVisibility()
 {
   // hide some settings if necessary
-#if defined(TARGET_DARWIN)
+#if defined(TARGET_DARWIN_IOS)
   std::shared_ptr<CSettingString> timezonecountry = std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_LOCALE_TIMEZONECOUNTRY));
   std::shared_ptr<CSettingString> timezone = std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_LOCALE_TIMEZONE));
 
-  if (CDarwinUtils::GetIOSVersion() >= 4.3)
-  {
-    timezonecountry->SetRequirementsMet(false);
-    timezone->SetRequirementsMet(false);
-  }
+  timezonecountry->SetRequirementsMet(false);
+  timezone->SetRequirementsMet(false);
 #endif
 }
 


### PR DESCRIPTION
## Description
The minimum iOS version is 9.0 so there is no need to check if something higher then x, but not higher then 9.0.

## How Has This Been Tested?
compiled for iOS and OSX

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
