### PR TITLE
[PVR][Estuary] Generate thumbnail picture for channel groups.

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRGroupManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRGroupManager.xml
@@ -56,6 +56,13 @@
 					<font>font25_title</font>
 					<label>$LOCALIZE[31046]</label>
 				</control>
+				<control type="button" id="35">
+					<description>Regenerate Group Thumbnail</description>
+					<width>370</width>
+					<include>SettingsItemCommon</include>
+					<font>font25_title</font>
+					<label>$LOCALIZE[13315]</label>
+				</control>
 				<control type="togglebutton" id="34">
 					<description>TV/Radio toggle</description>
 					<width>370</width>
@@ -73,6 +80,16 @@
 					<label>$LOCALIZE[186]</label>
 				</control>
 			</control>
+			<control type="image">
+				<left>85</left>
+				<bottom>30</bottom>
+				<width>200</width>
+				<height>200</height>
+				<texture>$INFO[Container(13).ListItem.Icon]</texture>
+				<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+				<bordersize>2</bordersize>
+				<aspectratio>keep</aspectratio>
+			</control>
 			<control type="group">
 				<left>350</left>
 				<top>80</top>
@@ -85,7 +102,6 @@
 					<label>$LOCALIZE[31089]: [COLOR white]$INFO[Container(13).NumItems][/COLOR]</label>
 					<align>center</align>
 					<aligny>center</aligny>
-					<font>font12</font>
 					<textcolor>button_focus</textcolor>
 				</control>
 				<control type="image">
@@ -106,10 +122,56 @@
 					<onright>73</onright>
 					<pagecontrol>73</pagecontrol>
 					<scrolltime>200</scrolltime>
-					<include content="DefaultSimpleListLayout">
-						<param name="width" value="320" />
-						<param name="list_id" value="13" />
-					</include>
+					<itemlayout width="320" height="70">
+						<control type="label">
+							<left>20</left>
+							<right>70</right>
+							<height>70</height>
+							<aligny>center</aligny>
+							<font>font27</font>
+							<textcolor>grey</textcolor>
+							<label>$INFO[ListItem.Label]</label>
+						</control>
+						<control type="image">
+							<width>60</width>
+							<height>60</height>
+							<right>5</right>
+							<top>5</top>
+							<texture>$INFO[ListItem.Icon]</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>2</bordersize>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</itemlayout>
+					<focusedlayout width="320" height="70">
+						<control type="image">
+							<left>0</left>
+							<top>0</top>
+							<right>0</right>
+							<bottom>0</bottom>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<visible>Control.HasFocus(13)</visible>
+						</control>
+						<control type="label">
+							<left>20</left>
+							<right>70</right>
+							<height>70</height>
+							<aligny>center</aligny>
+							<font>font27</font>
+							<label>$INFO[ListItem.Label]</label>
+							<scroll>true</scroll>
+						</control>
+						<control type="image">
+							<width>60</width>
+							<height>60</height>
+							<right>5</right>
+							<top>5</top>
+							<texture>$INFO[ListItem.Icon]</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>2</bordersize>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</focusedlayout>
 				</control>
 				<control type="scrollbar" id="73">
 					<left>340</left>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -849,6 +849,13 @@ bool CFileItem::IsPVRChannel() const
   return HasPVRChannelInfoTag();
 }
 
+bool CFileItem::IsPVRChannelGroup() const
+{
+  return !StringUtils::EndsWithNoCase(m_strPath, ".pvr") &&
+         (StringUtils::StartsWithNoCase(m_strPath, "pvr://channels/tv/") ||
+          StringUtils::StartsWithNoCase(m_strPath, "pvr://channels/radio/"));
+}
+
 bool CFileItem::IsPVRRecording() const
 {
   return HasPVRRecordingInfoTag();

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -223,6 +223,7 @@ public:
   bool IsVideoDb() const;
   bool IsEPG() const;
   bool IsPVRChannel() const;
+  bool IsPVRChannelGroup() const;
   bool IsPVRRecording() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -22,6 +22,7 @@
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "music/MusicThumbLoader.h"
 #include "pictures/PictureThumbLoader.h"
+#include "pvr/PVRThumbLoader.h"
 #include "pvr/PVRManager.h"
 #include "pvr/dialogs/GUIDialogPVRGuideInfo.h"
 #include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
@@ -109,6 +110,11 @@ public:
     {
       initThumbLoader<CPictureThumbLoader>(InfoTagType::PICTURE);
       return m_thumbloaders[InfoTagType::PICTURE];
+    }
+    if (item->IsPVRChannelGroup())
+    {
+      initThumbLoader<CPVRThumbLoader>(InfoTagType::PVR);
+      return m_thumbloaders[InfoTagType::PVR];
     }
     initThumbLoader<CProgramThumbLoader>(InfoTagType::PROGRAM);
     return m_thumbloaders[InfoTagType::PROGRAM];
@@ -298,7 +304,8 @@ void CDirectoryProvider::OnPVRManagerEvent(const PVR::PVREvent& event)
         event == PVR::PVREvent::ManagerError ||
         event == PVR::PVREvent::ManagerInterrupted ||
         event == PVR::PVREvent::RecordingsInvalidated ||
-        event == PVR::PVREvent::TimersInvalidated)
+        event == PVR::PVREvent::TimersInvalidated ||
+        event == PVR::PVREvent::ChannelGroupsInvalidated)
       m_updateState = INVALIDATED;
   }
 }

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -31,7 +31,8 @@ enum class InfoTagType
   VIDEO,
   AUDIO,
   PICTURE,
-  PROGRAM
+  PROGRAM,
+  PVR,
 };
 
 class CDirectoryProvider :

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -14,7 +14,8 @@ set(SOURCES PVRActionListener.cpp
             PVRGUIProgressHandler.cpp
             PVRGUITimerInfo.cpp
             PVRGUITimesInfo.cpp
-            PVRStreamProperties.cpp)
+            PVRStreamProperties.cpp
+            PVRThumbLoader.cpp)
 
 set(HEADERS PVRActionListener.h
             PVRDatabase.h
@@ -33,6 +34,7 @@ set(HEADERS PVRActionListener.h
             PVRGUIProgressHandler.h
             PVRGUITimerInfo.h
             PVRGUITimesInfo.h
-            PVRStreamProperties.h)
+            PVRStreamProperties.h
+            PVRThumbLoader.h)
 
 core_add_library(pvr)

--- a/xbmc/pvr/PVRGUIDirectory.h
+++ b/xbmc/pvr/PVRGUIDirectory.h
@@ -89,11 +89,15 @@ public:
    */
   static bool GetChannelGroupsDirectory(bool bRadio, bool bExcludeHidden, CFileItemList& results);
 
-private:
-
-  bool FilterDirectory(CFileItemList& results) const;
-
+  /*!
+   * @brief Get the list of channels.
+   * @param results The file list to store the results in.
+   * @return True on success, false otherwise..
+   */
   bool GetChannelsDirectory(CFileItemList& results) const;
+
+private:
+  bool FilterDirectory(CFileItemList& results) const;
   bool GetTimersDirectory(CFileItemList& results) const;
   bool GetRecordingsDirectory(CFileItemList& results) const;
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -49,7 +49,10 @@ namespace PVR
 
     // Timer events
     TimersInvalidated,
-    AnnounceReminder
+    AnnounceReminder,
+
+    // Channel events
+    ChannelGroupsInvalidated,
   };
 
   class CPVRManagerJobQueue

--- a/xbmc/pvr/PVRThumbLoader.cpp
+++ b/xbmc/pvr/PVRThumbLoader.cpp
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRThumbLoader.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "TextureCache.h"
+#include "TextureCacheJob.h"
+#include "pictures/Picture.h"
+#include "pvr/PVRGUIDirectory.h"
+#include "pvr/PVRManager.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <ctime>
+
+using namespace PVR;
+
+bool CPVRThumbLoader::LoadItem(CFileItem* item)
+{
+  bool result = LoadItemCached(item);
+  result |= LoadItemLookup(item);
+  return result;
+}
+
+bool CPVRThumbLoader::LoadItemCached(CFileItem* item)
+{
+  return FillThumb(*item);
+}
+
+bool CPVRThumbLoader::LoadItemLookup(CFileItem* item)
+{
+  return false;
+}
+
+void CPVRThumbLoader::OnLoaderFinish()
+{
+  if (m_bInvalidated)
+  {
+    m_bInvalidated = false;
+    CServiceBroker::GetPVRManager().PublishEvent(PVREvent::ChannelGroupsInvalidated);
+  }
+  CThumbLoader::OnLoaderFinish();
+}
+
+void CPVRThumbLoader::ClearCachedImage(CFileItem& item)
+{
+  const std::string thumb = item.GetArt("thumb");
+  if (!thumb.empty())
+  {
+    CTextureCache::GetInstance().ClearCachedImage(thumb);
+    if (m_textureDatabase->Open())
+    {
+      m_textureDatabase->ClearTextureForPath(item.GetPath(), "thumb");
+      m_textureDatabase->Close();
+    }
+    item.SetArt("thumb", "");
+    m_bInvalidated = true;
+  }
+}
+
+void CPVRThumbLoader::ClearCachedImages(CFileItemList& items)
+{
+  for (auto& item : items)
+    ClearCachedImage(*item);
+}
+
+bool CPVRThumbLoader::FillThumb(CFileItem& item)
+{
+  // see whether we have a cached image for this item
+  std::string thumb = GetCachedImage(item, "thumb");
+  if (thumb.empty())
+  {
+    if (item.IsPVRChannelGroup())
+      thumb = CreateChannelGroupThumb(item);
+    else
+      CLog::LogF(LOGERROR, "Unsupported PVR item '%s'", item.GetPath().c_str());
+
+    if (!thumb.empty())
+    {
+      SetCachedImage(item, "thumb", thumb);
+      m_bInvalidated = true;
+    }
+  }
+
+  if (thumb.empty())
+    return false;
+
+  item.SetArt("thumb", thumb);
+  return true;
+}
+
+std::string CPVRThumbLoader::CreateChannelGroupThumb(const CFileItem& channelGroupItem)
+{
+  const CPVRGUIDirectory channelGroupDir(channelGroupItem.GetPath());
+  CFileItemList channels;
+  if (channelGroupDir.GetChannelsDirectory(channels))
+  {
+    std::vector<std::string> channelIcons;
+    for (const auto& channel : channels)
+    {
+      const std::string& icon = channel->GetIconImage();
+      if (!icon.empty())
+        channelIcons.emplace_back(icon);
+
+      if (channelIcons.size() == 9) // limit number of tiles
+        break;
+    }
+
+    const std::string thumb = StringUtils::Format("%s?ts=%d", // append timestamp to Thumb URL to enforce texture refresh
+                                                  CTextureUtils::GetWrappedImageURL(channelGroupItem.GetPath(), "pvr"),
+                                                  std::time(nullptr));
+    const std::string relativeCacheFile = CTextureCache::GetCacheFile(thumb) + ".png";
+    if (CPicture::CreateTiledThumb(channelIcons, CTextureCache::GetCachedPath(relativeCacheFile)))
+    {
+      CTextureDetails details;
+      details.file = relativeCacheFile;
+      details.width = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes;
+      details.height = details.width;
+      CTextureCache::GetInstance().AddCachedTexture(thumb, details);
+      return thumb;
+    }
+  }
+
+  return {};
+}

--- a/xbmc/pvr/PVRThumbLoader.h
+++ b/xbmc/pvr/PVRThumbLoader.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ThumbLoader.h"
+
+#include <string>
+
+namespace PVR
+{
+
+class CPVRThumbLoader : public CThumbLoader
+{
+public:
+  CPVRThumbLoader() = default;
+  ~CPVRThumbLoader() override = default;
+
+  bool LoadItem(CFileItem* item) override;
+  bool LoadItemCached(CFileItem* item) override;
+  bool LoadItemLookup(CFileItem* item) override;
+
+  void ClearCachedImage(CFileItem& item);
+  void ClearCachedImages(CFileItemList& items);
+
+protected:
+  void OnLoaderFinish() override;
+
+private:
+  bool FillThumb(CFileItem& item);
+  std::string CreateChannelGroupThumb(const CFileItem& channelGroupItem);
+
+  bool m_bInvalidated = false;
+};
+
+}

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "guilib/GUIDialog.h"
+#include "pvr/PVRThumbLoader.h"
 #include "pvr/PVRTypes.h"
 #include "view/GUIViewControl.h"
 
@@ -34,6 +35,7 @@ namespace PVR
 
   private:
     void Clear();
+    void ClearSelectedGroupsThumbnail();
     void Update();
     bool PersistChanges(void);
     bool CancelChanges(void);
@@ -46,6 +48,7 @@ namespace PVR
     bool ActionButtonChannelGroups(CGUIMessage &message);
     bool ActionButtonHideGroup(CGUIMessage &message);
     bool ActionButtonToggleRadioTV(CGUIMessage &message);
+    bool ActionButtonRecreateThumbnail(CGUIMessage& message);
     bool OnMessageClick(CGUIMessage &message);
 
     CPVRChannelGroupPtr m_selectedGroup;
@@ -62,5 +65,7 @@ namespace PVR
     CGUIViewControl   m_viewUngroupedChannels;
     CGUIViewControl   m_viewGroupMembers;
     CGUIViewControl   m_viewChannelGroups;
+
+    CPVRThumbLoader m_thumbLoader;
   };
 }


### PR DESCRIPTION
This improvement will automatically generate a thumbnail picture for channelgroups out of the logos contained in the group, showing it in the respective channel groups Estuary home screen widgets.

![screenshot000](https://user-images.githubusercontent.com/3226626/60800787-13170780-a176-11e9-854b-ecb6da8d4703.png)

Group manager can be used to recreate the thumbnails in case user feels they are outdated (because channels and/or their logos changed). 

![screenshot001](https://user-images.githubusercontent.com/3226626/60800821-232ee700-a176-11e9-9d8f-f67ac625860a.png)

Note: Automatically detecting and outdated thumbs could be done, but is not trivial, and out of scope of this PR as well as user or PVR backend defined group thumb nails. These enhancements may be part of a future PR, though.

@Jalle19 mind taking a look at the core code changes
@ronie are the skin changes okay? They are straight-forward, imo.