### PR TITLE
Remove CDatabase::InTransaction

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -686,12 +686,6 @@ void CDatabase::RollbackTransaction()
   }
 }
 
-bool CDatabase::InTransaction()
-{
-  if (NULL != m_pDB.get()) return false;
-  return m_pDB->in_transaction();
-}
-
 bool CDatabase::CreateDatabase()
 {
   BeginTransaction();

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -104,7 +104,6 @@ public:
   void BeginTransaction();
   virtual bool CommitTransaction();
   void RollbackTransaction();
-  bool InTransaction();
   void CopyDB(const std::string& latestDb);
   void DropAnalytics();
 


### PR DESCRIPTION
## Description
Remove unused function `CDatabase::InTransaction`.

## Motivation and Context
It looks like there's a bug in `CDatabase::InTransaction` - we return `false` if `m_pDB` is non-NULL, otherwise dereference the NULL pointer. Grepping around the code, it seems this function is not used anywhere, so may as well remove it.

## How Has This Been Tested?
Compiled, linked & running locally on Ubuntu 18.04 x86_64.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
