### PR TITLE
Use fanart to hide spoilers if available

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -360,7 +360,15 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
       !setting->FindIntInList(CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE)
      )
   {
-    pItem->SetArt("thumb", "OverlaySpoiler.png");
+    // use fanart if available
+    if(pItem->HasArt("fanart"))
+    {
+      pItem->SetArt("thumb", pItem->GetArt("fanart"));
+    }
+    else
+    {
+      pItem->SetArt("thumb", "OverlaySpoiler.png");
+    }
   }
 
   m_videoDatabase->Close();


### PR DESCRIPTION
## Description
Currently if thumbnails are hidden to prevent spoilers a generic OverlaySoiler image are shown instead of the thumbnail. In my opinion it would look way better if the fanart of the show is displayed instead of this, this pull requests implements this change. Of course maybe this only my opinion, so I'm open for suggestions, maybe it should be put behind a setting.

## Motivation and Context
I'm a long time user of trakt.tv where the hiding of spoilers are achieved with the fanart, that's the source of this idea. Also it helps the visual identification of the show especially in the recently added section.

## How Has This Been Tested?
Manually by checking on the GUI.

## Screenshots (if appropriate):
With the old behavior:
![image](https://user-images.githubusercontent.com/6945600/56762965-6e557280-67a1-11e9-8f7a-604fa6dc8e91.png)

With the new behavior:
![image](https://user-images.githubusercontent.com/6945600/56763015-904ef500-67a1-11e9-8a1f-4c4a34c49223.png)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

I marked it as improvement, but it can be also a "new feature"

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
