### PR TITLE
CWinSystemGbm: only lock the front buffer if something is rendered

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -207,11 +207,19 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
     m_videoLayerBridge->Disable();
   }
 
-  struct gbm_bo *bo = m_GBM->LockFrontBuffer();
+  struct gbm_bo *bo = nullptr;
+
+  if (rendered)
+  {
+    bo = m_GBM->LockFrontBuffer();
+  }
 
   m_DRM->FlipPage(bo, rendered, videoLayer);
 
-  m_GBM->ReleaseBuffer();
+  if (rendered)
+  {
+    m_GBM->ReleaseBuffer();
+  }
 
   if (m_videoLayerBridge && !videoLayer)
   {


### PR DESCRIPTION
We shouldn't be locking the front buffer if there isn't anything to be rendered (ie. when only a video plane is active).

Not having this will produce a lot of debug log spam when egl debugging is enabled.