### PR TITLE
DVDVideoCodecDRMPRIME: update process info in get format callback

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -220,11 +220,17 @@ static const AVCodec* FindDecoder(CDVDStreamInfo& hints)
   return nullptr;
 }
 
-static enum AVPixelFormat GetFormat(struct AVCodecContext* avctx, const enum AVPixelFormat* fmt)
+enum AVPixelFormat CDVDVideoCodecDRMPRIME::GetFormat(struct AVCodecContext* avctx, const enum AVPixelFormat* fmt)
 {
   for (int n = 0; fmt[n] != AV_PIX_FMT_NONE; n++)
+  {
     if (fmt[n] == AV_PIX_FMT_DRM_PRIME)
+    {
+      CDVDVideoCodecDRMPRIME* ctx = static_cast<CDVDVideoCodecDRMPRIME*>(avctx->opaque);
+      ctx->UpdateProcessInfo(avctx, fmt[n]);
       return fmt[n];
+    }
+  }
 
   return AV_PIX_FMT_NONE;
 }
@@ -259,6 +265,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   }
 
   m_pCodecContext->pix_fmt = AV_PIX_FMT_DRM_PRIME;
+  m_pCodecContext->opaque = static_cast<void*>(this);
   m_pCodecContext->get_format = GetFormat;
   m_pCodecContext->codec_tag = hints.codec_tag;
   m_pCodecContext->coded_width = hints.width;
@@ -281,20 +288,25 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
     return false;
   }
 
-  const char* pixFmtName = av_get_pix_fmt_name(m_pCodecContext->pix_fmt);
-  m_processInfo.SetVideoPixelFormat(pixFmtName ? pixFmtName : "");
-  m_processInfo.SetVideoDimensions(hints.width, hints.height);
+  UpdateProcessInfo(m_pCodecContext, m_pCodecContext->pix_fmt);
   m_processInfo.SetVideoDeintMethod("none");
   m_processInfo.SetVideoDAR(hints.aspect);
 
-  if (pCodec->name)
-    m_name = std::string("ff-") + pCodec->name;
+  return true;
+}
+
+void CDVDVideoCodecDRMPRIME::UpdateProcessInfo(struct AVCodecContext* avctx, const enum AVPixelFormat pix_fmt)
+{
+  const char* pixFmtName = av_get_pix_fmt_name(pix_fmt);
+  m_processInfo.SetVideoPixelFormat(pixFmtName ? pixFmtName : "");
+  m_processInfo.SetVideoDimensions(avctx->coded_width, avctx->coded_height);
+
+  if (avctx->codec && avctx->codec->name)
+    m_name = std::string("ff-") + avctx->codec->name;
   else
     m_name = "ffmpeg";
 
-  m_processInfo.SetVideoDecoderName(m_name, true);
-
-  return true;
+  m_processInfo.SetVideoDecoderName(m_name, pix_fmt == AV_PIX_FMT_DRM_PRIME);
 }
 
 bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -281,13 +281,6 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
     return false;
   }
 
-  if (m_pCodecContext->pix_fmt != AV_PIX_FMT_DRM_PRIME)
-  {
-    CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unexpected pix fmt %s", __FUNCTION__, av_get_pix_fmt_name(m_pCodecContext->pix_fmt));
-    avcodec_free_context(&m_pCodecContext);
-    return false;
-  }
-
   const char* pixFmtName = av_get_pix_fmt_name(m_pCodecContext->pix_fmt);
   m_processInfo.SetVideoPixelFormat(pixFmtName ? pixFmtName : "");
   m_processInfo.SetVideoDimensions(hints.width, hints.height);
@@ -412,9 +405,18 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
 
   SetPictureParams(pVideoPicture);
 
-  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_videoBufferPool->Get());
-  buffer->SetRef(m_pFrame);
-  pVideoPicture->videoBuffer = buffer;
+  if (m_pFrame->format == AV_PIX_FMT_DRM_PRIME)
+  {
+    CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_videoBufferPool->Get());
+    buffer->SetRef(m_pFrame);
+    pVideoPicture->videoBuffer = buffer;
+  }
+
+  if (!pVideoPicture->videoBuffer)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__, av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
+    return VC_ERROR;
+  }
 
   return VC_PICTURE;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -73,6 +73,8 @@ public:
 protected:
   void Drain();
   void SetPictureParams(VideoPicture* pVideoPicture);
+  void UpdateProcessInfo(struct AVCodecContext* avctx, const enum AVPixelFormat fmt);
+  static enum AVPixelFormat GetFormat(struct AVCodecContext* avctx, const enum AVPixelFormat* fmt);
 
   std::string m_name;
   int m_codecControlFlags = 0;


### PR DESCRIPTION
## Description
This PR adds support for using ~~threads when decoding~~, changes to update process info in get format callback and fixes a potential issue in case v4l2 request api hwaccel fails to init and sw pix fmt is used.

## Motivation and Context
Fixes wrong info in process info dialog (pix fmt, hw/sw) in some cases and prepares for sw decode fallback in case hwaccel fails to init.

## How Has This Been Tested?
Tested on Allwinner and Rockchip devices using LibreELEC and mainline kernel.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
