### PR TITLE
fixed: DVD playback from http(s) sources (fixes #15694)

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1601,9 +1601,6 @@ extern "C"
   {
     if (!strnicmp(path, "shout://", 8)) // don't stat shoutcast
       return -1;
-    if (!strnicmp(path, "http://", 7)
-    ||  !strnicmp(path, "https://", 8)) // don't stat http
-      return -1;
     if (!strnicmp(path, "mms://", 6)) // don't stat mms
       return -1;
 
@@ -1646,9 +1643,6 @@ extern "C"
   int dll_stat64(const char *path, struct __stat64 *buffer)
   {
     if (!strnicmp(path, "shout://", 8)) // don't stat shoutcast
-      return -1;
-    if (!strnicmp(path, "http://", 7)
-    ||  !strnicmp(path, "https://", 8)) // don't stat http
       return -1;
     if (!strnicmp(path, "mms://", 6)) // don't stat mms
       return -1;


### PR DESCRIPTION
Not sure if this will cause any regressions, but since our http/https filesystem supports stat(64), we shouldn't prevent dll_stat/dll_stat64 from doing so.