### PR TITLE
Sort whitelist lowres to highres and match exact framerate at higher

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -682,7 +682,7 @@ RESOLUTION CDisplaySettings::GetResolutionForScreen()
 
 static inline bool ModeSort(StringSettingOption i,StringSettingOption j)
 {
-  return (i.value > j.value);
+  return (i.value < j.value);
 }
 
 void CDisplaySettings::SettingOptionsModesFiller(std::shared_ptr<const CSetting> setting, std::vector<StringSettingOption> &list, std::string &current, void *data)

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -682,6 +682,30 @@ bool CVariant::operator==(const CVariant &rhs) const
   return false;
 }
 
+bool CVariant::operator<(const CVariant &rhs) const
+{
+  if (m_type == rhs.m_type)
+  {
+    switch (m_type)
+    {
+    case VariantTypeInteger:
+      return m_data.integer < rhs.m_data.integer;
+    case VariantTypeUnsignedInteger:
+      return m_data.unsignedinteger < rhs.m_data.unsignedinteger;
+    case VariantTypeDouble:
+      return m_data.dvalue < rhs.m_data.dvalue;
+    case VariantTypeString:
+      return *m_data.string < *rhs.m_data.string;
+    case VariantTypeWideString:
+      return *m_data.wstring < *rhs.m_data.wstring;
+    default:
+      break;
+    }
+  }
+
+  return false;
+}
+
 void CVariant::push_back(const CVariant &variant)
 {
   if (m_type == VariantTypeNull)

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -101,6 +101,7 @@ public:
   CVariant &operator=(CVariant &&rhs);
   bool operator==(const CVariant &rhs) const;
   bool operator!=(const CVariant &rhs) const { return !(*this == rhs); }
+  bool operator<(const CVariant &rhs) const;
 
   void push_back(const CVariant &variant);
   void push_back(CVariant &&variant);


### PR DESCRIPTION
resolutions

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
For displays which don't have an exact or 2x framerate at default resolution, prefer higher resolutions
at exact framerate to scaling the source framerate.  Effect is similar to https://github.com/fritsch/xbmc/commit/613d5f968a433262521461c3ab8b001fd97d973d but implemented by sorting the whitelist from lowest to highest resolution.  This sorting also stops 4096x2160 being chosen above 3840x2160 when both are whitelisted.
Suggest also to sort whitelist low to high in settings since it's the lowres modes people are more likely to whitelist and the higher modes (eg 75Hz+) more likely to blacklist, and it's consistent with sorting of the GUI resolution choices

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Users without 25Hz or 50Hz at 1080p but having 25/50Hz at 2160p get smoother playback of PAL content at 2160p than at 1080p60Hz
Fixes bug choosing 4096 when 3840 is available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on AML (Vero 4k).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
