### PR TITLE
[docs] update header include coding guideline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,11 +35,18 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+  - Regex:           '(["/]PlatformDefs|"(system|system_gl))\.h"'
+    Priority:        5
+  - Regex:           '"platform/[^/]+/'
     Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
+  - Regex:           '^<[a-z0-9_]+>$'
     Priority:        3
+  - Regex:           '^<(assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>$'
+    Priority:        3
+  - Regex:           '^<'
+    Priority:        4
   - Regex:           '.*'
     Priority:        1
 IncludeIsMainRegex: '$'

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -366,35 +366,37 @@ static void test();
 **[back to top](#table-of-contents)**
 
 ## 7. Headers
-Included header files have to be sorted alphabetically to prevent duplicates and allow better overview, with an empty line clearly separating sections.
+Included header files have to be sorted (case sensitive) alphabetically to prevent duplicates and allow better overview, with an empty line clearly separating sections.
 
 Header order has to be:
 * Own header file
-* Other Kodi includes
+* Other Kodi includes (platform independent)
+* Other Kodi includes (platform specific)
 * C and C++ system files
 * Other libraries' header files
+* special Kodi headers (PlatformDefs.h, system.h and system_gl.h)
 
 ```cpp
 #include "PVRManager.h"
 
+#include "Application.h"
+#include "ServiceBroker.h"
 #include "addons/AddonInstaller.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
-#include "messaging/helpers/DialogHelper.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
-#include "music/tags/MusicInfoTag.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "music/MusicDatabase.h"
+#include "music/tags/MusicInfoTag.h"
 #include "network/Network.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/JobManager.h"
-#include "utils/log.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 #include "video/VideoDatabase.h"
-#include "Application.h"
-#include "ServiceBroker.h"
 
 #include <cassert>
 #include <utility>
@@ -402,7 +404,7 @@ Header order has to be:
 #include <libavutil/pixfmt.h>
 ```
 
-Place directories before files. If the headers aren't sorted, either do your best to match the existing order, or precede your commit with an alphabetization commit.
+If the headers aren't sorted, either do your best to match the existing order, or precede your commit with an alphabetization commit.
 
 If possible, avoid including headers in another header. Instead, you can forward-declare the class and use a `std::unique_ptr` (or similar):
 


### PR DESCRIPTION
## Motivation and Context
have a coding standard for includes which can also be checked by clang-format

## How Has This Been Tested?
run clang-format on the include blocks, see https://github.com/xbmc/xbmc/compare/master...Rechi:clang-format-includes for the result

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
