### PR TITLE
[video] Use special sort order when selecting first unwatched

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -271,8 +271,10 @@ int CGUIWindowVideoNav::GetFirstUnwatchedItemIndex(bool includeAllSeasons, bool 
 {
   int iIndex = 0;
   int iUnwatchedSeason = INT_MAX;
+  int iUnwatchedEpisode = INT_MAX;
+  NODE_TYPE nodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_vecItems->GetPath());
 
-  // Run through the list of items and find the season number of the first season with unwatched episodes
+  // Run through the list of items and find the first unwatched season/episode
   for (int i = 0; i < m_vecItems->Size(); ++i)
   {
     CFileItemPtr pItem = m_vecItems->Get(i);
@@ -284,36 +286,29 @@ int CGUIWindowVideoNav::GetFirstUnwatchedItemIndex(bool includeAllSeasons, bool 
     if ((!includeAllSeasons && pTag->m_iSeason < 0) || (!includeSpecials && pTag->m_iSeason == 0))
       continue;
 
-    // Is the season unwatched, and is its season number lower than the currently identified
-    // first unwatched season
-    if (pTag->GetPlayCount() == 0 && pTag->m_iSeason < iUnwatchedSeason)
+    // Use the special sort values if they're available
+    int iSeason = pTag->m_iSpecialSortSeason >= 0 ? pTag->m_iSpecialSortSeason : pTag->m_iSeason;
+    int iEpisode = pTag->m_iSpecialSortEpisode >= 0 ? pTag->m_iSpecialSortEpisode : pTag->m_iEpisode;
+
+    if (nodeType == NODE_TYPE::NODE_TYPE_SEASONS)
     {
-      iUnwatchedSeason = pTag->m_iSeason;
-      iIndex = i;
-    }
-  }
-
-  NODE_TYPE nodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_vecItems->GetPath());
-  if (nodeType == NODE_TYPE::NODE_TYPE_EPISODES)
-  {
-    iIndex = 0;
-    int iUnwatchedEpisode = INT_MAX;
-
-    // Now run through the list of items and check episodes from the season identified above
-    // to find the first (lowest episode number) unwatched episode.
-    for (int i = 0; i < m_vecItems->Size(); ++i)
-    {
-      CFileItemPtr pItem = m_vecItems->Get(i);
-      if (pItem->IsParentFolder() || !pItem->HasVideoInfoTag())
-        continue;
-
-      CVideoInfoTag *pTag = pItem->GetVideoInfoTag();
-
-      // Does the episode belong to the unwatched season and Is the episode unwatched, and is its episode number
-      // lower than the currently identified first unwatched episode
-      if (pTag->m_iSeason == iUnwatchedSeason && pTag->GetPlayCount() == 0 && pTag->m_iEpisode < iUnwatchedEpisode)
+      // Is the season unwatched, and is its season number lower than the currently identified
+      // first unwatched season
+      if (pTag->GetPlayCount() == 0 && iSeason < iUnwatchedSeason)
       {
-        iUnwatchedEpisode = pTag->m_iEpisode;
+        iUnwatchedSeason = iSeason;
+        iIndex = i;
+      }
+    }
+
+    if (nodeType == NODE_TYPE::NODE_TYPE_EPISODES)
+    {
+      // Is the episode unwatched, and is its season number lower
+      // or is its episode number lower within the current season
+      if (pTag->GetPlayCount() == 0 && (iSeason < iUnwatchedSeason || (iSeason == iUnwatchedSeason && iEpisode < iUnwatchedEpisode)))
+      {
+        iUnwatchedSeason = iSeason;
+        iUnwatchedEpisode = iEpisode;
         iIndex = i;
       }
     }


### PR DESCRIPTION
## Description
This PR updates the `GetFirstUnwatchedItemIndex` function to look at `displayseason` and `displayepisode` when determining the order. 

## Motivation and Context
Currently, if `Select first unwatched` is enabled and Specials are included, then the unwatched special episodes are always selected first, regardless of where they're placed amongst the rest of the episodes.

## How Has This Been Tested?
Tested on macOS 10.14 and Xcode 10.2, using:
- `Select first unwatched` set to `Always`
- `Include "All seasons" and "Specials"` set to `Neither` and `Both`

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
