### PR TITLE
[GUI]Fix blank Visualisation Preset List dialog 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5136,6 +5136,7 @@ msgstr ""
 #empty string with id 10121
 
 #: xbmc/guilib/WindowIDs.h
+#: xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
 msgctxt "#10122"
 msgid "Visualization preset list"
 msgstr ""
@@ -6913,8 +6914,9 @@ msgctxt "#13388"
 msgid "Preset"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
 msgctxt "#13389"
-msgid "There are no presets available\nfor this visualisation"
+msgid "There are no presets available for this visualisation"
 msgstr ""
 
 msgctxt "#13390"
@@ -7004,6 +7006,7 @@ msgctxt "#13406"
 msgid "Picture information"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
 msgctxt "#13407"
 msgid "{0:s} presets"
 msgstr ""

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -29,7 +29,7 @@ bool CGUIDialogVisualisationPresetList::OnMessage(CGUIMessage &message)
   switch (message.GetMessage())
   {
   case GUI_MSG_VISUALISATION_UNLOADING:
-    SetVisualisation(nullptr);
+    ClearVisualisation();
     break;
   }
   return CGUIDialogSelect::OnMessage(message);
@@ -41,11 +41,23 @@ void CGUIDialogVisualisationPresetList::OnSelect(int idx)
     m_viz->SetPreset(idx);
 }
 
+void CGUIDialogVisualisationPresetList::ClearVisualisation()
+{
+  m_viz = nullptr;
+  Reset();
+}
+
 void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationControl* vis)
 {
   m_viz = vis;
   Reset();
-  if (m_viz)
+  if (!m_viz)
+  { // No viz, but show something if this dialog activated
+    SetHeading(CVariant{ 10122 });
+    CFileItem item(g_localizeStrings.Get(13389));
+    Add(item);
+  }
+  else
   {
     SetUseDetails(false);
     SetMultiSelection(false);
@@ -61,6 +73,12 @@ void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationContro
       }
       SetSelected(m_viz->GetActivePreset());
     }
+    else
+    { // Viz does not have any presets
+      // "There are no presets available for this visualisation"
+      CFileItem item(g_localizeStrings.Get(13389));
+      Add(item);
+    }
   }
 }
 
@@ -68,13 +86,12 @@ void CGUIDialogVisualisationPresetList::OnInitWindow()
 {
   CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
-  if (msg.GetPointer())
-    SetVisualisation(static_cast<CGUIVisualisationControl*>(msg.GetPointer()));
+  SetVisualisation(static_cast<CGUIVisualisationControl*>(msg.GetPointer()));
   CGUIDialogSelect::OnInitWindow();
 }
 
 void CGUIDialogVisualisationPresetList::OnDeinitWindow(int nextWindowID)
 {
-  SetVisualisation(nullptr);
+  ClearVisualisation();
   CGUIDialogSelect::OnDeinitWindow(nextWindowID);
 }

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.h
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.h
@@ -26,6 +26,7 @@ protected:
   void OnSelect(int idx) override;
 
 private:
+  void ClearVisualisation();
   void SetVisualisation(CGUIVisualisationControl *addon);
   CGUIVisualisationControl* m_viz = nullptr;
 };


### PR DESCRIPTION
During music playback showing OSD, pressing `<p>` on the keyboard displays the Visualisation Preset List dialog. If there is no visualisation then a blank selection dialog (no labels or heading) gets shown. 

![Before - blank ](https://i.imgur.com/yN4sSJh.png)

If the visualisation does not have presets e.g.  Spectrum then before the refactoring of this dialog by https://github.com/xbmc/xbmc/pull/9210  text "There are no presets available for this visualisation" was shown, but now this also shows a blank selection dialog.

Fix to ensure that the Visualisation Preset List dialog always displays informative text in both those situations.

After
![After](https://i.imgur.com/8M4oeXq.png)

See  https://github.com/xbmc/xbmc/blob/725a20711c1dd811cd41ad1465356d4b98a06dc5/system/keymaps/keyboard.xml#L486
means that a key press will bring up the dialog regardless of visualization being none.
