### PR TITLE
Read APE tag embedded cover art

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -571,7 +571,7 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
       // The image data follows a null byte, which can optionally be preceded by a filename
       const uint offset = tdata.find('\0') + 1;
       ByteVector bv(tdata.data() + offset, tdata.size() - offset);
-      // Determine mimetype from file signature
+      // Infer the mimetype
       std::string mime{};
       if (bv.startsWith("\xFF\xD8\xFF"))
         mime = "image/jpeg";
@@ -581,7 +581,7 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
         mime = "image/gif";
       else if (bv.startsWith("\x42\x4D"))
         mime = "image/bmp";
-      if ((offset > 0) && (offset < tdata.size()) && (mime.size() > 0)) {
+      if ((offset > 0) && (offset <= tdata.size()) && (mime.size() > 0)) {
         tag.SetCoverArtInfo(bv.size(), mime);
         if (art)
           art->Set(reinterpret_cast<const uint8_t *>(bv.data()), bv.size(), mime);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Add parsing of APEv2 tag cover art to the TagLib tag loader.

## Motivation and Context
APEv2 embedded cover art is not currently parsed.

## How Has This Been Tested?
Disabled non-local scraping. Added sources containing jpg, png, gif, and bmp picture data. The embedded album cover art was found and parsed correctly. Verified that the cover art was from the embedded cover art of the test file set.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
