### PR TITLE
Revert "changed: Improve handling of internet filesystems (http/https) on LANs"

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1005,14 +1005,6 @@ bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */
       url.IsProtocol("sftp"))
     return bStrictCheck;
 
-  if (url.IsProtocol("http") || url.IsProtocol("https"))
-  {
-    if (IsOnLAN(url.Get()))
-      return bStrictCheck;
-    else
-      return true;
-  }
-
   std::string protocol = url.GetTranslatedProtocol();
   if (CURL::IsProtocolEqual(protocol, "http")  || CURL::IsProtocolEqual(protocol, "https")  ||
       CURL::IsProtocolEqual(protocol, "tcp")   || CURL::IsProtocolEqual(protocol, "udp")    ||

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -298,19 +298,10 @@ TEST_F(TestURIUtils, IsInRAR)
 
 TEST_F(TestURIUtils, IsInternetStream)
 {
-  CURL url1("http://internet.path/to/file");
-  CURL url2("https://internet.path/to/file");
-  CURL url3("davs://internet.path/to/file");
-  CURL url4("http://lan/to/file");
-  CURL url5("/path/to/file");
+  CURL url1("http://path/to/file");
+  CURL url2("https://path/to/file");
   EXPECT_TRUE(URIUtils::IsInternetStream(url1));
   EXPECT_TRUE(URIUtils::IsInternetStream(url2));
-  EXPECT_FALSE(URIUtils::IsInternetStream(url3));
-  EXPECT_TRUE(URIUtils::IsInternetStream(url3, true /* =strict */));
-  EXPECT_FALSE(URIUtils::IsInternetStream(url4));
-  EXPECT_TRUE(URIUtils::IsInternetStream(url4, true /* =strict */));
-  EXPECT_FALSE(URIUtils::IsInternetStream(url5));
-  EXPECT_FALSE(URIUtils::IsInternetStream(url5, true /* strict */));
 }
 
 TEST_F(TestURIUtils, IsInZIP)


### PR DESCRIPTION
Reverts xbmc/xbmc#16070. It causes to many regressions (with eg. emby, pvr) and has too little benefits for now.