### PR TITLE
[iOS] fix occasional rotation to portrait mode of external screen

### DIFF
--- a/xbmc/platform/darwin/ios/IOSExternalTouchController.mm
+++ b/xbmc/platform/darwin/ios/IOSExternalTouchController.mm
@@ -103,6 +103,11 @@ const CGFloat timeFadeSecs                    = 2.0;
   return self;
 }
 //--------------------------------------------------------------
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+  return UIInterfaceOrientationMaskLandscape;
+}
+//--------------------------------------------------------------
 - (void)startSleepTimer
 {
   NSDate *fireDate = [NSDate dateWithTimeIntervalSinceNow:touchScreenDimTimeoutSecs];


### PR DESCRIPTION
## Description
When iOS app is connected to external screen and uses it as main screen (not mirroring), sometimes main screen rotates to portrait mode together with the iOS device. This fixes it.

## Motivation and Context
The issue has been discovered while testing external screen mode in #16015.
> rotating device to portrait mode rotates picture on TV, although on device UI doesn't rotate

> it starts happening only after you try to enable external screen mode (I think this Navigation Help screen with Kodi logo is responsible, as the logo also rotated initially). Also one more bug because of that: keyboard isn't shown any more.

## How Has This Been Tested?
Tested on iPhone with external screen connected by rotating the device like mad.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed