### PR TITLE
LibInputKeyboard: re-add support for KEY_STOP as we had in CLinuxInputDevices

### DIFF
--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -137,7 +137,7 @@ static const std::map<xkb_keysym_t, XBMCKey> xkbMap =
 
   // Media keys
   { XKB_KEY_XF86Eject, XBMCK_EJECT },
-  // XBMCK_STOP clashes with XBMCK_MEDIA_STOP
+  { XKB_KEY_Cancel, XBMCK_STOP },
   { XKB_KEY_XF86AudioRecord, XBMCK_RECORD },
   // XBMCK_REWIND clashes with XBMCK_MEDIA_REWIND
   { XKB_KEY_XF86Phone, XBMCK_PHONE },


### PR DESCRIPTION
## Description

This re-adds support for KEY_STOP which some remotes use.

The issue was discovered when testing a new remote which does not have an eventlircd evmap yet, as events were being picked up via uinput instead of an LIRC socket.

## Motivation and Context

This re-adds support for KEY_STOP which was supported with CLinuxInputDevices in the past.

## How Has This Been Tested?

* Tested on Kodi v18.2 RC-1 without adverse effect

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
