### PR TITLE
Avoid video library clean on scan and video playback

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21719,3 +21719,15 @@ msgstr ""
 msgctxt "#39116"
 msgid "Episode plot"
 msgstr ""
+
+#. Header for warning notification during video playback
+#: xbmc/interfaces/builtins/LibraryBuiltins.cpp
+msgctxt "#39117"
+msgid "Clean video library"
+msgstr ""
+
+#. Message for warning notification during video playback
+#: xbmc/interfaces/builtins/LibraryBuiltins.cpp
+msgctxt "#39118"
+msgid "Not possible during video playback"
+msgstr ""

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -11,6 +11,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogFileBrowser.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/LocalizeStrings.h"
@@ -41,13 +42,20 @@ static int CleanLibrary(const std::vector<std::string>& params)
                      || StringUtils::EqualsNoCase(params[0], "tvshows")
                      || StringUtils::EqualsNoCase(params[0], "musicvideos"))
   {
-    if (!g_application.IsVideoScanning())
+    if (g_application.IsVideoScanning())
+    {
+      CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning or cleaning");
+    }
+    else if (g_application.GetAppPlayer().IsPlayingVideo())
+    {
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(39117), g_localizeStrings.Get(39118));
+      CLog::Log(LOGERROR, "CleanLibrary is not possible while playing video");
+    }
+    else
     {
       const std::string content = (params.empty() || params[0] == "video") ? "" : params[0];
       g_application.StartVideoCleanup(userInitiated, content);
     }
-    else
-      CLog::Log(LOGERROR, "CleanLibrary is not possible while scanning or cleaning");
   }
   else if (StringUtils::EqualsNoCase(params[0], "music"))
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This change avoids cleaning the video library while Kodi plays video as at the same time of the video library cleaning and stopping the video will cause a crash. 

See: https://forum.kodi.tv/showthread.php?tid=345261

I don't call it a fix. It's just an idea I had. Also changed the logging to be more specific why the cleaning of the video library won't start.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Cleaning the video library during playback of a video can also be triggered by accident via a mapped remote button. It might be obvious to cancel the the cleaning, but in case someone stops the video instead, Kodi crashes. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested that on Ubuntu 18.04

Before that change: 

- play a video
- during playback executre: `kodi-send -a "CleanLibrary(video)"
- during the library clean execute: `kodi-send -a "stop"`
- Kodi will crash

After that change: 

- play a video
- during playback execute: `kodi-send -a "CleanLibrary(video)"`
- a notification will be triggered that a video library clean is not possible during video playback
- a log message saying the same will be written in the logfile. 
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
