### PR TITLE
[video] Add support for HEVC to CDVDDemuxClient::GetStreamCodecName.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -608,6 +608,8 @@ std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
       strName = "vp8";
     else if (stream->codec == AV_CODEC_ID_VP9)
       strName = "vp9";
+    else if (stream->codec == AV_CODEC_ID_HEVC)
+      strName = "hevc";
   }
   return strName;
 }


### PR DESCRIPTION
This fixes codecname for hevc streams not set, resulting in missing info, for instance in video info display for HEVC Live TV streams in Estuary.

Before:
![screenshot001](https://user-images.githubusercontent.com/3226626/57808843-89921d00-7764-11e9-8c33-6d8f014134a9.png)

After:
![screenshot000](https://user-images.githubusercontent.com/3226626/57808827-80a14b80-7764-11e9-853f-daa96170419c.png)

@peak3d does this look okay?
