### PR TITLE
[PVR] Prevent concurrent updates for all pvr windows.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -437,6 +437,14 @@ void CGUIWindowPVRBase::SetChannelGroup(CPVRChannelGroupPtr &&group, bool bUpdat
 
 bool CGUIWindowPVRBase::Update(const std::string &strDirectory, bool updateFilterPath /*= true*/)
 {
+  if (m_bUpdating)
+  {
+    // no concurrent updates
+    return false;
+  }
+
+  CUpdateGuard guard(m_bUpdating);
+
   if (!GetChannelGroup())
   {
     // no updates before fully initialized

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -102,6 +102,7 @@ namespace PVR
 
     CCriticalSection m_critSection;
     bool m_bRadio;
+    std::atomic_bool m_bUpdating = {false};
 
   private:
     bool OpenChannelGroupSelectionDialog(void);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -192,14 +192,12 @@ void CGUIWindowPVRGuideBase::UpdateButtons(void)
 
 bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
-  if (m_vecItemsUpdating)
+  if (m_bUpdating)
   {
     // Prevent concurrent updates. Instead, let the timeline items refresh thread pick it up later.
     m_bRefreshTimelineItems = true;
     return true;
   }
-
-  CUpdateGuard guard(m_vecItemsUpdating);
 
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory, updateFilterPath);
 


### PR DESCRIPTION
Concurrent updates of GUI windows may lead to several problems, including deadlocks, like the one reported here: https://github.com/kodi-pvr/pvr.vuplus/issues/227

Sample stacktrace:

```
Thread 1 (Thread 0xf2430000 (LWP 594)):
#0  0xf6fde384 in __libc_do_syscall () from /lib/arm-linux-gnueabihf/libpthread.so.0
#1  0xf6fd9f86 in pthread_cond_timedwait@@GLIBC_2.4 () from /lib/arm-linux-gnueabihf/libpthread.so.0

#2  0xab5ba616 in ?? ()
#3  0xab5baa4c in CGUIMediaWindow::GetDirectoryItems(CURL&, CFileItemList&, bool) ()
#4  0xab5bcb80 in CGUIMediaWindow::GetDirectory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CFileItemList&) ()
#5  0xab5bde22 in CGUIMediaWindow::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#6  0xab977a00 in PVR::CGUIWindowPVRBase::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#7  0xab97e7ae in PVR::CGUIWindowPVRRecordingsBase::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#8  0xab5b8c9e in CGUIMediaWindow::Refresh(bool) ()
#9  0xab97edd8 in PVR::CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage&) ()
#10 0xab75d3a8 in CGUIWindowManager::SendMessage(CGUIMessage&) ()
#11 0xab762996 in CGUIWindowManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage*) ()
#12 0xab6b0254 in KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::ThreadMessage*) ()
#13 0xab6b08ba in KODI::MESSAGING::CApplicationMessenger::ProcessWindowMessages() ()
#14 0xab8977fe in CApplication::Process() ()
#15 0xab75d990 in CGUIWindowManager::ProcessRenderLoop(bool) ()
#16 0xab5ba752 in ?? ()
#17 0xab5baa4c in CGUIMediaWindow::GetDirectoryItems(CURL&, CFileItemList&, bool) ()
#18 0xab5bcb80 in CGUIMediaWindow::GetDirectory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CFileItemList&) ()
#19 0xab5bde22 in CGUIMediaWindow::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#20 0xab977a00 in PVR::CGUIWindowPVRBase::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#21 0xab97e7ae in PVR::CGUIWindowPVRRecordingsBase::Update(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#22 0xab5b8c9e in CGUIMediaWindow::Refresh(bool) ()
#23 0xab97edd8 in PVR::CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage&) ()
#24 0xab75d3a8 in CGUIWindowManager::SendMessage(CGUIMessage&) ()
#25 0xab762996 in CGUIWindowManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage*) ()
#26 0xab6b0254 in KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::ThreadMessage*) ()
#27 0xab6b08ba in KODI::MESSAGING::CApplicationMessenger::ProcessWindowMessages() ()
#28 0xab8977fe in CApplication::Process() ()
#29 0xab75d990 in CGUIWindowManager::ProcessRenderLoop(bool) ()
#30 0xab77df64 in CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) ()
#31 0xab77e2f8 in CGUIDialogBusy::Wait(IRunnable*, unsigned int, bool) ()
#32 0xaba0c10c in PVR::AsyncRecordingAction::Execute(std::shared_ptr<CFileItem> const&) ()
#33 0xaba0c2de in PVR::CPVRGUIActions::DeleteRecording(std::shared_ptr<CFileItem> const&) const ()
#34 0xaba030ca in PVR::CONTEXTMENUITEM::DeleteRecording::Execute(std::shared_ptr<CFileItem> const&) const ()
#35 0xab5bc19a in CGUIMediaWindow::OnPopupMenu(int) ()
#36 0xab97f19a in PVR::CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage&) ()
#37 0xab6fe34c in CGUIBaseContainer::OnClick(int) ()
#38 0xab7591e2 in CGUIWindow::OnAction(CAction const&) ()
#39 0xab5bc8fc in CGUIMediaWindow::OnAction(CAction const&) ()
#40 0xab9775b2 in PVR::CGUIWindowPVRBase::OnAction(CAction const&) ()
#41 0xab97e562 in PVR::CGUIWindowPVRRecordingsBase::OnAction(CAction const&) ()
#42 0xab7618d8 in CGUIWindowManager::HandleAction(CAction const&) const ()
#43 0xab761a74 in CGUIWindowManager::OnAction(CAction const&) const ()
#44 0xab8956aa in CApplication::OnAction(CAction const&) ()
#45 0xab6d3834 in CInputManager::HandleKey(CKey const&) ()
#46 0xab6d4962 in CInputManager::OnEvent(XBMC_Event&) ()
#47 0xab89669a in CApplication::HandlePortEvents() ()
#48 0xab89681a in CApplication::FrameMove(bool, bool) ()
#49 0xab90165c in CXBApplicationEx::Run(CAppParamParser const&) ()
#50 0xab69955e in XBMC_Run ()
#51 0xab289dfa in main ()
```

This PR ensures for all PVR windows that no concurrent updates are possible . This is what is done in several other places of the Kodi code base already (example: file manager window).

@Jalle19 good to go? (This PR simply extends what has been done before for only the guide window to all pvr windows.)