### PR TITLE
[Cleanup][Python] Drop monitor.onDatabaseUpdated and monitor.onDatabaseScanStarted

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -153,6 +153,11 @@ web applications or frameworks for the Python programming language.
       "",
       <b>xbmc.monitor().onDatabaseUpdated()</b> function was removed completely.
 }
+\python_removed_function{
+      onDatabaseScanStarted,
+      "",
+      <b>xbmc.monitor().onDatabaseScanStarted()</b> function was removed completely.
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -148,6 +148,11 @@ web applications or frameworks for the Python programming language.
 
 /*!
 @page python_v19 Python API v19
+\python_removed_function{
+      onDatabaseUpdated,
+      "",
+      <b>xbmc.monitor().onDatabaseUpdated()</b> function was removed completely.
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -50,7 +50,6 @@ namespace XBMCAddon
       {
 	XBMC_TRACE;
 	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onScanFinished,library));
-	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseUpdated,library));
       }
       inline void    OnCleanStarted(const String &library) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onCleanStarted,library)); }
       inline void    OnCleanFinished(const String &library) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onCleanFinished,library)); }
@@ -187,18 +186,6 @@ namespace XBMCAddon
       onDatabaseScanStarted(...);
 #else
       virtual void onDatabaseScanStarted(const String database) { XBMC_TRACE; }
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-      ///
-      /// \ingroup python_monitor
-      /// @brief \python_func{ onDatabaseUpdated(database) }
-      ///-----------------------------------------------------------------------
-      /// @python_v14 Deprecated. Use **onScanFinished()**.
-      ///
-      onDatabaseUpdated(...);
-#else
-      virtual void onDatabaseUpdated(const String database) { XBMC_TRACE; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -44,7 +44,6 @@ namespace XBMCAddon
       {
 	XBMC_TRACE;
 	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onScanStarted,library));
-	invokeCallback(new CallbackFunction<Monitor,const String>(this,&Monitor::onDatabaseScanStarted,library));
       }
       inline void    OnScanFinished(const String &library)
       {
@@ -173,19 +172,6 @@ namespace XBMCAddon
       onScanFinished(...);
 #else
       virtual void onScanFinished(const String library) { XBMC_TRACE; }
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-      ///
-      /// \ingroup python_monitor
-      /// @brief \python_func{ onDatabaseScanStarted(database) }
-      ///-----------------------------------------------------------------------
-      /// @python_v13 New function added.
-      /// @python_v14 Deprecated. Use **onScanStarted()**.
-      ///
-      onDatabaseScanStarted(...);
-#else
-      virtual void onDatabaseScanStarted(const String database) { XBMC_TRACE; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS


### PR DESCRIPTION
## Description
Both monitor class methods are deprecated since Helix in favor of onScanStarted() and onScanFinished().

## Motivation and Context
Remove deprecated and redundant functionality on the python API

## How Has This Been Tested?
Compiled and tested

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
