### PR TITLE
[Cleanup] Remove SetIconImage, GetIconImage, HasIcon and SetThumbnailImage

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1310,7 +1310,7 @@ void CFileItem::FillInDefaultIcon()
   //   for .. folders the default picture for parent folder
   //   for other folders the defaultFolder.png
 
-  if (GetIconImage().empty())
+  if (GetArt("icon").empty())
   {
     if (!m_bIsFolder)
     {
@@ -1629,8 +1629,6 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     SetLabel2(item.GetLabel2());
   if (!item.GetArt().empty())
     SetArt(item.GetArt());
-  if (!item.GetIconImage().empty())
-    SetArt("icon", item.GetIconImage());
   AppendProperties(item);
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -164,14 +164,14 @@ CFileItem::CFileItem(const CPVREpgInfoTagPtr& tag)
   m_dateTime = tag->StartAsLocalTime();
 
   if (!tag->Icon().empty())
-    SetIconImage(tag->Icon());
+    SetArt("icon", tag->Icon());
   else
   {
     const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
     if (channel)
     {
       if (!channel->IconPath().empty())
-        SetIconImage(channel->IconPath());
+        SetArt("icon", channel->IconPath());
 
       FillMusicInfoTag(channel, tag);
     }
@@ -192,11 +192,11 @@ CFileItem::CFileItem(const CPVRChannelPtr& channel)
   SetLabel(channel->ChannelName());
 
   if (!channel->IconPath().empty())
-    SetIconImage(channel->IconPath());
+    SetArt("icon", channel->IconPath());
   else if (channel->IsRadio())
-    SetIconImage("DefaultAudio.png");
+    SetArt("icon", "DefaultAudio.png");
   else
-    SetIconImage("DefaultTVShows.png");
+    SetArt("icon", "DefaultTVShows.png");
 
   SetProperty("channelid", channel->ChannelID());
   SetProperty("path", channel->Path());
@@ -219,7 +219,6 @@ CFileItem::CFileItem(const CPVRRecordingPtr& record)
   // Set art
   if (!record->m_strIconPath.empty())
   {
-    SetIconImage(record->m_strIconPath);
     SetArt("icon", record->m_strIconPath);
   }
 
@@ -243,7 +242,7 @@ CFileItem::CFileItem(const CPVRTimerInfoTagPtr& timer)
   m_dateTime = timer->StartAsLocalTime();
 
   if (!timer->ChannelIcon().empty())
-    SetIconImage(timer->ChannelIcon());
+    SetArt("icon", timer->ChannelIcon());
 
   FillInMimeType(false);
 }
@@ -363,7 +362,7 @@ CFileItem::CFileItem(const EventPtr& eventLogEntry)
   SetLabel(eventLogEntry->GetLabel());
   m_dateTime = eventLogEntry->GetDateTime();
   if (!eventLogEntry->GetIcon().empty())
-    SetIconImage(eventLogEntry->GetIcon());
+    SetArt("icon", eventLogEntry->GetIcon());
 }
 
 CFileItem::~CFileItem(void)
@@ -1323,75 +1322,75 @@ void CFileItem::FillInDefaultIcon()
       if (IsPVRChannel())
       {
         if (GetPVRChannelInfoTag()->IsRadio())
-          SetIconImage("DefaultAudio.png");
+          SetArt("icon", "DefaultAudio.png");
         else
-          SetIconImage("DefaultTVShows.png");
+          SetArt("icon", "DefaultTVShows.png");
       }
       else if ( IsLiveTV() )
       {
         // Live TV Channel
-        SetIconImage("DefaultTVShows.png");
+        SetArt("icon", "DefaultTVShows.png");
       }
       else if ( URIUtils::IsArchive(m_strPath) )
       { // archive
-        SetIconImage("DefaultFile.png");
+        SetArt("icon", "DefaultFile.png");
       }
       else if ( IsUsablePVRRecording() )
       {
         // PVR recording
-        SetIconImage("DefaultVideo.png");
+        SetArt("icon", "DefaultVideo.png");
       }
       else if ( IsDeletedPVRRecording() )
       {
         // PVR deleted recording
-        SetIconImage("DefaultVideoDeleted.png");
+        SetArt("icon", "DefaultVideoDeleted.png");
       }
       else if ( IsAudio() )
       {
         // audio
-        SetIconImage("DefaultAudio.png");
+        SetArt("icon", "DefaultAudio.png");
       }
       else if ( IsVideo() )
       {
         // video
-        SetIconImage("DefaultVideo.png");
+        SetArt("icon", "DefaultVideo.png");
       }
       else if (IsPVRTimer())
       {
-        SetIconImage("DefaultVideo.png");
+        SetArt("icon", "DefaultVideo.png");
       }
       else if ( IsPicture() )
       {
         // picture
-        SetIconImage("DefaultPicture.png");
+        SetArt("icon", "DefaultPicture.png");
       }
       else if ( IsPlayList() || IsSmartPlayList())
       {
-        SetIconImage("DefaultPlaylist.png");
+        SetArt("icon", "DefaultPlaylist.png");
       }
       else if ( IsPythonScript() )
       {
-        SetIconImage("DefaultScript.png");
+        SetArt("icon", "DefaultScript.png");
       }
       else
       {
         // default icon for unknown file type
-        SetIconImage("DefaultFile.png");
+        SetArt("icon", "DefaultFile.png");
       }
     }
     else
     {
       if ( IsPlayList() || IsSmartPlayList())
       {
-        SetIconImage("DefaultPlaylist.png");
+        SetArt("icon", "DefaultPlaylist.png");
       }
       else if (IsParentFolder())
       {
-        SetIconImage("DefaultFolderBack.png");
+        SetArt("icon", "DefaultFolderBack.png");
       }
       else
       {
-        SetIconImage("DefaultFolder.png");
+        SetArt("icon", "DefaultFolder.png");
       }
     }
   }
@@ -1631,7 +1630,7 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
   if (!item.GetArt().empty())
     SetArt(item.GetArt());
   if (!item.GetIconImage().empty())
-    SetIconImage(item.GetIconImage());
+    SetArt("icon", item.GetIconImage());
   AppendProperties(item);
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9744,14 +9744,14 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
       case LISTITEM_PROGRAM_COUNT:
         return StringUtils::Format("%i", item->m_iprogramCount);
       case LISTITEM_ACTUAL_ICON:
-        return item->GetIconImage();
+        return item->GetArt("icon");
       case LISTITEM_ICON:
       {
         std::string strThumb = item->GetArt("thumb");
         if (strThumb.empty())
-          strThumb = item->GetIconImage();
+          strThumb = item->GetArt("icon");
         if (fallback)
-          *fallback = item->GetIconImage();
+          *fallback = item->GetArt("icon");
         return strThumb;
       }
       case LISTITEM_ART:

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -228,13 +228,13 @@ int CGUIDialogAddonInfo::AskForVersion(std::vector<std::pair<AddonVersion, std::
     if (versionInfo.second == LOCAL_CACHE)
     {
       item.SetLabel2(g_localizeStrings.Get(24095));
-      item.SetIconImage("DefaultAddonRepository.png");
+      item.SetArt("icon", "DefaultAddonRepository.png");
       dialog->Add(item);
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(versionInfo.second, repo, ADDON_REPOSITORY))
     {
       item.SetLabel2(repo->Name());
-      item.SetIconImage(repo->Icon());
+      item.SetArt("icon", repo->Icon());
       dialog->Add(item);
     }
   }
@@ -497,7 +497,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::Dependency
                                           g_localizeStrings.Get(39018).c_str());
 
       item->SetLabel2(str.str());
-      item->SetIconImage(info_addon->Icon());
+      item->SetArt("icon", info_addon->Icon());
       item->SetProperty("addon_id", it.id);
       items.Add(item);
     }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -491,7 +491,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
     CFileItemPtr item(new CFileItem("", false));
     item->SetLabel(g_localizeStrings.Get(231));
     item->SetLabel2(g_localizeStrings.Get(24040));
-    item->SetIconImage("DefaultAddonNone.png");
+    item->SetArt("icon", "DefaultAddonNone.png");
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
   }

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -122,7 +122,6 @@ CAddonCallbacksGUI::CAddonCallbacksGUI(CAddon* addon)
   m_callbacks->ListItem_SetLabel              = CAddonCallbacksGUI::ListItem_SetLabel;
   m_callbacks->ListItem_GetLabel2             = CAddonCallbacksGUI::ListItem_GetLabel2;
   m_callbacks->ListItem_SetLabel2             = CAddonCallbacksGUI::ListItem_SetLabel2;
-  m_callbacks->ListItem_SetThumbnailImage     = CAddonCallbacksGUI::ListItem_SetThumbnailImage;
   m_callbacks->ListItem_SetInfo               = CAddonCallbacksGUI::ListItem_SetInfo;
   m_callbacks->ListItem_SetProperty           = CAddonCallbacksGUI::ListItem_SetProperty;
   m_callbacks->ListItem_GetProperty           = CAddonCallbacksGUI::ListItem_GetProperty;
@@ -1544,15 +1543,6 @@ void CAddonCallbacksGUI::ListItem_SetLabel2(void *addonData, GUIHANDLE handle, c
     return;
 
   static_cast<CFileItem*>(handle)->SetLabel2(label);
-}
-
-void CAddonCallbacksGUI::ListItem_SetThumbnailImage(void *addonData, GUIHANDLE handle, const char *image)
-{
-  CAddonInterfaces* helper = (CAddonInterfaces*) addonData;
-  if (!helper || !handle)
-    return;
-
-  static_cast<CFileItem*>(handle)->SetArt("thumb", image);
 }
 
 void CAddonCallbacksGUI::ListItem_SetInfo(void *addonData, GUIHANDLE handle, const char *info)

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -122,7 +122,6 @@ CAddonCallbacksGUI::CAddonCallbacksGUI(CAddon* addon)
   m_callbacks->ListItem_SetLabel              = CAddonCallbacksGUI::ListItem_SetLabel;
   m_callbacks->ListItem_GetLabel2             = CAddonCallbacksGUI::ListItem_GetLabel2;
   m_callbacks->ListItem_SetLabel2             = CAddonCallbacksGUI::ListItem_SetLabel2;
-  m_callbacks->ListItem_SetIconImage          = CAddonCallbacksGUI::ListItem_SetIconImage;
   m_callbacks->ListItem_SetThumbnailImage     = CAddonCallbacksGUI::ListItem_SetThumbnailImage;
   m_callbacks->ListItem_SetInfo               = CAddonCallbacksGUI::ListItem_SetInfo;
   m_callbacks->ListItem_SetProperty           = CAddonCallbacksGUI::ListItem_SetProperty;
@@ -1495,7 +1494,7 @@ GUIHANDLE CAddonCallbacksGUI::ListItem_Create(void *addonData, const char *label
   if (label2)
     pItem->SetLabel2(label2);
   if (iconImage)
-    pItem->SetIconImage(iconImage);
+    pItem->SetArt("icon", iconImage);
   if (thumbnailImage)
     pItem->SetArt("thumb", thumbnailImage);
   if (path)
@@ -1545,15 +1544,6 @@ void CAddonCallbacksGUI::ListItem_SetLabel2(void *addonData, GUIHANDLE handle, c
     return;
 
   static_cast<CFileItem*>(handle)->SetLabel2(label);
-}
-
-void CAddonCallbacksGUI::ListItem_SetIconImage(void *addonData, GUIHANDLE handle, const char *image)
-{
-  CAddonInterfaces* helper = (CAddonInterfaces*) addonData;
-  if (!helper || !handle)
-    return;
-
-  static_cast<CFileItem*>(handle)->SetIconImage(image);
 }
 
 void CAddonCallbacksGUI::ListItem_SetThumbnailImage(void *addonData, GUIHANDLE handle, const char *image)

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.h
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.h
@@ -121,7 +121,6 @@ public:
   static void         ListItem_SetLabel(void *addonData, GUIHANDLE handle, const char *label);
   static const char * ListItem_GetLabel2(void *addonData, GUIHANDLE handle);
   static void         ListItem_SetLabel2(void *addonData, GUIHANDLE handle, const char *label);
-  static void         ListItem_SetIconImage(void *addonData, GUIHANDLE handle, const char *image);
   static void         ListItem_SetThumbnailImage(void *addonData, GUIHANDLE handle, const char *image);
   static void         ListItem_SetInfo(void *addonData, GUIHANDLE handle, const char *info);
   static void         ListItem_SetProperty(void *addonData, GUIHANDLE handle, const char *key, const char *value);

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.h
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.h
@@ -121,7 +121,6 @@ public:
   static void         ListItem_SetLabel(void *addonData, GUIHANDLE handle, const char *label);
   static const char * ListItem_GetLabel2(void *addonData, GUIHANDLE handle);
   static void         ListItem_SetLabel2(void *addonData, GUIHANDLE handle, const char *label);
-  static void         ListItem_SetThumbnailImage(void *addonData, GUIHANDLE handle, const char *image);
   static void         ListItem_SetInfo(void *addonData, GUIHANDLE handle, const char *info);
   static void         ListItem_SetProperty(void *addonData, GUIHANDLE handle, const char *key, const char *value);
   static const char * ListItem_GetProperty(void *addonData, GUIHANDLE handle, const char *key);

--- a/xbmc/addons/interfaces/GUI/ListItem.cpp
+++ b/xbmc/addons/interfaces/GUI/ListItem.cpp
@@ -66,7 +66,7 @@ void* Interface_GUIListItem::create(void* kodiBase, const char* label, const cha
   if (label2)
     item->get()->SetLabel2(label2);
   if (icon_image)
-    item->get()->SetIconImage(icon_image);
+    item->get()->SetArt("icon", icon_image);
   if (path)
     item->get()->SetPath(path);
 
@@ -239,7 +239,7 @@ void Interface_GUIListItem::set_icon_image(void* kodiBase, void* handle, const c
   }
 
   Interface_GUIGeneral::lock();
-  item->get()->SetIconImage(image);
+  item->get()->SetArt("icon", image);
   Interface_GUIGeneral::unlock();
 }
 

--- a/xbmc/addons/interfaces/GUI/ListItem.cpp
+++ b/xbmc/addons/interfaces/GUI/ListItem.cpp
@@ -213,7 +213,7 @@ char* Interface_GUIListItem::get_icon_image(void* kodiBase, void* handle)
 
   char* ret;
   Interface_GUIGeneral::lock();
-  ret = strdup(item->get()->GetIconImage().c_str());
+  ret = strdup(item->get()->GetArt("icon").c_str());
   Interface_GUIGeneral::unlock();
   return ret;
 }

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -148,6 +148,11 @@ web applications or frameworks for the Python programming language.
 
 /*!
 @page python_v19 Python API v19
+\python_removed_function{
+      setIconImage,
+      "",
+      <b>xbmcgui.Listitem().setIconImage(icon)</b> function was removed completely.
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -153,6 +153,11 @@ web applications or frameworks for the Python programming language.
       "",
       <b>xbmcgui.Listitem().setIconImage(icon)</b> function was removed completely.
 }
+\python_removed_function{
+      setThumbnailImage,
+      "",
+      <b>xbmcgui.Listitem().setThumbnailImage(thumb)</b> function was removed completely.
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
@@ -209,22 +209,6 @@ namespace gui
     //==========================================================================
     ///
     /// \ingroup cpp_kodi_gui_CListItem
-    /// @brief To set icon image of entry
-    ///
-    /// @param image                    The image to use for.
-    ///
-    /// @note Alternative can be \ref SetArt used
-    ///
-    ///
-    void SetIconImage(const std::string& image)
-    {
-      m_interface->kodi_gui->listItem->set_icon_image(m_interface->kodiBase, m_controlHandle, image.c_str());
-    }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_CListItem
     /// @brief Sets the listitem's art
     ///
     /// @param[in] type                 Type of Art to set

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
@@ -188,27 +188,6 @@ namespace gui
     //==========================================================================
     ///
     /// \ingroup cpp_kodi_gui_CListItem
-    /// @brief To get current icon image of entry
-    ///
-    /// @return The current icon image path (if present)
-    ///
-    std::string GetIconImage()
-    {
-      std::string image;
-      char* ret = m_interface->kodi_gui->listItem->get_icon_image(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          image = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return image;
-    }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_CListItem
     /// @brief Sets the listitem's art
     ///
     /// @param[in] type                 Type of Art to set

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
@@ -110,7 +110,6 @@ typedef struct CB_GUILib
   void (*ListItem_SetLabel)(void *addonData, GUIHANDLE handle, const char *label);
   const char* (*ListItem_GetLabel2)(void *addonData, GUIHANDLE handle);
   void (*ListItem_SetLabel2)(void *addonData, GUIHANDLE handle, const char *label);
-  void (*ListItem_SetIconImage)(void *addonData, GUIHANDLE handle, const char *image);
   void (*ListItem_SetThumbnailImage)(void *addonData, GUIHANDLE handle, const char *image);
   void (*ListItem_SetInfo)(void *addonData, GUIHANDLE handle, const char *info);
   void (*ListItem_SetProperty)(void *addonData, GUIHANDLE handle, const char *key, const char *value);
@@ -220,12 +219,6 @@ public:
   {
     if (m_controlHandle)
       m_cb->ListItem_SetLabel2(m_Handle->addonData, m_controlHandle, label);
-  }
-
-  void SetIconImage(const char *image)
-  {
-    if (m_controlHandle)
-      m_cb->ListItem_SetIconImage(m_Handle->addonData, m_controlHandle, image);
   }
 
   void SetThumbnailImage(const char *image)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
@@ -110,7 +110,6 @@ typedef struct CB_GUILib
   void (*ListItem_SetLabel)(void *addonData, GUIHANDLE handle, const char *label);
   const char* (*ListItem_GetLabel2)(void *addonData, GUIHANDLE handle);
   void (*ListItem_SetLabel2)(void *addonData, GUIHANDLE handle, const char *label);
-  void (*ListItem_SetThumbnailImage)(void *addonData, GUIHANDLE handle, const char *image);
   void (*ListItem_SetInfo)(void *addonData, GUIHANDLE handle, const char *info);
   void (*ListItem_SetProperty)(void *addonData, GUIHANDLE handle, const char *key, const char *value);
   const char* (*ListItem_GetProperty)(void *addonData, GUIHANDLE handle, const char *key);
@@ -219,12 +218,6 @@ public:
   {
     if (m_controlHandle)
       m_cb->ListItem_SetLabel2(m_Handle->addonData, m_controlHandle, label);
-  }
-
-  void SetThumbnailImage(const char *image)
-  {
-    if (m_controlHandle)
-      m_cb->ListItem_SetThumbnailImage(m_Handle->addonData, m_controlHandle, image);
   }
 
   void SetInfo(const char *Info)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -44,8 +44,8 @@
 #define ADDON_GLOBAL_VERSION_GENERAL_XML_ID           "kodi.binary.global.general"
 #define ADDON_GLOBAL_VERSION_GENERAL_DEPENDS          "General.h"
 
-#define ADDON_GLOBAL_VERSION_GUI                      "5.12.1"
-#define ADDON_GLOBAL_VERSION_GUI_MIN                  "5.10.0"
+#define ADDON_GLOBAL_VERSION_GUI                      "5.13.0"
+#define ADDON_GLOBAL_VERSION_GUI_MIN                  "5.13.0"
 #define ADDON_GLOBAL_VERSION_GUI_XML_ID               "kodi.binary.global.gui"
 #define ADDON_GLOBAL_VERSION_GUI_DEPENDS              "libKODI_guilib.h" \
                                                       "gui/"

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -390,7 +390,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       }
       // and add a "no thumb" entry as well
       CFileItemPtr nothumb(new CFileItem("thumb://None", false));
-      nothumb->SetArt("icon", item->GetIconImage());
+      nothumb->SetArt("icon", item->GetArt("icon"));
       nothumb->SetLabel(g_localizeStrings.Get(20018));
       items.Add(nothumb);
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -390,7 +390,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       }
       // and add a "no thumb" entry as well
       CFileItemPtr nothumb(new CFileItem("thumb://None", false));
-      nothumb->SetIconImage(item->GetIconImage());
+      nothumb->SetArt("icon", item->GetIconImage());
       nothumb->SetLabel(g_localizeStrings.Get(20018));
       items.Add(nothumb);
 

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -615,7 +615,7 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList &items, const VE
   {
     CFileItemPtr item(new CFileItem("image://Browse", false));
     item->SetLabel(g_localizeStrings.Get(20153));
-    item->SetIconImage("DefaultFolder.png");
+    item->SetArt("icon", "DefaultFolder.png");
     browser->m_vecItems->Add(item);
   }
   browser->SetHeading(heading);
@@ -734,7 +734,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
     CDirectory::GetDirectory(directory,*browser->m_vecItems, "", DIR_FLAG_DEFAULTS);
     CFileItemPtr item(new CFileItem("file://Browse", false));
     item->SetLabel(g_localizeStrings.Get(20153));
-    item->SetIconImage("DefaultFolder.png");
+    item->SetArt("icon", "DefaultFolder.png");
     browser->m_vecItems->Add(item);
     browser->m_singleList = true;
   }

--- a/xbmc/favourites/GUIDialogFavourites.cpp
+++ b/xbmc/favourites/GUIDialogFavourites.cpp
@@ -240,7 +240,7 @@ bool CGUIDialogFavourites::ChooseAndSetNewThumbnail(const CFileItemPtr &item)
   }
 
   const CFileItemPtr none(std::make_shared<CFileItem>("thumb://None", false));
-  none->SetIconImage(item->GetIconImage());
+  none->SetArt("icon", item->GetIconImage());
   none->SetLabel(g_localizeStrings.Get(20018)); // No thumb
   prefilledItems.Add(none);
 

--- a/xbmc/favourites/GUIDialogFavourites.cpp
+++ b/xbmc/favourites/GUIDialogFavourites.cpp
@@ -240,7 +240,7 @@ bool CGUIDialogFavourites::ChooseAndSetNewThumbnail(const CFileItemPtr &item)
   }
 
   const CFileItemPtr none(std::make_shared<CFileItem>("thumb://None", false));
-  none->SetArt("icon", item->GetIconImage());
+  none->SetArt("icon", item->GetArt("icon"));
   none->SetLabel(g_localizeStrings.Get(20018)); // No thumb
   prefilledItems.Add(none);
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -610,21 +610,21 @@ static void RootDirectory(CFileItemList& items)
   {
     CFileItemPtr item(new CFileItem("addons://user/", true));
     item->SetLabel(g_localizeStrings.Get(24998));
-    item->SetIconImage("DefaultAddonsInstalled.png");
+    item->SetArt("icon", "DefaultAddonsInstalled.png");
     items.Add(item);
   }
   if (CServiceBroker::GetAddonMgr().HasAvailableUpdates())
   {
     CFileItemPtr item(new CFileItem("addons://outdated/", true));
     item->SetLabel(g_localizeStrings.Get(24043));
-    item->SetIconImage("DefaultAddonsUpdates.png");
+    item->SetArt("icon", "DefaultAddonsUpdates.png");
     items.Add(item);
   }
   if (CAddonInstaller::GetInstance().IsDownloading())
   {
     CFileItemPtr item(new CFileItem("addons://downloading/", true));
     item->SetLabel(g_localizeStrings.Get(24067));
-    item->SetIconImage("DefaultNetwork.png");
+    item->SetArt("icon", "DefaultNetwork.png");
     items.Add(item);
   }
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == ADDON::AUTO_UPDATES_ON
@@ -632,26 +632,26 @@ static void RootDirectory(CFileItemList& items)
   {
     CFileItemPtr item(new CFileItem("addons://recently_updated/", true));
     item->SetLabel(g_localizeStrings.Get(24004));
-    item->SetIconImage("DefaultAddonsRecentlyUpdated.png");
+    item->SetArt("icon", "DefaultAddonsRecentlyUpdated.png");
     items.Add(item);
   }
   if (CServiceBroker::GetAddonMgr().HasAddons(ADDON_REPOSITORY))
   {
     CFileItemPtr item(new CFileItem("addons://repos/", true));
     item->SetLabel(g_localizeStrings.Get(24033));
-    item->SetIconImage("DefaultAddonsRepo.png");
+    item->SetArt("icon", "DefaultAddonsRepo.png");
     items.Add(item);
   }
   {
     CFileItemPtr item(new CFileItem("addons://install/", false));
     item->SetLabel(g_localizeStrings.Get(24041));
-    item->SetIconImage("DefaultAddonsZip.png");
+    item->SetArt("icon", "DefaultAddonsZip.png");
     items.Add(item);
   }
   {
     CFileItemPtr item(new CFileItem("addons://search/", true));
     item->SetLabel(g_localizeStrings.Get(137));
-    item->SetIconImage("DefaultAddonsSearch.png");
+    item->SetArt("icon", "DefaultAddonsSearch.png");
     items.Add(item);
   }
 }
@@ -821,7 +821,7 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
   item->SetLabel(strLabel);
   item->SetArt(addon->Art());
   item->SetArt("thumb", addon->Icon());
-  item->SetIconImage("DefaultAddon.png");
+  item->SetArt("icon", "DefaultAddon.png");
 
   //! @todo fix hacks that depends on these
   item->SetProperty("Addon.ID", addon->ID());

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -127,7 +127,7 @@ CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const st
   chap = StringUtils::Format(g_localizeStrings.Get(25007).c_str(), title->chapter_count, StringUtils::SecondsToTimeString(duration).c_str());
   item->SetLabel2(chap);
   item->m_dwSize = 0;
-  item->SetIconImage("DefaultVideo.png");
+  item->SetArt("icon", "DefaultVideo.png");
   for(unsigned int i = 0; i < title->clip_count; ++i)
     item->m_dwSize += title->clips[i].pkt_count * 192;
 
@@ -188,7 +188,7 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     item->SetPath(path.Get());
     item->m_bIsFolder = true;
     item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
-    item->SetIconImage("DefaultVideoPlaylists.png");
+    item->SetArt("icon", "DefaultVideoPlaylists.png");
     items.Add(item);
 
     const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
@@ -203,7 +203,7 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     item->SetPath(path.Get());
     item->m_bIsFolder = false;
     item->SetLabel(g_localizeStrings.Get(25003) /* Menus */);
-    item->SetIconImage("DefaultProgram.png");
+    item->SetArt("icon", "DefaultProgram.png");
     items.Add(item);
 }
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -117,7 +117,7 @@ bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
       item->SetLabel(label);
       if (!icon.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(icon))
-        item->SetIconImage(icon);
+        item->SetArt("icon", icon);
       item->m_iprogramCount = order;
       items.Add(item);
     }

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -45,7 +45,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
     {
       std::string strImage = GetIcon(item->GetPath());
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))
-        item->SetIconImage(strImage);
+        item->SetArt("icon", strImage);
     }
   }
   items.SetLabel(pNode->GetLocalizedName());

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -41,7 +41,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
   for (int i=0;i<items.Size();++i)
   {
     CFileItemPtr item = items[i];
-    if (item->m_bIsFolder && !item->HasIcon() && !item->HasArt("thumb"))
+    if (item->m_bIsFolder && !item->HasArt("icon") && !item->HasArt("thumb"))
     {
       std::string strImage = GetIcon(item->GetPath());
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -86,7 +86,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
     else
       strIcon = "DefaultHardDisk.png";
 
-    pItem->SetIconImage(strIcon);
+    pItem->SetArt("icon", strIcon);
     if (share.m_iHasLock == 2 && m_profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_LOCKED);
     else

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -42,7 +42,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
   for (int i=0;i<items.Size();++i)
   {
     CFileItemPtr item = items[i];
-    if (item->m_bIsFolder && !item->HasIcon() && !item->HasArt("thumb"))
+    if (item->m_bIsFolder && !item->HasArt("icon") && !item->HasArt("thumb"))
     {
       std::string strImage = GetIcon(item->GetPath());
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -46,7 +46,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
     {
       std::string strImage = GetIcon(item->GetPath());
       if (!strImage.empty() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture(strImage))
-        item->SetIconImage(strImage);
+        item->SetArt("icon", strImage);
     }
     if (item->GetVideoInfoTag())
     {

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -62,7 +62,7 @@ void CControllerInstaller::Process()
   for (const auto &addon : installableAddons)
   {
     CFileItemPtr item(new CFileItem(addon->Name()));
-    item->SetIconImage(addon->Icon());
+    item->SetArt("icon", addon->Icon());
     items.Add(std::move(item));
   }
 

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -151,17 +151,12 @@ bool CGUIListItem::HasArt(const std::string &type) const
   return !GetArt(type).empty();
 }
 
-void CGUIListItem::SetIconImage(const std::string& strIcon)
-{
-  if (m_strIcon == strIcon)
-    return;
-  m_strIcon = strIcon;
-  SetInvalid();
-}
-
 const std::string& CGUIListItem::GetIconImage() const
 {
-  return m_strIcon;
+  auto i = m_art.find("icon");
+  if (i != m_art.end())
+    return i->second;
+  return "";
 }
 
 void CGUIListItem::SetOverlayImage(GUIIconOverlay icon, bool bOnOff)
@@ -201,7 +196,7 @@ void CGUIListItem::Select(bool bOnOff)
 
 bool CGUIListItem::HasIcon() const
 {
-  return (m_strIcon.size() != 0);
+  return (m_art.find("icon") != m_art.end());
 }
 
 bool CGUIListItem::HasOverlay() const
@@ -222,7 +217,6 @@ CGUIListItem& CGUIListItem::operator =(const CGUIListItem& item)
   m_sortLabel = item.m_sortLabel;
   FreeMemory();
   m_bSelected = item.m_bSelected;
-  m_strIcon = item.m_strIcon;
   m_overlayIcon = item.m_overlayIcon;
   m_bIsFolder = item.m_bIsFolder;
   m_mapProperties = item.m_mapProperties;
@@ -240,7 +234,6 @@ void CGUIListItem::Archive(CArchive &ar)
     ar << m_strLabel;
     ar << m_strLabel2;
     ar << m_sortLabel;
-    ar << m_strIcon;
     ar << m_bSelected;
     ar << m_overlayIcon;
     ar << (int)m_mapProperties.size();
@@ -268,7 +261,6 @@ void CGUIListItem::Archive(CArchive &ar)
     ar >> m_strLabel;
     ar >> m_strLabel2;
     ar >> m_sortLabel;
-    ar >> m_strIcon;
     ar >> m_bSelected;
 
     int overlayIcon;
@@ -310,7 +302,6 @@ void CGUIListItem::Serialize(CVariant &value)
   value["strLabel"] = m_strLabel;
   value["strLabel2"] = m_strLabel2;
   value["sortLabel"] = m_sortLabel;
-  value["strIcon"] = m_strIcon;
   value["selected"] = m_bSelected;
 
   for (PropertyMap::const_iterator it = m_mapProperties.begin(); it != m_mapProperties.end(); ++it)
@@ -325,7 +316,6 @@ void CGUIListItem::FreeIcons()
 {
   FreeMemory();
   ClearArt();
-  m_strIcon = "";
   SetInvalid();
 }
 

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -186,11 +186,6 @@ void CGUIListItem::Select(bool bOnOff)
   m_bSelected = bOnOff;
 }
 
-bool CGUIListItem::HasIcon() const
-{
-  return (m_art.find("icon") != m_art.end());
-}
-
 bool CGUIListItem::HasOverlay() const
 {
   return (m_overlayIcon != CGUIListItem::ICON_OVERLAY_NONE);

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -151,14 +151,6 @@ bool CGUIListItem::HasArt(const std::string &type) const
   return !GetArt(type).empty();
 }
 
-const std::string& CGUIListItem::GetIconImage() const
-{
-  auto i = m_art.find("icon");
-  if (i != m_art.end())
-    return i->second;
-  return "";
-}
-
 void CGUIListItem::SetOverlayImage(GUIIconOverlay icon, bool bOnOff)
 {
   GUIIconOverlay newIcon = (bOnOff) ? GUIIconOverlay((int)(icon)+1) : icon;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -61,7 +61,6 @@ public:
   void SetLabel2(const std::string& strLabel);
   const std::string& GetLabel2() const;
 
-  void SetIconImage(const std::string& strIcon);
   const std::string& GetIconImage() const;
 
   void SetOverlayImage(GUIIconOverlay icon, bool bOnOff=false);
@@ -166,7 +165,6 @@ public:
 
 protected:
   std::string m_strLabel2;     // text of column2
-  std::string m_strIcon;      // filename of icon
   GUIIconOverlay m_overlayIcon; // type of overlay icon
 
   CGUIListItemLayoutPtr m_layout;

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -122,7 +122,6 @@ public:
   void Select(bool bOnOff);
   bool IsSelected() const;
 
-  bool HasIcon() const;
   bool HasOverlay() const;
   virtual bool IsFileItem() const { return false; };
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -61,8 +61,6 @@ public:
   void SetLabel2(const std::string& strLabel);
   const std::string& GetLabel2() const;
 
-  const std::string& GetIconImage() const;
-
   void SetOverlayImage(GUIIconOverlay icon, bool bOnOff=false);
   std::string GetOverlayImage() const;
 

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -35,7 +35,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
   SetLabel(label.GetLabel(parentID));
   SetLabel2(label2.GetLabel(parentID));
   SetArt("thumb", thumb.GetLabel(parentID, true));
-  SetIconImage(icon.GetLabel(parentID, true));
+  SetArt("icon", icon.GetLabel(parentID, true));
   if (!label.IsConstant())  m_info.push_back(std::make_pair(label, "label"));
   if (!label2.IsConstant()) m_info.push_back(std::make_pair(label2, "label2"));
   if (!thumb.IsConstant())  m_info.push_back(std::make_pair(thumb, "thumb"));
@@ -78,7 +78,7 @@ void CGUIStaticItem::UpdateProperties(int contextWindow)
     else if (StringUtils::EqualsNoCase(name, "thumb"))
       SetArt("thumb", value);
     else if (StringUtils::EqualsNoCase(name, "icon"))
-      SetIconImage(value);
+      SetArt("icon", value);
     else
       SetProperty(name, value.c_str());
   }

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -290,9 +290,9 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case PLAYER_ICON:
       value = item->GetArt("thumb");
       if (value.empty())
-        value = item->GetIconImage();
+        value = item->GetArt("icon");
       if (fallback)
-        *fallback = item->GetIconImage();
+        *fallback = item->GetArt("icon");
       return true;
     case PLAYER_CUTLIST:
     case PLAYER_CHAPTERS:

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -49,7 +49,7 @@ namespace XBMCAddon
       if (!label2.empty())
         item->SetLabel2( label2 );
       if (!iconImage.empty())
-        item->SetIconImage( iconImage );
+        item->SetArt("icon", iconImage);
       if (!thumbnailImage.empty())
         item->SetArt("thumb",  thumbnailImage );
       if (!path.empty())
@@ -107,15 +107,6 @@ namespace XBMCAddon
       }
     }
 
-    void ListItem::setIconImage(const String& iconImage)
-    {
-      if (!item) return;
-      {
-        XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-        item->SetIconImage(iconImage);
-      }
-    }
-
     void ListItem::setThumbnailImage(const String& thumbFilename)
     {
       if (!item) return;
@@ -134,10 +125,7 @@ namespace XBMCAddon
         {
           std::string artName = it.first;
           StringUtils::ToLower(artName);
-          if (artName == "icon")
-            item->SetIconImage(it.second);
-          else
-            item->SetArt(artName, it.second);
+          item->SetArt(artName, it.second);
         }
       }
     }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -51,7 +51,7 @@ namespace XBMCAddon
       if (!iconImage.empty())
         item->SetArt("icon", iconImage);
       if (!thumbnailImage.empty())
-        item->SetArt("thumb",  thumbnailImage );
+        item->SetArt("thumb",  thumbnailImage);
       if (!path.empty())
         item->SetPath(path);
     }
@@ -104,15 +104,6 @@ namespace XBMCAddon
       {
         XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
         item->SetLabel2(label);
-      }
-    }
-
-    void ListItem::setThumbnailImage(const String& thumbFilename)
-    {
-      if (!item) return;
-      {
-        XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-        item->SetArt("thumb", thumbFilename);
       }
     }
 

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -31,8 +31,6 @@ namespace XBMCAddon
   {
     ListItem::ListItem(const String& label,
                        const String& label2,
-                       const String& iconImage,
-                       const String& thumbnailImage,
                        const String& path,
                        bool offscreen) :
       m_offscreen(offscreen)
@@ -48,10 +46,6 @@ namespace XBMCAddon
         item->SetLabel( label );
       if (!label2.empty())
         item->SetLabel2( label2 );
-      if (!iconImage.empty())
-        item->SetArt("icon", iconImage);
-      if (!thumbnailImage.empty())
-        item->SetArt("thumb",  thumbnailImage);
       if (!path.empty())
         item->SetPath(path);
     }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -199,18 +199,6 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
-      /// @brief \python_func{ setIconImage(iconImage) }
-      ///-----------------------------------------------------------------------
-      /// @python_v16 Deprecated. Use **setArt()**.
-      ///
-      setIconImage(...);
-#else
-      void setIconImage(const String& iconImage);
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-      ///
-      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ setThumbnailImage(thumbFilename) }
       ///-----------------------------------------------------------------------
       /// @python_v16 Deprecated. Use **setArt()**.

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -52,13 +52,12 @@ namespace XBMCAddon
     ///
     /// @param label                [opt] string
     /// @param label2               [opt] string
-    /// @param iconImage            __Deprecated. Use setArt__
-    /// @param thumbnailImage       __Deprecated. Use setArt__
     /// @param path                 [opt] string
     ///
     ///
     ///-----------------------------------------------------------------------
     /// @python_v16 **iconImage** and **thumbnailImage** are deprecated. Use **setArt()**.
+    /// @python_v19 Removed **iconImage** and **thumbnailImage** arguments
     ///
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
@@ -76,8 +75,6 @@ namespace XBMCAddon
 
       ListItem(const String& label = emptyString,
                const String& label2 = emptyString,
-               const String& iconImage = emptyString,
-               const String& thumbnailImage = emptyString,
                const String& path = emptyString,
                bool offscreen = false);
 

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -199,18 +199,6 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
-      /// @brief \python_func{ setThumbnailImage(thumbFilename) }
-      ///-----------------------------------------------------------------------
-      /// @python_v16 Deprecated. Use **setArt()**.
-      ///
-      setThumbnailImage(...);
-#else
-      void setThumbnailImage(const String& thumbFilename);
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-      ///
-      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ setArt(values) }
       ///-----------------------------------------------------------------------
       /// Sets the listitem's art

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -547,7 +547,7 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
     CMediaSource share;
     share.strName = item->GetLabel();
     share.strPath = item->GetPath();
-    share.m_strThumbnailImage = item->GetIconImage();
+    share.m_strThumbnailImage = item->GetArt("icon");
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     m_sources.push_back(share);
   }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4318,7 +4318,7 @@ bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filt
         pItem->SetPath(itemUrl.ToString());
 
         pItem->GetMusicInfoTag()->SetDatabaseId(artist.idArtist, MediaTypeArtist);
-        pItem->SetIconImage("DefaultArtist.png");
+        pItem->SetArt("icon", "DefaultArtist.png");
 
         SetPropertiesFromArtist(*pItem, artist);
         items.Add(pItem);
@@ -4488,7 +4488,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
         itemUrl.AppendPath(path);
 
         CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), GetAlbumFromDataset(record)));
-        pItem->SetIconImage("DefaultAlbumCover.png");
+        pItem->SetArt("icon", "DefaultAlbumCover.png");
         items.Add(pItem);
       }
       catch (...)

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -750,7 +750,7 @@ void CGUIDialogMusicInfo::OnGetArt()
     // For album it could be a fallback from artist
     CFileItemPtr item(new CFileItem("thumb://Current", false));
     item->SetArt("thumb", m_item->GetArt(type));
-    item->SetIconImage("DefaultPicture.png");
+    item->SetArt("icon", "DefaultPicture.png");
     item->SetLabel(g_localizeStrings.Get(13512));
     items.Add(item);
   }
@@ -770,7 +770,7 @@ void CGUIDialogMusicInfo::OnGetArt()
       std::string thumb = m_artist.fanart.GetPreviewURL(i);
       std::string wrappedthumb = CTextureUtils::GetWrappedThumbURL(thumb);
       item->SetArt("thumb", wrappedthumb);
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(20441));
 
       items.Add(item);
@@ -792,7 +792,7 @@ void CGUIDialogMusicInfo::OnGetArt()
       strItemPath = StringUtils::Format("thumb://Remote%i", i);
       CFileItemPtr item(new CFileItem(strItemPath, false));
       item->SetArt("thumb", remotethumbs[i]);
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13513));
 
       items.Add(item);
@@ -860,9 +860,9 @@ void CGUIDialogMusicInfo::OnGetArt()
     // allow the user to delete it by selecting "no art".
     CFileItemPtr item(new CFileItem("thumb://None", false));
     if (m_bArtistInfo)
-      item->SetIconImage("DefaultArtist.png");
+      item->SetArt("icon", "DefaultArtist.png");
     else
-      item->SetIconImage("DefaultAlbumCover.png");
+      item->SetArt("icon", "DefaultAlbumCover.png");
     item->SetLabel(g_localizeStrings.Get(13515));
     items.Add(item);
   }

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -345,7 +345,7 @@ void CGUIDialogSongInfo::OnGetArt()
     // Add item for current artwork, could a fallback from album/artist
     CFileItemPtr item(new CFileItem("thumb://Current", false));
     item->SetArt("thumb", m_song->GetArt(type));
-    item->SetIconImage("DefaultPicture.png");
+    item->SetArt("icon", "DefaultPicture.png");
     item->SetLabel(g_localizeStrings.Get(13512));  //! @todo: label fallback art so user knows?
     items.Add(item);
   }
@@ -356,7 +356,7 @@ void CGUIDialogSongInfo::OnGetArt()
     {
       CFileItemPtr item(new CFileItem("thumb://Thumb", false));
       item->SetArt("thumb", m_song->GetArt("thumb"));
-      item->SetIconImage("DefaultAlbumCover.png");
+      item->SetArt("icon", "DefaultAlbumCover.png");
       item->SetLabel(g_localizeStrings.Get(21371));
       items.Add(item);
     }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -958,13 +958,13 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       CFileItemPtr newPlaylist(new CFileItem(profileManager->GetUserDataItem("PartyMode.xsp"),false));
       newPlaylist->SetLabel(g_localizeStrings.Get(16035));
       newPlaylist->SetLabelPreformatted(true);
-      newPlaylist->SetIconImage("DefaultPartyMode.png");
+      newPlaylist->SetArt("icon", "DefaultPartyMode.png");
       newPlaylist->m_bIsFolder = true;
       items.Add(newPlaylist);
 
       newPlaylist.reset(new CFileItem("newplaylist://", false));
       newPlaylist->SetLabel(g_localizeStrings.Get(525));
-      newPlaylist->SetIconImage("DefaultAddSource.png");
+      newPlaylist->SetArt("icon", "DefaultAddSource.png");
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetSpecialSort(SortSpecialOnBottom);
       newPlaylist->SetCanQueue(false);
@@ -972,7 +972,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
 
       newPlaylist.reset(new CFileItem("newsmartplaylist://music", false));
       newPlaylist->SetLabel(g_localizeStrings.Get(21437));
-      newPlaylist->SetIconImage("DefaultAddSource.png");
+      newPlaylist->SetArt("icon", "DefaultAddSource.png");
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetSpecialSort(SortSpecialOnBottom);
       newPlaylist->SetCanQueue(false);

--- a/xbmc/network/GUIDialogAccessPoints.cpp
+++ b/xbmc/network/GUIDialogAccessPoints.cpp
@@ -92,7 +92,7 @@ void CGUIDialogAccessPoints::OnInitWindow()
       else if (q <= 100) item->SetArt("thumb", "ap-signal5.png");
 
       if (m_aps[i].getEncryptionMode() != ENC_NONE)
-         item->SetIconImage("ap-lock.png");
+        item->SetArt("icon", "ap-lock.png");
 
       m_accessPoints->Add(item);
   }

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -312,7 +312,7 @@ void CPeripheralAddon::GetDirectory(const std::string &strPath, CFileItemList &i
     peripheralFile->SetProperty("location", peripheral->Location());
     peripheralFile->SetProperty("class", PeripheralTypeTranslator::TypeToString(peripheral->Type()));
     peripheralFile->SetProperty("version", peripheral->GetVersionInfo());
-    peripheralFile->SetIconImage(peripheral->GetIcon());
+    peripheralFile->SetArt("icon", peripheral->GetIcon());
     items.Add(peripheralFile);
   }
 }

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -302,7 +302,7 @@ void CPeripheralBus::GetDirectory(const std::string &strPath, CFileItemList &ite
 
     peripheralFile->SetProperty("version", strVersion);
     peripheralFile->SetLabel2(strDetails);
-    peripheralFile->SetIconImage("DefaultAddon.png");
+    peripheralFile->SetArt("icon", "DefaultAddon.png");
     items.Add(peripheralFile);
   }
 }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -201,7 +201,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
             {
               ProcessFoldersAndArchives(item.get());
               pItem->SetArt("thumb", items[i]->GetArt("thumb"));
-              pItem->SetIconImage(items[i]->GetIconImage());
+              pItem->SetArt("icon", items[i]->GetIconImage());
               return;
             }
           }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -201,7 +201,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
             {
               ProcessFoldersAndArchives(item.get());
               pItem->SetArt("thumb", items[i]->GetArt("thumb"));
-              pItem->SetArt("icon", items[i]->GetIconImage());
+              pItem->SetArt("icon", items[i]->GetArt("icon"));
               return;
             }
           }

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -238,7 +238,7 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   CFileItemList items;
   CFileItemPtr item(new CFileItem());
   item->SetLabel(g_localizeStrings.Get(37014)); // Last used profile
-  item->SetIconImage("DefaultUser.png");
+  item->SetArt("icon", "DefaultUser.png");
   items.Add(item);
 
   for (unsigned int i = 0; i < profileManager->GetNumberOfProfiles(); i++)
@@ -250,7 +250,7 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
     std::string thumb = profile->getThumb();
     if (thumb.empty())
       thumb = "DefaultUser.png";
-    item->SetIconImage(thumb);
+    item->SetArt("icon", thumb);
     items.Add(item);
   }
 

--- a/xbmc/pvr/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/PVRGUIDirectory.cpp
@@ -427,7 +427,7 @@ namespace
     item->SetLabel(g_localizeStrings.Get(19026)); // "Add timer..."
     item->SetLabelPreformatted(true);
     item->SetSpecialSort(SortSpecialOnTop);
-    item->SetIconImage("DefaultTVShows.png");
+    item->SetArt("icon", "DefaultTVShows.png");
     results.Add(item);
 
     bool bRadio = path.IsRadio();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -351,7 +351,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
 
   // and add a "no thumb" entry as well
   CFileItemPtr nothumb(new CFileItem("thumb://None", false));
-  nothumb->SetArt("icon", pItem->GetIconImage());
+  nothumb->SetArt("icon", pItem->GetArt("icon"));
   nothumb->SetLabel(g_localizeStrings.Get(19283));
   items.Add(nothumb);
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -351,7 +351,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
 
   // and add a "no thumb" entry as well
   CFileItemPtr nothumb(new CFileItem("thumb://None", false));
-  nothumb->SetIconImage(pItem->GetIconImage());
+  nothumb->SetArt("icon", pItem->GetIconImage());
   nothumb->SetLabel(g_localizeStrings.Get(19283));
   items.Add(nothumb);
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -151,7 +151,7 @@ void CGUIWindowPVRSearchBase::OnPrepareFileItems(CFileItemList &items)
     item->SetLabel(g_localizeStrings.Get(19140)); // "Search..."
     item->SetLabelPreformatted(true);
     item->SetSpecialSort(SortSpecialOnTop);
-    item->SetIconImage("DefaultTVShows.png");
+    item->SetArt("icon", "DefaultTVShows.png");
     items.Add(item);
   }
 }

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -379,7 +379,7 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
     CMediaSource share;
     share.strName=item->GetLabel();
     share.strPath = item->GetPath();
-    share.m_strThumbnailImage= item->GetIconImage();
+    share.m_strThumbnailImage = item->GetArt("icon");
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     m_sources.push_back(share);
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6363,9 +6363,9 @@ bool CVideoDatabase::GetActorsNav(const std::string& strBaseDir, CFileItemList& 
     {
       CFileItemPtr pItem = items[i];
       if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
-        pItem->SetIconImage("DefaultArtist.png");
+        pItem->SetArt("icon", "DefaultArtist.png");
       else
-        pItem->SetIconImage("DefaultActor.png");
+        pItem->SetArt("icon", "DefaultActor.png");
     }
     return true;
   }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -324,7 +324,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       CFileItemPtr item(new CFileItem(*it));
       if (!thumb.empty())
         item->SetArt("thumb", thumb);
-      item->SetIconImage("DefaultArtist.png");
+      item->SetArt("icon", "DefaultArtist.png");
       m_castList->Add(item);
     }
   }
@@ -356,7 +356,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
           CTextureCache::GetInstance().BackgroundCacheImage(thumb);
         }
       }
-      item->SetIconImage("DefaultActor.png");
+      item->SetArt("icon", "DefaultActor.png");
       item->SetLabel(it->strName);
       item->SetLabel2(it->strRole);
       m_castList->Add(item);
@@ -791,7 +791,7 @@ void CGUIDialogVideoInfo::OnGetArt()
     {
       CFileItemPtr item(new CFileItem("thumb://Current", false));
       item->SetArt("thumb", m_movieItem->GetArt(type));
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13512));
       items.Add(item);
     }
@@ -799,7 +799,7 @@ void CGUIDialogVideoInfo::OnGetArt()
     { // add the 'thumb' type in
       CFileItemPtr item(new CFileItem("thumb://Thumb", false));
       item->SetArt("thumb", m_movieItem->GetArt("thumb"));
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13512));
       items.Add(item);
     }
@@ -834,7 +834,7 @@ void CGUIDialogVideoInfo::OnGetArt()
       std::string strItemPath = StringUtils::Format("thumb://Remote%i", i);
       CFileItemPtr item(new CFileItem(strItemPath, false));
       item->SetArt("thumb", thumbs[i]);
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13513));
 
       //! @todo Do we need to clear the cached image?
@@ -847,7 +847,7 @@ void CGUIDialogVideoInfo::OnGetArt()
     {
       CFileItemPtr item(new CFileItem("thumb://Local", false));
       item->SetArt("thumb", localThumb);
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13514));
       items.Add(item);
     }
@@ -856,7 +856,7 @@ void CGUIDialogVideoInfo::OnGetArt()
       // which is probably the IMDb thumb.  These could be wrong, so allow the user
       // to delete the incorrect thumb
       CFileItemPtr item(new CFileItem("thumb://None", false));
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13515));
       items.Add(item);
     }
@@ -922,7 +922,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
   {
     CFileItemPtr itemCurrent(new CFileItem("fanart://Current",false));
     itemCurrent->SetArt("thumb", m_movieItem->GetArt("fanart"));
-    itemCurrent->SetIconImage("DefaultPicture.png");
+    itemCurrent->SetArt("icon", "DefaultPicture.png");
     itemCurrent->SetLabel(g_localizeStrings.Get(20440));
     items.Add(itemCurrent);
   }
@@ -956,7 +956,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
     CFileItemPtr item(new CFileItem(strItemPath, false));
     std::string thumb = m_movieItem->GetVideoInfoTag()->m_fanart.GetPreviewURL(i);
     item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));
-    item->SetIconImage("DefaultPicture.png");
+    item->SetArt("icon", "DefaultPicture.png");
     item->SetLabel(g_localizeStrings.Get(20441));
 
     //! @todo Do we need to clear the cached image?
@@ -970,7 +970,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
   {
     CFileItemPtr itemLocal(new CFileItem("fanart://Local",false));
     itemLocal->SetArt("thumb", strLocal);
-    itemLocal->SetIconImage("DefaultPicture.png");
+    itemLocal->SetArt("icon", "DefaultPicture.png");
     itemLocal->SetLabel(g_localizeStrings.Get(20438));
 
     //! @todo Do we need to clear the cached image?
@@ -980,7 +980,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
   else
   {
     CFileItemPtr itemNone(new CFileItem("fanart://None", false));
-    itemNone->SetIconImage("DefaultPicture.png");
+    itemNone->SetArt("icon", "DefaultPicture.png");
     itemNone->SetLabel(g_localizeStrings.Get(20439));
     items.Add(itemNone);
   }
@@ -1903,7 +1903,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
     item->SetLabel(g_localizeStrings.Get(13512));
     items.Add(item);
   }
-  noneitem->SetIconImage("DefaultFolder.png");
+  noneitem->SetArt("icon", "DefaultFolder.png");
   noneitem->SetLabel(g_localizeStrings.Get(13515));
 
   bool local = false;
@@ -1943,7 +1943,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
     {
       CFileItemPtr item(new CFileItem(StringUtils::Format("thumb://Remote{0}", i), false));
       item->SetArt("thumb", thumbs[i]);
-      item->SetIconImage("DefaultPicture.png");
+      item->SetArt("icon", "DefaultPicture.png");
       item->SetLabel(g_localizeStrings.Get(13513));
       items.Add(item);
 
@@ -1964,11 +1964,11 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
         local = true;
       }
       else
-        noneitem->SetIconImage("DefaultActor.png");
+        noneitem->SetArt("icon", "DefaultActor.png");
     }
 
     if (type == MediaTypeVideoCollection)
-      noneitem->SetIconImage("DefaultVideo.png");
+      noneitem->SetArt("icon", "DefaultVideo.png");
   }
   else
   {
@@ -1996,7 +1996,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
       local = true;
     }
     else
-      noneitem->SetIconImage("DefaultArtist.png");
+      noneitem->SetArt("icon", "DefaultArtist.png");
   }
 
   if (!local)
@@ -2196,7 +2196,7 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
       {
         CFileItemPtr item(new CFileItem(StringUtils::Format("fanart://Remote{0}", iFanart++), false));
         item->SetArt("thumb", fanart);
-        item->SetIconImage("DefaultPicture.png");
+        item->SetArt("icon", "DefaultPicture.png");
         item->SetLabel(g_localizeStrings.Get(20441)); // "Remote fanart"
         items.Add(item);
       }
@@ -2212,7 +2212,7 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
           CFileItemPtr item(new CFileItem(strItemPath, false));
           std::string thumb = movies[i]->GetVideoInfoTag()->m_fanart.GetPreviewURL(j);
           item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));
-          item->SetIconImage("DefaultPicture.png");
+          item->SetArt("icon", "DefaultPicture.png");
           item->SetLabel(g_localizeStrings.Get(20441));
           thumbs.push_back(movies[i]->GetVideoInfoTag()->m_fanart.GetImageURL(j));
 
@@ -2225,7 +2225,7 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
   // add the none option
   {
     CFileItemPtr itemNone(new CFileItem("fanart://None", false));
-    itemNone->SetIconImage("DefaultVideo.png");
+    itemNone->SetArt("icon", "DefaultVideo.png");
     itemNone->SetLabel(g_localizeStrings.Get(20439));
     items.Add(itemNone);
   }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1275,7 +1275,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
     CFileItemPtr newPlaylist(new CFileItem(profileManager->GetUserDataItem("PartyMode-Video.xsp"),false));
     newPlaylist->SetLabel(g_localizeStrings.Get(16035));
     newPlaylist->SetLabelPreformatted(true);
-    newPlaylist->SetIconImage("DefaultPartyMode.png");
+    newPlaylist->SetArt("icon", "DefaultPartyMode.png");
     newPlaylist->m_bIsFolder = true;
     items.Add(newPlaylist);
 
@@ -1286,7 +1286,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
 */
     newPlaylist.reset(new CFileItem("newsmartplaylist://video", false));
     newPlaylist->SetLabel(g_localizeStrings.Get(21437));  // "new smart playlist..."
-    newPlaylist->SetIconImage("DefaultAddSource.png");
+    newPlaylist->SetArt("icon", "DefaultAddSource.png");
     newPlaylist->SetLabelPreformatted(true);
     items.Add(newPlaylist);
   }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -889,7 +889,7 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     std::string strLabel = g_localizeStrings.Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
-    pItem->SetIconImage("DefaultAddSource.png");
+    pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);
     pItem->m_bIsFolder = true;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -493,7 +493,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
     std::string strLabel = g_localizeStrings.Get(1026);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
-    pItem->SetIconImage("DefaultAddSource.png");
+    pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);
     pItem->m_bIsFolder = true;


### PR DESCRIPTION
## Description
Time to remove more annoying stuff. We've been asking addon developers since Jarvis to remove the following methods in favor of the `art` alternatives:

`xbmcgui.Listitem().SetIconImage(x)` -> `xbmcgui.Listitem().setArt({"icon": x})`
`xbmcgui.Listitem().SetThumbnailImage(y)` -> `xbmcgui.Listitem().setArt({"thumb": y})`
`xbmcgui.Listitem(iconImage=x, thumbnailImage=y)` -> `xbmcgui.Listitem().setArt()`

The PR also drops the `GetIconImage` and `HasIcon` in favor of `GetArt("icon")` and `HasArt("icon")`.

@AlwinEsch do you know if any of those methods is in use by binary addons?
@ksooo are they used in PVR?

## Motivation and Context
Cleanup deprecated python methods.

## How Has This Been Tested?
Compiled, runtime tested, check if behaviour stays the same

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
