### PR TITLE
DRMUtils: Don't fail when aspect ratio cap isn't present

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -608,10 +608,9 @@ bool CDRMUtils::InitDrm()
 
 #if defined(DRM_CLIENT_CAP_ASPECT_RATIO)
     ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 0);
-    if (ret)
+    if (ret != 0)
     {
-      CLog::Log(LOGERROR, "CDRMUtils::{} - failed to unset aspect ratio capability: {}", __FUNCTION__, strerror(errno));
-      return false;
+      CLog::Log(LOGERROR, "CDRMUtils::{} - aspect ratio capability is not supported: {}", __FUNCTION__, strerror(errno));
     }
 #endif
 


### PR DESCRIPTION
Right now we bail out in case the drmSetClientCap fails. Failure to set
the client cap just means that the cap isn't supported. So, log the
failure and continue instead of returning false.

## Motivation and Context
When kodi is compiled against latest libdrm headers but is run on a kernel where ASPECT_RATIO cap isn't present, kodi-gbm fails to launch as we return false in such cases. Instead, just log the error and don't return.

## How Has This Been Tested?
Tested by starting kodi-gbm on a system with kernel version 4.15. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
