### PR TITLE
[JSON-RPC] Adding support for plugin based video source inside json-rpc command GetFileDetails

### DIFF
--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -168,10 +168,10 @@ JSONRPC_STATUS CFileOperations::GetFileDetails(const std::string &method, ITrans
   if (!URIUtils::IsPlugin(file))
   {
     if (!CFile::Exists(file))
-	  return InvalidParams;
+      return InvalidParams;
 
-	if (!CFileUtils::RemoteAccessAllowed(file))
-	  return InvalidParams;
+    if (!CFileUtils::RemoteAccessAllowed(file))
+      return InvalidParams;
   }
   std::string path;
   CFileItemList items;
@@ -184,7 +184,7 @@ JSONRPC_STATUS CFileOperations::GetFileDetails(const std::string &method, ITrans
       return InvalidParams;
     item = items.Get(file);
 
-	if (!URIUtils::IsUPnP(file))
+    if (!URIUtils::IsUPnP(file))
       FillFileItem(item, item, parameterObject["media"].asString(), parameterObject);
   }
   else
@@ -203,7 +203,7 @@ JSONRPC_STATUS CFileOperations::GetFileDetails(const std::string &method, ITrans
       }
       CURL n_url(o_file);
       url = n_url;
-	}
+    }
 
     if (!plugin.GetDirectory(url, items))
       return InvalidParams;


### PR DESCRIPTION
## Description
My code change only touch one function of JSON-RPC, it check if the item that we asked for is based on plugin. Next it try to access that plugin and get items from it, like the old way but I adapted it to the way the creator did with video source (using PluginDirectory). I rearange old code so if its non plugin content it works exactly the same as it did and if its plugin source it try to extract the proper url for it because without extracting the proper url this would end up with playing the while trying to match it. DB saves the url for file and we check against plugin, thats why It tries to get the url thats ends with `/` because we need to execute the plugin to get the ListItems for that file.

## Motivation and Context
From Kodi 18.2 you can use video plugins as video library source, this is awesome feature, but not everything support this source. For example the JSON-RPC that could return information about file and ID from db. With current code the function return INVALID Parameters which is other way of saying `Not supported` instead of `you used wrong parameters`.
This fix issue that I posted some time ago: https://github.com/xbmc/xbmc/issues/15897
Also I would love this being backported to 18.x - this code should be compatible with it because I started on 18.x and then upgraded to 19.x

## How Has This Been Tested?
This code only touch one function of JSON-RPC call for item inside db, as before `plugin://` wan't avaiable to be inside video library this code does not break any compatibility.
I coded/compiled/run this code on Win10Pro with VisualStudio2017, I added few normal files to video library and I added `plugin.video.nakamori` as source test, I then executed JSON-RPC GetFileDetails with full url from DB to get ID to verify it working - it did return proper ids. I run JSOn-RPC GetFileDetails on normal (file) objects from db and the results was proper ids.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
