### PR TITLE
[VideoPlayer][Leia] Fix initialization of AVD3D11VAContext structure

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -841,6 +841,7 @@ CDecoder::CDecoder(CProcessInfo& processInfo)
 {
   m_event.Set();
   m_context          = static_cast<AVD3D11VAContext*>(calloc(1, sizeof(AVD3D11VAContext)));
+  m_context->context_mutex = INVALID_HANDLE_VALUE;
   m_context->cfg     = reinterpret_cast<D3D11_VIDEO_DECODER_CONFIG*>(calloc(1, sizeof(D3D11_VIDEO_DECODER_CONFIG)));
   m_context->surface = reinterpret_cast<ID3D11VideoDecoderOutputView**>(calloc(32, sizeof(ID3D11VideoDecoderOutputView*)));
   m_bufferPool.reset();


### PR DESCRIPTION
## Description
This PR is for the Leia baseline ONLY as a quick-fix for a problem that has been resolved on the Matrix baseline but was not back-ported to Leia.  The Leia baseline continues to not properly initialize the ffmpeg AVD3D11VAContext stucture's context_mutex member to INVALID_HANDLE_VALUE as opposed to NULL.  This causes detectable runtime exceptions when the context_mutex member is subsequently used by ffmpeg.

It is understood that there may not be any more dot releases for Kodi Leia, but if there are I believe this minor tweak will resolve the encountered problem for DXVA11 users and would be a worthwhile inclusion.

## Motivation and Context
The defect was noted by running Kodi Leia through the Microsoft Application Verifier tool after replacing EasyHook64.dll with a newer version and setting the ffmpeg build to use --enable-debug instead of --disable-debug.  The tool detected attempts to wait on the mutex as invalid since the handle initialization was bypassed due to the value being set to NULL instead of INVALID_HANDLE_VALUE.

## How Has This Been Tested?
Tested on Kodi 18.3, Windows x64, using the Microsoft Application Verifier tool.  As noted, this change does not apply to Matrix as the code has been refactored to use the ffmpeg initialization function that sets the context_mutex member appropriately.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
