### PR TITLE
[RFC] ActiveAE: handle sink disappearance better

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -619,6 +619,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             CLog::Log(LOGWARNING,"CActiveAE - received %ld device change events within one second", m_extLastDeviceChange.size());
             return;
           }
+          m_sinkIsGone = true;
           m_extLastDeviceChange.push(now);
           UnconfigureSink();
           m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
@@ -1143,7 +1144,8 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       m_currDevice.compare(device) != 0 ||
       m_settings.driver.compare(driver) != 0)
   {
-    FlushEngine();
+    if (! m_sinkIsGone)
+      FlushEngine();
     if (!InitSink())
       return;
     m_settings.driver = driver;
@@ -1151,6 +1153,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
     initSink = true;
     m_stats.Reset(m_sinkFormat.m_sampleRate, m_mode == MODE_PCM);
     m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::VOLUME, &m_volume, sizeof(float));
+    m_sinkIsGone = false;
 
     if (m_sinkRequestFormat.m_dataFormat != AE_FMT_RAW)
     {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -330,6 +330,7 @@ protected:
   bool m_extDeferData;
   std::queue<time_t> m_extLastDeviceChange;
   bool m_isWinSysReg = false;
+  bool m_sinkIsGone = false;
 
   enum
   {


### PR DESCRIPTION
## Description

Currently, removal of an AudioEngine sink suddenly can cause the state machine to end up in a stuck state. This is because AudioEngine will attempt to flush buffers of a device which is no longer present. 

This will then mean that even after re-adding the device, it will not be enumerated because the state machine is stuck.

```
2019-04-27 09:34:35.015 T:4040159984   ERROR: ActiveAE::InitSink - failed to init
2019-04-27 09:34:35.015 T:4040159984 WARNING: CActiveAE::StateMachine - signal: 1 from port: OutputDataPort not handled for state: 2
2019-04-27 09:34:37.519 T:4040159984 WARNING: Previous line repeats 3 times.
2019-04-27 09:34:37.519 T:4040159984   ERROR: ActiveAE::FlushEngine - failed to flush
2019-04-27 09:34:42.519 T:4040159984   ERROR: ActiveAE::InitSink - failed to init
2019-04-27 09:34:45.020 T:4040159984   ERROR: ActiveAE::FlushEngine - failed to flush
2019-04-27 09:34:50.020 T:4040159984   ERROR: ActiveAE::InitSink - failed to init
2019-04-27 09:34:52.522 T:4040159984   ERROR: ActiveAE::FlushEngine - failed to flush
```
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This change allows us to hotplug audio sinks, even during playback. For example, unplugging a USB sound card during Kodi and re-adding it will work as expected. Kodi will then fall back to an available sink. 

* We should not flush a sink that is no longer present
* We do not need to flush a sink that is being initialised

## How Has This Been Tested?

I have been able to test this with PulseAudio and ALSA on Linux; but some testing would be appreciated for other platforms to make sure that there are no regressions. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
