### PR TITLE
[PVR] Fix component dependencies: CPVRManager::IsPlayingChannel(int i…

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -655,10 +655,10 @@ bool CPVRManager::IsPlayingEpgTag(const CPVREpgInfoTagPtr &epgTag) const
   return bReturn;
 }
 
-bool CPVRManager::MatchPlayingChannel(int iClientID, int iUniqueChannelID) const
+bool CPVRManager::IsPlayingChannel(int iClientID, int iUniqueChannelID) const
 {
   if (m_playingChannel)
-    return m_playingChannel->ClientID() == iClientID && m_playingChannel->UniqueID() == iUniqueChannelID;
+    return m_playingClientId == iClientID && m_iplayingChannelUniqueID == iUniqueChannelID;
 
   return false;
 }
@@ -691,7 +691,7 @@ int CPVRManager::GetPlayingClientID(void) const
 bool CPVRManager::IsRecordingOnPlayingChannel(void) const
 {
   const CPVRChannelPtr currentChannel = GetPlayingChannel();
-  return currentChannel && CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*currentChannel);
+  return currentChannel && m_timers && m_timers->IsRecordingOnChannel(*currentChannel);
 }
 
 bool CPVRManager::CanRecordOnPlayingChannel(void) const
@@ -804,6 +804,7 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
   m_playingRecording.reset();
   m_playingEpgTag.reset();
   m_playingClientId = -1;
+  m_iplayingChannelUniqueID = -1;
   m_strPlayingClientName.clear();
 
   if (item->HasPVRChannelInfoTag())
@@ -812,6 +813,7 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
 
     m_playingChannel = channel;
     m_playingClientId = m_playingChannel->ClientID();
+    m_iplayingChannelUniqueID = m_playingChannel->UniqueID();
 
     SetPlayingGroup(channel);
 
@@ -883,18 +885,21 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
 
     m_playingChannel.reset();
     m_playingClientId = -1;
+    m_iplayingChannelUniqueID = -1;
     m_strPlayingClientName.clear();
   }
   else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag() == m_playingRecording)
   {
     m_playingRecording.reset();
     m_playingClientId = -1;
+    m_iplayingChannelUniqueID = -1;
     m_strPlayingClientName.clear();
   }
   else if (item->HasEPGInfoTag() && item->GetEPGInfoTag() == m_playingEpgTag)
   {
     m_playingEpgTag.reset();
     m_playingClientId = -1;
+    m_iplayingChannelUniqueID = -1;
     m_strPlayingClientName.clear();
   }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -248,7 +248,7 @@ namespace PVR
      * @param iUniqueChannelID The channel uid.
      * @return True on match, false if there is no match or no channel is playing.
      */
-    bool MatchPlayingChannel(int iClientID, int iUniqueChannelID) const;
+    bool IsPlayingChannel(int iClientID, int iUniqueChannelID) const;
 
     /*!
      * @brief Return the channel that is currently playing.
@@ -557,6 +557,7 @@ namespace PVR
     CPVREpgInfoTagPtr m_playingEpgTag;
     std::string m_strPlayingClientName;
     int m_playingClientId = -1;
+    int m_iplayingChannelUniqueID = -1;
 
     class CLastWatchedUpdateTimer;
     std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -219,7 +219,7 @@ void CPVREpgInfoTag::ToSortable(SortItem& sortable, Field field) const
 
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
 {
-  if (CServiceBroker::GetPVRManager().MatchPlayingChannel(ClientID(), UniqueChannelID()))
+  if (CServiceBroker::GetPVRManager().IsPlayingChannel(ClientID(), UniqueChannelID()))
   {
     // start time valid?
     time_t startTime = CServiceBroker::GetDataCacheCore().GetStartTime();


### PR DESCRIPTION
…ClientID, int iUniqueChannelID) must not call into other PVR subcomponents, as this method must be callable from *any* other PVR component.

This is a small fix that prevents a potential deadlock.

`CPVREpgInfoTag::GetCurrentPlayingTime()` -> `CPVRManager::IsPlayingChannel(int iClientID, int iUniqueChannelID)` -> `CPVRChannel::ClientID()`

=> epg subcomponent must not call channels subcomponent!

@Jalle19 good to go?