### PR TITLE
CVaapiRenderPicture: inherit from IVideoBufferDRMPRIME class

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -179,8 +179,6 @@ public:
   // IVideoBufferDRMPRIME
 #if VA_CHECK_VERSION(1, 1, 0)
   AVDRMFrameDescriptor* GetDescriptor() const override;
-  uint32_t GetWidth() const override { return DVDPic.iWidth; }
-  uint32_t GetHeight() const override { return DVDPic.iHeight; }
   int GetColorEncoding() const override;
   int GetColorRange() const override;
 
@@ -188,9 +186,9 @@ public:
   void Unmap() override;
 #else
   AVDRMFrameDescriptor* GetDescriptor() const override { return nullptr; }
+#endif
   uint32_t GetWidth() const override { return DVDPic.iWidth; }
   uint32_t GetHeight() const override { return DVDPic.iHeight; }
-#endif
 
   VideoPicture DVDPic;
   CVaapiProcessedPicture procPic;

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -16,11 +16,6 @@ extern "C"
 #include <libavutil/pixdesc.h>
 }
 
-IVideoBufferDRMPRIME::IVideoBufferDRMPRIME(int id)
-  : CVideoBuffer(id)
-{
-}
-
 CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
   : IVideoBufferDRMPRIME(id)
 {

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -61,7 +61,7 @@ public:
   uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
 
 protected:
-  explicit IVideoBufferDRMPRIME(int id);
+  explicit IVideoBufferDRMPRIME(int id) : CVideoBuffer(id) { }
 };
 
 class CVideoBufferDRMPRIME : public IVideoBufferDRMPRIME


### PR DESCRIPTION
This allows us to render vaapi frames in the drm prime renderers. This is needed in order to support HDR.

This PR is a little premature but I wanted to get some early feedback and to share some of the issues that I forsee.

1) This will break AMD vaapi because the mesa va tracker doesn't support `VA_EXPORT_SURFACE_COMPOSED_LAYERS`. I have some code I am testing that adds a test for this but it seems to be pretty method specific and I'm seeing if I can make it more general. We don't explicitly need to be able to export composed layers, however, we need to be able to have the drm format be explicit for the entire buffer. Currently only the `composed` method allows specifying the drm format for the whole buffer even though it may be multiple planes (see NV12). When exporting as separate layers each layer gets a drm format instead.

I do have a PR to mesa that will fix this [here](https://gitlab.freedesktop.org/mesa/mesa/merge_requests/710) but @fhvwy said that it's separate because the buffer isn't actually composed (one buffer?). The AMDGPU driver will gain support for exposing NV12 planes in the upcoming linux 5.2 so that may be reason enough to allow exporting `COMPOSED` buffers as only intel was able to do that previously.

@Kwiboo has come up with an ffmpeg patch that may also address this [here](https://github.com/Kwiboo/FFmpeg/commit/bd88c6d37be0caa06e7dd0067118a75aeda4b2ef). This will actually allow us to have ffmpeg export the `AVDRMFrameDescriptor` for us. Then we can parse it and decide what to do with it (render 1img vs 2img).

Either way we may have to actually parse the layers/planes to figure out what the actual buffer format is which I don't really like and hopefully we can find a solution for.

2) I'm allocating the memory for `VADRMPRIMESurfaceDescriptor` and `AVDRMFrameDescriptor` in `Map()` because `Map()` needs to be called before `GetDescriptor()`. I also didn't allocate them in the constructor because `CVaapiRenderPicture` may be used by the regular vaapi renderer and won't be needed in that case. Ideally I would like to get rid of the vaapi render method and move to the drmprime method exclusively in the future. I am still working on this.

CC: @Kwiboo 