### PR TITLE
[Estuary] favourites widget would not scroll to end on 16:10 displays

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -527,7 +527,7 @@
 						<orientation>vertical</orientation>
 						<pagecontrol>14010</pagecontrol>
 						<visible>Integer.IsGreater(Container(14100).NumItems,0) | Container(14100).IsUpdating</visible>
-						<itemlayout width="330" height="396">
+						<itemlayout width="330" height="401">
 							<control type="group">
 								<top>130</top>
 								<include content="InfoWallMusicLayout">
@@ -536,7 +536,7 @@
 								</include>
 							</control>
 						</itemlayout>
-						<focusedlayout width="330" height="396">
+						<focusedlayout width="330" height="401">
 							<control type="group">
 								<depth>DepthContentPopout</depth>
 								<top>130</top>


### PR DESCRIPTION
the favourites widget on the home window would not fully scroll to the bottom on displays with a 16:10 aspect ratio.

![favs](https://user-images.githubusercontent.com/687265/56914893-8dac1280-6ab5-11e9-855f-fd61346abb66.jpg)

@ksooo 