### PR TITLE
 [PVR] Group manager: Automatically fill channel lists upon group selection.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -17,6 +17,7 @@
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers//DialogOKHelper.h"
 #include "pvr/PVRGUIDirectory.h"
@@ -50,9 +51,6 @@ using namespace PVR;
 CGUIDialogPVRGroupManager::CGUIDialogPVRGroupManager() :
     CGUIDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER, "DialogPVRGroupManager.xml")
 {
-  m_iSelectedUngroupedChannel = 0;
-  m_iSelectedGroupMember = 0;
-  m_iSelectedChannelGroup = 0;
   m_ungroupedChannels = new CFileItemList;
   m_groupMembers      = new CFileItemList;
   m_channelGroups     = new CFileItemList;
@@ -317,10 +315,59 @@ bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogPVRGroupManager::OnActionMove(const CAction& action)
+{
+  bool bReturn = false;
+  int iActionId = action.GetID();
+
+  if (GetFocusedControlID() == CONTROL_LIST_CHANNEL_GROUPS)
+  {
+    if (iActionId == ACTION_MOUSE_MOVE)
+    {
+      int iSelected = m_viewChannelGroups.GetSelectedItem();
+      if (m_iSelectedChannelGroup < iSelected)
+      {
+        iActionId = ACTION_MOVE_DOWN;
+      }
+      else if (m_iSelectedChannelGroup > iSelected)
+      {
+        iActionId = ACTION_MOVE_UP;
+      }
+      else
+      {
+        return bReturn;
+      }
+    }
+
+    if (iActionId == ACTION_MOVE_DOWN || iActionId == ACTION_MOVE_UP ||
+        iActionId == ACTION_PAGE_DOWN || iActionId == ACTION_PAGE_UP ||
+        iActionId == ACTION_FIRST_PAGE || iActionId == ACTION_LAST_PAGE)
+    {
+      CGUIDialog::OnAction(action);
+      int iSelected = m_viewChannelGroups.GetSelectedItem();
+
+      bReturn = true;
+      if (iSelected != m_iSelectedChannelGroup)
+      {
+        m_iSelectedChannelGroup = iSelected;
+        Update();
+      }
+    }
+  }
+
+  return bReturn;
+}
+
+bool CGUIDialogPVRGroupManager::OnAction(const CAction& action)
+{
+  return OnActionMove(action) ||
+         CGUIDialog::OnAction(action);
+}
+
 void CGUIDialogPVRGroupManager::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();
-  m_iSelectedUngroupedChannel  = 0;
+  m_iSelectedUngroupedChannel = 0;
   m_iSelectedGroupMember = 0;
   m_iSelectedChannelGroup = 0;
   Update();

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -78,12 +78,6 @@ bool CGUIDialogPVRGroupManager::PersistChanges(void)
   return CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)->PersistAll();
 }
 
-bool CGUIDialogPVRGroupManager::CancelChanges(void)
-{
-  //! @todo
-  return false;
-}
-
 bool CGUIDialogPVRGroupManager::ActionButtonOk(CGUIMessage &message)
 {
   bool bReturn = false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -36,7 +36,6 @@ namespace PVR
     void Clear();
     void Update();
     bool PersistChanges(void);
-    bool CancelChanges(void);
     bool ActionButtonOk(CGUIMessage &message);
     bool ActionButtonNewGroup(CGUIMessage &message);
     bool ActionButtonDeleteGroup(CGUIMessage &message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -23,6 +23,7 @@ namespace PVR
     CGUIDialogPVRGroupManager(void);
     ~CGUIDialogPVRGroupManager(void) override;
     bool OnMessage(CGUIMessage& message) override;
+    bool OnAction(const CAction& action) override;
     void OnWindowLoaded() override;
     void OnWindowUnload() override;
 
@@ -46,13 +47,14 @@ namespace PVR
     bool ActionButtonHideGroup(CGUIMessage &message);
     bool ActionButtonToggleRadioTV(CGUIMessage &message);
     bool OnMessageClick(CGUIMessage &message);
+    bool OnActionMove(const CAction& action);
 
     CPVRChannelGroupPtr m_selectedGroup;
     bool              m_bIsRadio;
 
-    unsigned int      m_iSelectedUngroupedChannel;
-    unsigned int      m_iSelectedGroupMember;
-    unsigned int      m_iSelectedChannelGroup;
+    int m_iSelectedUngroupedChannel = 0;
+    int m_iSelectedGroupMember = 0;
+    int m_iSelectedChannelGroup = 0;
 
     CFileItemList *   m_ungroupedChannels;
     CFileItemList *   m_groupMembers;


### PR DESCRIPTION
What subject says. Fill the group manager's channel lists automatically when focusing a new group entry. Formerly, this only happened when hitting Enter/OK on the group. This was not how the rest of Kodi GUI works and was pretty confusing for me.

@Jalle19 mind taking a look at the core code changes? Code is basically copied from PVR channel manager, btw.
