### PR TITLE
[iOS] remove some legacy code

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1841,11 +1841,7 @@ std::string CUtil::GetFrameworksPath(bool forPython)
 {
   std::string strFrameworksPath;
 #if defined(TARGET_DARWIN)
-  char     given_path[2*MAXPATHLEN];
-  size_t path_size =2*MAXPATHLEN;
-
-  CDarwinUtils::GetFrameworkPath(forPython, given_path, &path_size);
-  strFrameworksPath = given_path;
+  strFrameworksPath = CDarwinUtils::GetFrameworkPath(forPython);
 #endif
   return strFrameworksPath;
 }

--- a/xbmc/platform/darwin/DarwinUtils.h
+++ b/xbmc/platform/darwin/DarwinUtils.h
@@ -24,7 +24,7 @@ public:
   static const char *GetOSVersionString(void);
   static const char *GetIOSVersionString(void);
   static const char *GetOSXVersionString(void);
-  static int         GetFrameworkPath(bool forPython, char* path, size_t *pathsize);
+  static std::string GetFrameworkPath(bool forPython);
   static int         GetExecutablePath(char* path, size_t *pathsize);
   static const char *GetAppRootFolder(void);
   static bool        IsIosSandboxed(void);

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -88,33 +88,31 @@ using namespace KODI::MESSAGING;
   }
 }
 
-- (CGFloat) getScreenScale:(UIScreen *)screen
+- (CGFloat)getScreenScale:(UIScreen *)screen
 {
   CGFloat ret = 1.0;
-  if ([screen respondsToSelector:@selector(scale)])
+
+  // normal other iDevices report 1.0 here
+  // retina devices report 2.0 here
+  // this info is true as of 19.3.2012.
+  if ([screen scale] > 1.0)
   {
-    // normal other iDevices report 1.0 here
-    // retina devices report 2.0 here
-    // this info is true as of 19.3.2012.
-    if([screen scale] > 1.0)
-    {
-      ret = [screen scale];
-    }
+    ret = [screen scale];
+  }
 
-    //if no retina display scale detected yet -
-    //ensure retina resolution on supported devices mainScreen
-    //even on older iOS SDKs
-    double screenScale = 1.0;
-    if (ret == 1.0 && screen == [UIScreen mainScreen] && CDarwinUtils::DeviceHasRetina(screenScale))
-    {
-      ret = screenScale;//set scale factor from our static list in case older SDKs report 1.0
-    }
+  //if no retina display scale detected yet -
+  //ensure retina resolution on supported devices mainScreen
+  //even on older iOS SDKs
+  double screenScale = 1.0;
+  if (ret == 1.0 && screen == [UIScreen mainScreen] && CDarwinUtils::DeviceHasRetina(screenScale))
+  {
+    ret = screenScale;//set scale factor from our static list in case older SDKs report 1.0
+  }
 
-    // fix for ip6 plus which seems to report 2.0 when not compiled with ios8 sdk
-    if (CDarwinUtils::DeviceHasRetina(screenScale) && screenScale == 3.0)
-    {
-      ret = screenScale;
-    }
+  // fix for ip6 plus which seems to report 2.0 when not compiled with ios8 sdk
+  if (CDarwinUtils::DeviceHasRetina(screenScale) && screenScale == 3.0)
+  {
+    ret = screenScale;
   }
   return ret;
 }

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -104,13 +104,14 @@ using namespace KODI::MESSAGING;
   //ensure retina resolution on supported devices mainScreen
   //even on older iOS SDKs
   double screenScale = 1.0;
-  if (ret == 1.0 && screen == [UIScreen mainScreen] && CDarwinUtils::DeviceHasRetina(screenScale))
+  bool hasRetina = CDarwinUtils::DeviceHasRetina(screenScale);
+  if (ret == 1.0 && screen == [UIScreen mainScreen] && hasRetina)
   {
     ret = screenScale;//set scale factor from our static list in case older SDKs report 1.0
   }
 
   // fix for ip6 plus which seems to report 2.0 when not compiled with ios8 sdk
-  if (CDarwinUtils::DeviceHasRetina(screenScale) && screenScale == 3.0)
+  if (hasRetina && screenScale == 3.0)
   {
     ret = screenScale;
   }

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -94,23 +94,12 @@ static CEvent screenChangeEvent;
     if(toExternal)//changing the external screen might need some time ...
     {
       //deactivate any overscan compensation when switching to external screens
-      if([newScreen respondsToSelector:@selector(overscanCompensation)])
-      {
-        //since iOS5.0 tvout has an default overscan compensation and property
-        //we need to switch it off here so that the tv can handle any
-        //needed overscan compensation (else on tvs without "just scan" option
-        //we might end up with black borders.
-        //Beside that in Apples documentation to setOverscanCompensation
-        //the parameter enum is lacking the UIScreenOverscanCompensationNone value.
-        //Someone on stackoverflow figured out that value 3 is for turning it off
-        //(though there is no enum value for it).
-        [newScreen setOverscanCompensation:(UIScreenOverscanCompensation)3];
-        CLog::Log(LOGDEBUG, "[IOSScreenManager] Disabling overscancompensation.");
-      }
-      else
-      {
-        CLog::Log(LOGDEBUG, "[IOSScreenManager] Disabling overscancompensation not supported on this iOS version.");
-      }
+      //tvout has a default overscan compensation and property
+      //we need to switch it off here so that the tv can handle any
+      //needed overscan compensation (else on tvs without "just scan" option
+      //we might end up with black borders.
+      [newScreen setOverscanCompensation:UIScreenOverscanCompensationNone];
+      CLog::Log(LOGDEBUG, "[IOSScreenManager] Disabling overscancompensation.");
 
       [[IOSScreenManager sharedInstance] fadeFromBlack:timeSwitchingToExternalSecs];
     }

--- a/xbmc/platform/darwin/ios/XBMCApplication.mm
+++ b/xbmc/platform/darwin/ios/XBMCApplication.mm
@@ -24,10 +24,7 @@ XBMCController *m_xbmcController;
 // - if both say OK - rotation is allowed
 - (NSUInteger)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window
 {
-  if ([[window rootViewController] respondsToSelector:@selector(supportedInterfaceOrientations)])
-    return [[window rootViewController] supportedInterfaceOrientations];
-  else
-    return (1 << UIInterfaceOrientationLandscapeRight) | (1 << UIInterfaceOrientationLandscapeLeft);
+  return [[window rootViewController] supportedInterfaceOrientations];
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application

--- a/xbmc/platform/darwin/ios/XBMCController.h
+++ b/xbmc/platform/darwin/ios/XBMCController.h
@@ -69,7 +69,6 @@ typedef enum
 - (void) setFramebuffer;
 - (bool) presentFramebuffer;
 - (CGSize) getScreenSize;
-- (CGFloat) getScreenScale:(UIScreen *)screen;
 - (UIInterfaceOrientation) getOrientation;
 - (void) createGestureRecognizers;
 - (void) activateKeyboard:(UIView *)view;

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -133,37 +133,9 @@ XBMCController *g_xbmcController;
 }
 // END OF UIKeyInput protocol
 
-// - iOS6 rotation API - will be called on iOS7 runtime!--------
-- (NSUInteger)supportedInterfaceOrientations
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-  //mask defines available as of ios6 sdk
-  //return UIInterfaceOrientationMaskLandscape;
-  return (1 << UIInterfaceOrientationLandscapeLeft) | (1 << UIInterfaceOrientationLandscapeRight);
-}
-// - old rotation API will be called on iOS6 and lower - removed in iOS7
--(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
-{
-  //on external screens somehow the logic is rotated by 90°
-  //so we have to do this with our supported orientations then aswell
-  if([[IOSScreenManager sharedInstance] isExternalScreen])
-  {
-    if(interfaceOrientation == UIInterfaceOrientationPortrait)
-    {
-      return YES;
-    }
-  }
-  else//internal screen
-  {
-    if(interfaceOrientation == UIInterfaceOrientationLandscapeLeft)
-    {
-      return YES;
-    }
-    else if(interfaceOrientation == UIInterfaceOrientationLandscapeRight)
-    {
-      return YES;
-    }
-  }
-  return NO;
+  return UIInterfaceOrientationMaskLandscape;
 }
 //--------------------------------------------------------------
 - (UIInterfaceOrientation) getOrientation

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -673,12 +673,6 @@ XBMCController *g_xbmcController;
   return screensize;
 }
 //--------------------------------------------------------------
-- (CGFloat) getScreenScale:(UIScreen *)screen
-{
-  return [m_glView getScreenScale:screen];
-}
-//--------------------------------------------------------------
-//--------------------------------------------------------------
 - (BOOL) recreateOnReselect
 {
   PRINT_SIGNATURE();
@@ -893,10 +887,7 @@ XBMCController *g_xbmcController;
 - (void)setIOSNowPlayingInfo:(NSDictionary *)info
 {
   self.nowPlayingInfo = info;
-  // MPNowPlayingInfoCenter is an ios5+ class, following code will work on ios5 even if compiled by xcode3
-  Class NowPlayingInfoCenter = NSClassFromString(@"MPNowPlayingInfoCenter");
-  if (NowPlayingInfoCenter)
-    [[NowPlayingInfoCenter defaultCenter] setNowPlayingInfo:self.nowPlayingInfo];
+  [[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:self.nowPlayingInfo];
 }
 //--------------------------------------------------------------
 - (void)onPlay:(NSDictionary *)item
@@ -923,36 +914,32 @@ XBMCController *g_xbmcController;
   if (genres && genres.count > 0)
     [dict setObject:[genres componentsJoinedByString:@" "] forKey:MPMediaItemPropertyGenre];
 
-  if (NSClassFromString(@"MPNowPlayingInfoCenter"))
+  NSString *thumb = [item objectForKey:@"thumb"];
+  if (thumb && thumb.length > 0)
   {
-    NSString *thumb = [item objectForKey:@"thumb"];
-    if (thumb && thumb.length > 0)
+    UIImage *image = [UIImage imageWithContentsOfFile:thumb];
+    if (image)
     {
-      UIImage *image = [UIImage imageWithContentsOfFile:thumb];
-      if (image)
+      MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
+      if (mArt)
       {
-        MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
-        if (mArt)
-        {
-          [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
-          [mArt release];
-        }
+        [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
+        [mArt release];
       }
     }
-    // these property keys are ios5+ only
-    NSNumber *elapsed = [item objectForKey:@"elapsed"];
-    if (elapsed)
-      [dict setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
-    NSNumber *speed = [item objectForKey:@"speed"];
-    if (speed)
-      [dict setObject:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
-    NSNumber *current = [item objectForKey:@"current"];
-    if (current)
-      [dict setObject:current forKey:MPNowPlayingInfoPropertyPlaybackQueueIndex];
-    NSNumber *total = [item objectForKey:@"total"];
-    if (total)
-      [dict setObject:total forKey:MPNowPlayingInfoPropertyPlaybackQueueCount];
   }
+  NSNumber *elapsed = [item objectForKey:@"elapsed"];
+  if (elapsed)
+    [dict setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+  NSNumber *speed = [item objectForKey:@"speed"];
+  if (speed)
+    [dict setObject:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
+  NSNumber *current = [item objectForKey:@"current"];
+  if (current)
+    [dict setObject:current forKey:MPNowPlayingInfoPropertyPlaybackQueueIndex];
+  NSNumber *total = [item objectForKey:@"total"];
+  if (total)
+    [dict setObject:total forKey:MPNowPlayingInfoPropertyPlaybackQueueCount];
   /*
    other properties can be set:
    MPMediaItemPropertyAlbumTrackCount
@@ -976,18 +963,15 @@ XBMCController *g_xbmcController;
 - (void)OnSpeedChanged:(NSDictionary *)item
 {
   PRINT_SIGNATURE();
-  if (NSClassFromString(@"MPNowPlayingInfoCenter"))
-  {
-    NSMutableDictionary *info = [self.nowPlayingInfo mutableCopy];
-    NSNumber *elapsed = [item objectForKey:@"elapsed"];
-    if (elapsed)
-      [info setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
-    NSNumber *speed = [item objectForKey:@"speed"];
-    if (speed)
-      [info setObject:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
+  NSMutableDictionary *info = [self.nowPlayingInfo mutableCopy];
+  NSNumber *elapsed = [item objectForKey:@"elapsed"];
+  if (elapsed)
+    [info setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+  NSNumber *speed = [item objectForKey:@"speed"];
+  if (speed)
+    [info setObject:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
 
-    [self setIOSNowPlayingInfo:info];
-  }
+  [self setIOSNowPlayingInfo:info];
 }
 //--------------------------------------------------------------
 - (void)onPause:(NSDictionary *)item


### PR DESCRIPTION
## Description
This PR removes runtime checks for class/method presence that now always evaluate to `true` and pre-iOS 6 orientation code.

## Motivation and Context
The less legacy and unused code, the better :)

## How Has This Been Tested?
Verified that iOS build succeeds and app still works.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
