### PR TITLE
CRendererVAAPIGLES: remove overrides for render features

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -112,16 +112,6 @@ bool CRendererVAAPI::ConfigChanged(const VideoPicture &picture)
   return false;
 }
 
-bool CRendererVAAPI::Supports(ERENDERFEATURE feature)
-{
-  return CLinuxRendererGLES::Supports(feature);
-}
-
-bool CRendererVAAPI::Supports(ESCALINGMETHOD method)
-{
-  return CLinuxRendererGLES::Supports(method);
-}
-
 EShaderFormat CRendererVAAPI::GetShaderFormat()
 {
   EShaderFormat ret = SHADER_NONE;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -34,10 +34,6 @@ public:
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
 
-  // Feature support
-  bool Supports(ERENDERFEATURE feature) override;
-  bool Supports(ESCALINGMETHOD method) override;
-
 protected:
   bool LoadShadersHook() override;
   bool RenderHook(int idx) override;


### PR DESCRIPTION
Not needed. Was a leftover of the original implementation