### PR TITLE
[interfaces] Fix crash on Kodi exit caused by double freed AsyncCallbackMessage

### DIFF
--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -49,16 +49,13 @@ namespace XBMCAddon
     CallbackQueue::iterator iter = g_callQueue.begin();
     while (iter != g_callQueue.end())
     {
-      AddonClass::Ref<AsyncCallbackMessage> cur(*iter);
+      if ((*iter)->handler.get() == this) // then this message is because of me
       {
-        if (cur->handler.get() == this) // then this message is because of me
-        {
-          g_callQueue.erase(iter);
-          iter = g_callQueue.begin();
-        }
-        else
-          ++iter;
+        g_callQueue.erase(iter);
+        iter = g_callQueue.begin();
       }
+      else
+        ++iter;
     }
   }
 


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/16178