### PR TITLE
[jenkins] - ensure to export DEVELOPER_DIR to override used Xcode version

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -94,7 +94,7 @@ then
 fi
 
 # make osx environment aware of the selected xcode app
-DEVELOPER_DIR=/Applications/$XCODE_APP/Contents/Developer
+export DEVELOPER_DIR=/Applications/$XCODE_APP/Contents/Developer
 
 if [ "$Configuration" == "Default" ]
 then


### PR DESCRIPTION
fixes binary addon build - credits to Rechi for this one.

Fixes regression introduced in #16218

Once this is in we can remove the DEVELOPER_DIR=init in the jenkins jobs for kodi ios/tvos/macos ...