### PR TITLE
CDRMUtils: explicitly set the caps we want (atomic brings them in)

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -595,9 +595,25 @@ bool CDRMUtils::InitDrm()
     auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
     if (ret)
     {
-      CLog::Log(LOGERROR, "CDRMUtils::%s - failed to set Universal planes capability: %s", __FUNCTION__, strerror(errno));
+      CLog::Log(LOGERROR, "CDRMUtils::{} - failed to set universal planes capability: {}", __FUNCTION__, strerror(errno));
       return false;
     }
+
+    ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_STEREO_3D, 1);
+    if (ret)
+    {
+      CLog::Log(LOGERROR, "CDRMUtils::{} - failed to set stereo 3d capability: {}", __FUNCTION__, strerror(errno));
+      return false;
+    }
+
+#if defined(DRM_CLIENT_CAP_ASPECT_RATIO)
+    ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 0);
+    if (ret)
+    {
+      CLog::Log(LOGERROR, "CDRMUtils::{} - failed to unset aspect ratio capability: {}", __FUNCTION__, strerror(errno));
+      return false;
+    }
+#endif
 
     if(!GetResources())
     {


### PR DESCRIPTION
The `DRM_CLIENT_CAP_ASPECT_RATIO` exposes aspect ratio information to userspace. We don't handle this inKkodi so we shouldn't expose it because kodi will just see duplicate modes. This also caused an issue on my system where Kodi would use the wrong mode and caused a heavy modeset during startup.

we can keep `DRM_CLIENT_CAP_STEREO_3D` because we do handle 3D modes in Kodi (though I've never tried 3D with GBM).

CC @Kwiboo 