### PR TITLE
[Music]Tell user that scanning is in progress if try to scan another source

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -673,7 +673,11 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     return true;
 
   case CONTEXT_BUTTON_SCAN:
-    OnScan(itemNumber, true);
+    // Check if scanning already and inform user
+    if (g_application.IsMusicScanning())
+      HELPERS::ShowOKDialogText(CVariant{ 189 }, CVariant{ 14057 });
+    else
+      OnScan(itemNumber, true);
     return true;
 
   case CONTEXT_BUTTON_CDDB:


### PR DESCRIPTION
Inform user that scanning is already in progress if they try to scan another music source into the library at the same time.

Current behaviour any running scan is stopped and nothing further happens, but this can be confusing for the user as they may not notice. The improvement is to tell the user they can not scan another source because scanning is in progress (same message as if they hit attempt to refresh artist or album information during a scan). If they want to stop the scan they can hit "stop scanning" on the side blade. 

@KarellenX this should make behaviour clearer