### PR TITLE
Fix / secure 2 code places

### DIFF
--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -417,12 +417,12 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 
 void CGUIDialogMediaSource::OnPath(int item)
 {
-  if (item < 0 || item > m_paths->Size()) return;
-
-  if (m_name != CUtil::GetTitleFromPath(m_paths->Get(item)->GetPath()))
-    m_bNameChanged = true;
+  if (item < 0 || item >= m_paths->Size()) return;
 
   std::string path(m_paths->Get(item)->GetPath());
+  if (m_name != CUtil::GetTitleFromPath(path))
+    m_bNameChanged = true;
+
   CGUIKeyboardFactory::ShowAndGetInput(path, CVariant{ g_localizeStrings.Get(1021) }, false);
   m_paths->Get(item)->SetPath(path);
 

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -136,8 +136,12 @@ int CApplicationMessenger::SendMsg(ThreadMessage&& message, bool wait)
                  //  waitEvent ... just for such contingencies :)
   {
     // ensure the thread doesn't hold the graphics lock
-    CSingleExit exit(CServiceBroker::GetWinSystem()->GetGfxContext());
-    waitEvent->Wait();
+    CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
+    if (winSystem)
+    {
+      CSingleExit exit(winSystem->GetGfxContext());
+      waitEvent->Wait();
+    }
     return *result;
   }
 


### PR DESCRIPTION
## Description
There are 2 reports in Android playstore which provide only minimal information.
This PR fixes one issue and makes one place safer to not segfault badly.

## Motivation and Context
playstore analytics / remove the top rated segfaults

## Stack traces
backtrace:
 ```
 #00  pc 0000000000c017e8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CWinSystemBase::GetGfxContext())
  #01  pc 0000000000d0b9b8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (KODI::MESSAGING::CApplicationMessenger::SendMsg(KODI::MESSAGING::ThreadMessage&&, bool)+776)
  #02  pc 0000000000d0bfa8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (KODI::MESSAGING::CApplicationMessenger::SendMsg(unsigned int, int, int, void*)+92)
  #03  pc 0000000000864fb8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CXBMCApp::XBMC_DestroyDisplay()+64)
  #04  pc 0000000000869fb0  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CXBMCApp::surfaceDestroyed(CJNISurfaceHolder)+100)
  #05  pc 000000000144e5b0  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CJNIXBMCMainView::surfaceDestroyed(CJNISurfaceHolder)+180)
  #06  pc 000000000144e0f8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CJNIXBMCMainView::_surfaceDestroyed(_JNIEnv*, _jobject*, _jobject*)+120)

```
and

```
#00  pc 000000000086a99c  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::basic_string(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+28)
  #01  pc 0000000000fd7f70  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CUtil::ValidatePath(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+20)
  #02  pc 0000000000fcfb28  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CURL::Parse(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+52)
  #03  pc 000000000086aee4  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CURL::CURL(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+76)
  #04  pc 0000000000fd4518  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CUtil::GetTitleFromPath(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+44)
  #05  pc 0000000000e09050  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIDialogMediaSource::OnPath(int)+92)
  #06  pc 0000000000e08ee8  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIDialogMediaSource::OnMessage(CGUIMessage&)+164)
  #07  pc 0000000000d634e4  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIBaseContainer::OnClick(int)+296)
  #08  pc 0000000000d64d44  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIBaseContainer::OnMouseEvent(CPointGen<float> const&, CMouseEvent const&)+228)
  #09  pc 0000000000d6cebc  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIControl::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&)+200)
  #10  pc 0000000000d78914  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&)+224)
  #11  pc 0000000000d78914  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&)+224)
  #12  pc 0000000000dc0d60  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIWindow::OnMouseAction(CAction const&)+332)
  #13  pc 0000000000dc0a3c  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIWindow::OnAction(CAction const&)+76)
  #14  pc 0000000000dc7fd0  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIWindowManager::HandleAction(CAction const&) const+228)
  #15  pc 0000000000dc7eac  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIWindowManager::OnAction(CAction const&) const+128)
  #16  pc 0000000000f46f04  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CApplication::OnAction(CAction const&)+388)
  #17  pc 0000000000dc799c  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CGUIWindowManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage*)+420)
  #18  pc 0000000000d0bc9c  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::ThreadMessage*)+264)
  #19  pc 0000000000d0ceb4  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (KODI::MESSAGING::CApplicationMessenger::ProcessMessages()+164)
  #20  pc 0000000000f5d488  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CApplication::Process()+600)
  #21  pc 0000000000fe1ba8  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CXBApplicationEx::Run(CAppParamParser const&)+152)
  #22  pc 0000000000ceb5b8  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (XBMC_Run+264)
  #23  pc 00000000008642c4  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (CXBMCApp::run()+96)
  #24  pc 000000000086a284  /data/app/org.xbmc.kodi-0aCwlKyr1qO3GgSNbrSeFA==/lib/arm/libkodi.so (void* thread_run<CXBMCApp, &CXBMCApp::run>(void*)+8)

```


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
