### PR TITLE
Fix PAPlayer to handle passthrough for TrueHD - backport

### DIFF
--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -514,6 +514,11 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
       format.m_streamInfo.m_sampleRate = samplerate;
       break;
 
+    case AV_CODEC_ID_TRUEHD:
+      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+      format.m_streamInfo.m_sampleRate = samplerate;
+      break;
+
     default:
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_NULL;
   }


### PR DESCRIPTION
Backport of #16336

Restore passthrough of TrueHD after all the player changes in v18  (similar to how DTS-HD was restored in 18.3 () by #16027). User testing confirms fix working.