### PR TITLE
[cmake] pass all CPPFLAGS to libcpluff configure

### DIFF
--- a/cmake/modules/FindCpluff.cmake
+++ b/cmake/modules/FindCpluff.cmake
@@ -12,14 +12,9 @@ if(CORE_SYSTEM_NAME MATCHES windows)
   set(CPLUFF_LIBRARIES $<TARGET_FILE:libcpluff> ${EXPAT_LIBRARIES})
 else()
   string(REPLACE ";" " " defines "${CMAKE_C_FLAGS} ${SYSTEM_DEFINES} -I${EXPAT_INCLUDE_DIR}")
+  string(REPLACE ";" " " cppflags "${CMAKE_CPP_FLAGS}")
   get_filename_component(expat_dir ${EXPAT_LIBRARY} DIRECTORY)
   set(ldflags "-L${expat_dir}")
-
-  # iOS: Without specifying -arch, configure tries to use /bin/cpp as C-preprocessor
-  # http://stackoverflow.com/questions/38836754/cant-cross-compile-c-library-for-arm-ios
-  if(CORE_SYSTEM_NAME STREQUAL ios)
-    set(cppflags "-arch ${CPU}")
-  endif()
 
   ExternalProject_Add(libcpluff SOURCE_DIR ${CMAKE_SOURCE_DIR}/lib/cpluff
                       BUILD_IN_SOURCE 1


### PR DESCRIPTION
## Motivation and Context
building for iOS always caused failures because of the CPPFLAGS hack on my system

## How Has This Been Tested?
built Kodi for iOS

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
