### PR TITLE
[windowing/gbm] Select best CRTC+planes option

### DIFF
--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -39,6 +39,19 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       return;
     }
 
+    if (m_active && m_orig_crtc && m_orig_crtc->crtc->crtc_id != m_crtc->crtc->crtc_id)
+    {
+      // if using a different CRTC than the original, disable original to avoid EINVAL
+      if (!AddProperty(m_orig_crtc, "MODE_ID", 0))
+      {
+        return;
+      }
+      if (!AddProperty(m_orig_crtc, "ACTIVE", 0))
+      {
+        return;
+      }
+    }
+
     if (!AddProperty(m_crtc, "MODE_ID", blob_id))
     {
       return;

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -134,7 +134,7 @@ private:
   bool GetResources();
   bool FindConnector();
   bool FindEncoder();
-  bool FindCrtc();
+  bool FindCrtcs();
   bool FindPlanes();
   bool FindModifiersForPlane(struct plane *object);
   bool FindPreferredMode();
@@ -144,11 +144,12 @@ private:
   bool CheckConnector(int connectorId);
 
   KODI::UTILS::POSIX::CFileHandle m_renderFd;
-  int m_crtc_index;
   std::string m_module;
 
   drmModeResPtr m_drm_resources = nullptr;
   drmModeCrtcPtr m_orig_crtc = nullptr;
+
+  std::vector<crtc*> m_crtcs;
 };
 
 }

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -120,6 +120,7 @@ protected:
   struct connector *m_connector = nullptr;
   struct encoder *m_encoder = nullptr;
   struct crtc *m_crtc = nullptr;
+  struct crtc* m_orig_crtc = nullptr;
   struct plane *m_video_plane = nullptr;
   struct plane *m_gui_plane = nullptr;
   drmModeModeInfo *m_mode = nullptr;
@@ -147,7 +148,6 @@ private:
   std::string m_module;
 
   drmModeResPtr m_drm_resources = nullptr;
-  drmModeCrtcPtr m_orig_crtc = nullptr;
 
   std::vector<crtc*> m_crtcs;
 };


### PR DESCRIPTION
## Description

On a platform with multiple CRTCs connected to the selected encoder, instead of using the default CRTC currently driving the encoder, get the availability of video and GUI planes on each CRTC, then select the best out of all found CRTC+planes options.
v2: smarter CRTC selection.
v3: iterate over CRTC options and use the best "scoring" one instead of sorting the list. Follow coding guidelines on alignment & spacing.
v4: base on https://github.com/lrusak/xbmc/commit/86000d34446ecc89f9e170cfcee8502f22ef352c and disable original CRTC in atomic modeset if choosing a different one.

## Motivation and Context

On an RK3399 SoC (Rockpro64 board) with the mainline kernel, there are two CRTCs that can be used to drive HDMI, the "little VOP" or vopl with only one primary plane and one cursor plane, and the "big VOP" or vopb which supports several planes. The mainline kernel configures HDMI to be driven by vopl by default.

Kodi doesn't use cursor planes, and the single primary plane supports NV12 format which is the only criteria used when searching for `KODI_VIDEO_PLANE`, so in `FindPlanes()` the primary plane is used for the `KODI_VIDEO_PLANE` and then no GUI plane can be found. Kodi segfaults later in `FindPlanes()` when it tries to get the properties of the null GUI plane. Kodi should be smarter in CRTC+planes selection and pick the more suitable CRTC.

## How Has This Been Tested?

Tested on a 5.2-rc1 kernel on the Rockpro64 board - with this patch kodi-gbm will start, scan the available CRTCs, switch HDMI to be driven by vopb and display the normal UI on an attached HDMI monitor. Previously it would exit with a segmentation fault.
Also tested on Raspberry Pi 2 using the vc4 DRM and Mesa GBM driver.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed