### PR TITLE
Require OpenSSL 1.0.2 and manage thread ids consistently on all platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ set(required_deps ASS
                   Iconv
                   LibDvd
                   Lzo2
-                  OpenSSL
+                  OpenSSL>=1.0.2
                   PCRE
                   RapidJSON
                   Sqlite3

--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -30,7 +30,8 @@ void lock_callback(int mode, int type, const char* file, int line)
     getlock(type)->unlock();
 }
 
-unsigned long GetCryptThreadId() {
+unsigned long GetCryptThreadId()
+{
   static std::atomic<unsigned long> tidSequence{0};
   static thread_local unsigned long tidTl{0};
 
@@ -75,7 +76,8 @@ CCriticalSection* CryptThreadingInitializer::GetLock(int index)
   return curlock.get();
 }
 
-unsigned long CryptThreadingInitializer::GetCurrentCryptThreadId() {
+unsigned long CryptThreadingInitializer::GetCurrentCryptThreadId()
+{
   return GetCryptThreadId();
 }
 

--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -75,4 +75,8 @@ CCriticalSection* CryptThreadingInitializer::GetLock(int index)
   return curlock.get();
 }
 
+unsigned long CryptThreadingInitializer::GetCurrentCryptThreadId() {
+  return GetCryptThreadId();
+}
+
 #endif

--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -7,17 +7,13 @@
  */
 
 #include "CryptThreading.h"
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
 #include "threads/Thread.h"
 #include "utils/log.h"
 
-#include <openssl/crypto.h>
+#include <atomic>
 
-//! @todo Remove support for OpenSSL <1.0 in v19
-
-#define KODI_OPENSSL_NEEDS_LOCK_CALLBACK (OPENSSL_VERSION_NUMBER < 0x10100000L)
-#define KODI_OPENSSL_USE_THREADID (OPENSSL_VERSION_NUMBER >= 0x10000000L)
-
-#if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
 namespace
 {
 
@@ -34,48 +30,37 @@ void lock_callback(int mode, int type, const char* file, int line)
     getlock(type)->unlock();
 }
 
-#if KODI_OPENSSL_USE_THREADID
+unsigned long GetCryptThreadId() {
+  static std::atomic<unsigned long> tidSequence{0};
+  static thread_local unsigned long tidTl{0};
+
+  if (tidTl == 0)
+    tidTl = ++tidSequence;
+  return tidTl;
+}
+
 void thread_id(CRYPTO_THREADID* tid)
 {
   // C-style cast required due to vastly differing native ID return types
-  CRYPTO_THREADID_set_numeric(tid, (unsigned long)CThread::GetCurrentThreadId());
+  CRYPTO_THREADID_set_numeric(tid, GetCryptThreadId());
 }
-#else
-unsigned long thread_id()
-{
-  // C-style cast required due to vastly differing native ID return types
-  return (unsigned long)CThread::GetCurrentThreadId();
-}
-#endif
 
 }
-#endif
 
 CryptThreadingInitializer::CryptThreadingInitializer()
 {
-#if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
   // OpenSSL < 1.1 needs integration code to support multi-threading
   // This is absolutely required for libcurl if it uses the OpenSSL backend
   m_locks.resize(CRYPTO_num_locks());
-#if KODI_OPENSSL_USE_THREADID
   CRYPTO_THREADID_set_callback(thread_id);
-#else
-  CRYPTO_set_id_callback(thread_id);
-#endif
   CRYPTO_set_locking_callback(lock_callback);
-#endif
 }
 
 CryptThreadingInitializer::~CryptThreadingInitializer()
 {
-#if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
   CSingleLock l(m_locksLock);
-#if !KODI_OPENSSL_USE_THREADID
-  CRYPTO_set_id_callback(nullptr);
-#endif
   CRYPTO_set_locking_callback(nullptr);
   m_locks.clear();
-#endif
 }
 
 CCriticalSection* CryptThreadingInitializer::GetLock(int index)
@@ -90,6 +75,4 @@ CCriticalSection* CryptThreadingInitializer::GetLock(int index)
   return curlock.get();
 }
 
-
-
-
+#endif

--- a/xbmc/utils/CryptThreading.h
+++ b/xbmc/utils/CryptThreading.h
@@ -29,6 +29,11 @@ public:
 
   CCriticalSection* GetLock(int index);
 
+  /**
+   * This is so testing can reach the thread id generation.
+   */
+  unsigned long GetCurrentCryptThreadId();
+
 private:
   CryptThreadingInitializer(const CryptThreadingInitializer &rhs) = delete;
   CryptThreadingInitializer& operator=(const CryptThreadingInitializer&) = delete;

--- a/xbmc/utils/CryptThreading.h
+++ b/xbmc/utils/CryptThreading.h
@@ -8,6 +8,11 @@
 
 #pragma once
 
+#include <openssl/crypto.h>
+
+//! @todo - once we're at OpenSSL 1.1 this class and its .cpp file should be deleted.
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
 #include <memory>
 #include <vector>
 #include "utils/GlobalsHandling.h"
@@ -31,3 +36,5 @@ private:
 
 XBMC_GLOBAL_REF(CryptThreadingInitializer,g_cryptThreadingInitializer);
 #define g_cryptThreadingInitializer XBMC_GLOBAL_USE(CryptThreadingInitializer)
+
+#endif

--- a/xbmc/utils/test/TestCryptThreading.cpp
+++ b/xbmc/utils/test/TestCryptThreading.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "utils/CryptThreading.h"
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
 #include "gtest/gtest.h"
 
@@ -15,3 +16,4 @@ TEST(TestCryptThreadingInitializer, General)
   std::cout << "g_cryptThreadingInitializer address: " <<
     testing::PrintToString(&g_cryptThreadingInitializer) << "\n";
 }
+#endif

--- a/xbmc/utils/test/TestCryptThreading.cpp
+++ b/xbmc/utils/test/TestCryptThreading.cpp
@@ -38,17 +38,17 @@ TEST(TestCryptThreadingInitializer, ProducesValidThreadIds)
   for (int i = 0; i < PVTID_NUM_THREADS; i++)
   {
     testThreads[i] = std::thread([&gatheredIds, &gatheredIdsMutex, &threadsWaiting, &gate]() {
-        threadsWaiting++;
+      threadsWaiting++;
 
-        while (!gate);
+      while (!gate);
 
-        unsigned long myTid = g_cryptThreadingInitializer.GetCurrentCryptThreadId();
+      unsigned long myTid = g_cryptThreadingInitializer.GetCurrentCryptThreadId();
 
-        {
-          CSingleLock gatheredIdsLock(gatheredIdsMutex);
-          gatheredIds.push_back(myTid);
-        }
-      });        
+      {
+        CSingleLock gatheredIdsLock(gatheredIdsMutex);
+        gatheredIds.push_back(myTid);
+      }
+    });        
   }
 
   gate = true;

--- a/xbmc/utils/test/TestCryptThreading.cpp
+++ b/xbmc/utils/test/TestCryptThreading.cpp
@@ -8,6 +8,12 @@
 
 #include "utils/CryptThreading.h"
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#include "threads/SingleLock.h"
+
+#include <atomic>
+#include <set>
+#include <thread>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -15,5 +21,59 @@ TEST(TestCryptThreadingInitializer, General)
 {
   std::cout << "g_cryptThreadingInitializer address: " <<
     testing::PrintToString(&g_cryptThreadingInitializer) << "\n";
+}
+
+#define PVTID_NUM_THREADS 10
+
+TEST(TestCryptThreadingInitializer, ProducesValidThreadIds)
+{
+  std::thread testThreads[PVTID_NUM_THREADS];
+
+  std::vector<unsigned long> gatheredIds;
+  CCriticalSection gatheredIdsMutex;
+
+  std::atomic<unsigned long> threadsWaiting{0};
+  std::atomic<bool> gate{false};
+
+  for (int i = 0; i < PVTID_NUM_THREADS; i++)
+  {
+    testThreads[i] = std::thread([&gatheredIds, &gatheredIdsMutex, &threadsWaiting, &gate]() {
+        threadsWaiting++;
+
+        while (!gate);
+
+        unsigned long myTid = g_cryptThreadingInitializer.GetCurrentCryptThreadId();
+
+        {
+          CSingleLock gatheredIdsLock(gatheredIdsMutex);
+          gatheredIds.push_back(myTid);
+        }
+      });        
+  }
+
+  gate = true;
+
+  for (int i = 0; i < PVTID_NUM_THREADS; i++)
+    // This is somewhat dangerous but C++ doesn't have a join with timeout or a way to check
+    // if a thread is still running.
+    testThreads[i].join();
+
+  // Verify that all of the thread id's are unique, and that there are 10 of them, and that none
+  // of them is zero
+  std::set<unsigned long> checkIds;
+  for (std::vector<unsigned long>::const_iterator i = gatheredIds.begin(); i != gatheredIds.end(); ++i)
+  {
+    unsigned long curId = *i;
+    // Thread ID isn't zero (since the sequence is pre-incremented and starts at 0)
+    ASSERT_TRUE(curId != 0);
+
+    // Make sure the ID isn't duplicated
+    ASSERT_TRUE(checkIds.find(curId) == checkIds.end());
+    checkIds.insert(curId);
+  }
+
+  // Make sure there's exactly PVTID_NUM_THREADS of them
+  ASSERT_EQ(PVTID_NUM_THREADS, gatheredIds.size());
+  ASSERT_EQ(PVTID_NUM_THREADS, checkIds.size());
 }
 #endif


### PR DESCRIPTION
## Description
This change moves the required OpenSSL minimum version to 1.0.2 and removes code that depends on older versions.

## Motivation and Context
Requiring OpenSSL 1.0.2 removes the need to manage custom thread ids in OpenSSL threads. This is a requirement for https://github.com/xbmc/xbmc/pull/13721

## How Has This Been Tested?
Built an run on Ubuntu.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
Note: I removed code and didn't change existing code.
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
