### PR TITLE
Remove 3:2 pullback from current check

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -163,13 +163,12 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     }
   }
 
-  CLog::Log(LOGDEBUG, "No double refresh rate whitelisted resolution matched, trying current resolution");
+  CLog::Log(LOGDEBUG, "No 3:2 pullback refresh rate whitelisted resolution matched, trying current resolution");
 
   if (width <= curr.iScreenWidth
     && height <= curr.iScreenHeight
     && (MathUtils::FloatEquals(curr.fRefreshRate, fps, 0.01f)
-      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2, 0.01f)
-      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2.5f, 0.01f)))
+      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2, 0.01f)))
   {
     CLog::Log(LOGDEBUG, "Matched current Resolution %s (%d)", curr.strMode.c_str(), resolution);
     return;


### PR DESCRIPTION
## Description
This PR reverts the logic, that 59.94Hz "current mode" is used for 23.97fps videos (and 60Hz for 24fps)

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=343524

## How Has This Been Tested?
- Set Kodi GUI display mode to 59,94 Hz
- Enable Adjust display refresh rate
- Play 23.97 video stream

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)
