### PR TITLE
VideoRenderers: remove unused method SupportsMultiPassRendering()

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -69,7 +69,6 @@ public:
   virtual bool ConfigChanged(const VideoPicture &picture) = 0;
 
   // Feature support
-  virtual bool SupportsMultiPassRendering() = 0;
   virtual bool Supports(ERENDERFEATURE feature) { return false; };
   virtual bool Supports(ESCALINGMETHOD method) = 0;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -148,7 +148,6 @@ public:
   virtual bool         IsPictureHW(const VideoPicture &picture) override { return false; };
   virtual CRenderInfo GetRenderInfo() override;
 
-  virtual bool         SupportsMultiPassRendering() override { return false; };
   virtual bool         Supports(ERENDERFEATURE feature) override;
   virtual bool         Supports(ESCALINGMETHOD method) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -30,7 +30,6 @@ public:
   virtual void UnInit() override {};
   virtual void Update() override {};
   virtual void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
-  virtual bool SupportsMultiPassRendering()override { return false; };
 
   // Player functions
   virtual bool IsGuiLayer() override { return false; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -40,7 +40,6 @@ public:
   bool ConfigChanged(const VideoPicture& picture) override;
 
   // Feature support
-  bool SupportsMultiPassRendering() override { return false; };
   bool Supports(ERENDERFEATURE feature) override;
   bool Supports(ESCALINGMETHOD method) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -31,7 +31,6 @@ public:
   virtual void UnInit() override {};
   virtual void Update() override {};
   virtual void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
-  virtual bool SupportsMultiPassRendering() override { return false; };
 
   // Player functions
   virtual bool IsGuiLayer() override { return false; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -2581,11 +2581,6 @@ bool CLinuxRendererGL::Supports(ERENDERFEATURE feature)
   return false;
 }
 
-bool CLinuxRendererGL::SupportsMultiPassRendering()
-{
-  return m_renderSystem->IsExtSupported("GL_EXT_framebuffer_object");
-}
-
 bool CLinuxRendererGL::Supports(ESCALINGMETHOD method)
 {
   //nearest neighbor doesn't work on YUY2 and UYVY

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -88,7 +88,6 @@ public:
   bool ConfigChanged(const VideoPicture &picture) override;
 
   // Feature support
-  bool SupportsMultiPassRendering() override;
   bool Supports(ERENDERFEATURE feature) override;
   bool Supports(ESCALINGMETHOD method) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1612,11 +1612,6 @@ bool CLinuxRendererGLES::Supports(ERENDERFEATURE feature)
   return false;
 }
 
-bool CLinuxRendererGLES::SupportsMultiPassRendering()
-{
-  return true;
-}
-
 bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method)
 {
   if(method == VS_SCALINGMETHOD_NEAREST ||

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -82,7 +82,6 @@ public:
   virtual bool ConfigChanged(const VideoPicture &picture) override;
 
   // Feature support
-  virtual bool SupportsMultiPassRendering() override;
   virtual bool Supports(ERENDERFEATURE feature) override;
   virtual bool Supports(ESCALINGMETHOD method) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -39,7 +39,6 @@ public:
   bool NeedBuffer(int idx) override;
 
   // Feature support
-  bool SupportsMultiPassRendering() override { return false; }
   bool Supports(ERENDERFEATURE feature) override;
   bool Supports(ESCALINGMETHOD method) override;
 


### PR DESCRIPTION
This method is unused. I'm not sure if it's a leftover or not.