### PR TITLE
VideoBufferDRMPRIME: extract video buffer interface

### DIFF
--- a/cmake/treedata/optional/common/gbm.txt
+++ b/cmake/treedata/optional/common/gbm.txt
@@ -1,2 +1,3 @@
 xbmc/cores/RetroPlayer/process/gbm cores/RetroPlayer/process/gbm # GBM
+xbmc/cores/VideoPlayer/Process/gbm cores/VideoPlayer/Process/gbm # GBM
 xbmc/windowing/gbm windowing/gbm # GBM

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
+#include "cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -23,137 +24,6 @@ extern "C" {
 }
 
 using namespace KODI::WINDOWING::GBM;
-
-//------------------------------------------------------------------------------
-// Video Buffers
-//------------------------------------------------------------------------------
-
-CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
-  : CVideoBuffer(id)
-{
-  m_pFrame = av_frame_alloc();
-}
-
-CVideoBufferDRMPRIME::~CVideoBufferDRMPRIME()
-{
-  Unref();
-  av_frame_free(&m_pFrame);
-}
-
-void CVideoBufferDRMPRIME::SetRef(AVFrame* frame)
-{
-  av_frame_move_ref(m_pFrame, frame);
-}
-
-void CVideoBufferDRMPRIME::Unref()
-{
-  av_frame_unref(m_pFrame);
-}
-
-int CVideoBufferDRMPRIME::GetColorEncoding() const
-{
-  switch (m_pFrame->colorspace)
-  {
-    case AVCOL_SPC_BT2020_CL:
-    case AVCOL_SPC_BT2020_NCL:
-      return DRM_COLOR_YCBCR_BT2020;
-    case AVCOL_SPC_SMPTE170M:
-    case AVCOL_SPC_BT470BG:
-    case AVCOL_SPC_FCC:
-      return DRM_COLOR_YCBCR_BT601;
-    case AVCOL_SPC_BT709:
-      return DRM_COLOR_YCBCR_BT709;
-    case AVCOL_SPC_RESERVED:
-    case AVCOL_SPC_UNSPECIFIED:
-    default:
-      if (m_pFrame->width > 1024 || m_pFrame->height >= 600)
-        return DRM_COLOR_YCBCR_BT709;
-      else
-        return DRM_COLOR_YCBCR_BT601;
-  }
-}
-
-int CVideoBufferDRMPRIME::GetColorRange() const
-{
-  switch (m_pFrame->color_range)
-  {
-    case AVCOL_RANGE_JPEG:
-      return DRM_COLOR_YCBCR_FULL_RANGE;
-    case AVCOL_RANGE_MPEG:
-    default:
-      return DRM_COLOR_YCBCR_LIMITED_RANGE;
-  }
-}
-
-//------------------------------------------------------------------------------
-
-class CVideoBufferPoolDRMPRIME
-  : public IVideoBufferPool
-{
-public:
-  ~CVideoBufferPoolDRMPRIME();
-  void Return(int id) override;
-  CVideoBuffer* Get() override;
-
-protected:
-  CCriticalSection m_critSection;
-  std::vector<CVideoBufferDRMPRIME*> m_all;
-  std::deque<int> m_used;
-  std::deque<int> m_free;
-};
-
-CVideoBufferPoolDRMPRIME::~CVideoBufferPoolDRMPRIME()
-{
-  for (auto buf : m_all)
-    delete buf;
-}
-
-CVideoBuffer* CVideoBufferPoolDRMPRIME::Get()
-{
-  CSingleLock lock(m_critSection);
-
-  CVideoBufferDRMPRIME* buf = nullptr;
-  if (!m_free.empty())
-  {
-    int idx = m_free.front();
-    m_free.pop_front();
-    m_used.push_back(idx);
-    buf = m_all[idx];
-  }
-  else
-  {
-    int id = m_all.size();
-    buf = new CVideoBufferDRMPRIME(*this, id);
-    m_all.push_back(buf);
-    m_used.push_back(id);
-  }
-
-  buf->Acquire(GetPtr());
-  return buf;
-}
-
-void CVideoBufferPoolDRMPRIME::Return(int id)
-{
-  CSingleLock lock(m_critSection);
-
-  m_all[id]->Unref();
-  auto it = m_used.begin();
-  while (it != m_used.end())
-  {
-    if (*it == id)
-    {
-      m_used.erase(it);
-      break;
-    }
-    else
-      ++it;
-  }
-  m_free.push_back(id);
-}
-
-//------------------------------------------------------------------------------
-// main class
-//------------------------------------------------------------------------------
 
 CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
   : CDVDVideoCodec(processInfo)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -13,45 +13,6 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "cores/VideoPlayer/Process/VideoBuffer.h"
 
-extern "C" {
-#include <libavutil/frame.h>
-#include <libavutil/hwcontext_drm.h>
-}
-
-// Color enums is copied from linux include/drm/drm_color_mgmt.h (strangely not part of uapi)
-enum drm_color_encoding {
-  DRM_COLOR_YCBCR_BT601,
-  DRM_COLOR_YCBCR_BT709,
-  DRM_COLOR_YCBCR_BT2020,
-};
-enum drm_color_range {
-  DRM_COLOR_YCBCR_LIMITED_RANGE,
-  DRM_COLOR_YCBCR_FULL_RANGE,
-};
-
-class CVideoBufferPoolDRMPRIME;
-
-class CVideoBufferDRMPRIME
-  : public CVideoBuffer
-{
-public:
-  CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id);
-  ~CVideoBufferDRMPRIME();
-  void SetRef(AVFrame* frame);
-  void Unref();
-
-  uint32_t m_fb_id = 0;
-  uint32_t m_handles[AV_DRM_MAX_PLANES] = {0};
-
-  AVDRMFrameDescriptor* GetDescriptor() const { return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]); }
-  uint32_t GetWidth() const { return m_pFrame->width; }
-  uint32_t GetHeight() const { return m_pFrame->height; }
-  int GetColorEncoding() const;
-  int GetColorRange() const;
-protected:
-  AVFrame* m_pFrame = nullptr;
-};
-
 class CDVDVideoCodecDRMPRIME
   : public CDVDVideoCodec
 {
@@ -80,5 +41,5 @@ protected:
   int m_codecControlFlags = 0;
   AVCodecContext* m_pCodecContext = nullptr;
   AVFrame* m_pFrame = nullptr;
-  std::shared_ptr<CVideoBufferPoolDRMPRIME> m_videoBufferPool;
+  std::shared_ptr<IVideoBufferPool> m_videoBufferPool;
 };

--- a/xbmc/cores/VideoPlayer/Process/gbm/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Process/gbm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES ProcessInfoGBM.cpp)
+
+set(HEADERS ProcessInfoGBM.h)
+
+core_add_library(processGBM)

--- a/xbmc/cores/VideoPlayer/Process/gbm/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Process/gbm/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES ProcessInfoGBM.cpp)
+set(SOURCES ProcessInfoGBM.cpp
+            VideoBufferDRMPRIME.cpp)
 
-set(HEADERS ProcessInfoGBM.h)
+set(HEADERS ProcessInfoGBM.h
+            VideoBufferDRMPRIME.h)
 
 core_add_library(processGBM)

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ProcessInfoGBM.h"
+
+using namespace VIDEOPLAYER;
+
+CProcessInfo* CProcessInfoGBM::Create()
+{
+  return new CProcessInfoGBM();
+}
+
+void CProcessInfoGBM::Register()
+{
+  CProcessInfo::RegisterProcessControl("gbm", CProcessInfoGBM::Create);
+}
+
+CProcessInfoGBM::CProcessInfoGBM()
+{
+}
+
+EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
+{
+#if defined(__arm__)
+  return EINTERLACEMETHOD::VS_INTERLACEMETHOD_DEINTERLACE_HALF;
+#else
+  return CProcessInfo::GetFallbackDeintMethod();
+#endif
+}

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/IPlayer.h"
+#include "cores/VideoPlayer/Process/ProcessInfo.h"
+
+namespace VIDEOPLAYER
+{
+
+class CProcessInfoGBM : public CProcessInfo
+{
+public:
+  CProcessInfoGBM();
+  static CProcessInfo* Create();
+  static void Register();
+  EINTERLACEMETHOD GetFallbackDeintMethod() override;
+};
+
+} // namespace VIDEOPLAYER

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -16,8 +16,13 @@ extern "C"
 #include <libavutil/pixdesc.h>
 }
 
-CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
+IVideoBufferDRMPRIME::IVideoBufferDRMPRIME(int id)
   : CVideoBuffer(id)
+{
+}
+
+CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
+  : IVideoBufferDRMPRIME(id)
 {
   m_pFrame = av_frame_alloc();
 }

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoBufferDRMPRIME.h"
+
+#include "threads/SingleLock.h"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavutil/pixdesc.h>
+}
+
+CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
+  : CVideoBuffer(id)
+{
+  m_pFrame = av_frame_alloc();
+}
+
+CVideoBufferDRMPRIME::~CVideoBufferDRMPRIME()
+{
+  Unref();
+  av_frame_free(&m_pFrame);
+}
+
+void CVideoBufferDRMPRIME::SetRef(AVFrame* frame)
+{
+  av_frame_move_ref(m_pFrame, frame);
+}
+
+void CVideoBufferDRMPRIME::Unref()
+{
+  av_frame_unref(m_pFrame);
+}
+
+int CVideoBufferDRMPRIME::GetColorEncoding() const
+{
+  switch (m_pFrame->colorspace)
+  {
+  case AVCOL_SPC_BT2020_CL:
+  case AVCOL_SPC_BT2020_NCL:
+    return DRM_COLOR_YCBCR_BT2020;
+  case AVCOL_SPC_SMPTE170M:
+  case AVCOL_SPC_BT470BG:
+  case AVCOL_SPC_FCC:
+    return DRM_COLOR_YCBCR_BT601;
+  case AVCOL_SPC_BT709:
+    return DRM_COLOR_YCBCR_BT709;
+  case AVCOL_SPC_RESERVED:
+  case AVCOL_SPC_UNSPECIFIED:
+  default:
+    if (m_pFrame->width > 1024 || m_pFrame->height >= 600)
+      return DRM_COLOR_YCBCR_BT709;
+    else
+      return DRM_COLOR_YCBCR_BT601;
+  }
+}
+
+int CVideoBufferDRMPRIME::GetColorRange() const
+{
+  switch (m_pFrame->color_range)
+  {
+  case AVCOL_RANGE_JPEG:
+    return DRM_COLOR_YCBCR_FULL_RANGE;
+  case AVCOL_RANGE_MPEG:
+  default:
+    return DRM_COLOR_YCBCR_LIMITED_RANGE;
+  }
+}
+
+CVideoBufferPoolDRMPRIME::~CVideoBufferPoolDRMPRIME()
+{
+  for (auto buf : m_all)
+    delete buf;
+}
+
+CVideoBuffer* CVideoBufferPoolDRMPRIME::Get()
+{
+  CSingleLock lock(m_critSection);
+
+  CVideoBufferDRMPRIME* buf = nullptr;
+  if (!m_free.empty())
+  {
+    int idx = m_free.front();
+    m_free.pop_front();
+    m_used.push_back(idx);
+    buf = m_all[idx];
+  }
+  else
+  {
+    int id = m_all.size();
+    buf = new CVideoBufferDRMPRIME(*this, id);
+    m_all.push_back(buf);
+    m_used.push_back(id);
+  }
+
+  buf->Acquire(GetPtr());
+  return buf;
+}
+
+void CVideoBufferPoolDRMPRIME::Return(int id)
+{
+  CSingleLock lock(m_critSection);
+
+  m_all[id]->Unref();
+  auto it = m_used.begin();
+  while (it != m_used.end())
+  {
+    if (*it == id)
+    {
+      m_used.erase(it);
+      break;
+    }
+    else
+      ++it;
+  }
+  m_free.push_back(id);
+}

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -78,6 +78,12 @@ int CVideoBufferDRMPRIME::GetColorRange() const
   }
 }
 
+bool CVideoBufferDRMPRIME::IsValid() const
+{
+  AVDRMFrameDescriptor* descriptor = GetDescriptor();
+  return descriptor && descriptor->nb_layers;
+}
+
 CVideoBufferPoolDRMPRIME::~CVideoBufferPoolDRMPRIME()
 {
   for (auto buf : m_all)

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -47,6 +47,16 @@ public:
     return DRM_COLOR_YCBCR_LIMITED_RANGE;
   };
 
+  virtual bool IsValid() const
+  {
+    return true;
+  };
+  virtual bool Map()
+  {
+    return true;
+  };
+  virtual void Unmap() {};
+
   uint32_t m_fb_id = 0;
   uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
 
@@ -76,6 +86,8 @@ public:
   }
   int GetColorEncoding() const override;
   int GetColorRange() const override;
+
+  bool IsValid() const override;
 
 protected:
   AVFrame* m_pFrame = nullptr;

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -29,7 +29,32 @@ enum drm_color_range
   DRM_COLOR_YCBCR_FULL_RANGE,
 };
 
-class CVideoBufferDRMPRIME : public CVideoBuffer
+class IVideoBufferDRMPRIME : public CVideoBuffer
+{
+public:
+  IVideoBufferDRMPRIME() = delete;
+  virtual ~IVideoBufferDRMPRIME() = default;
+
+  virtual AVDRMFrameDescriptor* GetDescriptor() const = 0;
+  virtual uint32_t GetWidth() const = 0;
+  virtual uint32_t GetHeight() const = 0;
+  virtual int GetColorEncoding() const
+  {
+    return DRM_COLOR_YCBCR_BT709;
+  };
+  virtual int GetColorRange() const
+  {
+    return DRM_COLOR_YCBCR_LIMITED_RANGE;
+  };
+
+  uint32_t m_fb_id = 0;
+  uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
+
+protected:
+  explicit IVideoBufferDRMPRIME(int id);
+};
+
+class CVideoBufferDRMPRIME : public IVideoBufferDRMPRIME
 {
 public:
   CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id);
@@ -37,23 +62,20 @@ public:
   void SetRef(AVFrame* frame);
   void Unref();
 
-  uint32_t m_fb_id = 0;
-  uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
-
-  AVDRMFrameDescriptor* GetDescriptor() const
+  AVDRMFrameDescriptor* GetDescriptor() const override
   {
     return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]);
   }
-  uint32_t GetWidth() const
+  uint32_t GetWidth() const override
   {
     return m_pFrame->width;
   }
-  uint32_t GetHeight() const
+  uint32_t GetHeight() const override
   {
     return m_pFrame->height;
   }
-  int GetColorEncoding() const;
-  int GetColorRange() const;
+  int GetColorEncoding() const override;
+  int GetColorRange() const override;
 
 protected:
   AVFrame* m_pFrame = nullptr;

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Process/VideoBuffer.h"
+
+extern "C"
+{
+#include <libavutil/frame.h>
+#include <libavutil/hwcontext_drm.h>
+}
+
+// Color enums is copied from linux include/drm/drm_color_mgmt.h (strangely not part of uapi)
+enum drm_color_encoding
+{
+  DRM_COLOR_YCBCR_BT601,
+  DRM_COLOR_YCBCR_BT709,
+  DRM_COLOR_YCBCR_BT2020,
+};
+enum drm_color_range
+{
+  DRM_COLOR_YCBCR_LIMITED_RANGE,
+  DRM_COLOR_YCBCR_FULL_RANGE,
+};
+
+class CVideoBufferDRMPRIME : public CVideoBuffer
+{
+public:
+  CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id);
+  ~CVideoBufferDRMPRIME();
+  void SetRef(AVFrame* frame);
+  void Unref();
+
+  uint32_t m_fb_id = 0;
+  uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
+
+  AVDRMFrameDescriptor* GetDescriptor() const
+  {
+    return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]);
+  }
+  uint32_t GetWidth() const
+  {
+    return m_pFrame->width;
+  }
+  uint32_t GetHeight() const
+  {
+    return m_pFrame->height;
+  }
+  int GetColorEncoding() const;
+  int GetColorRange() const;
+
+protected:
+  AVFrame* m_pFrame = nullptr;
+};
+
+class CVideoBufferPoolDRMPRIME : public IVideoBufferPool
+{
+public:
+  ~CVideoBufferPoolDRMPRIME();
+  void Return(int id) override;
+  CVideoBuffer* Get() override;
+
+protected:
+  CCriticalSection m_critSection;
+  std::vector<CVideoBufferDRMPRIME*> m_all;
+  std::deque<int> m_used;
+  std::deque<int> m_free;
+};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -15,7 +15,7 @@ void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
   m_eglImage.reset(new CEGLImage(eglDisplay));
 }
 
-bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME *buffer)
+bool CDRMPRIMETexture::Map(IVideoBufferDRMPRIME* buffer)
 {
   if (m_primebuffer)
     return true;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -20,6 +20,9 @@ bool CDRMPRIMETexture::Map(IVideoBufferDRMPRIME* buffer)
   if (m_primebuffer)
     return true;
 
+  if (!buffer->Map())
+    return false;
+
   m_texWidth = buffer->GetWidth();
   m_texHeight = buffer->GetHeight();
 
@@ -73,6 +76,8 @@ void CDRMPRIMETexture::Unmap()
   m_eglImage->DestroyImage();
 
   glDeleteTextures(1, &m_texture);
+
+  m_primebuffer->Unmap();
 
   m_primebuffer->Release();
   m_primebuffer = nullptr;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h"
 #include "utils/EGLImage.h"
+#include "utils/Geometry.h"
 
 #include "system_gl.h"
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -17,7 +17,7 @@
 class CDRMPRIMETexture
 {
 public:
-  bool Map(CVideoBufferDRMPRIME *buffer);
+  bool Map(IVideoBufferDRMPRIME* buffer);
   void Unmap();
   void Init(EGLDisplay eglDisplay);
 
@@ -25,7 +25,7 @@ public:
   CSizeInt GetTextureSize() { return { m_texWidth, m_texHeight }; }
 
 protected:
-  CVideoBufferDRMPRIME *m_primebuffer{nullptr};
+  IVideoBufferDRMPRIME* m_primebuffer{nullptr};
   std::unique_ptr<CEGLImage> m_eglImage;
 
   const GLenum m_textureTarget{GL_TEXTURE_EXTERNAL_OES};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -35,7 +35,7 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 {
-  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer) &&
+  if (buffer && dynamic_cast<IVideoBufferDRMPRIME*>(buffer) &&
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
     CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
@@ -133,7 +133,7 @@ bool CRendererDRMPRIME::NeedBuffer(int index)
   if (m_iLastRenderBuffer == index)
     return true;
 
-  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
+  IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
   if (buffer && buffer->m_fb_id)
     return true;
 
@@ -163,7 +163,7 @@ void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned
     return;
   }
 
-  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
+  IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
   if (!buffer)
     return;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -8,20 +8,21 @@
 
 #include "RendererDRMPRIME.h"
 
-#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "ServiceBroker.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
-#include "settings/lib/Setting.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "utils/log.h"
+#include "windowing/GraphicContext.h"
 #include "windowing/gbm/DRMAtomic.h"
 #include "windowing/gbm/WinSystemGbm.h"
-#include "windowing/GraphicContext.h"
-#include "ServiceBroker.h"
 
 using namespace KODI::WINDOWING::GBM;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -164,11 +164,7 @@ void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned
   }
 
   IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
-  if (!buffer)
-    return;
-
-  AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
-  if (!descriptor || !descriptor->nb_layers)
+  if (!buffer || !buffer->IsValid())
     return;
 
   if (!m_videoLayerBridge)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -25,7 +25,7 @@ CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 
 CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
 {
-  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer))
+  if (buffer && dynamic_cast<IVideoBufferDRMPRIME*>(buffer))
     return new CRendererDRMPRIMEGLES();
 
   return nullptr;
@@ -99,7 +99,7 @@ bool CRendererDRMPRIMEGLES::UploadTexture(int index)
 {
   CPictureBuffer &buf = m_buffers[index];
 
-  CVideoBufferDRMPRIME *buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
+  IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(buf.videoBuffer);
 
   if (!buffer)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -101,7 +101,7 @@ bool CRendererDRMPRIMEGLES::UploadTexture(int index)
 
   IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(buf.videoBuffer);
 
-  if (!buffer)
+  if (!buffer || !buffer->IsValid())
   {
     CLog::Log(LOGNOTICE, "CRendererDRMPRIMEGLES::%s - no buffer", __FUNCTION__);
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -8,7 +8,7 @@
 
 #include "VideoLayerBridgeDRMPRIME.h"
 
-#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h"
 #include "utils/log.h"
 #include "windowing/gbm/DRMUtils.h"
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -33,7 +33,7 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
 }
 
-void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Acquire(IVideoBufferDRMPRIME* buffer)
 {
   // release the buffer that is no longer presented on screen
   Release(m_prev_buffer);
@@ -46,7 +46,7 @@ void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
   m_buffer->Acquire();
 }
 
-void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Release(IVideoBufferDRMPRIME* buffer)
 {
   if (!buffer)
     return;
@@ -55,7 +55,7 @@ void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
   buffer->Release();
 }
 
-bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
+bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
 {
   if (buffer->m_fb_id)
     return true;
@@ -108,7 +108,7 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
   return true;
 }
 
-void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Unmap(IVideoBufferDRMPRIME* buffer)
 {
   if (buffer->m_fb_id)
   {
@@ -127,7 +127,7 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
   }
 }
 
-void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Configure(IVideoBufferDRMPRIME* buffer)
 {
   struct plane* plane = m_DRM->GetVideoPlane();
   if (m_DRM->SupportsProperty(plane, "COLOR_ENCODING") &&
@@ -138,7 +138,7 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   }
 }
 
-void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)
+void CVideoLayerBridgeDRMPRIME::SetVideoPlane(IVideoBufferDRMPRIME* buffer, const CRect& destRect)
 {
   if (!Map(buffer))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -60,6 +60,9 @@ bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
   if (buffer->m_fb_id)
     return true;
 
+  if (!buffer->Map())
+    return false;
+
   AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
   uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0}, flags = 0;
   uint64_t modifier[4] = {0};
@@ -125,6 +128,8 @@ void CVideoLayerBridgeDRMPRIME::Unmap(IVideoBufferDRMPRIME* buffer)
       buffer->m_handles[i] = 0;
     }
   }
+
+  buffer->Unmap();
 }
 
 void CVideoLayerBridgeDRMPRIME::Configure(IVideoBufferDRMPRIME* buffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -24,7 +24,7 @@ namespace GBM
 }
 }
 
-class CVideoBufferDRMPRIME;
+class IVideoBufferDRMPRIME;
 
 class CVideoLayerBridgeDRMPRIME
   : public KODI::WINDOWING::GBM::CVideoLayerBridge
@@ -34,19 +34,19 @@ public:
   ~CVideoLayerBridgeDRMPRIME();
   void Disable() override;
 
-  virtual void Configure(CVideoBufferDRMPRIME* buffer);
-  virtual void SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect);
+  virtual void Configure(IVideoBufferDRMPRIME* buffer);
+  virtual void SetVideoPlane(IVideoBufferDRMPRIME* buffer, const CRect& destRect);
   virtual void UpdateVideoPlane();
 
 protected:
   std::shared_ptr<KODI::WINDOWING::GBM::CDRMUtils> m_DRM;
 
 private:
-  void Acquire(CVideoBufferDRMPRIME* buffer);
-  void Release(CVideoBufferDRMPRIME* buffer);
-  bool Map(CVideoBufferDRMPRIME* buffer);
-  void Unmap(CVideoBufferDRMPRIME* buffer);
+  void Acquire(IVideoBufferDRMPRIME* buffer);
+  void Release(IVideoBufferDRMPRIME* buffer);
+  bool Map(IVideoBufferDRMPRIME* buffer);
+  void Unmap(IVideoBufferDRMPRIME* buffer);
 
-  CVideoBufferDRMPRIME* m_buffer = nullptr;
-  CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
+  IVideoBufferDRMPRIME* m_buffer = nullptr;
+  IVideoBufferDRMPRIME* m_prev_buffer = nullptr;
 };

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -14,6 +14,7 @@
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGBM.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
+#include "cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 
@@ -65,6 +66,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   CRendererDRMPRIMEGLES::Register();
   CRendererDRMPRIME::Register();
   CDVDVideoCodecDRMPRIME::Register();
+  VIDEOPLAYER::CProcessInfoGBM::Register();
 
   return true;
 }


### PR DESCRIPTION
## Description
This PR moves `CVideoBufferDRMPRIME` code, extracts a new `IVideoBufferDRMPRIME` interface and adds `Map`/`Unmap` callbacks.
`ProcessInfoGBM` is also registered with GBM GLES to use Deinterlace Half as fallback on arm devices (current fallback used for rpi, amlogic and android).

@lrusak please test this with your onging vaapi work, gem close is needed or v4l2 buffers is never released.

## Motivation and Context
Preparations to be able to use direct-to-plane rendering with sw decoded video.

## How Has This Been Tested?
Tested on LibreELEC using Rockchip and Allwinner devices.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
