### PR TITLE
[Android] activate keyframe search

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -963,6 +963,9 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
     m_videobuffer.pts = DVD_NOPTS_VALUE;
 
     m_indexInputBuffer = -1;
+
+    if (m_bitstream)
+      m_bitstream->ResetStartDecode();
   }
 }
 


### PR DESCRIPTION
## Description
Keyframe search for MediaCodec Decoder is currently not working / activated.
This seems to lead to issues for some kind of HEVC streams

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=341201&pid=2847668

## How Has This Been Tested?
Cannot be reproduced with my sample streams - user feedback required.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
