### PR TITLE
fixed: Flagging video aspect ratio was broken (partially fixes #15934)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -521,6 +521,7 @@ void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux
         s.height = vstream->iHeight;
         s.stereo_mode = vstream->stereo_mode;
         s.bitrate = vstream->iBitRate;
+        s.aspect_ratio = vstream->fAspect;
       }
       if(stream->type == STREAM_AUDIO)
       {


### PR DESCRIPTION
I don't understand why this previously worked, but at least this fixes one of the issues in #15934