### PR TITLE
[fix] use correct include path for fribidi.h

### DIFF
--- a/cmake/modules/FindFriBidi.cmake
+++ b/cmake/modules/FindFriBidi.cmake
@@ -17,7 +17,8 @@ if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_FRIBIDI fribidi QUIET)
 endif()
 
-find_path(FRIBIDI_INCLUDE_DIR NAMES fribidi/fribidi.h
+find_path(FRIBIDI_INCLUDE_DIR NAMES fribidi.h
+                              PATH_SUFFIXES fribidi
                               PATHS ${PC_FRIBIDI_INCLUDEDIR})
 find_library(FRIBIDI_LIBRARY NAMES fribidi libfribidi
                              PATHS ${PC_FRIBIDI_LIBDIR})

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -15,7 +15,7 @@
 #elif TARGET_FREEBSD
 #include "/usr/include/iconv.h"
 #endif
-#include <fribidi/fribidi.h>
+#include <fribidi.h>
 
 #include "guilib/LocalizeStrings.h"
 #include "LangInfo.h"


### PR DESCRIPTION
## Description
According to fribidi.pc file the correct usage is to pass `-I${includedir}/fribidi` to the compiler and use `#include <fribidi.h>`.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
