### PR TITLE
Remove redundant smart pointer get()

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3353,7 +3353,7 @@ bool CFileItem::LoadMusicTag()
   CLog::Log(LOGDEBUG, "%s: loading tag information for file: %s", __FUNCTION__, m_strPath.c_str());
   CMusicInfoTagLoaderFactory factory;
   std::unique_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(*this));
-  if (pLoader != NULL)
+  if (pLoader)
   {
     if (pLoader->Load(m_strPath, *GetMusicInfoTag()))
       return true;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3353,7 +3353,7 @@ bool CFileItem::LoadMusicTag()
   CLog::Log(LOGDEBUG, "%s: loading tag information for file: %s", __FUNCTION__, m_strPath.c_str());
   CMusicInfoTagLoaderFactory factory;
   std::unique_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(*this));
-  if (pLoader.get() != NULL)
+  if (pLoader != NULL)
   {
     if (pLoader->Load(m_strPath, *GetMusicInfoTag()))
       return true;

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -239,8 +239,10 @@ bool CTextureDatabase::GetCachedTexture(const std::string &url, CTextureDetails 
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("SELECT id, cachedurl, lasthashcheck, imagehash, width, height FROM texture JOIN sizes ON (texture.id=sizes.idtexture AND sizes.size=1) WHERE url='%s'", url.c_str());
     m_pDS->query(sql);
@@ -270,8 +272,10 @@ bool CTextureDatabase::GetTextures(CVariant &items, const Filter &filter)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = "SELECT %s FROM texture JOIN sizes ON (texture.id=sizes.idtexture AND sizes.size=1)";
     std::string sqlFilter;
@@ -323,8 +327,10 @@ bool CTextureDatabase::AddCachedTexture(const std::string &url, const CTextureDe
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("DELETE FROM texture WHERE url='%s'", url.c_str());
     m_pDS->exec(sql);
@@ -355,8 +361,10 @@ bool CTextureDatabase::ClearCachedTexture(int id, std::string &cacheFile)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("select cachedurl from texture where id=%u", id);
     m_pDS->query(sql);
@@ -390,8 +398,10 @@ std::string CTextureDatabase::GetTextureForPath(const std::string &url, const st
 {
   try
   {
-    if (NULL == m_pDB) return "";
-    if (NULL == m_pDS) return "";
+    if (!m_pDB)
+      return "";
+    if (!m_pDS)
+      return "";
 
     if (url.empty())
       return "";
@@ -418,8 +428,10 @@ void CTextureDatabase::SetTextureForPath(const std::string &url, const std::stri
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     if (url.empty())
       return;
@@ -451,8 +463,10 @@ void CTextureDatabase::ClearTextureForPath(const std::string &url, const std::st
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     std::string sql = PrepareSQL("DELETE FROM path WHERE url='%s' and type='%s'", url.c_str(), type.c_str());
     m_pDS->exec(sql);

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -239,8 +239,8 @@ bool CTextureDatabase::GetCachedTexture(const std::string &url, CTextureDetails 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("SELECT id, cachedurl, lasthashcheck, imagehash, width, height FROM texture JOIN sizes ON (texture.id=sizes.idtexture AND sizes.size=1) WHERE url='%s'", url.c_str());
     m_pDS->query(sql);
@@ -270,8 +270,8 @@ bool CTextureDatabase::GetTextures(CVariant &items, const Filter &filter)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = "SELECT %s FROM texture JOIN sizes ON (texture.id=sizes.idtexture AND sizes.size=1)";
     std::string sqlFilter;
@@ -323,8 +323,8 @@ bool CTextureDatabase::AddCachedTexture(const std::string &url, const CTextureDe
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("DELETE FROM texture WHERE url='%s'", url.c_str());
     m_pDS->exec(sql);
@@ -355,8 +355,8 @@ bool CTextureDatabase::ClearCachedTexture(int id, std::string &cacheFile)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("select cachedurl from texture where id=%u", id);
     m_pDS->query(sql);
@@ -390,8 +390,8 @@ std::string CTextureDatabase::GetTextureForPath(const std::string &url, const st
 {
   try
   {
-    if (NULL == m_pDB.get()) return "";
-    if (NULL == m_pDS.get()) return "";
+    if (NULL == m_pDB) return "";
+    if (NULL == m_pDS) return "";
 
     if (url.empty())
       return "";
@@ -418,8 +418,8 @@ void CTextureDatabase::SetTextureForPath(const std::string &url, const std::stri
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (url.empty())
       return;
@@ -451,8 +451,8 @@ void CTextureDatabase::ClearTextureForPath(const std::string &url, const std::st
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     std::string sql = PrepareSQL("DELETE FROM path WHERE url='%s' and type='%s'", url.c_str(), type.c_str());
     m_pDS->exec(sql);

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -310,8 +310,8 @@ void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids,
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     std::set<std::string> db;
     m_pDS->query(PrepareSQL("SELECT addonID FROM installed"));
@@ -374,8 +374,8 @@ void CAddonDatabase::GetInstalled(std::vector<CAddonBuilder>& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     m_pDS->query(PrepareSQL("SELECT * FROM installed"));
     while (!m_pDS->eof())
@@ -400,8 +400,8 @@ bool CAddonDatabase::SetLastUpdated(const std::string& addonId, const CDateTime&
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     m_pDS->exec(PrepareSQL("UPDATE installed SET lastUpdated='%s' WHERE addonID='%s'",
         dateTime.GetAsDBDateTime().c_str(), addonId.c_str()));
@@ -418,8 +418,8 @@ bool CAddonDatabase::SetOrigin(const std::string& addonId, const std::string& or
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s'", origin.c_str(), addonId.c_str()));
     return true;
@@ -435,8 +435,8 @@ bool CAddonDatabase::SetLastUsed(const std::string& addonId, const CDateTime& da
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     auto start = XbmcThreads::SystemClockMillis();
     m_pDS->exec(PrepareSQL("UPDATE installed SET lastUsed='%s' WHERE addonID='%s'",
@@ -457,8 +457,8 @@ std::pair<AddonVersion, std::string> CAddonDatabase::GetAddonVersion(const std::
   auto empty = std::make_pair(AddonVersion("0.0.0"), "");
   try
   {
-    if (NULL == m_pDB.get()) return empty;
-    if (NULL == m_pDS2.get()) return empty;
+    if (NULL == m_pDB) return empty;
+    if (NULL == m_pDS2) return empty;
 
     std::vector<std::pair<ADDON::AddonVersion, std::string>> versions;
     if (GetAvailableVersions(id, versions) && versions.size() > 0)
@@ -475,8 +475,8 @@ bool CAddonDatabase::FindByAddonId(const std::string& addonId, ADDON::VECADDONS&
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL(
         "SELECT addons.version, addons.name, addons.summary, addons.description, addons.metadata, addons.news,"
@@ -525,8 +525,8 @@ bool CAddonDatabase::GetAvailableVersions(const std::string& addonId,
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL(
         "SELECT addons.version, repo.addonID AS repoID FROM addons "
@@ -558,8 +558,8 @@ bool CAddonDatabase::GetAddon(const std::string& addonID, const AddonVersion& ve
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
   std::string sql = PrepareSQL(
       "SELECT addons.id FROM addons "
@@ -586,8 +586,8 @@ bool CAddonDatabase::GetAddon(const std::string& id, AddonPtr& addon)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false;
 
     // there may be multiple addons with this id (eg from different repositories) in the database,
     // so we want to retrieve the latest version.  Order by version won't work as the database
@@ -624,8 +624,8 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false;
 
     m_pDS2->query(PrepareSQL("SELECT * FROM addons WHERE id=%i", id));
     if (m_pDS2->eof())
@@ -657,8 +657,8 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     auto start = XbmcThreads::SystemClockMillis();
 
@@ -753,8 +753,8 @@ void CAddonDatabase::DeleteRepository(const std::string& id)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     m_pDS->query(PrepareSQL("SELECT id FROM repo WHERE addonID='%s'", id.c_str()));
     if (m_pDS->eof())
@@ -777,8 +777,8 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository, cons
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     DeleteRepository(repository);
 
@@ -828,8 +828,8 @@ int CAddonDatabase::GetRepoChecksum(const std::string& id, std::string& checksum
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
     m_pDS->query(strSQL);
@@ -853,7 +853,7 @@ std::pair<CDateTime, ADDON::AddonVersion> CAddonDatabase::LastChecked(const std:
   AddonVersion version("0.0.0");
   try
   {
-    if (m_pDB.get() != nullptr && m_pDS.get() != nullptr)
+    if (m_pDB != nullptr && m_pDS != nullptr)
     {
       std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
       m_pDS->query(strSQL);
@@ -876,8 +876,8 @@ int CAddonDatabase::SetLastChecked(const std::string& id,
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int retId = -1;
     std::string sql = PrepareSQL("SELECT * FROM repo WHERE addonID='%s'", id.c_str());
@@ -911,8 +911,8 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     strSQL=PrepareSQL("SELECT addonID FROM addons WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
@@ -943,8 +943,8 @@ bool CAddonDatabase::DisableAddon(const std::string &addonID, bool disable /* = 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("UPDATE installed SET enabled=%d WHERE addonID='%s'", disable ? 0 : 1, addonID.c_str());
     m_pDS->exec(sql);
@@ -970,8 +970,8 @@ bool CAddonDatabase::GetDisabled(std::set<std::string>& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("SELECT addonID FROM installed WHERE enabled=0");
     m_pDS->query(sql);
@@ -994,8 +994,8 @@ bool CAddonDatabase::GetBlacklisted(std::set<std::string>& addons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("SELECT addonID FROM blacklist");
     m_pDS->query(sql);
@@ -1023,8 +1023,8 @@ bool CAddonDatabase::BlacklistAddon(const std::string& addonID)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("INSERT INTO blacklist(id, addonID) VALUES(NULL, '%s')", addonID.c_str());
     m_pDS->exec(sql);
@@ -1041,8 +1041,8 @@ bool CAddonDatabase::RemoveAddonFromBlacklist(const std::string& addonID)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("DELETE FROM blacklist WHERE addonID='%s'", addonID.c_str());
     m_pDS->exec(sql);
@@ -1089,8 +1089,8 @@ void CAddonDatabase::OnPostUnInstall(const std::string& addonId)
   //! @todo should be done before uninstall to avoid any race conditions
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
     m_pDS->exec(PrepareSQL("DELETE FROM installed WHERE addonID='%s'", addonId.c_str()));
   }
   catch (...)

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -310,8 +310,10 @@ void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids,
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     std::set<std::string> db;
     m_pDS->query(PrepareSQL("SELECT addonID FROM installed"));
@@ -374,8 +376,10 @@ void CAddonDatabase::GetInstalled(std::vector<CAddonBuilder>& addons)
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     m_pDS->query(PrepareSQL("SELECT * FROM installed"));
     while (!m_pDS->eof())
@@ -400,8 +404,10 @@ bool CAddonDatabase::SetLastUpdated(const std::string& addonId, const CDateTime&
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     m_pDS->exec(PrepareSQL("UPDATE installed SET lastUpdated='%s' WHERE addonID='%s'",
         dateTime.GetAsDBDateTime().c_str(), addonId.c_str()));
@@ -418,8 +424,10 @@ bool CAddonDatabase::SetOrigin(const std::string& addonId, const std::string& or
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s'", origin.c_str(), addonId.c_str()));
     return true;
@@ -435,8 +443,10 @@ bool CAddonDatabase::SetLastUsed(const std::string& addonId, const CDateTime& da
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     auto start = XbmcThreads::SystemClockMillis();
     m_pDS->exec(PrepareSQL("UPDATE installed SET lastUsed='%s' WHERE addonID='%s'",
@@ -457,8 +467,10 @@ std::pair<AddonVersion, std::string> CAddonDatabase::GetAddonVersion(const std::
   auto empty = std::make_pair(AddonVersion("0.0.0"), "");
   try
   {
-    if (NULL == m_pDB) return empty;
-    if (NULL == m_pDS2) return empty;
+    if (!m_pDB)
+      return empty;
+    if (!m_pDS2)
+      return empty;
 
     std::vector<std::pair<ADDON::AddonVersion, std::string>> versions;
     if (GetAvailableVersions(id, versions) && versions.size() > 0)
@@ -475,8 +487,10 @@ bool CAddonDatabase::FindByAddonId(const std::string& addonId, ADDON::VECADDONS&
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL(
         "SELECT addons.version, addons.name, addons.summary, addons.description, addons.metadata, addons.news,"
@@ -525,8 +539,10 @@ bool CAddonDatabase::GetAvailableVersions(const std::string& addonId,
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL(
         "SELECT addons.version, repo.addonID AS repoID FROM addons "
@@ -558,8 +574,10 @@ bool CAddonDatabase::GetAddon(const std::string& addonID, const AddonVersion& ve
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
   std::string sql = PrepareSQL(
       "SELECT addons.id FROM addons "
@@ -586,8 +604,10 @@ bool CAddonDatabase::GetAddon(const std::string& id, AddonPtr& addon)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false;
 
     // there may be multiple addons with this id (eg from different repositories) in the database,
     // so we want to retrieve the latest version.  Order by version won't work as the database
@@ -624,8 +644,10 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false;
 
     m_pDS2->query(PrepareSQL("SELECT * FROM addons WHERE id=%i", id));
     if (m_pDS2->eof())
@@ -657,8 +679,10 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     auto start = XbmcThreads::SystemClockMillis();
 
@@ -753,8 +777,10 @@ void CAddonDatabase::DeleteRepository(const std::string& id)
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     m_pDS->query(PrepareSQL("SELECT id FROM repo WHERE addonID='%s'", id.c_str()));
     if (m_pDS->eof())
@@ -777,8 +803,10 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository, cons
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     DeleteRepository(repository);
 
@@ -828,8 +856,10 @@ int CAddonDatabase::GetRepoChecksum(const std::string& id, std::string& checksum
 {
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
     m_pDS->query(strSQL);
@@ -853,7 +883,7 @@ std::pair<CDateTime, ADDON::AddonVersion> CAddonDatabase::LastChecked(const std:
   AddonVersion version("0.0.0");
   try
   {
-    if (m_pDB != nullptr && m_pDS != nullptr)
+    if (m_pDB && m_pDS)
     {
       std::string strSQL = PrepareSQL("select * from repo where addonID='%s'",id.c_str());
       m_pDS->query(strSQL);
@@ -876,8 +906,10 @@ int CAddonDatabase::SetLastChecked(const std::string& id,
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     int retId = -1;
     std::string sql = PrepareSQL("SELECT * FROM repo WHERE addonID='%s'", id.c_str());
@@ -911,8 +943,10 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     strSQL=PrepareSQL("SELECT addonID FROM addons WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
@@ -943,8 +977,10 @@ bool CAddonDatabase::DisableAddon(const std::string &addonID, bool disable /* = 
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("UPDATE installed SET enabled=%d WHERE addonID='%s'", disable ? 0 : 1, addonID.c_str());
     m_pDS->exec(sql);
@@ -970,8 +1006,10 @@ bool CAddonDatabase::GetDisabled(std::set<std::string>& addons)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("SELECT addonID FROM installed WHERE enabled=0");
     m_pDS->query(sql);
@@ -994,8 +1032,10 @@ bool CAddonDatabase::GetBlacklisted(std::set<std::string>& addons)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("SELECT addonID FROM blacklist");
     m_pDS->query(sql);
@@ -1023,8 +1063,10 @@ bool CAddonDatabase::BlacklistAddon(const std::string& addonID)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("INSERT INTO blacklist(id, addonID) VALUES(NULL, '%s')", addonID.c_str());
     m_pDS->exec(sql);
@@ -1041,8 +1083,10 @@ bool CAddonDatabase::RemoveAddonFromBlacklist(const std::string& addonID)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("DELETE FROM blacklist WHERE addonID='%s'", addonID.c_str());
     m_pDS->exec(sql);
@@ -1089,8 +1133,10 @@ void CAddonDatabase::OnPostUnInstall(const std::string& addonId)
   //! @todo should be done before uninstall to avoid any race conditions
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
     m_pDS->exec(PrepareSQL("DELETE FROM installed WHERE addonID='%s'", addonId.c_str()));
   }
   catch (...)


### PR DESCRIPTION
## Description
Apply clang-tidy check `readability-redundant-smartptr-get`.

## Motivation and Context
Slight code simplification.

## How Has This Been Tested?
Compiled & ran existing tests. Currently running a local build.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
