### PR TITLE
[Estuary] prefer watched icon over inprogress icon

### DIFF
--- a/addons/skin.estuary/playlists/inprogress_movies.xsp
+++ b/addons/skin.estuary/playlists/inprogress_movies.xsp
@@ -3,6 +3,9 @@
     <name>In-progress movies</name>
     <match>all</match>
     <rule field="inprogress" operator="true" />
+    <rule field="playcount" operator="is">
+        <value>0</value>
+    </rule>
     <limit>15</limit>
     <order direction="descending">lastplayed</order>
 </smartplaylist>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -329,7 +329,7 @@
 	<variable name="ListWatchedIconVar">
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
-		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
+		<value condition="ListItem.IsResumable + Integer.IsEqual(ListItem.Playcount,0)">overlays/watched/resume.png</value>
 		<value condition="ListItem.IsCollection">overlays/set.png</value>
 		<value condition="ListItem.IsFolder + String.IsEmpty(Listitem.dbtype) + !String.IsEqual(ListItem.Overlay,OverlayWatched.png) + !ListItem.IsParentFolder">overlays/folder.png</value>
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
@@ -339,7 +339,7 @@
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.IsCollection">overlays/set.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
-		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
+		<value condition="ListItem.IsResumable + Integer.IsEqual(ListItem.Playcount,0)">overlays/watched/resume.png</value>
 		<value condition="ListItem.HasArchive">windows/pvr/archive.png</value>
 		<value condition="Integer.IsGreater(ListItem.Playcount,0)">$INFO[ListItem.Overlay]</value>
 	</variable>


### PR DESCRIPTION
when `playcountminimumpercent` is set to a value below 100% in advancedsettings.xml,
a movie will be marked as watched (when the percentage is reached) but still be in progress at the same time.

in those cases we should:
- display a watched icon, instead of an inprogress icon
- remove the item from the 'in progress' widget on the home screen

fixes https://github.com/xbmc/xbmc/issues/15331