### PR TITLE
CLinuxRendererGLES: remove single pass rendering and always use FBO's

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -93,8 +93,15 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
     }
 
      // create the yuv textures
-    UpdateVideoFilter();
+    if (m_renderMethod & RENDER_GLSL)
+      UpdateVideoFilter();
+
     LoadShaders();
+
+    if (m_renderMethod < 0)
+    {
+      return false;
+    }
 
     for (int i = 0 ; i < m_NumYV12Buffers ; i++)
     {
@@ -467,6 +474,7 @@ void CLinuxRendererGLES::UpdateVideoFilter()
     if (!m_fbo.fbo.Initialize())
     {
       CLog::Log(LOGERROR, "GLES: Error initializing FBO");
+      return;
     }
 
     if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA))
@@ -524,7 +532,6 @@ void CLinuxRendererGLES::LoadShaders(int field)
   {
     ReleaseShaders();
 
-    // Try GLSL shaders if supported and user requested auto or GLSL.
     if (glCreateProgram())
     {
       // create regular scan shader
@@ -672,7 +679,7 @@ void CLinuxRendererGLES::Render(unsigned int flags, int index)
   {
     ;
   }
-  else
+  else if (m_renderMethod & RENDER_GLSL)
   {
     UpdateVideoFilter();
     RenderToFBO(index, m_currentField);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -46,14 +46,6 @@ enum RenderMethod
   RENDER_CUSTOM = 0x02,
 };
 
-enum RenderQuality
-{
-  RQ_LOW = 1,
-  RQ_SINGLEPASS,
-  RQ_MULTIPASS,
-  RQ_SOFTWARE
-};
-
 class CEvent;
 
 class CLinuxRendererGLES : public CBaseRenderer
@@ -141,7 +133,6 @@ protected:
   bool m_bValidated{false};
   GLenum m_textureTarget;
   int m_renderMethod{RENDER_GLSL};
-  RenderQuality m_renderQuality{RQ_SINGLEPASS};
 
   // Raw data used by renderer
   int m_currentField{FIELD_FULL};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -98,7 +98,7 @@ protected:
   virtual bool ValidateRenderTarget();
   virtual void LoadShaders(int field=FIELD_FULL);
   virtual void ReleaseShaders();
-  void SetTextureFilter(GLenum method);
+  void SetTextureFilter(ESCALINGMETHOD scalingMethod);
   void UpdateVideoFilter();
   AVColorPrimaries GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned int width, unsigned int height);
 
@@ -121,7 +121,6 @@ protected:
   // renderers
   void RenderToFBO(int index, int field);
   void RenderFromFBO();
-  void RenderSinglePass(int index, int field); // single pass glsl renderer
 
   // hooks for HwDec Renderered
   virtual bool LoadShadersHook() { return false; };


### PR DESCRIPTION
This is a bit big of a commit. I originally had things more separate but even though they were logically separated it would have broken the build as much of this is intertwined.

This change makes it so that `CLinuxRendererGLES` will always use the FBO dual pass render method. GLES 2 supports fbo's in the spec so there is no point in complicating the render system supporting multiple different methods.