### PR TITLE
[Android] Fix segfault when calling GetMemoryInfo

### DIFF
--- a/xbmc/platform/android/MemUtils.cpp
+++ b/xbmc/platform/android/MemUtils.cpp
@@ -39,7 +39,7 @@ void GetMemoryStatus(MemoryStatus* buffer)
 
   if (CXBMCApp::get()->GetMemoryInfo(availMem, totalMem))
   {
-    buffer = {};
+    *buffer = {};
     buffer->totalPhys = totalMem;
     buffer->availPhys = availMem;
   }


### PR DESCRIPTION
## Description
Trying to open PlayerInfo OSD currently lead to crash on android devices.

## Motivation and Context
Fix segfault

## How Has This Been Tested?
Run video, press o

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
