### PR TITLE
LinuxRendererGLES: fixed memory leak, fixed segfault when NV12 textur…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -289,11 +289,18 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
     }
     else
     {
+      size_t planeSize = width * height * bps;
+      if (m_planeBufferSize < planeSize)
+      {
+        m_planeBuffer = static_cast<unsigned char*>(realloc(m_planeBuffer, planeSize));
+        m_planeBufferSize = planeSize;
+      }
+
       unsigned char *src(static_cast<unsigned char*>(data)),
                     *dst(m_planeBuffer);
 
-      for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bpp)
-        memcpy(dst, src, width * bpp);
+      for (unsigned int y = 0; y < height; ++y, src += stride, dst += width * bps)
+        memcpy(dst, src, width * bps);
 
       pixelData = m_planeBuffer;
     }
@@ -1292,11 +1299,9 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
   im.planesize[1] = im.stride[1] * (im.height >> im.cshift_y);
   im.planesize[2] = im.stride[2] * (im.height >> im.cshift_y);
 
-  m_planeBuffer = static_cast<unsigned char*>(realloc(m_planeBuffer, m_sourceHeight * m_sourceWidth * im.bpp));
-
   for (int i = 0; i < 3; i++)
   {
-    im.plane[i] = new uint8_t[im.planesize[i]];
+    im.plane[i] = nullptr; // will be set in UploadTexture()
   }
 
   for(int f = 0; f < MAX_FIELDS; f++)
@@ -1459,7 +1464,7 @@ bool CLinuxRendererGLES::CreateNV12Texture(int index)
 
   for (int i = 0; i < 2; i++)
   {
-    im.plane[i] = new uint8_t[im.planesize[i]];
+    im.plane[i] = nullptr; // will be set in UploadTexture()
   }
 
   for(int f = 0; f < MAX_FIELDS; f++)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -203,6 +203,7 @@ protected:
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
   unsigned char* m_planeBuffer = nullptr;
+  size_t m_planeBufferSize = 0;
 
   // clear colour for "black" bars
   float m_clearColour{0.0f};


### PR DESCRIPTION
…es are in use, when (stride != width*bps) and GL_UNPACK_ROW_LENGTH is not available

NOTES:

- The memory leak occurs on all platforms using GLES when video playback is started/stopped.
- The segfault remained undiscovered so far, because it only applies to some rare platforms, namely where GL_UNPACK_ROW_LENGTH is not available (GLES<v3) and where the video codec doesn't provide a stride that is (width*bps).
