### PR TITLE
[Android] Check for icon stride instead assuming 4 BPP

### DIFF
--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -128,8 +128,15 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
 
   AndroidBitmapInfo info;
   AndroidBitmap_getInfo(env, bmp.get_raw(), &info);
+
   if (!info.width || !info.height)
     return 0;
+
+  if (info.stride != info.width * 4)
+  {
+    CLog::Log(LOGWARNING, "CFileAndroidApp::ReadIcon: Usupported icon format %d", info.format);
+    return 0;
+  }
 
   *width = info.width;
   *height = info.height;


### PR DESCRIPTION
## Description
AndroidIcon read method assumes 4 byte per pixel icons.
We read currently ahead the provided source if pixel size is smaller.
This PR checks for this

## Motivation and Context
playstore

```
  #00  pc 000000000000f6b4  /system/lib/libc.so (__memcpy_base+92)
  #01  pc 0000000001447c0c  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (XFILE::CFileAndroidApp::ReadIcon(unsigned char**, unsigned int*, unsigned int*)+552)
  #02  pc 0000000000dd5670  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CBaseTexture::LoadFromFile(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, unsigned int, unsigned int, bool, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)+120)
  #03  pc 0000000000fa2224  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CImageLoader::DoWork()+344)
  #04  pc 0000000000c530ec  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CJobWorker::Process()+168)
  #05  pc 0000000000cc3d38  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CThread::Action()+40)
  #06  pc 0000000000cc2dc8  /data/app/org.xbmc.kodi-1/lib/arm/libkodi.so (CThread::staticThread(void*)+200)
  #07  pc 0000000000012f33  /system/lib/libc.so (__pthread_start(void*)+30)
  #08  pc 0000000000010ff7  /system/lib/libc.so (__start_thread+6)
```

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
