### PR TITLE
[WiP] Remove redundant smart pointer get()

### DIFF
--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -98,7 +98,7 @@ bool CCDDARipper::RipCD()
     CFileItemPtr pItem = vecItems[i];
     CMusicInfoTagLoaderFactory factory;
     std::unique_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(*pItem));
-    if (NULL != pLoader)
+    if (pLoader)
     {
       pLoader->Load(pItem->GetPath(), *pItem->GetMusicInfoTag()); // get tag from file
       if (!pItem->GetMusicInfoTag()->Loaded())

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -98,7 +98,7 @@ bool CCDDARipper::RipCD()
     CFileItemPtr pItem = vecItems[i];
     CMusicInfoTagLoaderFactory factory;
     std::unique_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(*pItem));
-    if (NULL != pLoader.get())
+    if (NULL != pLoader)
     {
       pLoader->Load(pItem->GetPath(), *pItem->GetMusicInfoTag()); // get tag from file
       if (!pItem->GetMusicInfoTag()->Loaded())

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -112,7 +112,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
   // SUBTITLE
 
   // Crypto
-  if ((cryptoSession.get() == nullptr) != (right.cryptoSession.get() == nullptr))
+  if ((cryptoSession == nullptr) != (right.cryptoSession == nullptr))
     return false;
 
   if (cryptoSession && !(*cryptoSession.get() == *right.cryptoSession.get()))

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -667,7 +667,7 @@ CVideoSettings CProcessInfo::GetVideoSettings()
 CVideoSettingsLocked& CProcessInfo::UpdateVideoSettings()
 {
   CSingleLock lock(m_settingsSection);
-  return *m_videoSettingsLocked.get();
+  return *m_videoSettingsLocked;
 }
 
 void CProcessInfo::SetVideoSettings(CVideoSettings &settings)

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -161,7 +161,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   CDVDStreamInfo hint(*pStream, true);
 
   CAEStreamInfo::DataType ptStreamTye = GetPassthroughStreamType(hint.codec, hint.samplerate);
-  m_pAudioCodec = CDVDFactoryCodec::CreateAudioCodec(hint, *m_processInfo.get(), true, true, ptStreamTye);
+  m_pAudioCodec = CDVDFactoryCodec::CreateAudioCodec(hint, *m_processInfo, true, true, ptStreamTye);
   if (!m_pAudioCodec)
   {
     CLog::Log(LOGERROR, "%s: Could not create audio codec", __FUNCTION__);

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -247,7 +247,7 @@ std::string CDatabase::PrepareSQL(std::string strStmt, ...) const
 {
   std::string strResult = "";
 
-  if (NULL != m_pDB)
+  if (m_pDB)
   {
     va_list args;
     va_start(args, strStmt);
@@ -336,8 +336,11 @@ bool CDatabase::ExecuteQuery(const std::string &strQuery)
 
   try
   {
-    if (NULL == m_pDB) return bReturn;
-    if (NULL == m_pDS) return bReturn;
+    if (!m_pDB)
+      return bReturn;
+    if (!m_pDS)
+      return bReturn;
+
     m_pDS->exec(strQuery);
     bReturn = true;
   }
@@ -356,8 +359,10 @@ bool CDatabase::ResultQuery(const std::string &strQuery)
 
   try
   {
-    if (NULL == m_pDB) return bReturn;
-    if (NULL == m_pDS) return bReturn;
+    if (!m_pDB)
+      return bReturn;
+    if (!m_pDS)
+      return bReturn;
 
     std::string strPreparedQuery = PrepareSQL(strQuery.c_str());
 
@@ -379,8 +384,10 @@ bool CDatabase::QueueInsertQuery(const std::string &strQuery)
 
   if (!m_bMultiWrite)
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false;
 
     m_bMultiWrite = true;
     m_pDS2->insert();
@@ -596,8 +603,11 @@ void CDatabase::Close()
   m_openCount = 0;
   m_multipleExecute = false;
 
-  if (NULL == m_pDB ) return ;
-  if (NULL != m_pDS) m_pDS->close();
+  if (!m_pDB)
+    return;
+  if (m_pDS)
+    m_pDS->close();
+
   m_pDB->disconnect();
   m_pDB.reset();
   m_pDS.reset();
@@ -611,8 +621,10 @@ bool CDatabase::Compress(bool bForce /* =true */)
 
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
     if (!bForce)
     {
       m_pDS->query("select iCompressCount from version");
@@ -649,7 +661,7 @@ void CDatabase::BeginTransaction()
 {
   try
   {
-    if (NULL != m_pDB)
+    if (m_pDB)
       m_pDB->start_transaction();
   }
   catch (...)
@@ -662,7 +674,7 @@ bool CDatabase::CommitTransaction()
 {
   try
   {
-    if (NULL != m_pDB)
+    if (m_pDB)
       m_pDB->commit_transaction();
   }
   catch (...)
@@ -677,7 +689,7 @@ void CDatabase::RollbackTransaction()
 {
   try
   {
-    if (NULL != m_pDB)
+    if (m_pDB)
       m_pDB->rollback_transaction();
   }
   catch (...)

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -247,7 +247,7 @@ std::string CDatabase::PrepareSQL(std::string strStmt, ...) const
 {
   std::string strResult = "";
 
-  if (NULL != m_pDB.get())
+  if (NULL != m_pDB)
   {
     va_list args;
     va_start(args, strStmt);
@@ -336,8 +336,8 @@ bool CDatabase::ExecuteQuery(const std::string &strQuery)
 
   try
   {
-    if (NULL == m_pDB.get()) return bReturn;
-    if (NULL == m_pDS.get()) return bReturn;
+    if (NULL == m_pDB) return bReturn;
+    if (NULL == m_pDS) return bReturn;
     m_pDS->exec(strQuery);
     bReturn = true;
   }
@@ -356,8 +356,8 @@ bool CDatabase::ResultQuery(const std::string &strQuery)
 
   try
   {
-    if (NULL == m_pDB.get()) return bReturn;
-    if (NULL == m_pDS.get()) return bReturn;
+    if (NULL == m_pDB) return bReturn;
+    if (NULL == m_pDS) return bReturn;
 
     std::string strPreparedQuery = PrepareSQL(strQuery.c_str());
 
@@ -379,8 +379,8 @@ bool CDatabase::QueueInsertQuery(const std::string &strQuery)
 
   if (!m_bMultiWrite)
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false;
 
     m_bMultiWrite = true;
     m_pDS2->insert();
@@ -596,8 +596,8 @@ void CDatabase::Close()
   m_openCount = 0;
   m_multipleExecute = false;
 
-  if (NULL == m_pDB.get() ) return ;
-  if (NULL != m_pDS.get()) m_pDS->close();
+  if (NULL == m_pDB ) return ;
+  if (NULL != m_pDS) m_pDS->close();
   m_pDB->disconnect();
   m_pDB.reset();
   m_pDS.reset();
@@ -611,8 +611,8 @@ bool CDatabase::Compress(bool bForce /* =true */)
 
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     if (!bForce)
     {
       m_pDS->query("select iCompressCount from version");
@@ -649,7 +649,7 @@ void CDatabase::BeginTransaction()
 {
   try
   {
-    if (NULL != m_pDB.get())
+    if (NULL != m_pDB)
       m_pDB->start_transaction();
   }
   catch (...)
@@ -662,7 +662,7 @@ bool CDatabase::CommitTransaction()
 {
   try
   {
-    if (NULL != m_pDB.get())
+    if (NULL != m_pDB)
       m_pDB->commit_transaction();
   }
   catch (...)
@@ -677,7 +677,7 @@ void CDatabase::RollbackTransaction()
 {
   try
   {
-    if (NULL != m_pDB.get())
+    if (NULL != m_pDB)
       m_pDB->rollback_transaction();
   }
   catch (...)

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -322,7 +322,7 @@ bool CDirectory::Create(const CURL& url)
       CPasswordManager::GetInstance().AuthenticateURL(realURL);
 
     std::unique_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
-    if (pDirectory.get())
+    if (pDirectory)
       if(pDirectory->Create(realURL))
         return true;
   }
@@ -361,7 +361,7 @@ bool CDirectory::Exists(const CURL& url, bool bUseCache /* = true */)
       CPasswordManager::GetInstance().AuthenticateURL(realURL);
 
     std::unique_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
-    if (pDirectory.get())
+    if (pDirectory)
       return pDirectory->Exists(realURL);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
@@ -394,7 +394,7 @@ bool CDirectory::Remove(const CURL& url)
       CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
     std::unique_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
-    if (pDirectory.get())
+    if (pDirectory)
       if(pDirectory->Remove(authUrl))
       {
         g_directoryCache.ClearFile(realURL.Get());
@@ -420,7 +420,7 @@ bool CDirectory::RemoveRecursive(const CURL& url)
       CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
     std::unique_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
-    if (pDirectory.get())
+    if (pDirectory)
       if(pDirectory->RemoveRecursive(authUrl))
       {
         g_directoryCache.ClearFile(realURL.Get());
@@ -446,7 +446,7 @@ void CDirectory::FilterFileDirectories(CFileItemList &items, const std::string &
     if (!pItem->m_bIsFolder && pItem->IsFileFolder(mode))
     {
       std::unique_ptr<IFileDirectory> pDirectory(CFileDirectoryFactory::Create(pItem->GetURL(),pItem.get(),mask));
-      if (pDirectory.get())
+      if (pDirectory)
         pItem->m_bIsFolder = true;
       else
         if (pItem->m_bIsFolder)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -327,7 +327,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
         m_pFile = pRedirectEx->m_pNewFileImp;
         delete pRedirectEx;
 
-        if (pNewUrl.get())
+        if (pNewUrl)
         {
           CURL newAuthUrl(*pNewUrl);
           if (CPasswordManager::GetInstance().IsURLSupported(newAuthUrl) && newAuthUrl.GetUserName().empty())
@@ -455,9 +455,9 @@ bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
       std::unique_ptr<CURL> pNewUrl(pRedirectEx->m_pNewUrl);
       delete pRedirectEx;
 
-      if (pImp.get())
+      if (pImp)
       {
-        if (pNewUrl.get())
+        if (pNewUrl)
         {
           if (bUseCache)
           {
@@ -538,9 +538,9 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
       std::unique_ptr<CURL> pNewUrl(pRedirectEx->m_pNewUrl);
       delete pRedirectEx;
 
-      if (pNewUrl.get())
+      if (pNewUrl)
       {
-        if (pImp.get())
+        if (pImp)
         {
           CURL newAuthUrl = *pNewUrl;
           if (CPasswordManager::GetInstance().IsURLSupported(newAuthUrl) && newAuthUrl.GetUserName().empty())

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -212,12 +212,6 @@ void CFileCache::Process()
 
   // create our read buffer
   std::unique_ptr<char[]> buffer(new char[m_chunkSize]);
-  if (buffer == NULL)
-  {
-    CLog::Log(LOGERROR, "%s - failed to allocate read buffer", __FUNCTION__);
-    return;
-  }
-
   CWriteRate limiter;
   CWriteRate average;
   bool cacheReachEOF = false;

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -212,7 +212,7 @@ void CFileCache::Process()
 
   // create our read buffer
   std::unique_ptr<char[]> buffer(new char[m_chunkSize]);
-  if (buffer.get() == NULL)
+  if (buffer == NULL)
   {
     CLog::Log(LOGERROR, "%s - failed to allocate read buffer", __FUNCTION__);
     return;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -249,7 +249,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this));
 
   bool bSuccess=false;
-  if (pNode.get())
+  if (pNode)
   {
     pNode->m_options = m_options;
     bSuccess=pNode->GetContent(items);

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -24,7 +24,7 @@ namespace XFILE
   {
     const std::string pathToUrl = url.Get();
     std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(pathToUrl));
-    if ( NULL != pPlayList.get())
+    if ( NULL != pPlayList)
     {
       // load it
       if (!pPlayList->Load(pathToUrl))
@@ -46,7 +46,7 @@ namespace XFILE
   {
     const std::string pathToUrl = url.Get();
     std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(pathToUrl));
-    if ( NULL != pPlayList.get())
+    if ( NULL != pPlayList)
     {
       // load it
       if (!pPlayList->Load(pathToUrl))

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -24,7 +24,7 @@ namespace XFILE
   {
     const std::string pathToUrl = url.Get();
     std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(pathToUrl));
-    if ( NULL != pPlayList)
+    if (pPlayList)
     {
       // load it
       if (!pPlayList->Load(pathToUrl))
@@ -46,7 +46,7 @@ namespace XFILE
   {
     const std::string pathToUrl = url.Get();
     std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(pathToUrl));
-    if ( NULL != pPlayList)
+    if (pPlayList)
     {
       // load it
       if (!pPlayList->Load(pathToUrl))

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -244,7 +244,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this));
 
   bool bSuccess=false;
-  if (pNode.get())
+  if (pNode)
   {
     pNode->m_options = m_options;
     bSuccess = pNode->GetContent(items);

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -449,7 +449,7 @@ static int PlayMedia(const std::vector<std::string>& params)
       }
 
       std::unique_ptr<CGUIViewState> state(CGUIViewState::GetViewState(containsVideo ? WINDOW_VIDEO_NAV : WINDOW_MUSIC_NAV, items));
-      if (state.get())
+      if (state)
         items.Sort(state->GetSortMethod());
       else
         items.Sort(SortByLabel, SortOrderAscending);

--- a/xbmc/interfaces/legacy/PlayList.cpp
+++ b/xbmc/interfaces/legacy/PlayList.cpp
@@ -69,7 +69,7 @@ namespace XBMCAddon
         // load a playlist like .m3u, .pls
         // first get correct factory to load playlist
         std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(item));
-        if ( NULL != pPlayList.get())
+        if ( NULL != pPlayList)
         {
           // load it
           if (!pPlayList->Load(item.GetPath()))

--- a/xbmc/interfaces/legacy/PlayList.cpp
+++ b/xbmc/interfaces/legacy/PlayList.cpp
@@ -69,7 +69,7 @@ namespace XBMCAddon
         // load a playlist like .m3u, .pls
         // first get correct factory to load playlist
         std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(item));
-        if ( NULL != pPlayList)
+        if (pPlayList)
         {
           // load it
           if (!pPlayList->Load(item.GetPath()))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -568,8 +568,8 @@ int CMusicDatabase::AddSong(const int idAlbum,
     if (strTitle.empty())
       return -1;
 
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strPath, strFileName;
     SplitPath(strPathAndFileName, strPath, strFileName);
@@ -658,8 +658,8 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
   {
     song.Clear();
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("SELECT songview.*,songartistview.* FROM songview "
                                  " JOIN songartistview ON songview.idSong = songartistview.idSong "
@@ -676,10 +676,10 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
 
     int songArtistOffset = song_enumCount;
 
-    song = GetSongFromDataset(m_pDS.get()->get_sql_record());
+    song = GetSongFromDataset(m_pDS->get_sql_record());
     while (!m_pDS->eof())
     {
-      const dbiplus::sql_record* const record = m_pDS.get()->get_sql_record();
+      const dbiplus::sql_record* const record = m_pDS->get_sql_record();
 
       int idSongArtistRole = record->at(songArtistOffset + artistCredit_idRole).get_asInt();
       if (idSongArtistRole == ROLE_ARTIST)
@@ -816,8 +816,8 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     if (!strMusicBrainzAlbumID.empty())
       strSQL = PrepareSQL("SELECT * FROM album WHERE strMusicBrainzAlbumID = '%s'",
@@ -968,8 +968,8 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (idAlbum == -1)
       return false; // not in the database
@@ -994,7 +994,7 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 
     int albumArtistOffset = album_enumCount;
 
-    album = GetAlbumFromDataset(m_pDS.get()->get_sql_record(), 0, true); // true to grab and parse the imageURL
+    album = GetAlbumFromDataset(m_pDS->get_sql_record(), 0, true); // true to grab and parse the imageURL
     while (!m_pDS->eof())
     {
       const dbiplus::sql_record* const record = m_pDS->get_sql_record();
@@ -1081,8 +1081,8 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
     if (strGenre.empty())
       strGenre=g_localizeStrings.Get(13205); // Unknown
 
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     auto it = m_genreCache.find(strGenre);
     if (it != m_genreCache.end())
@@ -1167,8 +1167,8 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
 
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     strSQL = PrepareSQL("SELECT strArtist, strSortName FROM artist WHERE idArtist = %i", idArtist);
     m_pDS->query(strSQL);
@@ -1206,8 +1206,8 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     // 1) MusicBrainz
     if (!strMusicBrainzArtistID.empty())
@@ -1369,8 +1369,8 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
   try
   {
     unsigned int time = XbmcThreads::SystemClockMillis();
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (idArtist == -1)
       return false; // not in the database
@@ -1404,12 +1404,12 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
     int discographyOffset = artist_enumCount;
 
     artist.discography.clear();
-    artist = GetArtistFromDataset(m_pDS.get()->get_sql_record(), 0, true); // inc scraped art URLs
+    artist = GetArtistFromDataset(m_pDS->get_sql_record(), 0, true); // inc scraped art URLs
     if (fetchAll)
     {
       while (!m_pDS->eof())
       {
-        const dbiplus::sql_record* const record = m_pDS.get()->get_sql_record();
+        const dbiplus::sql_record* const record = m_pDS->get_sql_record();
 
         artist.discography.emplace_back(record->at(discographyOffset + 1).get_asString(), record->at(discographyOffset + 2).get_asString());
         m_pDS->next();
@@ -1431,8 +1431,8 @@ bool CMusicDatabase::GetArtistExists(int idArtist)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL = PrepareSQL("SELECT 1 FROM artist WHERE artist.idArtist = %i LIMIT 1", idArtist);
 
@@ -1494,8 +1494,8 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // Combine entries from discography and album tables
     // When title in both, album entry will be before disco entry
@@ -1567,8 +1567,8 @@ int CMusicDatabase::AddRole(const std::string &strRole)
 
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
     strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole LIKE '%s'", strRole.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() > 0)
@@ -1612,8 +1612,8 @@ int CMusicDatabase::AddSongContributor(int idSong, const std::string& strRole, c
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     int idArtist = -1;
     // Add artist. As we only have name (no MBID) first try to identify artist from song
@@ -1669,8 +1669,8 @@ int CMusicDatabase::GetRoleByName(const std::string& strRole)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole like '%s'", strRole.c_str());
@@ -2074,8 +2074,8 @@ int CMusicDatabase::AddPath(const std::string& strPath1)
     if (!URIUtils::HasSlashAtEnd(strPath))
       URIUtils::AddSlashAtEnd(strPath);
 
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     auto it = m_pathCache.find(strPath);
     if (it != m_pathCache.end())
@@ -2364,8 +2364,8 @@ bool CMusicDatabase::GetSongByFileName(const std::string& strFileNameAndPath, CS
     return GetSong(atol(strFile.c_str()), song);
   }
 
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   std::string strPath, strFileName;
   SplitPath(strFileNameAndPath, strPath, strFileName);
@@ -2388,8 +2388,8 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL = PrepareSQL("SELECT DISTINCT idAlbum FROM song JOIN path ON song.idPath = path.idPath WHERE path.strPath='%s'", strPath.c_str());
     // run query
@@ -2443,8 +2443,8 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList &art
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strVariousArtists = g_localizeStrings.Get(340).c_str();
     std::string strSQL;
@@ -2493,8 +2493,8 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
@@ -2538,8 +2538,8 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // Get data from album and album_artist tables to fully populate albums
     std::string strSQL = "SELECT albumview.*, albumartistview.* FROM albumview "
@@ -2591,8 +2591,8 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && baseUrl.FromString(strBaseDir))
@@ -2635,8 +2635,8 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // Get data from album and album_artist tables to fully populate albums
     std::string strSQL = PrepareSQL("SELECT albumview.*, albumartistview.* FROM "
@@ -2688,8 +2688,8 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
@@ -2767,8 +2767,8 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // Get data from album and album_artist tables to fully populate albums
     // Use idAlbum to determine the recently added albums
@@ -2820,8 +2820,8 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, C
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
@@ -2900,8 +2900,8 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     int idSong = GetSongIDFromPath(item.GetPath());
 
@@ -2925,8 +2925,8 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songs
     if (!bAppendToMap)
       songs.clear();
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("SELECT * FROM songview WHERE strPath='%s'", strPath.c_str());
     if (!m_pDS->query(strSQL)) return false;
@@ -2985,8 +2985,8 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList &items
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CMusicDbUrl baseUrl;
     if (!baseUrl.FromString("musicdb://songs/"))
@@ -3025,8 +3025,8 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albu
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     if (search.size() >= MIN_FULL_SEARCH_LENGTH)
@@ -3063,8 +3063,8 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     // ok, now find all idSong's
     std::string strSQL=PrepareSQL("select * from song join path on song.idPath = path.idPath where song.idSong in %s", strSongIds.c_str());
     if (!m_pDS->query(strSQL)) return false;
@@ -3355,8 +3355,8 @@ bool CMusicDatabase::CleanupRoles()
 bool CMusicDatabase::CleanupOrphanedItems()
 {
   // paths aren't cleaned up here - they're cleaned up in RemoveSongsFromPath()
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
   SetLibraryLastUpdated();
   if (!CleanupAlbums()) return false;
   if (!CleanupArtists()) return false;
@@ -3368,8 +3368,8 @@ bool CMusicDatabase::CleanupOrphanedItems()
 
 int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
 {
-  if (NULL == m_pDB.get()) return ERROR_DATABASE;
-  if (NULL == m_pDS.get()) return ERROR_DATABASE;
+  if (NULL == m_pDB) return ERROR_DATABASE;
+  if (NULL == m_pDS) return ERROR_DATABASE;
 
   int ret = ERROR_OK;
   unsigned int time = XbmcThreads::SystemClockMillis();
@@ -3719,8 +3719,8 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir, CFileItemList& 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // get primary genres for songs - could be simplified to just SELECT * FROM genre?
     std::string strSQL = "SELECT %s FROM genre ";
@@ -3826,8 +3826,8 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir, CFileItemList&
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // Get sources for selection list when add/edit filter or smartplaylist rule
     std::string strSQL = "SELECT %s FROM source ";
@@ -3936,8 +3936,8 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     Filter extFilter = filter;
     CMusicDbUrl musicUrl;
@@ -3999,8 +3999,8 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     Filter extFilter = filter;
     CMusicDbUrl musicUrl;
@@ -4072,8 +4072,8 @@ bool CMusicDatabase::GetAlbumsByYear(const std::string& strBaseDir, CFileItemLis
 
 bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::string &table, const std::string &labelField, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   if (table.empty() || labelField.empty())
     return false;
@@ -4165,8 +4165,8 @@ bool CMusicDatabase::GetMusicLabelsNav(const std::string &strBaseDir, CFileItemL
 
 bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList& items, bool albumArtistsOnly /* = false */, int idGenre /* = -1 */, int idAlbum /* = -1 */, int idSong /* = -1 */, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
   try
   {
     CMusicDbUrl musicUrl;
@@ -4199,8 +4199,8 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList&
 
 bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -4349,8 +4349,8 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL = PrepareSQL("select albumview.* from song join albumview on song.idAlbum = albumview.idAlbum where song.idSong='%i'", idSong);
     if (!m_pDS->query(strSQL)) return false;
@@ -4392,7 +4392,7 @@ bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir, CFileItemList& 
 
 bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+  if (m_pDB == NULL || m_pDS == NULL)
     return false;
 
   try
@@ -4514,7 +4514,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
 
 bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool artistData /* = false*/)
 {
-  if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+  if (m_pDB == NULL || m_pDS == NULL)
     return false;
 
   try
@@ -4673,7 +4673,7 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
 
 bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+  if (m_pDB == NULL || m_pDS == NULL)
     return false;
 
   try
@@ -4866,8 +4866,8 @@ static const size_t NUM_ARTIST_FIELDS = sizeof(JSONtoDBArtist) / sizeof(translat
 bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, const std::string &baseDir,
   CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -5553,8 +5553,8 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
   CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
 {
   
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -6038,8 +6038,8 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
   CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
 {
 
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -7433,8 +7433,8 @@ int CMusicDatabase::GetMusicNeedsTagScan()
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string sql = "SELECT * FROM versiontagscan";
     if (!m_pDS->query(sql)) return -1;
@@ -7489,8 +7489,8 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
-    if (NULL == m_pDS.get()) return 0;
+    if (NULL == m_pDB) return 0;
+    if (NULL == m_pDS) return 0;
 
     std::string strSQL = "SELECT idSong FROM songview ";
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
@@ -7524,8 +7524,8 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
-    if (NULL == m_pDS.get()) return 0;
+    if (NULL == m_pDB) return 0;
+    if (NULL == m_pDS) return 0;
 
     std::string strSQL = "select count(idSong) as NumSongs from songview ";
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
@@ -7573,8 +7573,8 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false;
 
     // Get the unique paths of songs on the album, providing there are no songs from
     // other albums with the same path. This returns
@@ -7621,8 +7621,8 @@ int CMusicDatabase::GetDiscnumberForPathID(int idPath)
   int result = -1;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS2.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS2) return -1;
 
     strSQL = PrepareSQL("SELECT DISTINCT(song.iTrack >> 16) AS discnum FROM song "
       "WHERE idPath = %i", idPath);
@@ -7652,8 +7652,8 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string &basePath)
   basePath.clear();
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false;
 
     // find all albums from this artist, and all the paths to the songs from those albums
     std::string strSQL = PrepareSQL("SELECT strPath FROM album_artist "
@@ -7838,8 +7838,8 @@ int CMusicDatabase::AddSource(const std::string& strName, const std::string& str
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     // Check if source name already exists
     idSource = GetSourceByName(strName);
@@ -7917,8 +7917,8 @@ int CMusicDatabase::UpdateSource(const std::string& strOldName, const std::strin
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     // Get details of named old source 
     if (!strOldName.empty())
@@ -7989,8 +7989,8 @@ int CMusicDatabase::GetSourceFromPath(const std::string& strPath1)
     if (!URIUtils::HasSlashAtEnd(strPath))
       URIUtils::AddSlashAtEnd(strPath);
 
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     // Check if path is a source matching on multipath
     strSQL = PrepareSQL("SELECT idSource FROM source WHERE strMultipath = '%s'", strPath.c_str());
@@ -8035,8 +8035,8 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
   std::vector<int> sourceIds;
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (!strPath.empty())
     {
@@ -8055,7 +8055,7 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
     else
     { 
       // Find sources using song paths, check each source path individually
-      if (NULL == m_pDS2.get()) return false;
+      if (NULL == m_pDS2) return false;
       strSQL = "SELECT idSource, strPath FROM source_path";
       if (!m_pDS->query(strSQL))
         return false;
@@ -8113,8 +8113,8 @@ bool CMusicDatabase::CheckSources(VECSOURCES& sources)
   // Check individual sources match
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     for (const auto& source : sources)
@@ -8220,8 +8220,8 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // Get music sources and individual source paths (may not be scanned or have albums etc.)
     std::string strSQL = "SELECT source.idSource, source.strName, source.strMultipath, source_path.strPath "
@@ -8289,8 +8289,8 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
 
 bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -8342,8 +8342,8 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
 
 bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -8371,7 +8371,7 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
       // usually fewer source paths than songs
       m_pDS->close();
      
-      if (NULL == m_pDS2.get()) return false;
+      if (NULL == m_pDS2) return false;
       strSQL = "SELECT idSource, strPath FROM source_path";
       if (!m_pDS->query(strSQL))
         return false;
@@ -8405,8 +8405,8 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
 
 bool CMusicDatabase::GetSourcesBySong(int idSong, const std::string& strPath1, CFileItem* item)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -8452,8 +8452,8 @@ int CMusicDatabase::GetSourceByName(const std::string& strSource)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idSource FROM source WHERE strName LIKE '%s'", strSource.c_str());
@@ -8483,8 +8483,8 @@ int CMusicDatabase::GetArtistByName(const std::string& strArtist)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("select idArtist from artist where artist.strArtist like '%s'", strArtist.c_str());
 
@@ -8512,7 +8512,7 @@ int CMusicDatabase::GetArtistByMatch(const CArtist& artist)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get() || NULL == m_pDS.get())
+    if (NULL == m_pDB || NULL == m_pDS)
       return false;
     // Match on MusicBrainz ID, definitively unique
     if (!artist.strMusicBrainzArtistID.empty())
@@ -8545,8 +8545,8 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL = PrepareSQL(
       "SELECT artistview.* FROM song_artist "
@@ -8597,8 +8597,8 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     if (strArtist.empty())
@@ -8632,7 +8632,7 @@ int CMusicDatabase::GetAlbumByMatch(const CAlbum &album)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get() || NULL == m_pDS.get())
+    if (NULL == m_pDB || NULL == m_pDS)
       return false;
     // Match on MusicBrainz ID, definitively unique
     if (!album.strMusicBrainzAlbumID.empty())
@@ -8768,8 +8768,8 @@ int CMusicDatabase::GetGenreByName(const std::string& strGenre)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     strSQL=PrepareSQL("select idGenre from genre where genre.strGenre like '%s'", strGenre.c_str());
@@ -8795,8 +8795,8 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     strSQL = "SELECT %s FROM genre ";
     Filter extFilter;
@@ -8938,8 +8938,8 @@ bool CMusicDatabase::SetPathHash(const std::string &path, const std::string &has
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (hash.empty())
     { // this is an empty folder - we need only add it to the path table
@@ -8967,8 +8967,8 @@ bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
     m_pDS->query(strSQL);
@@ -9020,8 +9020,8 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
     if (!URIUtils::HasSlashAtEnd(path))
       URIUtils::AddSlashAtEnd(path);
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string where;
     if (exact)
@@ -9068,8 +9068,8 @@ bool CMusicDatabase::GetPaths(std::set<std::string> &paths)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     paths.clear();
 
@@ -9101,8 +9101,8 @@ bool CMusicDatabase::SetSongUserrating(const std::string &filePath, int userrati
   try
   {
     if (filePath.empty()) return false;
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int songID = GetSongIDFromPath(filePath);
     if (-1 == songID) return false;
@@ -9120,8 +9120,8 @@ bool CMusicDatabase::SetSongUserrating(int idSong, int userrating)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("UPDATE song SET userrating='%i' WHERE idSong = %i", userrating, idSong);
     m_pDS->exec(sql);
@@ -9138,8 +9138,8 @@ bool CMusicDatabase::SetAlbumUserrating(const int idAlbum, int userrating)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (-1 == idAlbum) return false;
 
@@ -9159,8 +9159,8 @@ bool CMusicDatabase::SetSongVotes(const std::string &filePath, int votes)
   try
   {
     if (filePath.empty()) return false;
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int songID = GetSongIDFromPath(filePath);
     if (-1 == songID) return false;
@@ -9189,8 +9189,8 @@ int CMusicDatabase::GetSongIDFromPath(const std::string &filePath)
   // hit the db
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strPath, strFileName;
     SplitPath(filePath, strPath, strFileName);
@@ -9232,8 +9232,8 @@ bool CMusicDatabase::CommitTransaction()
 
 bool CMusicDatabase::SetScraperAll(const std::string & strBaseDir, const ADDON::ScraperPtr scraper)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
   std::string strSQL;
   int idSetting = -1;
   try
@@ -9307,8 +9307,8 @@ bool CMusicDatabase::SetScraperAll(const std::string & strBaseDir, const ADDON::
 
 bool CMusicDatabase::SetScraper(int id, const CONTENT_TYPE &content, const ADDON::ScraperPtr scraper)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
   std::string strSQL;
   int idSetting = -1;
   try
@@ -9362,8 +9362,8 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::Scra
   std::string strSettings;
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     strSQL = "SELECT strScraperPath, strSettings FROM infosetting JOIN ";
@@ -9415,8 +9415,8 @@ bool CMusicDatabase::ScraperInUse(const std::string &scraperID) const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("SELECT COUNT(1) FROM infosetting WHERE strScraperPath='%s'",scraperID.c_str());
     if (!m_pDS->query(sql) || m_pDS->num_rows() == 0)
@@ -9530,9 +9530,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
   int iFailCount = 0;
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
-    if (NULL == m_pDS2.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
+    if (NULL == m_pDS2) return;
 
     // Create our xml document
     CXBMCTinyXML xmlDoc;
@@ -9913,8 +9913,8 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
 {  
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     CXBMCTinyXML xmlDoc;
     if (!xmlDoc.LoadFile(xmlFile) && progressDialog)
@@ -10411,8 +10411,8 @@ void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, co
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     // don't set <foo>.<bar> art types - these are derivative types from parent items
     if (artType.find('.') != std::string::npos)
@@ -10446,8 +10446,8 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
   try
   {
     if (!(songId > 0 || albumId > 0 || artistId > 0)) return false;
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     Filter filter;
     if (songId > 0)
@@ -10553,8 +10553,8 @@ bool CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, st
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
     m_pDS2->query(sql);
@@ -10597,8 +10597,8 @@ bool CMusicDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL = PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
 
@@ -11118,8 +11118,8 @@ void CMusicDatabase::UpdateFileDateAdded(int songId, const std::string& strFileN
   CDateTime dateAdded;
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     // 1 preferring to use the files mtime(if it's valid) and only using the file's ctime if the mtime isn't valid
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iMusicLibraryDateAdded == 1)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -568,8 +568,10 @@ int CMusicDatabase::AddSong(const int idAlbum,
     if (strTitle.empty())
       return -1;
 
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     std::string strPath, strFileName;
     SplitPath(strPathAndFileName, strPath, strFileName);
@@ -658,8 +660,10 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
   {
     song.Clear();
 
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL=PrepareSQL("SELECT songview.*,songartistview.* FROM songview "
                                  " JOIN songartistview ON songview.idSong = songartistview.idSong "
@@ -816,8 +820,10 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     if (!strMusicBrainzAlbumID.empty())
       strSQL = PrepareSQL("SELECT * FROM album WHERE strMusicBrainzAlbumID = '%s'",
@@ -968,8 +974,10 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     if (idAlbum == -1)
       return false; // not in the database
@@ -1081,8 +1089,10 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
     if (strGenre.empty())
       strGenre=g_localizeStrings.Get(13205); // Unknown
 
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     auto it = m_genreCache.find(strGenre);
     if (it != m_genreCache.end())
@@ -1167,8 +1177,10 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
 
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     strSQL = PrepareSQL("SELECT strArtist, strSortName FROM artist WHERE idArtist = %i", idArtist);
     m_pDS->query(strSQL);
@@ -1206,8 +1218,10 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     // 1) MusicBrainz
     if (!strMusicBrainzArtistID.empty())
@@ -1369,8 +1383,10 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* =
   try
   {
     unsigned int time = XbmcThreads::SystemClockMillis();
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     if (idArtist == -1)
       return false; // not in the database
@@ -1431,8 +1447,10 @@ bool CMusicDatabase::GetArtistExists(int idArtist)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL = PrepareSQL("SELECT 1 FROM artist WHERE artist.idArtist = %i LIMIT 1", idArtist);
 
@@ -1494,8 +1512,10 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     // Combine entries from discography and album tables
     // When title in both, album entry will be before disco entry
@@ -1567,8 +1587,10 @@ int CMusicDatabase::AddRole(const std::string &strRole)
 
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
     strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole LIKE '%s'", strRole.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() > 0)
@@ -1669,8 +1691,10 @@ int CMusicDatabase::GetRoleByName(const std::string& strRole)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole like '%s'", strRole.c_str());
@@ -2074,8 +2098,10 @@ int CMusicDatabase::AddPath(const std::string& strPath1)
     if (!URIUtils::HasSlashAtEnd(strPath))
       URIUtils::AddSlashAtEnd(strPath);
 
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     auto it = m_pathCache.find(strPath);
     if (it != m_pathCache.end())
@@ -2364,8 +2390,10 @@ bool CMusicDatabase::GetSongByFileName(const std::string& strFileNameAndPath, CS
     return GetSong(atol(strFile.c_str()), song);
   }
 
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   std::string strPath, strFileName;
   SplitPath(strFileNameAndPath, strPath, strFileName);
@@ -2388,8 +2416,10 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL = PrepareSQL("SELECT DISTINCT idAlbum FROM song JOIN path ON song.idPath = path.idPath WHERE path.strPath='%s'", strPath.c_str());
     // run query
@@ -2443,8 +2473,10 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList &art
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strVariousArtists = g_localizeStrings.Get(340).c_str();
     std::string strSQL;
@@ -2493,8 +2525,10 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
@@ -2591,8 +2625,10 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && baseUrl.FromString(strBaseDir))
@@ -2635,8 +2671,10 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     // Get data from album and album_artist tables to fully populate albums
     std::string strSQL = PrepareSQL("SELECT albumview.*, albumartistview.* FROM "
@@ -2688,8 +2726,10 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir, 
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
@@ -2767,8 +2807,10 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
   try
   {
     albums.erase(albums.begin(), albums.end());
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     // Get data from album and album_artist tables to fully populate albums
     // Use idAlbum to determine the recently added albums
@@ -2820,8 +2862,10 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir, C
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     CMusicDbUrl baseUrl;
     if (!strBaseDir.empty() && !baseUrl.FromString(strBaseDir))
@@ -2900,8 +2944,10 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     int idSong = GetSongIDFromPath(item.GetPath());
 
@@ -2925,8 +2971,10 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1, MAPSONGS& songs
     if (!bAppendToMap)
       songs.clear();
 
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL=PrepareSQL("SELECT * FROM songview WHERE strPath='%s'", strPath.c_str());
     if (!m_pDS->query(strSQL)) return false;
@@ -2985,8 +3033,10 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList &items
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     CMusicDbUrl baseUrl;
     if (!baseUrl.FromString("musicdb://songs/"))
@@ -3025,8 +3075,10 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList &albu
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     if (search.size() >= MIN_FULL_SEARCH_LENGTH)
@@ -3063,8 +3115,10 @@ bool CMusicDatabase::CleanupSongsByIds(const std::string &strSongIds)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
     // ok, now find all idSong's
     std::string strSQL=PrepareSQL("select * from song join path on song.idPath = path.idPath where song.idSong in %s", strSongIds.c_str());
     if (!m_pDS->query(strSQL)) return false;
@@ -3355,8 +3409,10 @@ bool CMusicDatabase::CleanupRoles()
 bool CMusicDatabase::CleanupOrphanedItems()
 {
   // paths aren't cleaned up here - they're cleaned up in RemoveSongsFromPath()
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
   SetLibraryLastUpdated();
   if (!CleanupAlbums()) return false;
   if (!CleanupArtists()) return false;
@@ -3368,8 +3424,10 @@ bool CMusicDatabase::CleanupOrphanedItems()
 
 int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
 {
-  if (NULL == m_pDB) return ERROR_DATABASE;
-  if (NULL == m_pDS) return ERROR_DATABASE;
+  if (!m_pDB)
+    return ERROR_DATABASE;
+  if (!m_pDS)
+    return ERROR_DATABASE;
 
   int ret = ERROR_OK;
   unsigned int time = XbmcThreads::SystemClockMillis();
@@ -3719,8 +3777,10 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir, CFileItemList& 
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     // get primary genres for songs - could be simplified to just SELECT * FROM genre?
     std::string strSQL = "SELECT %s FROM genre ";
@@ -3936,8 +3996,8 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB) return false;
+    if (!m_pDS) return false;
 
     Filter extFilter = filter;
     CMusicDbUrl musicUrl;
@@ -3999,8 +4059,10 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     Filter extFilter = filter;
     CMusicDbUrl musicUrl;
@@ -4072,8 +4134,10 @@ bool CMusicDatabase::GetAlbumsByYear(const std::string& strBaseDir, CFileItemLis
 
 bool CMusicDatabase::GetCommonNav(const std::string &strBaseDir, const std::string &table, const std::string &labelField, CFileItemList &items, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   if (table.empty() || labelField.empty())
     return false;
@@ -4165,8 +4229,10 @@ bool CMusicDatabase::GetMusicLabelsNav(const std::string &strBaseDir, CFileItemL
 
 bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList& items, bool albumArtistsOnly /* = false */, int idGenre /* = -1 */, int idAlbum /* = -1 */, int idSong /* = -1 */, const Filter &filter /* = Filter() */, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
   try
   {
     CMusicDbUrl musicUrl;
@@ -4199,8 +4265,10 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir, CFileItemList&
 
 bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -4349,8 +4417,10 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum &album)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL = PrepareSQL("select albumview.* from song join albumview on song.idAlbum = albumview.idAlbum where song.idSong='%i'", idSong);
     if (!m_pDS->query(strSQL)) return false;
@@ -4392,7 +4462,7 @@ bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir, CFileItemList& 
 
 bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool countOnly /* = false */)
 {
-  if (m_pDB == NULL || m_pDS == NULL)
+  if (!m_pDB || !m_pDS)
     return false;
 
   try
@@ -4514,7 +4584,7 @@ bool CMusicDatabase::GetAlbumsByWhere(const std::string &baseDir, const Filter &
 
 bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool artistData /* = false*/)
 {
-  if (m_pDB == NULL || m_pDS == NULL)
+  if (!m_pDB || !m_pDS)
     return false;
 
   try
@@ -4673,7 +4743,7 @@ bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filte
 
 bool CMusicDatabase::GetSongsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  if (m_pDB == NULL || m_pDS == NULL)
+  if (!m_pDB || !m_pDS)
     return false;
 
   try
@@ -4866,8 +4936,10 @@ static const size_t NUM_ARTIST_FIELDS = sizeof(JSONtoDBArtist) / sizeof(translat
 bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, const std::string &baseDir,
   CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -5553,8 +5625,10 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
   CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
 {
   
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -6038,8 +6112,10 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
   CVariant& result, int& total, const SortDescription &sortDescription /* = SortDescription() */)
 {
 
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -7433,8 +7509,10 @@ int CMusicDatabase::GetMusicNeedsTagScan()
 {
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     std::string sql = "SELECT * FROM versiontagscan";
     if (!m_pDS->query(sql)) return -1;
@@ -7489,8 +7567,10 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<
 {
   try
   {
-    if (NULL == m_pDB) return 0;
-    if (NULL == m_pDS) return 0;
+    if (!m_pDB)
+      return 0;
+    if (!m_pDS)
+      return 0;
 
     std::string strSQL = "SELECT idSong FROM songview ";
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
@@ -7524,8 +7604,10 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
 {
   try
   {
-    if (NULL == m_pDB) return 0;
-    if (NULL == m_pDS) return 0;
+    if (!m_pDB)
+      return 0;
+    if (!m_pDS)
+      return 0;
 
     std::string strSQL = "select count(idSong) as NumSongs from songview ";
     if (!CDatabase::BuildSQL(strSQL, filter, strSQL))
@@ -7573,8 +7655,10 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false;
 
     // Get the unique paths of songs on the album, providing there are no songs from
     // other albums with the same path. This returns
@@ -7652,8 +7736,10 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string &basePath)
   basePath.clear();
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false;
 
     // find all albums from this artist, and all the paths to the songs from those albums
     std::string strSQL = PrepareSQL("SELECT strPath FROM album_artist "
@@ -7838,8 +7924,10 @@ int CMusicDatabase::AddSource(const std::string& strName, const std::string& str
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     // Check if source name already exists
     idSource = GetSourceByName(strName);
@@ -7917,8 +8005,10 @@ int CMusicDatabase::UpdateSource(const std::string& strOldName, const std::strin
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     // Get details of named old source 
     if (!strOldName.empty())
@@ -7989,8 +8079,10 @@ int CMusicDatabase::GetSourceFromPath(const std::string& strPath1)
     if (!URIUtils::HasSlashAtEnd(strPath))
       URIUtils::AddSlashAtEnd(strPath);
 
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     // Check if path is a source matching on multipath
     strSQL = PrepareSQL("SELECT idSource FROM source WHERE strMultipath = '%s'", strPath.c_str());
@@ -8035,8 +8127,10 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
   std::vector<int> sourceIds;
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     if (!strPath.empty())
     {
@@ -8055,7 +8149,8 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
     else
     { 
       // Find sources using song paths, check each source path individually
-      if (NULL == m_pDS2) return false;
+      if (!m_pDS2)
+        return false;
       strSQL = "SELECT idSource, strPath FROM source_path";
       if (!m_pDS->query(strSQL))
         return false;
@@ -8113,8 +8208,10 @@ bool CMusicDatabase::CheckSources(VECSOURCES& sources)
   // Check individual sources match
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     for (const auto& source : sources)
@@ -8220,8 +8317,10 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     // Get music sources and individual source paths (may not be scanned or have albums etc.)
     std::string strSQL = "SELECT source.idSource, source.strName, source.strMultipath, source_path.strPath "
@@ -8289,8 +8388,10 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
 
 bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -8342,8 +8443,10 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
 
 bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -8405,8 +8508,10 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
 
 bool CMusicDatabase::GetSourcesBySong(int idSong, const std::string& strPath1, CFileItem* item)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
 
   try
   {
@@ -8452,8 +8557,10 @@ int CMusicDatabase::GetSourceByName(const std::string& strSource)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     strSQL = PrepareSQL("SELECT idSource FROM source WHERE strName LIKE '%s'", strSource.c_str());
@@ -8483,8 +8590,10 @@ int CMusicDatabase::GetArtistByName(const std::string& strArtist)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL=PrepareSQL("select idArtist from artist where artist.strArtist like '%s'", strArtist.c_str());
 
@@ -8512,7 +8621,7 @@ int CMusicDatabase::GetArtistByMatch(const CArtist& artist)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB || NULL == m_pDS)
+    if (!m_pDB || !m_pDS)
       return false;
     // Match on MusicBrainz ID, definitively unique
     if (!artist.strMusicBrainzArtistID.empty())
@@ -8545,8 +8654,10 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL = PrepareSQL(
       "SELECT artistview.* FROM song_artist "
@@ -8597,8 +8708,10 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     if (strArtist.empty())
@@ -8632,7 +8745,7 @@ int CMusicDatabase::GetAlbumByMatch(const CAlbum &album)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB || NULL == m_pDS)
+    if (!m_pDB || !m_pDS)
       return false;
     // Match on MusicBrainz ID, definitively unique
     if (!album.strMusicBrainzAlbumID.empty())
@@ -8768,8 +8881,10 @@ int CMusicDatabase::GetGenreByName(const std::string& strGenre)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     strSQL=PrepareSQL("select idGenre from genre where genre.strGenre like '%s'", strGenre.c_str());
@@ -8795,8 +8910,10 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     strSQL = "SELECT %s FROM genre ";
     Filter extFilter;
@@ -8938,8 +9055,10 @@ bool CMusicDatabase::SetPathHash(const std::string &path, const std::string &has
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     if (hash.empty())
     { // this is an empty folder - we need only add it to the path table
@@ -8967,8 +9086,10 @@ bool CMusicDatabase::GetPathHash(const std::string &path, std::string &hash)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
     m_pDS->query(strSQL);
@@ -9020,8 +9141,10 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string &path1, MAPSONGS& son
     if (!URIUtils::HasSlashAtEnd(path))
       URIUtils::AddSlashAtEnd(path);
 
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string where;
     if (exact)
@@ -9068,8 +9191,10 @@ bool CMusicDatabase::GetPaths(std::set<std::string> &paths)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     paths.clear();
 
@@ -9101,8 +9226,10 @@ bool CMusicDatabase::SetSongUserrating(const std::string &filePath, int userrati
   try
   {
     if (filePath.empty()) return false;
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     int songID = GetSongIDFromPath(filePath);
     if (-1 == songID) return false;
@@ -9120,8 +9247,10 @@ bool CMusicDatabase::SetSongUserrating(int idSong, int userrating)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("UPDATE song SET userrating='%i' WHERE idSong = %i", userrating, idSong);
     m_pDS->exec(sql);
@@ -9138,8 +9267,10 @@ bool CMusicDatabase::SetAlbumUserrating(const int idAlbum, int userrating)
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     if (-1 == idAlbum) return false;
 
@@ -9159,8 +9290,10 @@ bool CMusicDatabase::SetSongVotes(const std::string &filePath, int votes)
   try
   {
     if (filePath.empty()) return false;
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     int songID = GetSongIDFromPath(filePath);
     if (-1 == songID) return false;
@@ -9189,8 +9322,10 @@ int CMusicDatabase::GetSongIDFromPath(const std::string &filePath)
   // hit the db
   try
   {
-    if (NULL == m_pDB) return -1;
-    if (NULL == m_pDS) return -1;
+    if (!m_pDB)
+      return -1;
+    if (!m_pDS)
+      return -1;
 
     std::string strPath, strFileName;
     SplitPath(filePath, strPath, strFileName);
@@ -9232,8 +9367,10 @@ bool CMusicDatabase::CommitTransaction()
 
 bool CMusicDatabase::SetScraperAll(const std::string & strBaseDir, const ADDON::ScraperPtr scraper)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
   std::string strSQL;
   int idSetting = -1;
   try
@@ -9307,8 +9444,10 @@ bool CMusicDatabase::SetScraperAll(const std::string & strBaseDir, const ADDON::
 
 bool CMusicDatabase::SetScraper(int id, const CONTENT_TYPE &content, const ADDON::ScraperPtr scraper)
 {
-  if (NULL == m_pDB) return false;
-  if (NULL == m_pDS) return false;
+  if (!m_pDB)
+    return false;
+  if (!m_pDS)
+    return false;
   std::string strSQL;
   int idSetting = -1;
   try
@@ -9362,8 +9501,10 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::Scra
   std::string strSettings;
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL;
     strSQL = "SELECT strScraperPath, strSettings FROM infosetting JOIN ";
@@ -9415,8 +9556,10 @@ bool CMusicDatabase::ScraperInUse(const std::string &scraperID) const
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string sql = PrepareSQL("SELECT COUNT(1) FROM infosetting WHERE strScraperPath='%s'",scraperID.c_str());
     if (!m_pDS->query(sql) || m_pDS->num_rows() == 0)
@@ -9530,9 +9673,12 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
   int iFailCount = 0;
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
-    if (NULL == m_pDS2) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
+    if (!m_pDS2)
+      return;
 
     // Create our xml document
     CXBMCTinyXML xmlDoc;
@@ -9913,8 +10059,10 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
 {  
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     CXBMCTinyXML xmlDoc;
     if (!xmlDoc.LoadFile(xmlFile) && progressDialog)
@@ -10411,8 +10559,10 @@ void CMusicDatabase::SetArtForItem(int mediaId, const std::string &mediaType, co
 {
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     // don't set <foo>.<bar> art types - these are derivative types from parent items
     if (artType.find('.') != std::string::npos)
@@ -10446,8 +10596,10 @@ bool CMusicDatabase::GetArtForItem(int songId, int albumId, int artistId, bool b
   try
   {
     if (!(songId > 0 || albumId > 0 || artistId > 0)) return false;
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     Filter filter;
     if (songId > 0)
@@ -10553,8 +10705,10 @@ bool CMusicDatabase::GetArtForItem(int mediaId, const std::string &mediaType, st
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (!m_pDB)
+      return false;
+    if (!m_pDS2)
+      return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
     m_pDS2->query(sql);
@@ -10597,8 +10751,10 @@ bool CMusicDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     std::string strSQL = PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
 
@@ -11118,8 +11274,10 @@ void CMusicDatabase::UpdateFileDateAdded(int songId, const std::string& strFileN
   CDateTime dateAdded;
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     // 1 preferring to use the files mtime(if it's valid) and only using the file's ctime if the mtime isn't valid
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iMusicLibraryDateAdded == 1)

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -125,7 +125,7 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
   // fetch the lyrics and add it to the current music info tag
   CFileItem tempItem(path, false);
   std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(tempItem));
-  if (NULL != pLoader.get())
+  if (NULL != pLoader)
   {
     CMusicInfoTag tag;
     pLoader->Load(path, tag);
@@ -225,7 +225,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         // always try to load cddb info
         // get correct tag parser
         std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
-        if (NULL != pLoader.get())
+        if (NULL != pLoader)
           // get tag
           pLoader->Load(pItem->GetPath(), *pItem->GetMusicInfoTag());
         m_tagReads++;

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -125,7 +125,7 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
   // fetch the lyrics and add it to the current music info tag
   CFileItem tempItem(path, false);
   std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(tempItem));
-  if (NULL != pLoader)
+  if (pLoader)
   {
     CMusicInfoTag tag;
     pLoader->Load(path, tag);
@@ -225,7 +225,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         // always try to load cddb info
         // get correct tag parser
         std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
-        if (NULL != pLoader)
+        if (pLoader)
           // get tag
           pLoader->Load(pItem->GetPath(), *pItem->GetMusicInfoTag());
         m_tagReads++;

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -331,7 +331,7 @@ bool CMusicThumbLoader::GetEmbeddedThumb(const std::string &path, EmbeddedArt &a
   CFileItem item(path, false);
   std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(item));
   CMusicInfoTag tag;
-  if (NULL != pLoader.get())
+  if (NULL != pLoader)
     pLoader->Load(path, tag, &art);
 
   return !art.Empty();

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -331,7 +331,7 @@ bool CMusicThumbLoader::GetEmbeddedThumb(const std::string &path, EmbeddedArt &a
   CFileItem item(path, false);
   std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(item));
   CMusicInfoTag tag;
-  if (NULL != pLoader)
+  if (pLoader)
     pLoader->Load(path, tag, &art);
 
   return !art.Empty();

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -573,7 +573,7 @@ CInfoScanner::INFO_RET CMusicInfoScanner::ScanTags(const CFileItemList& items,
     if (!tag.Loaded())
     {
       std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
-      if (NULL != pLoader.get())
+      if (NULL != pLoader)
         pLoader->Load(pItem->GetPath(), tag);
     }
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -573,7 +573,7 @@ CInfoScanner::INFO_RET CMusicInfoScanner::ScanTags(const CFileItemList& items,
     if (!tag.Loaded())
     {
       std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
-      if (NULL != pLoader)
+      if (pLoader)
         pLoader->Load(pItem->GetPath(), tag);
     }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -399,7 +399,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem, bool first)
     CServiceBroker::GetPlaylistPlayer().Add(playlist, queuedItems);
   if (CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size() && !g_application.GetAppPlayer().IsPlaying())
   {
-    if (m_guiState.get())
+    if (m_guiState)
       m_guiState->SetPlaylistDirectory("playlistmusic://");
 
     CServiceBroker::GetPlaylistPlayer().Reset();
@@ -459,7 +459,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     if (pItem->IsPlayList())
     {
       std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(*pItem));
-      if (pPlayList.get())
+      if (pPlayList)
       {
         // load it
         if (!pPlayList->Load(pItem->GetPath()))
@@ -801,7 +801,7 @@ void CGUIWindowMusicBase::LoadPlayList(const std::string& strPlayList)
   // load a playlist like .m3u, .pls
   // first get correct factory to load playlist
   std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-  if (pPlayList.get())
+  if (pPlayList)
   {
     // load it
     if (!pPlayList->Load(strPlayList))
@@ -814,7 +814,7 @@ void CGUIWindowMusicBase::LoadPlayList(const std::string& strPlayList)
   int iSize = pPlayList->size();
   if (g_application.ProcessAndStartPlaylist(strPlayList, *pPlayList, PLAYLIST_MUSIC))
   {
-    if (m_guiState.get())
+    if (m_guiState)
       m_guiState->SetPlaylistDirectory("playlistmusic://");
     // activate the playlist window if its not activated yet
     if (GetID() == CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() && iSize > 1)

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -138,7 +138,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
           }
 
           // Playlist directory is the root of the playlist window
-          if (m_guiState.get()) m_guiState->SetPlaylistDirectory("playlistmusic://");
+          if (m_guiState) m_guiState->SetPlaylistDirectory("playlistmusic://");
 
           return true;
         }
@@ -838,7 +838,7 @@ bool CGUIWindowMusicNav::GetSongsFromPlayList(const std::string& strPlayList, CF
   CLog::Log(LOGDEBUG,"CGUIWindowMusicNav, opening playlist [%s]", strPlayList.c_str());
 
   std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-  if ( NULL != pPlayList.get())
+  if ( NULL != pPlayList)
   {
     // load it
     if (!pPlayList->Load(strPlayList))

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -838,7 +838,7 @@ bool CGUIWindowMusicNav::GetSongsFromPlayList(const std::string& strPlayList, CF
   CLog::Log(LOGDEBUG,"CGUIWindowMusicNav, opening playlist [%s]", strPlayList.c_str());
 
   std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-  if ( NULL != pPlayList)
+  if (pPlayList)
   {
     // load it
     if (!pPlayList->Load(strPlayList))

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -425,7 +425,7 @@ bool CGUIWindowMusicPlayList::OnPlayMedia(int iItem, const std::string &player)
     int iPlaylist=m_guiState->GetPlaylist();
     if (iPlaylist!=PLAYLIST_NONE)
     {
-      if (m_guiState.get())
+      if (m_guiState)
         m_guiState->SetPlaylistDirectory(m_vecItems->GetPath());
 
       CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist( iPlaylist );

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -533,7 +533,7 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
 {
   CLog::Log(LOGDEBUG,"CGUIWindowPictures::LoadPlayList()... converting playlist into slideshow: %s", strPlayList.c_str());
   std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-  if ( NULL != pPlayList.get())
+  if ( NULL != pPlayList)
   {
     if (!pPlayList->Load(strPlayList))
     {

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -533,7 +533,7 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
 {
   CLog::Log(LOGDEBUG,"CGUIWindowPictures::LoadPlayList()... converting playlist into slideshow: %s", strPlayList.c_str());
   std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-  if ( NULL != pPlayList)
+  if (pPlayList)
   {
     if (!pPlayList->Load(strPlayList))
     {

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -451,7 +451,7 @@ bool CPlayList::Expand(int position)
 {
   CFileItemPtr item = m_vecItems[position];
   std::unique_ptr<CPlayList> playlist (CPlayListFactory::Create(*item.get()));
-  if (playlist.get() == nullptr)
+  if (playlist == nullptr)
     return false;
 
   std::string path = item->GetDynPath();

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -451,7 +451,7 @@ bool CPlayList::Expand(int position)
 {
   CFileItemPtr item = m_vecItems[position];
   std::unique_ptr<CPlayList> playlist (CPlayListFactory::Create(*item.get()));
-  if (playlist == nullptr)
+  if (!playlist)
     return false;
 
   std::string path = item->GetDynPath();

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -372,7 +372,7 @@ bool CPlayListASX::LoadData(std::istream& stream)
         if (!value.empty())
         { // found an entryref, let's try loading that url
           std::unique_ptr<CPlayList> playlist(CPlayListFactory::Create(value));
-          if (NULL != playlist.get())
+          if (NULL != playlist)
             if (playlist->Load(value))
               Add(*playlist);
         }

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -372,7 +372,7 @@ bool CPlayListASX::LoadData(std::istream& stream)
         if (!value.empty())
         { // found an entryref, let's try loading that url
           std::unique_ptr<CPlayList> playlist(CPlayListFactory::Create(value));
-          if (NULL != playlist)
+          if (playlist)
             if (playlist->Load(value))
               Add(*playlist);
         }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -87,7 +87,7 @@ void CGUIWindowPVRGuideBase::ClearData()
 
 void CGUIWindowPVRGuideBase::OnInitWindow()
 {
-  if (m_guiState.get())
+  if (m_guiState)
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
 
   if (InitChannelGroup()) // no channels -> lazy init
@@ -671,7 +671,7 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
       if (endDate > maxFutureDate)
         endDate = maxFutureDate;
 
-      if (m_guiState.get())
+      if (m_guiState)
         timeline->Sort(m_guiState->GetSortMethod());
 
       // can be very expensive. never call with lock acquired.

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -542,8 +542,8 @@ int CVideoDatabase::GetPathId(const std::string& strPath)
   try
   {
     int idPath=-1;
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strPath1(strPath);
     if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
@@ -570,8 +570,8 @@ bool CVideoDatabase::GetPaths(std::set<std::string> &paths)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     paths.clear();
 
@@ -662,8 +662,8 @@ bool CVideoDatabase::GetPathsForTvShow(int idShow, std::set<int>& paths)
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // add base path
     strSQL = PrepareSQL("SELECT strPath FROM tvshow_view WHERE idShow=%i", idShow);
@@ -742,8 +742,8 @@ int CVideoDatabase::AddPath(const std::string& strPath, const std::string &paren
     if (idPath >= 0)
       return idPath; // already have the path
 
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strPath1(strPath);
     if (URIUtils::IsStack(strPath) || StringUtils::StartsWithNoCase(strPath, "rar://") || StringUtils::StartsWithNoCase(strPath, "zip://"))
@@ -783,8 +783,8 @@ bool CVideoDatabase::GetPathHash(const std::string &path, std::string &hash)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("select strHash from path where strPath='%s'", path.c_str());
     m_pDS->query(strSQL);
@@ -812,7 +812,7 @@ bool CVideoDatabase::GetSourcePath(const std::string &path, std::string &sourceP
   try
   {
     if (path.empty() ||
-        m_pDB.get() == NULL || m_pDS.get() == NULL)
+        m_pDB == NULL || m_pDS == NULL)
       return false;
 
     std::string strPath2;
@@ -890,8 +890,8 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath)
   try
   {
     int idFile;
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strFileName, strPath;
     SplitPath(strFileNameAndPath,strPath,strFileName);
@@ -943,8 +943,8 @@ void CVideoDatabase::UpdateFileDateAdded(int idFile, const std::string& strFileN
   CDateTime finalDateAdded = dateAdded;
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (!finalDateAdded.IsValid())
     {
@@ -975,8 +975,8 @@ bool CVideoDatabase::SetPathHash(const std::string &path, const std::string &has
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int idPath = AddPath(path);
     if (idPath < 0) return false;
@@ -998,8 +998,8 @@ bool CVideoDatabase::LinkMovieToTvshow(int idMovie, int idShow, bool bRemove)
 {
    try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (bRemove) // delete link
     {
@@ -1025,8 +1025,8 @@ bool CVideoDatabase::IsLinkedToTvshow(int idMovie)
 {
    try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("select * from movielinktvshow where idMovie=%i", idMovie);
     m_pDS->query(strSQL);
@@ -1051,8 +1051,8 @@ bool CVideoDatabase::GetLinksToTvShow(int idMovie, std::vector<int>& ids)
 {
    try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("select * from movielinktvshow where idMovie=%i", idMovie);
     m_pDS2->query(strSQL);
@@ -1079,8 +1079,8 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
     std::string strPath, strFileName;
     SplitPath(strFilenameAndPath,strPath,strFileName);
 
@@ -1122,8 +1122,8 @@ int CVideoDatabase::GetMovieId(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
     int idMovie = -1;
 
     // needed for query parameters
@@ -1169,8 +1169,8 @@ int CVideoDatabase::GetTvShowId(const std::string& strPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
     int idTvShow = -1;
 
     // have to join movieinfo table for correct results
@@ -1218,13 +1218,13 @@ int CVideoDatabase::GetEpisodeId(const std::string& strFilenameAndPath, int idEp
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     // need this due to the nested GetEpisodeInfo query
     std::unique_ptr<Dataset> pDS;
     pDS.reset(m_pDB->CreateDataset());
-    if (NULL == pDS.get()) return -1;
+    if (NULL == pDS) return -1;
 
     int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0)
@@ -1274,8 +1274,8 @@ int CVideoDatabase::GetMusicVideoId(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0)
@@ -1304,8 +1304,8 @@ int CVideoDatabase::AddMovie(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     int idMovie = GetMovieId(strFilenameAndPath);
     if (idMovie < 0)
@@ -1379,8 +1379,8 @@ int CVideoDatabase::AddEpisode(int idShow, const std::string& strFilenameAndPath
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     int idFile = AddFile(strFilenameAndPath);
     if (idFile < 0)
@@ -1402,8 +1402,8 @@ int CVideoDatabase::AddMusicVideo(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     int idMVideo = GetMusicVideoId(strFilenameAndPath);
     if (idMVideo < 0)
@@ -1431,8 +1431,8 @@ int CVideoDatabase::AddToTable(const std::string& table, const std::string& firs
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strSQL = PrepareSQL("select %s from %s where %s like '%s'", firstField.c_str(), table.c_str(), secondField.c_str(), value.substr(0, 255).c_str());
     m_pDS->query(strSQL);
@@ -1464,8 +1464,8 @@ int CVideoDatabase::UpdateRatings(int mediaId, const char *mediaType, const Rati
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string sql = PrepareSQL("DELETE FROM rating WHERE media_id=%i AND media_type='%s'", mediaId, mediaType);
     m_pDS->exec(sql);
@@ -1484,8 +1484,8 @@ int CVideoDatabase::AddRatings(int mediaId, const char *mediaType, const RatingM
   int ratingid = -1;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     for (const auto& i : values)
     {
@@ -1525,8 +1525,8 @@ int CVideoDatabase::UpdateUniqueIDs(int mediaId, const char *mediaType, const CV
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string sql = PrepareSQL("DELETE FROM uniqueid WHERE media_id=%i AND media_type='%s'", mediaId, mediaType);
     m_pDS->exec(sql);
@@ -1545,8 +1545,8 @@ int CVideoDatabase::AddUniqueIDs(int mediaId, const char *mediaType, const CVide
   int uniqueid = -1;
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     for (const auto& i : details.GetUniqueIDs())
     {
@@ -1589,7 +1589,7 @@ int CVideoDatabase::AddSet(const std::string& strSet, const std::string& strOver
 
   try
   {
-    if (m_pDB.get() == nullptr || m_pDS.get() == nullptr)
+    if (m_pDB == nullptr || m_pDS == nullptr)
       return -1;
 
     std::string strSQL = PrepareSQL("SELECT idSet FROM sets WHERE strSet LIKE '%s'", strSet.c_str());
@@ -1629,8 +1629,8 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
     int idActor = -1;
 
     // ATTENTION: the trimming of actor names should really not be done here but after the scraping / NFO-parsing
@@ -1803,8 +1803,8 @@ bool CVideoDatabase::HasMovieInfo(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     int idMovie = GetMovieId(strFilenameAndPath);
     return (idMovie > 0); // index of zero is also invalid
   }
@@ -1819,8 +1819,8 @@ bool CVideoDatabase::HasTvShowInfo(const std::string& strPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     int idTvShow = GetTvShowId(strPath);
     return (idTvShow > 0); // index of zero is also invalid
   }
@@ -1835,8 +1835,8 @@ bool CVideoDatabase::HasEpisodeInfo(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     int idEpisode = GetEpisodeId(strFilenameAndPath);
     return (idEpisode > 0); // index of zero is also invalid
   }
@@ -1851,8 +1851,8 @@ bool CVideoDatabase::HasMusicVideoInfo(const std::string& strFilenameAndPath)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     int idMVideo = GetMusicVideoId(strFilenameAndPath);
     return (idMVideo > 0); // index of zero is also invalid
   }
@@ -1874,8 +1874,8 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     std::string strSQL;
     strSQL=PrepareSQL("DELETE from genre_link WHERE media_id=%i AND media_type='tvshow'", idTvShow);
@@ -1955,8 +1955,8 @@ void CVideoDatabase::GetMusicVideosByArtist(const std::string& strArtist, CFileI
   try
   {
     items.Clear();
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     std::string strSQL;
     if (strArtist.empty())  //! @todo SMARTPLAYLISTS what is this here for???
@@ -3020,8 +3020,8 @@ void CVideoDatabase::GetFilePathById(int idMovie, std::string &filePath, VIDEODB
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     if (idMovie < 0) return ;
 
@@ -3076,8 +3076,8 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
       if (idFile < 0) return ;
       if (!bAppend)
         bookmarks.erase(bookmarks.begin(), bookmarks.end());
-      if (NULL == m_pDB.get()) return ;
-      if (NULL == m_pDS.get()) return ;
+      if (NULL == m_pDB) return ;
+      if (NULL == m_pDS) return ;
 
       std::string strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
       m_pDS->query( strSQL );
@@ -3201,8 +3201,8 @@ void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, co
     int idFile = AddFile(strFilenameAndPath);
     if (idFile < 0)
       return;
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     std::string strSQL;
     int idBookmark=-1;
@@ -3246,8 +3246,8 @@ void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath, 
   {
     int idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0) return ;
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     /* a little bit uggly, we clear first bookmark that is within one second of given */
     /* should be no problem since we never add bookmarks that are closer than that   */
@@ -3291,8 +3291,8 @@ void CVideoDatabase::ClearBookMarksOfFile(int idFile, CBookmark::EType type /*= 
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     std::string strSQL=PrepareSQL("delete from bookmark where idFile=%i and type=%i", idFile, (int)type);
     m_pDS->exec(strSQL);
@@ -3389,8 +3389,8 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     BeginTransaction();
 
@@ -3436,8 +3436,8 @@ void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */)
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     BeginTransaction();
 
@@ -3492,9 +3492,9 @@ void CVideoDatabase::DeleteSeason(int idSeason, bool bKeepId /* = false */)
 
   try
   {
-    if (m_pDB.get() == NULL ||
-        m_pDS.get() == NULL ||
-        m_pDS2.get() == NULL)
+    if (m_pDB == NULL ||
+        m_pDS == NULL ||
+        m_pDS2 == NULL)
       return;
 
     BeginTransaction();
@@ -3534,8 +3534,8 @@ void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */)
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     //! @todo move this below CommitTransaction() once UPnP doesn't rely on this anymore
     if (!bKeepId)
@@ -3575,8 +3575,8 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     BeginTransaction();
 
@@ -3628,8 +3628,8 @@ void CVideoDatabase::DeleteSet(int idSet)
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     std::string strSQL;
     strSQL=PrepareSQL("delete from sets where idSet = %i", idSet);
@@ -3660,7 +3660,7 @@ void CVideoDatabase::DeleteTag(int idTag, VIDEODB_CONTENT_TYPE mediaType)
 {
   try
   {
-    if (m_pDB.get() == NULL || m_pDS.get() == NULL)
+    if (m_pDB == NULL || m_pDS == NULL)
       return;
 
     std::string type;
@@ -4337,8 +4337,8 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
   try
   {
     if (idFile < 0) return false;
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL=PrepareSQL("select * from settings where settings.idFile = '%i'", idFile);
     m_pDS->query( strSQL );
@@ -4402,9 +4402,9 @@ void CVideoDatabase::SetVideoSettings(int idFile, const CVideoSettings &setting)
 {
   try
   {
-    if (NULL == m_pDB.get())
+    if (NULL == m_pDB)
       return;
-    if (NULL == m_pDS.get())
+    if (NULL == m_pDS)
       return;
     if (idFile < 0)
       return;
@@ -4465,8 +4465,8 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
 {
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     // don't set <foo>.<bar> art types - these are derivative types from parent items
     if (artType.find('.') != std::string::npos)
@@ -4502,8 +4502,8 @@ bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaType, std:
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT type,url FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
     m_pDS2->query(sql);
@@ -4546,8 +4546,8 @@ bool CVideoDatabase::HasArtForItem(int mediaId, const MediaType &mediaType)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::string sql = PrepareSQL("SELECT 1 FROM art WHERE media_id=%i AND media_type='%s' LIMIT 1", mediaId, mediaType.c_str());
     m_pDS2->query(sql);
@@ -4566,8 +4566,8 @@ bool CVideoDatabase::GetTvShowSeasons(int showId, std::map<int, int> &seasons)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     // get all seasons for this show
     std::string sql = PrepareSQL("select idSeason,season from seasons where idShow=%i", showId);
@@ -4593,8 +4593,8 @@ bool CVideoDatabase::GetTvShowNamedSeasons(int showId, std::map<int, std::string
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     // get all named seasons for this show
     std::string sql = PrepareSQL("select season, name from seasons where season > 0 and name is not null and name <> '' and idShow = %i", showId);
@@ -4620,8 +4620,8 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, std::map<std::
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false; // using dataset 2 as we're likely called in loops on dataset 1
 
     std::map<int, int> seasons;
     GetTvShowSeasons(showId, seasons);
@@ -4645,8 +4645,8 @@ bool CVideoDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("SELECT DISTINCT type FROM art WHERE media_type='%s'", mediaType.c_str());
     int numRows = RunQuery(sql);
@@ -4788,8 +4788,8 @@ bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<uint
     // obtain the FileID (if it exists)
     int idFile = GetFileId(filePath);
     if (idFile < 0) return false;
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
     // ok, now obtain the settings for this file
     std::string strSQL=PrepareSQL("select times from stacktimes where idFile=%i\n", idFile);
     m_pDS->query( strSQL );
@@ -4821,8 +4821,8 @@ void CVideoDatabase::SetStackTimes(const std::string& filePath, const std::vecto
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
     int idFile = AddFile(filePath);
     if (idFile < 0)
       return;
@@ -4856,8 +4856,8 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath, CGUIDialog
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     if (progress)
     {
@@ -4939,8 +4939,8 @@ void CVideoDatabase::SetScraperForPath(const std::string& filePath, const Scrape
 
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     int idPath = AddPath(filePath);
     if (idPath < 0)
@@ -4973,8 +4973,8 @@ bool CVideoDatabase::ScraperInUse(const std::string &scraperID) const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("select count(1) from path where strScraper='%s'", scraperID.c_str());
     if (!m_pDS->query(sql) || m_pDS->num_rows() == 0)
@@ -5461,7 +5461,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
     // need this due to the nested GetScraperPath query
     std::unique_ptr<Dataset> pDS;
     pDS.reset(m_pDB->CreateDataset());
-    if (NULL == pDS.get()) return;
+    if (NULL == pDS) return;
 
     pDS->exec("CREATE TABLE uniqueid (uniqueid_id INTEGER PRIMARY KEY, media_id INTEGER, media_type TEXT, value TEXT, type TEXT)");
 
@@ -5618,8 +5618,8 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
   try
   {
     // error!
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql =
       "SELECT"
@@ -5698,8 +5698,8 @@ int CVideoDatabase::GetPlayCount(int iFileId)
   try
   {
     // error!
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strSQL = PrepareSQL("select playCount from files WHERE idFile=%i", iFileId);
     int count = 0;
@@ -5731,8 +5731,8 @@ int CVideoDatabase::GetPlayCount(const CFileItem &item)
 
 void CVideoDatabase::UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE type)
 {
-  if (NULL == m_pDB.get()) return;
-  if (NULL == m_pDS.get()) return;
+  if (NULL == m_pDB) return;
+  if (NULL == m_pDS) return;
   if (!item.HasVideoInfoTag() || item.GetVideoInfoTag()->m_iDbId < 0) return;
 
   std::string exec;
@@ -5774,8 +5774,8 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
   // and mark as watched
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
 
     std::string strSQL;
     if (count)
@@ -5827,8 +5827,8 @@ void CVideoDatabase::UpdateMovieTitle(int idMovie, const std::string& strNewMovi
 {
   try
   {
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+    if (NULL == m_pDB) return ;
+    if (NULL == m_pDS) return ;
     std::string content;
     if (iType == VIDEODB_CONTENT_MOVIES)
     {
@@ -5873,7 +5873,7 @@ bool CVideoDatabase::UpdateVideoSortTitle(int idDb, const std::string& strNewSor
 {
   try
   {
-    if (NULL == m_pDB.get() || NULL == m_pDS.get())
+    if (NULL == m_pDB || NULL == m_pDS)
       return false;
     if (iType != VIDEODB_CONTENT_MOVIES && iType != VIDEODB_CONTENT_TVSHOWS)
       return false;
@@ -5980,8 +5980,8 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir, CFileItemList& 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     Filter extFilter = filter;
@@ -6184,8 +6184,8 @@ bool CVideoDatabase::GetSetsByWhere(const std::string& strBaseDir, const Filter 
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CVideoDbUrl videoUrl;
     if (!videoUrl.FromString(strBaseDir))
@@ -6221,8 +6221,8 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     CVideoDbUrl videoUrl;
     if (!videoUrl.FromString(strBaseDir))
@@ -6374,8 +6374,8 @@ bool CVideoDatabase::GetActorsNav(const std::string& strBaseDir, CFileItemList& 
 
 bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir, CFileItemList& items, const char *type, int idContent /* = -1 */, const Filter &filter /* = Filter() */, bool countOnly /* = false */)
 {
-  if (NULL == m_pDB.get()) return false;
-  if (NULL == m_pDS.get()) return false;
+  if (NULL == m_pDB) return false;
+  if (NULL == m_pDS) return false;
 
   try
   {
@@ -6618,8 +6618,8 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string strSQL;
     Filter extFilter = filter;
@@ -6822,8 +6822,8 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int total = -1;
 
@@ -6945,7 +6945,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
 
 bool CVideoDatabase::GetSortedVideos(const MediaType &mediaType, const std::string& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter /* = Filter() */)
 {
-  if (NULL == m_pDB.get() || NULL == m_pDS.get())
+  if (NULL == m_pDB || NULL == m_pDS)
     return false;
 
   if (mediaType != MediaTypeMovie && mediaType != MediaTypeTvShow && mediaType != MediaTypeEpisode && mediaType != MediaTypeMusicVideo)
@@ -7108,8 +7108,8 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
     movieTime = 0;
     castTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     // parse the base path to get additional filters
     CVideoDbUrl videoUrl;
@@ -7221,8 +7221,8 @@ bool CVideoDatabase::GetTvShowsByWhere(const std::string& strBaseDir, const Filt
   {
     movieTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int total = -1;
 
@@ -7347,8 +7347,8 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
     movieTime = 0;
     castTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int total = -1;
 
@@ -7533,8 +7533,8 @@ bool CVideoDatabase::HasSets() const
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     m_pDS->query("SELECT movie_view.idSet,COUNT(1) AS c FROM movie_view "
                  "JOIN sets ON sets.idSet = movie_view.idSet "
@@ -7555,8 +7555,8 @@ int CVideoDatabase::GetTvShowForEpisode(int idEpisode)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS2.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS2) return false;
 
     // make sure we use m_pDS2, as this is called in loops using m_pDS
     std::string strSQL=PrepareSQL("select idShow from episode where idEpisode=%i", idEpisode);
@@ -7598,8 +7598,8 @@ bool CVideoDatabase::HasContent(VIDEODB_CONTENT_TYPE type)
   bool result = false;
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql;
     if (type == VIDEODB_CONTENT_MOVIES)
@@ -7816,8 +7816,8 @@ void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileIte
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id = genre.genre_id INNER JOIN movie ON (genre_link.media_type='movie' = genre_link.media_id=movie.idMovie) INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE genre.name LIKE '%%%s%%'",strSearch.c_str());
@@ -7856,8 +7856,8 @@ void CVideoDatabase::GetMovieCountriesByName(const std::string& strSearch, CFile
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT country.country_id, country.name, path.strPath FROM country INNER JOIN country_link ON country_link.country_id=country.country_id INNER JOIN movie ON country_link.media_id=movie.idMovie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE country_link.media_type='movie' AND country.name LIKE '%%%s%%'", strSearch.c_str());
@@ -7896,8 +7896,8 @@ void CVideoDatabase::GetTvShowGenresByName(const std::string& strSearch, CFileIt
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id INNER JOIN tvshow ON genre_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE genre_link.media_type='tvshow' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
@@ -7935,8 +7935,8 @@ void CVideoDatabase::GetMovieActorsByName(const std::string& strSearch, CFileIte
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN movie ON actor_link.media_id=movie.idMovie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='movie' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -7974,8 +7974,8 @@ void CVideoDatabase::GetTvShowsActorsByName(const std::string& strSearch, CFileI
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN tvshow ON actor_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idPath=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE actor_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8013,8 +8013,8 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const std::string& strSearch, CF
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     std::string strLike;
     if (!strSearch.empty())
@@ -8055,8 +8055,8 @@ void CVideoDatabase::GetMusicVideoGenresByName(const std::string& strSearch, CFi
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id INNER JOIN musicvideo ON genre_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE genre_link.media_type='musicvideo' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8094,8 +8094,8 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     strSQL = StringUtils::Format("SELECT DISTINCT"
                                  "  musicvideo.c%02d,"
@@ -8148,8 +8148,8 @@ void CVideoDatabase::GetMusicVideosByAlbum(const std::string& strSearch, CFileIt
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT musicvideo.idMVideo, musicvideo.c%02d,musicvideo.c%02d, path.strPath FROM musicvideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE musicvideo.c%02d LIKE '%%%s%%'", VIDEODB_ID_MUSICVIDEO_ALBUM, VIDEODB_ID_MUSICVIDEO_TITLE, VIDEODB_ID_MUSICVIDEO_ALBUM, strSearch.c_str());
@@ -8189,8 +8189,8 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
     movieTime = 0;
     castTime = 0;
 
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     int total = -1;
 
@@ -8267,8 +8267,8 @@ unsigned int CVideoDatabase::GetRandomMusicVideoIDs(const std::string& strWhere,
 {
   try
   {
-    if (NULL == m_pDB.get()) return 0;
-    if (NULL == m_pDS.get()) return 0;
+    if (NULL == m_pDB) return 0;
+    if (NULL == m_pDS) return 0;
 
     std::string strSQL = "select distinct idMVideo from musicvideo_view";
     if (!strWhere.empty())
@@ -8302,8 +8302,8 @@ int CVideoDatabase::GetMatchingMusicVideo(const std::string& strArtist, const st
 {
   try
   {
-    if (NULL == m_pDB.get()) return -1;
-    if (NULL == m_pDS.get()) return -1;
+    if (NULL == m_pDB) return -1;
+    if (NULL == m_pDS) return -1;
 
     std::string strSQL;
     if (strAlbum.empty() && strTitle.empty())
@@ -8349,8 +8349,8 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT movie.idMovie, movie.c%02d, path.strPath, movie.idSet FROM movie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE movie.c%02d LIKE '%%%s%%'", VIDEODB_ID_TITLE, VIDEODB_ID_TITLE, strSearch.c_str());
@@ -8394,8 +8394,8 @@ void CVideoDatabase::GetTvShowsByName(const std::string& strSearch, CFileItemLis
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT tvshow.idShow, tvshow.c%02d, path.strPath FROM tvshow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE tvshow.c%02d LIKE '%%%s%%'", VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_TITLE, strSearch.c_str());
@@ -8435,8 +8435,8 @@ void CVideoDatabase::GetEpisodesByName(const std::string& strSearch, CFileItemLi
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d, path.strPath FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow INNER JOIN files ON files.idFile=episode.idFile INNER JOIN path ON path.idPath=files.idPath WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_TITLE, strSearch.c_str());
@@ -8478,8 +8478,8 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT musicvideo.idMVideo, musicvideo.c%02d, path.strPath FROM musicvideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE musicvideo.c%02d LIKE '%%%s%%'", VIDEODB_ID_MUSICVIDEO_TITLE, VIDEODB_ID_MUSICVIDEO_TITLE, strSearch.c_str());
@@ -8525,8 +8525,8 @@ void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemLi
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d, path.strPath FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow INNER JOIN files ON files.idFile=episode.idFile INNER JOIN path ON path.idPath=files.idPath WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_PLOT, strSearch.c_str());
@@ -8564,8 +8564,8 @@ void CVideoDatabase::GetMoviesByPlot(const std::string& strSearch, CFileItemList
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("select movie.idMovie, movie.c%02d, path.strPath FROM movie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%'", VIDEODB_ID_TITLE,VIDEODB_ID_PLOT, strSearch.c_str(), VIDEODB_ID_PLOTOUTLINE, strSearch.c_str(), VIDEODB_ID_TAGLINE,strSearch.c_str());
@@ -8606,8 +8606,8 @@ void CVideoDatabase::GetMovieDirectorsByName(const std::string& strSearch, CFile
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name, path.strPath FROM movie INNER JOIN director_link ON (director_link.media_id=movie.idMovie AND director_link.media_type='movie') INNER JOIN actor ON actor.actor_id=director_link.actor_id INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8647,8 +8647,8 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const std::string& strSearch, CFi
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name, path.strPath FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN tvshow ON director_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE director_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8688,8 +8688,8 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
 
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name, path.strPath FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN musicvideo ON director_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE director_link.media_type='musicvideo' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8728,9 +8728,9 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
-    if (NULL == m_pDS2.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
+    if (NULL == m_pDS2) return;
 
     unsigned int time = XbmcThreads::SystemClockMillis();
     CLog::Log(LOGNOTICE, "%s: Starting videodatabase cleanup ..", __FUNCTION__);
@@ -9244,18 +9244,18 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
-    if (NULL == m_pDS2.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
+    if (NULL == m_pDS2) return;
 
     // create a 3rd dataset as well as GetEpisodeDetails() etc. uses m_pDS2, and we need to do 3 nested queries on tv shows
     std::unique_ptr<Dataset> pDS;
     pDS.reset(m_pDB->CreateDataset());
-    if (NULL == pDS.get()) return;
+    if (NULL == pDS) return;
 
     std::unique_ptr<Dataset> pDS2;
     pDS2.reset(m_pDB->CreateDataset());
-    if (NULL == pDS2.get()) return;
+    if (NULL == pDS2) return;
 
     // if we're exporting to a single folder, we export thumbs as well
     std::string exportRoot = URIUtils::AddFileToFolder(path, "kodi_videodb_" + CDateTime::GetCurrentDateTime().GetAsDBDate());
@@ -9771,8 +9771,8 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB.get()) return;
-    if (NULL == m_pDS.get()) return;
+    if (NULL == m_pDB) return;
+    if (NULL == m_pDS) return;
 
     CXBMCTinyXML xmlDoc;
     if (!xmlDoc.LoadFile(URIUtils::AddFileToFolder(path, "videodb.xml")))
@@ -10026,7 +10026,7 @@ bool CVideoDatabase::SetSingleValue(VIDEODB_CONTENT_TYPE type, int dbId, int dbF
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB.get() || NULL == m_pDS.get())
+    if (NULL == m_pDB || NULL == m_pDS)
       return false;
 
     std::string strTable, strField;
@@ -10085,7 +10085,7 @@ bool CVideoDatabase::SetSingleValue(const std::string &table, const std::string 
   std::string sql;
   try
   {
-    if (NULL == m_pDB.get() || NULL == m_pDS.get())
+    if (NULL == m_pDB || NULL == m_pDS)
       return false;
 
     sql = PrepareSQL("UPDATE %s SET %s='%s'", table.c_str(), fieldName.c_str(), strValue.c_str());
@@ -10422,8 +10422,8 @@ bool CVideoDatabase::SetVideoUserRating(int dbId, int rating, const MediaType& m
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     if (mediaType == MediaTypeNone)
       return false;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9255,7 +9255,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
     std::unique_ptr<Dataset> pDS2;
     pDS2.reset(m_pDB->CreateDataset());
-    if (NULL == pDS2) return;
+    if (!pDS2)
+      return;
 
     // if we're exporting to a single folder, we export thumbs as well
     std::string exportRoot = URIUtils::AddFileToFolder(path, "kodi_videodb_" + CDateTime::GetCurrentDateTime().GetAsDBDate());
@@ -9771,8 +9772,10 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
   CGUIDialogProgress *progress=NULL;
   try
   {
-    if (NULL == m_pDB) return;
-    if (NULL == m_pDS) return;
+    if (!m_pDB)
+      return;
+    if (!m_pDS)
+      return;
 
     CXBMCTinyXML xmlDoc;
     if (!xmlDoc.LoadFile(URIUtils::AddFileToFolder(path, "videodb.xml")))
@@ -10026,7 +10029,7 @@ bool CVideoDatabase::SetSingleValue(VIDEODB_CONTENT_TYPE type, int dbId, int dbF
   std::string strSQL;
   try
   {
-    if (NULL == m_pDB || NULL == m_pDS)
+    if (!m_pDB || !m_pDS)
       return false;
 
     std::string strTable, strField;
@@ -10085,7 +10088,7 @@ bool CVideoDatabase::SetSingleValue(const std::string &table, const std::string 
   std::string sql;
   try
   {
-    if (NULL == m_pDB || NULL == m_pDS)
+    if (!m_pDB || !m_pDS)
       return false;
 
     sql = PrepareSQL("UPDATE %s SET %s='%s'", table.c_str(), fieldName.c_str(), strValue.c_str());
@@ -10422,8 +10425,10 @@ bool CVideoDatabase::SetVideoUserRating(int dbId, int rating, const MediaType& m
 {
   try
   {
-    if (NULL == m_pDB) return false;
-    if (NULL == m_pDS) return false;
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
 
     if (mediaType == MediaTypeNone)
       return false;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -516,7 +516,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     if (pItem->IsPlayList())
     {
       std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(*pItem));
-      if (pPlayList.get())
+      if (pPlayList)
       {
         // load it
         if (!pPlayList->Load(pItem->GetPath()))
@@ -1187,7 +1187,7 @@ void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList, int iPlay
   // load a playlist like .m3u, .pls
   // first get correct factory to load playlist
   std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-  if (pPlayList.get())
+  if (pPlayList)
   {
     // load it
     if (!pPlayList->Load(strPlayList))
@@ -1199,7 +1199,7 @@ void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList, int iPlay
 
   if (g_application.ProcessAndStartPlaylist(strPlayList, *pPlayList, iPlayList))
   {
-    if (m_guiState.get())
+    if (m_guiState)
       m_guiState->SetPlaylistDirectory("playlistvideo://");
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -193,7 +193,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
           }
 
           // Playlist directory is the root of the playlist window
-          if (m_guiState.get()) m_guiState->SetPlaylistDirectory("playlistvideo://");
+          if (m_guiState) m_guiState->SetPlaylistDirectory("playlistvideo://");
 
           return true;
         }

--- a/xbmc/view/ViewDatabase.cpp
+++ b/xbmc/view/ViewDatabase.cpp
@@ -116,8 +116,8 @@ bool CViewDatabase::GetViewState(const std::string &path, int window, CViewState
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string path1(path);
     URIUtils::AddSlashAtEnd(path1);
@@ -152,8 +152,8 @@ bool CViewDatabase::SetViewState(const std::string &path, int window, const CVie
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string path1(path);
     URIUtils::AddSlashAtEnd(path1);
@@ -188,8 +188,8 @@ bool CViewDatabase::ClearViewStates(int windowID)
 {
   try
   {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+    if (NULL == m_pDB) return false;
+    if (NULL == m_pDS) return false;
 
     std::string sql = PrepareSQL("delete from view where window = %i", windowID);
     m_pDS->exec(sql);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -286,7 +286,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         else
           viewMode = m_viewControl.GetNextViewMode();
 
-        if (m_guiState.get())
+        if (m_guiState)
           m_guiState->SaveViewAsControl(viewMode);
 
         UpdateButtons();
@@ -294,7 +294,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNSORTASC) // sort asc
       {
-        if (m_guiState.get())
+        if (m_guiState)
           m_guiState->SetNextSortOrder();
         UpdateFileList();
         return true;
@@ -485,7 +485,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       else if (message.GetParam2())
         viewMode = m_viewControl.GetNextViewMode(message.GetParam2());
 
-      if (m_guiState.get())
+      if (m_guiState)
         m_guiState->SaveViewAsControl(viewMode);
       UpdateButtons();
       return true;
@@ -493,7 +493,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_CHANGE_SORT_METHOD:
     {
-      if (m_guiState.get())
+      if (m_guiState)
       {
         if (message.GetParam1())
           m_guiState->SetCurrentSortMethod(message.GetParam1());
@@ -506,7 +506,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_CHANGE_SORT_DIRECTION:
     {
-      if (m_guiState.get())
+      if (m_guiState)
         m_guiState->SetNextSortOrder();
       UpdateFileList();
       return true;
@@ -578,7 +578,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
  */
 void CGUIMediaWindow::UpdateButtons()
 {
-  if (m_guiState.get())
+  if (m_guiState)
   {
     // Update sorting controls
     if (m_guiState->GetSortOrder() == SortOrderNone)
@@ -628,7 +628,7 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
 {
   std::unique_ptr<CGUIViewState> guiState(CGUIViewState::GetViewState(GetID(), items));
 
-  if (guiState.get())
+  if (guiState)
   {
     SortDescription sorting = guiState->GetSortMethod();
     sorting.sortOrder = guiState->GetSortOrder();
@@ -692,7 +692,7 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
 {
   std::unique_ptr<CGUIViewState> viewState(CGUIViewState::GetViewState(GetID(), items));
 
-  if (viewState.get())
+  if (viewState)
   {
     LABEL_MASKS labelMasks;
     viewState->GetSortMethodLabelMasks(labelMasks);
@@ -1529,7 +1529,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string 
     }
 
     // Save current window and directory to know where the selected item was
-    if (m_guiState.get())
+    if (m_guiState)
       m_guiState->SetPlaylistDirectory(m_vecItems->GetPath());
 
     // figure out where we start playback

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -635,7 +635,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
   {
     std::string strPlayList = pItem->GetPath();
     std::unique_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
-    if (NULL != pPlayList.get())
+    if (NULL != pPlayList)
     {
       if (!pPlayList->Load(strPlayList))
       {


### PR DESCRIPTION
## Description
Apply clang-tidy check `readability-redundant-smartptr-get`. Followed up with manual removal of comparisons against NULL & splitting one-line ifs.

## Motivation and Context
Slight code simplification.

## How Has This Been Tested?
Running on Ubuntu 18.04 x86_64.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
