### PR TITLE
[video] Fix info for movies which are part of sets.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -703,7 +703,8 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
   if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
     return CGUIDialogAddonInfo::ShowForItem(item);
 
-  if (item->IsVideoDb() &&
+  if (item->m_bIsFolder &&
+      item->IsVideoDb() &&
       StringUtils::StartsWith(item->GetPath(), "videodb://movies/sets/"))
     return ShowIMDB(item, nullptr, true);
 


### PR DESCRIPTION
Fix fallout from https://github.com/xbmc/xbmc/pull/15315 - cast (and maybe other info) for movies which are part of sets are no longer displayed in video info dialog.

@notspiff mind taking a look? 

@ronie fyi