### PR TITLE
[fix] ColorManager initialization and lcms2 usage

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -208,10 +208,12 @@ bool CColorManager::GetVideo3dLut(int videoFlags, int *cmsToken, CMS_DATA_FORMAT
       cmsHTRANSFORM deviceLink =  cmsCreateTransform(sourceProfile, fmt, m_hProfile, fmt, INTENT_ABSOLUTE_COLORIMETRIC, 0);
 
       // sample the transformation
-      Create3dLut(deviceLink, format, clutSize, clutData);
+      if (deviceLink)
+        Create3dLut(deviceLink, format, clutSize, clutData);
 
       // free gamma curve, source profile and transformation
-      cmsDeleteTransform(deviceLink);
+      if (deviceLink)
+        cmsDeleteTransform(deviceLink);
       cmsCloseProfile(sourceProfile);
       cmsFreeToneCurve(gammaCurve);
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -123,6 +123,7 @@ void CRenderBuffer::QueueCopyFromGPU()
 CRendererBase::CRendererBase(CVideoSettings& videoSettings)
   : m_videoSettings(videoSettings)
 {
+  m_colorManager.reset(new CColorManager());
 }
 
 CRendererBase::~CRendererBase()


### PR DESCRIPTION
## Description
2nd commit might fix #16133

## How Has This Been Tested?
- started a video
- opened Colour management (at Settings)
- enabled Colour management
- changed Colour management mode

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
