### PR TITLE
settings: allow setting the DRMPRIME renderer without having the DRMPRIME decoder enabled

### DIFF
--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -17,11 +17,6 @@
         </setting>
         <setting id="videoplayer.useprimerenderer" type="integer" label="13462" help="13463">
           <visible>false</visible>
-          <dependencies>
-            <dependency type="enable">
-              <condition setting="videoplayer.useprimedecoder" operator="is">true</condition>
-            </dependency>
-          </dependencies>
           <level>2</level>
           <default>0</default>
           <constraints>


### PR DESCRIPTION
This removes the dependency to switch the `DRMPRIME` render method from the `DRMPRIME` decoder switch.

This is needed to allow switching render methods when not using the `DRMPRIME` decoder (for upcoming vaapi support). This setting is only visible if the `DRMPRIME` render method has been properly registered (because a video plane is available). Otherwise you won't see this setting at all if only the `DRMPRIMEGLES` render method is available.

CC: @Kwiboo 