### PR TITLE
Fix Sources Path Substitution

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -104,7 +104,7 @@ void CAdvancedSettings::Initialize(const CAppParamParser &params, CSettingsManag
   params.SetAdvancedSettings(*this);
 
   settingsMgr.RegisterSettingOptionsFiller("loggingcomponents", SettingOptionsLoggingComponentsFiller);
-  settingsMgr.RegisterSettingsHandler(this);
+  settingsMgr.RegisterSettingsHandler(this, true);
   std::set<std::string> settingSet;
   settingSet.insert(CSettings::SETTING_DEBUG_SHOWLOGINFO);
   settingSet.insert(CSettings::SETTING_DEBUG_EXTRALOGGING);
@@ -1050,10 +1050,10 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     {
       std::string strFrom, strTo;
       TiXmlNode* pFrom = pSubstitute->FirstChild("from");
-      if (pFrom)
+      if (pFrom && !pFrom->NoChildren())
         strFrom = CSpecialProtocol::TranslatePath(pFrom->FirstChild()->Value()).c_str();
       TiXmlNode* pTo = pSubstitute->FirstChild("to");
-      if (pTo)
+      if (pTo && !pTo->NoChildren())
         strTo = pTo->FirstChild()->Value();
 
       if (!strFrom.empty() && !strTo.empty())

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -423,14 +423,19 @@ void CSettingsManager::RegisterSettingControl(const std::string &controlType, IS
     m_settingControlCreators.insert(std::make_pair(controlType, settingControlCreator));
 }
 
-void CSettingsManager::RegisterSettingsHandler(ISettingsHandler *settingsHandler)
+void CSettingsManager::RegisterSettingsHandler(ISettingsHandler *settingsHandler, bool bFront /* = false */)
 {
   if (settingsHandler == nullptr)
     return;
 
   CExclusiveLock lock(m_critical);
   if (find(m_settingsHandlers.begin(), m_settingsHandlers.end(), settingsHandler) == m_settingsHandlers.end())
-    m_settingsHandlers.push_back(settingsHandler);
+  {
+    if (bFront)
+      m_settingsHandlers.insert(m_settingsHandlers.begin(), settingsHandler);
+    else
+      m_settingsHandlers.emplace_back(settingsHandler);
+  }
 }
 
 void CSettingsManager::UnregisterSettingsHandler(ISettingsHandler *settingsHandler)

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -223,8 +223,9 @@ public:
    \brief Registers the given ISettingsHandler implementation.
 
    \param settingsHandler ISettingsHandler implementation
+   \param bFront If True, insert the handler in front of other registered handlers, insert at the end otherwise.
    */
-  void RegisterSettingsHandler(ISettingsHandler *settingsHandler);
+  void RegisterSettingsHandler(ISettingsHandler *settingsHandler, bool bFront = false);
   /*!
    \brief Unregisters the given ISettingsHandler implementation.
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This fixes the broken media sources path substitution.

The CMediaSourceSettings module loads the media sources before the CAdvancedSettings module loads the path substitutions therefore path substitution fails with CMediaSourceSettings attempting to read the sources.xml file from the local rather than the substituted remote path.

This fix ensures that media sources settings are loaded after advanced settings,

This also fixes a kodi crash when parsing an advancedsettings.xml file which has an empty path substitution 'from' or 'to' node.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Discussion at the forums: https://forum.kodi.tv/showthread.php?tid=336371

The WiKi states that "Path substition for "sources" is broken, and will not be fixed" but it doesn't seem logical not to fix something for which the majority of code still exists:
WiKi Page: https://kodi.wiki/view/Path_substitution


## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested with this advancedsettings.xml file on Windows with remote Windows server:

```
<advancedsettings>
  <pathsubstitution>
    <substitute>
      <from>special://profile/keymaps/</from>
      <to>smb://MEDIASERVER/Shared Media/Kodi/UserData/keymaps/</to>
    </substitute>
    <substitute>
      <from>special://profile/sources.xml</from>
      <to>smb://MEDIASERVER/Shared Media/Kodi/UserData/sources.xml</to>
    </substitute>
    <substitute>
      <from>special://profile/mediasources.xml</from>
      <to>smb://MEDIASERVER/Shared Media/Kodi/UserData/mediasources.xml</to>
    </substitute>
    <substitute>
      <from>special://profile/favourites.xml</from>
      <to>smb://MEDIASERVER/Shared Media/Kodi/UserData/favourites.xml</to>
    </substitute>
  </pathsubstitution>
</advancedsettings>
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
