### PR TITLE
[cmake][addons] add THIRD_PARTY_PATH definition

### DIFF
--- a/cmake/addons/CMakeLists.txt
+++ b/cmake/addons/CMakeLists.txt
@@ -123,6 +123,17 @@ if(CMAKE_TOOLCHAIN_FILE)
   message(STATUS ${BUILD_ARGS})
 endif()
 
+# used for addons where need special folders to store there content (if
+# not set the addon define it byself).
+# e.g. Google Chromium addon where his git bring:
+# - "unable to create file" ... "Filename too long"
+# see also WARNING by Windows on: https://bitbucket.org/chromiumembedded/cef/wiki/MasterBuildQuickStart
+if(THIRD_PARTY_PATH)
+  message(STATUS "Third party lib path specified")
+  message(STATUS ${THIRD_PARTY_PATH})
+  list(APPEND BUILD_ARGS -DTHIRD_PARTY_PATH=${THIRD_PARTY_PATH})
+endif()
+
 if(NOT ADDONS_TO_BUILD)
   set(ADDONS_TO_BUILD "all")
 else()

--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -88,6 +88,17 @@ function(add_addon_depends addon searchpath)
           message(${BUILD_ARGS})
         endif()
 
+        # used for addons where need special folders to store there content (if
+        # not set the addon define it byself).
+        # e.g. Google Chromium addon where his git bring:
+        # - "unable to create file" ... "Filename too long"
+        # see also WARNING by Windows on: https://bitbucket.org/chromiumembedded/cef/wiki/MasterBuildQuickStart
+        if(THIRD_PARTY_PATH)
+          message(STATUS "Third party lib path specified")
+          message(STATUS ${THIRD_PARTY_PATH})
+          list(APPEND BUILD_ARGS -DTHIRD_PARTY_PATH=${THIRD_PARTY_PATH})
+        endif()
+
         set(PATCH_COMMAND)
 
         # if there's a CMakeLists.txt use it to prepare the build


### PR DESCRIPTION
## Description
Used for addons where need special folders to store there content (if not set the addon define it byself).
e.g. Google Chromium addon where his git bring:
`unable to create file" ... "Filename too long`
see also WARNING by Windows on: https://bitbucket.org/chromiumembedded/cef/wiki/MasterBuildQuickStart
(WARNING: If you change the above directory names/locations make sure to (a) use only ASCII characters and (b) choose a short file path (less than 35 characters total). Otherwise, some tooling may fail later in the build process due to invalid or overly long file paths.)

Here how used on addon:
https://github.com/AlwinEsch/web.browser.chromium/blob/master/depends/common/chromium/CMakeLists.txt#L101
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
I think it a bit stupid to bring this change in. But for Windows, there is no way around. There, the maximum length on a path is limited to 256 characters.

Unfortunately Chromium comes in its construction as clearly above and does not bring directly traceable errors. No matter what I tried, this could not be fixed, since Chromium takes a completely different route than we do to create his library and expects, e.g. this https://chromium.googlesource.com/chromium/tools/depot_tools.git which uses its own git programs and settings and builds over Python, GN and its ninja.

The only good thing is synonymous for other OS, Chromium can stored in another place and when the addon build folder is deleted the Chromium code remains and the countless hours of downloading and unpacking (> 15 GB) is avoided.

On my system was it needed to set by addon build a `-DTHIRD_PARTY_PATH=D:/chromium`. My drive C: is a 128 GByte SSD where only 9 GByte are free, thats why defines over this way and not only on addon, think this situation have also some others for other projects to use different Discs for build.

## How Has This Been Tested?
On Webbrowser addon creation on Linux and Windows
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
