### PR TITLE
windowing/gbm: add option to limit gui size

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7256,7 +7256,17 @@ msgctxt "#13465"
 msgid "EGL"
 msgstr ""
 
-#empty strings from id 13466 to 13504
+#: system/settings/gbm.xml
+msgctxt "#13466"
+msgid "1080 / 720 (>30Hz)"
+msgstr ""
+
+#: system/settings/gbm.xml
+msgctxt "#13467"
+msgid "Unlimited / 1080 (>30Hz)"
+msgstr ""
+
+#empty strings from id 13468 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"
@@ -20306,6 +20316,7 @@ msgid "Use higher quality textures for covers and fanart (uses more memory)"
 msgstr ""
 
 #: system/settings/rbp.xml
+#: system/settings/gbm.xml
 msgctxt "#36548"
 msgid "Limits resolution of GUI to save memory. Does not affect video playback. Requires restart."
 msgstr ""
@@ -20923,6 +20934,7 @@ msgid "Enable higher colour depth artwork"
 msgstr ""
 
 #: system/settings/rbp.xml
+#: system/settings/gbm.xml
 msgctxt "#37021"
 msgid "Set GUI resolution limit"
 msgstr ""
@@ -20960,6 +20972,7 @@ msgstr ""
 
 #: system/settings/rbp.xml
 #: system/settings/android.xml
+#: system/settings/gbm.xml
 msgctxt "#37028"
 msgid "720"
 msgstr ""
@@ -20971,6 +20984,7 @@ msgstr ""
 
 #: system/settings/rbp.xml
 #: system/settings/android.xml
+#: system/settings/gbm.xml
 msgctxt "#37030"
 msgid "Unlimited"
 msgstr ""
@@ -21066,6 +21080,7 @@ msgid "Extract chapter thumbnails for presentation in the chapters / bookmarks d
 msgstr ""
 
 #: system/settings/android.xml
+#: system/settings/gbm.xml
 msgctxt "#37046"
 msgid "1080"
 msgstr ""

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -36,6 +36,21 @@
         <setting id="videoscreen.screen">
           <visible>false</visible>
         </setting>
+        <setting id="videoscreen.limitguisize" type="integer" label="37021" help="36548">
+          <visible>false</visible>
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="37030">0</option> <!-- Unlimited -->
+              <option label="37028">1</option> <!-- 720 -->
+              <option label="13466">2</option> <!-- 1080 / 720 (>30Hz) -->
+              <option label="37046">3</option> <!-- 1080 -->
+              <option label="13467">4</option> <!-- Unlimited / 1080 (>30Hz) -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="videoscreen.limitedrange" type="boolean" label="36042" help="36359">
           <level>3</level>
           <default>false</default>


### PR DESCRIPTION
## Description
This PR adds a new video setting `Limit GUI Size` for `GBM` platform that can be used on devices / SoCs with weaker GPUs in order to improve user experience by limiting the gui plane size used.

This setting is `<visible>false</visible>` by default and is only intended to be set visible or forced in `appliance.xml` for devices / SoCs with weaker GPUs.

## Motivation and Context
Allows for video to render in 4K using direct-to-plane rendering and having a 720/1080p gui plane for osd / subtitles.

## How Has This Been Tested?
This has been included in LibreELEC Rockchip, Allwinner and mainline Amlogic builds for a long time.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
