### PR TITLE
Fix PAPlayer to do passthrough for TrueHD

### DIFF
--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -514,6 +514,11 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
       format.m_streamInfo.m_sampleRate = samplerate;
       break;
 
+    case AV_CODEC_ID_TRUEHD:
+      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+      format.m_streamInfo.m_sampleRate = samplerate;
+      break;
+
     default:
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_NULL;
   }


### PR DESCRIPTION
Fix PAPlayer to handle passthrough for TrueHD.

Passthrough of DTS-HD was restored in 18.3 (after all the player changes in v18) by https://github.com/xbmc/xbmc/pull/16027, this does the same for TrueHD. 

Test TrueHD and Atmos music files can be found under /samples/audio of the ftp.kodi.tv
