### PR TITLE
settings: add "Dark Grey" subtitles color option

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3458,8 +3458,12 @@ msgctxt "#767"
 msgid "Grey"
 msgstr ""
 
-#empty strings from id 768 to 769
-#strings 768 and 769 reserved for more subtitle colours
+msgctxt "#768"
+msgid "Dark Grey"
+msgstr ""
+
+#empty string id 769
+#string 769 reserved for more subtitle colours
 
 msgctxt "#770"
 msgid "Error {0:d}: share not available"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -553,6 +553,7 @@
               <option label="765">5</option> <!-- Cyan -->
               <option label="766">6</option> <!-- Light grey -->
               <option label="767">7</option> <!-- Grey -->
+              <option label="768">8</option> <!-- Dark Grey -->
             </options>
           </constraints>
           <dependencies>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -62,7 +62,7 @@ CDVDOverlayCodecTX3G::CDVDOverlayCodecTX3G() : CDVDOverlayCodec("TX3G Subtitle D
 {
   m_pOverlay = NULL;
   // stupid, this comes from a static global in GUIWindowFullScreen.cpp
-  uint32_t colormap[8] = { 0xFFFFFF00, 0xFFFFFFFF, 0xFF0099FF, 0xFF00FF00, 0xFFCCFF00, 0xFF00FFFF, 0xFFE5E5E5, 0xFFC0C0C0 };
+  uint32_t colormap[9] = { 0xFFFFFF00, 0xFFFFFFFF, 0xFF0099FF, 0xFF00FF00, 0xFFCCFF00, 0xFF00FFFF, 0xFFE5E5E5, 0xFFC0C0C0, 0xFF808080 };
   m_textColor = colormap[CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_SUBTITLES_COLOR)];
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
@@ -25,14 +25,15 @@
 
 using namespace OVERLAY;
 
-static UTILS::Color colors[8] = { UTILS::COLOR::YELLOW,
+static UTILS::Color colors[9] = { UTILS::COLOR::YELLOW,
                                   UTILS::COLOR::WHITE,
                                   UTILS::COLOR::BLUE,
                                   UTILS::COLOR::BRIGHTGREEN,
                                   UTILS::COLOR::YELLOWGREEN,
                                   UTILS::COLOR::CYAN,
                                   UTILS::COLOR::LIGHTGREY,
-                                  UTILS::COLOR::GREY };
+                                  UTILS::COLOR::GREY,
+                                  UTILS::COLOR::DARKGREY };
 
 CGUITextLayout* COverlayText::GetFontLayout(const std::string &font, int color, int opacity, int height, int style,
                                             const std::string &fontcache, const std::string &fontbordercache)

--- a/xbmc/utils/Color.h
+++ b/xbmc/utils/Color.h
@@ -27,5 +27,6 @@ namespace COLOR
   static const Color BRIGHTGREEN = 0xFF00FF00;
   static const Color YELLOWGREEN = 0xFFCCFF00;
   static const Color CYAN = 0xFF00FFFF;
+  static const Color DARKGREY = 0xFF808080;
 } // namespace COLOR
 } // namespace UTILS


### PR DESCRIPTION
This can be useful when watching HDR content with subs, and "Grey" is still too bright.

## Description
This PR adds a "Dark Grey" color option for subtitles.

## Motivation and Context
When you watch HDR content with subs, the available colors may be too bright.
Adding a Dark Grey option, with the hex value of 0xFF808080 should keep the subs brightness circa 100 nits in HDR.

## How Has This Been Tested?
In Kodi 18.2, using the Dark Grey option.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
