### PR TITLE
Added more metadata to Android TV channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+This is a kodi branch to display rich metadata through Android TV's Channels
+
+Video preview:
+
+https://www.youtube.com/watch?v=Lcz5V_s6uCA
+
+Information on Kodi in general:
+
 ![Kodi Logo](docs/resources/banner.png)
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-This is a kodi branch to display rich metadata through Android TV's Channels
-
-Video preview:
-
-https://www.youtube.com/watch?v=Lcz5V_s6uCA
-
-Information on Kodi in general:
-
 ![Kodi Logo](docs/resources/banner.png)
 
 <p align="center">

--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -21,308 +21,265 @@ import android.os.HandlerThread;
 import android.widget.RelativeLayout;
 
 import java.util.ArrayList;
+import java.util.List;
 
+import @APP_PACKAGE@.channels.model.Subscription;
+import @APP_PACKAGE@.channels.model.XBMCDatabase;
 import @APP_PACKAGE@.channels.util.TvUtil;
 
-public class Main extends NativeActivity implements Choreographer.FrameCallback
-{
-  private static final String TAG = "@APP_NAME@";
+public class Main extends NativeActivity implements Choreographer.FrameCallback {
+    private static final String TAG = "Kodi";
 
-  public static Main MainActivity = null;
-  public XBMCMainView mMainView = null;
+    public static Main MainActivity = null;
+    public XBMCMainView mMainView = null;
 
-  private XBMCSettingsContentObserver mSettingsContentObserver;
-  private XBMCInputDeviceListener mInputDeviceListener;
-  private XBMCJsonRPC mJsonRPC = null;
-  private View mDecorView = null;
-  private RelativeLayout mVideoLayout = null;
-  private Handler handler = new Handler();
+    private XBMCSettingsContentObserver mSettingsContentObserver;
+    private XBMCInputDeviceListener mInputDeviceListener;
+    private XBMCJsonRPC mJsonRPC = null;
+    private View mDecorView = null;
+    private RelativeLayout mVideoLayout = null;
+    private Handler handler = new Handler();
 
-  private class DelayedIntent
-  {
-    public Intent mIntent = null;
-    public int mDelay = 0;
+    private class DelayedIntent {
+        public Intent mIntent = null;
+        public int mDelay = 0;
 
-    public DelayedIntent(Intent intent, int delay) {
-      mIntent = intent;
-      mDelay = delay;
-    }
-  }
-  private ArrayList<DelayedIntent> mDelayedIntents = new ArrayList<DelayedIntent>();
-  private boolean mPaused = true;
-
-
-  native void _onNewIntent(Intent intent);
-
-  native void _onActivityResult(int requestCode, int resultCode, Intent resultData);
-
-  native void _doFrame(long frameTimeNanos);
-
-  native void _onVisibleBehindCanceled();
-
-  private Runnable leanbackUpdateRunnable = new Runnable()
-  {
-    @Override
-    public void run()
-    {
-      Log.d(TAG, "Updating recommendations");
-      new Thread()
-      {
-        public void run()
-        {
-          mJsonRPC.updateLeanback(Main.this);
+        public DelayedIntent(Intent intent, int delay) {
+            mIntent = intent;
+            mDelay = delay;
         }
-      }.start();
-      handler.postDelayed(this, XBMCProperties.getIntProperty("xbmc.leanbackrefresh", 60 * 60) * 1000);
-    }
-  };
-
-  public Main()
-  {
-    super();
-    MainActivity = this;
-  }
-
-  public Rect getDisplayRect()
-  {
-    Rect ret = new Rect();
-    ret.top = 0;
-    ret.left = 0;
-    ret.right = 0;
-    ret.bottom = 0;
-
-    try
-    {
-      ret.right = mDecorView.getRootView().getWidth();
-      ret.bottom = mDecorView.getRootView().getHeight();
-    }
-    catch (Exception e)
-    {
     }
 
-    return ret;
-  }
+    private ArrayList<DelayedIntent> mDelayedIntents = new ArrayList<DelayedIntent>();
+    private boolean mPaused = true;
 
-  public void registerMediaButtonEventReceiver()
-  {
-    AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
-    manager.registerMediaButtonEventReceiver(new ComponentName(getPackageName(), XBMCBroadcastReceiver.class.getName()));
-  }
 
-  public void unregisterMediaButtonEventReceiver()
-  {
-    AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
-    manager.unregisterMediaButtonEventReceiver(new ComponentName(getPackageName(), XBMCBroadcastReceiver.class.getName()));
-  }
+    native void _onNewIntent(Intent intent);
 
-  @Override
-  public void onCreate(Bundle savedInstanceState)
-  {
-    System.loadLibrary("@APP_NAME_LC@");
+    native void _onActivityResult(int requestCode, int resultCode, Intent resultData);
 
-    super.onCreate(savedInstanceState);
+    native void _doFrame(long frameTimeNanos);
 
-    setContentView(R.layout.activity_main);
-    setVolumeControlStream(AudioManager.STREAM_MUSIC);
+    native void _onVisibleBehindCanceled();
 
-    mSettingsContentObserver = new XBMCSettingsContentObserver(this, handler);
-    getApplicationContext().getContentResolver().registerContentObserver(android.provider.Settings.System.CONTENT_URI, true, mSettingsContentObserver);
-
-    // Delayed Intent
-    if (getIntent().getData() != null)
-    {
-      mDelayedIntents.add(new DelayedIntent(new Intent(getIntent()), 5000));
-      getIntent().setData(null);
-    }
-
-    if (getPackageManager().hasSystemFeature("android.software.leanback"))
-    {
-      if (Build.VERSION.SDK_INT >= VERSION_CODES.O)
-        TvUtil.scheduleSyncingChannel(this);
-      else
-      {
-        // Leanback
-        mJsonRPC = new XBMCJsonRPC();
-        handler.removeCallbacks(leanbackUpdateRunnable);
-        handler.postDelayed(leanbackUpdateRunnable, 30 * 1000);
-      }
-    }
-
-    // register the InputDeviceListener implementation
-    mInputDeviceListener = new XBMCInputDeviceListener();
-    InputManager manager = (InputManager) getSystemService(INPUT_SERVICE);
-    manager.registerInputDeviceListener(mInputDeviceListener, handler);
-
-    mDecorView = getWindow().getDecorView();
-    mDecorView.setBackground(null);
-    getWindow().takeSurface(null);
-    setContentView(R.layout.activity_main);
-    mVideoLayout = (RelativeLayout) findViewById(R.id.VideoLayout);
-
-    mMainView = new XBMCMainView(this);
-    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
-    mMainView.setElevation(1);  // Always on Top
-    mVideoLayout.addView(mMainView, layoutParams);
-
-    mDecorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener()
-    {
-      @Override
-      public void onSystemUiVisibilityChange(int visibility)
-      {
-        if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0)
-        {
-          handler.post(new Runnable()
-          {
-            public void run()
-            {
-              if (android.os.Build.VERSION.SDK_INT >= 19)
-              {
-                // Immersive mode
-
-                // Constants from API > 17
-                final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
-
-                mDecorView.setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN
-                                | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-              }
-            }
-          });
-        }
-      }
-    });
-  }
-
-  @Override
-  protected void onNewIntent(Intent intent)
-  {
-    super.onNewIntent(intent);
-    // Delay until after Resume
-    if (mPaused)
-    {
-      Log.d("Main", "onNewIntent (delayed)");
-      mDelayedIntents.add(new DelayedIntent(new Intent(intent), 500));
-    }
-    else
-    {
-      Log.d("Main", "onNewIntent (immediate)");
-      _onNewIntent(intent);
-    }
-  }
-
-  @Override
-  public void onStart()
-  {
-    super.onStart();
-    mDecorView.setBackgroundColor(Color.TRANSPARENT);
-
-    Choreographer.getInstance().removeFrameCallback(this);
-    Choreographer.getInstance().postFrameCallback(this);
-  }
-
-  @Override
-  public void onResume()
-  {
-    super.onResume();
-
-    if (android.os.Build.VERSION.SDK_INT >= 19)
-    {
-      // Immersive mode
-
-      // Constants from API > 17
-      final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
-
-      mDecorView.setSystemUiVisibility(
-              View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                      | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                      | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                      | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                      | View.SYSTEM_UI_FLAG_FULLSCREEN
-                      | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-    }
-
-    // New intent ?
-    for (final DelayedIntent delayedIntent : mDelayedIntents)
-    {
-      handler.postDelayed(new Runnable()
-      {
+    private Runnable leanbackUpdateRunnable = new Runnable() {
         @Override
-        public void run()
-        {
-          try
-          {
-            _onNewIntent(delayedIntent.mIntent);
-          }
-          catch (UnsatisfiedLinkError e)
-          {
-            Log.e("Main", "Native not registered");
-          }
+        public void run() {
+            Log.d(TAG, "Updating recommendations");
+            new Thread() {
+                public void run() {
+                    mJsonRPC.updateLeanback(Main.this);
+                }
+            }.start();
+            handler.postDelayed(this, XBMCProperties.getIntProperty("xbmc.leanbackrefresh", 60 * 60) * 1000);
         }
-      }, delayedIntent.mDelay);
+    };
+
+    public Main() {
+        super();
+        MainActivity = this;
     }
-    mDelayedIntents.clear();
-    mPaused = false;
-  }
 
-  @Override
-  public void onPause()
-  {
-    super.onPause();
+    public Rect getDisplayRect() {
+        Rect ret = new Rect();
+        ret.top = 0;
+        ret.left = 0;
+        ret.right = 0;
+        ret.bottom = 0;
 
-    if (getPackageManager().hasSystemFeature("android.software.leanback") && Build.VERSION.SDK_INT >= VERSION_CODES.O)
-      TvUtil.scheduleSyncingChannel(this);
+        try {
+            ret.right = mDecorView.getRootView().getWidth();
+            ret.bottom = mDecorView.getRootView().getHeight();
+        } catch (Exception e) {
+        }
 
-    mPaused = true;
-  }
+        return ret;
+    }
 
-  @Override
-  public void onActivityResult(int requestCode, int resultCode,
-                               Intent resultData)
-  {
-    super.onActivityResult(requestCode, resultCode, resultData);
-    _onActivityResult(requestCode, resultCode, resultData);
-  }
+    public void registerMediaButtonEventReceiver() {
+        AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
+        manager.registerMediaButtonEventReceiver(new ComponentName(getPackageName(), XBMCBroadcastReceiver.class.getName()));
+    }
 
-  @Override
-  public void onDestroy()
-  {
-    // unregister the InputDeviceListener implementation
-    InputManager manager = (InputManager) getSystemService(INPUT_SERVICE);
-    manager.unregisterInputDeviceListener(mInputDeviceListener);
+    public void unregisterMediaButtonEventReceiver() {
+        AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
+        manager.unregisterMediaButtonEventReceiver(new ComponentName(getPackageName(), XBMCBroadcastReceiver.class.getName()));
+    }
 
-    getApplicationContext().getContentResolver().unregisterContentObserver(mSettingsContentObserver);
-    super.onDestroy();
-  }
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        System.loadLibrary("kodi");
 
-  @Override
-  public void onVisibleBehindCanceled()
-  {
-    _onVisibleBehindCanceled();
-    super.onVisibleBehindCanceled();
-  }
+        super.onCreate(savedInstanceState);
 
-  @Override
-  public void doFrame(long frameTimeNanos)
-  {
-    Choreographer.getInstance().postFrameCallback(this);
-    _doFrame(frameTimeNanos);
-  }
+        setContentView(R.layout.activity_main);
+        setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
-  private native void _callNative(long funcAddr, long variantAddr);
+        mSettingsContentObserver = new XBMCSettingsContentObserver(this, handler);
+        getApplicationContext().getContentResolver().registerContentObserver(android.provider.Settings.System.CONTENT_URI, true, mSettingsContentObserver);
 
-  private void runNativeOnUiThread(final long funcAddr, final long variantAddr)
-  {
-    runOnUiThread(new Runnable()
-    {
-      @Override
-      public void run()
-      {
-        _callNative(funcAddr, variantAddr);
-      }
-    });
-  }
+        // Delayed Intent
+        if (getIntent().getData() != null) {
+            mDelayedIntents.add(new DelayedIntent(new Intent(getIntent()), 5000));
+            getIntent().setData(null);
+        }
+
+        // register the InputDeviceListener implementation
+        mInputDeviceListener = new XBMCInputDeviceListener();
+        InputManager manager = (InputManager) getSystemService(INPUT_SERVICE);
+        manager.registerInputDeviceListener(mInputDeviceListener, handler);
+
+        mDecorView = getWindow().getDecorView();
+        mDecorView.setBackground(null);
+        getWindow().takeSurface(null);
+        setContentView(R.layout.activity_main);
+        mVideoLayout = (RelativeLayout) findViewById(R.id.VideoLayout);
+
+        mMainView = new XBMCMainView(this);
+        RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+        mMainView.setElevation(1);  // Always on Top
+        mVideoLayout.addView(mMainView, layoutParams);
+
+        mDecorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+            @Override
+            public void onSystemUiVisibilityChange(int visibility) {
+                if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0) {
+                    handler.post(new Runnable() {
+                        public void run() {
+                            if (android.os.Build.VERSION.SDK_INT >= 19) {
+                                // Immersive mode
+
+                                // Constants from API > 17
+                                final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
+
+                                mDecorView.setSystemUiVisibility(
+                                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                                                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                                                | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                            }
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        // Delay until after Resume
+        if (mPaused) {
+            Log.d("Main", "onNewIntent (delayed)");
+            mDelayedIntents.add(new DelayedIntent(new Intent(intent), 500));
+        } else {
+            Log.d("Main", "onNewIntent (immediate)");
+            _onNewIntent(intent);
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        mDecorView.setBackgroundColor(Color.TRANSPARENT);
+
+        Choreographer.getInstance().removeFrameCallback(this);
+        Choreographer.getInstance().postFrameCallback(this);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        if (android.os.Build.VERSION.SDK_INT >= 19) {
+            // Immersive mode
+
+            // Constants from API > 17
+            final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
+
+            mDecorView.setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_FULLSCREEN
+                            | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        }
+
+        // New intent ?
+        for (final DelayedIntent delayedIntent : mDelayedIntents) {
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        _onNewIntent(delayedIntent.mIntent);
+                    } catch (UnsatisfiedLinkError e) {
+                        Log.e("Main", "Native not registered");
+                    }
+                }
+            }, delayedIntent.mDelay);
+        }
+        mDelayedIntents.clear();
+        mPaused = false;
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        if (getPackageManager().hasSystemFeature("android.software.leanback") && Build.VERSION.SDK_INT >= VERSION_CODES.O) {
+            TvUtil.scheduleSyncingChannel(this);
+            List<Subscription> subscriptions = XBMCDatabase.getSubscriptions(this);
+
+            for (Subscription sub: subscriptions) {
+                if (sub.isAddToPlayNext()) {
+                    TvUtil.scheduleSyncingProgramsForChannel(this, sub.getChannelId());
+                }
+            }
+        }
+
+        mPaused = true;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode,
+                                 Intent resultData) {
+        super.onActivityResult(requestCode, resultCode, resultData);
+        _onActivityResult(requestCode, resultCode, resultData);
+    }
+
+    @Override
+    public void onDestroy() {
+        // unregister the InputDeviceListener implementation
+        InputManager manager = (InputManager) getSystemService(INPUT_SERVICE);
+        manager.unregisterInputDeviceListener(mInputDeviceListener);
+
+        getApplicationContext().getContentResolver().unregisterContentObserver(mSettingsContentObserver);
+        super.onDestroy();
+    }
+
+    @Override
+    public void onVisibleBehindCanceled() {
+        _onVisibleBehindCanceled();
+        super.onVisibleBehindCanceled();
+    }
+
+    @Override
+    public void doFrame(long frameTimeNanos) {
+        Choreographer.getInstance().postFrameCallback(this);
+        _doFrame(frameTimeNanos);
+    }
+
+    private native void _callNative(long funcAddr, long variantAddr);
+
+    private void runNativeOnUiThread(final long funcAddr, final long variantAddr) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                _callNative(funcAddr, variantAddr);
+            }
+        });
+    }
 }

--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -3,14 +3,19 @@ package @APP_PACKAGE@;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.TimeZone;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -37,1226 +42,1236 @@ import @APP_PACKAGE@.content.XBMCFileContentProvider;
 import @APP_PACKAGE@.model.File;
 import @APP_PACKAGE@.model.Media;
 
-public class XBMCJsonRPC
-{
-  native String _requestJSON(String request);
+public class XBMCJsonRPC {
+    native String _requestJSON(String request);
 
-  public final static String APP_NAME = "@APP_NAME@ Search";
-  public final static String COLUMN_FULL_PATH = "COLUMN_FULL_PATH";
-  public final static String COLUMN_BASE_PATH = "COLUMN_BASE_PATH";
-  public final static String COLUMN_FILENAME = "COLUMN_FILENAME";
-  public final static String COLUMN_TITLE = "COLUMN_TITLE";
-  public final static String COLUMN_TAGLINE = "COLUMN_TAGLINE";
-  public final static String COLUMN_THUMB = "COLUMN_THUMB";
-  public final static String COLUMN_FANART = "COLUMN_FANART";
-  public final static String COLUMN_ID = "COLUMN_ID";
-  public final static String COLUMN_VIEW_PROGRESS = "COLUMN_VIEW_PROGRESS";
-  public final static String COLUMN_RECOMMENDATION_REASON = "COLUMN_RECOMMENDATION_REASON";
+    public final static String APP_NAME = "Kodi Search";
+    public final static String COLUMN_FULL_PATH = "COLUMN_FULL_PATH";
+    public final static String COLUMN_BASE_PATH = "COLUMN_BASE_PATH";
+    public final static String COLUMN_FILENAME = "COLUMN_FILENAME";
+    public final static String COLUMN_TITLE = "COLUMN_TITLE";
+    public final static String COLUMN_TAGLINE = "COLUMN_TAGLINE";
+    public final static String COLUMN_THUMB = "COLUMN_THUMB";
+    public final static String COLUMN_POSTER = "COLUMN_POSTER";
+    public final static String COLUMN_FANART = "COLUMN_FANART";
+    public final static String COLUMN_ID = "COLUMN_ID";
+    public final static String COLUMN_VIEW_PROGRESS = "COLUMN_VIEW_PROGRESS";
+    public final static String COLUMN_RECOMMENDATION_REASON = "COLUMN_RECOMMENDATION_REASON";
 
-  public final static String REQ_ID_MOVIES = "1";
-  public final static String REQ_ID_SHOWS = "2";
-  public final static String REQ_ID_ALBUMS = "3";
-  public final static String REQ_ID_ARTISTS = "4";
-  public final static String REQ_ID_MOVIES_ACTOR = "5";
-  public final static String REQ_ID_SHOWS_ACTOR = "6";
+    public final static String REQ_ID_MOVIES = "1";
+    public final static String REQ_ID_SHOWS = "2";
+    public final static String REQ_ID_ALBUMS = "3";
+    public final static String REQ_ID_ARTISTS = "4";
+    public final static String REQ_ID_MOVIES_ACTOR = "5";
+    public final static String REQ_ID_SHOWS_ACTOR = "6";
 
-  private final static int MAX_ITEMS = 20;
+    private final static int MAX_ITEMS = 20;
 
-  private static String TAG = "@APP_NAME@json";
+    private static String TAG = "Kodijson";
 
-  private String m_xbmc_web_url = "http://localhost:8080";
-  private java.util.HashSet<Integer> mRecomendationIds = new java.util.HashSet<Integer>();
+    private String m_xbmc_web_url = "http://localhost:8080";
+    private java.util.HashSet<Integer> mRecomendationIds = new java.util.HashSet<Integer>();
 
-  private int MAX_RECOMMENDATIONS = 3;
+    private int MAX_RECOMMENDATIONS = 3;
 
-  private String GET_VERSION =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"JSONRPC.Version\", \"id\": 1 }";
-  private String RECOMMENDATION_MOVIES_JSON =
-                  "{\"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovies\", "
-                  + "\"params\": { \"filter\": {\"field\": \"playcount\", \"operator\": \"is\", \"value\": \"0\"}, "
-                  + "\"limits\": { \"start\" : 0, \"end\": 10}, "
-                  + "\"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\", \"file\", \"plot\"], "
-                  + "\"sort\": { \"order\": \"descending\", \"method\": \"random\", \"ignorearticle\": true } }, "
-                  + "\"id\": \"1\"}";
+    private String GET_VERSION =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"JSONRPC.Version\", \"id\": 1 }";
+    private String RECOMMENDATION_MOVIES_JSON =
+            "{\"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovies\", "
+                    + "\"params\": { \"filter\": {\"field\": \"playcount\", \"operator\": \"is\", \"value\": \"0\"}, "
+                    + "\"limits\": { \"start\" : 0, \"end\": 10}, "
+                    + "\"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\", \"file\", \"plot\"], "
+                    + "\"sort\": { \"order\": \"descending\", \"method\": \"random\", \"ignorearticle\": true } }, "
+                    + "\"id\": \"1\"}";
 
-  private String RECOMMENDATIONS_SHOWS_JSON =
-                 "{\"jsonrpc\":\"2.0\",\"method\":\"VideoLibrary.GetTVShows\",\"params\":{\"filter\":{\"and\":[{\"field\":\"playcount\",\"operator\":\"is\",\"value\":\"0\"},{\"field\":\"plot\",\"operator\":\"isnot\",\"value\":\"\"}]},\"limits\":{\"start\":0,\"end\":10},\"properties\":[\"imdbnumber\",\"title\",\"plot\",\"thumbnail\",\"fanart\", \"studio\"],\"sort\":{\"order\":\"descending\",\"method\":\"lastplayed\",\"ignorearticle\":true}},\"id\":\"1\"}";
+    private String RECOMMENDATIONS_SHOWS_JSON =
+            "{\"jsonrpc\":\"2.0\",\"method\":\"VideoLibrary.GetTVShows\",\"params\":{\"filter\":{\"and\":[{\"field\":\"playcount\",\"operator\":\"is\",\"value\":\"0\"},{\"field\":\"plot\",\"operator\":\"isnot\",\"value\":\"\"}]},\"limits\":{\"start\":0,\"end\":10},\"properties\":[\"imdbnumber\",\"title\",\"plot\",\"thumbnail\",\"fanart\", \"studio\"],\"sort\":{\"order\":\"descending\",\"method\":\"lastplayed\",\"ignorearticle\":true}},\"id\":\"1\"}";
 
-  private String RECOMMENDATIONS_ALBUMS_JSON =
-                 "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetAlbums\", \"params\": { \"limits\": { \"start\" : 0, \"end\": 3}, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"random\", \"ignorearticle\": true } }, \"id\": \"1\"}";
+    private String RECOMMENDATIONS_ALBUMS_JSON =
+            "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetAlbums\", \"params\": { \"limits\": { \"start\" : 0, \"end\": 3}, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"random\", \"ignorearticle\": true } }, \"id\": \"1\"}";
 
-  private String SEARCH_MOVIES_JSON =
-                  "{\"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovies\", "
-                  + "\"params\": { \"filter\": {%s}, "
-                  + "\"limits\": { \"start\" : 0, \"end\": 10}, "
-                  + "\"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\"], "
-                  + "\"sort\": { \"order\": \"ascending\", \"method\": \"title\", \"ignorearticle\": true } }, "
-                  + "\"id\": \"%s\"}";
+    private String SEARCH_MOVIES_JSON =
+            "{\"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovies\", "
+                    + "\"params\": { \"filter\": {%s}, "
+                    + "\"limits\": { \"start\" : 0, \"end\": 10}, "
+                    + "\"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\"], "
+                    + "\"sort\": { \"order\": \"ascending\", \"method\": \"title\", \"ignorearticle\": true } }, "
+                    + "\"id\": \"%s\"}";
 
-  private String SEARCH_SHOWS_JSON =
-           "{\"jsonrpc\":\"2.0\",\"method\":\"VideoLibrary.GetTVShows\",\"params\":{\"filter\":{%s},\"limits\":{\"start\":0,\"end\":10},\"properties\":[\"imdbnumber\",\"title\",\"plot\",\"thumbnail\",\"fanart\",\"year\"],\"sort\":{\"order\":\"descending\",\"method\":\"lastplayed\",\"ignorearticle\":true}},\"id\":\"%s\"}";
+    private String SEARCH_SHOWS_JSON =
+            "{\"jsonrpc\":\"2.0\",\"method\":\"VideoLibrary.GetTVShows\",\"params\":{\"filter\":{%s},\"limits\":{\"start\":0,\"end\":10},\"properties\":[\"imdbnumber\",\"title\",\"plot\",\"thumbnail\",\"fanart\",\"year\"],\"sort\":{\"order\":\"descending\",\"method\":\"lastplayed\",\"ignorearticle\":true}},\"id\":\"%s\"}";
 
-  private String SEARCH_ALBUMS_JSON =
-                 "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetAlbums\", \"params\": {\"filter\":{%s},\"limits\": { \"start\" : 0, \"end\": 10}, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"dateadded\", \"ignorearticle\": true } }, \"id\": \"%s\"}";
+    private String SEARCH_ALBUMS_JSON =
+            "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetAlbums\", \"params\": {\"filter\":{%s},\"limits\": { \"start\" : 0, \"end\": 10}, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"dateadded\", \"ignorearticle\": true } }, \"id\": \"%s\"}";
 
-  private String SEARCH_ARTISTS_JSON =
-                 "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetArtists\", \"params\": {\"filter\":{%s},\"limits\": { \"start\" : 0, \"end\": 10}, \"properties\" : [\"description\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"dateadded\", \"ignorearticle\": true } }, \"id\": \"%s\"}";
+    private String SEARCH_ARTISTS_JSON =
+            "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetArtists\", \"params\": {\"filter\":{%s},\"limits\": { \"start\" : 0, \"end\": 10}, \"properties\" : [\"description\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"dateadded\", \"ignorearticle\": true } }, \"id\": \"%s\"}";
 
-  private String RETRIEVE_MOVIE_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovieDetails\", \"params\": { \"movieid\" : %s, \"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\", \"file\", \"plot\", \"trailer\"] }, \"id\": \"%s\" }";
+    private String RETRIEVE_MOVIE_DETAILS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovieDetails\", \"params\": { \"movieid\" : %s, \"properties\" : [\"title\", \"genre\", \"year\", \"rating\", \"director\", \"trailer\", \"tagline\", \"plot\", \"studio\", \"mpaa\", \"imdbnumber\", \"lastplayed\", \"runtime\", \"resume\", \"fanart\", \"thumbnail\", \"art\", \"file\"] }, \"id\": \"%s\" }";
 
-  private String RETRIEVE_EPISODE_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetEpisodeDetails\", \"params\": { \"episodeid\" : %s, \"properties\" : [\"title\", \"tvshowid\", \"showtitle\", \"season\", \"episode\", \"thumbnail\", \"fanart\", \"file\"] }, \"id\": \"%s\" }";
 
-  private String RETRIEVE_TVSHOW_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetTVShowDetails\", \"params\": { \"tvshowid\" : %s, \"properties\" : [\"title\", \"studio\", \"thumbnail\", \"fanart\"] }, \"id\": \"%s\" }";
+    private String RETRIEVE_EPISODE_DETAILS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetEpisodeDetails\", \"params\": { \"episodeid\" : %s, \"properties\" : [\"title\", \"plot\", \"rating\", \"firstaired\", \"lastplayed\", \"runtime\", \"resume\", \"season\", \"episode\", \"showtitle\", \"tvshowid\", \"thumbnail\", \"fanart\", \"art\", \"file\"] }, \"id\": \"%s\" }";
 
-  private String RETRIEVE_ALBUM_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetAlbumDetails\", \"params\": { \"albumid\" : %s, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\",  \"artistid\"] }, \"id\": \"%s\" }";
+    private String RETRIEVE_TVSHOW_DETAILS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetTVShowDetails\", \"params\": { \"tvshowid\" : %s, \"properties\" : [\"title\", \"genre\", \"imdbnumber\", \"mpaa\", \"rating\", \"season\", \"studio\", \"year\", \"plot\", \"thumbnail\", \"fanart\", \"art\"] }, \"id\": \"%s\" }";
 
-  private String RETRIEVE_SONG_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetSongDetails\", \"params\": { \"songid\" : %s, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\", \"albumid\", \"artistid\", \"file\"] }, \"id\": \"%s\" }";
+    private String RETRIEVE_ALBUM_DETAILS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetAlbumDetails\", \"params\": { \"albumid\" : %s, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\",  \"artistid\"] }, \"id\": \"%s\" }";
 
-  private String RETRIEVE_MUSICVIDEO_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMusicVideoDetails\", \"params\": { \"musicvideoid\" : %s, \"properties\" : [\"title\", \"artist\", \"thumbnail\", \"fanart\", \"file\"] }, \"id\": \"%s\" }";
+    private String RETRIEVE_SONG_DETAILS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetSongDetails\", \"params\": { \"songid\" : %s, \"properties\" : [\"title\", \"displayartist\", \"thumbnail\", \"fanart\", \"albumid\", \"artistid\", \"file\"] }, \"id\": \"%s\" }";
 
-  private String RETRIEVE_FILE_ITEMS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"Files.GetDirectory\", \"params\": { \"directory\" : \"%s\" }, \"id\": \"%s\" }";
+    private String RETRIEVE_MUSICVIDEO_DETAILS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMusicVideoDetails\", \"params\": { \"musicvideoid\" : %s, \"properties\" : [\"title\", \"artist\", \"thumbnail\", \"fanart\", \"file\"] }, \"id\": \"%s\" }";
 
-  private NotificationManager mNotificationManager;
+    private String RETRIEVE_FILE_ITEMS =
+            "{ \"jsonrpc\": \"2.0\", \"method\": \"Files.GetDirectory\", \"params\": { \"directory\" : \"%s\" }, \"id\": \"%s\" }";
 
-  public XBMCJsonRPC()
-  {
-    String jsonPort = XBMCProperties.getStringProperty("xbmc.jsonPort", "8080");
-    m_xbmc_web_url = "http://localhost:" + jsonPort;
-  }
+    private NotificationManager mNotificationManager;
 
-  public String request_string(String jsonRequest)
-  {
-    try
-    {
-      return _requestJSON(jsonRequest);
+    public XBMCJsonRPC() {
+        String jsonPort = XBMCProperties.getStringProperty("xbmc.jsonPort", "8080");
+        m_xbmc_web_url = "http://localhost:" + jsonPort;
     }
-    catch (Exception e)
-    {
-      Log.e(TAG, "Failed to read JSON");
-      e.printStackTrace();
-      return null;
-    }
-    catch (UnsatisfiedLinkError e)
-    {
-      Log.e(TAG, "_requestJSON: Not available");
-      return null;
-    }
-  }
 
-  public JsonObject request_object(String jsonRequest)
-  {
-    try
-    {
-      String stringResp = request_string(jsonRequest);
-      if (stringResp == null)
-        return null;
-
-      JsonParser parser = new JsonParser();
-      JsonElement element = parser.parse(stringResp);
-      JsonObject resp = element.getAsJsonObject();
-      return resp;
-    }
-    catch (Exception e)
-    {
-      Log.e(TAG, "Failed to parse JSON");
-      e.printStackTrace();
-      return null;
-    }
-  }
-
-  public JsonArray request_array(String jsonRequest)
-  {
-    try
-    {
-      String stringResp = request_string(jsonRequest);
-      if (stringResp == null)
-        return null;
-
-      JsonParser parser = new JsonParser();
-      JsonElement element = parser.parse(stringResp);
-      JsonArray resp = element.getAsJsonArray();
-      return resp;
-    }
-    catch (Exception e)
-    {
-      Log.e(TAG, "Failed to parse JSON");
-      e.printStackTrace();
-      return null;
-    }
-  }
-
-  public Bitmap getBitmap(Context ctx, String src)
-  {
-    try
-    {
-      ContentResolver resolver = ctx.getContentResolver();
-      InputStream input = resolver.openInputStream(XBMCFileContentProvider.buildUri(src));
-      Bitmap bitmap = BitmapFactory.decodeStream(input);
-      input.close();
-      return bitmap;
-    }
-    catch (Exception e)
-    {
-      e.printStackTrace();
-      return null;
-    }
-  }
-
-  public String getDownloadUrl(String src)
-  {
-    return src;
-  }
-
-  public boolean Ping()
-  {
-    try
-    {
-      JsonObject req = request_object(GET_VERSION);
-      if (req == null || !req.has("result"))
-        return false;
-    }
-    catch (Exception e)
-    {
-      return false;
-    }
-    return true;
-  }
-
-  public Cursor search(String query)
-  {
-      String[] menuCols = new String[] {
-              BaseColumns._ID,
-              COLUMN_TITLE,
-              COLUMN_TAGLINE,
-              COLUMN_THUMB,
-              COLUMN_FANART,
-      };
-      MatrixCursor mc = new MatrixCursor(menuCols);
-
-      try
-      {
-        JsonObject req = request_object(String.format(SEARCH_MOVIES_JSON, /*"\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"", limit));*/
-        "\"or\": [" +
-        "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"originaltitle\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"set\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]"));
-
-        if (req == null || !req.has("result"))
-          return null;
-
-        JsonObject results = req.getAsJsonObject("result");
-        JsonArray movies = results.getAsJsonArray("movies");
-
-        for (int i = 0; i < movies.size(); ++i)
-        {
-          JsonObject movie = movies.get(i).getAsJsonObject();
-          mc.addRow(new Object[]{movie.get("movieid"), movie.get("title"), movie.get("tagline"), movie.get("thumbnail"), movie.get("fanart")});
+    public String request_string(String jsonRequest) {
+        try {
+            return _requestJSON(jsonRequest);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read JSON");
+            e.printStackTrace();
+            return null;
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "_requestJSON: Not available");
+            return null;
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-        return null;
-      }
+    }
 
-      try
-      {
-        JsonObject req = request_object(String.format(SEARCH_SHOWS_JSON, /*"\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"", limit));*/
-        "\"or\": [" +
-        "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]"));
+    public JsonObject request_object(String jsonRequest) {
+        try {
+            String stringResp = request_string(jsonRequest);
+            if (stringResp == null)
+                return null;
 
-        if (req == null || !req.has("result"))
-          return null;
-
-        JsonObject results = req.getAsJsonObject("result");
-        JsonArray tvshows = results.getAsJsonArray("tvshows");
-
-        for (int i = 0; i < tvshows.size(); ++i)
-        {
-          JsonObject tvshow = tvshows.get(i).getAsJsonObject();
-          mc.addRow(new Object[]{tvshow.get("movieid"), tvshow.get("title"), tvshow.get("plot"), tvshow.get("thumbnail"), tvshow.get("fanart")});
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(stringResp);
+            JsonObject resp = element.getAsJsonObject();
+            return resp;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to parse JSON");
+            e.printStackTrace();
+            return null;
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-        return null;
-      }
+    }
 
-      return mc;
-  }
+    public JsonArray request_array(String jsonRequest) {
+        try {
+            String stringResp = request_string(jsonRequest);
+            if (stringResp == null)
+                return null;
 
-  public Cursor getSuggestions(String query, int limit)
-  {
-    //Log.d(TAG, "query: " + query);
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(stringResp);
+            JsonArray resp = element.getAsJsonArray();
+            return resp;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to parse JSON");
+            e.printStackTrace();
+            return null;
+        }
+    }
 
-    int totCount = 0;
-    String[] menuCols = new String[]
-    {
-        BaseColumns._ID,
-        SearchManager.SUGGEST_COLUMN_TEXT_1,
-        SearchManager.SUGGEST_COLUMN_TEXT_2,
-        SearchManager.SUGGEST_COLUMN_ICON_1,
-        SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE,
-        SearchManager.SUGGEST_COLUMN_INTENT_ACTION,
-        SearchManager.SUGGEST_COLUMN_INTENT_DATA,
-        SearchManager.SUGGEST_COLUMN_VIDEO_WIDTH,
-        SearchManager.SUGGEST_COLUMN_VIDEO_HEIGHT,
-        SearchManager.SUGGEST_COLUMN_PRODUCTION_YEAR,
-        SearchManager.SUGGEST_COLUMN_DURATION,
-        SearchManager.SUGGEST_COLUMN_SHORTCUT_ID
-    };
-    MatrixCursor mc = new MatrixCursor(menuCols);
+    public Bitmap getBitmap(Context ctx, String src) {
+        try {
+            ContentResolver resolver = ctx.getContentResolver();
+            InputStream input = resolver.openInputStream(XBMCFileContentProvider.buildUri(src));
+            Bitmap bitmap = BitmapFactory.decodeStream(input);
+            input.close();
+            return bitmap;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 
-    String str_req = "[" +
-      String.format(SEARCH_MOVIES_JSON,
-        "\"or\": [" +
-        "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"originaltitle\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"set\", \"value\": \"" + query + "\"}]", REQ_ID_MOVIES) +
-      "," +
-      String.format(SEARCH_SHOWS_JSON,
-        "\"or\": [" +
-        "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"originaltitle\", \"value\": \"" + query + "\"}]", REQ_ID_SHOWS) +
-    "," +
-      String.format(SEARCH_ALBUMS_JSON,
-        "\"or\": [" +
-        "{\"operator\": \"contains\", \"field\": \"album\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"label\", \"value\": \"" + query + "\"}]", REQ_ID_ALBUMS) +
-    "," +
-      String.format(SEARCH_ARTISTS_JSON,
-        "\"operator\": \"contains\", \"field\": \"artist\", \"value\": \"" + query + "\"", REQ_ID_ARTISTS) +
-    "," +
-      String.format(SEARCH_MOVIES_JSON,
-        "\"or\": [" +
-         "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]", REQ_ID_MOVIES_ACTOR) +
-    "," +
-      String.format(SEARCH_SHOWS_JSON,
-        "\"or\": [" +
-        "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
-        "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]", REQ_ID_SHOWS_ACTOR) +
-    "]";
+    public String getDownloadUrl(String src) {
+        return src;
+    }
 
-    JsonArray res_array = request_array(str_req);
-    if (res_array == null)
-      return null;
+    public boolean Ping() {
+        try {
+            JsonObject req = request_object(GET_VERSION);
+            if (req == null || !req.has("result"))
+                return false;
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
 
-    int nb_movies = 0;
-    int nb_shows = 0;
-    for (int j = 0; j < res_array.size(); ++j)
-    {
-      String id;
-      JsonObject resp;
-      try
-      {
-        resp = res_array.get(j).getAsJsonObject();
-        if (resp == null)
-          continue;
+    public Cursor search(String query) {
+        String[] menuCols = new String[]{
+                BaseColumns._ID,
+                COLUMN_TITLE,
+                COLUMN_TAGLINE,
+                COLUMN_THUMB,
+                COLUMN_FANART,
+        };
+        MatrixCursor mc = new MatrixCursor(menuCols);
 
-        id = resp.get("id").getAsString();
-      }
-      catch (Exception e)
-      {
-        e.printStackTrace();
-        continue;
-      }
+        try {
+            JsonObject req = request_object(String.format(SEARCH_MOVIES_JSON, /*"\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"", limit));*/
+                    "\"or\": [" +
+                            "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
+                            "{\"operator\": \"contains\", \"field\": \"originaltitle\", \"value\": \"" + query + "\"}," +
+                            "{\"operator\": \"contains\", \"field\": \"set\", \"value\": \"" + query + "\"}," +
+                            "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
+                            "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]"));
 
-      if (id.equals(REQ_ID_MOVIES) || ((nb_movies + nb_shows) < 3 && id.equals(REQ_ID_MOVIES_ACTOR)))
-      {
-        searchmovies: try
-        {
-          if (resp == null || !resp.has("result"))
-            break searchmovies;
-          JsonObject results = resp.getAsJsonObject("result");
-          if (results == null || !results.has("movies"))
-            break searchmovies;
-          JsonArray movies = results.get("movies").getAsJsonArray();
+            if (req == null || !req.has("result"))
+                return null;
 
-          for (int i = 0; i < movies.size() && totCount < limit; ++i)
-          {
-            JsonObject movie = movies.get(i).getAsJsonObject();
+            JsonObject results = req.getAsJsonObject("result");
+            JsonArray movies = results.getAsJsonArray("movies");
 
-            int rYear = 0;
-            long rDur = 0;
-            try
-            {
-              rYear = movie.get("year").getAsInt();
-              rDur = movie.get("runtime").getAsLong() * 1000;
+            for (int i = 0; i < movies.size(); ++i) {
+                JsonObject movie = movies.get(i).getAsJsonObject();
+                mc.addRow(new Object[]{movie.get("movieid"), movie.get("title"), movie.get("tagline"), movie.get("thumbnail"), movie.get("fanart")});
             }
-            catch (Exception e)
-            {
-              e.printStackTrace();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        try {
+            JsonObject req = request_object(String.format(SEARCH_SHOWS_JSON, /*"\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"", limit));*/
+                    "\"or\": [" +
+                            "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
+                            "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
+                            "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]"));
+
+            if (req == null || !req.has("result"))
+                return null;
+
+            JsonObject results = req.getAsJsonObject("result");
+            JsonArray tvshows = results.getAsJsonArray("tvshows");
+
+            for (int i = 0; i < tvshows.size(); ++i) {
+                JsonObject tvshow = tvshows.get(i).getAsJsonObject();
+                mc.addRow(new Object[]{tvshow.get("movieid"), tvshow.get("title"), tvshow.get("plot"), tvshow.get("thumbnail"), tvshow.get("fanart")});
             }
-            mc.addRow(new Object[]
-            {
-              movie.get("movieid").getAsString(),
-              movie.get("title").getAsString(),
-              movie.get("tagline").getAsString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(movie.get("thumbnail").getAsString())).toString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(movie.get("thumbnail").getAsString())).toString(),
-              Intent.ACTION_GET_CONTENT,
-              Uri.parse("videodb://movies/titles/" + movie.get("movieid").getAsString() + "?showinfo=true"),
-              0,
-              0,
-              rYear,
-              rDur,
-              -1
-            });
-            nb_movies++;
-            totCount++;
-          }
-        } catch (Exception e)
-        {
-          e.printStackTrace();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
         }
-      }
-      else if (id.equals(REQ_ID_SHOWS) || ((nb_movies + nb_shows) < 3 && id.equals(REQ_ID_SHOWS_ACTOR)))
-      {
-        searchtv: try
-        {
-          if(!resp.has("result"))
-            break searchtv;
-          JsonObject results = resp.getAsJsonObject("result");
-          if (results == null || !results.has("tvshows"))
-            break searchtv;
-          JsonArray tvshows = results.get("tvshows").getAsJsonArray();
 
-          for (int i = 0; i < tvshows.size() && totCount < limit; ++i)
-          {
-            JsonObject tvshow = tvshows.get(i).getAsJsonObject();
+        return mc;
+    }
 
-            int rYear = 0;
-            long rDur = 0;
-            try
-            {
-              rYear = tvshow.get("year").getAsInt();
+    public Cursor getSuggestions(String query, int limit) {
+        //Log.d(TAG, "query: " + query);
+
+        int totCount = 0;
+        String[] menuCols = new String[]
+                {
+                        BaseColumns._ID,
+                        SearchManager.SUGGEST_COLUMN_TEXT_1,
+                        SearchManager.SUGGEST_COLUMN_TEXT_2,
+                        SearchManager.SUGGEST_COLUMN_ICON_1,
+                        SearchManager.SUGGEST_COLUMN_RESULT_CARD_IMAGE,
+                        SearchManager.SUGGEST_COLUMN_INTENT_ACTION,
+                        SearchManager.SUGGEST_COLUMN_INTENT_DATA,
+                        SearchManager.SUGGEST_COLUMN_VIDEO_WIDTH,
+                        SearchManager.SUGGEST_COLUMN_VIDEO_HEIGHT,
+                        SearchManager.SUGGEST_COLUMN_PRODUCTION_YEAR,
+                        SearchManager.SUGGEST_COLUMN_DURATION,
+                        SearchManager.SUGGEST_COLUMN_SHORTCUT_ID
+                };
+        MatrixCursor mc = new MatrixCursor(menuCols);
+
+        String str_req = "[" +
+                String.format(SEARCH_MOVIES_JSON,
+                        "\"or\": [" +
+                                "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
+                                "{\"operator\": \"contains\", \"field\": \"originaltitle\", \"value\": \"" + query + "\"}," +
+                                "{\"operator\": \"contains\", \"field\": \"set\", \"value\": \"" + query + "\"}]", REQ_ID_MOVIES) +
+                "," +
+                String.format(SEARCH_SHOWS_JSON,
+                        "\"or\": [" +
+                                "{\"operator\": \"contains\", \"field\": \"title\", \"value\": \"" + query + "\"}," +
+                                "{\"operator\": \"contains\", \"field\": \"originaltitle\", \"value\": \"" + query + "\"}]", REQ_ID_SHOWS) +
+                "," +
+                String.format(SEARCH_ALBUMS_JSON,
+                        "\"or\": [" +
+                                "{\"operator\": \"contains\", \"field\": \"album\", \"value\": \"" + query + "\"}," +
+                                "{\"operator\": \"contains\", \"field\": \"label\", \"value\": \"" + query + "\"}]", REQ_ID_ALBUMS) +
+                "," +
+                String.format(SEARCH_ARTISTS_JSON,
+                        "\"operator\": \"contains\", \"field\": \"artist\", \"value\": \"" + query + "\"", REQ_ID_ARTISTS) +
+                "," +
+                String.format(SEARCH_MOVIES_JSON,
+                        "\"or\": [" +
+                                "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
+                                "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]", REQ_ID_MOVIES_ACTOR) +
+                "," +
+                String.format(SEARCH_SHOWS_JSON,
+                        "\"or\": [" +
+                                "{\"operator\": \"contains\", \"field\": \"actor\", \"value\": \"" + query + "\"}," +
+                                "{\"operator\": \"contains\", \"field\": \"director\", \"value\": \"" + query + "\"}]", REQ_ID_SHOWS_ACTOR) +
+                "]";
+
+        JsonArray res_array = request_array(str_req);
+        if (res_array == null)
+            return null;
+
+        int nb_movies = 0;
+        int nb_shows = 0;
+        for (int j = 0; j < res_array.size(); ++j) {
+            String id;
+            JsonObject resp;
+            try {
+                resp = res_array.get(j).getAsJsonObject();
+                if (resp == null)
+                    continue;
+
+                id = resp.get("id").getAsString();
+            } catch (Exception e) {
+                e.printStackTrace();
+                continue;
             }
-            catch (Exception e)
-            {
-              e.printStackTrace();
+
+            if (id.equals(REQ_ID_MOVIES) || ((nb_movies + nb_shows) < 3 && id.equals(REQ_ID_MOVIES_ACTOR))) {
+                searchmovies:
+                try {
+                    if (resp == null || !resp.has("result"))
+                        break searchmovies;
+                    JsonObject results = resp.getAsJsonObject("result");
+                    if (results == null || !results.has("movies"))
+                        break searchmovies;
+                    JsonArray movies = results.get("movies").getAsJsonArray();
+
+                    for (int i = 0; i < movies.size() && totCount < limit; ++i) {
+                        JsonObject movie = movies.get(i).getAsJsonObject();
+
+                        int rYear = 0;
+                        long rDur = 0;
+                        try {
+                            rYear = movie.get("year").getAsInt();
+                            rDur = movie.get("runtime").getAsLong() * 1000;
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                        mc.addRow(new Object[]
+                                {
+                                        movie.get("movieid").getAsString(),
+                                        movie.get("title").getAsString(),
+                                        movie.get("tagline").getAsString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(movie.get("thumbnail").getAsString())).toString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(movie.get("thumbnail").getAsString())).toString(),
+                                        Intent.ACTION_GET_CONTENT,
+                                        Uri.parse("videodb://movies/titles/" + movie.get("movieid").getAsString() + "?showinfo=true"),
+                                        0,
+                                        0,
+                                        rYear,
+                                        rDur,
+                                        -1
+                                });
+                        nb_movies++;
+                        totCount++;
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else if (id.equals(REQ_ID_SHOWS) || ((nb_movies + nb_shows) < 3 && id.equals(REQ_ID_SHOWS_ACTOR))) {
+                searchtv:
+                try {
+                    if (!resp.has("result"))
+                        break searchtv;
+                    JsonObject results = resp.getAsJsonObject("result");
+                    if (results == null || !results.has("tvshows"))
+                        break searchtv;
+                    JsonArray tvshows = results.get("tvshows").getAsJsonArray();
+
+                    for (int i = 0; i < tvshows.size() && totCount < limit; ++i) {
+                        JsonObject tvshow = tvshows.get(i).getAsJsonObject();
+
+                        int rYear = 0;
+                        long rDur = 0;
+                        try {
+                            rYear = tvshow.get("year").getAsInt();
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                        mc.addRow(new Object[]
+                                {
+                                        tvshow.get("tvshowid").getAsString(),
+                                        tvshow.get("title").getAsString(),
+                                        tvshow.get("plot").getAsString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(tvshow.get("thumbnail").getAsString())).toString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(tvshow.get("thumbnail").getAsString())).toString(),
+                                        Intent.ACTION_GET_CONTENT,
+                                        Uri.parse("videodb://tvshows/titles/" + tvshow.get("tvshowid").getAsString() + "?showinfo=true"),
+                                        0,
+                                        0,
+                                        rYear,
+                                        45 * 60 * 1000,
+                                        -1
+                                });
+                        Log.d(TAG, "tvshow: " + tvshow.get("title").getAsString() + ", " + tvshow.get("year").getAsInt());
+                        nb_shows++;
+                        totCount++;
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else if (id.equals(REQ_ID_ALBUMS)) {
+                searchalbums:
+                try {
+                    if (!resp.has("result"))
+                        break searchalbums;
+                    JsonObject results = resp.getAsJsonObject("result");
+                    if (results == null || !results.has("albums"))
+                        break searchalbums;
+                    JsonArray albums = results.get("albums").getAsJsonArray();
+
+                    for (int i = 0; i < albums.size() && totCount < limit; ++i) {
+                        JsonObject album = albums.get(i).getAsJsonObject();
+                        mc.addRow(new Object[]
+                                {
+                                        album.get("albumid").getAsString(),
+                                        album.get("title").getAsString(),
+                                        album.get("displayartist").getAsString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(album.get("thumbnail").getAsString())).toString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(album.get("thumbnail").getAsString())).toString(),
+                                        Intent.ACTION_GET_CONTENT,
+                                        Uri.parse("musicdb://albums/" + album.get("albumid").getAsString() + "/"),
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        -1
+                                });
+                        totCount++;
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else if (id.equals(REQ_ID_ARTISTS)) {
+                searchartists:
+                try {
+                    if (!resp.has("result"))
+                        break searchartists;
+                    JsonObject results = resp.getAsJsonObject("result");
+                    if (results == null || !results.has("artists"))
+                        break searchartists;
+                    JsonArray artists = results.get("artists").getAsJsonArray();
+
+                    for (int i = 0; i < artists.size() && totCount < limit; ++i) {
+                        JsonObject artist = artists.get(i).getAsJsonObject();
+                        mc.addRow(new Object[]
+                                {
+                                        artist.get("artistid").getAsString(),
+                                        artist.get("artist").getAsString(),
+                                        artist.get("description").getAsString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(artist.get("thumbnail").getAsString())).toString(),
+                                        XBMCFileContentProvider.buildUri(getDownloadUrl(artist.get("thumbnail").getAsString())).toString(),
+                                        Intent.ACTION_GET_CONTENT,
+                                        Uri.parse("musicdb://artists/" + artist.get("artistid").getAsString() + "/"),
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        -1
+                                });
+                        totCount++;
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
-            mc.addRow(new Object[]
-            {
-              tvshow.get("tvshowid").getAsString(),
-              tvshow.get("title").getAsString(),
-              tvshow.get("plot").getAsString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(tvshow.get("thumbnail").getAsString())).toString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(tvshow.get("thumbnail").getAsString())).toString(),
-              Intent.ACTION_GET_CONTENT,
-              Uri.parse("videodb://tvshows/titles/" + tvshow.get("tvshowid").getAsString() + "?showinfo=true"),
-              0,
-              0,
-              rYear,
-              45*60*1000,
-              -1
-            });
-            Log.d(TAG, "tvshow: " + tvshow.get("title").getAsString() + ", " + tvshow.get("year").getAsInt());
-            nb_shows++;
-            totCount++;
-          }
-        } catch (Exception e)
-        {
-          e.printStackTrace();
         }
-      }
-      else if (id.equals(REQ_ID_ALBUMS))
-      {
-        searchalbums: try
-        {
-          if (!resp.has("result"))
-            break searchalbums;
-          JsonObject results = resp.getAsJsonObject("result");
-          if (results == null || !results.has("albums"))
-            break searchalbums;
-          JsonArray albums = results.get("albums").getAsJsonArray();
 
-          for (int i = 0; i < albums.size() && totCount < limit; ++i)
-          {
-            JsonObject album = albums.get(i).getAsJsonObject();
-            mc.addRow(new Object[]
-            {
-              album.get("albumid").getAsString(),
-              album.get("title").getAsString(),
-              album.get("displayartist").getAsString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(album.get("thumbnail").getAsString())).toString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(album.get("thumbnail").getAsString())).toString(),
-              Intent.ACTION_GET_CONTENT,
-              Uri.parse("musicdb://albums/" + album.get("albumid").getAsString() + "/"),
-              0,
-              0,
-              0,
-              0,
-              -1
-            });
-            totCount++;
-          }
-        } catch (Exception e)
-        {
-          e.printStackTrace();
-        }
-      }
-      else if (id.equals(REQ_ID_ARTISTS))
-      {
-        searchartists: try
-        {
-          if (!resp.has("result"))
-            break searchartists;
-          JsonObject results = resp.getAsJsonObject("result");
-          if (results == null || !results.has("artists"))
-            break searchartists;
-          JsonArray artists = results.get("artists").getAsJsonArray();
-
-          for (int i = 0; i < artists.size() && totCount < limit; ++i)
-          {
-            JsonObject artist = artists.get(i).getAsJsonObject();
-            mc.addRow(new Object[]
-            {
-              artist.get("artistid").getAsString(),
-              artist.get("artist").getAsString(),
-              artist.get("description").getAsString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(artist.get("thumbnail").getAsString())).toString(),
-              XBMCFileContentProvider.buildUri(getDownloadUrl(artist.get("thumbnail").getAsString())).toString(),
-              Intent.ACTION_GET_CONTENT,
-              Uri.parse("musicdb://artists/" + artist.get("artistid").getAsString() + "/"),
-              0,
-              0,
-              0,
-              0,
-              -1
-            });
-            totCount++;
-          }
-        } catch (Exception e)
-        {
-          e.printStackTrace();
-        }
-      }
+        return mc;
     }
 
-    return mc;
-  }
+    public void updateLeanback(Context ctx) {
+        if (mNotificationManager == null) {
+            mNotificationManager = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        }
+        for (Integer id : mRecomendationIds)
+            mNotificationManager.cancel(id);
+        mRecomendationIds.clear();
 
-  public void updateLeanback(Context ctx)
-  {
-    if (mNotificationManager == null)
-    {
-      mNotificationManager = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
-    }
-    for(Integer id : mRecomendationIds)
-      mNotificationManager.cancel(id);
-    mRecomendationIds.clear();
+        JsonObject rep = request_object(RECOMMENDATION_MOVIES_JSON);
+        if (rep != null && rep.has("result")) {
+            try {
+                JsonObject results = rep.getAsJsonObject("result");
+                JsonArray movies = results.get("movies").getAsJsonArray();
 
-    JsonObject rep = request_object(RECOMMENDATION_MOVIES_JSON);
-    if (rep != null && rep.has("result"))
-    {
-      try
-      {
-        JsonObject results = rep.getAsJsonObject("result");
-        JsonArray movies = results.get("movies").getAsJsonArray();
+                int count = 0;
+                for (int i = 0; i < movies.size() && count < MAX_RECOMMENDATIONS; ++i) {
+                    try {
+                        JsonObject movie = movies.get(i).getAsJsonObject();
+                        int id = movie.get("movieid").getAsInt() + 1000000;
 
-        int count = 0;
-        for (int i = 0; i < movies.size() && count < MAX_RECOMMENDATIONS; ++i)
-        {
-          try
-          {
-            JsonObject movie = movies.get(i).getAsJsonObject();
-            int id = movie.get("movieid").getAsInt() + 1000000;
+                        final XBMCRecommendationBuilder notificationBuilder = new XBMCRecommendationBuilder()
+                                .setContext(ctx)
+                                .setSmallIcon(R.drawable.notif_icon)
+                                .setId(id).setPriority(MAX_RECOMMENDATIONS - count)
+                                .setTitle(movie.get("title").getAsString())
+                                .setDescription(movie.get("plot").getAsString())
+                                .setIntent(buildPendingMovieIntent(ctx, movie));
 
-            final XBMCRecommendationBuilder notificationBuilder = new XBMCRecommendationBuilder()
-                    .setContext(ctx)
-                    .setSmallIcon(R.drawable.notif_icon)
-                    .setId(id).setPriority(MAX_RECOMMENDATIONS - count)
-                    .setTitle(movie.get("title").getAsString())
-                    .setDescription(movie.get("tagline").getAsString())
-                    .setIntent(buildPendingMovieIntent(ctx, movie));
-
-            if (movie.has("fanart") && !movie.get("fanart").getAsString().isEmpty())
-              notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
-                      getDownloadUrl(movie.get("fanart").getAsString())).toString());
-            if (movie.has("thumbnail") && !movie.get("thumbnail").getAsString().isEmpty())
-            {
-              Bitmap bitmap = getBitmap(ctx, movie.get("thumbnail").getAsString());
-              notificationBuilder.setBitmap(bitmap);
+                        if (movie.has("fanart") && !movie.get("fanart").getAsString().isEmpty())
+                            notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
+                                    getDownloadUrl(movie.get("fanart").getAsString())).toString());
+                        if (movie.has("thumbnail") && !movie.get("thumbnail").getAsString().isEmpty()) {
+                            Bitmap bitmap = getBitmap(ctx, movie.get("thumbnail").getAsString());
+                            notificationBuilder.setBitmap(bitmap);
+                        }
+                        Notification notification = notificationBuilder.build();
+                        mNotificationManager.notify(id, notification);
+                        mRecomendationIds.add(id);
+                        ++count;
+                    } catch (Exception e) {
+                        continue;
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-            Notification notification = notificationBuilder.build();
-            mNotificationManager.notify(id, notification);
-            mRecomendationIds.add(id);
-            ++count;
-          } catch (Exception e)
-          {
-            continue;
-          }
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-      }
-    }
 
-    rep = request_object(RECOMMENDATIONS_SHOWS_JSON);
-    if (rep != null && rep.has("result"))
-    {
-      try
-      {
-        JsonObject results = rep.getAsJsonObject("result");
-        JsonArray tvshows = results.get("tvshows").getAsJsonArray();
+        rep = request_object(RECOMMENDATIONS_SHOWS_JSON);
+        if (rep != null && rep.has("result")) {
+            try {
+                JsonObject results = rep.getAsJsonObject("result");
+                JsonArray tvshows = results.get("tvshows").getAsJsonArray();
 
-        int count = 0;
-        for (int i = 0; i < tvshows.size() && count < MAX_RECOMMENDATIONS; ++i)
-        {
-          try
-          {
-            JsonObject tvshow = tvshows.get(i).getAsJsonObject();
-            int id = tvshow.get("tvshowid").getAsInt() + 2000000;
+                int count = 0;
+                for (int i = 0; i < tvshows.size() && count < MAX_RECOMMENDATIONS; ++i) {
+                    try {
+                        JsonObject tvshow = tvshows.get(i).getAsJsonObject();
+                        int id = tvshow.get("tvshowid").getAsInt() + 2000000;
 
-            final XBMCRecommendationBuilder notificationBuilder = new XBMCRecommendationBuilder()
-                    .setContext(ctx)
-                    .setSmallIcon(R.drawable.notif_icon)
-                    .setId(id).setPriority(MAX_RECOMMENDATIONS - count)
-                    .setTitle(tvshow.get("title").getAsString())
-                    .setDescription(tvshow.get("plot").getAsString())
-                    .setIntent(buildPendingShowIntent(ctx, tvshow));
+                        final XBMCRecommendationBuilder notificationBuilder = new XBMCRecommendationBuilder()
+                                .setContext(ctx)
+                                .setSmallIcon(R.drawable.notif_icon)
+                                .setId(id).setPriority(MAX_RECOMMENDATIONS - count)
+                                .setTitle(tvshow.get("title").getAsString())
+                                .setDescription(tvshow.get("plot").getAsString())
+                                .setIntent(buildPendingShowIntent(ctx, tvshow));
 
-            if (tvshow.has("fanart") && !tvshow.get("fanart").getAsString().isEmpty())
-              notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
-                      getDownloadUrl(tvshow.get("fanart").getAsString())).toString());
-            if (tvshow.has("thumbnail") && !tvshow.get("thumbnail").getAsString().isEmpty())
-            {
-              Bitmap bitmap = getBitmap(ctx, tvshow.get("thumbnail").getAsString());
-              notificationBuilder.setBitmap(bitmap);
+                        if (tvshow.has("fanart") && !tvshow.get("fanart").getAsString().isEmpty())
+                            notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
+                                    getDownloadUrl(tvshow.get("fanart").getAsString())).toString());
+                        if (tvshow.has("thumbnail") && !tvshow.get("thumbnail").getAsString().isEmpty()) {
+                            Bitmap bitmap = getBitmap(ctx, tvshow.get("thumbnail").getAsString());
+                            notificationBuilder.setBitmap(bitmap);
+                        }
+                        Notification notification = notificationBuilder.build();
+                        mNotificationManager.notify(id, notification);
+                        mRecomendationIds.add(id);
+                        ++count;
+                    } catch (Exception e) {
+                        continue;
+                    }
+
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-            Notification notification = notificationBuilder.build();
-            mNotificationManager.notify(id, notification);
-            mRecomendationIds.add(id);
-            ++count;
-          } catch (Exception e)
-          {
-            continue;
-          }
-
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-      }
-    }
 
-    rep = request_object(RECOMMENDATIONS_ALBUMS_JSON);
-    if (rep != null && rep.has("result"))
-    {
-      try
-      {
-        JsonObject results = rep.getAsJsonObject("result");
-        JsonArray albums = results.get("albums").getAsJsonArray();
+        rep = request_object(RECOMMENDATIONS_ALBUMS_JSON);
+        if (rep != null && rep.has("result")) {
+            try {
+                JsonObject results = rep.getAsJsonObject("result");
+                JsonArray albums = results.get("albums").getAsJsonArray();
 
-        int count = 0;
-        for (int i = 0; i < albums.size() && count < MAX_RECOMMENDATIONS; ++i)
-        {
-          try
-          {
-            JsonObject album = albums.get(i).getAsJsonObject();
-            int id = album.get("albumid").getAsInt() + 3000000;
+                int count = 0;
+                for (int i = 0; i < albums.size() && count < MAX_RECOMMENDATIONS; ++i) {
+                    try {
+                        JsonObject album = albums.get(i).getAsJsonObject();
+                        int id = album.get("albumid").getAsInt() + 3000000;
 
-            final XBMCRecommendationBuilder notificationBuilder = new XBMCRecommendationBuilder()
-                    .setContext(ctx)
-                    .setSmallIcon(R.drawable.notif_icon)
-                    .setId(id).setPriority(MAX_RECOMMENDATIONS - count)
-                    .setTitle(album.get("title").getAsString())
-                    .setDescription(album.get("displayartist").getAsString())
-                    .setIntent(buildPendingAlbumIntent(ctx, album));
+                        final XBMCRecommendationBuilder notificationBuilder = new XBMCRecommendationBuilder()
+                                .setContext(ctx)
+                                .setSmallIcon(R.drawable.notif_icon)
+                                .setId(id).setPriority(MAX_RECOMMENDATIONS - count)
+                                .setTitle(album.get("title").getAsString())
+                                .setDescription(album.get("displayartist").getAsString())
+                                .setIntent(buildPendingAlbumIntent(ctx, album));
 
-            if (album.has("fanart") && !album.get("fanart").getAsString().isEmpty())
-              notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
-                      getDownloadUrl(album.get("fanart").getAsString())).toString());
-            if (album.has("thumbnail") && !album.get("thumbnail").getAsString().isEmpty())
-            {
-              Bitmap bitmap = getBitmap(ctx, album.get("thumbnail").getAsString());
-              notificationBuilder.setBitmap(bitmap);
+                        if (album.has("fanart") && !album.get("fanart").getAsString().isEmpty())
+                            notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
+                                    getDownloadUrl(album.get("fanart").getAsString())).toString());
+                        if (album.has("thumbnail") && !album.get("thumbnail").getAsString().isEmpty()) {
+                            Bitmap bitmap = getBitmap(ctx, album.get("thumbnail").getAsString());
+                            notificationBuilder.setBitmap(bitmap);
+                        }
+                        Notification notification = notificationBuilder.build();
+                        mNotificationManager.notify(id, notification);
+                        mRecomendationIds.add(id);
+                        ++count;
+                    } catch (Exception e) {
+                        continue;
+                    }
+
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-            Notification notification = notificationBuilder.build();
-            mNotificationManager.notify(id, notification);
-            mRecomendationIds.add(id);
-            ++count;
-          } catch (Exception e)
-          {
-            continue;
-          }
-
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-      }
+
     }
 
-  }
+    private PendingIntent buildPendingMovieIntent(Context ctx, JsonObject movie) {
+        try {
+            Intent detailsIntent = new Intent(ctx, Splash.class);
+            detailsIntent.setAction(Intent.ACTION_VIEW);
+            detailsIntent.setData(Uri.parse("videodb://movies/titles/" + movie.get("movieid").getAsString() + "?showinfo=true"));
+            //detailsIntent.putExtra(MovieDetailsActivity.MOVIE, movie);
+            //detailsIntent.putExtra(MovieDetailsActivity.NOTIFICATION_ID, id);
 
-  private PendingIntent buildPendingMovieIntent(Context ctx, JsonObject movie)
-  {
-    try
-    {
-      Intent detailsIntent = new Intent(ctx, Splash.class);
-      detailsIntent.setAction(Intent.ACTION_VIEW);
-      detailsIntent.setData(Uri.parse("videodb://movies/titles/" + movie.get("movieid").getAsString() + "?showinfo=true"));
-      //detailsIntent.putExtra(MovieDetailsActivity.MOVIE, movie);
-      //detailsIntent.putExtra(MovieDetailsActivity.NOTIFICATION_ID, id);
-
-      return PendingIntent.getActivity(ctx, 0, detailsIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-    } catch (Exception e)
-    {
-      e.printStackTrace();
-      return null;
+            return PendingIntent.getActivity(ctx, 0, detailsIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
-  }
 
-  private PendingIntent buildPendingShowIntent(Context ctx, JsonObject tvshow)
-  {
-    try
-    {
-      Intent detailsIntent = new Intent(ctx, Splash.class);
-      detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
-      detailsIntent.setData(Uri.parse("videodb://tvshows/titles/" + tvshow.get("tvshowid").getAsString() + "/"));
+    private PendingIntent buildPendingShowIntent(Context ctx, JsonObject tvshow) {
+        try {
+            Intent detailsIntent = new Intent(ctx, Splash.class);
+            detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
+            detailsIntent.setData(Uri.parse("videodb://tvshows/titles/" + tvshow.get("tvshowid").getAsString() + "/"));
 
-      return PendingIntent.getActivity(ctx, 0, detailsIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-    } catch (Exception e)
-    {
-      e.printStackTrace();
-      return null;
+            return PendingIntent.getActivity(ctx, 0, detailsIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
-  }
 
-  private PendingIntent buildPendingAlbumIntent(Context ctx, JsonObject album)
-  {
-    try
-    {
-      Intent detailsIntent = new Intent(ctx, Splash.class);
-      detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
-      detailsIntent.setData(Uri.parse("musicdb://albums/" + album.get("albumid").getAsString() + "/"));
+    private PendingIntent buildPendingAlbumIntent(Context ctx, JsonObject album) {
+        try {
+            Intent detailsIntent = new Intent(ctx, Splash.class);
+            detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
+            detailsIntent.setData(Uri.parse("musicdb://albums/" + album.get("albumid").getAsString() + "/"));
 
-      return PendingIntent.getActivity(ctx, 0, detailsIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-    } catch (Exception e)
-    {
-      e.printStackTrace();
-      return null;
+            return PendingIntent.getActivity(ctx, 0, detailsIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
-  }
 
-  public List<File> getFiles(String url)
-  {
-    List<File> files = new ArrayList<File>();
+    public List<File> getFiles(String url) {
+        List<File> files = new ArrayList<File>();
 
-    try
-    {
-      JsonObject req = request_object(String.format(RETRIEVE_FILE_ITEMS, url, "1"));
+        try {
+            JsonObject req = request_object(String.format(RETRIEVE_FILE_ITEMS, url, "1"));
 
-      if (req == null || !req.has("result"))
+            if (req == null || !req.has("result"))
+                return files;
+
+            JsonObject results = req.getAsJsonObject("result");
+            if (!results.has("files"))
+                return files;
+
+            JsonArray filesA = results.get("files").getAsJsonArray();
+
+            for (int i = 0; i < filesA.size(); ++i) {
+                JsonObject fileO = filesA.get(i).getAsJsonObject();
+                Uri uri = Uri.parse(fileO.get("file").getAsString());
+                File file = File.createFile(fileO.get("label").getAsString(), fileO.get("filetype").getAsString(), XBMCFileContentProvider.buildUri(uri.toString()).toString());
+                if (fileO.has("id"))
+                    file.setId(fileO.get("id").getAsInt());
+                if (fileO.has("type") && !fileO.get("type").getAsString().equals("unknown"))
+                    file.setMediatype(fileO.get("type").getAsString());
+
+                Log.d(TAG, "getFiles: " + file.toString());
+                files.add(file);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         return files;
-
-      JsonObject results = req.getAsJsonObject("result");
-      if (!results.has("files"))
-        return files;
-
-      JsonArray filesA = results.get("files").getAsJsonArray();
-
-      for (int i = 0; i < filesA.size(); ++i)
-      {
-        JsonObject fileO = filesA.get(i).getAsJsonObject();
-        Uri uri = Uri.parse(fileO.get("file").getAsString());
-        File file = File.createFile(fileO.get("label").getAsString(), fileO.get("filetype").getAsString(), XBMCFileContentProvider.buildUri(uri.toString()).toString());
-        if (fileO.has("id"))
-          file.setId(fileO.get("id").getAsInt());
-        if (fileO.has("type") && !fileO.get("type").getAsString().equals("unknown"))
-          file.setMediatype(fileO.get("type").getAsString());
-        files.add(file);
-      }
-    } catch (Exception e)
-    {
-      e.printStackTrace();
     }
 
-    return files;
-  }
+    private Movie createMovieFromJson(Context ctx, JsonObject details) {
+        Movie med = new Movie();
 
-  private Movie createMovieFromJson(JsonObject details)
-  {
-    Movie med = new Movie();
+        try {
+            JsonObject art = details.getAsJsonObject("art");
+            med.setId(details.get("movieid").getAsInt());
+            med.setTitle(details.get("title").getAsString());
+            med.setDescription(details.get("tagline").getAsString());
+            med.setPlot(details.get("plot").getAsString());
+            med.setCategory(Media.MEDIA_TYPE_MOVIE);
+            med.setRating(details.get("rating").getAsDouble());
+            med.setYear(details.get("year").getAsString());
+            med.setDuration(details.get("runtime").getAsInt() * 1000);
+            med.setPosition(details.getAsJsonObject("resume").get("position").getAsInt() * 1000);
 
-    try
-    {
-      med.setId(details.get("movieid").getAsInt());
-      med.setTitle(details.get("title").getAsString());
-      med.setDescription(details.get("tagline").getAsString());
-      if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("thumbnail").getAsString());
-        if (url != null && url != null && !url.isEmpty())
-          med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setCardImageAspectRatio("2:3");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setXbmcUrl("videodb://movies/titles/" + details.get("movieid").getAsString() + "?showinfo=true");
+            long lastPlayed = dateToEpoch(details.get("lastplayed").getAsString());
+            Log.d(TAG, "createMovieFromJson: lastPlayed Movie: " + lastPlayed);
+            med.setLastPlayed(lastPlayed);
 
-      /*
-      if (details.has("trailer") && !details.get("trailer").getAsString().isEmpty())
-      {
-        String trailer_url = details.get("trailer").getAsString();
-        if (trailer_url.startsWith("plugin://plugin.video.youtube"))
-        {
-          Uri u = Uri.parse(trailer_url);
-          String videoid = u.getQueryParameter("videoid");
-          String yturl = Uri.parse(m_xbmc_web_url)
-                  .buildUpon()
-                  .appendPath("addons").appendPath("webinterface.youtube-dl")
-                  .appendQueryParameter("url", "http://www.youtube.com/watch?v=" + videoid)
-                  .build()
-                  .toString();
-          med.setVideoUrl(XBMCYTDLContentProvider.GetYTDLUri(yturl).toString());
-          Log.d(TAG, "createMovieFromJson: " + med.getVideoUrl());
+            Log.d(TAG, "createMovieFromJson: " + details.toString());
+
+            Bitmap bitmap = getBitmap(ctx, details.get("thumbnail").getAsString());
+            double width = bitmap.getWidth();
+            double height = bitmap.getHeight();
+
+            if (width / height > 1.0)
+                med.setHasLandscapeArt(true);
+            else
+                med.setHasLandscapeArt(false);
+
+            if (art.has("poster") && !art.get("poster").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("poster").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                    med.setPosterImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
+
+            if (art.has("landscape") && !art.get("landscape").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("landscape").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setLandscapeImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                    med.setHasLandscapeArt(true);
+                }
+            }
+
+            if (art.has("thumb") && !art.get("thumb").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("thumb").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setThumbnailImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
+
+            if (art.has("fanart") && !art.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("fanart").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setFanartImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
+            med.setCardImageAspectRatio("2:3");
+            if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("fanart").getAsString());
+                if (url != null && url != null && !url.isEmpty())
+                    med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
+            med.setXbmcUrl("videodb://movies/titles/" + details.get("movieid").getAsString() + "?showinfo=true");
+
+//      if (details.has("trailer") && !details.get("trailer").getAsString().isEmpty())
+//      {
+//        String trailer_url = details.get("trailer").getAsString();
+//        if (trailer_url.startsWith("plugin://plugin.video.youtube"))
+//        {
+//          Uri u = Uri.parse(trailer_url);
+//          String videoid = u.getQueryParameter("videoid");
+//          String yturl = Uri.parse(m_xbmc_web_url)
+//                  .buildUpon()
+//                  .appendPath("addons").appendPath("webinterface.youtube-dl")
+//                  .appendQueryParameter("url", "http://www.youtube.com/watch?v=" + videoid)
+//                  .build()
+//                  .toString();
+//          med.setVideoUrl("https://www.youtube.com/watch?v=nN2yBBSRC78");
+//          Log.d(TAG, "createMovieFromJson: " + med.getVideoUrl());
+//        }
+//        elseF
+//          med.setVideoUrl("https://www.youtube.com/watch?v=nN2yBBSRC78");
+//      }
+
+        } catch (Exception e) {
+            Log.d(TAG, "createMovieFromJson: exception: " + e.toString());
+            return null;
         }
-        else
-          med.setVideoUrl(trailer_url);
-      }
-      */
-      med.setCategory(Media.MEDIA_TYPE_MOVIE);
 
-      med.setYear(details.get("year").getAsString());
-      med.setPlot(details.get("plot").getAsString());
-    }
-    catch (Exception e)
-    {
-      return null;
+        return med;
     }
 
-    return med;
-  }
+    private TVShow createTVShowFromJson(Context ctx, JsonObject details) {
+        TVShow med = new TVShow();
 
-  private TVShow createTVShowFromJson(JsonObject details)
-  {
-    TVShow med = new TVShow();
+        try {
+            Log.d(TAG, "createTVShowFromJson: details: " + details.toString());
+            JsonObject art = details.getAsJsonObject("art");
 
-    try
-    {
-      med.setId(details.get("tvshowid").getAsInt());
-      med.setTitle(details.get("title").getAsString());
-      JsonArray ja = details.get("studio").getAsJsonArray();
-      if (ja.size() > 0)
-        med.setDescription(ja.get(0).getAsString());
-      if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("thumbnail").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setCardImageAspectRatio("2:3");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setXbmcUrl("videodb://tvshows/titles/" + details.get("tvshowid").getAsInt() + "/");
-      med.setCategory(Media.MEDIA_TYPE_TVSHOW);
-    }
-    catch (Exception e)
-    {
-      return null;
-    }
+            med.setId(details.get("tvshowid").getAsInt());
+            med.setTitle(details.get("title").getAsString());
+            med.setYear(details.get("year").getAsInt());
+            med.setSeason(details.get("season").getAsInt());
+            med.setRating(details.get("rating").getAsLong());
+            med.setPlot(details.get("plot").getAsString());
 
-    return med;
-  }
+            if (art.has("poster") && !art.get("poster").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("poster").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setPosterImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
 
-  private TVEpisode createTVEpisodeFromJson(JsonObject details)
-  {
-    TVEpisode med = new TVEpisode();
+            if (art.has("thumb") && !art.get("thumb").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("thumb").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setThumbnailImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                    med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
 
-    try
-    {
-      med.setId(details.get("episodeid").getAsInt());
-      med.setTitle(details.get("title").getAsString());
-      med.setDescription(details.get("showtitle").getAsString());
-      if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("thumbnail").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setCardImageAspectRatio("16:9");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setXbmcUrl("videodb://tvshows/titles/" + details.get("tvshowid").getAsInt() + "/" + details.get("episodeid").getAsInt() + "?showinfo=true");
-/*
-      String url = getDownloadUrl(details.get("file").getAsString());
-      if (!url.isEmpty())
-        med.setVideoUrl(url);
-*/
-      med.setCategory(Media.MEDIA_TYPE_TVEPISODE);
+            if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty()) {
+                Bitmap bitmap = getBitmap(ctx, details.get("thumbnail").getAsString());
+                double width = bitmap.getWidth();
+                double height = bitmap.getHeight();
 
-      med.setSeason(details.get("season").getAsInt());
-      med.setEpisode(details.get("episode").getAsInt());
-    }
-    catch (Exception e)
-    {
-      return null;
-    }
+                if (width / height > 1.0)
+                    med.setHasLandscapeArt(true);
+                else
+                    med.setHasLandscapeArt(false);
+            } else {
+                med.setHasLandscapeArt(false);
+            }
 
-    return med;
-  }
+            if (art.has("landscape") && !art.get("landscape").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("landscape").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setLandscapeImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                    med.setHasLandscapeArt(true);
+                    Bitmap bitmap = getBitmap(ctx, art.get("landscape").getAsString());
+                    double width = bitmap.getWidth();
+                    double height = bitmap.getHeight();
 
-  private Album createAlbumFromJson(JsonObject details)
-  {
-    Album med = new Album();
+                    if (width / height > 1.0)
+                        med.setHasLandscapeArt(true);
+                    else
+                        med.setHasLandscapeArt(false);
+                } else {
+                    med.setHasLandscapeArt(false);
+                }
+            }
 
-    try
-    {
-      med.setId(details.get("albumid").getAsInt());
-      med.setTitle(details.get("title").getAsString());
-      med.setDescription(details.get("displayartist").getAsString());
-      if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("thumbnail").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setCardImageAspectRatio("1:1");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setXbmcUrl("musicdb://albums/" + details.get("albumid").getAsString() + "/");
-      med.setCategory(Media.MEDIA_TYPE_ALBUM);
-    }
-    catch (Exception e)
-    {
-      return null;
+                if (art.has("fanart") && !art.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("fanart").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setFanartImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
+            med.setCardImageAspectRatio("16:9");
+            if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("fanart").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
+            med.setXbmcUrl("videodb://tvshows/titles/" + details.get("tvshowid").getAsInt() + "/");
+            med.setCategory(Media.MEDIA_TYPE_TVSHOW);
+        } catch (Exception e) {
+            return null;
+        }
+
+        return med;
     }
 
-    return med;
-  }
+    private TVEpisode createTVEpisodeFromJson(Context ctx, JsonObject details) {
+        TVEpisode med = new TVEpisode();
 
-  private Song createSongFromJson(JsonObject details)
-  {
-    Song med = new Song();
+        try {
 
-    try
-    {
-      med.setId(details.get("songid").getAsInt());
-      med.setTitle(details.get("title").getAsString());
-      med.setDescription(details.get("displayartist").getAsString());
-      if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("thumbnail").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setCardImageAspectRatio("1:1");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
+            med.setCategory(Media.MEDIA_TYPE_TVEPISODE);
+            med.setSeason(details.get("season").getAsInt());
+            med.setEpisode(details.get("episode").getAsInt());
+            med.setId(details.get("episodeid").getAsInt());
+            med.setTitle(details.get("title").getAsString());
+            med.setDescription(details.get("showtitle").getAsString());
+            med.setPlot(details.get("plot").getAsString());
+            med.setRating(details.get("rating").getAsLong());
+            med.setYear(details.get("firstaired").getAsString());
+            med.setRuntime(details.get("runtime").getAsInt() * 1000);
+            med.setPosition(details.getAsJsonObject("resume").get("position").getAsInt() * 1000);
 
-      String extension = "";
-      if (details.has("file") && !details.get("file").getAsString().isEmpty())
-      {
-        String file = details.get("file").getAsString();
-        extension = file.substring(file.lastIndexOf("."));
-      }
+            long lastPlayed = dateToEpoch(details.get("lastplayed").getAsString());
+            med.setLastPlayed(lastPlayed);
 
-      if (details.has("albumid") && !details.get("albumid").getAsString().isEmpty())
-        med.setXbmcUrl("musicdb://albums/" + details.get("albumid").getAsString() + "/" + details.get("songid").getAsInt() + extension);
-      else
-        med.setXbmcUrl("musicdb://songs/" + details.get("songid").getAsInt() + extension);
+            long releasedDateAsEpoch = dateToEpoch(med.getYear()+" 00:00:00");
+            med.setReleaseDate(releasedDateAsEpoch);
 
+            Log.d(TAG, "createTVEpisodeFromJson: " + details.toString());
+
+            JsonObject art = details.getAsJsonObject("art");
+            if (art.has("season.poster") && !art.get("season.poster").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("season.poster").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setPosterImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                    med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
+
+            if (art.has("tvshow.poster") && !art.get("tvshow.poster").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("tvshow.poster").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setTvShowPosterImagerUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
+
+            if (art.has("tvshow.landscape") && !art.get("tvshow.landscape").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("tvshow.landscape").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setLandscapeImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                    med.setHasLandscapeArt(true);
+                }
+            }
+
+//            if (art.has("thumb") && !art.get("thumb").getAsString().isEmpty()) {
+//                String url = getDownloadUrl(art.get("thumb").getAsString());
+//                if (url != null && url != null && !url.isEmpty()) {
+//                    med.setThumbnailImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+//                }
+//            }
+
+//            Bitmap bitmap = getBitmap(ctx, art.get("thumb").getAsString());
+//            double width = bitmap.getWidth();
+//            double height = bitmap.getHeight();
+//
+//            if (width / height > 1.0)
+//                med.setHasLandscapeArt(true);
+
+            med.setCardImageAspectRatio("2:3");
+            if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("fanart").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
+            med.setXbmcUrl("videodb://tvshows/titles/" + details.get("tvshowid").getAsInt() + "/" + details.get("episodeid").getAsInt() + "?showinfo=true");
 /*
       String url = getDownloadUrl(details.get("file").getAsString());
       if (!url.isEmpty())
         med.setVideoUrl(url);
 */
 
-      med.setCategory(Media.MEDIA_TYPE_SONG);
+        } catch (Exception e) {
+            Log.d(TAG, "createTVEpisodeFromJson: exception: " + e.toString());
+            e.printStackTrace();
+            return null;
+        }
+        Log.d(TAG, "createTVEpisodeFromJson: returning :" + med.toString());
+        return med;
     }
-    catch (Exception e)
-    {
-      return null;
+
+    private Album createAlbumFromJson(JsonObject details) {
+        Album med = new Album();
+
+        try {
+            med.setId(details.get("albumid").getAsInt());
+            med.setTitle(details.get("title").getAsString());
+            med.setDescription(details.get("displayartist").getAsString());
+            if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("thumbnail").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
+            med.setCardImageAspectRatio("1:1");
+            if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("fanart").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
+            med.setXbmcUrl("musicdb://albums/" + details.get("albumid").getAsString() + "/");
+            med.setCategory(Media.MEDIA_TYPE_ALBUM);
+        } catch (Exception e) {
+            return null;
+        }
+
+        return med;
     }
 
-    return med;
-  }
+    private Song createSongFromJson(JsonObject details) {
+        Song med = new Song();
 
-  private MusicVideo createMusicvideoFromJson(JsonObject details)
-  {
-    MusicVideo med = new MusicVideo();
+        try {
+            med.setId(details.get("songid").getAsInt());
+            med.setTitle(details.get("title").getAsString());
+            med.setDescription(details.get("displayartist").getAsString());
+            if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("thumbnail").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
+            med.setCardImageAspectRatio("1:1");
+            if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("fanart").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+            }
 
-    try
-    {
-      med.setId(details.get("musicvideoid").getAsInt());
-      med.setTitle(details.get("title").getAsString());
-      JsonArray ja = details.get("artist").getAsJsonArray();
-      if (ja.size() > 0)
-        med.setDescription(ja.get(0).getAsString());
-      if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("thumbnail").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
-      med.setCardImageAspectRatio("1:1");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
-      {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-      }
+            String extension = "";
+            if (details.has("file") && !details.get("file").getAsString().isEmpty()) {
+                String file = details.get("file").getAsString();
+                extension = file.substring(file.lastIndexOf("."));
+            }
 
-      med.setXbmcUrl("videodb://musicvideos/titles/" + details.get("musicvideoid").getAsInt());
+            if (details.has("albumid") && !details.get("albumid").getAsString().isEmpty())
+                med.setXbmcUrl("musicdb://albums/" + details.get("albumid").getAsString() + "/" + details.get("songid").getAsInt() + extension);
+            else
+                med.setXbmcUrl("musicdb://songs/" + details.get("songid").getAsInt() + extension);
 
+/*
       String url = getDownloadUrl(details.get("file").getAsString());
-      if (url != null && !url.isEmpty())
-        med.setVideoUrl(XBMCFileContentProvider.buildUri(url).toString());
+      if (!url.isEmpty())
+        med.setVideoUrl(url);
+*/
 
-      med.setCategory(Media.MEDIA_TYPE_MUSICVIDEO);
-    }
-    catch (Exception e)
-    {
-      return null;
-    }
-
-    return med;
-  }
-
-  public List<Media> getSuggestions()
-  {
-    List<Media> medias = new ArrayList<Media>();
-
-    JsonObject rep = request_object(RECOMMENDATION_MOVIES_JSON);
-    if (rep != null && rep.has("result"))
-    {
-      try
-      {
-        JsonObject results = rep.getAsJsonObject("result");
-        if (results.has("movies"))
-        {
-          JsonArray movies = results.get("movies").getAsJsonArray();
-
-          int count = 0;
-          for (int i = 0; i < movies.size() && count < MAX_RECOMMENDATIONS; ++i)
-          {
-            try
-            {
-              JsonObject details = movies.get(i).getAsJsonObject();
-              Movie med = createMovieFromJson(details);
-              if (med != null)
-              {
-                medias.add(med);
-                ++count;
-              }
-            }
-            catch (Exception e)
-            {
-              continue;
-            }
-          }
+            med.setCategory(Media.MEDIA_TYPE_SONG);
+        } catch (Exception e) {
+            return null;
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-      }
+
+        return med;
     }
 
-    rep = request_object(RECOMMENDATIONS_SHOWS_JSON);
-    if (rep != null && rep.has("result"))
-    {
-      try
-      {
-        JsonObject results = rep.getAsJsonObject("result");
-        if (results.has("tvshows"))
-        {
-          JsonArray tvshows = results.get("tvshows").getAsJsonArray();
+    private MusicVideo createMusicvideoFromJson(JsonObject details) {
+        MusicVideo med = new MusicVideo();
 
-          int count = 0;
-          for (int i = 0; i < tvshows.size() && count < MAX_RECOMMENDATIONS; ++i)
-          {
-            try
-            {
-              JsonObject tvshow = tvshows.get(i).getAsJsonObject();
-              TVShow med = createTVShowFromJson(tvshow);
-              if (med != null)
-              {
-                medias.add(med);
-                ++count;
-              }
+        try {
+            med.setId(details.get("musicvideoid").getAsInt());
+            med.setTitle(details.get("title").getAsString());
+            JsonArray ja = details.get("artist").getAsJsonArray();
+            if (ja.size() > 0)
+                med.setDescription(ja.get(0).getAsString());
+            if (details.has("thumbnail") && !details.get("thumbnail").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("thumbnail").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
             }
-            catch (Exception e)
-            {
-              continue;
+            med.setCardImageAspectRatio("1:1");
+            if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {
+                String url = getDownloadUrl(details.get("fanart").getAsString());
+                if (url != null && !url.isEmpty())
+                    med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
             }
-          }
+
+            med.setXbmcUrl("videodb://musicvideos/titles/" + details.get("musicvideoid").getAsInt());
+
+            String url = getDownloadUrl(details.get("file").getAsString());
+            if (url != null && !url.isEmpty())
+                med.setVideoUrl(XBMCFileContentProvider.buildUri(url).toString());
+
+            med.setCategory(Media.MEDIA_TYPE_MUSICVIDEO);
+        } catch (Exception e) {
+            return null;
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-      }
+
+        return med;
     }
 
-    rep = request_object(RECOMMENDATIONS_ALBUMS_JSON);
-    if (rep != null && rep.has("result"))
-    {
-      try
-      {
-        JsonObject results = rep.getAsJsonObject("result");
-        if (results.has("albums"))
-        {
-          JsonArray albums = results.get("albums").getAsJsonArray();
+    public List<Media> getSuggestions(Context ctx) {
+        List<Media> medias = new ArrayList<Media>();
 
-          int count = 0;
-          for (int i = 0; i < albums.size() && count < MAX_RECOMMENDATIONS; ++i)
-          {
-            try
-            {
-              JsonObject album = albums.get(i).getAsJsonObject();
-              Album med = createAlbumFromJson(album);
-              if (med != null)
-              {
-                medias.add(med);
-                ++count;
-              }
+        JsonObject rep = request_object(RECOMMENDATION_MOVIES_JSON);
+        if (rep != null && rep.has("result")) {
+            try {
+                JsonObject results = rep.getAsJsonObject("result");
+                if (results.has("movies")) {
+                    JsonArray movies = results.get("movies").getAsJsonArray();
+
+                    int count = 0;
+                    for (int i = 0; i < movies.size() && count < MAX_RECOMMENDATIONS; ++i) {
+                        try {
+                            JsonObject details = movies.get(i).getAsJsonObject();
+                            Movie med = createMovieFromJson(ctx, details);
+                            if (med != null) {
+                                medias.add(med);
+                                ++count;
+                            }
+                        } catch (Exception e) {
+                            continue;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-            catch (Exception e)
-            {
-              continue;
-            }
-          }
         }
-      } catch (Exception e)
-      {
-        e.printStackTrace();
-      }
-    }
 
-    return medias;
-  }
+        rep = request_object(RECOMMENDATIONS_SHOWS_JSON);
+        if (rep != null && rep.has("result")) {
+            try {
+                JsonObject results = rep.getAsJsonObject("result");
+                if (results.has("tvshows")) {
+                    JsonArray tvshows = results.get("tvshows").getAsJsonArray();
 
-  public List<Media> getMedias(List<File> files)
-  {
-    List<Media> medias = new ArrayList<Media>();
+                    int count = 0;
+                    for (int i = 0; i < tvshows.size() && count < MAX_RECOMMENDATIONS; ++i) {
+                        try {
+                            JsonObject tvshow = tvshows.get(i).getAsJsonObject();
+                            TVShow med = createTVShowFromJson(ctx, tvshow);
+                            if (med != null) {
+                                medias.add(med);
+                                ++count;
+                            }
+                        } catch (Exception e) {
+                            continue;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
 
-    try
-    {
-      int nbItems = 0;
-      String strReq = "[";
-      for (int i = 0; i < files.size()  && nbItems < MAX_ITEMS; ++i)
-      {
-        File file = files.get(i);
-        String mediaType = file.getMediatype();
-        long mediaId = file.getId();
-        if (mediaType.equals("movie"))
-          strReq += String.format(RETRIEVE_MOVIE_DETAILS, mediaId, String.valueOf(++nbItems));
-        else if (mediaType.equals("episode"))
-          strReq += String.format(RETRIEVE_EPISODE_DETAILS, mediaId, String.valueOf(++nbItems));
-        else if (mediaType.equals("tvshow"))
-          strReq += String.format(RETRIEVE_TVSHOW_DETAILS, mediaId, String.valueOf(++nbItems));
-        else if (mediaType.equals("album"))
-          strReq += String.format(RETRIEVE_ALBUM_DETAILS, mediaId, String.valueOf(++nbItems));
-        else if (mediaType.equals("song"))
-          strReq += String.format(RETRIEVE_SONG_DETAILS, mediaId, String.valueOf(++nbItems));
-        else if (mediaType.equals("musicvideo"))
-          strReq += String.format(RETRIEVE_MUSICVIDEO_DETAILS, mediaId, String.valueOf(++nbItems));
+        rep = request_object(RECOMMENDATIONS_ALBUMS_JSON);
+        if (rep != null && rep.has("result")) {
+            try {
+                JsonObject results = rep.getAsJsonObject("result");
+                if (results.has("albums")) {
+                    JsonArray albums = results.get("albums").getAsJsonArray();
 
-        if (i+1 < files.size()  && nbItems < MAX_ITEMS)
-          strReq += ",";
-      }
-      strReq += "]";
+                    int count = 0;
+                    for (int i = 0; i < albums.size() && count < MAX_RECOMMENDATIONS; ++i) {
+                        try {
+                            JsonObject album = albums.get(i).getAsJsonObject();
+                            Album med = createAlbumFromJson(album);
+                            if (med != null) {
+                                medias.add(med);
+                                ++count;
+                            }
+                        } catch (Exception e) {
+                            continue;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
 
-      JsonArray reqBatch = request_array(strReq);
-      if (reqBatch == null)
         return medias;
-
-      nbItems = 0;
-      for (int i = 0; i < reqBatch.size(); ++i)
-      {
-        JsonObject req = reqBatch.get(i).getAsJsonObject();
-        if (req == null || !req.has("result"))
-          continue;
-
-        File file = files.get(i);
-        String mediaType = file.getMediatype();
-        if (mediaType.equals("movie"))
-        {
-          JsonObject details = req.getAsJsonObject("result").getAsJsonObject("moviedetails");
-          Movie med = createMovieFromJson(details);
-          if (med != null)
-          {
-            medias.add(med);
-            nbItems++;
-          }
-        }
-        else if (mediaType.equals("episode"))
-        {
-          JsonObject details = req.getAsJsonObject("result").getAsJsonObject("episodedetails");
-          TVEpisode med = createTVEpisodeFromJson(details);
-          if (med != null)
-          {
-            medias.add(med);
-            nbItems++;
-          }
-        }
-        else if (mediaType.equals("tvshow"))
-        {
-          JsonObject details = req.getAsJsonObject("result").getAsJsonObject("tvshowdetails");
-          TVShow med = createTVShowFromJson(details);
-          medias.add(med);
-          nbItems++;
-        }
-        else if (mediaType.equals("album"))
-        {
-          JsonObject details = req.getAsJsonObject("result").getAsJsonObject("albumdetails");
-          Album med = createAlbumFromJson(details);
-          medias.add(med);
-          nbItems++;
-        }
-        else if (mediaType.equals("song"))
-        {
-          JsonObject details = req.getAsJsonObject("result").getAsJsonObject("songdetails");
-          Song med = createSongFromJson(details);
-          medias.add(med);
-          nbItems++;
-        }
-        else if (mediaType.equals("musicvideo"))
-        {
-          JsonObject details = req.getAsJsonObject("result").getAsJsonObject("musicvideodetails");
-          MusicVideo med = createMusicvideoFromJson(details);
-          medias.add(med);
-          nbItems++;
-        }
-      }
-    } catch (Exception e)
-    {
-      e.printStackTrace();
     }
 
-    return medias;
-  }
+    public List<Media> getMedias(Context ctx, List<File> files) {
+        List<Media> medias = new ArrayList<Media>();
+
+        try {
+            int nbItems = 0;
+            String strReq = "[";
+            for (int i = 0; i < files.size() && nbItems < MAX_ITEMS; ++i) {
+                File file = files.get(i);
+                String mediaType = file.getMediatype();
+                long mediaId = file.getId();
+                if (mediaType.equals("movie"))
+                    strReq += String.format(RETRIEVE_MOVIE_DETAILS, mediaId, String.valueOf(++nbItems));
+                else if (mediaType.equals("episode"))
+                    strReq += String.format(RETRIEVE_EPISODE_DETAILS, mediaId, String.valueOf(++nbItems));
+                else if (mediaType.equals("tvshow"))
+                    strReq += String.format(RETRIEVE_TVSHOW_DETAILS, mediaId, String.valueOf(++nbItems));
+                else if (mediaType.equals("album"))
+                    strReq += String.format(RETRIEVE_ALBUM_DETAILS, mediaId, String.valueOf(++nbItems));
+                else if (mediaType.equals("song"))
+                    strReq += String.format(RETRIEVE_SONG_DETAILS, mediaId, String.valueOf(++nbItems));
+                else if (mediaType.equals("musicvideo"))
+                    strReq += String.format(RETRIEVE_MUSICVIDEO_DETAILS, mediaId, String.valueOf(++nbItems));
+
+                if (i + 1 < files.size() && nbItems < MAX_ITEMS)
+                    strReq += ",";
+            }
+            strReq += "]";
+            JsonArray reqBatch = request_array(strReq);
+            if (reqBatch == null)
+                return medias;
+
+            nbItems = 0;
+            String lastTitle = "";
+            long lowestRating = 0;
+            for (int i = 0; i < reqBatch.size(); ++i) {
+                JsonObject req = reqBatch.get(i).getAsJsonObject();
+                if (req == null || !req.has("result"))
+                    continue;
+
+                File file = files.get(i);
+                String mediaType = file.getMediatype();
+                Log.d(TAG, "getMedias: mediaType: " + mediaType);
+                if (mediaType.equals("movie")) {
+                    JsonObject details = req.getAsJsonObject("result").getAsJsonObject("moviedetails");
+
+                    Log.d(TAG, "getMedias: " + details.toString());
+
+                    Movie med = createMovieFromJson(ctx, details);
+                    if (med != null) {
+                        medias.add(med);
+                        nbItems++;
+                    }
+
+                } else if (mediaType.equals("episode")) {
+                    Log.d(TAG, "getMedias: getEpisode");
+                    JsonObject details = req.getAsJsonObject("result").getAsJsonObject("episodedetails");
+                    TVEpisode med = createTVEpisodeFromJson(ctx, details);
+
+                    if (med != null && med.getDescription().equals(lastTitle)) {
+                        if (med.getRating() < lowestRating) {
+                            medias.add(med);
+                            nbItems++;
+                        }
+                    } else if (med != null) {
+                        Log.d(TAG, "getMedias: tvshow is not null");
+                        medias.add(med);
+                        nbItems++;
+                    } else {
+                        Log.d(TAG, "getMedias: tvshow is null");
+                    }
+
+//                    Log.d(TAG, "getMedias: " + med.toString());
+//                    if (med != null) {
+//                        Log.d(TAG, "getMedias: tvshow is not null");
+//                        medias.add(med);
+//                        nbItems++;
+//                    } else {
+//                        Log.d(TAG, "getMedias: tvshow is null");
+//                    }
+
+                } else if (mediaType.equals("tvshow")) {
+                    JsonObject details = req.getAsJsonObject("result").getAsJsonObject("tvshowdetails");
+                    TVShow med = createTVShowFromJson(ctx, details);
+                    if (med != null) {
+                        medias.add(med);
+                        nbItems++;
+                    }
+                } else if (mediaType.equals("album")) {
+                    JsonObject details = req.getAsJsonObject("result").getAsJsonObject("albumdetails");
+                    Album med = createAlbumFromJson(details);
+                    medias.add(med);
+                    nbItems++;
+                } else if (mediaType.equals("song")) {
+                    JsonObject details = req.getAsJsonObject("result").getAsJsonObject("songdetails");
+                    Song med = createSongFromJson(details);
+                    medias.add(med);
+                    nbItems++;
+                } else if (mediaType.equals("musicvideo")) {
+                    JsonObject details = req.getAsJsonObject("result").getAsJsonObject("musicvideodetails");
+                    MusicVideo med = createMusicvideoFromJson(details);
+                    medias.add(med);
+                    nbItems++;
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return medias;
+    }
+
+    private long dateToEpoch(String date) throws ParseException {
+        if (date.equals("")) {
+            return 0;
+        }
+        @SuppressLint("SimpleDateFormat") SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        df.setTimeZone(TimeZone.getTimeZone("GMT-04:00"));
+        Date parsedDate = df.parse(date);
+        return parsedDate.getTime();
+    }
 }

--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -858,7 +858,7 @@ public class XBMCJsonRPC {
                 }
             }
 
-                if (art.has("fanart") && !art.get("fanart").getAsString().isEmpty()) {
+            if (art.has("fanart") && !art.get("fanart").getAsString().isEmpty()) {
                 String url = getDownloadUrl(art.get("fanart").getAsString());
                 if (url != null && url != null && !url.isEmpty()) {
                     med.setFanartImageUrl(XBMCFileContentProvider.buildUri(url).toString());
@@ -899,8 +899,10 @@ public class XBMCJsonRPC {
             long lastPlayed = dateToEpoch(details.get("lastplayed").getAsString());
             med.setLastPlayed(lastPlayed);
 
-            long releasedDateAsEpoch = dateToEpoch(med.getYear()+" 00:00:00");
-            med.setReleaseDate(releasedDateAsEpoch);
+            if (details.has("firstaired") && !details.get("firstaired").getAsString().isEmpty()) {
+                long releasedDateAsEpoch = dateToEpoch(med.getYear() + " 00:00:00");
+                med.setReleaseDate(releasedDateAsEpoch);
+            }
 
             Log.d(TAG, "createTVEpisodeFromJson: " + details.toString());
 
@@ -1186,8 +1188,6 @@ public class XBMCJsonRPC {
                 return medias;
 
             nbItems = 0;
-            String lastTitle = "";
-            long lowestRating = 0;
             for (int i = 0; i < reqBatch.size(); ++i) {
                 JsonObject req = reqBatch.get(i).getAsJsonObject();
                 if (req == null || !req.has("result"))
@@ -1198,9 +1198,6 @@ public class XBMCJsonRPC {
                 Log.d(TAG, "getMedias: mediaType: " + mediaType);
                 if (mediaType.equals("movie")) {
                     JsonObject details = req.getAsJsonObject("result").getAsJsonObject("moviedetails");
-
-                    Log.d(TAG, "getMedias: " + details.toString());
-
                     Movie med = createMovieFromJson(ctx, details);
                     if (med != null) {
                         medias.add(med);
@@ -1208,24 +1205,12 @@ public class XBMCJsonRPC {
                     }
 
                 } else if (mediaType.equals("episode")) {
-                    Log.d(TAG, "getMedias: getEpisode");
                     JsonObject details = req.getAsJsonObject("result").getAsJsonObject("episodedetails");
                     TVEpisode med = createTVEpisodeFromJson(ctx, details);
-
-//                    if (med != null && med.getDescription().equals(lastTitle)) {
-//                        if (med.getRating() < lowestRating) {
-//                            medias.add(med);
-//                            nbItems++;
-//                        }
-//                    } else
-                        if (med != null) {
-                        Log.d(TAG, "getMedias: tvshow is not null");
+                    if (med != null) {
                         medias.add(med);
                         nbItems++;
-                    } else {
-                        Log.d(TAG, "getMedias: tvshow is null");
                     }
-
                 } else if (mediaType.equals("tvshow")) {
                     JsonObject details = req.getAsJsonObject("result").getAsJsonObject("tvshowdetails");
                     TVShow med = createTVShowFromJson(ctx, details);

--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -928,19 +928,19 @@ public class XBMCJsonRPC {
                 }
             }
 
-//            if (art.has("thumb") && !art.get("thumb").getAsString().isEmpty()) {
-//                String url = getDownloadUrl(art.get("thumb").getAsString());
-//                if (url != null && url != null && !url.isEmpty()) {
-//                    med.setThumbnailImageUrl(XBMCFileContentProvider.buildUri(url).toString());
-//                }
-//            }
+            if (art.has("thumb") && !art.get("thumb").getAsString().isEmpty()) {
+                String url = getDownloadUrl(art.get("thumb").getAsString());
+                if (url != null && url != null && !url.isEmpty()) {
+                    med.setThumbnailImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+                }
+            }
 
-//            Bitmap bitmap = getBitmap(ctx, art.get("thumb").getAsString());
-//            double width = bitmap.getWidth();
-//            double height = bitmap.getHeight();
-//
-//            if (width / height > 1.0)
-//                med.setHasLandscapeArt(true);
+            Bitmap bitmap = getBitmap(ctx, art.get("thumb").getAsString());
+            double width = bitmap.getWidth();
+            double height = bitmap.getHeight();
+
+            if (width / height > 1.0)
+                med.setHasLandscapeArt(true);
 
             med.setCardImageAspectRatio("2:3");
             if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {

--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -934,13 +934,13 @@ public class XBMCJsonRPC {
                     med.setThumbnailImageUrl(XBMCFileContentProvider.buildUri(url).toString());
                 }
             }
-
-            Bitmap bitmap = getBitmap(ctx, art.get("thumb").getAsString());
-            double width = bitmap.getWidth();
-            double height = bitmap.getHeight();
-
-            if (width / height > 1.0)
-                med.setHasLandscapeArt(true);
+//
+//            Bitmap bitmap = getBitmap(ctx, art.get("thumb").getAsString());
+//            double width = bitmap.getWidth();
+//            double height = bitmap.getHeight();
+//
+//            if (width / height > 1.0)
+//                med.setHasLandscapeArt(true);
 
             med.setCardImageAspectRatio("2:3");
             if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty()) {

--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -1212,27 +1212,19 @@ public class XBMCJsonRPC {
                     JsonObject details = req.getAsJsonObject("result").getAsJsonObject("episodedetails");
                     TVEpisode med = createTVEpisodeFromJson(ctx, details);
 
-                    if (med != null && med.getDescription().equals(lastTitle)) {
-                        if (med.getRating() < lowestRating) {
-                            medias.add(med);
-                            nbItems++;
-                        }
-                    } else if (med != null) {
+//                    if (med != null && med.getDescription().equals(lastTitle)) {
+//                        if (med.getRating() < lowestRating) {
+//                            medias.add(med);
+//                            nbItems++;
+//                        }
+//                    } else
+                        if (med != null) {
                         Log.d(TAG, "getMedias: tvshow is not null");
                         medias.add(med);
                         nbItems++;
                     } else {
                         Log.d(TAG, "getMedias: tvshow is null");
                     }
-
-//                    Log.d(TAG, "getMedias: " + med.toString());
-//                    if (med != null) {
-//                        Log.d(TAG, "getMedias: tvshow is not null");
-//                        medias.add(med);
-//                        nbItems++;
-//                    } else {
-//                        Log.d(TAG, "getMedias: tvshow is null");
-//                    }
 
                 } else if (mediaType.equals("tvshow")) {
                     JsonObject details = req.getAsJsonObject("result").getAsJsonObject("tvshowdetails");

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -152,42 +152,34 @@ public class SyncChannelJobService extends JobService {
 
 
 
-            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.channel_icon_main);
-            freshsubscriptions.add(sub);
-            if (subscriptions.size() == 0)  // First-run: Add default channel
-            {
-                long channelId = TvUtil.createChannel(mContext, sub);
-                sub.setChannelId(channelId);
-                subscriptions.add(sub);
-
-                TvContractCompat.requestChannelBrowsable(mContext, channelId);
-            }
-
-            for (File file : playlistsContent) {
-                int channelLogo;
-                if (file.getName().toLowerCase().contains("movies")) {
-                    Log.d(TAG, "doInBackground: movie icon");
-                    channelLogo = R.drawable.channel_icon_movies;
-                } else if (file.getName().toLowerCase().contains("tv")
-                        || file.getName().toLowerCase().contains("episodes")) {
-                    channelLogo = R.drawable.channel_icon_tv;
-                    Log.d(TAG, "doInBackground: tv icon");
-                } else {
-                    channelLogo = R.drawable.channel_icon_main;
-                    Log.d(TAG, "doInBackground: main icon");
-                }
-                sub = Subscription.createSubscription(file.getName(), file.getUri(), channelLogo);
-
-                int subidx = subscriptions.indexOf(sub);
-                if (subidx == -1) {
+            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.ic_recommendation_80dp);
+                  freshsubscriptions.add(sub);
+                  if (subscriptions.size() == 0)  // First-run: Add default channel
+                  {
                     long channelId = TvUtil.createChannel(mContext, sub);
                     sub.setChannelId(channelId);
                     subscriptions.add(sub);
-                } else
-                    sub.setChannelId(subscriptions.get(subidx).getChannelId());
 
-                freshsubscriptions.add(sub);
-            }
+                    TvContractCompat.requestChannelBrowsable(mContext, channelId);
+                  }
+
+                  for (File file : playlistsContent)
+                  {
+                    sub = Subscription.createSubscription(file.getName(), file.getUri(), R.drawable.ic_recommendation_80dp);
+
+                    int subidx = subscriptions.indexOf(sub);
+                    if (subidx == -1)
+                    {
+                      long channelId = TvUtil.createChannel(mContext, sub);
+                      sub.setChannelId(channelId);
+                      subscriptions.add(sub);
+                    }
+                    else
+                      sub.setChannelId(subscriptions.get(subidx).getChannelId());
+
+                    freshsubscriptions.add(sub);
+                  }
+
 
             // Kick off a job to update default programs.
             // The program job should verify if the channel is visible before updating programs.

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -39,176 +39,214 @@ import @APP_PACKAGE@.model.File;
  * A service that will populate the TV provider with channels that every user should have. Once a
  * channel is created, it trigger another service to add programs.
  */
-public class SyncChannelJobService extends JobService
-{
+public class SyncChannelJobService extends JobService {
 
-  private static final String TAG = "RecommendChannelJobSvc";
+    private static final String TAG = "RecommendChannelJobSvc";
 
-  private SyncChannelTask mSyncChannelTask;
+    private SyncChannelTask mSyncChannelTask;
 
-  @Override
-  public boolean onStartJob(final JobParameters jobParameters)
-  {
-    Log.d(TAG, "Starting channel creation job");
+    @Override
+    public boolean onStartJob(final JobParameters jobParameters) {
+        Log.d(TAG, "Starting channel creation job");
 
-    mSyncChannelTask =
-            new SyncChannelTask(getApplicationContext())
-            {
-              @Override
-              protected void onPostExecute(Boolean success)
-              {
-                super.onPostExecute(success);
-                jobFinished(jobParameters, !success);
-              }
-            };
-    mSyncChannelTask.execute();
-    return true;
-  }
-
-  @Override
-  public boolean onStopJob(JobParameters jobParameters)
-  {
-    if (mSyncChannelTask != null)
-    {
-      mSyncChannelTask.cancel(true);
-    }
-    return true;
-  }
-
-  private static class SyncChannelTask extends AsyncTask<Void, Void, Boolean>
-  {
-
-    private final Context mContext;
-
-    SyncChannelTask(Context context)
-    {
-      this.mContext = context;
+        mSyncChannelTask =
+                new SyncChannelTask(getApplicationContext()) {
+                    @Override
+                    protected void onPostExecute(Boolean success) {
+                        super.onPostExecute(success);
+                        jobFinished(jobParameters, !success);
+                    }
+                };
+        mSyncChannelTask.execute();
+        return true;
     }
 
     @Override
-    protected Boolean doInBackground(Void... voids)
-    {
-      XBMCJsonRPC json = new XBMCJsonRPC();
-      if (!json.Ping())
-        return false;
-      json = null;
-
-      List<Subscription> subscriptions = XBMCDatabase.getSubscriptions(mContext);
-      List<Subscription> freshsubscriptions = new ArrayList<>();
-      List<File> playlistsContent = new ArrayList<>();
-
-      try (Cursor cursor =
-                   mContext.getContentResolver()
-                           .query(
-                                   XBMCFileContentProvider.buildUri("special://profile/playlists/video/"),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null)
-        {
-          while (cursor.moveToNext())
-            playlistsContent.add(File.fromCursor(cursor));
+    public boolean onStopJob(JobParameters jobParameters) {
+        if (mSyncChannelTask != null) {
+            mSyncChannelTask.cancel(true);
         }
-      }
-      try (Cursor cursor =
-                   mContext.getContentResolver()
-                           .query(
-                                   XBMCFileContentProvider.buildUri("special://profile/playlists/mixed/"),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null)
-        {
-          while (cursor.moveToNext())
-            playlistsContent.add(File.fromCursor(cursor));
-        }
-      }
-      try (Cursor cursor =
-                   mContext.getContentResolver()
-                           .query(
-                                   XBMCFileContentProvider.buildUri("special://profile/playlists/music/"),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null)
-        {
-          while (cursor.moveToNext())
-            playlistsContent.add(File.fromCursor(cursor));
-        }
-      }
-
-      Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.ic_recommendation_80dp);
-      freshsubscriptions.add(sub);
-      if (subscriptions.size() == 0)  // First-run: Add default channel
-      {
-        long channelId = TvUtil.createChannel(mContext, sub);
-        sub.setChannelId(channelId);
-        subscriptions.add(sub);
-
-        TvContractCompat.requestChannelBrowsable(mContext, channelId);
-      }
-
-      for (File file : playlistsContent)
-      {
-        sub = Subscription.createSubscription(file.getName(), file.getUri(), R.drawable.ic_recommendation_80dp);
-
-        int subidx = subscriptions.indexOf(sub);
-        if (subidx == -1)
-        {
-          long channelId = TvUtil.createChannel(mContext, sub);
-          sub.setChannelId(channelId);
-          subscriptions.add(sub);
-        }
-        else
-          sub.setChannelId(subscriptions.get(subidx).getChannelId());
-
-        freshsubscriptions.add(sub);
-      }
-
-      // Kick off a job to update default programs.
-      // The program job should verify if the channel is visible before updating programs.
-      for (Iterator<Subscription> iterator = subscriptions.iterator(); iterator.hasNext();)
-      {
-        Subscription channel = iterator.next();
-
-        if (freshsubscriptions.indexOf(channel) == -1)
-        {
-          // Channel is gone
-          Long chanid = channel.getChannelId();
-          mContext.getContentResolver()
-                  .delete(
-                          TvContractCompat.buildPreviewProgramsUriForChannel(chanid),
-                          null,
-                          null);
-          mContext.getContentResolver()
-                  .delete(
-                          TvContractCompat.buildChannelUri(chanid),
-                          null,
-                          null);
-          XBMCDatabase.removeMedias(mContext, chanid);
-          iterator.remove();
-
-          JobScheduler scheduler =
-                  (JobScheduler) mContext.getSystemService(Context.JOB_SCHEDULER_SERVICE);
-          if (scheduler.getPendingJob(TvUtil.getTriggeredJobIdForChannelId(chanid)) != null)
-            scheduler.cancel(TvUtil.getTriggeredJobIdForChannelId(chanid));
-          if (scheduler.getPendingJob(TvUtil.getTimedJobIdForChannelId(chanid)) != null)
-            scheduler.cancel(TvUtil.getTimedJobIdForChannelId(chanid));
-
-          continue;
-        }
-        TvUtil.scheduleTriggeredSyncingProgramsForChannel(mContext, channel.getChannelId());
-        TvUtil.scheduleTimedSyncingProgramsForChannel(mContext, channel.getChannelId());
-      }
-      XBMCDatabase.saveSubscriptions(mContext, freshsubscriptions);
-
-      return true;
+        return true;
     }
-  }
+
+    private static class SyncChannelTask extends AsyncTask<Void, Void, Boolean> {
+
+        private final Context mContext;
+
+        SyncChannelTask(Context context) {
+            this.mContext = context;
+        }
+
+        @Override
+        protected Boolean doInBackground(Void... voids) {
+            XBMCJsonRPC json = new XBMCJsonRPC();
+            if (!json.Ping())
+                return false;
+            json = null;
+
+            List<Subscription> subscriptions = XBMCDatabase.getSubscriptions(mContext);
+            List<Subscription> freshsubscriptions = new ArrayList<>();
+            List<File> playlistsContent = new ArrayList<>();
+
+            try (Cursor cursor =
+                         mContext.getContentResolver()
+                                 .query(
+                                         XBMCFileContentProvider.buildUri("special://profile/playlists/video/"),
+                                         null,
+                                         null,
+                                         null,
+                                         null)) {
+                if (cursor != null) {
+                    while (cursor.moveToNext())
+                        playlistsContent.add(File.fromCursor(cursor));
+                }
+            }
+            try (Cursor cursor =
+                         mContext.getContentResolver()
+                                 .query(
+                                         XBMCFileContentProvider.buildUri("special://profile/playlists/mixed/"),
+                                         null,
+                                         null,
+                                         null,
+                                         null)) {
+                if (cursor != null) {
+                    while (cursor.moveToNext())
+                        playlistsContent.add(File.fromCursor(cursor));
+                }
+            }
+            try (Cursor cursor =
+                         mContext.getContentResolver()
+                                 .query(
+                                         XBMCFileContentProvider.buildUri("special://profile/playlists/music/"),
+                                         null,
+                                         null,
+                                         null,
+                                         null)) {
+                if (cursor != null) {
+                    while (cursor.moveToNext())
+                        playlistsContent.add(File.fromCursor(cursor));
+                }
+            }
+
+      /*
+      paul dhaliwal specific mods
+
+      adds favourites as channels
+       */
+
+            try (Cursor cursor =
+                         mContext.getContentResolver()
+                                 .query(
+//                                     XBMCFileContentProvider.buildUri("plugin://plugin.video.plexkodiconnect?mode=hub"),
+                                         XBMCFileContentProvider.buildUri("plugin://script.skin.helper.widgets/?mediatype=favourites"),
+                                         null,
+                                         null,
+                                         null,
+                                         null)) {
+                if (cursor != null) {
+                    while (cursor.moveToNext())
+                        playlistsContent.add(File.fromCursor(cursor));
+
+                }
+            }
+
+
+            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.channel_icon_main);
+            freshsubscriptions.add(sub);
+            if (subscriptions.size() == 0)  // First-run: Add default channel
+            {
+                long channelId = TvUtil.createChannel(mContext, sub);
+                sub.setChannelId(channelId);
+                subscriptions.add(sub);
+
+                TvContractCompat.requestChannelBrowsable(mContext, channelId);
+            }
+
+            for (File file : playlistsContent) {
+                int channelLogo;
+                if (file.getName().toLowerCase().contains("movies")) {
+                    Log.d(TAG, "doInBackground: movie icon");
+                    channelLogo = R.drawable.channel_icon_movies;
+                } else if (file.getName().toLowerCase().contains("tv")
+                        || file.getName().toLowerCase().contains("episodes")) {
+                    channelLogo = R.drawable.channel_icon_tv;
+                    Log.d(TAG, "doInBackground: tv icon");
+                } else {
+                    channelLogo = R.drawable.channel_icon_main;
+                    Log.d(TAG, "doInBackground: main icon");
+                }
+                sub = Subscription.createSubscription(file.getName(), file.getUri(), channelLogo);
+
+        /*
+         paul dhaliwal specific mods
+         Checks to see if subscriptions have On Deck names so we can add them to Play Next
+         */
+                if (sub.getName().equals("On Deck Movies ") ||
+                        sub.getName().equals("On Deck TV Shows ") ||
+                        sub.getName().equals("Continue Watching")) {
+                    sub.setAddToPlayNext(true);
+                    Log.d(TAG, "doInBackground: sub.toString: " + sub.toString());
+                }
+
+                switch (sub.getName()) {
+                    case "On Deck TV Shows ":
+                        sub.setCategory(Subscription.SUBSCRIPTION_TYPE_ON_DECK);
+                        break;
+                    case "Continue Watching":
+                        sub.setCategory(Subscription.SUBSCRIPTION_TYPE_CONTINUE_WATCHING);
+                        break;
+                    default:
+                        sub.setCategory(Subscription.SUBSCRIPTION_TYPE_REGULAR);
+                        break;
+                }
+
+                int subidx = subscriptions.indexOf(sub);
+                if (subidx == -1) {
+                    long channelId = TvUtil.createChannel(mContext, sub);
+                    sub.setChannelId(channelId);
+                    subscriptions.add(sub);
+                } else
+                    sub.setChannelId(subscriptions.get(subidx).getChannelId());
+
+                freshsubscriptions.add(sub);
+            }
+
+            // Kick off a job to update default programs.
+            // The program job should verify if the channel is visible before updating programs.
+            for (Iterator<Subscription> iterator = subscriptions.iterator(); iterator.hasNext(); ) {
+                Subscription channel = iterator.next();
+
+                if (freshsubscriptions.indexOf(channel) == -1) {
+                    // Channel is gone
+                    Long chanid = channel.getChannelId();
+                    mContext.getContentResolver()
+                            .delete(
+                                    TvContractCompat.buildPreviewProgramsUriForChannel(chanid),
+                                    null,
+                                    null);
+                    mContext.getContentResolver()
+                            .delete(
+                                    TvContractCompat.buildChannelUri(chanid),
+                                    null,
+                                    null);
+                    XBMCDatabase.removeMedias(mContext, chanid);
+                    iterator.remove();
+
+                    JobScheduler scheduler =
+                            (JobScheduler) mContext.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+                    if (scheduler.getPendingJob(TvUtil.getTriggeredJobIdForChannelId(chanid)) != null)
+                        scheduler.cancel(TvUtil.getTriggeredJobIdForChannelId(chanid));
+                    if (scheduler.getPendingJob(TvUtil.getTimedJobIdForChannelId(chanid)) != null)
+                        scheduler.cancel(TvUtil.getTimedJobIdForChannelId(chanid));
+
+                    continue;
+                }
+                TvUtil.scheduleTriggeredSyncingProgramsForChannel(mContext, channel.getChannelId());
+                TvUtil.scheduleTimedSyncingProgramsForChannel(mContext, channel.getChannelId());
+            }
+            XBMCDatabase.saveSubscriptions(mContext, freshsubscriptions);
+
+            return true;
+        }
+    }
 }

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -130,9 +130,7 @@ public class SyncChannelJobService extends JobService {
 
       /*
       paul dhaliwal specific mods
-
-      adds favourites as channels
-       */
+            adds favourites as channels
 
             try (Cursor cursor =
                          mContext.getContentResolver()
@@ -149,44 +147,36 @@ public class SyncChannelJobService extends JobService {
 
                 }
             }
+       */
 
-            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.ic_recommendation_80dp);
-                 freshsubscriptions.add(sub);
-                 if (subscriptions.size() == 0)  // First-run: Add default channel
-                 {
-                   long channelId = TvUtil.createChannel(mContext, sub);
-                   sub.setChannelId(channelId);
-                   subscriptions.add(sub);
 
-                   TvContractCompat.requestChannelBrowsable(mContext, channelId);
-                 }
 
-                 for (File file : playlistsContent)
-                 {
-                   sub = Subscription.createSubscription(file.getName(), file.getUri(), R.drawable.ic_recommendation_80dp);
 
-        /*
-         paul dhaliwal specific mods
-         Checks to see if subscriptions have On Deck names so we can add them to Play Next
-         */
-                if (sub.getName().equals("On Deck Movies ") ||
-                        sub.getName().equals("On Deck TV Shows ") ||
-                        sub.getName().equals("Continue Watching")) {
-                    sub.setAddToPlayNext(true);
-                    Log.d(TAG, "doInBackground: sub.toString: " + sub.toString());
+            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.channel_icon_main);
+            freshsubscriptions.add(sub);
+            if (subscriptions.size() == 0)  // First-run: Add default channel
+            {
+                long channelId = TvUtil.createChannel(mContext, sub);
+                sub.setChannelId(channelId);
+                subscriptions.add(sub);
+
+                TvContractCompat.requestChannelBrowsable(mContext, channelId);
+            }
+
+            for (File file : playlistsContent) {
+                int channelLogo;
+                if (file.getName().toLowerCase().contains("movies")) {
+                    Log.d(TAG, "doInBackground: movie icon");
+                    channelLogo = R.drawable.channel_icon_movies;
+                } else if (file.getName().toLowerCase().contains("tv")
+                        || file.getName().toLowerCase().contains("episodes")) {
+                    channelLogo = R.drawable.channel_icon_tv;
+                    Log.d(TAG, "doInBackground: tv icon");
+                } else {
+                    channelLogo = R.drawable.channel_icon_main;
+                    Log.d(TAG, "doInBackground: main icon");
                 }
-
-                switch (sub.getName()) {
-                    case "On Deck TV Shows ":
-                        sub.setCategory(Subscription.SUBSCRIPTION_TYPE_ON_DECK);
-                        break;
-                    case "Continue Watching":
-                        sub.setCategory(Subscription.SUBSCRIPTION_TYPE_CONTINUE_WATCHING);
-                        break;
-                    default:
-                        sub.setCategory(Subscription.SUBSCRIPTION_TYPE_REGULAR);
-                        break;
-                }
+                sub = Subscription.createSubscription(file.getName(), file.getUri(), channelLogo);
 
                 int subidx = subscriptions.indexOf(sub);
                 if (subidx == -1) {

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -150,32 +150,20 @@ public class SyncChannelJobService extends JobService {
                 }
             }
 
+            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.ic_recommendation_80dp);
+                 freshsubscriptions.add(sub);
+                 if (subscriptions.size() == 0)  // First-run: Add default channel
+                 {
+                   long channelId = TvUtil.createChannel(mContext, sub);
+                   sub.setChannelId(channelId);
+                   subscriptions.add(sub);
 
-            Subscription sub = Subscription.createSubscription(mContext.getString(R.string.suggestion_channel), "", R.drawable.channel_icon_main);
-            freshsubscriptions.add(sub);
-            if (subscriptions.size() == 0)  // First-run: Add default channel
-            {
-                long channelId = TvUtil.createChannel(mContext, sub);
-                sub.setChannelId(channelId);
-                subscriptions.add(sub);
+                   TvContractCompat.requestChannelBrowsable(mContext, channelId);
+                 }
 
-                TvContractCompat.requestChannelBrowsable(mContext, channelId);
-            }
-
-            for (File file : playlistsContent) {
-                int channelLogo;
-                if (file.getName().toLowerCase().contains("movies")) {
-                    Log.d(TAG, "doInBackground: movie icon");
-                    channelLogo = R.drawable.channel_icon_movies;
-                } else if (file.getName().toLowerCase().contains("tv")
-                        || file.getName().toLowerCase().contains("episodes")) {
-                    channelLogo = R.drawable.channel_icon_tv;
-                    Log.d(TAG, "doInBackground: tv icon");
-                } else {
-                    channelLogo = R.drawable.channel_icon_main;
-                    Log.d(TAG, "doInBackground: main icon");
-                }
-                sub = Subscription.createSubscription(file.getName(), file.getUri(), channelLogo);
+                 for (File file : playlistsContent)
+                 {
+                   sub = Subscription.createSubscription(file.getName(), file.getUri(), R.drawable.ic_recommendation_80dp);
 
         /*
          paul dhaliwal specific mods

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -303,12 +303,15 @@ public class SyncProgramsJobService extends JobService {
                 movie = (Movie) media;
                 builder.setDescription(movie.getPlot())
                         .setReleaseDate(movie.getYear())
-                        .setReviewRating(String.valueOf(movie.getRating() * 0.5))
                         .setDurationMillis(movie.getDuration())
                         .setLastPlaybackPositionMillis(movie.getPosition())
                         .setType(TvContractCompat.PreviewProgramColumns.TYPE_MOVIE);
 
                 Log.d(TAG, "buildProgram: movie.toString = " + movie.toString());
+
+                if (movie.getRating() > 0) {
+                    builder.setReviewRating(String.valueOf(movie.getRating() * 0.5));
+                }
 
                 if (movie.getHasLandscapeArt()) {
                     if (movie.getLandscapeImageUrl() != null && movie.getRating() >= 8.5) {

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -26,12 +26,14 @@ import android.support.annotation.NonNull;
 import android.support.media.tv.Channel;
 import android.support.media.tv.PreviewProgram;
 import android.support.media.tv.TvContractCompat;
+import android.support.media.tv.WatchNextProgram;
 import android.util.Log;
 
 import @APP_PACKAGE@.Splash;
 import @APP_PACKAGE@.XBMCJsonRPC;
 import @APP_PACKAGE@.model.Movie;
 import @APP_PACKAGE@.model.TVEpisode;
+import @APP_PACKAGE@.model.TVShow;
 import @APP_PACKAGE@.model.File;
 import @APP_PACKAGE@.model.Media;
 import @APP_PACKAGE@.channels.model.Subscription;
@@ -40,6 +42,7 @@ import @APP_PACKAGE@.channels.util.TvUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -48,253 +51,511 @@ import java.util.List;
  * completes, it will reschedule itself to listen for the next change to the channel. See {@link
  * TvUtil#scheduleTriggeredSyncingProgramsForChannel(Context, long)} for more details about the scheduling.
  */
-public class SyncProgramsJobService extends JobService
-{
 
-  private static final String TAG = "SyncProgramsJobService";
+public class SyncProgramsJobService extends JobService {
 
-  private SyncProgramsTask mSyncProgramsTask;
+    private static final String TAG = "SyncProgramsJobService";
 
-  @Override
-  public boolean onStartJob(final JobParameters jobParameters)
-  {
-    Log.d(TAG, "onStartJob(): " + jobParameters);
+    private static SyncProgramsTask mSyncProgramsTask;
 
-    final long channelId = getChannelId(jobParameters);
-    if (channelId == -1L)
-    {
-      return false;
-    }
-    Log.d(TAG, "onStartJob(): Scheduling syncing for programs for channel " + channelId);
+    @Override
+    public boolean onStartJob(final JobParameters jobParameters) {
+        Log.d(TAG, "onStartJob(): " + jobParameters);
 
-    mSyncProgramsTask =
-            new SyncProgramsTask(getApplicationContext())
-            {
-              @Override
-              protected void onPostExecute(Boolean finished)
-              {
-                super.onPostExecute(finished);
-                // Daisy chain listening for the next change to the channel.
-                TvUtil.scheduleTriggeredSyncingProgramsForChannel(
-                        SyncProgramsJobService.this, channelId);
-                mSyncProgramsTask = null;
-                jobFinished(jobParameters, !finished);
-              }
-            };
-    mSyncProgramsTask.execute(channelId);
+        final long channelId = getChannelId(jobParameters);
+        if (channelId == -1L) {
+            return false;
+        }
+        Log.d(TAG, "onStartJob(): Scheduling syncing for programs for channel " + channelId);
 
-    return true;
-  }
+        mSyncProgramsTask =
+                new SyncProgramsTask(getApplicationContext()) {
+                    @Override
+                    protected void onPostExecute(Boolean finished) {
+                        super.onPostExecute(finished);
+                        // Daisy chain listening for the next change to the channel.
+                        TvUtil.scheduleTriggeredSyncingProgramsForChannel(
+                                SyncProgramsJobService.this, channelId);
+                        mSyncProgramsTask = null;
+                        jobFinished(jobParameters, !finished);
+                    }
+                };
+        mSyncProgramsTask.execute(channelId);
 
-  @Override
-  public boolean onStopJob(JobParameters jobParameters)
-  {
-    if (mSyncProgramsTask != null)
-    {
-      mSyncProgramsTask.cancel(true);
-    }
-    return true;
-  }
-
-  private long getChannelId(JobParameters jobParameters)
-  {
-    PersistableBundle extras = jobParameters.getExtras();
-    if (extras == null)
-    {
-      return -1L;
-    }
-
-    return extras.getLong(TvContractCompat.EXTRA_CHANNEL_ID, -1L);
-  }
-
-  private class SyncProgramsTask extends AsyncTask<Long, Void, Boolean>
-  {
-
-    private final Context mContext;
-
-    private SyncProgramsTask(Context context)
-    {
-      this.mContext = context;
+        return true;
     }
 
     @Override
-    protected Boolean doInBackground(Long... channelIds)
-    {
-      XBMCJsonRPC json = new XBMCJsonRPC();
-      if (!json.Ping())
-        return false;
-      json = null;
-
-      List<Long> params = Arrays.asList(channelIds);
-      if (!params.isEmpty())
-      {
-        for (Long channelId : params)
-        {
-          Subscription subscription =
-                  XBMCDatabase.findSubscriptionByChannelId(mContext, channelId);
-          if (subscription != null)
-          {
-            List<Media> cachedMedias = XBMCDatabase.getMedias(mContext, channelId);
-            syncPrograms(channelId, subscription.getUri(), cachedMedias);
-          }
+    public boolean onStopJob(JobParameters jobParameters) {
+        Log.d(TAG, "onStopJob: starts");
+        if (mSyncProgramsTask != null) {
+            mSyncProgramsTask.cancel(true);
         }
-      }
-      return true;
+        return true;
     }
 
-    /*
- * Syncs programs by querying the given channel id.
- *
- * If the channel is not browsable, the programs will be removed to avoid showing
- * stale programs when the channel becomes browsable in the future.
- *
- * If the channel is browsable, then it will check if the channel has any programs.
- *      If the channel does not have any programs, new programs will be added.
- *      If the channel does have programs, then a fresh list of programs will be fetched and the
- *          channel's programs will be updated.
- */
-    private void syncPrograms(long channelId, String uri, List<Media> initialMedias)
-    {
-      Log.d(TAG, "Sync programs for channel: " + channelId);
-      List<Media> medias = new ArrayList<>(initialMedias);
-
-      try (Cursor cursor =
-                   getContentResolver()
-                           .query(
-                                   TvContractCompat.buildChannelUri(channelId),
-                                   null,
-                                   null,
-                                   null,
-                                   null))
-      {
-        if (cursor != null && cursor.moveToNext())
-        {
-          Channel channel = Channel.fromCursor(cursor);
-          
-          XBMCJsonRPC jsonrpc = new XBMCJsonRPC();
-          if (uri.isEmpty())
-          {
-            // Suggestion channel
-            Log.d(TAG, "Suggestion channel is browsable: " + channelId);
-
-            deletePrograms(channelId, medias);
-            medias = createPrograms(channelId, jsonrpc.getSuggestions());
-          }
-          else
-          {
-            Log.d(TAG, "Channel is browsable: " + channelId);
-
-            String xbmcURL = Uri.parse(uri).getFragment();
-            List<File> files = jsonrpc.getFiles(xbmcURL);
-
-            deletePrograms(channelId, medias);
-            medias = createPrograms(channelId, jsonrpc.getMedias(files));
-          }
-          jsonrpc = null;
+    private long getChannelId(JobParameters jobParameters) {
+        Log.d(TAG, "getChannelId: starts");
+        PersistableBundle extras = jobParameters.getExtras();
+        if (extras == null) {
+            return -1L;
         }
-        XBMCDatabase.saveMedias(getApplicationContext(), channelId, medias);
-      }
+
+        return extras.getLong(TvContractCompat.EXTRA_CHANNEL_ID, -1L);
     }
 
-    private List<Media> createPrograms(long channelId, List<Media> medias)
-    {
-      List<Media> mediasAdded = new ArrayList<>(medias.size());
-      for (Media media : medias)
-      {
-        PreviewProgram previewProgram = buildProgram(channelId, media);
+    private class SyncProgramsTask extends AsyncTask<Long, Void, Boolean> {
 
-        Uri programUri =
-                getContentResolver()
-                        .insert(
-                                TvContractCompat.PreviewPrograms.CONTENT_URI,
-                                previewProgram.toContentValues());
-        long programId = ContentUris.parseId(programUri);
-        Log.d(TAG, "Inserted new program: " + programId);
-        media.setProgramId(programId);
-        mediasAdded.add(media);
-      }
+        private final Context mContext;
 
-      return mediasAdded;
+        private SyncProgramsTask(Context context) {
+            this.mContext = context;
+        }
+
+        @Override
+        protected Boolean doInBackground(Long... channelIds) {
+            Log.d(TAG, "SyncProgramsJobService doInBackground: starts");
+            XBMCJsonRPC json = new XBMCJsonRPC();
+            if (!json.Ping())
+                return false;
+            json = null;
+
+            List<Long> params = Arrays.asList(channelIds);
+            if (!params.isEmpty()) {
+                for (Long channelId : params) {
+                    Subscription subscription =
+                            XBMCDatabase.findSubscriptionByChannelId(mContext, channelId);
+                    if (subscription != null) {
+                        List<Media> cachedMedias = XBMCDatabase.getMedias(mContext, channelId);
+                        XBMCDatabase.removeMedias(mContext, 75);
+                        boolean isPlayNext = subscription.isAddToPlayNext();
+                        String category = subscription.getCategory();
+                        Log.d(TAG, "doInBackground: cachedMedias.size: " + cachedMedias.size());
+                        syncPrograms(mContext, channelId, category, isPlayNext, subscription.getUri(), cachedMedias);
+                    }
+                }
+            }
+            return true;
+        }
+
+        /*
+         * Syncs programs by querying the given channel id.
+         *
+         * If the channel is not browsable, the programs will be removed to avoid showing
+         * stale programs when the channel becomes browsable in the future.
+         *
+         * If the channel is browsable, then it will check if the channel has any programs.
+         *      If the channel does not have any programs, new programs will be added.
+         *      If the channel does have programs, then a fresh list of programs will be fetched and the
+         *          channel's programs will be updated.
+         */
+        private void syncPrograms(Context ctx, long channelId, String category, boolean isPlayNext, String uri, List<Media> initialMedias) {
+            Log.d(TAG, "Sync programs for channel: " + channelId);
+            List<Media> medias = new ArrayList<>(initialMedias);
+
+            try (Cursor cursor =
+                         getContentResolver()
+                                 .query(
+                                         TvContractCompat.buildChannelUri(channelId),
+                                         null,
+                                         null,
+                                         null,
+                                         null)) {
+                if (cursor != null && cursor.moveToNext()) {
+                    Channel channel = Channel.fromCursor(cursor);
+
+                    XBMCJsonRPC jsonrpc = new XBMCJsonRPC();
+                    if (uri.isEmpty()) {
+                        // Suggestion channel
+                        Log.d(TAG, "Suggestion channel is browsable: " + channelId);
+
+                        deletePrograms(channelId, medias);
+                        medias = createPrograms(channelId, category, isPlayNext, jsonrpc.getSuggestions(ctx));
+                    } else {
+                        Log.d(TAG, "Channel is browsable: " + channelId);
+
+                        String xbmcURL = Uri.parse(uri).getFragment();
+                        List<File> files = jsonrpc.getFiles(xbmcURL);
+
+                        deletePrograms(channelId, medias);
+                        List<Media> mediasToCreate = jsonrpc.getMedias(ctx, files);
+                        for (Media media : mediasToCreate) {
+                            Log.d(TAG, "syncPrograms: media.toString: " + media.toString());
+                        }
+                        if (isPlayNext) {
+                            Collections.reverse(mediasToCreate);
+                        }
+                        medias = createPrograms(channelId, category, isPlayNext, mediasToCreate);
+                    }
+                    jsonrpc = null;
+                }
+                XBMCDatabase.saveMedias(getApplicationContext(), channelId, medias);
+            }
+        }
+
+        private List<Media> createPrograms(long channelId, String category, boolean isPlayNext, List<Media> medias) {
+            Log.d(TAG, "createPrograms: starts");
+            List<Media> mediasAdded = new ArrayList<>(medias.size());
+            Log.d(TAG, "createPrograms: mediasAdded: " + mediasAdded.toString() + "size: " + medias.size());
+            for (Media media : medias) {
+                Log.d(TAG, "createPrograms: media in for lopp: " + media.toString());
+                if (isPlayNext) {
+                    Log.d(TAG, "createPrograms: before check");
+                    if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
+                            && category.equals(Subscription.SUBSCRIPTION_TYPE_ON_DECK)) {
+                        Log.d(TAG, "createPrograms: after check");
+                        TVEpisode tvEpisode = (TVEpisode) media;
+                        if (tvEpisode.getPosition() <= 60000) {
+                            WatchNextProgram watchNextProgram = buildWatchNextProgram(channelId, isPlayNext, media);
+                            Uri programUri =
+                                    getContentResolver()
+                                            .insert(
+                                                    TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                                                    watchNextProgram.toContentValues());
+                            long programId = ContentUris.parseId(programUri);
+                            Log.d(TAG, "Inserted new program: " + programId);
+                            Log.d(TAG, "medias.size(): " + medias.size());
+                            media.setProgramId(programId);
+                            mediasAdded.add(media);
+
+                            Log.d(TAG, "createPrograms: " + media.toString());
+                        }
+
+                    } else {
+                        WatchNextProgram watchNextProgram = buildWatchNextProgram(channelId, isPlayNext, media);
+                        Uri programUri =
+                                getContentResolver()
+                                        .insert(
+                                                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                                                watchNextProgram.toContentValues());
+                        long programId = ContentUris.parseId(programUri);
+                        Log.d(TAG, "Inserted new program: " + programId);
+                        Log.d(TAG, "medias.size(): " + medias.size());
+                        media.setProgramId(programId);
+                        mediasAdded.add(media);
+                    }
+
+                } else {
+                    PreviewProgram previewProgram = buildProgram(channelId, isPlayNext, media);
+                    Uri programUri =
+                            getContentResolver()
+                                    .insert(
+                                            TvContractCompat.PreviewPrograms.CONTENT_URI,
+                                            previewProgram.toContentValues());
+                    long programId = ContentUris.parseId(programUri);
+                    Log.d(TAG, "Inserted new program: " + programId);
+                    Log.d(TAG, "Inserted new program: " + media.toString());
+                    Log.d(TAG, "medias.size(): " + medias.size());
+                    media.setProgramId(programId);
+                    mediasAdded.add(media);
+                }
+            }
+            return mediasAdded;
+        }
+
+        private void deletePrograms(long channelId, List<Media> medias) {
+            Log.d(TAG, "deletePrograms: starts");
+            if (medias.isEmpty()) {
+                return;
+            }
+
+            int previewCount = 0;
+            for (Media media : medias) {
+                previewCount +=
+                        getContentResolver()
+                                .delete(
+                                        TvContractCompat.buildPreviewProgramUri(media.getProgramId()),
+                                        null,
+                                        null);
+            }
+            Log.d(TAG, "Deleted " + previewCount + " programs for  channel " + channelId);
+
+            int watchNextCount = 0;
+            for (Media media : medias) {
+                watchNextCount +=
+                        getContentResolver()
+                                .delete(
+                                        TvContractCompat.buildWatchNextProgramUri(media.getProgramId()),
+                                        null,
+                                        null);
+            }
+            Log.d(TAG, "Deleted " + watchNextCount + " programs for  channel " + channelId);
+
+
+            // Remove our local records to stay in sync with the TV Provider.
+            XBMCDatabase.removeMedias(getApplicationContext(), channelId);
+        }
+
+        @NonNull
+        private PreviewProgram buildProgram(long channelId, boolean isPlayNext, Media media) {
+            Log.d(TAG, "buildProgram: starts");
+            Intent detailsIntent = new Intent(mContext, Splash.class);
+            detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
+            detailsIntent.setData(Uri.parse(media.getXbmcUrl()));
+
+            PreviewProgram.Builder builder = new PreviewProgram.Builder();
+            builder.setChannelId(channelId)
+                    .setTitle(media.getTitle())
+                    .setIntent(detailsIntent);
+
+            if (media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)) {
+                Movie movie = new Movie();
+                movie = (Movie) media;
+                builder.setDescription(movie.getPlot())
+                        .setReleaseDate(movie.getYear())
+                        .setReviewRating(String.valueOf(movie.getRating() * 0.5))
+                        .setDurationMillis(movie.getDuration())
+                        .setLastPlaybackPositionMillis(movie.getPosition())
+                        .setType(TvContractCompat.PreviewProgramColumns.TYPE_MOVIE);
+
+                Log.d(TAG, "buildProgram: movie.toString = " + movie.toString());
+
+                if (movie.getHasLandscapeArt()) {
+                    if (movie.getLandscapeImageUrl() != null && movie.getRating() >= 8.5) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getLandscapeImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (movie.getThumbnailImageUrl() != null && movie.getRating() >= 8.5) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getThumbnailImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (movie.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+
+                } else {
+                    if (movie.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+                }
+
+            } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW)) {
+                TVShow tvShow = new TVShow();
+                tvShow = (TVShow) media;
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_SERIES)
+                        .setLongDescription(tvShow.getPlot());
+
+                Log.d(TAG, "buildProgram: tvshow.toString = " + tvShow.toString());
+
+                if (tvShow.getHasLandscapeArt()) {
+                    if (tvShow.getLandscapeImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getLandscapeImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (tvShow.getThumbnailImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getThumbnailImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (tvShow.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+                } else {
+                    if (tvShow.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+                }
+
+                int numberOfSeasons = tvShow.getSeason();
+                builder.setDescription(tvShow.getPlot())
+                        .setReviewRating(String.valueOf((double) tvShow.getRating() * 0.5));
+
+            } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)) {
+                TVEpisode tvEpisode = new TVEpisode();
+                tvEpisode = (TVEpisode) media;
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_EPISODE)
+                        .setEpisodeTitle(tvEpisode.getEpisodeTitle())
+                        .setEpisodeNumber(tvEpisode.getEpisode())
+                        .setSeasonNumber(tvEpisode.getSeason())
+                        .setReviewRating(String.valueOf((double) tvEpisode.getRating() * 0.5))
+                        .setDescription(tvEpisode.getPlot())
+                        .setDurationMillis(tvEpisode.getRuntime())
+                        .setReleaseDate(tvEpisode.getYear());
+
+                if (tvEpisode.getHasLandscapeArt()) {
+                    if (tvEpisode.getLandscapeImageUrl() != null && tvEpisode.getRating() >= 8.0) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getLandscapeImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (tvEpisode.getThumbnailImageUrl() != null && tvEpisode.getRating() >= 8.0) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getThumbnailImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (tvEpisode.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+                }
+
+            } else if (media.getCategory().equals(Media.MEDIA_TYPE_ALBUM))
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_ALBUM);
+            else if (media.getCategory().equals(Media.MEDIA_TYPE_SONG))
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TRACK);
+            else if (media.getCategory().equals(Media.MEDIA_TYPE_MUSICVIDEO))
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_CLIP);
+
+
+            if (!media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)
+                    && !media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
+                    && !media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW)) {
+                if (media.getCardImageUrl() != null) {
+                    builder.setPosterArtUri(Uri.parse(media.getCardImageUrl()));
+                    if (media.getCardImageAspectRatio().equals("2:3"))
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    else if (media.getCardImageAspectRatio().equals("1:1"))
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_1_1);
+                    else
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                } else if (media.getBackgroundImageUrl() != null) {
+                    builder.setPosterArtUri(Uri.parse(media.getBackgroundImageUrl()));
+                    builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                }
+                if (media.getVideoUrl() != null)
+                    builder.setPreviewVideoUri(Uri.parse(media.getVideoUrl()));
+            }
+
+            return builder.build();
+        }
+
+        @NonNull
+        private WatchNextProgram buildWatchNextProgram(long channelId, boolean isPlayNext, Media media) {
+            Log.d(TAG, "buildWatchNextProgram: starts");
+            Intent detailsIntent = new Intent(mContext, Splash.class);
+            detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
+            detailsIntent.setData(Uri.parse(media.getXbmcUrl()));
+
+            WatchNextProgram.Builder builder = new WatchNextProgram.Builder();
+            builder.setTitle(media.getTitle())
+                    .setIntent(detailsIntent);
+
+            if (media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)) {
+                Movie movie = new Movie();
+                movie = (Movie) media;
+                builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
+                        .setLastEngagementTimeUtcMillis(movie.getLastPlayed())
+                        .setDescription(movie.getPlot())
+                        .setReleaseDate(movie.getYear())
+                        .setReviewRating(String.valueOf(movie.getRating() * 0.5))
+                        .setDurationMillis(movie.getDuration())
+                        .setLastPlaybackPositionMillis(movie.getPosition())
+                        .setType(TvContractCompat.PreviewProgramColumns.TYPE_MOVIE);
+
+                Log.d(TAG, "buildWatchNextProgram: movie.toString = " + movie.toString());
+
+                if (movie.getHasLandscapeArt()) {
+                    if (movie.getLandscapeImageUrl() != null && movie.getRating() >= 8.5) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getLandscapeImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (movie.getThumbnailImageUrl() != null && movie.getRating() >= 8.5) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getThumbnailImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (movie.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+
+                } else {
+                    if (movie.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((Movie) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+                }
+
+//            } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW)) {
+//                TVShow tvShow = new TVShow();
+//                tvShow = (TVShow) media;
+//                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_SERIES)
+//                        .setLongDescription(tvShow.getPlot());
+//
+//                Log.d(TAG, "buildProgram: tvshow.toString = " + tvShow.toString());
+//
+//                if (tvShow.getHasLandscapeArt()) {
+//                    if (tvShow.getLandscapeImageUrl() != null) {
+//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getLandscapeImageUrl()));
+//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+//                    } else if (tvShow.getThumbnailImageUrl() != null) {
+//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getThumbnailImageUrl()));
+//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+//                    } else if (tvShow.getPosterImageUrl() != null) {
+//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getPosterImageUrl()));
+//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+//                    }
+//                } else {
+//                    if (tvShow.getPosterImageUrl() != null) {
+//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getPosterImageUrl()));
+//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+//                    }
+//                }
+//
+//                int numberOfSeasons = tvShow.getSeason();
+//                builder.setDescription(tvShow.getPlot())
+//                        .setReviewRating(String.valueOf((double) tvShow.getRating() * 0.5));
+
+            } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)) {
+                TVEpisode tvEpisode = new TVEpisode();
+                tvEpisode = (TVEpisode) media;
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_EPISODE)
+                        .setLastEngagementTimeUtcMillis(tvEpisode.getLastPlayed())
+                        .setEpisodeTitle(tvEpisode.getEpisodeTitle())
+                        .setEpisodeNumber(tvEpisode.getEpisode())
+                        .setSeasonNumber(tvEpisode.getSeason())
+                        .setReviewRating(String.valueOf((double) tvEpisode.getRating() * 0.5))
+                        .setDescription(tvEpisode.getPlot())
+                        .setDurationMillis(tvEpisode.getRuntime())
+                        .setLastPlaybackPositionMillis(tvEpisode.getPosition())
+                        .setReleaseDate(tvEpisode.getYear());
+
+                if (tvEpisode.getPosition() < 60000) {
+                    builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_NEXT);
+                    builder.setLastEngagementTimeUtcMillis(tvEpisode.getReleaseDate());
+                } else {
+                    builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE);
+                }
+
+                if (tvEpisode.getHasLandscapeArt()) {
+                    if (tvEpisode.getLandscapeImageUrl() != null && tvEpisode.getRating() >= 8.0) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getLandscapeImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (tvEpisode.getThumbnailImageUrl() != null && tvEpisode.getRating() >= 8.0) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getThumbnailImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                    } else if (tvEpisode.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getTvShowPosterImagerUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+
+                    if (tvEpisode.getPosition() < 60000) {
+                        builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_NEXT);
+                    } else {
+                        builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE);
+                    }
+                }
+
+            } else if (media.getCategory().equals(Media.MEDIA_TYPE_ALBUM))
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_ALBUM);
+            else if (media.getCategory().equals(Media.MEDIA_TYPE_SONG))
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TRACK);
+            else if (media.getCategory().equals(Media.MEDIA_TYPE_MUSICVIDEO))
+                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_CLIP);
+
+
+            if (!media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)
+                    && !media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
+                    && !media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW)) {
+                if (media.getCardImageUrl() != null) {
+                    builder.setPosterArtUri(Uri.parse(media.getCardImageUrl()));
+                    if (media.getCardImageAspectRatio().equals("2:3"))
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    else if (media.getCardImageAspectRatio().equals("1:1"))
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_1_1);
+                    else
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                } else if (media.getBackgroundImageUrl() != null) {
+                    builder.setPosterArtUri(Uri.parse(media.getBackgroundImageUrl()));
+                    builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
+                }
+                if (media.getVideoUrl() != null)
+                    builder.setPreviewVideoUri(Uri.parse(media.getVideoUrl()));
+            }
+
+            return builder.build();
+        }
     }
-
-    private void deletePrograms(long channelId, List<Media> medias)
-    {
-      if (medias.isEmpty())
-      {
-        return;
-      }
-
-      int count = 0;
-      for (Media media : medias)
-      {
-        count +=
-                getContentResolver()
-                        .delete(
-                                TvContractCompat.buildPreviewProgramUri(media.getProgramId()),
-                                null,
-                                null);
-      }
-      Log.d(TAG, "Deleted " + count + " programs for  channel " + channelId);
-
-      // Remove our local records to stay in sync with the TV Provider.
-      XBMCDatabase.removeMedias(getApplicationContext(), channelId);
-    }
-
-    @NonNull
-    private PreviewProgram buildProgram(long channelId, Media media)
-    {
-      Intent detailsIntent = new Intent(mContext, Splash.class);
-      detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
-      detailsIntent.setData(Uri.parse(media.getXbmcUrl()));
-
-      PreviewProgram.Builder builder = new PreviewProgram.Builder();
-      builder.setChannelId(channelId)
-              .setTitle(media.getTitle())
-              .setDescription(media.getDescription())
-              .setIntent(detailsIntent);
-
-      if(media.getCategory().equals(Media.MEDIA_TYPE_MOVIE))
-        builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_CLIP);
-      else if(media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW))
-        builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_SERIES);
-      else if(media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE))
-        builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_EPISODE);
-      else if(media.getCategory().equals(Media.MEDIA_TYPE_ALBUM))
-        builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_ALBUM);
-      else if(media.getCategory().equals(Media.MEDIA_TYPE_SONG))
-        builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TRACK);
-      else if(media.getCategory().equals(Media.MEDIA_TYPE_MUSICVIDEO))
-        builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_CLIP);
-
-      if (media.getCardImageUrl() != null)
-      {
-        builder.setPosterArtUri(Uri.parse(media.getCardImageUrl()));
-        if (media.getCardImageAspectRatio().equals("2:3"))
-          builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-        else if (media.getCardImageAspectRatio().equals("1:1"))
-          builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_1_1);
-        else
-          builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-      }
-      else if (media.getBackgroundImageUrl() != null)
-      {
-        builder.setPosterArtUri(Uri.parse(media.getBackgroundImageUrl()));
-        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-      }
-      if (media.getVideoUrl() != null)
-        builder.setPreviewVideoUri(Uri.parse(media.getVideoUrl()));
-
-      if (media instanceof Movie)
-      {
-        builder.setLongDescription(((Movie)media).getPlot());
-      }
-      if (media instanceof TVEpisode)
-      {
-        builder.setSeasonNumber(((TVEpisode)media).getSeason());
-        builder.setEpisodeNumber(((TVEpisode)media).getEpisode());
-      }
-
-      return builder.build();
-    }
-  }
 }

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -199,43 +199,47 @@ public class SyncProgramsJobService extends JobService {
             Log.d(TAG, "createPrograms: mediasAdded: " + mediasAdded.toString() + "size: " + medias.size());
             for (Media media : medias) {
                 Log.d(TAG, "createPrograms: media in for lopp: " + media.toString());
-                if (isPlayNext) {
-                    Log.d(TAG, "createPrograms: before check");
-                    if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
-                            && category.equals(Subscription.SUBSCRIPTION_TYPE_ON_DECK)) {
-                        Log.d(TAG, "createPrograms: after check");
-                        TVEpisode tvEpisode = (TVEpisode) media;
-                        if (tvEpisode.getPosition() <= 60000) {
-                            WatchNextProgram watchNextProgram = buildWatchNextProgram(channelId, isPlayNext, media);
-                            Uri programUri =
-                                    getContentResolver()
-                                            .insert(
-                                                    TvContractCompat.WatchNextPrograms.CONTENT_URI,
-                                                    watchNextProgram.toContentValues());
-                            long programId = ContentUris.parseId(programUri);
-                            Log.d(TAG, "Inserted new program: " + programId);
-                            Log.d(TAG, "medias.size(): " + medias.size());
-                            media.setProgramId(programId);
-                            mediasAdded.add(media);
 
-                            Log.d(TAG, "createPrograms: " + media.toString());
-                        }
-
-                    } else {
-                        WatchNextProgram watchNextProgram = buildWatchNextProgram(channelId, isPlayNext, media);
-                        Uri programUri =
-                                getContentResolver()
-                                        .insert(
-                                                TvContractCompat.WatchNextPrograms.CONTENT_URI,
-                                                watchNextProgram.toContentValues());
-                        long programId = ContentUris.parseId(programUri);
-                        Log.d(TAG, "Inserted new program: " + programId);
-                        Log.d(TAG, "medias.size(): " + medias.size());
-                        media.setProgramId(programId);
-                        mediasAdded.add(media);
-                    }
-
-                } else {
+                /*
+                Paul dhaliwal specific code
+                 */
+//                if (isPlayNext) {
+//                    Log.d(TAG, "createPrograms: before check");
+//                    if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
+//                            && category.equals(Subscription.SUBSCRIPTION_TYPE_ON_DECK)) {
+//                        Log.d(TAG, "createPrograms: after check");
+//                        TVEpisode tvEpisode = (TVEpisode) media;
+//                        if (tvEpisode.getPosition() <= 60000) {
+//                            WatchNextProgram watchNextProgram = buildWatchNextProgram(channelId, isPlayNext, media);
+//                            Uri programUri =
+//                                    getContentResolver()
+//                                            .insert(
+//                                                    TvContractCompat.WatchNextPrograms.CONTENT_URI,
+//                                                    watchNextProgram.toContentValues());
+//                            long programId = ContentUris.parseId(programUri);
+//                            Log.d(TAG, "Inserted new program: " + programId);
+//                            Log.d(TAG, "medias.size(): " + medias.size());
+//                            media.setProgramId(programId);
+//                            mediasAdded.add(media);
+//
+//                            Log.d(TAG, "createPrograms: " + media.toString());
+//                        }
+//
+//                    } else {
+//                        WatchNextProgram watchNextProgram = buildWatchNextProgram(channelId, isPlayNext, media);
+//                        Uri programUri =
+//                                getContentResolver()
+//                                        .insert(
+//                                                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+//                                                watchNextProgram.toContentValues());
+//                        long programId = ContentUris.parseId(programUri);
+//                        Log.d(TAG, "Inserted new program: " + programId);
+//                        Log.d(TAG, "medias.size(): " + medias.size());
+//                        media.setProgramId(programId);
+//                        mediasAdded.add(media);
+//                    }
+//
+//                } else {
                     PreviewProgram previewProgram = buildProgram(channelId, isPlayNext, media);
                     Uri programUri =
                             getContentResolver()
@@ -248,7 +252,7 @@ public class SyncProgramsJobService extends JobService {
                     Log.d(TAG, "medias.size(): " + medias.size());
                     media.setProgramId(programId);
                     mediasAdded.add(media);
-                }
+//                }
             }
             return mediasAdded;
         }
@@ -400,7 +404,6 @@ public class SyncProgramsJobService extends JobService {
                 builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TRACK);
             else if (media.getCategory().equals(Media.MEDIA_TYPE_MUSICVIDEO))
                 builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_CLIP);
-
 
             if (!media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)
                     && !media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -170,7 +170,7 @@ public class SyncProgramsJobService extends JobService {
                         Log.d(TAG, "Suggestion channel is browsable: " + channelId);
 
                         deletePrograms(channelId, medias);
-                        medias = createPrograms(channelId, category, isPlayNext, jsonrpc.getSuggestions(ctx));
+                        medias = createPrograms(channelId, category, jsonrpc.getSuggestions(ctx));
                     } else {
                         Log.d(TAG, "Channel is browsable: " + channelId);
 
@@ -182,10 +182,8 @@ public class SyncProgramsJobService extends JobService {
                         for (Media media : mediasToCreate) {
                             Log.d(TAG, "syncPrograms: media.toString: " + media.toString());
                         }
-                        if (isPlayNext) {
-                            Collections.reverse(mediasToCreate);
-                        }
-                        medias = createPrograms(channelId, category, isPlayNext, mediasToCreate);
+
+                        medias = createPrograms(channelId, category, mediasToCreate);
                     }
                     jsonrpc = null;
                 }
@@ -193,16 +191,12 @@ public class SyncProgramsJobService extends JobService {
             }
         }
 
-        private List<Media> createPrograms(long channelId, String category, boolean isPlayNext, List<Media> medias) {
+        private List<Media> createPrograms(long channelId, String category, List<Media> medias) {
             Log.d(TAG, "createPrograms: starts");
             List<Media> mediasAdded = new ArrayList<>(medias.size());
             Log.d(TAG, "createPrograms: mediasAdded: " + mediasAdded.toString() + "size: " + medias.size());
             for (Media media : medias) {
                 Log.d(TAG, "createPrograms: media in for lopp: " + media.toString());
-
-                /*
-                Paul dhaliwal specific code
-                 */
 //                if (isPlayNext) {
 //                    Log.d(TAG, "createPrograms: before check");
 //                    if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
@@ -240,19 +234,19 @@ public class SyncProgramsJobService extends JobService {
 //                    }
 //
 //                } else {
-                    PreviewProgram previewProgram = buildProgram(channelId, isPlayNext, media);
-                    Uri programUri =
-                            getContentResolver()
-                                    .insert(
-                                            TvContractCompat.PreviewPrograms.CONTENT_URI,
-                                            previewProgram.toContentValues());
-                    long programId = ContentUris.parseId(programUri);
-                    Log.d(TAG, "Inserted new program: " + programId);
-                    Log.d(TAG, "Inserted new program: " + media.toString());
-                    Log.d(TAG, "medias.size(): " + medias.size());
-                    media.setProgramId(programId);
-                    mediasAdded.add(media);
-//                }
+                PreviewProgram previewProgram = buildProgram(channelId, media);
+                Uri programUri =
+                        getContentResolver()
+                                .insert(
+                                        TvContractCompat.PreviewPrograms.CONTENT_URI,
+                                        previewProgram.toContentValues());
+                long programId = ContentUris.parseId(programUri);
+                Log.d(TAG, "Inserted new program: " + programId);
+                Log.d(TAG, "Inserted new program: " + media.toString());
+                Log.d(TAG, "medias.size(): " + medias.size());
+                media.setProgramId(programId);
+                mediasAdded.add(media);
+
             }
             return mediasAdded;
         }
@@ -291,7 +285,7 @@ public class SyncProgramsJobService extends JobService {
         }
 
         @NonNull
-        private PreviewProgram buildProgram(long channelId, boolean isPlayNext, Media media) {
+        private PreviewProgram buildProgram(long channelId, Media media) {
             Log.d(TAG, "buildProgram: starts");
             Intent detailsIntent = new Intent(mContext, Splash.class);
             detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
@@ -314,7 +308,9 @@ public class SyncProgramsJobService extends JobService {
                 Log.d(TAG, "buildProgram: movie.toString = " + movie.toString());
 
                 if (movie.getRating() > 0) {
-                    builder.setReviewRating(String.valueOf(movie.getRating() * 0.5));
+                    builder.setReviewRating(String.valueOf(movie.getRating() * 0.5))
+                            .setReviewRatingStyle(TvContractCompat.Programs.REVIEW_RATING_STYLE_STARS);
+
                 }
 
                 if (movie.getHasLandscapeArt()) {
@@ -340,11 +336,15 @@ public class SyncProgramsJobService extends JobService {
                 TVShow tvShow = new TVShow();
                 tvShow = (TVShow) media;
                 builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_SERIES)
-                        .setDescription(tvShow.getPlot())
-                        .setLongDescription(tvShow.getPlot());
+                        .setLongDescription(tvShow.getPlot())
+                        .setDescription(tvShow.getPlot());
+
+                Log.d(TAG, "buildProgram: tvshow.toString = " + tvShow.toString());
 
                 if (tvShow.getRating() > 0) {
-                    builder.setReviewRating(String.valueOf(tvShow.getRating() * 0.5));
+                    builder.setReviewRating(String.valueOf(tvShow.getRating() * 0.5))
+                            .setReviewRatingStyle(TvContractCompat.Programs.REVIEW_RATING_STYLE_STARS);
+
                 }
 
                 if (tvShow.getHasLandscapeArt()) {
@@ -365,6 +365,8 @@ public class SyncProgramsJobService extends JobService {
                     }
                 }
 
+                int numberOfSeasons = tvShow.getSeason();
+
             } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)) {
                 TVEpisode tvEpisode = new TVEpisode();
                 tvEpisode = (TVEpisode) media;
@@ -377,8 +379,11 @@ public class SyncProgramsJobService extends JobService {
                         .setReleaseDate(tvEpisode.getYear());
 
                 if (tvEpisode.getRating() > 0) {
-                    builder.setReviewRating(String.valueOf((double) tvEpisode.getRating() * 0.5));
+                    builder.setReviewRating(String.valueOf(tvEpisode.getRating() * 0.5))
+                            .setReviewRatingStyle(TvContractCompat.Programs.REVIEW_RATING_STYLE_STARS);
                 }
+
+                Log.d(TAG, "buildProgram: tvEpisode.toString = " + tvEpisode.toString());
 
                 if (tvEpisode.getHasLandscapeArt()) {
                     if (tvEpisode.getLandscapeImageUrl() != null && tvEpisode.getRating() >= 8.0) {
@@ -394,151 +399,11 @@ public class SyncProgramsJobService extends JobService {
                 } else {
                     if (tvEpisode.getPosterImageUrl() != null) {
                         builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getPosterImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-                    }
-                }
-
-            } else if (media.getCategory().equals(Media.MEDIA_TYPE_ALBUM))
-                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_ALBUM);
-            else if (media.getCategory().equals(Media.MEDIA_TYPE_SONG))
-                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TRACK);
-            else if (media.getCategory().equals(Media.MEDIA_TYPE_MUSICVIDEO))
-                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_CLIP);
-
-            if (!media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)
-                    && !media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)
-                    && !media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW)) {
-                if (media.getCardImageUrl() != null) {
-                    builder.setPosterArtUri(Uri.parse(media.getCardImageUrl()));
-                    if (media.getCardImageAspectRatio().equals("2:3"))
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-                    else if (media.getCardImageAspectRatio().equals("1:1"))
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_1_1);
-                    else
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-                } else if (media.getBackgroundImageUrl() != null) {
-                    builder.setPosterArtUri(Uri.parse(media.getBackgroundImageUrl()));
-                    builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-                }
-                if (media.getVideoUrl() != null)
-                    builder.setPreviewVideoUri(Uri.parse(media.getVideoUrl()));
-            }
-
-            return builder.build();
-        }
-
-        @NonNull
-        private WatchNextProgram buildWatchNextProgram(long channelId, boolean isPlayNext, Media media) {
-            Log.d(TAG, "buildWatchNextProgram: starts");
-            Intent detailsIntent = new Intent(mContext, Splash.class);
-            detailsIntent.setAction(Intent.ACTION_GET_CONTENT);
-            detailsIntent.setData(Uri.parse(media.getXbmcUrl()));
-
-            WatchNextProgram.Builder builder = new WatchNextProgram.Builder();
-            builder.setTitle(media.getTitle())
-                    .setIntent(detailsIntent);
-
-            if (media.getCategory().equals(Media.MEDIA_TYPE_MOVIE)) {
-                Movie movie = new Movie();
-                movie = (Movie) media;
-                builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
-                        .setLastEngagementTimeUtcMillis(movie.getLastPlayed())
-                        .setDescription(movie.getPlot())
-                        .setReleaseDate(movie.getYear())
-                        .setReviewRating(String.valueOf(movie.getRating() * 0.5))
-                        .setDurationMillis(movie.getDuration())
-                        .setLastPlaybackPositionMillis(movie.getPosition())
-                        .setType(TvContractCompat.PreviewProgramColumns.TYPE_MOVIE);
-
-                Log.d(TAG, "buildWatchNextProgram: movie.toString = " + movie.toString());
-
-                if (movie.getHasLandscapeArt()) {
-                    if (movie.getLandscapeImageUrl() != null && movie.getRating() >= 8.5) {
-                        builder.setPosterArtUri(Uri.parse(((Movie) media).getLandscapeImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-                    } else if (movie.getThumbnailImageUrl() != null && movie.getRating() >= 8.5) {
-                        builder.setPosterArtUri(Uri.parse(((Movie) media).getThumbnailImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-                    } else if (movie.getPosterImageUrl() != null) {
-                        builder.setPosterArtUri(Uri.parse(((Movie) media).getPosterImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-                    }
-
-                } else {
-                    if (movie.getPosterImageUrl() != null) {
-                        builder.setPosterArtUri(Uri.parse(((Movie) media).getPosterImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-                    }
-                }
-
-//            } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVSHOW)) {
-//                TVShow tvShow = new TVShow();
-//                tvShow = (TVShow) media;
-//                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_SERIES)
-//                        .setLongDescription(tvShow.getPlot());
-//
-//                Log.d(TAG, "buildProgram: tvshow.toString = " + tvShow.toString());
-//
-//                if (tvShow.getHasLandscapeArt()) {
-//                    if (tvShow.getLandscapeImageUrl() != null) {
-//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getLandscapeImageUrl()));
-//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-//                    } else if (tvShow.getThumbnailImageUrl() != null) {
-//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getThumbnailImageUrl()));
-//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-//                    } else if (tvShow.getPosterImageUrl() != null) {
-//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getPosterImageUrl()));
-//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-//                    }
-//                } else {
-//                    if (tvShow.getPosterImageUrl() != null) {
-//                        builder.setPosterArtUri(Uri.parse(((TVShow) media).getPosterImageUrl()));
-//                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
-//                    }
-//                }
-//
-//                int numberOfSeasons = tvShow.getSeason();
-//                builder.setDescription(tvShow.getPlot())
-//                        .setReviewRating(String.valueOf((double) tvShow.getRating() * 0.5));
-
-            } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)) {
-                TVEpisode tvEpisode = new TVEpisode();
-                tvEpisode = (TVEpisode) media;
-                builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_EPISODE)
-                        .setLastEngagementTimeUtcMillis(tvEpisode.getLastPlayed())
-                        .setEpisodeTitle(tvEpisode.getEpisodeTitle())
-                        .setEpisodeNumber(tvEpisode.getEpisode())
-                        .setSeasonNumber(tvEpisode.getSeason())
-                        .setReviewRating(String.valueOf((double) tvEpisode.getRating() * 0.5))
-                        .setDescription(tvEpisode.getPlot())
-                        .setDurationMillis(tvEpisode.getRuntime())
-                        .setLastPlaybackPositionMillis(tvEpisode.getPosition())
-                        .setReleaseDate(tvEpisode.getYear());
-
-                if (tvEpisode.getPosition() < 60000) {
-                    builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_NEXT);
-                    builder.setLastEngagementTimeUtcMillis(tvEpisode.getReleaseDate());
-                } else {
-                    builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE);
-                }
-
-                if (tvEpisode.getHasLandscapeArt()) {
-                    if (tvEpisode.getLandscapeImageUrl() != null && tvEpisode.getRating() >= 8.0) {
-                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getLandscapeImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-                    } else if (tvEpisode.getThumbnailImageUrl() != null && tvEpisode.getRating() >= 8.0) {
-                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getThumbnailImageUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
-                    } else if (tvEpisode.getPosterImageUrl() != null) {
+                    } else if (tvEpisode.getTvShowPosterImagerUrl() != null) {
                         builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getTvShowPosterImagerUrl()));
-                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
                     }
+                    builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
 
-                    if (tvEpisode.getPosition() < 60000) {
-                        builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_NEXT);
-                    } else {
-                        builder.setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE);
-                    }
                 }
 
             } else if (media.getCategory().equals(Media.MEDIA_TYPE_ALBUM))

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -336,9 +336,12 @@ public class SyncProgramsJobService extends JobService {
                 TVShow tvShow = new TVShow();
                 tvShow = (TVShow) media;
                 builder.setType(TvContractCompat.PreviewProgramColumns.TYPE_TV_SERIES)
+                        .setDescription(tvShow.getPlot())
                         .setLongDescription(tvShow.getPlot());
 
-                Log.d(TAG, "buildProgram: tvshow.toString = " + tvShow.toString());
+                if (tvShow.getRating() > 0) {
+                    builder.setReviewRating(String.valueOf(tvShow.getRating() * 0.5));
+                }
 
                 if (tvShow.getHasLandscapeArt()) {
                     if (tvShow.getLandscapeImageUrl() != null) {
@@ -358,10 +361,6 @@ public class SyncProgramsJobService extends JobService {
                     }
                 }
 
-                int numberOfSeasons = tvShow.getSeason();
-                builder.setDescription(tvShow.getPlot())
-                        .setReviewRating(String.valueOf((double) tvShow.getRating() * 0.5));
-
             } else if (media.getCategory().equals(Media.MEDIA_TYPE_TVEPISODE)) {
                 TVEpisode tvEpisode = new TVEpisode();
                 tvEpisode = (TVEpisode) media;
@@ -369,10 +368,13 @@ public class SyncProgramsJobService extends JobService {
                         .setEpisodeTitle(tvEpisode.getEpisodeTitle())
                         .setEpisodeNumber(tvEpisode.getEpisode())
                         .setSeasonNumber(tvEpisode.getSeason())
-                        .setReviewRating(String.valueOf((double) tvEpisode.getRating() * 0.5))
                         .setDescription(tvEpisode.getPlot())
                         .setDurationMillis(tvEpisode.getRuntime())
                         .setReleaseDate(tvEpisode.getYear());
+
+                if (tvEpisode.getRating() > 0) {
+                    builder.setReviewRating(String.valueOf((double) tvEpisode.getRating() * 0.5));
+                }
 
                 if (tvEpisode.getHasLandscapeArt()) {
                     if (tvEpisode.getLandscapeImageUrl() != null && tvEpisode.getRating() >= 8.0) {
@@ -382,6 +384,11 @@ public class SyncProgramsJobService extends JobService {
                         builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getThumbnailImageUrl()));
                         builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_16_9);
                     } else if (tvEpisode.getPosterImageUrl() != null) {
+                        builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getPosterImageUrl()));
+                        builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
+                    }
+                } else {
+                    if (tvEpisode.getPosterImageUrl() != null) {
                         builder.setPosterArtUri(Uri.parse(((TVEpisode) media).getPosterImageUrl()));
                         builder.setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_2_3);
                     }

--- a/tools/android/packaging/xbmc/src/channels/model/Subscription.java.in
+++ b/tools/android/packaging/xbmc/src/channels/model/Subscription.java.in
@@ -23,7 +23,6 @@ public class Subscription {
     private long channelId;
     private String name;
     private String uri;
-    private int channelLogo;
     private String category = null;
 
     private boolean addToPlayNext;
@@ -42,7 +41,6 @@ public class Subscription {
             String name, String uri, int channelLogo) {
         this.name = name;
         this.uri = uri;
-        this.channelLogo = channelLogo;
     }
 
     public static Subscription createSubscription(
@@ -72,14 +70,6 @@ public class Subscription {
 
     public void setUri(String uri) {
         this.uri = uri;
-    }
-
-    public int getChannelLogo() {
-        return channelLogo;
-    }
-
-    public void setChannelLogo(int channelLogo) {
-        this.channelLogo = channelLogo;
     }
 
     public boolean isAddToPlayNext() {
@@ -119,7 +109,6 @@ public class Subscription {
                 "channelId=" + channelId +
                 ", name='" + name + '\'' +
                 ", uri='" + uri + '\'' +
-                ", channelLogo=" + channelLogo +
                 ", addToPlayNext=" + addToPlayNext +
                 '}';
     }

--- a/tools/android/packaging/xbmc/src/channels/model/Subscription.java.in
+++ b/tools/android/packaging/xbmc/src/channels/model/Subscription.java.in
@@ -23,6 +23,7 @@ public class Subscription {
     private long channelId;
     private String name;
     private String uri;
+    private int channelLogo;
     private String category = null;
 
     private boolean addToPlayNext;
@@ -41,6 +42,7 @@ public class Subscription {
             String name, String uri, int channelLogo) {
         this.name = name;
         this.uri = uri;
+        this.channelLogo = channelLogo;
     }
 
     public static Subscription createSubscription(
@@ -62,6 +64,14 @@ public class Subscription {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public int getChannelLogo() {
+        return channelLogo;
+    }
+
+    public void setChannelLogo(int channelLogo) {
+        this.channelLogo = channelLogo;
     }
 
     public String getUri() {

--- a/tools/android/packaging/xbmc/src/channels/model/Subscription.java.in
+++ b/tools/android/packaging/xbmc/src/channels/model/Subscription.java.in
@@ -18,88 +18,109 @@ import android.net.Uri;
 /**
  * Contains the data about a channel that will be displayed on the launcher.
  */
-public class Subscription
-{
-  private long channelId;
-  private String name;
-  private String uri;
-  private int channelLogo;
 
-  /**
-   * Constructor for Gson to use.
-   */
-  public Subscription()
-  {
-  }
+public class Subscription {
+    private long channelId;
+    private String name;
+    private String uri;
+    private int channelLogo;
+    private String category = null;
 
-  private Subscription(
-          String name, String uri, int channelLogo)
-  {
-    this.name = name;
-    this.uri = uri;
-    this.channelLogo = channelLogo;
-  }
+    private boolean addToPlayNext;
 
-  public static Subscription createSubscription(
-          String name, String uri, int channelLogo)
-  {
-    return new Subscription(name, uri, channelLogo);
-  }
+    public static final String SUBSCRIPTION_TYPE_ON_DECK = "On Deck";
+    public static final String SUBSCRIPTION_TYPE_CONTINUE_WATCHING = "Continue Watching";
+    public static final String SUBSCRIPTION_TYPE_REGULAR = "Regular";
 
-  public long getChannelId()
-  {
-    return channelId;
-  }
+    /**
+     * Constructor for Gson to use.
+     */
+    public Subscription() {
+    }
 
-  public void setChannelId(long channelId)
-  {
-    this.channelId = channelId;
-  }
+    private Subscription(
+            String name, String uri, int channelLogo) {
+        this.name = name;
+        this.uri = uri;
+        this.channelLogo = channelLogo;
+    }
 
-  public String getName()
-  {
-    return name;
-  }
+    public static Subscription createSubscription(
+            String name, String uri, int channelLogo) {
+        return new Subscription(name, uri, channelLogo);
+    }
 
-  public void setName(String name)
-  {
-    this.name = name;
-  }
+    public long getChannelId() {
+        return channelId;
+    }
 
-  public String getUri()
-  {
-    return uri;
-  }
+    public void setChannelId(long channelId) {
+        this.channelId = channelId;
+    }
 
-  public void setUri(String uri)
-  {
-    this.uri = uri;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public int getChannelLogo()
-  {
-    return channelLogo;
-  }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-  public void setChannelLogo(int channelLogo)
-  {
-    this.channelLogo = channelLogo;
-  }
+    public String getUri() {
+        return uri;
+    }
 
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
 
-    Subscription that = (Subscription) o;
+    public int getChannelLogo() {
+        return channelLogo;
+    }
 
-    return name != null ? name.equals(that.name) : that.name == null;
-  }
+    public void setChannelLogo(int channelLogo) {
+        this.channelLogo = channelLogo;
+    }
 
-  @Override
-  public int hashCode()
-  {
-    return name != null ? name.hashCode() : 0;
-  }
+    public boolean isAddToPlayNext() {
+        return addToPlayNext;
+    }
+
+    public void setAddToPlayNext(boolean addToPlayNext) {
+        this.addToPlayNext = addToPlayNext;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Subscription that = (Subscription) o;
+
+        return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Subscription{" +
+                "channelId=" + channelId +
+                ", name='" + name + '\'' +
+                ", uri='" + uri + '\'' +
+                ", channelLogo=" + channelLogo +
+                ", addToPlayNext=" + addToPlayNext +
+                '}';
+    }
 }

--- a/tools/android/packaging/xbmc/src/model/Media.java.in
+++ b/tools/android/packaging/xbmc/src/model/Media.java.in
@@ -160,29 +160,19 @@ public class Media implements Serializable
   }
 
   @Override
-  public String toString()
-  {
-    return "Media{"
-            + "id="
-            + id
-            + ", programId='"
-            + programId
-            + '\''
-            + ", watchNextId='"
-            + watchNextId
-            + '\''
-            + ", title='"
-            + title
-            + '\''
-            + ", videoUrl='"
-            + videoUrl
-            + '\''
-            + ", backgroundImageUrl='"
-            + bgImageUrl
-            + '\''
-            + ", cardImageUrl='"
-            + cardImageUrl
-            + '\''
-            + '}';
+  public String toString() {
+    return "Media{" +
+            "id=" + id +
+            ", title='" + title + '\'' +
+            ", description='" + description + '\'' +
+            ", bgImageUrl='" + bgImageUrl + '\'' +
+            ", cardImageUrl='" + cardImageUrl + '\'' +
+            ", cardImageAspectRatio='" + cardImageAspectRatio + '\'' +
+            ", videoUrl='" + videoUrl + '\'' +
+            ", xbmcUrl='" + xbmcUrl + '\'' +
+            ", category='" + category + '\'' +
+            ", programId=" + programId +
+            ", watchNextId=" + watchNextId +
+            '}';
   }
 }

--- a/tools/android/packaging/xbmc/src/model/Movie.java.in
+++ b/tools/android/packaging/xbmc/src/model/Movie.java.in
@@ -8,26 +8,145 @@ import @APP_PACKAGE@.model.Media;
 
 public class Movie extends Media
 {
-  private String year;
-  private String plot;
+    private String year;
+    private String plot;
+    private double rating;
+    private int duration;
+    private int position;
+    private long lastPlayed;
+    private long releaseDate;
 
-  public String getYear()
-  {
-    return year;
-  }
+    private String posterImageUrl = null;
+    private String thumbnailImageUrl = null;
+    private String landscapeImageUrl = null;
+    private String fanartImageUrl = null;
 
-  public void setYear(String year)
-  {
-    this.year = year;
-  }
+    private boolean hasLandscapeArt;
 
-  public String getPlot()
-  {
-    return plot;
-  }
+    public String getYear()
+    {
+        return year;
+    }
 
-  public void setPlot(String plot)
-  {
-    this.plot = plot;
-  }
+    public void setYear(String year)
+    {
+        this.year = year;
+    }
+
+
+    public String getPlot()
+    {
+        return plot;
+    }
+
+    public void setPlot(String plot)
+    {
+        this.plot = plot;
+    }
+
+    public double getRating()
+    {
+        return rating;
+    }
+
+    public void setRating(double rating)
+    {
+        this.rating = rating;
+    }
+
+    public int getDuration()
+    {
+        return duration;
+    }
+
+    public void setDuration(int duration)
+    {
+        this.duration = duration;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public long getLastPlayed() {
+        return lastPlayed;
+    }
+
+    public void setLastPlayed(long lastPlayed) {
+        this.lastPlayed = lastPlayed;
+    }
+
+    public long getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(long releaseDate) {
+        this.releaseDate = releaseDate;
+    }
+
+    public String getPosterImageUrl() {
+        return posterImageUrl;
+    }
+
+    public void setPosterImageUrl(String posterImageUrl) {
+        this.posterImageUrl = posterImageUrl;
+    }
+
+    public String getThumbnailImageUrl() {
+        return thumbnailImageUrl;
+    }
+
+    public void setThumbnailImageUrl(String thumbnailImageUrl) {
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+
+    public String getFanartImageUrl() {
+        return fanartImageUrl;
+    }
+
+    public void setFanartImageUrl(String fanartImageUrl) {
+        this.fanartImageUrl = fanartImageUrl;
+    }
+
+    public String getLandscapeImageUrl() {
+        return landscapeImageUrl;
+    }
+
+    public void setLandscapeImageUrl(String landscapeImageUrl) {
+        this.landscapeImageUrl = landscapeImageUrl;
+    }
+
+    public boolean isHasLandscapeArt() {
+        return hasLandscapeArt;
+    }
+
+    public boolean getHasLandscapeArt() {
+        return hasLandscapeArt;
+    }
+
+    public void setHasLandscapeArt(boolean hasLandscapeArt) {
+        this.hasLandscapeArt = hasLandscapeArt;
+    }
+
+    @Override
+    public String toString() {
+        return "Movie{" +
+                "year='" + year + '\'' +
+                ", plot='" + plot + '\'' +
+                ", rating=" + rating +
+                ", duration=" + duration +
+                ", position=" + position +
+                ", lastPlayed=" + lastPlayed +
+                ", posterImageUrl='" + posterImageUrl + '\'' +
+                ", thumbnailImageUrl='" + thumbnailImageUrl + '\'' +
+                ", landscapeImageUrl='" + landscapeImageUrl + '\'' +
+                ", fanartImageUrl='" + fanartImageUrl + '\'' +
+                ", hasLandscapeArt=" + hasLandscapeArt +
+                '}';
+    }
 }
+

--- a/tools/android/packaging/xbmc/src/model/TVEpisode.java.in
+++ b/tools/android/packaging/xbmc/src/model/TVEpisode.java.in
@@ -8,26 +8,178 @@ import @APP_PACKAGE@.model.Media;
 
 public class TVEpisode extends Media
 {
+
+  private String episodeTitle;
+  private String plot;
+  private long rating;
+  private String year;
+  private int runtime;
+  private int position;
+  private long lastPlayed;
+  private long releaseDate;
   private int season;
   private int episode;
 
-  public int getSeason()
-  {
+  private String posterImageUrl = null;
+  private String tvShowPosterImagerUrl = null;
+  private String thumbnailImageUrl = null;
+  private String landscapeImageUrl = null;
+  private String fanartImageUrl = null;
+
+  private boolean hasLandscapeArt;
+
+
+  public String getEpisodeTitle() {
+    return episodeTitle;
+  }
+
+  public void setEpisodeTitle(String episodeTitle) {
+    this.episodeTitle = episodeTitle;
+  }
+
+  public String getPlot() {
+    return plot;
+  }
+
+  public void setPlot(String plot) {
+    this.plot = plot;
+  }
+
+  public long getRating() {
+    return rating;
+  }
+
+  public void setRating(long rating) {
+    this.rating = rating;
+  }
+
+  public String getYear() {
+    return year;
+  }
+
+  public void setYear(String year) {
+    this.year = year;
+  }
+
+  public int getRuntime() {
+    return runtime;
+  }
+
+  public void setRuntime(int runtime) {
+    this.runtime = runtime;
+  }
+
+  public int getPosition() {
+    return position;
+  }
+
+  public void setPosition(int position) {
+    this.position = position;
+  }
+
+  public long getLastPlayed() {
+    return lastPlayed;
+  }
+
+  public void setLastPlayed(long lastPlayed) {
+    this.lastPlayed = lastPlayed;
+  }
+
+  public long getReleaseDate() {
+    return releaseDate;
+  }
+
+  public void setReleaseDate(long releaseDate) {
+    this.releaseDate = releaseDate;
+  }
+
+  public int getSeason() {
     return season;
   }
 
-  public void setSeason(int season)
-  {
+  public void setSeason(int season) {
     this.season = season;
   }
 
-  public int getEpisode()
-  {
+  public int getEpisode() {
     return episode;
   }
 
-  public void setEpisode(int episode)
-  {
+  public void setEpisode(int episode) {
     this.episode = episode;
+  }
+
+  public String getPosterImageUrl() {
+    return posterImageUrl;
+  }
+
+  public void setPosterImageUrl(String posterImageUrl) {
+    this.posterImageUrl = posterImageUrl;
+  }
+
+  public String getTvShowPosterImagerUrl() {
+    return tvShowPosterImagerUrl;
+  }
+
+  public void setTvShowPosterImagerUrl(String tvShowPosterImagerUrl) {
+    this.tvShowPosterImagerUrl = tvShowPosterImagerUrl;
+  }
+
+  public String getThumbnailImageUrl() {
+    return thumbnailImageUrl;
+  }
+
+  public void setThumbnailImageUrl(String thumbnailImageUrl) {
+    this.thumbnailImageUrl = thumbnailImageUrl;
+  }
+
+  public String getFanartImageUrl() {
+    return fanartImageUrl;
+  }
+
+  public void setFanartImageUrl(String fanartImageUrl) {
+    this.fanartImageUrl = fanartImageUrl;
+  }
+
+  public String getLandscapeImageUrl() {
+    return landscapeImageUrl;
+  }
+
+  public void setLandscapeImageUrl(String landscapeImageUrl) {
+    this.landscapeImageUrl = landscapeImageUrl;
+  }
+
+  public boolean isHasLandscapeArt() {
+    return hasLandscapeArt;
+  }
+
+  public boolean getHasLandscapeArt() {
+    return hasLandscapeArt;
+  }
+
+  public void setHasLandscapeArt(boolean hasLandscapeArt) {
+    this.hasLandscapeArt = hasLandscapeArt;
+  }
+
+  @Override
+  public String toString() {
+    return "TVEpisode{" +
+            "episodeTitle='" + episodeTitle + '\'' +
+            ", plot='" + plot + '\'' +
+            ", rating=" + rating +
+            ", year='" + year + '\'' +
+            ", runtime=" + runtime +
+            ", position=" + position +
+            ", lastPlayed=" + lastPlayed +
+            ", season=" + season +
+            ", episode=" + episode +
+            ", posterImageUrl='" + posterImageUrl + '\'' +
+            ", tvShowPosterImagerUrl='" + tvShowPosterImagerUrl + '\'' +
+            ", thumbnailImageUrl='" + thumbnailImageUrl + '\'' +
+            ", landscapeImageUrl='" + landscapeImageUrl + '\'' +
+            ", fanartImageUrl='" + fanartImageUrl + '\'' +
+            ", hasLandscapeArt=" + hasLandscapeArt +
+            ", mediaCategory='" + this.getCategory() + '\'' +
+            '}';
   }
 }

--- a/tools/android/packaging/xbmc/src/model/TVShow.java.in
+++ b/tools/android/packaging/xbmc/src/model/TVShow.java.in
@@ -8,4 +8,146 @@ import @APP_PACKAGE@.model.Media;
 
 public class TVShow extends Media
 {
+    private String genre;
+    private String imdbNumber;
+    private String mpaa;
+    private double rating;
+    private int season;
+    private String studio;
+    private int year;
+    private String plot;
+
+    private String posterImageUrl = null;
+    private String thumbnailImageUrl = null;
+    private String landscapeImageUrl = null;
+    private String fanartImageUrl = null;
+
+    private boolean hasLandscapeArt;
+
+    public String getGenre() {
+        return genre;
+    }
+
+    public void setGenre(String genre) {
+        this.genre = genre;
+    }
+
+    public String getImdbNumber() {
+        return imdbNumber;
+    }
+
+    public void setImdbNumber(String imdbNumber) {
+        this.imdbNumber = imdbNumber;
+    }
+
+    public String getMpaa() {
+        return mpaa;
+    }
+
+    public void setMpaa(String mpaa) {
+        this.mpaa = mpaa;
+    }
+
+    public double getRating() {
+        return rating;
+    }
+
+    public void setRating(double rating) {
+        this.rating = rating;
+    }
+
+    public int getSeason() {
+        return season;
+    }
+
+    public void setSeason(int season) {
+        this.season = season;
+    }
+
+    public String getStudio() {
+        return studio;
+    }
+
+    public void setStudio(String studio) {
+        this.studio = studio;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    public String getPlot() {
+        return plot;
+    }
+
+    public void setPlot(String plot) {
+        this.plot = plot;
+    }
+
+    public String getPosterImageUrl() {
+        return posterImageUrl;
+    }
+
+    public void setPosterImageUrl(String posterImageUrl) {
+        this.posterImageUrl = posterImageUrl;
+    }
+
+    public String getThumbnailImageUrl() {
+        return thumbnailImageUrl;
+    }
+
+    public void setThumbnailImageUrl(String thumbnailImageUrl) {
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+
+    public String getFanartImageUrl() {
+        return fanartImageUrl;
+    }
+
+    public void setFanartImageUrl(String fanartImageUrl) {
+        this.fanartImageUrl = fanartImageUrl;
+    }
+
+    public String getLandscapeImageUrl() {
+        return landscapeImageUrl;
+    }
+
+    public void setLandscapeImageUrl(String landscapeImageUrl) {
+        this.landscapeImageUrl = landscapeImageUrl;
+    }
+
+    public boolean isHasLandscapeArt() {
+        return hasLandscapeArt;
+    }
+
+    public boolean getHasLandscapeArt() {
+        return hasLandscapeArt;
+    }
+
+    public void setHasLandscapeArt(boolean hasLandscapeArt) {
+        this.hasLandscapeArt = hasLandscapeArt;
+    }
+
+    @Override
+    public String toString() {
+        return "TVShow{" +
+                "genre='" + genre + '\'' +
+                ", imdbNumber='" + imdbNumber + '\'' +
+                ", mpaa='" + mpaa + '\'' +
+                ", rating=" + rating +
+                ", season=" + season +
+                ", studio='" + studio + '\'' +
+                ", year=" + year +
+                ", plot='" + plot + '\'' +
+                ", posterImageUrl='" + posterImageUrl + '\'' +
+                ", thumbnailImageUrl='" + thumbnailImageUrl + '\'' +
+                ", landscapeImageUrl='" + landscapeImageUrl + '\'' +
+                ", fanartImageUrl='" + fanartImageUrl + '\'' +
+                ", hasLandscapeArt=" + hasLandscapeArt +
+                '}';
+    }
 }


### PR DESCRIPTION
## Description
Added ability to display more metadeta on Android TV's channels. Metadata displayed now includes plot, year, rating and runtime for movies, as well as season number, episode number and air date for episodes. Landscape art support has been added as well.

## Motivation and Context
This addition makes browsing Kodi media from Android TV's home screen a richer experience.

## How Has This Been Tested?
Changes were tested on an Nvidia Shield TV

## Screenshots (if appropriate):
https://imgur.com/TX1F0Km
https://imgur.com/TTm7mbr
https://imgur.com/lurvGq7

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
