### PR TITLE
[darwin/jenkins] - bump to xcode10.2 and its SDKs for tvos, ios and macOS

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -19,25 +19,25 @@ DEPLOYED_BINARY_ADDONS="-e /addons"
 #$XBMC_PLATFORM_DIR matches the platform subdirs!
 case $XBMC_PLATFORM_DIR in
   ios)
-    DEFAULT_SDK_VERSION=11.0
+    DEFAULT_SDK_VERSION=12.2
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     DEFAULT_DARWIN_ARM_CPU="armv7"
-    DEFAULT_XCODE_APP="Xcode9.0.app"
+    DEFAULT_XCODE_APP="Xcode10.2.app"
     ;;
 
   tvos)
-    DEFAULT_SDK_VERSION=11.0
+    DEFAULT_SDK_VERSION=12.2
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
-    DEFAULT_XCODE_APP="Xcode9.0.app"
+    DEFAULT_XCODE_APP="Xcode10.2.app"
     ;;
 
   osx64)
-    DEFAULT_SDK_VERSION=10.13
+    DEFAULT_SDK_VERSION=10.14
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
-    DEFAULT_XCODE_APP="Xcode9.0.app"
+    DEFAULT_XCODE_APP="Xcode10.2.app"
     ;;
 
   android)

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1545,7 +1545,7 @@ std::vector<std::string> CVideoInfoTag::Trim(std::vector<std::string>&& items)
   std::for_each(items.begin(), items.end(), [](std::string &str){
     str = StringUtils::Trim(str);
   });
-  return items;
+  return std::move(items);
 }
 
 int CVideoInfoTag::GetPlayCount() const


### PR DESCRIPTION
As the title says.

Bump to iOS SDK 12.2, tvOS SDK 12.2 and macOS SDK 10.14.

This is also the final fix for #14994 (full screen size for iPad Pro 11").