### PR TITLE
Fix PlayMedia builtin for smart playlists and playlists

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -429,7 +429,7 @@ static int PlayMedia(const std::vector<std::string>& params)
     if ( CGUIWindowVideoBase::ShowResumeMenu(item) == false )
       return false;
   }
-  if (item.m_bIsFolder || item.IsPlayList() || item.IsSmartPlayList())
+  if (item.m_bIsFolder)
   {
     CFileItemList items;
     std::string extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + "|" + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
@@ -471,7 +471,7 @@ static int PlayMedia(const std::vector<std::string>& params)
       return 0;
     }
   }
-  if (item.IsAudio() || item.IsVideo())
+  if ((item.IsAudio() || item.IsVideo()) && !item.IsPlayList() && !item.IsSmartPlayList())
     CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
   else
     g_application.PlayMedia(item, "", PLAYLIST_NONE);


### PR DESCRIPTION
`PlayMedia` builtin is broken in v18 when called for a playlist or smart playlist that needs to be recursively expanded into actual media items e.g. a smart playlist of artist or albums. Reported in https://forum.kodi.tv/showthread.php?tid=344892

This regression was initially introduced by #11747 that ensured individual items are played with a playlist. It overlooked that item.IsVideo() returns true for .m3u and .xsp files and thus passed them to `CPlayListPlayer::Play`, which is unable to expand the .xsp file into the individual items to be queued, as if they were a single media file.  Then #14183 attempted to fix the consequences - PlayMedia was not playing smart playlists and simple playlists are played as a single huge item.  However this fix does not work for all smart playlists, they are not fully expanded and `CPlayListPlayer::Play` can not handle lists of artists or albums.

This fix restores the `PlayMedia` functionality for playlists and smartplaylists. 
