### PR TITLE
VideoPlayer: Properly propagate playback errors

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -636,6 +636,7 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
 
   m_displayLost = false;
   m_error = false;
+  m_bCloseRequest = false;
   CServiceBroker::GetWinSystem()->Register(this);
 }
 
@@ -675,6 +676,7 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
   m_processInfo->SetPlayTimes(0,0,0,0);
   m_bAbortRequest = false;
   m_error = false;
+  m_bCloseRequest = false;
   m_renderManager.PreInit();
 
   Create();
@@ -691,6 +693,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
 
   // set the abort request so that other threads can finish up
   m_bAbortRequest = true;
+  m_bCloseRequest = true;
 
   // tell demuxer to abort
   if(m_pDemuxer)
@@ -2443,9 +2446,9 @@ void CVideoPlayer::OnExit()
   m_bStop = true;
 
   bool error = m_error;
-  bool abort = m_bAbortRequest;
+  bool close = m_bCloseRequest;
   m_outboundEvents->Submit([=]() {
-    if (abort)
+    if (close)
       cb->OnPlayBackStopped();
     else if (error)
       cb->OnPlayBackError();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -443,6 +443,7 @@ protected:
   CPlayerOptions m_playerOptions;
   bool m_bAbortRequest;
   bool m_error;
+  bool m_bCloseRequest;
 
   ECacheState  m_caching;
   XbmcThreads::EndTime m_cachingTimer;


### PR DESCRIPTION
## Description
Since quite some time, we do not show the playback error dialog
box anymore, when we fail to create a demuxer.

As the m_bAbortRequest-Flag has precedence over the m_error flag,
when we choose between OnPlaybackStopped, OnPlaybackError or
OnPlaybackEnded, we ended up never reporting playback errors.

To fix this issue, we get rid of the double function that
m_bAbortRequest serves, by introducing a m_bCloseRequest-Flag.
This flag is set in CVideoPlayer::CloseFile and used
instead of the m_bAbortRequest-Flag, when we chose callbacks.

## Motivation and Context
When you try to open a non-existing stream we silently fail.
It would be better to show the user what happened.

## How Has This Been Tested?
Tested various playback scenarios on linux.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@FernetMenta Would you mind taking a look?