### PR TITLE
[PVR] Fix CPVREpg::(Add|Update)Entry to not overwrite channeldata and epgid

### DIFF
--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -258,11 +258,12 @@ void CPVREpg::AddEntry(const CPVREpgInfoTag &tag)
     newTag = it->second;
   else
   {
-    newTag = std::make_shared<CPVREpgInfoTag>(m_channelData, m_iEpgID);
+    newTag.reset(new CPVREpgInfoTag());
     m_tags.insert(std::make_pair(tag.StartAsUTC(), newTag));
   }
 
   newTag->Update(tag);
+  newTag->SetChannelData(m_channelData);
   newTag->SetEpgID(m_iEpgID);
 }
 
@@ -348,13 +349,14 @@ bool CPVREpg::UpdateEntry(const CPVREpgInfoTagPtr &tag, bool bUpdateDatabase)
   }
   else
   {
-    infoTag = std::make_shared<CPVREpgInfoTag>(m_channelData, m_iEpgID);
+    infoTag.reset(new CPVREpgInfoTag());
     infoTag->SetUniqueBroadcastID(tag->UniqueBroadcastID());
     m_tags.insert(std::make_pair(tag->StartAsUTC(), infoTag));
     bNewTag = true;
   }
 
   infoTag->Update(*tag, bNewTag);
+  infoTag->SetChannelData(m_channelData);
   infoTag->SetEpgID(m_iEpgID);
 
   if (bUpdateDatabase)


### PR DESCRIPTION
Fixes fallout from https://github.com/xbmc/xbmc/pull/15707 which can lead to garbage data in PVR guide window, at least if "store guide data in database" is active.

@Jalle19 please review.