### PR TITLE
Fix getting wrong "thumb" art URL from scraper results

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1659,7 +1659,7 @@ void CMusicInfoScanner::GetAlbumArtwork(long id, const CAlbum &album)
         (StringUtils::StartsWith(artURL, "image://") &&
          CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_PREFERONLINEALBUMART)))
     {
-      std::string thumb = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb());
+      std::string thumb = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb("thumb"));
       if (!thumb.empty())
       {
         CTextureCache::GetInstance().BackgroundCacheImage(thumb);
@@ -1998,16 +1998,13 @@ bool CMusicInfoScanner::SetArtistArtwork(CArtist& artist, const std::vector<std:
         }
       }
     }
-    // No local art, use first from scraped lists.
+    // No local art, use first of that type from scraped lists.
     // Fanart has own list. Art type is encoded into the scraper XML held in
-    // thumbURL as optional "aspect=" field. Type "thumb" or "" returns URLs for
-    // all types of art including those without aspect. Those URL without aspect
-    // are also returned for all other type values.
+    // thumbURL as optional "aspect=" field. Those URL without aspect are also
+    // returned for all other type values.
     if (strArt.empty())
     {
-      if (type == "thumb")
-        strArt = CScraperUrl::GetThumbURL(artist.thumbURL.GetFirstThumb());
-      else if (type == "fanart")
+      if (type == "fanart")
         strArt = artist.fanart.GetImageURL();
       else
         strArt = CScraperUrl::GetThumbURL(artist.thumbURL.GetFirstThumb(type));
@@ -2091,19 +2088,15 @@ bool CMusicInfoScanner::SetAlbumArtwork(CAlbum& album, std::vector<std::string>&
         }
       }
     }
-    // No local art, use first from scraped list.
-    // Art type is encoded into the scraper XML held in thumbURL as optional
-    // "aspect=" field. Type "thumb" or "" returns URLs for all types of art
-    // including those without aspect. Those URL without aspect are also
-    // returned for all other type values.
+    // No local art, use first of that type from scraped list.
+    // Art type is encoded into the scraper XML held in thumbURL as
+    // optional "aspect=" field. Those URL without aspect are also returned for
+    // all other type values.
     // Historically albums do not have fanart, so there is no special handling
     // of scraper results for it (unlike artist).
     if (strArt.empty())
     {
-      if (type == "thumb")
-        strArt = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb());
-      else
-        strArt = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb(type));
+      strArt = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb(type));
     }
     // Add art to album and library
     if (!strArt.empty())

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -139,7 +139,7 @@ const CScraperUrl::SUrlEntry CScraperUrl::GetFirstThumb(const std::string &type)
 {
   for (std::vector<SUrlEntry>::const_iterator iter=m_url.begin();iter != m_url.end();++iter)
   {
-    if (iter->m_type == URL_TYPE_GENERAL && (type.empty() || type == "thumb" || iter->m_aspect == type))
+    if (iter->m_type == URL_TYPE_GENERAL && (type.empty() || iter->m_aspect == type))
       return *iter;
   }
 


### PR DESCRIPTION
This fixes that the wrong type of art can sometimes be automatically picked from scraper results to be the default album or artist thumb. 

Music album and artist scrapers fetch lists of URLs of available art for that album or artist, for v18 onwards this includes a mix of art types. The type is returned in the "aspect"  value, but there is no guarantee that the URLs are in any particular order.  Consequently if the scraper results returned "clearlogo" before a "thumb" then the logo appeared as the artist image rather than the picture of the artist. This could happen for example if fanart.tv had logo but not poster art, with the paster then fetched from TADB.

Fix is for `CScraperUrl::GetFirstThumb("thumb")` to return the first URL in the list with aspect = "thumb", rather than just the first entry, and for CMusicInfoScanner to use "thumb" as a parameter. 

Only the music library use is impacted by this as only that calls `GetFirstThumb` for specific types of art. The consequnces of having `GetFirstThumb("thumb")` return the first art in the list regardless of type was overlooked when music support multi-type art was added.

Thanks @olympia for spotting this issue. @rmrector for interest
