### PR TITLE
LibInputKeyboard: re-add support for KEY_STOP as we had in CLinuxInputDevices

### DIFF
--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -137,7 +137,7 @@ static const std::map<xkb_keysym_t, XBMCKey> xkbMap =
 
   // Media keys
   { XKB_KEY_XF86Eject, XBMCK_EJECT },
-  // XBMCK_STOP clashes with XBMCK_MEDIA_STOP
+  { XKB_KEY_Cancel, XBMCK_STOP },
   { XKB_KEY_XF86AudioRecord, XBMCK_RECORD },
   // XBMCK_REWIND clashes with XBMCK_MEDIA_REWIND
   { XKB_KEY_XF86Phone, XBMCK_PHONE },


### PR DESCRIPTION
Backport of #15936