### PR TITLE
[VideoPlayer] Load program from stream property without using streaminfo

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -72,9 +72,9 @@ static const struct StereoModeConversionMap WmvToInternalStereoModeMap[] =
 
 std::string CDemuxStreamAudioFFmpeg::GetStreamName()
 {
-  if(!m_stream)
+  if (!m_stream)
     return "";
-  if(!m_description.empty())
+  if (!m_description.empty())
     return m_description;
   else
     return CDemuxStream::GetStreamName();
@@ -82,9 +82,9 @@ std::string CDemuxStreamAudioFFmpeg::GetStreamName()
 
 std::string CDemuxStreamSubtitleFFmpeg::GetStreamName()
 {
-  if(!m_stream)
+  if (!m_stream)
     return "";
-  if(!m_description.empty())
+  if (!m_description.empty())
     return m_description;
   else
     return CDemuxStream::GetStreamName();
@@ -114,7 +114,7 @@ CDemuxParserFFmpeg::~CDemuxParserFFmpeg()
 static int interrupt_cb(void* ctx)
 {
   CDVDDemuxFFmpeg* demuxer = static_cast<CDVDDemuxFFmpeg*>(ctx);
-  if(demuxer && demuxer->Aborted())
+  if (demuxer && demuxer->Aborted())
     return 1;
   return 0;
 }
@@ -123,15 +123,15 @@ static int interrupt_cb(void* ctx)
 ////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////
 /*
-static int dvd_file_open(URLContext *h, const char *filename, int flags)
+static int dvd_file_open(URLContext* h, const char* filename, int flags)
 {
   return -1;
 }
 */
 
-static int dvd_file_read(void *h, uint8_t* buf, int size)
+static int dvd_file_read(void* h, uint8_t* buf, int size)
 {
-  if(interrupt_cb(h))
+  if (interrupt_cb(h))
     return AVERROR_EXIT;
 
   std::shared_ptr<CDVDInputStream> pInputStream = static_cast<CDVDDemuxFFmpeg*>(h)->m_pInput;
@@ -142,18 +142,18 @@ static int dvd_file_read(void *h, uint8_t* buf, int size)
     return len;
 }
 /*
-static int dvd_file_write(URLContext *h, uint8_t* buf, int size)
+static int dvd_file_write(URLContext* h, uint8_t* buf, int size)
 {
   return -1;
 }
 */
-static int64_t dvd_file_seek(void *h, int64_t pos, int whence)
+static int64_t dvd_file_seek(void* h, int64_t pos, int whence)
 {
-  if(interrupt_cb(h))
+  if (interrupt_cb(h))
     return AVERROR_EXIT;
 
   std::shared_ptr<CDVDInputStream> pInputStream = static_cast<CDVDDemuxFFmpeg*>(h)->m_pInput;
-  if(whence == AVSEEK_SIZE)
+  if (whence == AVSEEK_SIZE)
     return pInputStream->GetLength();
   else
     return pInputStream->Seek(pos, whence & ~AVSEEK_FORCE);
@@ -188,11 +188,11 @@ CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg()
 
 bool CDVDDemuxFFmpeg::Aborted()
 {
-  if(m_timeout.IsTimePast())
+  if (m_timeout.IsTimePast())
     return true;
 
   std::shared_ptr<CDVDInputStreamFFmpeg> input = std::dynamic_pointer_cast<CDVDInputStreamFFmpeg>(m_pInput);
-  if(input && input->Aborted())
+  if (input && input->Aborted())
     return true;
 
   return false;
@@ -210,24 +210,25 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
 
   const AVIOInterruptCB int_cb = { interrupt_cb, this };
 
-  if (!pInput) return false;
+  if (!pInput)
+    return false;
 
   m_pInput = pInput;
   strFile = m_pInput->GetFileName();
 
-  if( m_pInput->GetContent().length() > 0 )
+  if (m_pInput->GetContent().length() > 0)
   {
     std::string content = m_pInput->GetContent();
     StringUtils::ToLower(content);
 
     /* check if we can get a hint from content */
-    if     ( content.compare("video/x-vobsub") == 0 )
+    if (content.compare("video/x-vobsub") == 0)
       iformat = av_find_input_format("mpeg");
-    else if( content.compare("video/x-dvd-mpeg") == 0 )
+    else if (content.compare("video/x-dvd-mpeg") == 0)
       iformat = av_find_input_format("mpeg");
-    else if( content.compare("video/mp2t") == 0 )
+    else if (content.compare("video/mp2t") == 0)
       iformat = av_find_input_format("mpegts");
-    else if( content.compare("multipart/x-mixed-replace") == 0 )
+    else if (content.compare("multipart/x-mixed-replace") == 0)
       iformat = av_find_input_format("mjpeg");
   }
 
@@ -242,11 +243,11 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   {
     // special stream type that makes avformat handle file opening
     // allows internal ffmpeg protocols to be used
-    AVDictionary *options = GetFFMpegOptionsFromInput();
+    AVDictionary* options = GetFFMpegOptionsFromInput();
 
     CURL url = m_pInput->GetURL();
 
-    int result=-1;
+    int result = -1;
     if (url.IsProtocol("mms"))
     {
       // try mmsh, then mmst
@@ -259,7 +260,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
         strFile = url.Get();
       }
     }
-    if (result < 0 && avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0 )
+    if (result < 0 && avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
     {
       CLog::Log(LOGDEBUG, "Error, could not open file %s", CURL::GetRedacted(strFile).c_str());
       Dispose();
@@ -298,7 +299,6 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
     if (iformat == nullptr)
     {
       // let ffmpeg decide which demuxer we have to open
-
       bool trySPDIFonly = (m_pInput->GetContent() == "audio/x-spdif-compressed");
 
       if (!trySPDIFonly)
@@ -326,7 +326,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
           CLog::Log(LOGERROR, "%s - error reading from input stream, %s", __FUNCTION__, CURL::GetRedacted(strFile).c_str());
           return false;
         }
-        memset(pd.buf+pd.buf_size, 0, AVPROBE_PADDING_SIZE);
+        memset(pd.buf + pd.buf_size, 0, AVPROBE_PADDING_SIZE);
 
         // restore position again
         avio_seek(m_ioContext , 0, SEEK_SET);
@@ -342,7 +342,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
           // is present, we assume it is PCM audio.
           // AC3 is always wrapped in iec61937 (ffmpeg "spdif"), while DTS
           // may be just padded.
-          AVInputFormat *iformat2;
+          AVInputFormat* iformat2;
           iformat2 = av_find_input_format("spdif");
 
           if (iformat2 && iformat2->read_probe(&pd) > AVPROBE_SCORE_MAX / 4)
@@ -369,18 +369,18 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
         }
       }
 
-      if(!iformat)
+      if (!iformat)
       {
         std::string content = m_pInput->GetContent();
 
         /* check if we can get a hint from content */
-        if( content.compare("audio/aacp") == 0 )
+        if (content.compare("audio/aacp") == 0)
           iformat = av_find_input_format("aac");
-        else if( content.compare("audio/aac") == 0 )
+        else if (content.compare("audio/aac") == 0)
           iformat = av_find_input_format("aac");
-        else if( content.compare("video/flv") == 0 )
+        else if (content.compare("video/flv") == 0)
           iformat = av_find_input_format("flv");
-        else if( content.compare("video/x-flv") == 0 )
+        else if (content.compare("video/x-flv") == 0)
           iformat = av_find_input_format("flv");
       }
 
@@ -401,7 +401,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
 
     m_pFormatContext->pb = m_ioContext;
 
-    AVDictionary *options = NULL;
+    AVDictionary* options = NULL;
     if (iformat->name && (strcmp(iformat->name, "mp3") == 0 || strcmp(iformat->name, "mp2") == 0))
     {
       CLog::Log(LOGDEBUG, "%s - setting usetoc to 0 for accurate VBR MP3 seek", __FUNCTION__);
@@ -462,7 +462,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   if (m_streaminfo)
   {
     /* to speed up dvd switches, only analyse very short */
-    if(m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
+    if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
       av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
 
     CLog::Log(LOGDEBUG, "%s - avformat_find_stream_info starting", __FUNCTION__);
@@ -546,7 +546,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
           for (unsigned int j = 0; j < m_pFormatContext->programs[i]->nb_stream_indexes; j++)
           {
             int idx = m_pFormatContext->programs[i]->stream_index[j];
-            AVStream *st = m_pFormatContext->streams[idx];
+            AVStream* st = m_pFormatContext->streams[idx];
             if ((st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && st->codec_info_nb_frames > 0) ||
                 (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && st->codecpar->sample_rate > 0))
             {
@@ -594,7 +594,7 @@ void CDVDDemuxFFmpeg::Dispose()
     avformat_close_input(&m_pFormatContext);
   }
 
-  if(m_ioContext)
+  if (m_ioContext)
   {
     av_free(m_ioContext->buffer);
     av_free(m_ioContext);
@@ -642,18 +642,18 @@ void CDVDDemuxFFmpeg::Abort()
 
 void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
 {
-  if(!m_pFormatContext)
+  if (!m_pFormatContext)
     return;
 
   if (m_speed == iSpeed)
     return;
 
-  if(m_speed != DVD_PLAYSPEED_PAUSE && iSpeed == DVD_PLAYSPEED_PAUSE)
+  if (m_speed != DVD_PLAYSPEED_PAUSE && iSpeed == DVD_PLAYSPEED_PAUSE)
   {
     m_pInput->Pause(m_currentPts);
     av_read_pause(m_pFormatContext);
   }
-  else if(m_speed == DVD_PLAYSPEED_PAUSE && iSpeed != DVD_PLAYSPEED_PAUSE)
+  else if (m_speed == DVD_PLAYSPEED_PAUSE && iSpeed != DVD_PLAYSPEED_PAUSE)
   {
     m_pInput->Pause(m_currentPts);
     av_read_play(m_pFormatContext);
@@ -661,31 +661,31 @@ void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
   m_speed = iSpeed;
 
   AVDiscard discard = AVDISCARD_NONE;
-  if(m_speed > 4*DVD_PLAYSPEED_NORMAL)
+  if (m_speed > 4 * DVD_PLAYSPEED_NORMAL)
     discard = AVDISCARD_NONKEY;
-  else if(m_speed > 2*DVD_PLAYSPEED_NORMAL)
+  else if (m_speed > 2 * DVD_PLAYSPEED_NORMAL)
     discard = AVDISCARD_BIDIR;
-  else if(m_speed < DVD_PLAYSPEED_PAUSE)
+  else if (m_speed < DVD_PLAYSPEED_PAUSE)
     discard = AVDISCARD_NONKEY;
 
 
   for(unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
   {
-    if(m_pFormatContext->streams[i])
+    if (m_pFormatContext->streams[i])
     {
-      if(m_pFormatContext->streams[i]->discard != AVDISCARD_ALL)
+      if (m_pFormatContext->streams[i]->discard != AVDISCARD_ALL)
         m_pFormatContext->streams[i]->discard = discard;
     }
   }
 }
 
-AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
+AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
 {
   const std::shared_ptr<CDVDInputStreamFFmpeg> input =
     std::dynamic_pointer_cast<CDVDInputStreamFFmpeg>(m_pInput);
 
   CURL url = m_pInput->GetURL();
-  AVDictionary *options = nullptr;
+  AVDictionary* options = nullptr;
 
   if (url.IsProtocol("http") || url.IsProtocol("https"))
   {
@@ -880,7 +880,7 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
       timestamp = 0;
   }
 
-  return timestamp*DVD_TIME_BASE;
+  return timestamp * DVD_TIME_BASE;
 }
 
 DemuxPacket* CDVDDemuxFFmpeg::Read()
@@ -893,7 +893,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
   if (m_pFormatContext)
   {
     // assume we are not eof
-    if(m_pFormatContext->pb)
+    if (m_pFormatContext->pb)
       m_pFormatContext->pb->eof_reached = 0;
 
     // check for saved packet after a program change
@@ -927,7 +927,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
              m_pkt.pkt.stream_index >= (int)m_pFormatContext->nb_streams)
     {
       // XXX, in some cases ffmpeg returns a negative packet size
-      if(m_pFormatContext->pb && !m_pFormatContext->pb->eof_reached)
+      if (m_pFormatContext->pb && !m_pFormatContext->pb->eof_reached)
       {
         CLog::Log(LOGERROR, "CDVDDemuxFFmpeg::Read() no valid packet");
         bReturnEmpty = true;
@@ -955,7 +955,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
         return pPacket;
       }
 
-      AVStream *stream = m_pFormatContext->streams[m_pkt.pkt.stream_index];
+      AVStream* stream = m_pFormatContext->streams[m_pkt.pkt.stream_index];
 
       if (IsVideoReady())
       {
@@ -964,7 +964,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
           /* check so packet belongs to selected program */
           for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
           {
-            if(m_pkt.pkt.stream_index == (int)m_pFormatContext->programs[m_program]->stream_index[i])
+            if (m_pkt.pkt.stream_index == (int)m_pFormatContext->programs[m_program]->stream_index[i])
             {
               pPacket = CDVDDemuxUtils::AllocateDemuxPacket(m_pkt.pkt.size);
               break;
@@ -1002,7 +1002,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
 
         CDVDDemuxUtils::StoreSideData(pPacket, &m_pkt.pkt);
 
-        CDVDInputStream::IDisplayTime *inputStream = m_pInput->GetIDisplayTime();
+        CDVDInputStream::IDisplayTime* inputStream = m_pInput->GetIDisplayTime();
         if (inputStream)
         {
           int dispTime = inputStream->GetTime();
@@ -1043,7 +1043,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
   // check streams, can we make this a bit more simple?
   if (pPacket && pPacket->iStreamId >= 0)
   {
-    CDemuxStream *stream = GetStream(pPacket->iStreamId);
+    CDemuxStream* stream = GetStream(pPacket->iStreamId);
     if (!stream ||
         stream->pPrivate != m_pFormatContext->streams[pPacket->iStreamId] ||
         stream->codec != m_pFormatContext->streams[pPacket->iStreamId]->codecpar->codec_id)
@@ -1086,7 +1086,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
   return pPacket;
 }
 
-bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
+bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
 {
   bool hitEnd = false;
 
@@ -1108,7 +1108,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
     if (!ist->PosTime(static_cast<int>(time)))
       return false;
 
-    if(startpts)
+    if (startpts)
       *startpts = DVD_NOPTS_VALUE;
 
     Flush();
@@ -1166,7 +1166,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
     }
   }
 
-  if(m_currentPts == DVD_NOPTS_VALUE)
+  if (m_currentPts == DVD_NOPTS_VALUE)
     CLog::Log(LOGDEBUG, "%s - unknown position after seek", __FUNCTION__);
   else
     CLog::Log(LOGDEBUG, "%s - seek ended up on time %d", __FUNCTION__, (int)(m_currentPts / DVD_TIME_BASE * 1000));
@@ -1191,7 +1191,7 @@ bool CDVDDemuxFFmpeg::SeekByte(int64_t pos)
   CSingleLock lock(m_critSection);
   int ret = av_seek_frame(m_pFormatContext, -1, pos, AVSEEK_FLAG_BYTE);
 
-  if(ret >= 0)
+  if (ret >= 0)
     UpdateCurrentPTS();
 
   m_pkt.result = -1;
@@ -1207,8 +1207,8 @@ void CDVDDemuxFFmpeg::UpdateCurrentPTS()
   int idx = av_find_default_stream_index(m_pFormatContext);
   if (idx >= 0)
   {
-    AVStream *stream = m_pFormatContext->streams[idx];
-    if(stream && stream->cur_dts != (int64_t)AV_NOPTS_VALUE)
+    AVStream* stream = m_pFormatContext->streams[idx];
+    if (stream && stream->cur_dts != (int64_t)AV_NOPTS_VALUE)
     {
       double ts = ConvertTimestamp(stream->cur_dts, stream->time_base.den, stream->time_base.num);
       m_currentPts = ts;
@@ -1274,7 +1274,7 @@ int CDVDDemuxFFmpeg::GetPrograms(std::vector<ProgramInfo>& programs)
     if (!m_pFormatContext->programs[i]->metadata)
       continue;
 
-    AVDictionaryEntry *tag = av_dict_get(m_pFormatContext->programs[i]->metadata, "", nullptr, AV_DICT_IGNORE_SUFFIX);
+    AVDictionaryEntry* tag = av_dict_get(m_pFormatContext->programs[i]->metadata, "", nullptr, AV_DICT_IGNORE_SUFFIX);
     while (tag)
     {
       os << " - " << tag->key << ": " << tag->value;
@@ -1299,7 +1299,7 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
     forced = true;
     double dar = av_q2d(st->sample_aspect_ratio);
     // for stereo modes, use codec aspect ratio
-    AVDictionaryEntry *entry = av_dict_get(st->metadata, "stereo_mode", NULL, 0);
+    AVDictionaryEntry* entry = av_dict_get(st->metadata, "stereo_mode", NULL, 0);
     if (entry)
     {
       if (strcmp(entry->value, "left_right") == 0 || strcmp(entry->value, "right_left") == 0)
@@ -1311,7 +1311,7 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
   }
 
   /* if stream aspect is 1:1 or 0:0 use codec aspect */
-  if((st->sample_aspect_ratio.den == 1 || st->sample_aspect_ratio.den == 0) &&
+  if ((st->sample_aspect_ratio.den == 1 || st->sample_aspect_ratio.den == 0) &&
      (st->sample_aspect_ratio.num == 1 || st->sample_aspect_ratio.num == 0) &&
       st->codecpar->sample_aspect_ratio.num != 0)
   {
@@ -1319,7 +1319,7 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
     return av_q2d(st->codecpar->sample_aspect_ratio);
   }
 
-  if(st->sample_aspect_ratio.num != 0)
+  if (st->sample_aspect_ratio.num != 0)
   {
     forced = true;
     return av_q2d(st->sample_aspect_ratio);
@@ -1430,7 +1430,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         if (st->iBitsPerSample == 0)
           st->iBitsPerSample = pStream->codecpar->bits_per_coded_sample;
 
-        if(av_dict_get(pStream->metadata, "title", NULL, 0))
+        if (av_dict_get(pStream->metadata, "title", NULL, 0))
           st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
 
         break;
@@ -1439,7 +1439,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       {
         CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(pStream);
         stream = st;
-        if(strcmp(m_pFormatContext->iformat->name, "flv") == 0)
+        if (strcmp(m_pFormatContext->iformat->name, "flv") == 0)
           st->bVFR = true;
         else
           st->bVFR = false;
@@ -1456,7 +1456,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           st->iFpsRate = pStream->avg_frame_rate.num;
           st->iFpsScale = pStream->avg_frame_rate.den;
         }
-        else if(r_frame_rate.den && r_frame_rate.num)
+        else if (r_frame_rate.den && r_frame_rate.num)
         {
           st->iFpsRate = r_frame_rate.num;
           st->iFpsScale = r_frame_rate.den;
@@ -1485,7 +1485,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iBitsPerPixel = pStream->codecpar->bits_per_coded_sample;
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
 
-        AVDictionaryEntry *rtag = av_dict_get(pStream->metadata, "rotate", NULL, 0);
+        AVDictionaryEntry* rtag = av_dict_get(pStream->metadata, "rotate", NULL, 0);
         if (rtag)
           st->iOrientation = atoi(rtag->value);
 
@@ -1498,7 +1498,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           st->stereo_mode = stereoMode;
 
 
-        if ( m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD) )
+        if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
         {
           if (pStream->codecpar->codec_id == AV_CODEC_ID_PROBE)
           {
@@ -1537,7 +1537,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           CDemuxStreamSubtitleFFmpeg* st = new CDemuxStreamSubtitleFFmpeg(pStream);
           stream = st;
 
-          if(av_dict_get(pStream->metadata, "title", NULL, 0))
+          if (av_dict_get(pStream->metadata, "title", NULL, 0))
             st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
 
           break;
@@ -1550,7 +1550,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         {
           std::string fileName = "special://temp/fonts/";
           XFILE::CDirectory::Create(fileName);
-          AVDictionaryEntry *nameTag = av_dict_get(pStream->metadata, "filename", NULL, 0);
+          AVDictionaryEntry* nameTag = av_dict_get(pStream->metadata, "filename", NULL, 0);
           if (!nameTag)
           {
             CLog::Log(LOGERROR, "%s: TTF attachment has no name", __FUNCTION__);
@@ -1559,7 +1559,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           {
             fileName += nameTag->value;
             XFILE::CFile file;
-            if(pStream->codecpar->extradata && file.OpenForWrite(fileName))
+            if (pStream->codecpar->extradata && file.OpenForWrite(fileName))
             {
               if (file.Write(pStream->codecpar->extradata, pStream->codecpar->extradata_size) !=
                   pStream->codecpar->extradata_size)
@@ -1602,14 +1602,14 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     stream->pPrivate = pStream;
     stream->flags = (StreamFlags)pStream->disposition;
 
-    AVDictionaryEntry *langTag = av_dict_get(pStream->metadata, "language", NULL, 0);
+    AVDictionaryEntry* langTag = av_dict_get(pStream->metadata, "language", NULL, 0);
     if (!langTag)
     {
       // only for avi audio streams
       if ((strcmp(m_pFormatContext->iformat->name, "avi") == 0) && (pStream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO))
       {
         // only defined for streams 1 to 9
-        if((streamIdx > 0) && (streamIdx < 10))
+        if ((streamIdx > 0) && (streamIdx < 10))
         {
           // search for language information in RIFF-Header ("IAS1": first language - "IAS9": ninth language)
           char riff_tag_string[5] = {'I', 'A', 'S', (char)(streamIdx + '0'), '\0'};
@@ -1625,7 +1625,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     if (langTag)
       stream->language = std::string(langTag->value, 3);
 
-    if( stream->type != STREAM_NONE && pStream->codecpar->extradata && pStream->codecpar->extradata_size > 0 )
+    if (stream->type != STREAM_NONE && pStream->codecpar->extradata && pStream->codecpar->extradata_size > 0)
     {
       stream->ExtraSize = pStream->codecpar->extradata_size;
       stream->ExtraData = new uint8_t[pStream->codecpar->extradata_size];
@@ -1655,12 +1655,12 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       std::static_pointer_cast<CDVDInputStreamBluray>(m_pInput)->GetStreamInfo(pStream->id, stream->language);
     }
 #endif
-    if( m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD) )
+    if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
     {
       // this stuff is really only valid for dvd's.
       // this is so that the physicalid matches the
       // id's reported from libdvdnav
-      switch(stream->codec)
+      switch (stream->codec)
       {
         case AV_CODEC_ID_AC3:
           stream->dvdNavId = pStream->id - 128;
@@ -1717,7 +1717,7 @@ void CDVDDemuxFFmpeg::AddStream(int streamIdx, CDemuxStream* stream)
 
 std::string CDVDDemuxFFmpeg::GetFileName()
 {
-  if(m_pInput)
+  if (m_pInput)
     return m_pInput->GetFileName();
   else
     return "";
@@ -1726,10 +1726,10 @@ std::string CDVDDemuxFFmpeg::GetFileName()
 int CDVDDemuxFFmpeg::GetChapterCount()
 {
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
-  if(ich)
+  if (ich)
     return ich->GetChapterCount();
 
-  if(m_pFormatContext == NULL)
+  if (m_pFormatContext == NULL)
     return 0;
 
   return m_pFormatContext->nb_chapters;
@@ -1738,17 +1738,17 @@ int CDVDDemuxFFmpeg::GetChapterCount()
 int CDVDDemuxFFmpeg::GetChapter()
 {
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
-  if(ich)
+  if (ich)
     return ich->GetChapter();
 
-  if(m_pFormatContext == NULL
+  if (m_pFormatContext == NULL
   || m_currentPts == DVD_NOPTS_VALUE)
     return 0;
 
   for(unsigned i = 0; i < m_pFormatContext->nb_chapters; i++)
   {
-    AVChapter *chapter = m_pFormatContext->chapters[i];
-    if(m_currentPts >= ConvertTimestamp(chapter->start, chapter->time_base.den, chapter->time_base.num)
+    AVChapter* chapter = m_pFormatContext->chapters[i];
+    if (m_currentPts >= ConvertTimestamp(chapter->start, chapter->time_base.den, chapter->time_base.num)
     && m_currentPts <  ConvertTimestamp(chapter->end,   chapter->time_base.den, chapter->time_base.num))
       return i + 1;
   }
@@ -1761,14 +1761,14 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx
   if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
     chapterIdx = GetChapter();
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
-  if(ich)
+  if (ich)
     ich->GetChapterName(strChapterName, chapterIdx);
   else
   {
-    if(chapterIdx <= 0)
+    if (chapterIdx <= 0)
       return;
 
-    AVDictionaryEntry *titleTag = av_dict_get(m_pFormatContext->chapters[chapterIdx-1]->metadata,
+    AVDictionaryEntry* titleTag = av_dict_get(m_pFormatContext->chapters[chapterIdx - 1]->metadata,
                                                           "title", NULL, 0);
     if (titleTag)
       strChapterName = titleTag->value;
@@ -1779,29 +1779,29 @@ int64_t CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
 {
   if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
     chapterIdx = GetChapter();
-  if(chapterIdx <= 0)
+  if (chapterIdx <= 0)
     return 0;
 
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
-  if(ich)
+  if (ich)
     return ich->GetChapterPos(chapterIdx);
 
-  return static_cast<int64_t>(m_pFormatContext->chapters[chapterIdx-1]->start*av_q2d(m_pFormatContext->chapters[chapterIdx-1]->time_base));
+  return static_cast<int64_t>(m_pFormatContext->chapters[chapterIdx - 1]->start * av_q2d(m_pFormatContext->chapters[chapterIdx - 1]->time_base));
 }
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 {
-  if(chapter < 1)
+  if (chapter < 1)
     chapter = 1;
 
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
-  if(ich)
+  if (ich)
   {
     CLog::Log(LOGDEBUG, "%s - chapter seeking using input stream", __FUNCTION__);
-    if(!ich->SeekChapter(chapter))
+    if (!ich->SeekChapter(chapter))
       return false;
 
-    if(startpts)
+    if (startpts)
     {
       *startpts = DVD_SEC_TO_TIME(static_cast<double>(ich->GetChapterPos(chapter)));
     }
@@ -1810,20 +1810,20 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
     return true;
   }
 
-  if(m_pFormatContext == NULL)
+  if (m_pFormatContext == NULL)
     return false;
 
-  if(chapter < 1 || chapter > (int)m_pFormatContext->nb_chapters)
+  if (chapter < 1 || chapter > (int)m_pFormatContext->nb_chapters)
     return false;
 
-  AVChapter *ch = m_pFormatContext->chapters[chapter-1];
+  AVChapter* ch = m_pFormatContext->chapters[chapter - 1];
   double dts = ConvertTimestamp(ch->start, ch->time_base.den, ch->time_base.num);
   return SeekTime(DVD_TIME_TO_MSEC(dts), true, startpts);
 }
 
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
 {
-  CDemuxStream *stream = GetStream(iStreamId);
+  CDemuxStream* stream = GetStream(iStreamId);
   std::string strName;
   if (stream)
   {
@@ -1840,7 +1840,7 @@ std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)
       return strName;
     }
 
-    AVCodec *codec = avcodec_find_decoder(stream->codec);
+    AVCodec* codec = avcodec_find_decoder(stream->codec);
     if (codec)
       strName = codec->name;
   }
@@ -1872,7 +1872,7 @@ bool CDVDDemuxFFmpeg::IsProgramChange()
     int idx = m_pFormatContext->programs[m_program]->stream_index[i];
     if (m_pFormatContext->streams[idx]->discard >= AVDISCARD_ALL)
       continue;
-    CDemuxStream *stream = GetStream(idx);
+    CDemuxStream* stream = GetStream(idx);
     if (!stream)
       return true;
     if (m_pFormatContext->streams[idx]->codecpar->codec_id != stream->codec)
@@ -1896,7 +1896,7 @@ unsigned int CDVDDemuxFFmpeg::HLSSelectProgram()
   for (unsigned int i = 0; i < m_pFormatContext->nb_programs; ++i)
   {
     int strBitrate = 0;
-    AVDictionaryEntry *tag = av_dict_get(m_pFormatContext->programs[i]->metadata, "variant_bitrate", NULL, 0);
+    AVDictionaryEntry* tag = av_dict_get(m_pFormatContext->programs[i]->metadata, "variant_bitrate", NULL, 0);
     if (tag)
       strBitrate = atoi(tag->value);
     else
@@ -1940,10 +1940,10 @@ unsigned int CDVDDemuxFFmpeg::HLSSelectProgram()
   return prog;
 }
 
-std::string CDVDDemuxFFmpeg::GetStereoModeFromMetadata(AVDictionary *pMetadata)
+std::string CDVDDemuxFFmpeg::GetStereoModeFromMetadata(AVDictionary* pMetadata)
 {
   std::string stereoMode;
-  AVDictionaryEntry *tag = NULL;
+  AVDictionaryEntry* tag = NULL;
 
   // matroska
   tag = av_dict_get(pMetadata, "stereo_mode", NULL, 0);
@@ -1965,7 +1965,7 @@ std::string CDVDDemuxFFmpeg::GetStereoModeFromMetadata(AVDictionary *pMetadata)
   return stereoMode;
 }
 
-std::string CDVDDemuxFFmpeg::ConvertCodecToInternalStereoMode(const std::string &mode, const StereoModeConversionMap *conversionMap)
+std::string CDVDDemuxFFmpeg::ConvertCodecToInternalStereoMode(const std::string &mode, const StereoModeConversionMap* conversionMap)
 {
   size_t i = 0;
   while (conversionMap[i].name)
@@ -1977,9 +1977,9 @@ std::string CDVDDemuxFFmpeg::ConvertCodecToInternalStereoMode(const std::string 
   return "";
 }
 
-void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
+void CDVDDemuxFFmpeg::ParsePacket(AVPacket* pkt)
 {
-  AVStream *st = m_pFormatContext->streams[pkt->stream_index];
+  AVStream* st = m_pFormatContext->streams[pkt->stream_index];
 
   if (st && st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
   {
@@ -1992,7 +1992,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
 
       parser->second->m_parserCtx = av_parser_init(st->codecpar->codec_id);
 
-      AVCodec *codec = avcodec_find_decoder(st->codecpar->codec_id);
+      AVCodec* codec = avcodec_find_decoder(st->codecpar->codec_id);
       if (codec == nullptr)
       {
         CLog::Log(LOGERROR, "%s - can't find decoder", __FUNCTION__);
@@ -2002,7 +2002,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
       parser->second->m_codecCtx = avcodec_alloc_context3(codec);
     }
 
-    CDemuxStream *stream = GetStream(st->index);
+    CDemuxStream* stream = GetStream(st->index);
     if (!stream)
       return;
 
@@ -2026,7 +2026,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
           {
             parser->second->m_codecCtx->extradata = st->codecpar->extradata;
             parser->second->m_codecCtx->extradata_size = st->codecpar->extradata_size;
-            const uint8_t *outbufptr;
+            const uint8_t* outbufptr;
             int bufSize;
             parser->second->m_parserCtx->flags |= PARSER_FLAG_COMPLETE_FRAMES;
             parser->second->m_parserCtx->parser->parser_parse(parser->second->m_parserCtx,
@@ -2054,7 +2054,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
 
 bool CDVDDemuxFFmpeg::IsVideoReady()
 {
-  AVStream *st;
+  AVStream* st;
   bool hasVideo = false;
 
   if (!m_checkvideo)
@@ -2063,7 +2063,7 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
   if (m_program == 0 && !m_pFormatContext->nb_programs)
     return false;
 
-  if(m_program != UINT_MAX)
+  if (m_program != UINT_MAX)
   {
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
@@ -2132,7 +2132,7 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
 
 void CDVDDemuxFFmpeg::ResetVideoStreams()
 {
-  AVStream *st;
+  AVStream* st;
   for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
   {
     st = m_pFormatContext->streams[i];

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -260,12 +260,27 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
         strFile = url.Get();
       }
     }
-    if (result < 0 && avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
+    if (result < 0)
     {
-      CLog::Log(LOGDEBUG, "Error, could not open file %s", CURL::GetRedacted(strFile).c_str());
-      Dispose();
+      m_pFormatContext->flags |= AVFMT_FLAG_PRIV_OPT;
+      if (avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
+      {
+        CLog::Log(LOGDEBUG, "Error, could not open file %s", CURL::GetRedacted(strFile).c_str());
+        Dispose();
+        av_dict_free(&options);
+        return false;
+      }
       av_dict_free(&options);
-      return false;
+      m_pFormatContext->flags &= ~AVFMT_FLAG_PRIV_OPT;
+      AVDictionary* options = GetFFMpegOptionsFromInput();
+      av_dict_set_int(&options, "load_all_variants", 0, AV_OPT_SEARCH_CHILDREN);
+      if (avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
+      {
+        CLog::Log(LOGDEBUG, "Error, could not open file (2) %s", CURL::GetRedacted(strFile).c_str());
+        Dispose();
+        av_dict_free(&options);
+        return false;
+      }
     }
     av_dict_free(&options);
   }
@@ -486,6 +501,9 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
     }
     CLog::Log(LOGDEBUG, "%s - av_find_stream_info finished", __FUNCTION__);
 
+    // print some extra information
+    av_dump_format(m_pFormatContext, 0, CURL::GetRedacted(strFile).c_str(), 0);
+
     if (m_checkvideo)
     {
       // make sure we start video with an i-frame
@@ -505,13 +523,16 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   // if format can be nonblocking, let's use that
   m_pFormatContext->flags |= AVFMT_FLAG_NONBLOCK;
 
-  // print some extra information
-  av_dump_format(m_pFormatContext, 0, CURL::GetRedacted(strFile).c_str(), 0);
-
   // deprecated, will be always set in future versions
   m_pFormatContext->flags |= AVFMT_FLAG_KEEP_SIDE_DATA;
 
   UpdateCurrentPTS();
+
+  // select the correct program if requested
+  m_initialProgramNumber = UINT_MAX;
+  CVariant programProp(pInput->GetProperty("program"));
+  if (!programProp.isNull())
+    m_initialProgramNumber = static_cast<int>(programProp.asInteger());
 
   // in case of mpegts and we have not seen pat/pmt, defer creation of streams
   if (!skipCreateStreams || m_pFormatContext->nb_programs > 0)
@@ -520,16 +541,14 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
     if (m_pFormatContext->nb_programs > 0)
     {
       // select the correct program if requested
-      CVariant programProp(pInput->GetProperty("program"));
-      if (!programProp.isNull())
+      if (m_initialProgramNumber != UINT_MAX)
       {
-        int programNumber = static_cast<int>(programProp.asInteger());
-
         for (unsigned int i = 0; i < m_pFormatContext->nb_programs; ++i)
         {
-          if (m_pFormatContext->programs[i]->program_num == programNumber)
+          if (m_pFormatContext->programs[i]->program_num == static_cast<int>(m_initialProgramNumber))
           {
             nProgram = i;
+            m_initialProgramNumber = UINT_MAX;
             break;
           }
         }
@@ -560,14 +579,26 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
     CreateStreams(nProgram);
   }
 
+  m_newProgram = m_program;
+
   // allow IsProgramChange to return true
   if (skipCreateStreams && GetNrOfStreams() == 0)
     m_program = 0;
 
-  m_newProgram = m_program;
   m_displayTime = 0;
   m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
   m_startTime = 0;
+  m_seekStream = -1;
+
+  if (m_checkvideo && m_streaminfo)
+  {
+    int64_t duration = m_pFormatContext->duration;
+    std::shared_ptr<CDVDInputStream> pInputStream = m_pInput;
+    Dispose();
+    if (!Open(pInputStream, false))
+      return false;
+    m_pFormatContext->duration = duration;
+  }
 
   // seems to be a bug in ffmpeg, hls jumps back to start after a couple of seconds
   // this cures the issue
@@ -868,12 +899,12 @@ double CDVDDemuxFFmpeg::ConvertTimestamp(int64_t pts, int den, int num)
   if (!menu && m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
     starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;
 
-  if (!m_streaminfo)
+  if (m_checkvideo)
     starttime = m_startTime;
 
   if (!m_bSup)
   {
-    if (timestamp > starttime || !m_streaminfo)
+    if (timestamp > starttime || m_checkvideo)
       timestamp -= starttime;
     // allow for largest possible difference in pts and dts for a single packet
     else if (timestamp + 0.5f > starttime)
@@ -945,6 +976,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
 
       if (IsProgramChange())
       {
+        CLog::Log(LOGNOTICE, "CDVDDemuxFFmpeg::Read() stream change");
+        av_dump_format(m_pFormatContext, 0, CURL::GetRedacted(m_pInput->GetFileName()).c_str(), 0);
+
         // update streams
         CreateStreams(m_program);
 
@@ -1126,21 +1160,27 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
   int64_t seek_pts = (int64_t)time * (AV_TIME_BASE / 1000);
   bool ismp3 = m_pFormatContext->iformat && (strcmp(m_pFormatContext->iformat->name, "mp3") == 0);
 
-  if (!m_streaminfo)
-    seek_pts += m_startTime * AV_TIME_BASE;
+  if (m_checkvideo)
+  {
+    AVStream* st = m_pFormatContext->streams[m_seekStream];
+    seek_pts = av_rescale(m_startTime + time / 1000, st->time_base.den, st->time_base.num);
+  }
   else if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE && !ismp3 && !m_bSup)
     seek_pts += m_pFormatContext->start_time;
 
   int ret;
   {
     CSingleLock lock(m_critSection);
-    ret = av_seek_frame(m_pFormatContext, -1, seek_pts, backwards ? AVSEEK_FLAG_BACKWARD : 0);
+    ret = av_seek_frame(m_pFormatContext, m_seekStream, seek_pts, backwards ? AVSEEK_FLAG_BACKWARD : 0);
 
     if (ret < 0)
     {
       int64_t starttime = m_pFormatContext->start_time;
-      if (!m_streaminfo)
-        starttime = m_startTime * AV_TIME_BASE;
+      if (m_checkvideo)
+      {
+        AVStream* st = m_pFormatContext->streams[m_seekStream];
+        starttime = av_rescale(m_startTime, st->time_base.num, st->time_base.den);
+      }
 
       // demuxer can return failure, if seeking behind eof
       if (m_pFormatContext->duration &&
@@ -1359,6 +1399,8 @@ void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
     }
     if (m_program != UINT_MAX)
     {
+      m_pFormatContext->programs[m_program]->discard = AVDISCARD_NONE;
+
       // add streams from selected program
       for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
       {
@@ -1855,6 +1897,21 @@ bool CDVDDemuxFFmpeg::IsProgramChange()
   if (m_program == 0 && !m_pFormatContext->nb_programs)
     return false;
 
+  if (m_initialProgramNumber != UINT_MAX)
+  {
+    for (unsigned int i = 0; i < m_pFormatContext->nb_programs; ++i)
+    {
+      if (m_pFormatContext->programs[i]->program_num == static_cast<int>(m_initialProgramNumber))
+      {
+        m_newProgram = i;
+        m_initialProgramNumber = UINT_MAX;
+        break;
+      }
+    }
+    if (m_initialProgramNumber != UINT_MAX)
+      return false;
+  }
+
   if (m_program != m_newProgram)
   {
     m_program = m_newProgram;
@@ -1914,7 +1971,7 @@ unsigned int CDVDDemuxFFmpeg::HLSSelectProgram()
       }
     }
 
-    if (strRes < selectedRes && selectedBitrate < bandwidth)
+    if ((strRes && strRes < selectedRes) && selectedBitrate < bandwidth)
       continue;
 
     bool want = false;
@@ -2074,7 +2131,10 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
         if (st->codecpar->extradata)
         {
           if (!m_startTime)
+          {
             m_startTime = av_rescale(st->cur_dts, st->time_base.num, st->time_base.den);
+            m_seekStream = i;
+          }
           return true;
         }
         hasVideo = true;
@@ -2091,6 +2151,7 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
         if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
         {
           m_startTime = static_cast<double>(av_rescale(st->cur_dts, st->time_base.num, st->time_base.den));
+          m_seekStream = i;
           break;
         }
       }
@@ -2106,7 +2167,10 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
         if (st->codecpar->extradata)
         {
           if (!m_startTime)
+          {
             m_startTime = av_rescale(st->cur_dts, st->time_base.num, st->time_base.den);
+            m_seekStream = i;
+          }
           return true;
         }
         hasVideo = true;
@@ -2122,6 +2186,7 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
         if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
         {
           m_startTime = static_cast<double>(av_rescale(st->cur_dts, st->time_base.num, st->time_base.den));
+          m_seekStream = i;
           break;
         }
       }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -145,6 +145,8 @@ protected:
   unsigned int m_program;
   unsigned int m_streamsInProgram;
   unsigned int m_newProgram;
+  unsigned int m_initialProgramNumber;
+  int m_seekStream;
 
   XbmcThreads::EndTime  m_timeout;
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -41,7 +41,7 @@ public:
 
   std::string m_description;
 protected:
-  CDVDDemuxFFmpeg *m_parent;
+  CDVDDemuxFFmpeg* m_parent;
   AVStream* m_stream  = nullptr;
 };
 
@@ -54,7 +54,7 @@ public:
 
   std::string m_description;
 protected:
-  CDVDDemuxFFmpeg *m_parent;
+  CDVDDemuxFFmpeg* m_parent;
   AVStream* m_stream = nullptr;
 };
 
@@ -99,7 +99,7 @@ public:
   int GetChapterCount() override;
   int GetChapter() override;
   void GetChapterName(std::string& strChapterName, int chapterIdx=-1) override;
-  int64_t GetChapterPos(int chapterIdx=-1) override;
+  int64_t GetChapterPos(int chapterIdx = -1) override;
   std::string GetStreamCodecName(int iStreamId) override;
 
   bool Aborted();
@@ -116,19 +116,19 @@ protected:
   void AddStream(int streamIdx, CDemuxStream* stream);
   void CreateStreams(unsigned int program = UINT_MAX);
   void DisposeStreams();
-  void ParsePacket(AVPacket *pkt);
+  void ParsePacket(AVPacket* pkt);
   bool IsVideoReady();
   void ResetVideoStreams();
-  AVDictionary *GetFFMpegOptionsFromInput();
+  AVDictionary* GetFFMpegOptionsFromInput();
   double ConvertTimestamp(int64_t pts, int den, int num);
   void UpdateCurrentPTS();
   bool IsProgramChange();
   unsigned int HLSSelectProgram();
 
-  std::string GetStereoModeFromMetadata(AVDictionary *pMetadata);
-  std::string ConvertCodecToInternalStereoMode(const std::string &mode, const StereoModeConversionMap *conversionMap);
+  std::string GetStereoModeFromMetadata(AVDictionary* pMetadata);
+  std::string ConvertCodecToInternalStereoMode(const std::string& mode, const StereoModeConversionMap* conversionMap);
 
-  void GetL16Parameters(int &channels, int &samplerate);
+  void GetL16Parameters(int& channels, int& samplerate);
   double SelectAspect(AVStream* st, bool& forced);
 
   CCriticalSection m_critSection;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

For PVR Streams that contain multiple streams (MPTS) the demuxer factory by default favours fast switching (not parsing streaminfo) to improve channel switch times even if the correct PID (program number) for the stream is supplied. The original PR tried to fix this by forcing reading streaminfo which was not the correct approach.

This change completely avoids reading streaminfo for TS (except for duration) and will correctly use the `program` stream property if supplied for both live and recorded streams.

Original PR which is superseded by this one:  https://github.com/xbmc/xbmc/pull/16244

Thanks for @FernetMenta for providing a solution that fixes the root cause. 

If accepted can be backported to Leia.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

In the pvr.vuplus addon certain TV providers use MPTS for their live streams. Therefore users with certain providers in some countries cannot view their channels. Example: Nos in portugal.

closes these issues:

- kodi-pvr/pvr.vuplus#195
- kodi-pvr/pvr.vuplus#208
- kodi-pvr/pvr.vuplus#219

Context:

For Enigma2 the STB simply passes the RAW TS stream. In the case of a recording the RAW stream is recorded to disk.

For the majority of providers only a single program (PID) is contained in the stream. For certain providers multiple program's are passed in the PMT but the program data packets are dropped. In this case as kodi does not parse streaminfo the correct stream is not selected.

Gist containing a log of this occurring: https://gist.github.com/phunkyfish/c6e267e57a703d0e44c4e97432415c02

In this log kodi uses Program 888 where in fact the correct program is 880.

Here is the ffmpeg output where for a bad streams where kodi would choose the wrong program. Clearly many programs are in the program table.

https://gist.github.com/phunkyfish/b1aa31816bea473168d4062796ec626c

The correct program should be 880.

Here is an example of a good stream's ffmpeg output where the only program present is 101:

https://gist.github.com/phunkyfish/1dfbf51b37f202ab75cbd4a7b28d40bb

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested on Windows 10 and Mac OS Mojave using the pvr.vuplus addon. Tested on both Matrix and Leia.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
