### PR TITLE
resolution whitelist version 2

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7856,10 +7856,7 @@ msgctxt "#14084"
 msgid "Queue songs on selection"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14085"
-msgid "Whitelist"
-msgstr ""
+#empty string with id 14085
 
 #: system/settings/settings.xml
 msgctxt "#14086"
@@ -8077,7 +8074,22 @@ msgctxt "#14125"
 msgid "Input"
 msgstr ""
 
-#empty strings from id 14126 to 14199
+#: system/settings/settings.xml
+msgctxt "#14126"
+msgid "Whitelist"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14127"
+msgid "Allow 3:2 pulldown refresh rates"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14128"
+msgid "Allow double refresh rates"
+msgstr ""
+
+#empty strings from id 14129 to 14199
 
 #: system/settings/settings.xml
 msgctxt "#14200"
@@ -19744,11 +19756,7 @@ msgctxt "#36355"
 msgid "In a multi-screen configuration, the screens not displaying this application are blacked out."
 msgstr ""
 
-#. Description of setting with label #14085 "Whitelist"
-#: system/settings/settings.xml
-msgctxt "#36356"
-msgid "Whitelisted modes are allowed to be switched to when changing resolution and refresh rate"
-msgstr ""
+#empty string with id 36356
 
 #. Description of setting with label #214 "Video calibration..."
 #: system/settings/settings.xml
@@ -20230,7 +20238,25 @@ msgctxt "#36442"
 msgid "Set the number of volume control steps."
 msgstr ""
 
-#empty strings from id 36443 to 36459
+#. Description of setting with label #14126 "Whitelist"
+#: system/settings/settings.xml
+msgctxt "#36443"
+msgid "Whitelisted modes give the user the control to choose which display modes are allowed or not allowed to be used"
+msgstr ""
+
+#. Description of setting with label #14127 "Whitelist"
+#: system/settings/settings.xml
+msgctxt "#36444"
+msgid "Select this option to allow using 3:2 pulldown refresh rates (playing 23.976 FPS video on a 59.94 Hz monitor or playing 24 FPS video on a 60 Hz monitor). You may want to use this option if your monitor doesn't have a 23.976 Hz or 24 Hz mode."
+msgstr ""
+
+#. Description of setting with label #14128 "Whitelist"
+#: system/settings/settings.xml
+msgctxt "#36445"
+msgid "Select this option to allow using double refresh rates (playing 29.97 FPS video on a 59.94 Hz monitor or playing 30 FPS video on a 60 Hz monitor). You may want to use this option if your monitor doesn't have a 29.97 Hz or 30 Hz mode."
+msgstr ""
+
+#empty strings from id 36446 to 36459
 
 #. Description of settings with label #14112 "Enable event logging"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2358,18 +2358,6 @@
           </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
-        <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14085" help="36356">
-          <level>3</level>
-          <constraints>
-            <options>modes</options>
-            <default></default>
-            <delimiter>,</delimiter>
-            <minimumitems>0</minimumitems>
-          </constraints>
-          <control type="list" format="string">
-            <multiselect>true</multiselect>
-          </control>
-        </setting>
         <setting id="videoscreen.resolution" type="integer" parent="videoscreen.screen" label="169" help="36352">
           <level>0</level>
           <default>16</default> <!-- RES_DESKTOP -->
@@ -2630,7 +2618,37 @@
           <control type="spinner" format="integer" />
         </setting>
       </group>
-      <group id="2" label="14232">
+      <group id="2" label="14126">
+        <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14126" help="36443">
+          <level>3</level>
+          <constraints>
+            <options>modes</options>
+            <default></default>
+            <delimiter>,</delimiter>
+            <minimumitems>0</minimumitems>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+          </control>
+        </setting>
+        <setting id="videoscreen.whitelistpulldown" type="boolean" parent="videoscreen.whitelist" label="14127" help="36444">
+          <level>3</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="videoscreen.whitelist" operator="!is"></dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="videoscreen.whitelistdoublerefreshrate" type="boolean" parent="videoscreen.whitelist" label="14128" help="36445">
+          <level>3</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="videoscreen.whitelist" operator="!is"></dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="3" label="14232">
         <setting id="videoscreen.stereoscopicmode" type="integer" label="36500" help="36539">
           <level>2</level>
           <default>0</default>
@@ -2651,7 +2669,7 @@
           <control type="list" format="integer"/>
         </setting>
       </group>
-      <group id="3" label="496">
+      <group id="4" label="496">
         <setting id="videoscreen.noofbuffers" type="integer" label="36043" help="36552">
           <level>2</level>
           <default>3</default> <!-- triple buffers -->

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -400,6 +400,16 @@ bool CDisplaySettings::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
   return false;
 }
 
+void CDisplaySettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
+{
+  if (!setting)
+    return;
+
+  const std::string& settingId = setting->GetId();
+  if (settingId == CSettings::SETTING_VIDEOSCREEN_WHITELIST)
+    CResolutionUtils::PrintWhitelist();
+}
+
 void CDisplaySettings::SetMonitor(const std::string& monitor)
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -38,6 +38,7 @@ public:
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
                        const char* oldSettingId,
                        const TiXmlNode* oldSettingNode) override;
+  void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
   /*!
    \brief Returns the currently active resolution

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -941,6 +941,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_3DLUT);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_DISPLAYPROFILE);
   settingSet.insert(CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS);
+  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
   GetSettingsManager()->RegisterCallback(&CDisplaySettings::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -20,6 +20,15 @@
 
 #include <cstdlib>
 
+namespace
+{
+
+const char* SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN{"videoscreen.whitelistpulldown"};
+const char* SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE{
+    "videoscreen.whitelistdoublerefreshrate"};
+
+} // namespace
+
 EdgeInsets::EdgeInsets(float l, float t, float r, float b) : left(l), top(t), right(r), bottom(b)
 {
 }
@@ -80,13 +89,16 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int heig
 void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution)
 {
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
-  CLog::Log(LOGINFO, "Whitelist search for: width: %d, height: %d, fps: %0.3f, 3D: %s", width,
-            height, fps, is3D ? "true" : "false");
+  CLog::Log(LOGINFO,
+            "[WHITELIST] Searching the whitelist for: width: {}, height: {}, fps: {:0.3f}, 3D: {}",
+            width, height, fps, is3D ? "true" : "false");
 
   std::vector<CVariant> indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+
   if (indexList.empty())
   {
-    CLog::Log(LOGDEBUG, "Whitelist is empty using default one");
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] Using the default whitelist because the user whitelist is empty");
     std::vector<RESOLUTION> candidates;
     RESOLUTION_INFO info;
     std::string resString;
@@ -110,7 +122,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     }
   }
 
-  CLog::Log(LOGDEBUG, "Trying to find exact refresh rate");
+  CLog::Log(LOGDEBUG, "[WHITELIST] Searching for an exact resolution with an exact refresh rate");
 
   for (const auto& mode : indexList)
   {
@@ -124,64 +136,78 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
-      CLog::Log(LOGDEBUG, "Matched exact whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
+      CLog::Log(LOGDEBUG,
+                "[WHITELIST] Matched an exact resolution with an exact refresh rate {} ({})",
+                info.strMode, i);
       resolution = i;
       return;
     }
   }
 
-  CLog::Log(LOGDEBUG, "No exact whitelisted resolution matched, trying double refresh rate");
+  CLog::Log(LOGDEBUG, "[WHITELIST] No match for an exact resolution with an exact refresh rate");
 
-  for (const auto& mode : indexList)
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE))
   {
-    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
-    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] Searching for an exact resolution with double the refresh rate");
 
-    // allow resolutions that are exact and have double the refresh rate
-    // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
-    if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
-         (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
-        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
+    for (const auto& mode : indexList)
     {
-      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
-      resolution = i;
-      return;
+      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+      // allow resolutions that are exact and have double the refresh rate
+      // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+      if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
+           (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
+          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+          MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
+      {
+        CLog::Log(LOGDEBUG,
+                  "[WHITELIST] Matched an exact resolution with double the refresh rate {} ({})",
+                  info.strMode, i);
+        resolution = i;
+        return;
+      }
     }
+
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] No match for an exact resolution with double the refresh rate");
   }
 
-  CLog::Log(LOGDEBUG, "No double whitelisted resolution matched, trying 3:2 pullback");
-
-  for (const auto& mode : indexList)
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN))
   {
-    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
-    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] Searching for an exact resolution with a 3:2 pulldown refresh rate");
 
-    // allow resolutions that are exact and have 2.5 times the refresh rate
-    // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
-    if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
-         (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
-        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps * 2.5f, 0.01f))
+    for (const auto& mode : indexList)
     {
-      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
-      resolution = i;
-      return;
+      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+      // allow resolutions that are exact and have 2.5 times the refresh rate
+      // allow macroblock alignement / padding errors (e.g. 1080 mod16 == 8)
+      if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
+           (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
+          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+          MathUtils::FloatEquals(info.fRefreshRate, fps * 2.5f, 0.01f))
+      {
+        CLog::Log(
+            LOGDEBUG,
+            "[WHITELIST] Matched an exact resolution with a 3:2 pulldown refresh rate {} ({})",
+            info.strMode, i);
+        resolution = i;
+        return;
+      }
     }
+
+    CLog::Log(LOGDEBUG, "[WHITELIST] No match for a resolution with a 3:2 pulldown refresh rate");
   }
 
-  CLog::Log(LOGDEBUG, "No 3:2 pullback refresh rate whitelisted resolution matched, trying current resolution");
 
-  if (width <= curr.iScreenWidth
-    && height <= curr.iScreenHeight
-    && (MathUtils::FloatEquals(curr.fRefreshRate, fps, 0.01f)
-      || MathUtils::FloatEquals(curr.fRefreshRate, fps * 2, 0.01f)))
-  {
-    CLog::Log(LOGDEBUG, "Matched current Resolution %s (%d)", curr.strMode.c_str(), resolution);
-    return;
-  }
-
-  CLog::Log(LOGDEBUG, "Current resolution doesn't match, trying default resolution");
+  CLog::Log(LOGDEBUG, "[WHITELIST] Searching for a desktop resolution with an exact refresh rate");
 
   const RESOLUTION_INFO desktop_info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(CDisplaySettings::GetInstance().GetCurrentResolution());
 
@@ -195,49 +221,76 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
-      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
+      CLog::Log(LOGDEBUG,
+                "[WHITELIST] Matched a desktop resolution with an exact refresh rate {} ({})",
+                info.strMode, i);
       resolution = i;
       return;
     }
   }
 
-  CLog::Log(LOGDEBUG, "Default resolution doesn't provide reqired refreshrate, trying default resolution with double refreshrate");
+  CLog::Log(LOGDEBUG, "[WHITELIST] No match for a desktop resolution with an exact refresh rate");
 
-  for (const auto& mode : indexList)
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE))
   {
-    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
-    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] Searching for a desktop resolution with double the refresh rate");
 
-    // allow resolutions that are desktop resolution but have double the refresh rate
-    if (info.iScreenWidth == desktop_info.iScreenWidth &&
-        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
+    for (const auto& mode : indexList)
     {
-      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
-      resolution = i;
-      return;
+      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+      // allow resolutions that are desktop resolution but have double the refresh rate
+      if (info.iScreenWidth == desktop_info.iScreenWidth &&
+          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) ==
+              (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+          MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
+      {
+        CLog::Log(LOGDEBUG,
+                  "[WHITELIST] Matched a desktop resolution with double the refresh rate {} ({})",
+                  info.strMode, i);
+        resolution = i;
+        return;
+      }
     }
+
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] No match for a desktop resolution with double the refresh rate");
   }
 
-  CLog::Log(LOGDEBUG, "Default resolution doesn't provide reqired refreshrate, trying default resolution with 3:2 pullback");
-
-  for (const auto& mode : indexList)
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN))
   {
-    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
-    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] Searching for a desktop resolution with a 3:2 pulldown refresh rate");
 
-    // allow resolutions that are desktop resolution but have 2.5 times the refresh rate
-    if (info.iScreenWidth == desktop_info.iScreenWidth &&
-        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps * 2.5f, 0.01f))
+    for (const auto& mode : indexList)
     {
-      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
-      resolution = i;
-      return;
+      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+      // allow resolutions that are desktop resolution but have 2.5 times the refresh rate
+      if (info.iScreenWidth == desktop_info.iScreenWidth &&
+          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) ==
+              (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+          MathUtils::FloatEquals(info.fRefreshRate, fps * 2.5f, 0.01f))
+      {
+        CLog::Log(
+            LOGDEBUG,
+            "[WHITELIST] Matched a desktop resolution with a 3:2 pulldown refresh rate {} ({})",
+            info.strMode, i);
+        resolution = i;
+        return;
+      }
     }
+
+    CLog::Log(LOGDEBUG,
+              "[WHITELIST] No match for a desktop resolution with a 3:2 pulldown refresh rate");
   }
 
-  CLog::Log(LOGDEBUG, "No whitelisted resolution matched");
+  CLog::Log(LOGDEBUG, "[WHITELIST] No resolution matched");
 }
 
 bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback)
@@ -322,4 +375,22 @@ bool CResolutionUtils::HasWhitelist()
 {
   std::vector<CVariant> indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
   return !indexList.empty();
+}
+
+void CResolutionUtils::PrintWhitelist()
+{
+  std::string modeStr;
+  auto indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+      CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+  if (!indexList.empty())
+  {
+    for (const auto& mode : indexList)
+    {
+      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+      modeStr.append("\n" + info.strMode);
+    }
+
+    CLog::Log(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
+  }
 }

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -80,6 +80,8 @@ class CResolutionUtils
 public:
   static RESOLUTION ChooseBestResolution(float fps, int width, int height, bool is3D);
   static bool HasWhitelist();
+  static void PrintWhitelist();
+
 protected:
   static void FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution);
   static bool FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback);

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -33,6 +33,9 @@ bool CWinSystemBase::InitWindowSystem()
 {
   UpdateResolutions();
   CDisplaySettings::GetInstance().ApplyCalibrations();
+
+  CResolutionUtils::PrintWhitelist();
+
   return true;
 }
 


### PR DESCRIPTION
This is a second go at the original whitelist implementation. Please read this PR description carefully!

I have done the following:
1) added uniform, clear, and helpfuly log messages
2) logged the whitelist at startup or when the whitelist changes (to help debugging)
3) added a setting for 3:2 pulldown refresh rates
4) added a setting for double refresh rates
5) moved the whitelist (and new settings) to it's own section in `settings->system->display`

The new logging looks like this
```
2019-05-28 21:14:01.070 T:139817693571520   DEBUG: [WHITELIST] whitelisted modes:
                                            1920x1080 @ 60.000000 Hz
                                            1920x1080 @ 59.940063 Hz
                                            1920x1080 @ 50.000000 Hz
                                            1920x1080 @ 24.000000 Hz
                                            1920x1080 @ 23.976025 Hz
```

The logic is now this:
1) find exact resolution and exact refresh rate
2) find exact resolution and double refresh rate (if setting is enabled)
3) find exact resolution and 3:2 pulldown refresh rate (if setting is enabled)
4) use desktop resolution with exact refresh rate
5) use desktop resolution with double refresh rate (if setting is enabled)
6) use desktop resolution with 3:2 pulldown refresh rate (if setting is enabled)

We want to be able to fine tune the whitelist for individual users needs. This help accomplish that by:
1) allowing users to select __ONLY__ the modes that they want to use.
2) adding the ability to use (or not use) 3:2 pulldown refresh rates
3) adding the ability to use (or not use) double refresh rates.

__This is not a final version.__ This needs more testing by users with 4K monitors/TV's

I can't think of any other needs at this moment. If you can think of something that is not present here please let me know. Please comment if you have an unusual modeswitch that you would like to use.

We want to keep it simple to use, obvious, and functional.

for reference: https://en.wikipedia.org/wiki/Three-two_pull_down

EDIT:
The standard behavior still exists as normal. If the whitelist __doesn't contain__ any modes then kodi will do the v17 logic and match any current resolution with the an exact or double refresh rate. So most users that will never even find the whitelist won't have to concern themselves with it at all.