### PR TITLE
[Android] Don't consider display mode ids constant.

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1418,6 +1418,12 @@ void CXBMCApp::onDisplayAdded(int displayId)
 void CXBMCApp::onDisplayChanged(int displayId)
 {
   CLog::Log(LOGDEBUG, "CXBMCApp::%s: id: %d", __FUNCTION__, displayId);
+
+  // Update display modes
+  CWinSystemAndroid* winSystemAndroid = dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem());
+  if (winSystemAndroid)
+    winSystemAndroid->UpdateDisplayModes();
+
   m_displayChangeEvent.Set();
   android_printf("%s: ", __PRETTY_FUNCTION__);
 }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -88,7 +88,7 @@ static std::string ModeFlagsToString(unsigned int flags, bool identifier)
 
 CDisplaySettings::CDisplaySettings()
 {
-  m_resolutions.insert(m_resolutions.begin(), RES_CUSTOM, RESOLUTION_INFO());
+  m_resolutions.resize(RES_CUSTOM);
 
   m_zoomAmount = 1.0f;
   m_pixelRatio = 1.0f;
@@ -219,6 +219,7 @@ void CDisplaySettings::Clear()
   CSingleLock lock(m_critical);
   m_calibrations.clear();
   m_resolutions.clear();
+  m_resolutions.resize(RES_CUSTOM);
 
   m_zoomAmount = 1.0f;
   m_pixelRatio = 1.0f;

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -239,7 +239,7 @@ bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO *res) const
 
 bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
 {
-  CLog::Log(LOGDEBUG, "CAndroidUtils: SetNativeResolution: %s: %dx%d %dx%d@%f", res.strId.c_str(), res.iWidth, res.iHeight, res.iScreenWidth, res.iScreenHeight, res.fRefreshRate);
+  CLog::Log(LOGNOTICE, "CAndroidUtils: SetNativeResolution: %s: %dx%d %dx%d@%f", res.strId.c_str(), res.iWidth, res.iHeight, res.iScreenWidth, res.iScreenHeight, res.fRefreshRate);
 
   if (s_hasModeApi)
   {
@@ -312,6 +312,12 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
     return true;
   }
   return false;
+}
+
+bool CAndroidUtils::UpdateDisplayModes()
+{
+  fetchDisplayModes();
+  return true;
 }
 
 void  CAndroidUtils::OnSettingChanged(std::shared_ptr<const CSetting> setting)

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -24,6 +24,7 @@ public:
   virtual bool  GetNativeResolution(RESOLUTION_INFO *res) const;
   virtual bool  SetNativeResolution(const RESOLUTION_INFO &res);
   virtual bool  ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
+  virtual bool UpdateDisplayModes();
 
   // Implementation of ISettingCallback
   static const std::string SETTING_LIMITGUI;

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -129,7 +129,7 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
 
   if (m_dispResetState != RESET_NOTWAITING)
   {
-    CLog::Log(LOGINFO, "CWinSystemAndroid::CreateNewWindow: cannot create window while resetting");
+    CLog::Log(LOGERROR, "CWinSystemAndroid::CreateNewWindow: cannot create window while resetting");
     return false;
   }
 
@@ -242,6 +242,11 @@ void CWinSystemAndroid::SetHDMIState(bool connected)
     for (auto resource : m_resources)
       resource->OnLostDisplay();
   }
+}
+
+void CWinSystemAndroid::UpdateDisplayModes()
+{
+  m_android->UpdateDisplayModes();
 }
 
 bool CWinSystemAndroid::Hide()

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -37,6 +37,8 @@ public:
 
   void SetHDMIState(bool connected);
 
+  void UpdateDisplayModes();
+
   bool HasCursor() override { return false; };
 
   bool Hide() override;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -78,4 +78,7 @@ protected:
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;
   CDecoderFilterManager *m_decoderFilterManager;
+
+private:
+  void UpdateResolutions(bool bUpdateDesktopRes);
 };


### PR DESCRIPTION
Display mode ids may change at any time, for instance after an HDMI reset. Not taking this into account makes switching native resolution fail in case mode ids have changed. 

@peak3d like discussed on Slack...