### PR TITLE
ActiveAE: Fix crash when song switches to 48khtz track and viz is on

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2191,7 +2191,7 @@ bool CActiveAE::RunStages()
             {
               // copy the samples into the viz input buffer
               CSampleBuffer *viz = m_vizBuffersInput->GetFreeBuffer();
-              int samples = out->pkt->nb_samples;
+              int samples = std::min(out->pkt->nb_samples, viz->pkt->max_nb_samples);
               int bytes = samples * out->pkt->config.channels / out->pkt->planes * out->pkt->bytes_per_sample;
               for(int i= 0; i < out->pkt->planes; i++)
               {


### PR DESCRIPTION
* Fixes segfault when switching to a 48khtz mp3 with visuals enabled,
  and "best match" as audio output setting. Issue is apparently due
  to miscalculation of samples. (it expects 2048) this does not
  impove the handling of the situation it simply fixes the segfault
  to allow a better UX.

* Credits to: Rainer Hochecker <rainer.hochecker@googlemail.com>

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>

## Description
Bugfix: This has been present since the first alpha of v14.

if playing a mix of 44.1khtz and 48khtz music files when a
44.1kthz song ends and a 48khtz song begins AND while music
visualizations are active, KODI will crash with a segfault
in the "Stages()" sections of AE. 

## Motivation and Context
When playing music with different sample rates when one song finishes and another beghins that is 48htz AND Visualizations are enabled (important! doesnt crash with em off. ANY ONE not just projectm) It also wont happen if you manually press skip + or - you have to let PAPlayer do it. it also does not happen with VideoPlayer

NA

## How Has This Been Tested?
Put my collection of the Band soundgarden on shuffle because it is a easy way for me to test with 48khtz since a whole album is in 48khtz. Let it play until it comes up on a 48kthz song. without my fix it would crash EVERY TIME. I tried different Linux flavors. different hardware... different PC.. doesnt happen on a raspbery Pi 3. only thing i didnt change was my AVR since i cant.

Ubuntu 14.04 LTS Minimal 3.13 - Ubuntu 18.04 4.18 Kernel, Nvidia GT 550 , Drivers version 304.122 and 375.166 (currently 375)

Tested for a few weeks. thrown all different sample rates etc at it. all seems fine. visuals still work and seem timed up

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
