### PR TITLE
[Ios] fix warnings python and ldflag

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -375,7 +375,7 @@ case $host in
         platform_cflags+=" -Wno-error=implicit-function-declaration"
         optimize_flags="-O3"
         use_sdk_path=[`$use_xcodebuild -version -sdk $sdk_name | grep ^Path | awk '{ print $2}'`]
-        platform_ldflags+=" -L$use_sdk_path/usr/lib/system"
+        platform_ldflags+=" -L$use_sdk_path/usr/lib"
         platform_cxxflags+=" $cpu_flags"
       ;;
     esac

--- a/tools/depends/target/python27/Makefile
+++ b/tools/depends/target/python27/Makefile
@@ -45,6 +45,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 ifeq ($(OS),ios)
 	cd $(PLATFORM); patch -p1 < ../make-fork-optional.patch
 	cd $(PLATFORM); patch -p1 < ../urllib.patch
+	cd $(PLATFORM); patch -p1 < ../python_register.patch
 	cd $(PLATFORM); sed -ie 's|MACHDEP="unknown"|MACHDEP="darwin"|' configure.ac
 endif
 	cp modules.setup $(PLATFORM)/Modules/Setup.dist

--- a/tools/depends/target/python27/python_register.patch
+++ b/tools/depends/target/python27/python_register.patch
@@ -1,0 +1,53 @@
+--- a/Include/stringobject.h
++++ b/Include/stringobject.h
+@@ -170,9 +170,9 @@ PyAPI_FUNC(PyObject*) PyString_AsDecoded
+    cause an exception).  */
+ 
+ PyAPI_FUNC(int) PyString_AsStringAndSize(
+-    register PyObject *obj,	/* string or Unicode object */
+-    register char **s,		/* pointer to buffer variable */
+-    register Py_ssize_t *len	/* pointer to length variable or NULL
++    PyObject *obj,	/* string or Unicode object */
++    char **s,		/* pointer to buffer variable */
++    Py_ssize_t *len	/* pointer to length variable or NULL
+ 				   (only possible for 0-terminated
+ 				   strings) */
+     );
+--- a/Include/unicodeobject.h
++++ b/Include/unicodeobject.h
+@@ -531,7 +531,7 @@ PyAPI_FUNC(int) PyUnicode_Resize(
+ */
+ 
+ PyAPI_FUNC(PyObject*) PyUnicode_FromEncodedObject(
+-    register PyObject *obj,     /* Object */
++    PyObject *obj,     /* Object */
+     const char *encoding,       /* encoding */
+     const char *errors          /* error handling */
+     );
+@@ -550,7 +550,7 @@ PyAPI_FUNC(PyObject*) PyUnicode_FromEnco
+ */
+ 
+ PyAPI_FUNC(PyObject*) PyUnicode_FromObject(
+-    register PyObject *obj      /* Object */
++    PyObject *obj      /* Object */
+     );
+ 
+ PyAPI_FUNC(PyObject *) PyUnicode_FromFormatV(const char*, va_list);
+@@ -572,7 +572,7 @@ PyAPI_FUNC(PyObject *) _PyUnicode_Format
+    The buffer is copied into the new object. */
+ 
+ PyAPI_FUNC(PyObject*) PyUnicode_FromWideChar(
+-    register const wchar_t *w,  /* wchar_t buffer */
++    const wchar_t *w,  /* wchar_t buffer */
+     Py_ssize_t size             /* size of buffer */
+     );
+ 
+@@ -590,7 +590,7 @@ PyAPI_FUNC(PyObject*) PyUnicode_FromWide
+ 
+ PyAPI_FUNC(Py_ssize_t) PyUnicode_AsWideChar(
+     PyUnicodeObject *unicode,   /* Unicode object */
+-    register wchar_t *w,        /* wchar_t buffer */
++    wchar_t *w,        /* wchar_t buffer */
+     Py_ssize_t size             /* size of buffer */
+     );
+ 


### PR DESCRIPTION
## Description
Remove register keyword from unicodeobject.h and stringobject.h to silence warning
Fix ldflags warning ld: warning: directory not found for option iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/usr/lib/system

## Motivation and Context
fix some warnings on ios builds.

Python register patch can be removed once Python 3 is implemented https://github.com/xbmc/xbmc/pull/16116
Python3 codebase removes usage of register already, so patch wont be needed.

## How Has This Been Tested?
built and run on iPad Air 2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
