### PR TITLE
Revert "VideoPlayerCodec: Ask Demuxer to seek for us"

### DIFF
--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -213,10 +213,10 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   m_bCanSeek = false;
   if (m_pInputStream->Seek(0, SEEK_POSSIBLE))
   {
-    if (m_pDemuxer->SeekTime(1, true))
+    if (Seek(1))
     {
       // rewind stream to beginning
-      m_pDemuxer->SeekTime(0, true);
+      Seek(0);
       m_bCanSeek = true;
     }
     else


### PR DESCRIPTION
This caused issues. Audiocodec was not resetted anymore which lead to a crack at the beginning. While it fixed some skipped samples in certain music file by workarounding ffmpeg loosing some data, this regression for all formats is way worse.