### PR TITLE
[PVR] Separate GUI from PVR core: remove CFileItem usage from core

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -31,6 +31,7 @@ extern "C" {
 
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRStreamProperties.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -704,28 +705,18 @@ PVR_ERROR CPVRClient::IsPlayable(const CConstPVREpgInfoTagPtr &tag, bool &bIsPla
   }, m_clientCapabilities.SupportsEPG());
 }
 
-void CPVRClient::WriteFileItemProperties(const PVR_NAMED_VALUE *properties, unsigned int iPropertyCount, CFileItem &fileItem)
+void CPVRClient::WriteStreamProperties(const PVR_NAMED_VALUE *properties, unsigned int iPropertyCount, CPVRStreamProperties& props)
 {
   for (unsigned int i = 0; i < iPropertyCount; ++i)
   {
-    if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_STREAMURL, strlen(PVR_STREAM_PROPERTY_STREAMURL)) == 0)
-    {
-        fileItem.SetDynPath(properties[i].strValue);
-    }
-    else if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_MIMETYPE, strlen(PVR_STREAM_PROPERTY_MIMETYPE)) == 0)
-    {
-      fileItem.SetMimeType(properties[i].strValue);
-      fileItem.SetContentLookup(false);
-    }
-
-    fileItem.SetProperty(properties[i].strName, properties[i].strValue);
+    props.emplace_back(std::make_pair(properties[i].strName, properties[i].strValue));
   }
 }
 
-PVR_ERROR CPVRClient::FillEpgTagStreamFileItem(CFileItem &fileItem)
+PVR_ERROR CPVRClient::GetEpgTagStreamProperties(const std::shared_ptr<CPVREpgInfoTag>& tag, CPVRStreamProperties& props)
 {
-  return DoAddonCall(__FUNCTION__, [&fileItem](const AddonInstance* addon) {
-    CAddonEpgTag addonTag(fileItem.GetEPGInfoTag());
+  return DoAddonCall(__FUNCTION__, [&tag, &props](const AddonInstance* addon) {
+    CAddonEpgTag addonTag(tag);
 
     unsigned int iPropertyCount = PVR_STREAM_MAX_PROPERTIES;
     std::unique_ptr<PVR_NAMED_VALUE[]> properties(new PVR_NAMED_VALUE[iPropertyCount]);
@@ -733,7 +724,7 @@ PVR_ERROR CPVRClient::FillEpgTagStreamFileItem(CFileItem &fileItem)
 
     PVR_ERROR error = addon->GetEPGTagStreamProperties(&addonTag, properties.get(), &iPropertyCount);
     if (error ==  PVR_ERROR_NO_ERROR)
-      WriteFileItemProperties(properties.get(), iPropertyCount, fileItem);
+      WriteStreamProperties(properties.get(), iPropertyCount, props);
 
     return error;
   });
@@ -1055,10 +1046,9 @@ PVR_ERROR CPVRClient::GetDescrambleInfo(PVR_DESCRAMBLE_INFO &descrambleinfo) con
   }, m_clientCapabilities.SupportsDescrambleInfo());
 }
 
-PVR_ERROR CPVRClient::FillChannelStreamFileItem(CFileItem &fileItem)
+PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<CPVRChannel>& channel, CPVRStreamProperties& props)
 {
-  return DoAddonCall(__FUNCTION__, [this, &fileItem](const AddonInstance* addon) {
-    const CPVRChannelPtr channel = fileItem.GetPVRChannelInfoTag();
+  return DoAddonCall(__FUNCTION__, [this, &channel, &props](const AddonInstance* addon) {
     if (!CanPlayChannel(channel))
       return PVR_ERROR_NO_ERROR; // no error, but no need to obtain the values from the addon
 
@@ -1071,19 +1061,17 @@ PVR_ERROR CPVRClient::FillChannelStreamFileItem(CFileItem &fileItem)
 
     PVR_ERROR error = addon->GetChannelStreamProperties(&tag, properties.get(), &iPropertyCount);
     if (error == PVR_ERROR_NO_ERROR)
-      WriteFileItemProperties(properties.get(), iPropertyCount, fileItem);
+      WriteStreamProperties(properties.get(), iPropertyCount, props);
 
     return error;
   });
 }
 
-PVR_ERROR CPVRClient::FillRecordingStreamFileItem(CFileItem &fileItem)
+PVR_ERROR CPVRClient::GetRecordingStreamProperties(const std::shared_ptr<CPVRRecording>& recording, CPVRStreamProperties& props)
 {
-  return DoAddonCall(__FUNCTION__, [this, &fileItem](const AddonInstance* addon) {
+  return DoAddonCall(__FUNCTION__, [this, &recording, &props](const AddonInstance* addon) {
     if (!m_clientCapabilities.SupportsRecordings())
       return PVR_ERROR_NO_ERROR; // no error, but no need to obtain the values from the addon
-
-    const CPVRRecordingPtr recording = fileItem.GetPVRRecordingInfoTag();
 
     PVR_RECORDING tag = {{0}};
     WriteClientRecordingInfo(*recording, tag);
@@ -1094,7 +1082,7 @@ PVR_ERROR CPVRClient::FillRecordingStreamFileItem(CFileItem &fileItem)
 
     PVR_ERROR error = addon->GetRecordingStreamProperties(&tag, properties.get(), &iPropertyCount);
     if (error == PVR_ERROR_NO_ERROR)
-      WriteFileItemProperties(properties.get(), iPropertyCount, fileItem);
+      WriteStreamProperties(properties.get(), iPropertyCount, props);
 
     return error;
   });
@@ -1196,17 +1184,10 @@ bool CPVRClient::CanPlayChannel(const CPVRChannelPtr &channel) const
             (m_clientCapabilities.SupportsRadio() && channel->IsRadio())));
 }
 
-PVR_ERROR CPVRClient::OpenLiveStream(const CFileItem& channelItem)
+PVR_ERROR CPVRClient::OpenLiveStream(const std::shared_ptr<CPVRChannel>& channel)
 {
-  std::shared_ptr<CPVRChannel> channel = channelItem.GetPVRChannelInfoTag();
   if (!channel)
-    channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetByPath(channelItem.GetPath());
-
-  if (!channel)
-  {
-    CLog::LogFC(LOGERROR, LOGPVR, "Unable to obtain channel for path '%s'", channelItem.GetPath().c_str());
     return PVR_ERROR_INVALID_PARAMETERS;
-  }
 
   return DoAddonCall(__FUNCTION__, [this, channel](const AddonInstance* addon) {
     CloseLiveStream();
@@ -1226,17 +1207,10 @@ PVR_ERROR CPVRClient::OpenLiveStream(const CFileItem& channelItem)
   });
 }
 
-PVR_ERROR CPVRClient::OpenRecordedStream(const CFileItem& recordingItem)
+PVR_ERROR CPVRClient::OpenRecordedStream(const std::shared_ptr<CPVRRecording>& recording)
 {
-  std::shared_ptr<CPVRRecording> recording = recordingItem.GetPVRRecordingInfoTag();
   if (!recording)
-    recording = CServiceBroker::GetPVRManager().Recordings()->GetByPath(recordingItem.GetPath());
-
-  if (!recording)
-  {
-    CLog::LogFC(LOGERROR, LOGPVR, "Unable to obtain recording for path '%s'", recordingItem.GetPath().c_str());
     return PVR_ERROR_INVALID_PARAMETERS;
-  }
 
   return DoAddonCall(__FUNCTION__, [this, recording](const AddonInstance* addon) {
     CloseRecordedStream();
@@ -1362,49 +1336,75 @@ std::shared_ptr<CPVRClientMenuHooks> CPVRClient::GetMenuHooks()
   return m_menuhooks;
 }
 
-PVR_ERROR CPVRClient::CallMenuHook(const CPVRClientMenuHook &hook, const CFileItemPtr &item)
+PVR_ERROR CPVRClient::CallEpgTagMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVREpgInfoTag>& tag)
 {
-  return DoAddonCall(__FUNCTION__, [&hook, &item](const AddonInstance* addon) {
-    PVR_MENUHOOK_DATA hookData;
-    hookData.cat = PVR_MENUHOOK_UNKNOWN;
+  return DoAddonCall(__FUNCTION__, [&hook, &tag](const AddonInstance* addon) {
+    PVR_MENUHOOK_DATA hookData = {};
+    hookData.cat = PVR_MENUHOOK_EPG;
+    hookData.data.iEpgUid = tag->UniqueBroadcastID();
 
-    if (item)
-    {
-      if (item->IsEPG())
-      {
-        hookData.cat = PVR_MENUHOOK_EPG;
-        hookData.data.iEpgUid = item->GetEPGInfoTag()->UniqueBroadcastID();
-      }
-      else if (item->IsPVRChannel())
-      {
-        hookData.cat = PVR_MENUHOOK_CHANNEL;
-        WriteClientChannelInfo(item->GetPVRChannelInfoTag(), hookData.data.channel);
-      }
-      else if (item->IsUsablePVRRecording())
-      {
-        hookData.cat = PVR_MENUHOOK_RECORDING;
-        WriteClientRecordingInfo(*item->GetPVRRecordingInfoTag(), hookData.data.recording);
-      }
-      else if (item->IsDeletedPVRRecording())
-      {
-        hookData.cat = PVR_MENUHOOK_DELETED_RECORDING;
-        WriteClientRecordingInfo(*item->GetPVRRecordingInfoTag(), hookData.data.recording);
-      }
-      else if (item->IsPVRTimer())
-      {
-        hookData.cat = PVR_MENUHOOK_TIMER;
-        WriteClientTimerInfo(*item->GetPVRTimerInfoTag(), hookData.data.timer);
-      }
-      else
-      {
-        CLog::LogF(LOGERROR, "Unhandled item type.");
-        return PVR_ERROR_INVALID_PARAMETERS;
-      }
-    }
-    else
-    {
-      hookData.cat = PVR_MENUHOOK_SETTING;
-    }
+    PVR_MENUHOOK menuHook = {0};
+    menuHook.category = hookData.cat;
+    menuHook.iHookId = hook.GetId();
+    menuHook.iLocalizedStringId = hook.GetLabelId();
+
+    return addon->MenuHook(menuHook, hookData);
+  });
+}
+
+PVR_ERROR CPVRClient::CallChannelMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVRChannel>& channel)
+{
+  return DoAddonCall(__FUNCTION__, [&hook, &channel](const AddonInstance* addon) {
+    PVR_MENUHOOK_DATA hookData = {};
+    hookData.cat = PVR_MENUHOOK_CHANNEL;
+    WriteClientChannelInfo(channel, hookData.data.channel);
+
+    PVR_MENUHOOK menuHook = {0};
+    menuHook.category = hookData.cat;
+    menuHook.iHookId = hook.GetId();
+    menuHook.iLocalizedStringId = hook.GetLabelId();
+
+    return addon->MenuHook(menuHook, hookData);
+  });
+}
+
+PVR_ERROR CPVRClient::CallRecordingMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVRRecording>& recording, bool bDeleted)
+{
+  return DoAddonCall(__FUNCTION__, [&hook, &recording, &bDeleted](const AddonInstance* addon) {
+    PVR_MENUHOOK_DATA hookData = {};
+    hookData.cat = bDeleted ? PVR_MENUHOOK_DELETED_RECORDING : PVR_MENUHOOK_RECORDING;
+    WriteClientRecordingInfo(*recording, hookData.data.recording);
+
+    PVR_MENUHOOK menuHook = {0};
+    menuHook.category = hookData.cat;
+    menuHook.iHookId = hook.GetId();
+    menuHook.iLocalizedStringId = hook.GetLabelId();
+
+    return addon->MenuHook(menuHook, hookData);
+  });
+}
+
+PVR_ERROR CPVRClient::CallTimerMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVRTimerInfoTag>& timer)
+{
+  return DoAddonCall(__FUNCTION__, [&hook, &timer](const AddonInstance* addon) {
+    PVR_MENUHOOK_DATA hookData = {};
+    hookData.cat = PVR_MENUHOOK_TIMER;
+    WriteClientTimerInfo(*timer, hookData.data.timer);
+
+    PVR_MENUHOOK menuHook = {0};
+    menuHook.category = hookData.cat;
+    menuHook.iHookId = hook.GetId();
+    menuHook.iLocalizedStringId = hook.GetLabelId();
+
+    return addon->MenuHook(menuHook, hookData);
+  });
+}
+
+PVR_ERROR CPVRClient::CallSettingsMenuHook(const CPVRClientMenuHook& hook)
+{
+  return DoAddonCall(__FUNCTION__, [&hook](const AddonInstance* addon) {
+    PVR_MENUHOOK_DATA hookData = {};
+    hookData.cat = PVR_MENUHOOK_SETTING;
 
     PVR_MENUHOOK menuHook = {0};
     menuHook.category = hookData.cat;

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1200,11 +1200,7 @@ PVR_ERROR CPVRClient::OpenLiveStream(const CFileItem& channelItem)
 {
   std::shared_ptr<CPVRChannel> channel = channelItem.GetPVRChannelInfoTag();
   if (!channel)
-  {
-    const std::shared_ptr<CFileItem> item = CServiceBroker::GetPVRManager().ChannelGroups()->GetByPath(channelItem.GetPath());
-    if (item)
-      channel = item->GetPVRChannelInfoTag();
-  }
+    channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetByPath(channelItem.GetPath());
 
   if (!channel)
   {
@@ -1234,11 +1230,7 @@ PVR_ERROR CPVRClient::OpenRecordedStream(const CFileItem& recordingItem)
 {
   std::shared_ptr<CPVRRecording> recording = recordingItem.GetPVRRecordingInfoTag();
   if (!recording)
-  {
-    const std::shared_ptr<CFileItem> item = CServiceBroker::GetPVRManager().Recordings()->GetByPath(recordingItem.GetPath());
-    if (item)
-      recording = item->GetPVRRecordingInfoTag();
-  }
+    recording = CServiceBroker::GetPVRManager().Recordings()->GetByPath(recordingItem.GetPath());
 
   if (!recording)
   {

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -22,10 +22,11 @@
 namespace PVR
 {
   class CPVRChannelGroups;
-  class CPVREpgChannelData;
-  class CPVRTimersContainer;
   class CPVRClientMenuHook;
   class CPVRClientMenuHooks;
+  class CPVREpgChannelData;
+  class CPVRStreamProperties;
+  class CPVRTimersContainer;
 
   class CPVRClient;
   typedef std::shared_ptr<CPVRClient> CPVRClientPtr;
@@ -389,11 +390,12 @@ namespace PVR
     PVR_ERROR IsPlayable(const CConstPVREpgInfoTagPtr &tag, bool &bIsPlayable) const;
 
     /*!
-     * @brief Fill the file item for an epg tag with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled.
+     * @brief Fill the given container with the properties required for playback of the given EPG tag. Values are obtained from the PVR backend.
+     * @param tag The EPG tag.
+     * @param props The container to be filled with the stream properties.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR FillEpgTagStreamFileItem(CFileItem &fileItem);
+    PVR_ERROR GetEpgTagStreamProperties(const std::shared_ptr<CPVREpgInfoTag>& tag, CPVRStreamProperties& props);
 
     //@}
     /** @name PVR EPG methods */
@@ -609,10 +611,10 @@ namespace PVR
 
     /*!
      * @brief Open a live stream on the server.
-     * @param channelItem The channel to stream.
+     * @param channel The channel to stream.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR OpenLiveStream(const CFileItem& channelItem);
+    PVR_ERROR OpenLiveStream(const std::shared_ptr<CPVRChannel>& channel);
 
     /*!
      * @brief Close an open live stream.
@@ -667,11 +669,12 @@ namespace PVR
     PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO &descrambleinfo) const;
 
     /*!
-     * @brief Fill the file item for a channel with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled.
+     * @brief Fill the given container with the properties required for playback of the given channel. Values are obtained from the PVR backend.
+     * @param channel The channel.
+     * @param props The container to be filled with the stream properties.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR FillChannelStreamFileItem(CFileItem &fileItem);
+    PVR_ERROR GetChannelStreamProperties(const std::shared_ptr<CPVRChannel>& channel, CPVRStreamProperties& props);
 
     /*!
      * @brief Check whether PVR backend supports pausing the currently playing stream
@@ -719,10 +722,10 @@ namespace PVR
 
     /*!
      * @brief Open a recording on the server.
-     * @param recordingItem The recording to open.
+     * @param recording The recording to open.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR OpenRecordedStream(const CFileItem& recordingItem);
+    PVR_ERROR OpenRecordedStream(const std::shared_ptr<CPVRRecording>& recording);
 
     /*!
      * @brief Close an open recording stream.
@@ -756,11 +759,12 @@ namespace PVR
     PVR_ERROR GetRecordedStreamLength(int64_t &iLength);
 
     /*!
-     * @brief Fill the file item for a recording with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled.
+     * @brief Fill the given container with the properties required for playback of the given recording. Values are obtained from the PVR backend.
+     * @param recording The recording.
+     * @param props The container to be filled with the stream properties.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR FillRecordingStreamFileItem(CFileItem &fileItem);
+    PVR_ERROR GetRecordingStreamProperties(const std::shared_ptr<CPVRRecording>& recording, CPVRStreamProperties& props);
 
     //@}
     /** @name PVR demultiplexer methods */
@@ -815,17 +819,49 @@ namespace PVR
 
     /*!
      * @brief Get the client's menu hooks.
-     * @return The hooks. Guaranteed never to be null.
+     * @return The hooks. Guaranteed never to be nullptr.
      */
     std::shared_ptr<CPVRClientMenuHooks> GetMenuHooks();
 
     /*!
-     * @brief Call one of the menu hooks of the client.
+     * @brief Call one of the EPG tag menu hooks of the client.
      * @param hook The hook to call.
-     * @param item The item associated with the hook to be called.
+     * @param tag The EPG tag associated with the hook to be called.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR CallMenuHook(const CPVRClientMenuHook &hook, const CFileItemPtr &item);
+    PVR_ERROR CallEpgTagMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVREpgInfoTag>& tag);
+
+    /*!
+     * @brief Call one of the channel menu hooks of the client.
+     * @param hook The hook to call.
+     * @param tag The channel associated with the hook to be called.
+     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+     */
+    PVR_ERROR CallChannelMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVRChannel>& channel);
+
+    /*!
+     * @brief Call one of the recording menu hooks of the client.
+     * @param hook The hook to call.
+     * @param tag The recording associated with the hook to be called.
+     * @param bDeleted True, if the recording is deleted (trashed), false otherwise
+     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+     */
+    PVR_ERROR CallRecordingMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVRRecording>& recording, bool bDeleted);
+
+    /*!
+     * @brief Call one of the timer menu hooks of the client.
+     * @param hook The hook to call.
+     * @param tag The timer associated with the hook to be called.
+     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+     */
+    PVR_ERROR CallTimerMenuHook(const CPVRClientMenuHook& hook, const std::shared_ptr<CPVRTimerInfoTag>& timer);
+
+    /*!
+     * @brief Call one of the settings menu hooks of the client.
+     * @param hook The hook to call.
+     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+     */
+    PVR_ERROR CallSettingsMenuHook(const CPVRClientMenuHook& hook);
 
     /*!
      * @brief Propagate power management events to this add-on
@@ -896,12 +932,12 @@ namespace PVR
     static void WriteClientChannelInfo(const CPVRChannelPtr &xbmcChannel, PVR_CHANNEL &addonChannel);
 
     /*!
-     * @brief Write the given addon properties to the properties of the given file item.
+     * @brief Write the given addon properties to the given properties container.
      * @param properties Pointer to an array of addon properties.
      * @param iPropertyCount The number of properties contained in the addon properties array.
-     * @param fileItem The item the addon properties shall be written to.
+     * @param props The container the addon properties shall be written to.
      */
-    static void WriteFileItemProperties(const PVR_NAMED_VALUE *properties, unsigned int iPropertyCount, CFileItem &fileItem);
+    static void WriteStreamProperties(const PVR_NAMED_VALUE *properties, unsigned int iPropertyCount, CPVRStreamProperties& props);
 
     /*!
      * @brief Whether a channel can be played by this add-on

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -445,11 +445,11 @@ JSONRPC_STATUS CPVROperations::GetRecordingDetails(const std::string &method, IT
   if (!recordings)
     return FailedToExecute;
 
-  CFileItemPtr recording = recordings->GetById((int)parameterObject["recordingid"].asInteger());
+  const std::shared_ptr<CPVRRecording> recording = recordings->GetById(static_cast<int>(parameterObject["recordingid"].asInteger()));
   if (!recording)
     return InvalidParams;
 
-  HandleFileItem("recordingid", true, "recordingdetails", recording, parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("recordingid", true, "recordingdetails", std::make_shared<CFileItem>(recording), parameterObject, parameterObject["properties"], result, false);
 
   return OK;
 }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -724,11 +724,11 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (!recordingsContainer)
       return FailedToExecute;
 
-    const CFileItemPtr fileItem = recordingsContainer->GetById(static_cast<int>(parameterObject["item"]["recordingid"].asInteger()));
-    if (!fileItem)
+    const std::shared_ptr<CPVRRecording> recording = recordingsContainer->GetById(static_cast<int>(parameterObject["item"]["recordingid"].asInteger()));
+    if (!recording)
       return InvalidParams;
 
-    if (!CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(fileItem))
+    if (!CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(std::make_shared<CFileItem>(recording)))
       return FailedToExecute;
 
     return ACK;

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES PVRActionListener.cpp
             PVRItem.cpp
             PVRChannelNumberInputHandler.cpp
             PVRJobs.cpp
+            PVRGUIChannelIconUpdater.cpp
             PVRGUIChannelNavigator.cpp
             PVRGUIDirectory.cpp
             PVRGUIProgressHandler.cpp
@@ -25,6 +26,7 @@ set(HEADERS PVRActionListener.h
             PVRTypes.h
             PVRChannelNumberInputHandler.h
             PVRJobs.h
+            PVRGUIChannelIconUpdater.h
             PVRGUIChannelNavigator.h
             PVRGUIDirectory.h
             PVRGUIProgressHandler.h

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -13,7 +13,8 @@ set(SOURCES PVRActionListener.cpp
             PVRGUIDirectory.cpp
             PVRGUIProgressHandler.cpp
             PVRGUITimerInfo.cpp
-            PVRGUITimesInfo.cpp)
+            PVRGUITimesInfo.cpp
+            PVRStreamProperties.cpp)
 
 set(HEADERS PVRActionListener.h
             PVRDatabase.h
@@ -31,6 +32,7 @@ set(HEADERS PVRActionListener.h
             PVRGUIDirectory.h
             PVRGUIProgressHandler.h
             PVRGUITimerInfo.h
-            PVRGUITimesInfo.h)
+            PVRGUITimesInfo.h
+            PVRStreamProperties.h)
 
 core_add_library(pvr)

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -242,12 +242,12 @@ bool CPVRActionListener::OnAction(const CAction &action)
 
       const CPVRChannelPtr currentChannel = CServiceBroker::GetPVRManager().GetPlayingChannel();
       const CPVRChannelGroupPtr selectedGroup = CServiceBroker::GetPVRManager().ChannelGroups()->Get(currentChannel->IsRadio())->GetSelectedGroup();
-      const CFileItemPtr item(selectedGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber)));
+      const std::shared_ptr<CPVRChannel> channel = selectedGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
 
-      if (!item)
+      if (!channel)
         return false;
 
-      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, false);
+      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(std::make_shared<CFileItem>(channel), false);
       return true;
     }
 

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -608,7 +608,18 @@ namespace PVR
       if (!client)
         return false;
 
-      return client->CallMenuHook(m_hook, item) == PVR_ERROR_NO_ERROR;
+      if (item->IsEPG())
+        return client->CallEpgTagMenuHook(m_hook, item->GetEPGInfoTag()) == PVR_ERROR_NO_ERROR;
+      else if (item->IsPVRChannel())
+        return client->CallChannelMenuHook(m_hook, item->GetPVRChannelInfoTag()) == PVR_ERROR_NO_ERROR;
+      else if (item->IsDeletedPVRRecording())
+        return client->CallRecordingMenuHook(m_hook, item->GetPVRRecordingInfoTag(), true) == PVR_ERROR_NO_ERROR;
+      else if (item->IsUsablePVRRecording())
+        return client->CallRecordingMenuHook(m_hook, item->GetPVRRecordingInfoTag(), false) == PVR_ERROR_NO_ERROR;
+      else if (item->IsPVRTimer())
+        return client->CallTimerMenuHook(m_hook, item->GetPVRTimerInfoTag()) == PVR_ERROR_NO_ERROR;
+      else
+        return false;
     }
 
   } // namespace CONEXTMENUITEM

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -473,7 +473,7 @@ namespace PVR
 
     bool DeleteTimerRule::Execute(const CFileItemPtr &item) const
     {
-      const CFileItemPtr parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(item));
+      const std::shared_ptr<CFileItem> parentTimer = CServiceBroker::GetPVRManager().GUIActions()->GetTimerRule(item);
       if (parentTimer)
         return CServiceBroker::GetPVRManager().GUIActions()->DeleteTimerRule(parentTimer);
 

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -148,6 +148,13 @@ namespace PVR
     bool EditTimerRule(const CFileItemPtr &item) const;
 
     /*!
+     * @brief Get the timer rule for a given timer
+     * @param item containg an item to query the timer rule for. item must be a timer or an epg tag.
+     * @return The timer rule item, or nullptr if none was found.
+     */
+    std::shared_ptr<CFileItem> GetTimerRule(const std::shared_ptr<CFileItem>& item) const;
+
+    /*!
      * @brief Rename a timer, showing a text input dialog.
      * @param item containing a timer to rename.
      * @return true, if the timer was renamed successfully, false otherwise.

--- a/xbmc/pvr/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/PVRGUIChannelIconUpdater.cpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (C) 2012-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRGUIChannelIconUpdater.h"
+
+#include <map>
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "Util.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include "pvr/PVRGUIProgressHandler.h"
+#include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroup.h"
+
+using namespace PVR;
+
+void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
+{
+  const std::string iconPath = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_PVRMENU_ICONPATH);
+  if (iconPath.empty())
+    return;
+
+  // fetch files in icon path for fast lookup
+  CFileItemList fileItemList;
+  XFILE::CDirectory::GetDirectory(iconPath, fileItemList, ".jpg|.png|.tbn", XFILE::DIR_FLAG_DEFAULTS);
+
+  if (fileItemList.IsEmpty())
+    return;
+
+  CLog::Log(LOGINFO, "Starting PVR channel icon search");
+
+  // create a map for fast lookup of normalized file base name
+  std::map<std::string, std::string> fileItemMap;
+  for (const auto& item : fileItemList)
+  {
+    std::string baseName = URIUtils::GetFileName(item->GetPath());
+    URIUtils::RemoveExtension(baseName);
+    StringUtils::ToLower(baseName);
+    fileItemMap.insert({baseName, item->GetPath()});
+  }
+
+  CPVRGUIProgressHandler* progressHandler = new CPVRGUIProgressHandler(g_localizeStrings.Get(19286)); // Searching for channel icons
+
+  for (const auto& group : m_groups)
+  {
+    const std::vector<PVRChannelGroupMember> members = group->GetMembers();
+    int channelIndex = 0;
+    for (const auto& member : members)
+    {
+      progressHandler->UpdateProgress(member.channel->ChannelName(), channelIndex++, members.size());
+
+      // skip if an icon is already set and exists
+      if (XFILE::CFile::Exists(member.channel->IconPath()))
+        continue;
+
+      // reset icon before searching for a new one
+      member.channel->SetIconPath("");
+
+      const std::string strChannelUid = StringUtils::Format("%08d", member.channel->UniqueID());
+      std::string strLegalClientChannelName = CUtil::MakeLegalFileName(member.channel->ClientChannelName());
+      StringUtils::ToLower(strLegalClientChannelName);
+      std::string strLegalChannelName = CUtil::MakeLegalFileName(member.channel->ChannelName());
+      StringUtils::ToLower(strLegalChannelName);
+
+      std::map<std::string, std::string>::iterator itItem;
+      if ((itItem = fileItemMap.find(strLegalClientChannelName)) != fileItemMap.end() ||
+          (itItem = fileItemMap.find(strLegalChannelName)) != fileItemMap.end() ||
+          (itItem = fileItemMap.find(strChannelUid)) != fileItemMap.end())
+      {
+        member.channel->SetIconPath(itItem->second, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRAutoScanIconsUserSet);
+      }
+
+      if (m_bUpdateDb)
+        member.channel->Persist();
+    }
+  }
+
+  progressHandler->DestroyProgress();
+}

--- a/xbmc/pvr/PVRGUIChannelIconUpdater.h
+++ b/xbmc/pvr/PVRGUIChannelIconUpdater.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2012-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace PVR
+{
+
+class CPVRChannelGroup;
+
+class CPVRGUIChannelIconUpdater
+{
+public:
+  /*!
+   * @brief ctor.
+   * @param groups The channel groups for which the channel icons shall be updated.
+   * @param bUpdateDb If true, persist the changed values in the PVR database.
+   */
+  CPVRGUIChannelIconUpdater(const std::vector<std::shared_ptr<CPVRChannelGroup>>& groups, bool bUpdateDb)
+  : m_groups(groups), m_bUpdateDb(bUpdateDb) {}
+
+  CPVRGUIChannelIconUpdater() = delete;
+  CPVRGUIChannelIconUpdater(const CPVRGUIChannelIconUpdater&) = delete;
+  CPVRGUIChannelIconUpdater& operator=(const CPVRGUIChannelIconUpdater&) = delete;
+
+  virtual ~CPVRGUIChannelIconUpdater() = default;
+
+  /*!
+   * @brief Search and update missing channel icons.
+   */
+  void SearchAndUpdateMissingChannelIcons() const;
+
+private:
+  const std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups;
+  const bool m_bUpdateDb = false;
+};
+
+}

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -61,14 +61,10 @@ namespace PVR
       if (group)
       {
         CSingleLock lock(m_critSection);
-        const CFileItemPtr item = bNext
-          ? group->GetNextChannel(m_currentChannel)
-          : group->GetPreviousChannel(m_currentChannel);;
-        if (item)
-          return item->GetPVRChannelInfoTag();
+        return bNext ? group->GetNextChannel(m_currentChannel) : group->GetPreviousChannel(m_currentChannel);
       }
     }
-    return CPVRChannelPtr();
+    return {};
   }
 
   void CPVRGUIChannelNavigator::SelectChannel(const CPVRChannelPtr channel, ChannelSwitchMode eSwitchMode)

--- a/xbmc/pvr/PVRGUIDirectory.h
+++ b/xbmc/pvr/PVRGUIDirectory.h
@@ -78,11 +78,19 @@ public:
    */
   static bool HasDeletedRadioRecordings();
 
+  /*!
+   * @brief Get the list of channel groups.
+   * @param bRadio If true, obtain radio groups, tv groups otherwise.
+   * @param bExcludeHidden If true exclude hidden groups, include hidden groups otherwise.
+   * @param results The file list to store the results in.
+   * @return True on success, false otherwise..
+   */
+  static bool GetChannelGroupsDirectory(bool bRadio, bool bExcludeHidden, CFileItemList& results);
+
 private:
 
   bool FilterDirectory(CFileItemList& results) const;
 
-  bool GetChannelGroupsDirectory(bool bRadio, CFileItemList& results) const;
   bool GetChannelsDirectory(CFileItemList& results) const;
   bool GetTimersDirectory(CFileItemList& results) const;
   bool GetRecordingsDirectory(CFileItemList& results) const;

--- a/xbmc/pvr/PVRJobs.cpp
+++ b/xbmc/pvr/PVRJobs.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "pvr/PVRGUIActions.h"
+#include "pvr/PVRGUIChannelIconUpdater.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -96,9 +97,14 @@ bool CPVREventlogJob::DoWork()
   return true;
 }
 
+CPVRSearchMissingChannelIconsJob::CPVRSearchMissingChannelIconsJob(const std::vector<std::shared_ptr<CPVRChannelGroup>>& groups, bool bUpdateDb)
+: m_updater(new CPVRGUIChannelIconUpdater(groups, bUpdateDb))
+{
+}
+
 bool CPVRSearchMissingChannelIconsJob::DoWork(void)
 {
-  CServiceBroker::GetPVRManager().SearchMissingChannelIcons();
+  m_updater->SearchAndUpdateMissingChannelIcons();
   return true;
 }
 

--- a/xbmc/pvr/PVRJobs.h
+++ b/xbmc/pvr/PVRJobs.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "FileItem.h"
@@ -157,14 +158,18 @@ namespace PVR
     bool DoWork() override;
   };
 
+  class CPVRGUIChannelIconUpdater;
+
   class CPVRSearchMissingChannelIconsJob : public CJob
   {
   public:
-    CPVRSearchMissingChannelIconsJob(void) = default;
+    CPVRSearchMissingChannelIconsJob(const std::vector<std::shared_ptr<CPVRChannelGroup>>& groups, bool bUpdateDb);
     ~CPVRSearchMissingChannelIconsJob() override = default;
     const char *GetType() const override { return "pvr-search-missing-channel-icons"; }
 
     bool DoWork() override;
+  private:
+    const std::unique_ptr<CPVRGUIChannelIconUpdater> m_updater;
   };
 
   class CPVRClientConnectionJob : public CJob

--- a/xbmc/pvr/PVRJobs.h
+++ b/xbmc/pvr/PVRJobs.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <vector>
 
-#include "FileItem.h"
 #include "addons/PVRClient.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "utils/JobManager.h"

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -850,7 +850,7 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
   }
 
   m_guiActions->OnPlaybackStarted(item);
-  m_epgContainer.OnPlaybackStarted(item);
+  m_epgContainer.OnPlaybackStarted();
 }
 
 void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
@@ -899,7 +899,7 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
   }
 
   m_guiActions->OnPlaybackStopped(item);
-  m_epgContainer.OnPlaybackStopped(item);
+  m_epgContainer.OnPlaybackStopped();
 }
 
 void CPVRManager::OnPlaybackEnded(const CFileItemPtr item)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -949,12 +949,6 @@ bool CPVRManager::IsPlayingEpgTag(void) const
   return IsStarted() && m_playingEpgTag;
 }
 
-void CPVRManager::SearchMissingChannelIcons(void)
-{
-  if (IsStarted() && m_channelGroups)
-    m_channelGroups->SearchMissingChannelIcons();
-}
-
 bool CPVRManager::FillStreamFileItem(CFileItem &fileItem)
 {
   const CPVRClientPtr client = GetClient(fileItem);
@@ -995,10 +989,16 @@ void CPVRManager::TriggerChannelGroupsUpdate(void)
   m_pendingUpdates.AppendJob(new CPVRChannelGroupsUpdateJob());
 }
 
-void CPVRManager::TriggerSearchMissingChannelIcons(void)
+void CPVRManager::TriggerSearchMissingChannelIcons()
 {
   if (IsStarted())
-    CJobManager::GetInstance().AddJob(new CPVRSearchMissingChannelIconsJob(), NULL);
+    CJobManager::GetInstance().AddJob(new CPVRSearchMissingChannelIconsJob({m_channelGroups->GetGroupAllTV(), m_channelGroups->GetGroupAllRadio()}, true), nullptr);
+}
+
+void CPVRManager::TriggerSearchMissingChannelIcons(const std::shared_ptr<CPVRChannelGroup>& group)
+{
+  if (IsStarted())
+    CJobManager::GetInstance().AddJob(new CPVRSearchMissingChannelIconsJob({group}, false), nullptr);
 }
 
 void CPVRManager::ConnectionStateChange(CPVRClient *client, std::string connectString, PVR_CONNECTION_STATE state, std::string message)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -211,15 +211,15 @@ CPVRClientPtr CPVRManager::GetClient(const CFileItem &item) const
     iClientID = item.GetEPGInfoTag()->ClientID();
   else if (URIUtils::IsPVRChannel(item.GetPath()))
   {
-    const std::shared_ptr<CFileItem> channelItem = m_channelGroups->GetByPath(item.GetPath());
-    if (channelItem)
-      iClientID = channelItem->GetPVRChannelInfoTag()->ClientID();
+    const std::shared_ptr<CPVRChannel> channel = m_channelGroups->GetByPath(item.GetPath());
+    if (channel)
+      iClientID = channel->ClientID();
   }
   else if (URIUtils::IsPVRRecording(item.GetPath()))
   {
-    const std::shared_ptr<CFileItem> recordingItem = m_recordings->GetByPath(item.GetPath());
-    if (recordingItem)
-      iClientID = recordingItem->GetPVRRecordingInfoTag()->ClientID();
+    const std::shared_ptr<CPVRRecording> recording = m_recordings->GetByPath(item.GetPath());
+    if (recording)
+      iClientID = recording->ClientID();
   }
   return GetClient(iClientID);
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -949,21 +949,6 @@ bool CPVRManager::IsPlayingEpgTag(void) const
   return IsStarted() && m_playingEpgTag;
 }
 
-bool CPVRManager::FillStreamFileItem(CFileItem &fileItem)
-{
-  const CPVRClientPtr client = GetClient(fileItem);
-  if (client)
-  {
-    if (fileItem.IsPVRChannel())
-      return client->FillChannelStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
-    else if (fileItem.IsPVRRecording())
-      return client->FillRecordingStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
-    else if (fileItem.IsEPG())
-      return client->FillEpgTagStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
-  }
-  return false;
-}
-
 void CPVRManager::TriggerEpgsCreate(void)
 {
   m_pendingUpdates.AppendJob(new CPVREpgsCreateJob());

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -369,9 +369,15 @@ namespace PVR
     void TriggerChannelGroupsUpdate(void);
 
     /*!
-     * @brief Let the background thread search for missing channel icons.
+     * @brief Let the background thread search for all missing channel icons.
      */
     void TriggerSearchMissingChannelIcons(void);
+
+    /*!
+     * @brief Let the background thread search for missing channel icons for channels contained in the given group.
+     * @param group The channel group.
+     */
+    void TriggerSearchMissingChannelIcons(const std::shared_ptr<CPVRChannelGroup>& group);
 
     /*!
      * @brief Check whether names are still correct after the language settings changed.
@@ -407,11 +413,6 @@ namespace PVR
      * @return True if it's playing, false otherwise.
      */
     bool IsPlayingEpgTag(void) const;
-
-    /*!
-     * @brief Try to find missing channel icons automatically
-     */
-    void SearchMissingChannelIcons(void);
 
     /*!
      * @brief Check if parental lock is overridden at the given moment.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "FileItem.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "interfaces/IAnnouncer.h"
 #include "threads/Event.h"
@@ -303,19 +302,19 @@ namespace PVR
      * @brief Inform PVR manager that playback of an item just started.
      * @param item The item that started to play.
      */
-    void OnPlaybackStarted(const CFileItemPtr item);
+    void OnPlaybackStarted(const std::shared_ptr<CFileItem> item);
 
     /*!
      * @brief Inform PVR manager that playback of an item was stopped due to user interaction.
      * @param item The item that stopped to play.
      */
-    void OnPlaybackStopped(const CFileItemPtr item);
+    void OnPlaybackStopped(const std::shared_ptr<CFileItem> item);
 
     /*!
      * @brief Inform PVR manager that playback of an item has stopped without user interaction.
      * @param item The item that ended to play.
      */
-    void OnPlaybackEnded(const CFileItemPtr item);
+    void OnPlaybackEnded(const std::shared_ptr<CFileItem> item);
 
     /*!
      * @brief Check whether there are active recordings.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -337,13 +337,6 @@ namespace PVR
     CPVRChannelGroupPtr GetPlayingGroup(bool bRadio = false) const;
 
     /*!
-     * @brief Fill the file item for a recording, a channel or an epg tag with the properties required for playback. Values are obtained from the PVR backend.
-     * @param fileItem The file item to be filled. Item must contain either a pvr recording, a pvr channel or an epg tag.
-     * @return True if the stream properties have been set, false otherwiese.
-     */
-    bool FillStreamFileItem(CFileItem &fileItem);
-
-    /*!
      * @brief Let the background thread create epg tags for all channels.
      */
     void TriggerEpgsCreate(void);

--- a/xbmc/pvr/PVRStreamProperties.cpp
+++ b/xbmc/pvr/PVRStreamProperties.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2012-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRStreamProperties.h"
+
+#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+
+using namespace PVR;
+
+std::string CPVRStreamProperties::GetStreamURL() const
+{
+  for (const auto& prop : *this)
+  {
+    if (prop.first == PVR_STREAM_PROPERTY_STREAMURL)
+      return prop.second;
+  }
+  return {};
+}
+
+std::string CPVRStreamProperties::GetStreamMimeType() const
+{
+  for (const auto& prop : *this)
+  {
+    if (prop.first == PVR_STREAM_PROPERTY_MIMETYPE)
+      return prop.second;
+  }
+  return {};
+}

--- a/xbmc/pvr/PVRStreamProperties.h
+++ b/xbmc/pvr/PVRStreamProperties.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2012-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace PVR
+{
+
+class CPVRStreamProperties : public std::vector<std::pair<std::string, std::string>>
+{
+public:
+  CPVRStreamProperties() = default;
+  virtual ~CPVRStreamProperties() = default;
+
+  /*!
+   * @brief Obtain the URL of the stream.
+   * @return The stream URL or empty string, if not found.
+   */
+  std::string GetStreamURL() const;
+
+  /*!
+   * @brief Obtain the MIME type of the stream.
+   * @return The stream's MIME type or empty string, if not found.
+   */
+  std::string GetStreamMimeType() const;
+};
+
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "addons/PVRClient.h"
-#include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
@@ -699,11 +698,6 @@ bool CPVRChannel::IsUserSetIcon(void) const
 {
   CSingleLock lock(m_critSection);
   return m_bIsUserSetIcon;
-}
-
-bool CPVRChannel::IsIconExists() const
-{
-  return XFILE::CFile::Exists(IconPath());
 }
 
 bool CPVRChannel::IsUserSetName() const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -166,11 +166,6 @@ namespace PVR
     bool IsUserSetIcon(void) const;
 
     /*!
-     * @return True if the channel icon path exists
-     */
-    bool IsIconExists(void) const;
-
-    /*!
      * @return whether the user has changed the channel name through the GUI
      */
     bool IsUserSetName(void) const;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -13,20 +13,14 @@
 #include <algorithm>
 
 #include "ServiceBroker.h"
-#include "Util.h"
-#include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
-#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include "pvr/PVRDatabase.h"
-#include "pvr/PVRGUIProgressHandler.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/epg/EpgChannelData.h"
@@ -193,72 +187,6 @@ bool CPVRChannelGroup::SetChannelNumber(const CPVRChannelPtr &channel, const CPV
   }
 
   return bReturn;
-}
-
-void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
-{
-  std::string iconPath = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_PVRMENU_ICONPATH);
-  if (iconPath.empty())
-    return;
-
-  /* fetch files in icon path for fast lookup */
-  CFileItemList fileItemList;
-  XFILE::CDirectory::GetDirectory(iconPath, fileItemList, ".jpg|.png|.tbn", XFILE::DIR_FLAG_DEFAULTS);
-
-  if (fileItemList.IsEmpty())
-    return;
-
-  CSingleLock lock(m_critSection);
-
-  /* create a map for fast lookup of normalized file base name */
-  std::map<std::string, std::string> fileItemMap;
-  for (const auto& item : fileItemList)
-  {
-    std::string baseName = URIUtils::GetFileName(item->GetPath());
-    URIUtils::RemoveExtension(baseName);
-    StringUtils::ToLower(baseName);
-    fileItemMap.insert(std::make_pair(baseName, item->GetPath()));
-  }
-
-  CPVRGUIProgressHandler* progressHandler = new CPVRGUIProgressHandler(g_localizeStrings.Get(19286)); // Searching for channel icons
-
-  int channelIndex = 0;
-  CPVRChannelPtr channel;
-  for(PVR_CHANNEL_GROUP_MEMBERS::const_iterator it = m_members.begin(); it != m_members.end(); ++it)
-  {
-    channel = it->second.channel;
-
-    /* update progress dialog */
-    progressHandler->UpdateProgress(channel->ChannelName(), channelIndex++, m_members.size());
-
-    /* skip if an icon is already set and exists */
-    if (channel->IsIconExists())
-      continue;
-
-    /* reset icon before searching for a new one */
-    channel->SetIconPath("");
-
-    std::string strChannelUid = StringUtils::Format("%08d", channel->UniqueID());
-    std::string strLegalClientChannelName = CUtil::MakeLegalFileName(channel->ClientChannelName());
-    StringUtils::ToLower(strLegalClientChannelName);
-    std::string strLegalChannelName = CUtil::MakeLegalFileName(channel->ChannelName());
-    StringUtils::ToLower(strLegalChannelName);
-
-    std::map<std::string, std::string>::iterator itItem;
-    if ((itItem = fileItemMap.find(strLegalClientChannelName)) != fileItemMap.end() ||
-        (itItem = fileItemMap.find(strLegalChannelName)) != fileItemMap.end() ||
-        (itItem = fileItemMap.find(strChannelUid)) != fileItemMap.end())
-    {
-      channel->SetIconPath(itItem->second, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRAutoScanIconsUserSet);
-    }
-
-    if (bUpdateDb)
-      channel->Persist();
-
-    //! @todo start channel icon scraper here if nothing was found
-  }
-
-  progressHandler->DestroyProgress();
 }
 
 /********** sort methods **********/
@@ -434,14 +362,14 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByChannelNumber(const CPVRChan
   return {};
 }
 
-CFileItemPtr CPVRChannelGroup::GetNextChannel(const CPVRChannelPtr &channel) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetNextChannel(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  CFileItemPtr retval;
+  std::shared_ptr<CPVRChannel> nextChannel;
 
   if (channel)
   {
     CSingleLock lock(m_critSection);
-    for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::const_iterator it = m_sortedMembers.begin(); !retval && it != m_sortedMembers.end(); ++it)
+    for (auto it = m_sortedMembers.cbegin(); !nextChannel && it != m_sortedMembers.cend(); ++it)
     {
       if ((*it).channel == channel)
       {
@@ -450,26 +378,25 @@ CFileItemPtr CPVRChannelGroup::GetNextChannel(const CPVRChannelPtr &channel) con
           if ((++it) == m_sortedMembers.end())
             it = m_sortedMembers.begin();
           if ((*it).channel && !(*it).channel->IsHidden())
-            retval = std::make_shared<CFileItem>((*it).channel);
-        } while (!retval && (*it).channel != channel);
+            nextChannel = (*it).channel;
+        } while (!nextChannel && (*it).channel != channel);
 
-        if (!retval)
-          retval = std::make_shared<CFileItem>();
+        break;
       }
     }
   }
 
-  return retval;
+  return nextChannel;
 }
 
-CFileItemPtr CPVRChannelGroup::GetPreviousChannel(const CPVRChannelPtr &channel) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetPreviousChannel(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  CFileItemPtr retval;
+  std::shared_ptr<CPVRChannel> previousChannel;
 
   if (channel)
   {
     CSingleLock lock(m_critSection);
-    for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::const_reverse_iterator it = m_sortedMembers.rbegin(); !retval && it != m_sortedMembers.rend(); ++it)
+    for (auto it = m_sortedMembers.rbegin(); !previousChannel && it != m_sortedMembers.rend(); ++it)
     {
       if ((*it).channel == channel)
       {
@@ -478,15 +405,14 @@ CFileItemPtr CPVRChannelGroup::GetPreviousChannel(const CPVRChannelPtr &channel)
           if ((++it) == m_sortedMembers.rend())
             it = m_sortedMembers.rbegin();
           if ((*it).channel && !(*it).channel->IsHidden())
-            retval = std::make_shared<CFileItem>((*it).channel);
-        } while (!retval && (*it).channel != channel);
+            previousChannel = (*it).channel;
+        } while (!previousChannel && (*it).channel != channel);
 
-        if (!retval)
-          retval = std::make_shared<CFileItem>();
+        break;
       }
     }
   }
-  return retval;
+  return previousChannel;
 }
 
 std::vector<PVRChannelGroupMember> CPVRChannelGroup::GetMembers(Include eFilter /* = Include::ALL */) const
@@ -1055,15 +981,20 @@ void CPVRChannelGroup::SetPreventSortAndRenumber(bool bPreventSortAndRenumber /*
   m_bPreventSortAndRenumber = bPreventSortAndRenumber;
 }
 
-bool CPVRChannelGroup::UpdateChannel(const CFileItem &item, bool bHidden, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const std::string &strChannelName, const std::string &strIconPath, bool bUserSetIcon)
+bool CPVRChannelGroup::UpdateChannel(const std::pair<int, int>& storageId,
+                                     const std::string& strChannelName,
+                                     const std::string& strIconPath,
+                                     int iEPGSource,
+                                     int iChannelNumber,
+                                     bool bHidden,
+                                     bool bEPGEnabled,
+                                     bool bParentalLocked,
+                                     bool bUserSetIcon)
 {
-  if (!item.HasPVRChannelInfoTag())
-    return false;
-
   CSingleLock lock(m_critSection);
 
   /* get the real channel from the group */
-  const PVRChannelGroupMember& member(GetByUniqueID(item.GetPVRChannelInfoTag()->StorageId()));
+  const PVRChannelGroupMember& member = GetByUniqueID(storageId);
   if (!member.channel)
     return false;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -394,7 +394,7 @@ CPVRChannelPtr CPVRChannelGroup::GetByChannelEpgID(int iEpgID) const
   return retval;
 }
 
-CFileItemPtr CPVRChannelGroup::GetLastPlayedChannel(int iCurrentChannel /* = -1 */) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetLastPlayedChannel(int iCurrentChannel /* = -1 */) const
 {
   CSingleLock lock(m_critSection);
 
@@ -411,7 +411,7 @@ CFileItemPtr CPVRChannelGroup::GetLastPlayedChannel(int iCurrentChannel /* = -1 
     }
   }
 
-  return CFileItemPtr(returnChannel ? new CFileItem(returnChannel) : nullptr);
+  return returnChannel;
 }
 
 CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(const CPVRChannelPtr &channel) const
@@ -421,18 +421,17 @@ CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(const CPVRChannelPtr &chann
   return member.channelNumber;
 }
 
-CFileItemPtr CPVRChannelGroup::GetByChannelNumber(const CPVRChannelNumber &channelNumber) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByChannelNumber(const CPVRChannelNumber& channelNumber) const
 {
-  CFileItemPtr retval;
   CSingleLock lock(m_critSection);
 
-  for (PVR_CHANNEL_GROUP_SORTED_MEMBERS::const_iterator it = m_sortedMembers.begin(); !retval && it != m_sortedMembers.end(); ++it)
+  for (const auto& groupMember : m_sortedMembers)
   {
-    if ((*it).channelNumber == channelNumber)
-      retval = CFileItemPtr(new CFileItem((*it).channel));
+    if (groupMember.channelNumber == channelNumber)
+      return groupMember.channel;
   }
 
-  return retval;
+  return {};
 }
 
 CFileItemPtr CPVRChannelGroup::GetNextChannel(const CPVRChannelPtr &channel) const

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -22,8 +22,6 @@
 class CFileItem;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
 
-class CFileItemList;
-
 namespace PVR
 {
 #define PVR_GROUP_TYPE_DEFAULT      0
@@ -273,18 +271,18 @@ namespace PVR
     CPVRChannelPtr GetByChannelEpgID(int iEpgID) const;
 
     /*!
-     * @brief The channel that was played last that has a valid client or NULL if there was none.
+     * @brief Get the channel that was played last.
      * @param iCurrentChannel The channelid of the current channel that is playing, or -1 if none
-     * @return The requested channel.
+     * @return The requested channel or nullptr.
      */
-    CFileItemPtr GetLastPlayedChannel(int iCurrentChannel = -1) const;
+    std::shared_ptr<CPVRChannel> GetLastPlayedChannel(int iCurrentChannel = -1) const;
 
     /*!
      * @brief Get a channel given it's channel number.
      * @param channelNumber The channel number.
-     * @return The channel or NULL if it wasn't found.
+     * @return The channel or nullptr if it wasn't found.
      */
-    CFileItemPtr GetByChannelNumber(const CPVRChannelNumber &channelNumber) const;
+    std::shared_ptr<CPVRChannel> GetByChannelNumber(const CPVRChannelNumber& channelNumber) const;
 
     /*!
      * @brief Get the channel number in this group of the given channel.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -19,9 +19,6 @@
 #include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRChannel.h"
 
-class CFileItem;
-typedef std::shared_ptr<CFileItem> CFileItemPtr;
-
 namespace PVR
 {
 #define PVR_GROUP_TYPE_DEFAULT      0
@@ -121,12 +118,6 @@ namespace PVR
      * @param channelNumber The new channel number.
      */
     bool SetChannelNumber(const CPVRChannelPtr &channel, const CPVRChannelNumber &channelNumber);
-
-    /*!
-     * @brief Search missing channel icons for all known channels.
-     * @param bUpdateDb If true, update the changed values in the database.
-     */
-    void SearchAndSetChannelIcons(bool bUpdateDb = false);
 
     /*!
      * @brief Remove a channel from this container.
@@ -294,16 +285,16 @@ namespace PVR
     /*!
      * @brief Get the next channel in this group.
      * @param channel The current channel.
-     * @return The channel or NULL if it wasn't found.
+     * @return The channel or nullptr if it wasn't found.
      */
-    CFileItemPtr GetNextChannel(const CPVRChannelPtr &channel) const;
+    std::shared_ptr<CPVRChannel> GetNextChannel(const std::shared_ptr<CPVRChannel>& channel) const;
 
     /*!
      * @brief Get the previous channel in this group.
      * @param channel The current channel.
-     * @return The channel or NULL if it wasn't found.
+     * @return The channel or nullptr if it wasn't found.
      */
-    CFileItemPtr GetPreviousChannel(const CPVRChannelPtr &channel) const;
+    std::shared_ptr<CPVRChannel> GetPreviousChannel(const std::shared_ptr<CPVRChannel>& channel) const;
 
     /*!
      * @brief Get a channel given it's channel ID.
@@ -385,7 +376,28 @@ namespace PVR
      */
     CDateTime GetLastEPGDate(void) const;
 
-    bool UpdateChannel(const CFileItem &channel, bool bHidden, bool bEPGEnabled, bool bParentalLocked, int iEPGSource, int iChannelNumber, const std::string &strChannelName, const std::string &strIconPath, bool bUserSetIcon = false);
+    /*!
+     * @brief Update a channel group member with given data.
+     * @param storageId The storage id of the channel.
+     * @param strChannelName The channel name to set.
+     * @param strIconPath The icon path to set.
+     * @param iEPGSource The EPG id.
+     * @param iChannelNumber The channel number to set.
+     * @param bHidden Set/Remove hidden flag for the channel group member identified by storage id.
+     * @param bEPGEnabled Set/Remove EPG enabled flag for the channel group member identified by storage id.
+     * @param bParentalLocked Set/Remove parental locked flag for the channel group member identified by storage id.
+     * @param bUserSetIcon Set/Remove user set icon flag for the channel group member identified by storage id.
+     * @return True on success, false otherwise.
+     */
+    bool UpdateChannel(const std::pair<int, int>& storageId,
+                       const std::string& strChannelName,
+                       const std::string& strIconPath,
+                       int iEPGSource,
+                       int iChannelNumber,
+                       bool bHidden,
+                       bool bEPGEnabled,
+                       bool bParentalLocked,
+                       bool bUserSetIcon);
 
     /*!
      * @brief Get a channel given the channel number on the client.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -13,7 +13,6 @@
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Variant.h"
@@ -288,20 +287,13 @@ std::vector<CPVRChannelPtr> CPVRChannelGroupInternal::RemoveDeletedChannels(cons
 
 bool CPVRChannelGroupInternal::UpdateGroupEntries(const CPVRChannelGroup& channels, std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove)
 {
-  bool bReturn(false);
-
   if (CPVRChannelGroup::UpdateGroupEntries(channels, channelsToRemove))
   {
-    /* try to find channel icons */
-    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRChannelIconsAutoScan)
-      SearchAndSetChannelIcons();
-
     Persist();
-
-    bReturn = true;
+    return true;
   }
 
-  return bReturn;
+  return false;
 }
 
 void CPVRChannelGroupInternal::CreateChannelEpg(const std::shared_ptr<CPVRChannel>& channel)

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 
-#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "settings/Settings.h"
@@ -122,7 +121,7 @@ void CPVRChannelGroups::SortGroups()
   }
 }
 
-CFileItemPtr CPVRChannelGroups::GetByPath(const std::string &strInPath) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroups::GetByPath(const std::string& strInPath) const
 {
   std::string strPath = strInPath;
   URIUtils::RemoveSlashAtEnd(strPath);
@@ -141,13 +140,13 @@ CFileItemPtr CPVRChannelGroups::GetByPath(const std::string &strInPath) const
       {
         const CPVRChannelPtr channel = group->GetByUniqueID(atoi(split[1].c_str()), CServiceBroker::GetPVRManager().Clients()->GetClientId(split[0]));
         if (channel)
-          return CFileItemPtr(new CFileItem(channel));
+          return channel;
       }
     }
   }
 
   // no match
-  return CFileItemPtr(new CFileItem());
+  return {};
 }
 
 CPVRChannelGroupPtr CPVRChannelGroups::GetById(int iGroupId) const

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -12,6 +12,7 @@
 
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -233,6 +234,13 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
       std::vector<std::shared_ptr<CPVRChannel>> channelsToRemove;
       bReturn = group->Update(channelsToRemove) && bReturn;
       RemoveFromAllGroups(channelsToRemove);
+    }
+
+    if (bReturn &&
+        group->IsInternalGroup() &&
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRChannelIconsAutoScan)
+    {
+      CServiceBroker::GetPVRManager().TriggerSearchMissingChannelIcons(group);
     }
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -396,27 +396,6 @@ std::vector<CPVRChannelGroupPtr> CPVRChannelGroups::GetMembers(bool bExcludeHidd
   return groups;
 }
 
-int CPVRChannelGroups::GetGroupList(CFileItemList* results, bool bExcludeHidden /* = false */) const
-{
-  int iReturn(0);
-
-  CSingleLock lock(m_critSection);
-  for (std::vector<CPVRChannelGroupPtr>::const_iterator it = m_groups.begin(); it != m_groups.end(); ++it)
-  {
-    // exclude hidden groups if desired
-    if (bExcludeHidden && (*it)->IsHidden())
-      continue;
-
-    CFileItemPtr group(new CFileItem((*it)->GetPath(), true));
-    group->m_strTitle = (*it)->GroupName();
-    group->SetLabel((*it)->GroupName());
-    results->Add(group);
-    ++iReturn;
-  }
-
-  return iReturn;
-}
-
 CPVRChannelGroupPtr CPVRChannelGroups::GetPreviousGroup(const CPVRChannelGroup &group) const
 {
   bool bReturnNext(false);

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -15,9 +15,6 @@
 
 #include "pvr/channels/PVRChannelGroup.h"
 
-class CFileItem;
-typedef std::shared_ptr<CFileItem> CFileItemPtr;
-
 namespace PVR
 {
   /** A container class for channel groups */
@@ -66,9 +63,9 @@ namespace PVR
     /*!
      * @brief Get a channel given it's path
      * @param strPath The path to the channel
-     * @return The channel, or an empty fileitem when not found
+     * @return The channel, or nullptr if not found
      */
-    CFileItemPtr GetByPath(const std::string &strPath) const;
+    std::shared_ptr<CPVRChannel> GetByPath(const std::string& strPath) const;
 
     /*!
      * @brief Get a pointer to a channel group given it's ID.

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -17,7 +17,6 @@
 
 class CFileItem;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
-class CFileItemList;
 
 namespace PVR
 {
@@ -123,14 +122,6 @@ namespace PVR
      * @return The amount of items that were added.
      */
     std::vector<CPVRChannelGroupPtr> GetMembers(bool bExcludeHidden = false) const;
-
-    /*!
-     * @brief Get the list of groups.
-     * @param results The file list to store the results in.
-     * @param bExcludeHidden Decides whether to filter hidden groups
-     * @return The amount of items that were added.
-     */
-    int GetGroupList(CFileItemList* results, bool bExcludeHidden = false) const;
 
     /*!
      * @brief Get the previous group in this container.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -8,7 +8,6 @@
 
 #include "PVRChannelGroupsContainer.h"
 
-#include "FileItem.h"
 #include "utils/log.h"
 
 #include "pvr/epg/EpgInfoTag.h"
@@ -111,18 +110,13 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(con
   return groups->GetGroupAll()->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID());
 }
 
-CFileItemPtr CPVRChannelGroupsContainer::GetByPath(const std::string &strPath) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByPath(const std::string& strPath) const
 {
-  for (unsigned int bRadio = 0; bRadio <= 1; ++bRadio)
-  {
-    const CPVRChannelGroups *groups = Get(bRadio == 1);
-    CFileItemPtr retVal = groups->GetByPath(strPath);
-    if (retVal && retVal->HasPVRChannelInfoTag())
-      return retVal;
-  }
+  const std::shared_ptr<CPVRChannel> channel = m_groupsTV->GetByPath(strPath);
+  if (channel)
+    return channel;
 
-  CFileItemPtr retVal(new CFileItem);
-  return retVal;
+  return m_groupsRadio->GetByPath(strPath);
 }
 
 CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetSelectedGroup(bool bRadio) const
@@ -158,13 +152,13 @@ void CPVRChannelGroupsContainer::SearchMissingChannelIcons(void) const
     channelgroupradio->SearchAndSetChannelIcons(true);
 }
 
-CFileItemPtr CPVRChannelGroupsContainer::GetLastPlayedChannel(void) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetLastPlayedChannel() const
 {
-  CFileItemPtr channelTV = m_groupsTV->GetGroupAll()->GetLastPlayedChannel();
-  CFileItemPtr channelRadio = m_groupsRadio->GetGroupAll()->GetLastPlayedChannel();
+  const std::shared_ptr<CPVRChannel> channelTV = m_groupsTV->GetGroupAll()->GetLastPlayedChannel();
+  const std::shared_ptr<CPVRChannel> channelRadio = m_groupsRadio->GetGroupAll()->GetLastPlayedChannel();
 
   if (!channelTV ||
-      (channelRadio && channelRadio->GetPVRChannelInfoTag()->LastWatched() > channelTV->GetPVRChannelInfoTag()->LastWatched()))
+      (channelRadio && channelRadio->LastWatched() > channelTV->LastWatched()))
      return channelRadio;
 
   return channelTV;

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -139,19 +139,6 @@ CPVRChannelPtr CPVRChannelGroupsContainer::GetByUniqueID(int iUniqueChannelId, i
   return channel;
 }
 
-void CPVRChannelGroupsContainer::SearchMissingChannelIcons(void) const
-{
-  CLog::Log(LOGINFO, "Starting PVR channel icon search");
-
-  CPVRChannelGroupPtr channelgrouptv  = GetGroupAllTV();
-  CPVRChannelGroupPtr channelgroupradio = GetGroupAllRadio();
-
-  if (channelgrouptv)
-    channelgrouptv->SearchAndSetChannelIcons(true);
-  if (channelgroupradio)
-    channelgroupradio->SearchAndSetChannelIcons(true);
-}
-
 std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetLastPlayedChannel() const
 {
   const std::shared_ptr<CPVRChannel> channelTV = m_groupsTV->GetGroupAll()->GetLastPlayedChannel();

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -120,9 +120,9 @@ namespace PVR
     /*!
      * @brief Get a channel given it's path.
      * @param strPath The path.
-     * @return The channel or NULL if it wasn't found.
+     * @return The channel or nullptr if it wasn't found.
      */
-    CFileItemPtr GetByPath(const std::string &strPath) const;
+    std::shared_ptr<CPVRChannel> GetByPath(const std::string& strPath) const;
 
     /*!
      * @brief Get the group that is currently selected in the UI.
@@ -145,10 +145,10 @@ namespace PVR
     void SearchMissingChannelIcons(void) const;
 
     /*!
-     * @brief The channel that was played last that has a valid client or NULL if there was none.
-     * @return The requested channel.
+     * @brief Get the channel that was played last.
+     * @return The requested channel or nullptr.
      */
-    CFileItemPtr GetLastPlayedChannel(void) const;
+    std::shared_ptr<CPVRChannel> GetLastPlayedChannel() const;
 
     /*!
      * @brief The group that was played last and optionally contains the given channel.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -140,11 +140,6 @@ namespace PVR
     CPVRChannelPtr GetByUniqueID(int iUniqueChannelId, int iClientID) const;
 
     /*!
-     * @brief Try to find missing channel icons automatically
-     */
-    void SearchMissingChannelIcons(void) const;
-
-    /*!
      * @brief Get the channel that was played last.
      * @return The requested channel or nullptr.
      */

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -749,16 +749,15 @@ bool CGUIDialogPVRChannelManager::PersistChannel(const CFileItemPtr &pItem, cons
   if (!pItem || !pItem->HasPVRChannelInfoTag() || !group)
     return false;
 
-  /* get values from the form */
-  bool bHidden              = !pItem->GetProperty("ActiveChannel").asBoolean();
-  bool bEPGEnabled          = pItem->GetProperty("UseEPG").asBoolean();
-  bool bParentalLocked      = pItem->GetProperty("ParentalLocked").asBoolean();
-  int iEPGSource            = (int)pItem->GetProperty("EPGSource").asInteger();
-  std::string strChannelName= pItem->GetProperty("Name").asString();
-  std::string strIconPath   = pItem->GetProperty("Icon").asString();
-  bool bUserSetIcon         = pItem->GetProperty("UserSetIcon").asBoolean();
-
-  return group->UpdateChannel(*pItem, bHidden, bEPGEnabled, bParentalLocked, iEPGSource, ++(*iChannelNumber), strChannelName, strIconPath, bUserSetIcon);
+  return group->UpdateChannel(pItem->GetPVRChannelInfoTag()->StorageId(),
+                              pItem->GetProperty("Name").asString(),
+                              pItem->GetProperty("Icon").asString(),
+                              static_cast<int>(pItem->GetProperty("EPGSource").asInteger()),
+                              ++(*iChannelNumber),
+                              !pItem->GetProperty("ActiveChannel").asBoolean(), // hidden
+                              pItem->GetProperty("UseEPG").asBoolean(),
+                              pItem->GetProperty("ParentalLocked").asBoolean(),
+                              pItem->GetProperty("UserSetIcon").asBoolean());
 }
 
 void CGUIDialogPVRChannelManager::SaveList(void)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -21,6 +21,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
+#include "pvr/PVRGUIDirectory.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 
@@ -364,8 +365,9 @@ void CGUIDialogPVRGroupManager::Update()
 
   Clear();
 
-  /* get the groups list */
-  CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)->GetGroupList(m_channelGroups);
+  // get the groups list
+  CPVRGUIDirectory::GetChannelGroupsDirectory(m_bIsRadio, false, *m_channelGroups);
+
   m_viewChannelGroups.SetItems(*m_channelGroups);
   m_viewChannelGroups.SetSelectedItem(m_iSelectedChannelGroup);
 

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -862,13 +862,13 @@ int CPVREpgContainer::GetFutureDaysToDisplay() const
   return m_settings.GetIntValue(CSettings::SETTING_EPG_FUTURE_DAYSTODISPLAY);
 }
 
-void CPVREpgContainer::OnPlaybackStarted(const CFileItemPtr &item)
+void CPVREpgContainer::OnPlaybackStarted()
 {
   CSingleLock lock(m_critSection);
   m_bPlaying = true;
 }
 
-void CPVREpgContainer::OnPlaybackStopped(const CFileItemPtr &item)
+void CPVREpgContainer::OnPlaybackStopped()
 {
   CSingleLock lock(m_critSection);
   m_bPlaying = false;

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -23,8 +23,6 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgDatabase.h"
 
-class CFileItem;
-
 namespace PVR
 {
   class CPVREpgChannelData;
@@ -185,15 +183,13 @@ namespace PVR
 
     /*!
      * @brief Inform the epg container that playback of an item just started.
-     * @param item The item that started to play.
      */
-    void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
+    void OnPlaybackStarted();
 
     /*!
      * @brief Inform the epg container that playback of an item was stopped due to user interaction.
-     * @param item The item that stopped to play.
      */
-    void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
+    void OnPlaybackStopped();
 
   private:
     /*!

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -8,7 +8,6 @@
 
 #include "EpgSearchFilter.h"
 
-#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "utils/TextSearch.h"

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -10,9 +10,7 @@
 
 #include <utility>
 
-#include "FileItem.h"
 #include "ServiceBroker.h"
-#include "filesystem/Directory.h"
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -99,74 +97,6 @@ bool CPVRRecordings::HasDeletedRadioRecordings() const
 {
   CSingleLock lock(m_critSection);
   return m_bDeletedRadioRecordings;
-}
-
-bool CPVRRecordings::Delete(const CFileItem& item)
-{
-  return item.m_bIsFolder ? DeleteDirectory(item) : DeleteRecording(item);
-}
-
-bool CPVRRecordings::DeleteDirectory(const CFileItem& directory)
-{
-  CFileItemList items;
-  XFILE::CDirectory::GetDirectory(directory.GetPath(), items, "", XFILE::DIR_FLAG_DEFAULTS);
-
-  bool allDeleted = true;
-  for (const auto& item : items)
-    allDeleted &= Delete(*item);
-
-  return allDeleted;
-}
-
-bool CPVRRecordings::DeleteRecording(const CFileItem &item)
-{
-  if (!item.IsPVRRecording())
-  {
-    CLog::LogF(LOGERROR, "Cannot delete item: no valid recording tag");
-    return false;
-  }
-
-  CPVRRecordingPtr tag = item.GetPVRRecordingInfoTag();
-  return tag->Delete();
-}
-
-bool CPVRRecordings::Undelete(const CFileItem &item)
-{
-  if (!item.IsDeletedPVRRecording())
-  {
-    CLog::LogF(LOGERROR, "Cannot undelete item: no valid recording tag");
-    return false;
-  }
-
-  CPVRRecordingPtr tag = item.GetPVRRecordingInfoTag();
-  return tag->Undelete();
-}
-
-bool CPVRRecordings::RenameRecording(CFileItem &item, std::string &strNewName)
-{
-  if (!item.IsUsablePVRRecording())
-  {
-    CLog::LogF(LOGERROR, "Cannot rename item: no valid recording tag");
-    return false;
-  }
-
-  CPVRRecordingPtr tag = item.GetPVRRecordingInfoTag();
-  return tag->Rename(strNewName);
-}
-
-bool CPVRRecordings::DeleteAllRecordingsFromTrash()
-{
-  return CServiceBroker::GetPVRManager().Clients()->DeleteAllRecordingsFromTrash() == PVR_ERROR_NO_ERROR;
-}
-
-bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
-{
-  return ChangeRecordingsPlayCount(item, count);
-}
-
-bool CPVRRecordings::IncrementRecordingsPlayCount(const CFileItemPtr &item)
-{
-  return ChangeRecordingsPlayCount(item, INCREMENT_PLAY_COUNT);
 }
 
 std::vector<std::shared_ptr<CPVRRecording>> CPVRRecordings::GetAll() const
@@ -295,84 +225,55 @@ CPVRRecordingPtr CPVRRecordings::GetRecordingForEpgTag(const CPVREpgInfoTagPtr &
   return CPVRRecordingPtr();
 }
 
-bool CPVRRecordings::ChangeRecordingsPlayCount(const CFileItemPtr &item, int count)
+bool CPVRRecordings::SetRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count)
 {
-  bool bResult = false;
+  return ChangeRecordingsPlayCount(recording, count);
+}
 
-  CVideoDatabase& db = GetVideoDatabase();
-  if (db.IsOpen())
+bool CPVRRecordings::IncrementRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording)
+{
+  return ChangeRecordingsPlayCount(recording, INCREMENT_PLAY_COUNT);
+}
+
+bool CPVRRecordings::ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count)
+{
+  if (recording)
   {
-    bResult = true;
-
-    CLog::LogFC(LOGDEBUG, LOGPVR, "Item path %s", item->GetPath().c_str());
-    CFileItemList items;
-    if (item->m_bIsFolder)
+    CVideoDatabase& db = GetVideoDatabase();
+    if (db.IsOpen())
     {
-      XFILE::CDirectory::GetDirectory(item->GetPath(), items, "", XFILE::DIR_FLAG_DEFAULTS);
-    }
-    else
-      items.Add(item);
+      if (count == INCREMENT_PLAY_COUNT)
+        recording->IncrementPlayCount();
+      else
+        recording->SetPlayCount(count);
 
-    CLog::LogFC(LOGDEBUG, LOGPVR, "Will set watched for %d items", items.Size());
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      CLog::LogFC(LOGDEBUG, LOGPVR, "Setting watched for item %d", i);
-
-      CFileItemPtr pItem=items[i];
-      if (pItem->m_bIsFolder)
+      // Clear resume bookmark
+      if (recording->GetPlayCount() > 0)
       {
-        CLog::LogFC(LOGDEBUG, LOGPVR, "Path %s is a folder, will call recursively", pItem->GetPath().c_str());
-        if (pItem->GetLabel() != "..")
-        {
-          ChangeRecordingsPlayCount(pItem, count);
-        }
-        continue;
+        db.ClearBookMarksOfFile(recording->m_strFileNameAndPath, CBookmark::RESUME);
+        recording->SetResumePoint(CBookmark());
       }
 
-      if (!pItem->HasPVRRecordingInfoTag())
-        continue;
-
-      const CPVRRecordingPtr recording = pItem->GetPVRRecordingInfoTag();
-      if (recording)
-      {
-        if (count == INCREMENT_PLAY_COUNT)
-          recording->IncrementPlayCount();
-        else
-          recording->SetPlayCount(count);
-
-        // Clear resume bookmark
-        if (recording->GetPlayCount() > 0)
-        {
-          db.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
-          recording->SetResumePoint(CBookmark());
-        }
-
-        if (count == INCREMENT_PLAY_COUNT)
-          db.IncrementPlayCount(*pItem);
-        else
-          db.SetPlayCount(*pItem, count);
-      }
+      CServiceBroker::GetPVRManager().PublishEvent(PVREvent::RecordingsInvalidated);
+      return true;
     }
-
-    CServiceBroker::GetPVRManager().PublishEvent(PVREvent::RecordingsInvalidated);
   }
 
-  return bResult;
+  return false;
 }
 
-bool CPVRRecordings::MarkWatched(const CFileItemPtr &item, bool bWatched)
+bool CPVRRecordings::MarkWatched(const std::shared_ptr<CPVRRecording>& recording, bool bWatched)
 {
   if (bWatched)
-    return IncrementRecordingsPlayCount(item);
+    return IncrementRecordingsPlayCount(recording);
   else
-    return SetRecordingsPlayCount(item, 0);
+    return SetRecordingsPlayCount(recording, 0);
 }
 
-bool CPVRRecordings::ResetResumePoint(const CFileItemPtr item)
+bool CPVRRecordings::ResetResumePoint(const std::shared_ptr<CPVRRecording>& recording)
 {
   bool bResult = false;
 
-  const CPVRRecordingPtr recording = item->GetPVRRecordingInfoTag();
   if (recording)
   {
     CVideoDatabase& db = GetVideoDatabase();
@@ -380,7 +281,7 @@ bool CPVRRecordings::ResetResumePoint(const CFileItemPtr item)
     {
       bResult = true;
 
-      db.ClearBookMarksOfFile(item->GetPath(), CBookmark::RESUME);
+      db.ClearBookMarksOfFile(recording->m_strFileNameAndPath, CBookmark::RESUME);
       recording->SetResumePoint(CBookmark());
 
       CServiceBroker::GetPVRManager().PublishEvent(PVREvent::RecordingsInvalidated);

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -182,20 +182,19 @@ std::vector<std::shared_ptr<CPVRRecording>> CPVRRecordings::GetAll() const
   return recordings;
 }
 
-CFileItemPtr CPVRRecordings::GetById(unsigned int iId) const
+std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(unsigned int iId) const
 {
-  CFileItemPtr item;
   CSingleLock lock(m_critSection);
   for (const auto recording : m_recordings)
   {
     if (iId == recording.second->m_iRecordingId)
-      item = CFileItemPtr(new CFileItem(recording.second));
+      return recording.second;
   }
 
-  return item;
+  return {};
 }
 
-CFileItemPtr CPVRRecordings::GetByPath(const std::string &path)
+std::shared_ptr<CPVRRecording> CPVRRecordings::GetByPath(const std::string& path) const
 {
   CSingleLock lock(m_critSection);
 
@@ -213,13 +212,11 @@ CFileItemPtr CPVRRecordings::GetByPath(const std::string &path)
           bDeleted != current->IsDeleted() || bRadio != current->IsRadio())
         continue;
 
-      CFileItemPtr fileItem(new CFileItem(current));
-      return fileItem;
+      return current;
     }
   }
 
-  CFileItemPtr fileItem(new CFileItem);
-  return fileItem;
+  return {};
 }
 
 CPVRRecordingPtr CPVRRecordings::GetById(int iClientId, const std::string &strRecordingId) const

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -11,7 +11,6 @@
 #include <map>
 #include <memory>
 
-#include "FileItem.h"
 #include "video/VideoDatabase.h"
 
 #include "pvr/PVRTypes.h"
@@ -26,20 +25,20 @@ namespace PVR
   public:
     virtual ~CPVRRecordings(void);
 
-    /**
+    /*!
      * @brief (re)load the recordings from the clients.
      * @return the number of recordings loaded.
      */
     int Load();
 
-    /**
+    /*!
      * @brief unload all recordings.
      */
     void Unload();
 
     void UpdateFromClient(const CPVRRecordingPtr &tag);
 
-    /**
+    /*!
      * @brief refresh the recordings list from the clients.
      */
     void Update(void);
@@ -49,27 +48,25 @@ namespace PVR
     int GetNumRadioRecordings() const;
     bool HasDeletedRadioRecordings() const;
 
-    /**
-     * @brief Deletes the item in question, be it a directory or a file
-     * @param item the item to delete
-     * @return whether the item was deleted successfully
+    /*!
+     * @brief Set a recording's watched state
+     * @param recording The recording
+     * @param bWatched True to set watched, false to set unwatched state
+     * @return True on success, false otherwise
      */
-    bool Delete(const CFileItem &item);
+    bool MarkWatched(const std::shared_ptr<CPVRRecording>& recording, bool bWatched);
 
-    bool Undelete(const CFileItem &item);
-    bool DeleteAllRecordingsFromTrash();
-    bool RenameRecording(CFileItem &item, std::string &strNewName);
-    bool SetRecordingsPlayCount(const CFileItemPtr &item, int count);
-    bool IncrementRecordingsPlayCount(const CFileItemPtr &item);
-    bool MarkWatched(const CFileItemPtr &item, bool bWatched);
-
-    /**
-     * @brief Resets a recording's resume point, if any
-     * @param item The item to process
-     * @return True, if the item's resume point was reset successfully, false otherwise
+    /*!
+     * @brief Reset a recording's resume point, if any
+     * @param recording The recording
+     * @return True on success, false otherwise
      */
-    bool ResetResumePoint(const CFileItemPtr item);
+    bool ResetResumePoint(const std::shared_ptr<CPVRRecording>& recording);
 
+    /*!
+     * @brief Get a list of all recordings
+     * @return the list of all recordings
+     */
     std::vector<std::shared_ptr<CPVRRecording>> GetAll() const;
 
     std::shared_ptr<CPVRRecording> GetByPath(const std::string& path) const;
@@ -83,7 +80,7 @@ namespace PVR
      */
     CPVRRecordingPtr GetRecordingForEpgTag(const CPVREpgInfoTagPtr &epgTag) const;
 
-    /**
+    /*!
      * @brief Get/Open the video database.
      * @return A reference to the video database.
      */
@@ -102,25 +99,32 @@ namespace PVR
 
     void UpdateFromClients(void);
 
-    /**
-     * @brief recursively deletes all recordings in the specified directory
-     * @param item the directory
-     * @return true if all recordings were deleted
+    /*!
+     * @brief Set a recording's play count
+     * @param recording The recording
+     * @param count The new play count
+     * @return True on success, false otherwise
      */
-    bool DeleteDirectory(const CFileItem &item);
-    bool DeleteRecording(const CFileItem &item);
+    bool SetRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count);
 
-    /**
+    /*!
+     * @brief Increment a recording's play count
+     * @param recording The recording
+     * @return True on success, false otherwise
+     */
+    bool IncrementRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording);
+
+    /*!
      * @brief special value for parameter count of method ChangeRecordingsPlayCount
      */
     static const int INCREMENT_PLAY_COUNT = -1;
 
-    /**
-     * @brief change the playcount of the given recording or recursively of all children of the given recordings folder
-     * @param item the recording or directory containing recordings
-     * @param count the new playcount or INCREMENT_PLAY_COUNT to denote that the current playcount(s) are to be incremented by one
-     * @return true if all playcounts were changed
+    /*!
+     * @brief change the play count of the given recording
+     * @param recording The recording
+     * @param count The new play count or INCREMENT_PLAY_COUNT to denote that the current play count is to be incremented by one
+     * @return true if the play count was changed successfully
      */
-    bool ChangeRecordingsPlayCount(const CFileItemPtr &item, int count);
+    bool ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count);
   };
 }

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -72,9 +72,9 @@ namespace PVR
 
     std::vector<std::shared_ptr<CPVRRecording>> GetAll() const;
 
-    CFileItemPtr GetByPath(const std::string &path);
+    std::shared_ptr<CPVRRecording> GetByPath(const std::string& path) const;
     CPVRRecordingPtr GetById(int iClientId, const std::string &strRecordingId) const;
-    CFileItemPtr GetById(unsigned int iId) const;
+    std::shared_ptr<CPVRRecording> GetById(unsigned int iId) const;
 
     /*!
      * @brief Get the recording for the given epg tag, if any.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -10,7 +10,6 @@
 
 #include <utility>
 
-#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "addons/PVRClient.h"
 #include "settings/Settings.h"
@@ -1214,23 +1213,6 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerRule(const CPVRTimerInfoTagPtr &timer) c
     }
   }
   return CPVRTimerInfoTagPtr();
-}
-
-CFileItemPtr CPVRTimers::GetTimerRule(const CFileItemPtr &item) const
-{
-  CPVRTimerInfoTagPtr timer;
-  if (item && item->HasEPGInfoTag())
-    timer = GetTimerForEpgTag(item->GetEPGInfoTag());
-  else if (item && item->HasPVRTimerInfoTag())
-    timer = item->GetPVRTimerInfoTag();
-
-  if (timer)
-  {
-    timer = GetTimerRule(timer);
-    if (timer)
-      return CFileItemPtr(new CFileItem(timer));
-  }
-  return CFileItemPtr();
 }
 
 void CPVRTimers::Notify(const Observable &obs, const ObservableMessage msg)

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -22,9 +22,6 @@
 #include "pvr/PVRTypes.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 
-class CFileItem;
-typedef std::shared_ptr<CFileItem> CFileItemPtr;
-
 namespace PVR
 {
   class CPVRTimersPath;
@@ -241,18 +238,11 @@ namespace PVR
     CPVRTimerInfoTagPtr GetTimerForEpgTag(const CPVREpgInfoTagPtr &epgTag) const;
 
     /*!
-     * Get the timer rule for a given timer tag
+     * @brief Get the timer rule for a given timer tag
      * @param timer The timer to query the timer rule for
      * @return The timer rule, or nullptr if none was found.
      */
     CPVRTimerInfoTagPtr GetTimerRule(const CPVRTimerInfoTagPtr &timer) const;
-
-    /*!
-     * Get the timer rule for a given timer tag
-     * @param item The timer to query the timer rule for
-     * @return The timer rule, or an empty fileitemptr if none was found.
-     */
-    CFileItemPtr GetTimerRule(const CFileItemPtr &item) const;
 
     /*!
      * @brief Update the channel pointers.
@@ -262,7 +252,7 @@ namespace PVR
     void Notify(const Observable &obs, const ObservableMessage msg) override;
 
     /*!
-     * Get a timer tag given it's unique ID
+     * @brief Get a timer tag given it's unique ID
      * @param iTimerId The ID to find
      * @return The tag, or an empty one when not found
      */

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -10,6 +10,7 @@
 
 #include <tinyxml.h>
 
+#include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "guilib/DirtyRegion.h"

--- a/xbmc/pvr/windows/GUIEPGGridContainer.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.h
@@ -11,14 +11,18 @@
 #include <string>
 #include <vector>
 
-#include "FileItem.h"
 #include "XBDateTime.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
 #include "guilib/IGUIContainer.h"
 
+class CFileItem;
+class CFileItemList;
+
 namespace PVR
 {
+  class CPVRChannel;
+
   struct GridItem;
   class CGUIEPGGridContainerModel;
 
@@ -58,8 +62,8 @@ namespace PVR
     CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const override;
     std::string GetLabel(int info) const override;
 
-    CFileItemPtr GetSelectedGridItem(int offset = 0) const;
-    PVR::CPVRChannelPtr GetSelectedChannel() const;
+    std::shared_ptr<CFileItem> GetSelectedGridItem(int offset = 0) const;
+    std::shared_ptr<CPVRChannel> GetSelectedChannel() const;
     CDateTime GetSelectedDate() const;
 
     void LoadLayout(TiXmlElement *layout);
@@ -87,7 +91,8 @@ namespace PVR
      * @param channel the channel.
      * @return true if the selection was set to the given channel, false otherwise.
      */
-    bool SetChannel(const PVR::CPVRChannelPtr &channel);
+    bool SetChannel(const std::shared_ptr<CPVRChannel>& channel);
+
     /*!
      * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
      * @param channel the channel's path.
@@ -121,7 +126,7 @@ namespace PVR
     void GoToBlock(int blockIndex);
     void GoToChannel(int channelIndex);
     void UpdateScrollOffset(unsigned int currentTime);
-    void ProcessItem(float posX, float posY, const CFileItemPtr &item, CFileItemPtr &lastitem, bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout, unsigned int currentTime, CDirtyRegionList &dirtyregions, float resize = -1.0f);
+    void ProcessItem(float posX, float posY, const std::shared_ptr<CFileItem>& item, std::shared_ptr<CFileItem>& lastitem, bool focused, CGUIListItemLayout* normallayout, CGUIListItemLayout* focusedlayout, unsigned int currentTime, CDirtyRegionList &dirtyregions, float resize = -1.0f);
     void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);
     void GetCurrentLayouts();
 
@@ -209,8 +214,8 @@ namespace PVR
 
     CGUITexture m_guiProgressIndicatorTexture;
 
-    CFileItemPtr m_lastItem;
-    CFileItemPtr m_lastChannel;
+    std::shared_ptr<CFileItem> m_lastItem;
+    std::shared_ptr<CFileItem> m_lastChannel;
 
     int m_scrollTime;
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 
 #include "pvr/PVRGUIActions.h"
+#include "pvr/PVRGUIDirectory.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroup.h"
@@ -62,14 +63,9 @@ bool CGUIPVRChannelGroupsSelector::Initialize(CGUIWindow* parent, bool bRadio)
   {
     m_control = control;
     m_channelGroups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio)->GetMembers(true);
+
     CFileItemList channelGroupItems;
-    for (const auto& group : m_channelGroups)
-    {
-      CFileItemPtr item(new CFileItem(group->GetPath(), true));
-      item->m_strTitle = group->GroupName();
-      item->SetLabel(group->GroupName());
-      channelGroupItems.Add(item);
-    }
+    CPVRGUIDirectory::GetChannelGroupsDirectory(bRadio, true, channelGroupItems);
 
     CGUIMessage msg(GUI_MSG_LABEL_BIND, m_control->GetID(), CONTROL_LSTCHANNELGROUPS, 0, 0, &channelGroupItems);
     m_control->OnMessage(msg);
@@ -360,7 +356,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog(void)
     return false;
 
   CFileItemList options;
-  CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bRadio)->GetGroupList(&options, true);
+  CPVRGUIDirectory::GetChannelGroupsDirectory(m_bRadio, true, options);
 
   dialog->Reset();
   dialog->SetHeading(CVariant{g_localizeStrings.Get(19146)});

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -67,8 +67,16 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
       continue;
 #endif
 
-    if (item->HasPVRRecordingInfoTag() && CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item, m_mark))
+    if (item->HasPVRRecordingInfoTag() &&
+        CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item->GetPVRRecordingInfoTag(), m_mark))
+    {
+      if (m_mark)
+        db.IncrementPlayCount(*item);
+      else
+        db.SetPlayCount(*item, 0);
+
       continue;
+    }
 
     markItems.push_back(item);
   }

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -62,7 +62,8 @@ bool CVideoLibraryResetResumePointJob::Work(CVideoDatabase &db)
       continue;
 #endif
 
-    if (item->HasPVRRecordingInfoTag() && CServiceBroker::GetPVRManager().Recordings()->ResetResumePoint(item))
+    if (item->HasPVRRecordingInfoTag() &&
+        CServiceBroker::GetPVRManager().Recordings()->ResetResumePoint(item->GetPVRRecordingInfoTag()))
       continue;
 
     resetItems.emplace_back(item);


### PR DESCRIPTION
`CFileItem` and derived classes like `CFileItemList` should not be used in PVR core. `CFileItem` is derived from `CGUIListItem` and
* is carrying GUI data like layouts
* is accessing global gfx mutex
* is accessing PVR and other globals
* instance size is fairly large (compared to PVR core instances)

All this can lead to problems, mainly deadlocks and waste of system resources.

I carefully runtime-tested this changes on macOS and Android. No problems found.

@Jalle19 pleaes review. I tried to build logical units per commit.