### PR TITLE
Change subtitles opacity

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3398,7 +3398,11 @@ msgctxt "#751"
 msgid "Removing source"
 msgstr ""
 
-#empty strings from id 752 to 753
+msgctxt "#752"
+msgid "Opacity"
+msgstr ""
+
+#empty string with id 753
 
 msgctxt "#754"
 msgid "Add program link"
@@ -19076,7 +19080,13 @@ msgctxt "#36294"
 msgid "When sorting music items by artist use sortname e.g. Parton, Dolly rather than name."
 msgstr ""
 
-#empty strings from id 36295 to 36301
+#. Description of setting with label #752 "Opacity"
+#: system/settings/settings.xml
+msgctxt "#36295"
+msgid "Set the the subtitle opacity."
+msgstr ""
+
+#empty strings from id 36296 to 36301
 
 #: system/settings/settings.xml
 msgctxt "#36302"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -635,6 +635,14 @@
           </dependencies>
           <control type="list" format="string" />
         </setting>
+        <setting id="subtitles.opacity" type="integer" parent="subtitles.font" label="752" help="36295">
+          <level>3</level>
+          <default>100</default>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
+          <control type="slider" format="percentage" range="0,100" />
+        </setting>
         <setting id="subtitles.bgcolor" type="integer" parent="subtitles.font" label="745" help="36228">
           <level>3</level>
           <default>0</default> <!-- Black -->

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -109,7 +109,7 @@ void CDebugRenderer::CRenderer::Render(int idx)
 
     COverlayText *text = dynamic_cast<COverlayText*>(o);
     if (text)
-      text->PrepareRender("arial.ttf", 1, 16, 0, m_font, m_fontBorder, UTILS::COLOR::NONE, m_rv);
+      text->PrepareRender("arial.ttf", 1, 100, 16, 0, m_font, m_fontBorder, UTILS::COLOR::NONE, m_rv);
 
     RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -189,6 +189,7 @@ void CRenderer::Render(int idx)
       
       text->PrepareRender(settings->GetString(CSettings::SETTING_SUBTITLES_FONT),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_COLOR),
+		                  100,
                           settings->GetInt(CSettings::SETTING_SUBTITLES_HEIGHT),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE),
                           m_font, m_fontBorder, bgcolor, m_rv);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -189,7 +189,7 @@ void CRenderer::Render(int idx)
       
       text->PrepareRender(settings->GetString(CSettings::SETTING_SUBTITLES_FONT),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_COLOR),
-		                  settings->GetInt(CSettings::SETTING_SUBTITLES_OPACITY),
+                          settings->GetInt(CSettings::SETTING_SUBTITLES_OPACITY),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_HEIGHT),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE),
                           m_font, m_fontBorder, bgcolor, m_rv);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -189,7 +189,7 @@ void CRenderer::Render(int idx)
       
       text->PrepareRender(settings->GetString(CSettings::SETTING_SUBTITLES_FONT),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_COLOR),
-		                  100,
+		                  settings->GetInt(CSettings::SETTING_SUBTITLES_OPACITY),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_HEIGHT),
                           settings->GetInt(CSettings::SETTING_SUBTITLES_STYLE),
                           m_font, m_fontBorder, bgcolor, m_rv);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
@@ -44,18 +44,18 @@ CGUITextLayout* COverlayText::GetFontLayout(const std::string &font, int color, 
     if (!XFILE::CFile::Exists(font_path))
       font_path = URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", font_file);
 
-	// Apply opacity to the color
-	UTILS::Color fgcolor = colors[color];
-	UTILS::Color bordercolor = UTILS::COLOR::BLACK;
-	if (opacity > 0 && opacity < 100)
-	{
+    // Apply opacity to the color
+    UTILS::Color fgcolor = colors[color];
+    UTILS::Color bordercolor = UTILS::COLOR::BLACK;
+    if (opacity > 0 && opacity < 100)
+    {
       fgcolor = ColorUtils::ChangeOpacity(fgcolor, opacity / 100.0f);
       bordercolor = ColorUtils::ChangeOpacity(bordercolor, opacity / 100.0f);
-	}
-	else if (opacity == 0)
-	{
+    }
+    else if (opacity == 0)
+    {
       fgcolor = bordercolor = UTILS::COLOR::NONE;
-	}
+    }
 
     // We scale based on PAL4x3 - this at least ensures all sizing is constant across resolutions.
     RESOLUTION_INFO pal(720, 576, 0);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
@@ -49,12 +49,12 @@ CGUITextLayout* COverlayText::GetFontLayout(const std::string &font, int color, 
 	UTILS::Color bordercolor = UTILS::COLOR::BLACK;
 	if (opacity > 0 && opacity < 100)
 	{
-		fgcolor = ColorUtils::ChangeOpacity(fgcolor, opacity / 100.0f);
-		bordercolor = ColorUtils::ChangeOpacity(bordercolor, opacity / 100.0f);
+      fgcolor = ColorUtils::ChangeOpacity(fgcolor, opacity / 100.0f);
+      bordercolor = ColorUtils::ChangeOpacity(bordercolor, opacity / 100.0f);
 	}
 	else if (opacity == 0)
 	{
-		fgcolor = bordercolor = UTILS::COLOR::NONE;
+      fgcolor = bordercolor = UTILS::COLOR::NONE;
 	}
 
     // We scale based on PAL4x3 - this at least ensures all sizing is constant across resolutions.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
@@ -34,14 +34,15 @@ public:
   ~COverlayText() override;
   void Render(SRenderState& state) override;
   using COverlay::PrepareRender;
-  void PrepareRender(const std::string &font, int color, int height, int style, const std::string &fontcache,
+  void PrepareRender(const std::string &font, int color, int opacity, int height, int style, const std::string &fontcache,
                      const std::string &fontbordercache, const UTILS::Color bgcolor, const CRect &rectView);
-  virtual CGUITextLayout* GetFontLayout(const std::string &font, int color, int height, int style,
+  virtual CGUITextLayout* GetFontLayout(const std::string &font, int color, int opacity, int height, int style,
                                         const std::string &fontcache, const std::string &fontbordercache);
 
   CGUITextLayout* m_layout;
   std::string m_text;
   int m_subalign;
+  UTILS::Color m_bordercolor = UTILS::COLOR::BLACK;
   UTILS::Color m_bgcolor = UTILS::COLOR::NONE;
 protected:
   // target Rect for subtitles (updated on PrepareRender)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -165,6 +165,7 @@ const std::string CSettings::SETTING_SUBTITLES_FONT = "subtitles.font";
 const std::string CSettings::SETTING_SUBTITLES_HEIGHT = "subtitles.height";
 const std::string CSettings::SETTING_SUBTITLES_STYLE = "subtitles.style";
 const std::string CSettings::SETTING_SUBTITLES_COLOR = "subtitles.color";
+const std::string CSettings::SETTING_SUBTITLES_OPACITY = "subtitles.opacity";
 const std::string CSettings::SETTING_SUBTITLES_BGCOLOR = "subtitles.bgcolor";
 const std::string CSettings::SETTING_SUBTITLES_BGOPACITY = "subtitles.bgopacity";
 const std::string CSettings::SETTING_SUBTITLES_CHARSET = "subtitles.charset";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -128,6 +128,7 @@ public:
   static const std::string SETTING_SUBTITLES_HEIGHT;
   static const std::string SETTING_SUBTITLES_STYLE;
   static const std::string SETTING_SUBTITLES_COLOR;
+  static const std::string SETTING_SUBTITLES_OPACITY;
   static const std::string SETTING_SUBTITLES_BGCOLOR;
   static const std::string SETTING_SUBTITLES_BGOPACITY;
   static const std::string SETTING_SUBTITLES_CHARSET;


### PR DESCRIPTION
## Description
Add an option to change the opacity of subtitles between 0% and 100%.

## Motivation and Context
Currently, subtitles in Kodi are always fully opaque, i.e. alpha=1.0. Such subtitles cause several problems:

- When viewing HDR content, when bright subtitles appear in dark scenes the brightness difference is very large and [sears the eyes](https://www.reddit.com/r/hometheater/comments/9yr4nn/hdr_has_a_big_problem_that_nobody_seems_to_talk/) ([another reference](https://www.reddit.com/r/OLED/comments/858dd8/lg_c7_netflix_prime_hdrdv_subtitles_too_bright/)).
-  On LCD TV's with local dimming, when a bright subtitle appears over a dark scene it [causes the picture to flash brighter](https://www.reddit.com/r/samsung/comments/9sv6ga/qled_brightness_changes_when_subtitles_appear_on/). In addition, sometimes [blooming appears around the subtitles](https://www.reddit.com/r/bravia/comments/a5aszu/x900f_subtitles_and_blooming/).
- On OLED TV's, subtitles can [cause burn-in over time](https://www.youtube.com/watch?v=nOcLasaRCzY&feature=youtu.be&t=406).

Making subtitles semitransparent solves all of these problems. Netflix already supports semitransparent subtitles, and Kodi should support them as well.

Kodi already has a feature that changes the opacity of the *background* of the subtitles. But the subtitles themselves remain fully opaque when using that feature, so it doesn't solve the problems described above.

It's also possible to change the *color* of the subtitles, e.g. to gray. I tried to do that (change the color instead of the transparency), but changing the color doesn't do a good enough job to solve the problems described above.

## How Has This Been Tested?
I have tested this on Windows 10 64-bit. I viewed subtitles with an opacity of 25-100%. (Setting opacity to 100%, which is the default, disables this feature.)

Go to Settings (as Expert) > Player > Language, and change the "Opacity" slider.

## Screenshots (if appropriate):
![Kodi-subtitles](https://user-images.githubusercontent.com/49862308/57433344-eb242a00-7240-11e9-8a32-503d66ab5433.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
