### PR TITLE
[PVR] Newly added channels cause EPG UI corruption

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -926,7 +926,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannelGroup::GetEPGAll(bool bI
     channel = (*it).channel;
     if (!channel->IsHidden())
     {
-      bool bEmpty = false;
+      bool bEmpty = true;
 
       CPVREpgPtr epg = channel->GetEPG();
       if (epg)


### PR DESCRIPTION
## Description
When new channels become available to a PVR addon while Kodi is offline, starting Kodi will cause an EPG UI issue wherein the newly added channel will be displayed briefly but very soon after be removed and cause a +1 channel shift in the displayed EPG data.

The proposed change alters the default state of a variable that keeps track of a channel's EPG data being empty/missing.

While this PR is against the 'master' branch, I request that if accepted it be applied to the 'Leia' branch as well -- let me know if separate pull requests for 'master' and 'Leia' should have been submitted.

## Motivation and Context
I traced this back as far as PVRChannelGroup.cpp (the modified file).  What I see is that the EPG UI is initialized twice.  The first time through, new channels get assigned a "gap" EPG tag so it will appear in the EPG with no entries.  However, the second time through initialization the new channel will be skipped completely since there are no EPG tags for it yet.  This appears to be the cause of the UI concerns.

## How Has This Been Tested?
Tested on Kodi 18.2 Windows x64.  While the PR has been applied to master branch, I was unable to test the change on that platform due to a problem with the version of "kodi.binary.global.audioengine".  I believe the PR could be applied to both master and Leia branches as-is, but only submitted against master.

Prior to the change adding new channels to the PVR backend would cause the behavior described under "Description".  After the change the Kodi 17 "Krypton" like behavior was restored -- newly added channels would end up with "gap" EPG entries in the UI.

Suggest review by @ksooo - there may be a much better way to handle this.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
