### PR TITLE
DRMPRIME: support frame descriptors with multiple layers

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -166,6 +166,17 @@ if(NOT ENABLE_INTERNAL_FFMPEG OR KODI_DEPENDSBUILD)
                                                     FFMPEG_VERSION
                                       FAIL_MESSAGE "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, please consider using -DENABLE_INTERNAL_FFMPEG=ON")
 
+    include(CheckCSourceCompiles)
+    set(CMAKE_REQUIRED_INCLUDES ${FFMPEG_INCLUDE_DIRS})
+    check_c_source_compiles("#include <libavutil/hwcontext_drm.h>
+
+                             int main()
+                             {
+                               AVDRMFrameDescriptor test;
+                               return test.format;
+                             }
+                             " FFMPEG_HAS_AVDRMFRAMEDESCRIPTOR_FORMAT)
+
   else()
     message(STATUS "FFmpeg ${REQUIRED_FFMPEG_VERSION} not found, falling back to internal build")
     unset(FFMPEG_INCLUDE_DIRS)
@@ -194,6 +205,10 @@ if(NOT ENABLE_INTERNAL_FFMPEG OR KODI_DEPENDSBUILD)
                          ${FFMPEG_LIBSWSCALE} ${FFMPEG_LIBSWRESAMPLE}
                          ${FFMPEG_LIBPOSTPROC} ${FFMPEG_LDFLAGS})
     list(APPEND FFMPEG_DEFINITIONS -DFFMPEG_VER_SHA=\"${FFMPEG_VERSION}\")
+
+    if(FFMPEG_HAS_AVDRMFRAMEDESCRIPTOR_FORMAT)
+      list(APPEND FFMPEG_DEFINITIONS -DHAVE_AVDRMFRAMEDESCRIPTOR_FORMAT=1)
+    endif()
 
     if(NOT TARGET ffmpeg)
       add_library(ffmpeg ${FFMPEG_LIB_TYPE} IMPORTED)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -87,6 +87,20 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
   uint64_t modifier[4] = {0};
   int ret;
 
+  // get drm format of the frame
+#ifdef HAVE_AVDRMFRAMEDESCRIPTOR_FORMAT
+  uint32_t format = descriptor->format;
+#else
+  uint32_t format = 0;
+#endif
+  if (!format && descriptor->nb_layers == 1)
+    format = descriptor->layers[0].format;
+  if (!format)
+  {
+    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to determine format", __FUNCTION__);
+    return false;
+  }
+
   // convert Prime FD to GEM handle
   for (int object = 0; object < descriptor->nb_objects; object++)
   {
@@ -102,18 +116,21 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
     }
   }
 
-  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
-
-  for (int plane = 0; plane < layer->nb_planes; plane++)
+  int index = 0;
+  for (int i = 0; i < descriptor->nb_layers; i++)
   {
-    int object = layer->planes[plane].object_index;
-    uint32_t handle = buffer->m_handles[object];
-    if (handle && layer->planes[plane].pitch)
+    AVDRMLayerDescriptor* layer = &descriptor->layers[i];
+    for (int j = 0; j < layer->nb_planes; j++)
     {
-      handles[plane] = handle;
-      pitches[plane] = layer->planes[plane].pitch;
-      offsets[plane] = layer->planes[plane].offset;
-      modifier[plane] = descriptor->objects[object].format_modifier;
+      AVDRMPlaneDescriptor* plane = &layer->planes[j];
+      int object = plane->object_index;
+
+      handles[index] = buffer->m_handles[object];
+      pitches[index] = plane->pitch;
+      offsets[index] = plane->offset;
+      modifier[index] = descriptor->objects[object].format_modifier;
+
+      index++;
     }
   }
 
@@ -122,8 +139,8 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
 
   // add the video frame FB
   ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(),
-                                   buffer->GetHeight(), layer->format, handles, pitches, offsets,
-                                   modifier, &buffer->m_fb_id, flags);
+                                   buffer->GetHeight(), format, handles, pitches, offsets, modifier,
+                                   &buffer->m_fb_id, flags);
   if (ret < 0)
   {
     CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",


### PR DESCRIPTION
## Description
This PR adds support for frame descriptors with multiple layers containing one plane for each layer instead of a single layer with multiple planes.

This is created as a draft PR since it depends on [functionality not yet in ffmpeg](https://github.com/ffmpeg/ffmpeg/compare/master...Kwiboo:drmprime-format).

## Motivation and Context
If `vaExportSurfaceHandle` is used with `VA_EXPORT_SURFACE_SEPARATE_LAYERS` and the result is transformed into a `AVDRMFrameDescriptor` , the resulting frame descriptor will contain multiple layers, each layer with a single plane.

In a single layer NV12 frame descriptor the layer format will be `DRM_FORMAT_NV12`.
For a multi-layer NV12 frame descriptor the first layer format will be `DRM_FORMAT_R8` and the second layer will be `DRM_FORMAT_RG88`, information about the frame format is missing.

A new field `format` was added to `AVDRMFrameDescriptor` to carry the frame format, `DRM_FORMAT_NV12` in the example above.

## How Has This Been Tested?
This has been tested running LibreELEC on an Intel NUC with VA-API decoding and DRMPRIME GLES rendering and on a Tinker Board S using the Direct-To-Plane renderer. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
