### PR TITLE
PAPlayer: Don't fallback to DTS too early

### DIFF
--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -510,7 +510,7 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
       break;
 
     case AV_CODEC_ID_DTS:
-      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_CORE;
+      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
       format.m_streamInfo.m_sampleRate = samplerate;
       break;
 
@@ -519,6 +519,12 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
   }
 
   bool supports = CServiceBroker::GetActiveAE()->SupportsRaw(format);
+
+  if (!supports && codecId == AV_CODEC_ID_DTS)
+  {
+    format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_CORE;
+    supports = CServiceBroker::GetActiveAE()->SupportsRaw(format);
+  }
 
   if (supports)
     return format.m_streamInfo.m_type;


### PR DESCRIPTION
Videoplayer Codec openend DTS directly, giving the DTSHD parser no chance to detect DTS-HD Audio tracks.

This adjusts the code similar to Videoplayer's own Codec opening sequence.

Fixes: https://github.com/xbmc/xbmc/issues/16022