### PR TITLE
[interfaces] Fix crash on Kodi exit caused by double freed AsyncCallbackMessage

### DIFF
--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -49,16 +49,13 @@ namespace XBMCAddon
     CallbackQueue::iterator iter = g_callQueue.begin();
     while (iter != g_callQueue.end())
     {
-      AddonClass::Ref<AsyncCallbackMessage> cur(*iter);
+      if ((*iter)->handler.get() == this) // then this message is because of me
       {
-        if (cur->handler.get() == this) // then this message is because of me
-        {
-          g_callQueue.erase(iter);
-          iter = g_callQueue.begin();
-        }
-        else
-          ++iter;
+        g_callQueue.erase(iter);
+        iter = g_callQueue.begin();
       }
+      else
+        ++iter;
     }
   }
 


### PR DESCRIPTION
This fixes a crash during Kodi shutdown. Crash is caused by a dangling python addon callback message while descructing the global instance  which holds the callback messages:

<img width="1043" alt="Screenshot 2019-05-20 at 19 50 25" src="https://user-images.githubusercontent.com/3226626/58043866-a0f35080-7b3e-11e9-9fd0-dde62f3c0efa.png">

<img width="1164" alt="Screenshot 2019-05-20 at 19 51 13" src="https://user-images.githubusercontent.com/3226626/58043870-a2bd1400-7b3e-11e9-84d9-f5d87e52c965.png">

My suggestion for a fix is not to instanciate a Ref in `RetardedAsyncCallbackHandler::~RetardedAsyncCallbackHandler`, but to use a raw pointer here.

@jimfcarroll by any chance, if you are around, is this fix correct and acceptable?