### PR TITLE
Container only refreshes with player announcement if media window active

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -232,7 +232,11 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const cha
          (std::find(m_itemTypes.begin(), m_itemTypes.end(), InfoTagType::AUDIO) == m_itemTypes.end())))
       return;
 
-    if (flag & ANNOUNCEMENT::Player)
+    if ((flag & ANNOUNCEMENT::Player) &&
+        ((CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) ||
+         (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO) ||
+         (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) ||
+         (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME)))
     {
       if (strcmp(message, "OnPlay") == 0 ||
           strcmp(message, "OnResume") == 0 ||

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -233,8 +233,8 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const cha
       return;
 
     if ((flag & ANNOUNCEMENT::Player) &&
-        ((CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) ||
-         (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO) ||
+        ((CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO) ||
+         (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION) ||
          (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW) ||
          (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME)))
     {


### PR DESCRIPTION
## Description
This very small addition changes unwanted behavior of the container refreshing when player OnStop/OnPlay/OnResume, and limiting the refresh action only to when media window is active.

## Motivation and Context
If user is currently viewing a container that is playing media outside of fullscreen media windows, it will call the container to refresh which could result in change of the content, especially if the container is not 'deterministic' in nature (e.g. random sort). Moreover, for content from plugins it will call for populating the container which takes more time or is not cached and is returning different result.
For example, in my skin, I implemented an auto-trailer feature but whenever a trailer starts/stops, the container will force refresh and thus change the currently viewed list and/or reposition (if item is in the refreshed list). Another example is when splashscreen is finished it is calling a refresh (OnStop) and all containers that has preloaded are now refreshed again.

At first I looked at the option to implement a parameter to play command such that will allow option to run 'silent' or defining as 'trailer' (there isn't a good enough trailer recognition for this unless it is left in the hands of the skinner/addon author) - these did not seem to be good solutions for this, as I believe the wider issue here is content changing when it is currently viewed when it should be happening in the background when not viewed, and not specifically with trailers.

## How Has This Been Tested?
It doesn't affect any other areas of the code. I've compiled and built it for win x64 and tested, it does not refresh if player starts/stops video in videowindow but does refresh if video starts/stops in fullscreen video window.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
