### PR TITLE
Fix blank dialog when Joystick X key hit and there is no visualisation

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -229,7 +229,7 @@
     <joystick profile="game.controller.default">
       <a>Pause</a>
       <b>Stop</b>
-      <x>ActivateWindow(AddonSettings)</x>
+      <x>Addon.Default.OpenSettings(xbmc.player.musicviz)</x>
       <y>ActivateWindow(VisualisationPresetList)</y>
       <start>Info</start>
       <rightthumb>ActivateWindow(MusicOSD)</rightthumb>


### PR DESCRIPTION
During music playback showing OSD without a visualisation, hitting the `<X>` on a Shield controller caused an odd blank dialog.

![screenshot002](https://user-images.githubusercontent.com/13371422/57126739-e6193380-6d85-11e9-9f8b-553857d84775.png)

The issue is the command in the joystick keymap calling `ActivateWindow(AddonSettings)` when there is no visualisation addon although the addon settings dialog exists.

Fix is to replace this with the `Addon.Default.OpenSettings` command used by other keymaps.

@Klojum thanks for reporting this issue, are you able to test this fix? No build needed, simply add a suitably edited joystick.xml to the userdata/keymaps folder on your device. 
