### PR TITLE
[filesystem][Leia] Corrections to CircularCache initialization and termination

### DIFF
--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -24,7 +24,7 @@ CCircularCache::CCircularCache(size_t front, size_t back)
  , m_size(front + back)
  , m_size_back(back)
 #ifdef TARGET_WINDOWS
- , m_handle(INVALID_HANDLE_VALUE)
+ , m_handle(NULL)
 #endif
 {
 }
@@ -44,7 +44,7 @@ int CCircularCache::Open()
 #else
   m_buf = new uint8_t[m_size];
 #endif
-  if(m_buf == 0)
+  if (m_buf == NULL)
     return CACHE_RC_ERROR;
   m_beg = 0;
   m_end = 0;
@@ -55,9 +55,11 @@ int CCircularCache::Open()
 void CCircularCache::Close()
 {
 #ifdef TARGET_WINDOWS
-  UnmapViewOfFile(m_buf);
-  CloseHandle(m_handle);
-  m_handle = INVALID_HANDLE_VALUE;
+  if (m_buf != NULL)
+    UnmapViewOfFile(m_buf);
+  if (m_handle != NULL)
+    CloseHandle(m_handle);
+  m_handle = NULL;
 #else
   delete[] m_buf;
 #endif
@@ -118,6 +120,9 @@ int CCircularCache::WriteToCache(const char *buf, size_t len)
   if(len == 0)
     return 0;
 
+  if (m_buf == NULL)
+    return 0;
+
   // write the data
   memcpy(m_buf + pos, buf, len);
   m_end += len;
@@ -156,6 +161,9 @@ int CCircularCache::ReadFromCache(char *buf, size_t len)
     len = avail;
 
   if(len == 0)
+    return 0;
+
+  if (m_buf == NULL)
     return 0;
 
   memcpy(buf, m_buf + pos, len);


### PR DESCRIPTION
## Description
While executing on Windows with the Microsoft Application Verifier enabled errors were noted with the filesystem/CircularCache class.  This PR intends to correct those errors.

## Motivation and Context

Backport of PR [16330](https://github.com/xbmc/xbmc/pull/16330) for Leia branch, if another dot release is to be generated.

While primarily affecting Windows, filesystem/CircularCache is not initializing its member variables properly and does not provide any guard against using those improperly initialized variables.  This can lead to abnormal program termination if an instance of the class is used without a successful call to .Open() when it is being unwound/destroyed.  CreateFileMapping() returns NULL on failure, not ERROR_INVALID_HANDLE.

## How Has This Been Tested?
Tested on Windows x64, Leia branch.  After the corrections the Application Verifier did not issue a stop at these particular locations in the code.  There should be little to no effect to any other portions of the Kodi baseline.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
