### PR TITLE
changed: Improve handling of internet filesystems (http/https) on LANs

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -765,7 +765,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
 {
   if (m_strPath.empty()
    || IsPath("add")
-   || IsInternetStream()
+   || (IsInternetStream() && !IsOnLAN())
    || IsParentFolder()
    || IsVirtualDirectoryRoot()
    || IsPlugin()
@@ -1008,7 +1008,7 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
   EFileFolderType always_type = EFILEFOLDER_TYPE_ALWAYS;
 
   /* internet streams are not directly expanded */
-  if(IsInternetStream())
+  if(IsInternetStream() && !IsOnLAN())
     always_type = EFILEFOLDER_TYPE_ONCLICK;
 
   if(types & always_type)
@@ -2976,7 +2976,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
    || StringUtils::StartsWithNoCase(m_strPath, "newsmartplaylist://")
    || StringUtils::StartsWithNoCase(m_strPath, "newplaylist://")
    || m_bIsShareOrDrive
-   || IsInternetStream()
+   || (IsInternetStream() && !IsOnLAN())
    || URIUtils::IsUPnP(m_strPath)
    || (URIUtils::IsFTP(m_strPath) && !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs)
    || IsPlugin()
@@ -3068,7 +3068,7 @@ bool CFileItem::SkipLocalArt() const
        || StringUtils::StartsWithNoCase(m_strPath, "newsmartplaylist://")
        || StringUtils::StartsWithNoCase(m_strPath, "newplaylist://")
        || m_bIsShareOrDrive
-       || IsInternetStream()
+       || (IsInternetStream() && !IsOnLAN())
        || URIUtils::IsUPnP(m_strPath)
        || (URIUtils::IsFTP(m_strPath) && !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs)
        || IsPlugin()
@@ -3264,7 +3264,7 @@ std::string CFileItem::GetLocalFanart() const
   }
 
   // no local fanart available for these
-  if (IsInternetStream()
+  if ((IsInternetStream() && !IsOnLAN())
    || URIUtils::IsUPnP(strFile)
    || URIUtils::IsBluray(strFile)
    || IsLiveTV()
@@ -3537,7 +3537,7 @@ std::string CFileItem::FindTrailer() const
   }
 
   // no local trailer available for these
-  if (IsInternetStream()
+  if ((IsInternetStream() && !IsOnLAN())
    || URIUtils::IsUPnP(strFile)
    || URIUtils::IsBluray(strFile)
    || IsLiveTV()

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1994,7 +1994,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   unsigned int startTimer = XbmcThreads::SystemClockMillis();
 
   CFileItem item(strMovie, false);
-  if (item.IsInternetStream()
+  if ((item.IsInternetStream() && !item.IsOnLAN())
     || item.IsPlayList()
     || item.IsLiveTV()
     || !item.IsVideo())
@@ -2281,7 +2281,7 @@ std::string CUtil::GetVobSubIdxFromSub(const std::string& vobSub)
 void CUtil::ScanForExternalDemuxSub(const std::string& videoPath, std::vector<std::string>& vecSubtitles)
 {
   CFileItem item(videoPath, false);
-  if (item.IsInternetStream()
+  if ((item.IsInternetStream() && !item.IsOnLAN())
     || item.IsPlayList()
     || item.IsLiveTV()
     || item.IsPVR()
@@ -2305,7 +2305,7 @@ void CUtil::ScanForExternalDemuxSub(const std::string& videoPath, std::vector<st
 void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio)
 {
   CFileItem item(videoPath, false);
-  if ( item.IsInternetStream()
+  if ((item.IsInternetStream() && !item.IsOnLAN())
    ||  item.IsPlayList()
    ||  item.IsLiveTV()
    ||  item.IsPVR()

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -90,8 +90,7 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFrameRa
    * network share.
    */
   const std::string strMovie = fileItem.GetDynPath();
-  if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
-      !URIUtils::IsInternetStream(strMovie))
+  if (URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie))
   {
     CLog::Log(LOGDEBUG, "%s - Checking for edit decision lists (EDL) on local drive or remote share for: %s",
               __FUNCTION__, CURL::GetRedacted(strMovie).c_str());

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -73,7 +73,7 @@ void CMusicInfoLoader::OnLoaderStart()
 bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 {
   if (!pItem || (pItem->m_bIsFolder && !pItem->IsAudio()) ||
-      pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+      pItem->IsPlayList() || pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsOnLAN()))
     return false;
 
   if (pItem->GetProperty("hasfullmusictag") == "true")
@@ -150,7 +150,7 @@ bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
       pItem->IsPlayList() || pItem->IsSmartPlayList() ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") ||
-      pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
+      pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsOnLAN() && !pItem->IsMusicDb()))
     return false;
 
   // Get thumb for item
@@ -168,7 +168,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
       pItem->IsPlayList() || pItem->IsSmartPlayList() ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") ||
-      pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
+      pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsOnLAN() && !pItem->IsMusicDb()))
     return false;
 
   if (!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded())

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -31,7 +31,7 @@ CMusicInfoTagLoaderFactory::~CMusicInfoTagLoaderFactory() = default;
 IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& item)
 {
   // dont try to read the tags for streams & shoutcast
-  if (item.IsInternetStream())
+  if (item.IsInternetStream() && !item.IsOnLAN())
     return NULL;
 
   if (item.IsMusicDb())

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1108,7 +1108,7 @@ void CTagLoaderTagLib::AddArtistInstrument(CMusicInfoTag &tag, const std::vector
 bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, const std::string& fallbackFileExtension, EmbeddedArt *art /* = NULL */)
 {
   // Dont try to read the tags for streams & shoutcast
-  if (URIUtils::IsInternetStream(strFileName))
+  if (URIUtils::IsInternetStream(strFileName) && !URIUtils::IsOnLAN(strFileName))
     return false;
 
   std::string strExtension = URIUtils::GetExtension(strFileName);

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -557,7 +557,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
         else if (item->IsPlayList() || m_vecItems->IsPlayList())
           buttons.Add(CONTEXT_BUTTON_EDIT, 586);
       }
-      if (!m_vecItems->IsMusicDb() && !m_vecItems->IsInternetStream()           &&
+      if (!m_vecItems->IsMusicDb() && (!m_vecItems->IsInternetStream() || m_vecItems->IsOnLAN()) &&
           !item->IsPath("add") && !item->IsParentFolder() &&
           !item->IsPlugin() && !item->IsMusicDb()         &&
           !item->IsLibraryFolder() &&
@@ -832,7 +832,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
     g_partyModeManager.AddUserSongs(playlistTemp, !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICPLAYER_QUEUEBYDEFAULT));
     return true;
   }
-  else if (!pItem->IsPlayList() && !pItem->IsInternetStream())
+  else if (!pItem->IsPlayList() && (!pItem->IsInternetStream() || pItem->IsOnLAN()))
   { // single music file - if we get here then we have autoplaynextitem turned off or queuebydefault
     // turned on, but we still want to use the playlist player in order to handle more queued items
     // following etc.

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -599,7 +599,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 #endif
-      if (!inPlaylists && !m_vecItems->IsInternetStream() &&
+      if (!inPlaylists && (!m_vecItems->IsInternetStream() || m_vecItems->IsOnLAN()) &&
         !item->IsPath("add") && !item->IsParentFolder() &&
         !item->IsPlugin() &&
         !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -49,7 +49,7 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CPictureInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || (pItem->IsInternetStream() && !pItem->IsOnLAN()) || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())
@@ -72,7 +72,7 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || (pItem->IsInternetStream() && !pItem->IsOnLAN()) || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -88,7 +88,7 @@ bool CThumbExtractor::DoWork()
   ||  m_item.IsDVD()
   ||  m_item.IsDiscImage()
   ||  m_item.IsDVDFile(false, true)
-  ||  m_item.IsInternetStream()
+  ||  (m_item.IsInternetStream() && !m_item.IsOnLAN())
   ||  m_item.IsDiscStub()
   ||  m_item.IsPlayList())
     return false;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1301,7 +1301,7 @@ bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items)
 {
   CURL url(items.GetPath());
   return !(items.IsPlugin() || items.IsAddonsPath()  ||
-           items.IsRSS() || items.IsInternetStream() ||
+           items.IsRSS() || (items.IsInternetStream() && !items.IsOnLAN()) ||
            items.IsVideoDb() || url.IsProtocol("playlistvideo"));
 }
 


### PR DESCRIPTION
Currently http/https filesystems used on LANs have limited functionality (compared to eg. WebDAV) since they are always treated as "true" internet streams. I therefor went over all the IsInternetStream() instances and modified the relevant ones to remove this limitation (for the most part). This should also prevent some confusion among users which don't understand why their http/https connections to their NASes are crippled.