### PR TITLE
Linux: Propagate sigterm so kodi.sh is easier to use from init systems

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -192,6 +192,12 @@ print_crash_report()
   echo "Crash report available at $FILE"
 }
 
+propagate_sigterm() {
+  kill -TERM "$CHILD" 2>/dev/null
+}
+
+trap propagate_sigterm TERM
+
 migrate_home
 
 if command_exists gdb; then
@@ -207,7 +213,9 @@ while [ $(( $LOOP )) = "1" ]
 do
   [ -f "${APPORT_CORE}" ] && rm -f "${APPORT_CORE}"
   LOOP=0
-  ${KODI_BINARY} $SAVED_ARGS
+  ${KODI_BINARY} $SAVED_ARGS &
+  CHILD=$!
+  wait "${CHILD}"
   RET=$?
   if [ $(( $RET == 65 )) = "1" ]
   then # User requested to restart app


### PR DESCRIPTION
## Description
Currently, if SIGTERM is sent to kodi.sh, it will capture the signal, but not propagate it to children. This makes managing kodi from init systems harder, as they must find the child PID somehow. 


## Motivation and Context
This makes it easier to manage kodi from the command-line and from init systems. 

## How Has This Been Tested?
Manually. 


## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
