### PR TITLE
VideoLayerBridgeDRMPRIME: set HDR metadata

### DIFF
--- a/cmake/modules/FindLibDRM.cmake
+++ b/cmake/modules/FindLibDRM.cmake
@@ -8,6 +8,7 @@
 # LIBDRM_FOUND - system has LibDRM
 # LIBDRM_INCLUDE_DIRS - the LibDRM include directory
 # LIBDRM_LIBRARIES - the LibDRM libraries
+# LIBDRM_DEFINITIONS  - the LibDRM definitions
 #
 # and the following imported targets::
 #
@@ -30,9 +31,23 @@ find_package_handle_standard_args(LibDRM
                                   REQUIRED_VARS LIBDRM_LIBRARY LIBDRM_INCLUDE_DIR
                                   VERSION_VAR LIBDRM_VERSION)
 
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_INCLUDES ${LIBDRM_INCLUDE_DIR})
+check_c_source_compiles("#include <drm_mode.h>
+
+                         int main()
+                         {
+                           struct hdr_output_metadata test;
+                           return test.metadata_type;
+                         }
+                         " LIBDRM_HAS_HDR_OUTPUT_METADATA)
+
 if(LIBDRM_FOUND)
   set(LIBDRM_LIBRARIES ${LIBDRM_LIBRARY})
   set(LIBDRM_INCLUDE_DIRS ${LIBDRM_INCLUDE_DIR})
+  if(LIBDRM_HAS_HDR_OUTPUT_METADATA)
+    set(LIBDRM_DEFINITIONS -DHAVE_HDR_OUTPUT_METADATA=1)
+  endif()
 
   if(NOT TARGET LIBDRM::LIBDRM)
     add_library(LIBDRM::LIBDRM UNKNOWN IMPORTED)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -295,6 +295,32 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
             m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10_INTRA))
     pVideoPicture->colorBits = 10;
 
+  pVideoPicture->hasDisplayMetadata = false;
+  AVFrameSideData* sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+  if (sd)
+  {
+    pVideoPicture->displayMetadata = *reinterpret_cast<AVMasteringDisplayMetadata*>(sd->data);
+    pVideoPicture->hasDisplayMetadata = true;
+  }
+  else if (m_hints.masteringMetadata)
+  {
+    pVideoPicture->displayMetadata = *m_hints.masteringMetadata.get();
+    pVideoPicture->hasDisplayMetadata = true;
+  }
+
+  pVideoPicture->hasLightMetadata = false;
+  sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+  if (sd)
+  {
+    pVideoPicture->lightMetadata = *reinterpret_cast<AVContentLightMetadata*>(sd->data);
+    pVideoPicture->hasLightMetadata = true;
+  }
+  else if (m_hints.contentLightMetadata)
+  {
+    pVideoPicture->lightMetadata = *m_hints.contentLightMetadata.get();
+    pVideoPicture->hasLightMetadata = true;
+  }
+
   pVideoPicture->iRepeatPicture = 0;
   pVideoPicture->iFlags = 0;
   pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -49,6 +49,30 @@ int GetColorRange(const VideoPicture& picture)
   return DRM_COLOR_YCBCR_LIMITED_RANGE;
 }
 
+uint8_t GetEOTF(const VideoPicture& picture)
+{
+  switch (picture.color_transfer)
+  {
+    case AVCOL_TRC_SMPTE2084:
+      return HDMI_EOTF_SMPTE_ST2084;
+    case AVCOL_TRC_ARIB_STD_B67:
+    case AVCOL_TRC_BT2020_10:
+      return HDMI_EOTF_BT_2100_HLG;
+    default:
+      return HDMI_EOTF_TRADITIONAL_GAMMA_SDR;
+  }
+}
+
+const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture)
+{
+  return picture.hasDisplayMetadata ? &picture.displayMetadata : nullptr;
+}
+
+const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture)
+{
+  return picture.hasLightMetadata ? &picture.lightMetadata : nullptr;
+}
+
 } // namespace DRMPRIME
 
 CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(int id) : CVideoBuffer(id)

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -15,6 +15,7 @@ extern "C"
 {
 #include <libavutil/frame.h>
 #include <libavutil/hwcontext_drm.h>
+#include <libavutil/mastering_display_metadata.h>
 }
 
 namespace DRMPRIME
@@ -33,8 +34,24 @@ enum drm_color_range
   DRM_COLOR_YCBCR_FULL_RANGE,
 };
 
+// HDR enums is copied from linux include/linux/hdmi.h (strangely not part of uapi)
+enum hdmi_metadata_type
+{
+  HDMI_STATIC_METADATA_TYPE1 = 1,
+};
+enum hdmi_eotf
+{
+  HDMI_EOTF_TRADITIONAL_GAMMA_SDR,
+  HDMI_EOTF_TRADITIONAL_GAMMA_HDR,
+  HDMI_EOTF_SMPTE_ST2084,
+  HDMI_EOTF_BT_2100_HLG,
+};
+
 int GetColorEncoding(const VideoPicture& picture);
 int GetColorRange(const VideoPicture& picture);
+uint8_t GetEOTF(const VideoPicture& picture);
+const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
+const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);
 
 } // namespace DRMPRIME
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -13,6 +13,36 @@
 
 #include <memory>
 
+#include <drm_mode.h>
+
+#ifndef HAVE_HDR_OUTPUT_METADATA
+// HDR structs is copied from linux include/linux/hdmi.h
+struct hdr_metadata_infoframe
+{
+  uint8_t eotf;
+  uint8_t metadata_type;
+  struct
+  {
+    uint16_t x, y;
+  } display_primaries[3];
+  struct
+  {
+    uint16_t x, y;
+  } white_point;
+  uint16_t max_display_mastering_luminance;
+  uint16_t min_display_mastering_luminance;
+  uint16_t max_cll;
+  uint16_t max_fall;
+};
+struct hdr_output_metadata
+{
+  uint32_t metadata_type;
+  union {
+    struct hdr_metadata_infoframe hdmi_metadata_type1;
+  };
+};
+#endif
+
 namespace KODI
 {
 namespace WINDOWING
@@ -48,4 +78,7 @@ private:
 
   CVideoBufferDRMPRIME* m_buffer = nullptr;
   CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
+
+  uint32_t m_hdr_blob_id = 0;
+  struct hdr_output_metadata m_hdr_metadata = {};
 };

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -111,6 +111,7 @@ public:
   std::vector<uint64_t> *GetVideoPlaneModifiersForFormat(uint32_t format) { return &m_video_plane->modifiers_map[format]; }
   std::vector<uint64_t> *GetGuiPlaneModifiersForFormat(uint32_t format) { return &m_gui_plane->modifiers_map[format]; }
   struct crtc* GetCrtc() const { return m_crtc; }
+  struct connector* GetConnector() const { return m_connector; }
 
   virtual RESOLUTION_INFO GetCurrentMode();
   virtual std::vector<RESOLUTION_INFO> GetModes();


### PR DESCRIPTION
## Description
This PR adds code to set HDR metadata for the Direct-To-Plane renderer on the `GBM` platform.

This is created as a draft PR as this [must not be merged before required patches land in kernel](https://www.kernel.org/doc/html/latest/gpu/drm-uapi.html?highlight=drm#open-source-userspace-requirements).

## Motivation and Context
HDR

## How Has This Been Tested?
This has been tested on a Rock64 and Rock Pi 4 with [HDR patchset v9](https://patchwork.freedesktop.org/series/25092/#rev9) and a [patch to set DRM InfoFrame in dw-hdmi driver](https://github.com/Kwiboo/linux-rockchip/commit/a9ccea6d3d51001f6b4ab9a1fb600a38e517b9ce). HDR mode is successfully activated/deactivated on my LG OLED B7.

(HDR is not fully usable on dw-hdmi as the driver lacks support for a full 10-bit HDMI pipeline)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
