### PR TITLE
[FFmpeg] drop use of deprecated methods

### DIFF
--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -92,7 +92,7 @@ bool CEncoderFFmpeg::Init(AddonToKodiFuncTable_AudioEncoder& callbacks)
   }
 
   /* set the stream's parameters */
-  m_CodecCtx                 = m_Stream->codec;
+  m_CodecCtx                 = avcodec_alloc_context3(codec);
   m_CodecCtx->codec_id       = codec->id;
   m_CodecCtx->codec_type     = AVMEDIA_TYPE_AUDIO;
   m_CodecCtx->bit_rate       = m_Format->bit_rate;

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -274,12 +274,7 @@ int CEncoderFFmpeg::Encode(int nNumBytesRead, uint8_t* pbtStream)
 
 bool CEncoderFFmpeg::WriteFrame()
 {
-  int encoded, got_output;
   AVFrame* frame;
-
-  av_init_packet(&m_Pkt);
-  m_Pkt.data = NULL;
-  m_Pkt.size = 0;
 
   if(m_NeedConversion)
   {
@@ -291,26 +286,41 @@ bool CEncoderFFmpeg::WriteFrame()
     }
     frame = m_ResampledFrame;
   }
-  else frame = m_BufferFrame;
+  else
+    frame = m_BufferFrame;
 
-  encoded = avcodec_encode_audio2(m_CodecCtx, &m_Pkt, frame, &got_output);
+  int ret = avcodec_send_frame(m_CodecCtx, frame);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CEncoderFFMmpeg::{} - avcodec_send_frame failed: ({})", __FUNCTION__, ret);
+  }
+
+  av_frame_free(&frame);
+
+  if (ret < 0)
+    return false;
+
+  av_init_packet(&m_Pkt);
+  m_Pkt.data = nullptr;
+  m_Pkt.size = 0;
+
+  ret = avcodec_receive_packet(m_CodecCtx, &m_Pkt);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CEncoderFFMmpeg::{} - avcodec_receive_packet failed: ({})", __FUNCTION__, ret);
+  }
 
   m_BufferSize = 0;
 
-  if (encoded < 0) {
-    CLog::Log(LOGERROR, "CEncoderFFmpeg::WriteFrame - Error encoding audio: %i", encoded);
-    return false;
-  }
-
-  if (got_output)
-  {
-    if (av_write_frame(m_Format, &m_Pkt) < 0) {
-      CLog::Log(LOGERROR, "CEncoderFFMmpeg::WriteFrame - Failed to write the frame data");
-      return false;
-    }
-  }
+  ret = av_write_frame(m_Format, &m_Pkt);
 
   av_packet_unref(&m_Pkt);
+
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CEncoderFFMmpeg::WriteFrame - Failed to write the frame data");
+    return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
Not sure if this is exactly correct. Maybe @FernetMenta can school me :stuck_out_tongue_winking_eye: 

Could use testing.