### PR TITLE
[PVR] Only skip parsing stream info if a PID (program number) is not supplied

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -64,9 +64,14 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(std::shared_ptr<CDVDInputStream> pI
   bool streaminfo = true; /* Look for streams before playback */
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
   {
-    /* Don't parse the streaminfo for some cases of streams to reduce the channel switch time */
-    bool useFastswitch = URIUtils::IsUsingFastSwitch(pInputStream->GetFileName());
-    streaminfo = !useFastswitch;
+    // Only skip parsing of streaminfo if a PID is not supplied. If it is we need to parse it so the right PID can be selected in DVDDemuxFFmpeg.
+    const CVariant programProp(pInputStream->GetProperty("program"));
+    if (programProp.isNull())
+    {
+      /* Don't parse the streaminfo for some cases of streams to reduce the channel switch time */
+      bool useFastswitch = URIUtils::IsUsingFastSwitch(pInputStream->GetFileName());
+      streaminfo = !useFastswitch;
+    }
   }
 
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

For Live PVR Streams that contain multiple streams (MPTS) the demuxer factory by default favours fast switching (not parsing streaminfo) to improve channel switch times even if the correct PID (program number) for the stream is supplied.

In the case a PID is supplied this change enforces the parsing of stream info. But only in the case of live PVR streams.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

In the pvr.vuplus addon certain TV providers use MPTS for their live streams. Therefore users with certain providers in some countries cannot view their channels. Exmaple: `Nos` in portugal.

closes these issues:

- https://github.com/kodi-pvr/pvr.vuplus/issues/195
- https://github.com/kodi-pvr/pvr.vuplus/issues/208
- https://github.com/kodi-pvr/pvr.vuplus/issues/219

Context:

For Enigma2 the STB simply passes the RAW TS stream (AFAIK). In the case of a recording the RAW stream is recorded to disk.

For the majority of providers only a single program (PID) is contained in the stream. Working assumption is that for certain providers multiple program's are passed in the PMT but the program data packets are dropped. In this case as kodi does not parse streaminfo the correct stream is not selected. 

Note that when playing back a recording as kodi processes the streaminfo the correct program is selected (without passing a "program" channel stream property).

If inputstreams are disabled both live channels and recordings play as expected as in these cases streaminfo would be parsed.

Gist containing a log of this occurring: https://gist.github.com/phunkyfish/c6e267e57a703d0e44c4e97432415c02

In this log kodi uses Program 888 where in fact the correct program is 880.

Here is the ffmpeg output where for a bad streams where kodi would choose the wrong program. Clearly many programs are in the program table.

https://gist.github.com/phunkyfish/b1aa31816bea473168d4062796ec626c

The correct program should be 880.

Here is an example of a good stream's ffmpeg output where the only program present is 101:

https://gist.github.com/phunkyfish/1dfbf51b37f202ab75cbd4a7b28d40bb

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested on Windows 10 and Mac OS Mojave using the pvr.vuplus addon.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
