### PR TITLE
Update ArchSetup.cmake for Raspberry Pi4

### DIFF
--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -40,7 +40,9 @@ endif()
 # temp until further cleanup is done
 # add Raspberry Pi 2 and 3 specific flags
 if(CORE_PLATFORM_NAME_LC STREQUAL rbpi)
-  if(CPU MATCHES "cortex-a7")
+  if(CPU STREQUAL "cortex-a72")
+	set (NEON_FLAGS "-fPIC -mcpu=cortex-a72 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad")
+  elseif(CPU MATCHES "cortex-a7")
     set(NEON_FLAGS "-fPIC -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad")
   elseif(CPU MATCHES "cortex-a53")
     set(NEON_FLAGS "-fPIC -mcpu=cortex-a53 -mfloat-abi=hard -mfpu=neon-fp-armv8 -mvectorize-with-neon-quad")


### PR DESCRIPTION
## Description
Added Cortex-A72 to initially support Raspberry Pi4
Specifying -DCPU=cortex-a72 to CMake will result in cortex-a7 being used for CFLAGS;
regardless of this modification being in place or not.
elseif(CPU MATCHES "cortex-a7") will be true on the cortex-a72;
so it has to come after the if(CPU STREQUAL "cortex-a72")<br>
On my Raspberry Pi4 this leads to the correct CFLAGS below being added to CFLAGS:
-mtls-dialect=gnu -fPIC -mcpu=cortex-a72 -mfloat-abi=hard -mfpu=neon-vfpv4 -mvectorize-with-neon-quad -D_ARMEL -DTARGET_RASPBERRY_PI -Wall

## Motivation and Context
I just got my Raspberry Pi4 4GB today and first thing after checking the proper -mcpu and -mfpu is to have kodi running at full speed on the Cortex-A72

## How Has This Been Tested?
By compiling directly on the Raspberry Pi4 and running Kodi on it as well.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
