### PR TITLE
Fix formatting of VideoThumbLoader

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -108,7 +108,7 @@ bool CThumbExtractor::DoWork()
     CTextureDetails details;
     details.file = CTextureCache::GetCacheFile(m_target) + ".jpg";
     result = CDVDFileInfo::ExtractThumb(m_item, details, m_fillStreamDetails ? &m_item.GetVideoInfoTag()->m_streamDetails : nullptr, m_pos);
-    if(result)
+    if (result)
     {
       CTextureCache::GetInstance().AddCachedTexture(m_target, details);
       m_item.SetProperty("HasAutoThumb", true);
@@ -361,7 +361,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
      )
   {
     // use fanart if available
-    if(pItem->HasArt("fanart"))
+    if (pItem->HasArt("fanart"))
     {
       pItem->SetArt("thumb", pItem->GetArt("fanart"));
     }


### PR DESCRIPTION
## Description
As noted in #15991 I made a formatting mistake, this pull request corrects that error and an other already present instance.
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
