### PR TITLE
[PVR] Refactor and fix channel paths

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9133,7 +9133,7 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
-#: xbmc/filesystem/PVRDirectory.cpp
+#: xbmc/pvr/PVRGUIDirectory.cpp
 msgctxt "#19017"
 msgid "Recordings"
 msgstr ""
@@ -9150,6 +9150,7 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/Home.xml
+#: xbmc/pvr/PVRGUIDirectory.cpp
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#19019"
 msgid "Channels"
@@ -9159,8 +9160,8 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/SkinSettings.xml:
 #: addons/skin.estuary/xml/Variables.xml
-#: xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
 #: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/PVRGUIDirectory.cpp
 msgctxt "#19020"
 msgid "TV"
 msgstr ""
@@ -9169,8 +9170,8 @@ msgstr ""
 #: addons/skin.estuary/xml/Home.xml
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
-#: xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
 #: xbmc/pvr/PVRGUIActions.cpp
+#: xbmc/pvr/PVRGUIDirectory.cpp
 msgctxt "#19021"
 msgid "Radio"
 msgstr ""
@@ -9206,7 +9207,7 @@ msgstr ""
 
 #. label for "add timer..." list item used in pvr timers / timer rules window
 #: xbmc/pvr/timers/PVRTimerInfoTag.cpp
-#: xbmc/pvr/timers/PVRTimers.cpp
+#: xbmc/pvr/PVRGUIDirectory.cpp
 msgctxt "#19026"
 msgid "Add timer..."
 msgstr ""
@@ -10180,6 +10181,7 @@ msgstr ""
 #. label for "deleted recordings" data source in media source window
 #: addons/skin.estuary/xml/Includes_MediaMenu.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
+#: xbmc/pvr/PVRGUIDirectory.cpp
 msgctxt "#19184"
 msgid "Deleted recordings"
 msgstr ""

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -5,6 +5,7 @@ xbmc/interfaces/python/test       test/python
 xbmc/music/tags/test              test/music_tags
 xbmc/network/test                 test/network
 xbmc/playlists/test               test/playlists
+xbmc/pvr/channels/test            test/pvrchannels
 xbmc/test                         test
 xbmc/threads/test                 test/threads
 xbmc/utils/test                   test/utils

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -851,9 +851,7 @@ bool CFileItem::IsPVRChannel() const
 
 bool CFileItem::IsPVRChannelGroup() const
 {
-  return !StringUtils::EndsWithNoCase(m_strPath, ".pvr") &&
-         (StringUtils::StartsWithNoCase(m_strPath, "pvr://channels/tv/") ||
-          StringUtils::StartsWithNoCase(m_strPath, "pvr://channels/radio/"));
+  return URIUtils::IsPVRChannelGroup(m_strPath);
 }
 
 bool CFileItem::IsPVRRecording() const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1253,7 +1253,7 @@ bool CFileItem::IsURL() const
 
 bool CFileItem::IsPVR() const
 {
-  return CUtil::IsPVR(m_strPath);
+  return URIUtils::IsPVR(m_strPath);
 }
 
 bool CFileItem::IsLiveTV() const
@@ -3202,7 +3202,7 @@ std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 
   if (m_pvrRecordingInfoTag)
     return m_pvrRecordingInfoTag->m_strTitle;
-  else if (CUtil::IsTVRecording(m_strPath))
+  else if (URIUtils::IsPVRRecording(m_strPath))
   {
     std::string title = CPVRRecording::GetTitleFromURL(m_strPath);
     if (!title.empty())

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -508,21 +508,6 @@ std::string CUtil::GetHomePath(std::string strTarget)
   return ::GetHomePath(strTarget, strPath);
 }
 
-bool CUtil::IsPVR(const std::string& strFile)
-{
-  return StringUtils::StartsWithNoCase(strFile, "pvr:");
-}
-
-bool CUtil::IsLiveTV(const std::string& strFile)
-{
-  return StringUtils::StartsWithNoCase(strFile, "pvr://channels");
-}
-
-bool CUtil::IsTVRecording(const std::string& strFile)
-{
-  return StringUtils::StartsWithNoCase(strFile, "pvr://recording");
-}
-
 bool CUtil::IsPicture(const std::string& strFile)
 {
   return URIUtils::HasExtension(strFile,
@@ -1509,7 +1494,7 @@ bool CUtil::SupportsWriteFileOperations(const std::string& strPath)
     return true;
   if (URIUtils::IsSmb(strPath))
     return true;
-  if (CUtil::IsTVRecording(strPath))
+  if (URIUtils::IsPVRRecording(strPath))
     return CPVRDirectory::SupportsWriteFileOperations(strPath);
   if (URIUtils::IsNfs(strPath))
     return true;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -49,10 +49,6 @@ public:
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);
   static std::string GetHomePath(std::string strTarget = "KODI_HOME"); // default target is "KODI_HOME"
-  static bool IsPVR(const std::string& strFile);
-  static bool IsHTSP(const std::string& strFile);
-  static bool IsLiveTV(const std::string& strFile);
-  static bool IsTVRecording(const std::string& strFile);
   static bool ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::vector<std::string>& regexps);
   static void GetFileAndProtocol(const std::string& strURL, std::string& strDir);
   static int GetDVDIfoTitle(const std::string& strPathFile);

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -573,7 +573,9 @@ bool CPVRDatabase::Get(CPVRChannelGroups &results)
     {
       while (!m_pDS->eof())
       {
-        CPVRChannelGroup data(m_pDS->fv("bIsRadio").get_asBool(), m_pDS->fv("idGroup").get_asInt(), m_pDS->fv("sName").get_asString(), results.GetGroupAll());
+        CPVRChannelGroup data(CPVRChannelsPath(m_pDS->fv("bIsRadio").get_asBool(), m_pDS->fv("sName").get_asString()),
+                              m_pDS->fv("idGroup").get_asInt(),
+                              results.GetGroupAll());
         data.SetGroupType(m_pDS->fv("iGroupType").get_asInt());
         data.SetLastWatched(static_cast<time_t>(m_pDS->fv("iLastWatched").get_asInt()));
         data.SetHidden(m_pDS->fv("bIsHidden").get_asBool());

--- a/xbmc/pvr/channels/CMakeLists.txt
+++ b/xbmc/pvr/channels/CMakeLists.txt
@@ -4,7 +4,8 @@ set(SOURCES PVRChannel.cpp
             PVRChannelGroups.cpp
             PVRChannelGroupsContainer.cpp
             PVRChannelNumber.cpp
-            PVRRadioRDSInfoTag.cpp)
+            PVRRadioRDSInfoTag.cpp
+            PVRChannelsPath.cpp)
 
 set(HEADERS PVRChannel.h
             PVRChannelGroup.h
@@ -12,6 +13,7 @@ set(HEADERS PVRChannel.h
             PVRChannelGroups.h
             PVRChannelGroupsContainer.h
             PVRChannelNumber.h
-            PVRRadioRDSInfoTag.h)
+            PVRRadioRDSInfoTag.h
+            PVRChannelsPath.h)
 
 core_add_library(pvr_channels)

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -14,6 +14,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgContainer.h"
@@ -414,16 +415,13 @@ bool CPVRChannel::SetClientID(int iClientId)
   return false;
 }
 
-void CPVRChannel::UpdatePath(const std::string& groupPath)
+void CPVRChannel::UpdatePath(const std::string& channelGroup)
 {
   const CPVRClientPtr client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client)
   {
     CSingleLock lock(m_critSection);
-    const std::string strFileNameAndPath = StringUtils::Format("%s%s_%d.pvr",
-                                                               groupPath,
-                                                               client->ID().c_str(),
-                                                               m_iUniqueId);
+    const std::string strFileNameAndPath = CPVRChannelsPath(m_bIsRadio, channelGroup, client->ID(), m_iUniqueId);
     if (m_strFileNameAndPath != strFileNameAndPath)
     {
       m_strFileNameAndPath = strFileNameAndPath;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -275,9 +275,9 @@ namespace PVR
 
     /*!
      * @brief Update the channel path
-     * @param groupPath The new path of the group this channel belongs to
+     * @param channelGroup The (new) name of the group this channel belongs to
      */
-    void UpdatePath(const std::string& groupPath);
+    void UpdatePath(const std::string& channelGroup);
 
     /*!
      * @return Storage id for this channel in CPVRChannelGroup

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -11,6 +11,7 @@
 #include "XBDateTime.h"
 #include "pvr/PVRTypes.h"
 #include "pvr/channels/PVRChannelNumber.h"
+#include "pvr/channels/PVRChannelsPath.h"
 #include "settings/lib/ISettingCallback.h"
 #include "utils/Observer.h"
 
@@ -61,12 +62,13 @@ namespace PVR
 
     /*!
      * @brief Create a new channel group instance.
-     * @param bRadio True if this group holds radio channels.
+     * @param path The channel group path.
      * @param iGroupId The database ID of this group or INVALID_GROUP_ID if the group was not yet stored in the database.
-     * @param strGroupName The name of this group.
      * @param allChannelsGroup The channel group containing all TV or radio channels.
      */
-    CPVRChannelGroup(bool bRadio, int iGroupId, const std::string& strGroupName, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+    CPVRChannelGroup(const CPVRChannelsPath& path,
+                     int iGroupId = INVALID_GROUP_ID,
+                     const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup = {});
 
     /*!
      * @brief Create a new channel group instance from a channel group provided by an add-on.
@@ -113,7 +115,13 @@ namespace PVR
      * @brief Get the path of this group.
      * @return the path.
      */
-    std::string GetPath() const;
+    const CPVRChannelsPath& GetPath() const;
+
+    /*!
+     * @brief Set the path of this group.
+     * @param the path.
+     */
+    void SetPath(const CPVRChannelsPath& path);
 
     /*!
      * @brief Change the channelnumber of a group. Used by CGUIDialogPVRChannelManager. Call SortByChannelNumber() and Renumber() after all changes are done.
@@ -141,10 +149,8 @@ namespace PVR
     /*!
      * @brief Change the name of this group.
      * @param strGroupName The new group name.
-     * @param bSaveInDb Save in the database or not.
-     * @return True if the something changed, false otherwise.
      */
-    bool SetGroupName(const std::string &strGroupName, bool bSaveInDb = false);
+    void SetGroupName(const std::string& strGroupName);
 
     /*!
      * @brief Persist changed or new data.
@@ -176,13 +182,7 @@ namespace PVR
      * @brief True if this group holds radio channels, false if it holds TV channels.
      * @return True if this group holds radio channels, false if it holds TV channels.
      */
-    bool IsRadio(void) const { return m_bRadio; }
-
-    /*!
-     * @brief Set 'radio' property of this group.
-     * @param bIsRadio The new value for the 'radio' property.
-     */
-    void SetRadio(bool bIsRadio) { m_bRadio = bIsRadio; }
+    bool IsRadio() const;
 
     /*!
      * @brief True if sorting should be prevented when adding/updating channels to the group.
@@ -439,8 +439,6 @@ namespace PVR
     bool IsMissingChannelsFromClient(int iClientId) const;
 
   protected:
-    CPVRChannelGroup();
-
     /*!
      * @brief Init class
      */
@@ -506,10 +504,8 @@ namespace PVR
      */
     bool UpdateClientPriorities();
 
-    bool             m_bRadio = false;                      /*!< true if this container holds radio channels, false if it holds TV channels */
     int              m_iGroupType = PVR_GROUP_TYPE_DEFAULT;                  /*!< The type of this group */
     int              m_iGroupId = INVALID_GROUP_ID; /*!< The ID of this group in the database */
-    std::string      m_strGroupName;                /*!< The name of this group */
     bool             m_bLoaded = false;                     /*!< True if this container is loaded, false otherwise */
     bool             m_bChanged = false;                    /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
     bool             m_bUsingBackendChannelOrder = false;   /*!< true to use the channel order from backends, false otherwise */
@@ -528,5 +524,6 @@ namespace PVR
     CDateTime GetEPGDate(EpgDateType epgDateType) const;
 
     std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
+    CPVRChannelsPath m_path;
   };
 }

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -69,7 +69,7 @@ namespace PVR
      * @param strPath The path to the channel
      * @return The channel, or nullptr if not found
      */
-    std::shared_ptr<CPVRChannel> GetByPath(const std::string& strPath) const;
+    std::shared_ptr<CPVRChannel> GetByPath(const CPVRChannelsPath& path) const;
 
     /*!
      * @brief Get a pointer to a channel group given its ID.

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -110,17 +110,16 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(con
   if (!epgTag)
     return {};
 
-  const CPVRChannelGroups* groups = epgTag->IsRadio() ? m_groupsRadio : m_groupsTV;
-  return groups->GetGroupAll()->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID());
+  return Get(epgTag->IsRadio())->GetGroupAll()->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID());
 }
 
 std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByPath(const std::string& strPath) const
 {
-  const std::shared_ptr<CPVRChannel> channel = m_groupsTV->GetByPath(strPath);
-  if (channel)
-    return channel;
+  const CPVRChannelsPath path(strPath);
+  if (path.IsValid())
+    return Get(path.IsRadio())->GetByPath(path);
 
-  return m_groupsRadio->GetByPath(strPath);
+  return {};
 }
 
 CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetSelectedGroup(bool bRadio) const

--- a/xbmc/pvr/channels/PVRChannelsPath.cpp
+++ b/xbmc/pvr/channels/PVRChannelsPath.cpp
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelsPath.h"
+
+#include "URL.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <string>
+#include <vector>
+
+using namespace PVR;
+
+const std::string CPVRChannelsPath::PATH_TV_CHANNELS = "pvr://channels/tv/";
+const std::string CPVRChannelsPath::PATH_RADIO_CHANNELS = "pvr://channels/radio/";
+
+
+CPVRChannelsPath::CPVRChannelsPath(const std::string& strPath)
+{
+  std::string strVarPath = TrimSlashes(strPath);
+  const std::vector<std::string> segments = URIUtils::SplitPath(strVarPath);
+
+  for (const std::string& segment : segments)
+  {
+    switch (m_kind)
+    {
+      case Kind::INVALID:
+        if (segment == "pvr://")
+          m_kind = Kind::PROTO; // pvr:// followed by something => go on
+        else if (segment == "pvr:" && segments.size() == 1) // just pvr:// => invalid
+          strVarPath = "pvr:/";
+        break;
+
+      case Kind::PROTO:
+        if (segment == "channels")
+          m_kind = Kind::EMPTY; // pvr://channels
+        else
+          m_kind = Kind::INVALID;
+        break;
+
+      case Kind::EMPTY:
+        if (segment == "tv" || segment == "radio")
+        {
+          m_kind = Kind::ROOT; // pvr://channels/(tv|radio)
+          m_bRadio = (segment == "radio");
+        }
+        else
+        {
+          CLog::LogF(LOGERROR, "Invalid channels path '%s' - channel root segment syntax error.", strPath.c_str());
+          m_kind = Kind::INVALID;
+        }
+        break;
+
+      case Kind::ROOT:
+        m_kind = Kind::GROUP; // pvr://channels/(tv|radio)/<groupname>
+        m_group = CURL::Decode(segment);
+        break;
+
+      case Kind::GROUP:
+      {
+        std::vector<std::string> tokens = StringUtils::Split(segment, "_");
+        if (tokens.size() == 2)
+        {
+          m_clientID = tokens[0];
+          tokens = StringUtils::Split(tokens[1], ".");
+          if (tokens.size() == 2 && tokens[1] == "pvr")
+          {
+            std::string channelUID = tokens[0];
+            if (!channelUID.empty() && channelUID.find_first_not_of("0123456789") == std::string::npos)
+              m_iChannelUID = std::atoi(channelUID.c_str());
+          }
+        }
+
+        if (!m_clientID.empty() && m_iChannelUID >= 0)
+        {
+          m_kind = Kind::CHANNEL; // pvr://channels/(tv|radio)/<groupname>/<addonid>_<channeluid>.pvr
+        }
+        else
+        {
+          CLog::LogF(LOGERROR, "Invalid channels path '%s' - channel segment syntax error.", strPath.c_str());
+          m_kind = Kind::INVALID;
+        }
+        break;
+      }
+
+      case Kind::CHANNEL:
+        CLog::LogF(LOGERROR, "Invalid channels path '%s' - too many path segments.", strPath.c_str());
+        m_kind = Kind::INVALID; // too many segments
+        break;
+    }
+
+    if (m_kind == Kind::INVALID)
+      break;
+  }
+
+  // append slash to all folders
+  if (m_kind < Kind::CHANNEL)
+    strVarPath.append("/");
+
+  m_path = strVarPath;
+}
+
+CPVRChannelsPath::CPVRChannelsPath(bool bRadio, bool bHidden, const std::string& strGroupName)
+  : m_bRadio(bRadio)
+{
+  if (!bHidden && strGroupName.empty())
+    m_kind = Kind::EMPTY;
+  else
+    m_kind = Kind::GROUP;
+
+  m_group = bHidden ? ".hidden" : strGroupName;
+  m_path = StringUtils::Format("pvr://channels/%s/%s", bRadio ? "radio" : "tv", CURL::Encode(m_group).c_str());
+
+  if (!m_group.empty())
+    m_path.append("/");
+}
+
+CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName)
+  : m_bRadio(bRadio)
+{
+  if (strGroupName.empty())
+    m_kind = Kind::EMPTY;
+  else
+    m_kind = Kind::GROUP;
+
+  m_group = strGroupName;
+  m_path = StringUtils::Format("pvr://channels/%s/%s", bRadio ? "radio" : "tv", CURL::Encode(m_group).c_str());
+
+  if (!m_group.empty())
+    m_path.append("/");
+}
+
+CPVRChannelsPath::CPVRChannelsPath(bool bRadio, const std::string& strGroupName, const std::string& strClientID, int iChannelUID)
+  : m_bRadio(bRadio)
+{
+  if (!strGroupName.empty() && !strClientID.empty() && iChannelUID >= 0)
+  {
+    m_kind = Kind::CHANNEL;
+    m_group = strGroupName;
+    m_clientID = strClientID;
+    m_iChannelUID = iChannelUID;
+    m_path = StringUtils::Format("pvr://channels/%s/%s/%s_%d.pvr",
+                                 bRadio ? "radio" : "tv", CURL::Encode(m_group).c_str(), m_clientID.c_str(), m_iChannelUID);
+  }
+}
+
+bool CPVRChannelsPath::IsHiddenChannelGroup() const
+{
+  return m_kind == Kind::GROUP && m_group == ".hidden";
+}
+
+std::string CPVRChannelsPath::TrimSlashes(const std::string& strString)
+{
+  std::string strTrimmed = strString;
+  while (!strTrimmed.empty() && strTrimmed.front() == '/')
+    strTrimmed.erase(0, 1);
+
+  while (!strTrimmed.empty() && strTrimmed.back() == '/')
+    strTrimmed.pop_back();
+
+  return strTrimmed;
+}

--- a/xbmc/pvr/channels/PVRChannelsPath.h
+++ b/xbmc/pvr/channels/PVRChannelsPath.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class CDateTime;
+
+namespace PVR
+{
+  class CPVRChannelsPath
+  {
+  public:
+    static const std::string PATH_TV_CHANNELS;
+    static const std::string PATH_RADIO_CHANNELS;
+
+    explicit CPVRChannelsPath(const std::string& strPath);
+    CPVRChannelsPath(bool bRadio, const std::string& strGroupName);
+    CPVRChannelsPath(bool bRadio, bool bHidden, const std::string& strGroupName);
+    CPVRChannelsPath(bool bRadio, const std::string& strGroupName, const std::string& strClientID, int iChannelUID);
+
+    operator std::string() const { return m_path; }
+    bool operator ==(const CPVRChannelsPath& right) const { return m_path == right.m_path; }
+    bool operator !=(const CPVRChannelsPath& right) const { return !(*this == right); }
+
+    bool IsValid() const { return m_kind > Kind::PROTO; }
+
+    bool IsEmpty() const { return m_kind == Kind::EMPTY; }
+    bool IsChannelsRoot() const { return m_kind == Kind::ROOT; }
+    bool IsChannelGroup() const { return m_kind == Kind::GROUP; }
+    bool IsChannel() const { return m_kind == Kind::CHANNEL; }
+
+    bool IsHiddenChannelGroup() const;
+
+    bool IsRadio() const { return m_bRadio; }
+
+    const std::string& GetGroupName() const { return m_group; }
+    const std::string& GetClientID() const { return m_clientID; }
+    int GetChannelUID() const { return m_iChannelUID; }
+
+  private:
+    static std::string TrimSlashes(const std::string& strString);
+
+    enum class Kind
+    {
+      INVALID,
+      PROTO,
+      EMPTY,
+      ROOT,
+      GROUP,
+      CHANNEL,
+    };
+
+    Kind m_kind = Kind::INVALID;
+    bool m_bRadio = false;;
+    std::string m_path;
+    std::string m_group;
+    std::string m_clientID;
+    int m_iChannelUID = -1;
+  };
+}

--- a/xbmc/pvr/channels/test/CMakeLists.txt
+++ b/xbmc/pvr/channels/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES TestPVRChannelsPath.cpp)
+set(HEADERS)
+
+core_add_test_library(pvrchannels_test)

--- a/xbmc/pvr/channels/test/TestPVRChannelsPath.cpp
+++ b/xbmc/pvr/channels/test/TestPVRChannelsPath.cpp
@@ -1,0 +1,403 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "pvr/channels/PVRChannelsPath.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestPVRChannelsPath, Parse_Protocol)
+{
+  // pvr protocol is generally fine, but not sufficient for channels pvr paths - component is missing for that.
+  PVR::CPVRChannelsPath path("pvr://");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Component_1)
+{
+  PVR::CPVRChannelsPath path("pvr://channels");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_TRUE(path.IsEmpty());
+}
+
+TEST(TestPVRChannelsPath, Parse_Component_2)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_TRUE(path.IsEmpty());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_Component)
+{
+  PVR::CPVRChannelsPath path("pvr://foo/");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_TV_Root_1)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_TRUE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_TV_Root_2)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv/");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_TRUE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_Radio_Root_1)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/radio");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/radio/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_TRUE(path.IsRadio());
+  EXPECT_TRUE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_Radio_Root_2)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/radio/");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/radio/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_TRUE(path.IsRadio());
+  EXPECT_TRUE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_Root)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/foo");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_TV_Group_1)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv/Group1");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/Group1/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_TV_Group_2)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv/Group1/");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/Group1/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_Hidden_TV_Group)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv/.hidden");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/.hidden/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_TRUE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), ".hidden");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_Special_TV_Group)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv/foo%2Fbar%20baz");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/foo%2Fbar%20baz/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "foo/bar baz");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_Special_TV_Group)
+{
+  // special chars in group name not escaped
+  PVR::CPVRChannelsPath path("pvr://channels/tv/foo/bar baz");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Radio_Group)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/radio/Group1/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_TRUE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Parse_TV_Channel)
+{
+  PVR::CPVRChannelsPath path("pvr://channels/tv/Group1/pvr.demo_4711.pvr");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/Group1/pvr.demo_4711.pvr");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_TRUE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "pvr.demo");
+  EXPECT_EQ(path.GetChannelUID(), 4711);
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_1)
+{
+  // trailing ".pvr" missing
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/pvr.demo_4711");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_2)
+{
+  // '-' instead of '_' as clientid / channeluid delimiter
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/pvr.demo-4711.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_3)
+{
+  // channeluid not numerical
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/pvr.demo_abc4711.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_4)
+{
+  // channeluid not positive or zero
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/pvr.demo_-4711.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_5)
+{
+  // empty clientid
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/_4711.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_6)
+{
+  // empty channeluid
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/pvr.demo_.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_7)
+{
+  // empty clientid and empty channeluid
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/_.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, Parse_Invalid_TV_Channel_8)
+{
+  // empty clientid and empty channeluid, only extension ".pvr" given
+  PVR::CPVRChannelsPath path("pvr://channels/radio/Group1/.pvr");
+
+  EXPECT_FALSE(path.IsValid());
+}
+
+TEST(TestPVRChannelsPath, TV_Channelgroup)
+{
+  PVR::CPVRChannelsPath path(false, "Group1");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/Group1/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Radio_Channelgroup)
+{
+  PVR::CPVRChannelsPath path(true, "Group1");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/radio/Group1/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_TRUE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Hidden_TV_Channelgroup)
+{
+  PVR::CPVRChannelsPath path(false, true, "Group1");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/.hidden/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_TRUE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), ".hidden");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, Hidden_Radio_Channelgroup)
+{
+  PVR::CPVRChannelsPath path(true, true, "Group1");
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/radio/.hidden/");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_TRUE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_TRUE(path.IsChannelGroup());
+  EXPECT_TRUE(path.IsHiddenChannelGroup());
+  EXPECT_FALSE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), ".hidden");
+  EXPECT_EQ(path.GetClientID(), "");
+  EXPECT_EQ(path.GetChannelUID(), -1);
+}
+
+TEST(TestPVRChannelsPath, TV_Channel)
+{
+  PVR::CPVRChannelsPath path(false, "Group1", "pvr.demo", 4711);
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/tv/Group1/pvr.demo_4711.pvr");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_FALSE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_TRUE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "pvr.demo");
+  EXPECT_EQ(path.GetChannelUID(), 4711);
+}
+
+TEST(TestPVRChannelsPath, Radio_Channel)
+{
+  PVR::CPVRChannelsPath path(true, "Group1", "pvr.demo", 4711);
+
+  EXPECT_EQ(static_cast<std::string>(path), "pvr://channels/radio/Group1/pvr.demo_4711.pvr");
+  EXPECT_TRUE(path.IsValid());
+  EXPECT_FALSE(path.IsEmpty());
+  EXPECT_TRUE(path.IsRadio());
+  EXPECT_FALSE(path.IsChannelsRoot());
+  EXPECT_FALSE(path.IsChannelGroup());
+  EXPECT_FALSE(path.IsHiddenChannelGroup());
+  EXPECT_TRUE(path.IsChannel());
+  EXPECT_EQ(path.GetGroupName(), "Group1");
+  EXPECT_EQ(path.GetClientID(), "pvr.demo");
+  EXPECT_EQ(path.GetChannelUID(), 4711);
+}
+
+TEST(TestPVRChannelsPath, Operator_Equals)
+{
+  PVR::CPVRChannelsPath path2(true, "Group1");
+  PVR::CPVRChannelsPath path(static_cast<std::string>(path2));
+
+  EXPECT_EQ(path, path2);
+}

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -170,7 +170,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonRenameGroup(CGUIMessage &message)
       if (!strGroupName.empty())
       {
         ClearSelectedGroupsThumbnail();
-        m_selectedGroup->SetGroupName(strGroupName, true);
+        m_selectedGroup->SetGroupName(strGroupName);
         Update();
       }
     }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -27,6 +27,7 @@
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
+#include "pvr/channels/PVRChannelsPath.h"
 #include "pvr/dialogs/GUIDialogPVRChannelManager.h"
 #include "pvr/dialogs/GUIDialogPVRGroupManager.h"
 #include "pvr/epg/Epg.h"
@@ -351,8 +352,7 @@ CGUIWindowPVRTVChannels::CGUIWindowPVRTVChannels()
 
 std::string CGUIWindowPVRTVChannels::GetDirectoryPath()
 {
-  return StringUtils::Format("pvr://channels/tv/%s/",
-                             m_bShowHiddenChannels ? ".hidden" : GetChannelGroup()->GroupName().c_str());
+  return CPVRChannelsPath(false, m_bShowHiddenChannels, GetChannelGroup()->GroupName());
 }
 
 CGUIWindowPVRRadioChannels::CGUIWindowPVRRadioChannels()
@@ -362,6 +362,5 @@ CGUIWindowPVRRadioChannels::CGUIWindowPVRRadioChannels()
 
 std::string CGUIWindowPVRRadioChannels::GetDirectoryPath()
 {
-  return StringUtils::Format("pvr://channels/radio/%s/",
-                             m_bShowHiddenChannels ? ".hidden" : GetChannelGroup()->GroupName().c_str());
+  return CPVRChannelsPath(true, m_bShowHiddenChannels, GetChannelGroup()->GroupName());
 }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -13,6 +13,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
 #include "network/DNSNameCache.h"
+#include "pvr/channels/PVRChannelsPath.h"
 #include "settings/AdvancedSettings.h"
 #include "URL.h"
 #include "utils/FileExtensionProvider.h"
@@ -29,6 +30,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+using namespace PVR;
 using namespace XFILE;
 
 const CAdvancedSettings* URIUtils::m_advancedSettings = nullptr;
@@ -964,7 +966,15 @@ bool URIUtils::IsPVRChannel(const std::string& strFile)
   if (IsStack(strFile))
     return IsPVRChannel(CStackDirectory::GetFirstStackedFile(strFile));
 
-  return StringUtils::StartsWithNoCase(strFile, "pvr://channels");
+  return IsProtocol(strFile, "pvr") && CPVRChannelsPath(strFile).IsChannel();
+}
+
+bool URIUtils::IsPVRChannelGroup(const std::string& strFile)
+{
+  if (IsStack(strFile))
+    return IsPVRChannelGroup(CStackDirectory::GetFirstStackedFile(strFile));
+
+  return IsProtocol(strFile, "pvr") && CPVRChannelsPath(strFile).IsChannelGroup();
 }
 
 bool URIUtils::IsPVRGuideItem(const std::string& strFile)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -951,6 +951,14 @@ bool URIUtils::IsTCP(const std::string& strFile)
   return IsProtocol(strFile, "tcp");
 }
 
+bool URIUtils::IsPVR(const std::string& strFile)
+{
+  if (IsStack(strFile))
+    return IsPVR(CStackDirectory::GetFirstStackedFile(strFile));
+
+  return IsProtocol(strFile, "pvr");
+}
+
 bool URIUtils::IsPVRChannel(const std::string& strFile)
 {
   if (IsStack(strFile))
@@ -1029,7 +1037,8 @@ bool URIUtils::IsLiveTV(const std::string& strFile)
   std::string strFileWithoutSlash(strFile);
   RemoveSlashAtEnd(strFileWithoutSlash);
 
-  if (StringUtils::EndsWithNoCase(strFileWithoutSlash, ".pvr") && !StringUtils::StartsWith(strFileWithoutSlash, "pvr://recordings"))
+  if (StringUtils::EndsWithNoCase(strFileWithoutSlash, ".pvr") &&
+      !StringUtils::StartsWith(strFileWithoutSlash, "pvr://recordings"))
     return true;
 
   return false;

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -154,6 +154,7 @@ public:
   static bool IsLibraryContent(const std::string& strFile);
   static bool IsPVR(const std::string& strFile);
   static bool IsPVRChannel(const std::string& strFile);
+  static bool IsPVRChannelGroup(const std::string& strFile);
   static bool IsPVRGuideItem(const std::string& strFile);
   static bool IsUsingFastSwitch(const std::string& strFile);
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -152,6 +152,7 @@ public:
   static bool IsAndroidApp(const std::string& strFile);
   static bool IsLibraryFolder(const std::string& strFile);
   static bool IsLibraryContent(const std::string& strFile);
+  static bool IsPVR(const std::string& strFile);
   static bool IsPVRChannel(const std::string& strFile);
   static bool IsPVRGuideItem(const std::string& strFile);
   static bool IsUsingFastSwitch(const std::string& strFile);

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -10,7 +10,7 @@
 
 #include "Application.h"
 #include "Autorun.h"
-#include "Util.h"
+#include "utils/URIUtils.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoBase.h"
 
@@ -65,7 +65,7 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
-      return CUtil::IsTVRecording(item.GetPath());
+      return URIUtils::IsPVRRecording(item.GetPath());
   }
   else if (!item.HasVideoInfoTag())
     return false;
@@ -91,7 +91,7 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
-      return CUtil::IsTVRecording(item.GetPath());
+      return URIUtils::IsPVRRecording(item.GetPath());
   }
   else if (!item.HasVideoInfoTag())
     return false;


### PR DESCRIPTION
Too many (inconsistent) string parsing and manipulation for pvr channel paths at random places scattered all over the code base.... This PR encapsulates PVR channel paths in its own class: `CPVRChannelsPath`, in a way I already did before with recordings and timers.

This also introduces proper encoding/decoding of the path segments, making channel group names like "Foo/Bar" working.

@Jalle19 good to go?