### PR TITLE
CRendererVAAPIGLES: use CEGLFence to sync rendering

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -8,10 +8,22 @@
 
 #pragma once
 
-#include <memory>
-
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "VaapiEGL.h"
+
+#include <array>
+#include <memory>
+
+namespace KODI
+{
+namespace UTILS
+{
+namespace EGL
+{
+class CEGLFence;
+}
+}
+}
 
 namespace VAAPI
 {
@@ -52,6 +64,6 @@ protected:
 
   bool m_isVAAPIBuffer = true;
   std::unique_ptr<VAAPI::CVaapiTexture> m_vaapiTextures[NUM_BUFFERS];
-  GLsync m_fences[NUM_BUFFERS];
+  std::array<std::unique_ptr<KODI::UTILS::EGL::CEGLFence>, NUM_BUFFERS> m_fences;
   static VAAPI::IVaapiWinSystem *m_pWinSystem;
 };


### PR DESCRIPTION
This allows using the CEGLFence helper class and simplifies the logic. This is the same that was done for the DRMPRIMEGLES renderer.