### PR TITLE
Add tools for mutithreaded testing and use them to remove dependency on timing in a test

### DIFF
--- a/xbmc/test/MtTestUtils.h
+++ b/xbmc/test/MtTestUtils.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2005-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/SystemClock.h"
+
+#include <chrono>
+#include <thread>
+
+namespace ConditionPoll
+{
+/**
+ * This is usually enough time for the condition to have occurred in a test.
+ */
+constexpr unsigned int defaultTimeout{20000};
+
+/**
+ * poll until the lambda returns true or the timeout occurs. If the timeout occurs then
+ * the function will return false. Otherwise it will return true.
+ */
+template<typename L> inline bool poll(unsigned int timeoutMillis, L lambda)
+{
+  XbmcThreads::EndTime endTime(timeoutMillis);
+  bool lastValue = false;
+  while (!endTime.IsTimePast() && (lastValue = lambda()) == false)
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  return lastValue;
+}
+
+/**
+ * poll until the lambda returns true or the defaultTimeout occurs. If the timeout occurs then
+ * the function will return false. Otherwise it will return true.
+ */
+template<typename L> inline bool poll(L lambda)
+{
+  return poll(defaultTimeout, lambda);
+}
+
+}


### PR DESCRIPTION
…on timing in the TestJobManager test.

## Description
Fix a continuously and randomly failing test by removing the dependency on timing characteristics. Also add some useful tools that can be used in other tests to do the same thing.

## Motivation and Context
No one should be depending on timing (by using sleeps in their code). This is true even in tests. This fixes a test that does this and provides some tools to avoid needing to do it in the future.

## How Has This Been Tested?
Test code.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
