### PR TITLE
VideoPlayerCodec: Ask Demuxer to seek for us

### DIFF
--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -213,10 +213,10 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   m_bCanSeek = false;
   if (m_pInputStream->Seek(0, SEEK_POSSIBLE))
   {
-    if (Seek(1))
+    if (m_pDemuxer->SeekTime(1, true))
     {
       // rewind stream to beginning
-      Seek(0);
+      m_pDemuxer->SeekTime(0, true);
       m_bCanSeek = true;
     }
     else


### PR DESCRIPTION
Fixes: https://github.com/xbmc/xbmc/issues/15945

Short summary:
Avoid flushing and resetting of codec by using Demuxer's seek capability