### PR TITLE
[PVR] Fix group manager crash when adding a new group. Closes #16079.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -34,13 +34,13 @@
 
 using namespace PVR;
 
-CPVRChannelGroup::CPVRChannelGroup(void)
+CPVRChannelGroup::CPVRChannelGroup()
 {
   OnInit();
 }
 
 CPVRChannelGroup::CPVRChannelGroup(bool bRadio,
-                                   unsigned int iGroupId,
+                                   int iGroupId,
                                    const std::string& strGroupName,
                                    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup) :
     m_bRadio(bRadio),
@@ -773,11 +773,11 @@ bool CPVRChannelGroup::Persist(void)
   CSingleLock lock(m_critSection);
 
   /* only persist if the group has changes and is fully loaded or never has been saved before */
-  if (!HasChanges() || (!m_bLoaded && m_iGroupId != -1))
+  if (!HasChanges() || (!m_bLoaded && m_iGroupId != INVALID_GROUP_ID))
     return bReturn;
 
   // Mark newly created groups as loaded so future updates will also be persisted...
-  if (m_iGroupId == -1)
+  if (m_iGroupId == INVALID_GROUP_ID)
     m_bLoaded = true;
 
   if (database)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -59,16 +59,16 @@ namespace PVR
     friend class CPVRDatabase;
 
   public:
-    CPVRChannelGroup(void);
+    static const int INVALID_GROUP_ID = -1;
 
     /*!
      * @brief Create a new channel group instance.
      * @param bRadio True if this group holds radio channels.
-     * @param iGroupId The database ID of this group.
+     * @param iGroupId The database ID of this group or INVALID_GROUP_ID if the group was not yet stored in the database.
      * @param strGroupName The name of this group.
      * @param allChannelsGroup The channel group containing all TV or radio channels.
      */
-    CPVRChannelGroup(bool bRadio, unsigned int iGroupId, const std::string& strGroupName, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+    CPVRChannelGroup(bool bRadio, int iGroupId, const std::string& strGroupName, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
 
     /*!
      * @brief Create a new channel group instance from a channel group provided by an add-on.
@@ -433,6 +433,8 @@ namespace PVR
     bool IsMissingChannelsFromClient(int iClientId) const;
 
   protected:
+    CPVRChannelGroup();
+
     /*!
      * @brief Init class
      */
@@ -500,7 +502,7 @@ namespace PVR
 
     bool             m_bRadio = false;                      /*!< true if this container holds radio channels, false if it holds TV channels */
     int              m_iGroupType = PVR_GROUP_TYPE_DEFAULT;                  /*!< The type of this group */
-    int              m_iGroupId = -1;                    /*!< The ID of this group in the database */
+    int              m_iGroupId = INVALID_GROUP_ID; /*!< The ID of this group in the database */
     std::string      m_strGroupName;                /*!< The name of this group */
     bool             m_bLoaded = false;                     /*!< True if this container is loaded, false otherwise */
     bool             m_bChanged = false;                    /*!< true if anything changed in this group that hasn't been persisted, false otherwise */

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -500,9 +500,8 @@ bool CPVRChannelGroups::AddGroup(const std::string &strName)
     if (!group)
     {
       // create a new group
-      group = CPVRChannelGroupPtr(new CPVRChannelGroup());
-      group->SetRadio(m_bRadio);
-      group->SetGroupName(strName);
+      group.reset(new CPVRChannelGroup(m_bRadio, CPVRChannelGroup::INVALID_GROUP_ID, strName, GetGroupAll()));
+
       m_groups.push_back(group);
       bPersist = true;
     }


### PR DESCRIPTION
Fixes #16079, fallout from #15707.

@Jalle19 good to go. Reason for the crash was `CChannelGroup::m_allChannelsGroup` null deref, because wrong `CChannelGroup` ctor was used in `CPVRChannelGroups::AddGroup`.

