### PR TITLE
[Leia][PVR] Create EPG when a PVR channel has been dynamically added at runtime

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -244,15 +244,19 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup &chan
       if (existingChannel.channel->UpdateFromClient(it->second.channel))
       {
         bReturn = true;
-        CLog::LogFC(LOGDEBUG, LOGPVR, "Updated %s channel '%s' from PVR client", m_bRadio ? "radio" : "TV", it->second.channel->ChannelName().c_str());
+        CLog::LogFC(LOGDEBUG, LOGPVR, "Updated {} channel '{}' from PVR client", m_bRadio ? "radio" : "TV", it->second.channel->ChannelName());
       }
     }
     else
     {
       /* new channel */
       UpdateFromClient(it->second.channel, bUseBackendChannelNumbers ? it->second.channel->ClientChannelNumber() : CPVRChannelNumber());
+      if (it->second.channel->CreateEPG())
+      {
+         CLog::LogFC(LOGDEBUG, LOGPVR, "Created EPG for {} channel '{}' from PVR client", m_bRadio ? "radio" : "TV", it->second.channel->ChannelName());
+      }
       bReturn = true;
-      CLog::LogFC(LOGDEBUG, LOGPVR,"Added %s channel '%s' from PVR client", m_bRadio ? "radio" : "TV", it->second.channel->ChannelName().c_str());
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Added {} channel '{}' from PVR client", m_bRadio ? "radio" : "TV", it->second.channel->ChannelName());
     }
   }
 


### PR DESCRIPTION
## Description
When a PVR channel is added dynamically while Kodi is running, the EPG for that channel is never created.  As a result, the EPG grid will always show empty information for that channel until Kodi is restarted.  Attempting to force an EPG update for the channel via **Channels / Manage ... / Update Guide Information** will fail with an error.

## Motivation and Context
After application of PRs [16036](https://github.com/xbmc/xbmc/pull/16036) (Matrix) and [16042](https://github.com/xbmc/xbmc/pull/16042) (Leia), dynamically added channels now appear in the EPG but are inelegible for EPG updates.  I determined that the EPG was never created for the channel when it has been added at runtime.

I think that PVRChannelGroupInternal.cpp is the appropriate place to add this, that appears to be the main location where channels are added/updated/removed at runtime.

Note that I had what I believe to be unrelated issues with Matrix and dynamically added channels -- no request for EPG data was ever issued from Kodi to the PVR addon even when using **Channels / Manage ... / Update Guide Information**.  This PR was primarily intended as a tweak to Leia.  On Matrix I also saw that the dynamically added channels may disappear from the EPG grid completely -- this odd behavior exists with or without this PR in place; I have not taken the time to look into that behavior further.

## How Has This Been Tested?
Tested on both Matrix (master) and Leia (18.3-rc1) branches, Windows 10 x64, debug builds.  As noted above, I did not get the expected results on Matrix but believe the concern to be unrelated as no request was ever made to the PVR addon to update the EPG data for the added channels.  On Leia, the EPG appears to be updated properly if the user selects **Channels / Manage ... / Update Guide Information** on the new channel, or just waits for the next EPG refresh.

## Screenshots (if appropriate):
**NOTE: Screenshots are from Leia 18.3-rc1**

Dynamically added channels prior to PR:
![beforepr](https://user-images.githubusercontent.com/706055/57117906-70817900-6d2d-11e9-9f17-01f67d30e440.png)

Dynamically added channels after PR, in this case I did need to use **Channels / Manage ... / Update Guide Information** to populate the grid, but that operation worked without error:
![afterpr](https://user-images.githubusercontent.com/706055/57117907-7a0ae100-6d2d-11e9-8f4e-004961beaf0c.png)


## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
