### PR TITLE
[iOS] separate storage provider

### DIFF
--- a/cmake/treedata/darwin_embedded/subdirs.txt
+++ b/cmake/treedata/darwin_embedded/subdirs.txt
@@ -2,8 +2,8 @@ xbmc/input/touch                      input/touch
 xbmc/input/touch/generic              input/touch/generic
 xbmc/platform/darwin                  platform/darwin
 xbmc/platform/darwin/ios-common       platform/ios-common
+xbmc/platform/darwin/ios-common/storage platform/ios-common/storage
 xbmc/platform/darwin/network          platform/darwin/network
-xbmc/platform/darwin/storage          platform/storage
 xbmc/platform/posix                   posix
 xbmc/platform/posix/filesystem        platform/posix/filesystem
 xbmc/platform/posix/network           platform/posix/network

--- a/cmake/treedata/osx/subdirs.txt
+++ b/cmake/treedata/osx/subdirs.txt
@@ -5,7 +5,7 @@ xbmc/platform/darwin/network          platform/darwin/network
 xbmc/platform/darwin/osx              platform/osx
 xbmc/platform/darwin/osx/peripherals  platform/osx/peripherals
 xbmc/platform/darwin/osx/powermanagement platform/darwin/osx/powermanagement
-xbmc/platform/darwin/storage          platform/storage
+xbmc/platform/darwin/osx/storage      platform/osx/storage
 xbmc/platform/posix                   posix
 xbmc/platform/posix/filesystem        platform/posix/filesystem
 xbmc/platform/posix/network           platform/posix/network

--- a/xbmc/platform/darwin/ios-common/storage/CMakeLists.txt
+++ b/xbmc/platform/darwin/ios-common/storage/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES IOSStorageProvider.mm)
+
+set(HEADERS IOSStorageProvider.h)
+
+core_add_library(platform_ios_storage)

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.h
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "storage/IStorageProvider.h"
+
+#include <string>
+#include <vector>
+
+class CIOSStorageProvider : public IStorageProvider
+{
+public:
+  CIOSStorageProvider() {}
+  virtual ~CIOSStorageProvider() {}
+
+  virtual void Initialize() {}
+  virtual void Stop() {}
+
+  virtual void GetLocalDrives(VECSOURCES& localDrives);
+  virtual void GetRemovableDrives(VECSOURCES& removableDrives) {}
+
+  virtual std::vector<std::string> GetDiskUsage(void);
+
+  virtual bool Eject(const std::string& mountpath) { return false; }
+
+  virtual bool PumpDriveChangeEvents(IStorageEventsCallback* callback) { return false; }
+};

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
@@ -37,5 +37,19 @@ void CIOSStorageProvider::GetLocalDrives(VECSOURCES& localDrives)
 
 std::vector<std::string> CIOSStorageProvider::GetDiskUsage()
 {
-  return {};
+  std::vector<std::string> result;
+  auto fileSystemAttributes = [NSFileManager.defaultManager attributesOfFileSystemForPath:@"/"
+                                                                                    error:nil];
+
+  auto formatter = [NSByteCountFormatter new];
+  formatter.includesActualByteCount = YES;
+  formatter.zeroPadsFractionDigits = YES;
+
+  for (const auto& pair :
+       {std::make_pair(NSFileSystemFreeSize, 160), std::make_pair(NSFileSystemSize, 20161)})
+    if (auto sizeStr = [formatter stringForObjectValue:fileSystemAttributes[pair.first]])
+      result.push_back(
+          StringUtils::Format("{}: {}", g_localizeStrings.Get(pair.second), sizeStr.UTF8String));
+
+  return result;
 }

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "IOSStorageProvider.h"
+
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+
+#import <Foundation/Foundation.h>
+
+IStorageProvider* IStorageProvider::CreateInstance()
+{
+  return new CIOSStorageProvider();
+}
+
+void CIOSStorageProvider::GetLocalDrives(VECSOURCES& localDrives)
+{
+  CMediaSource share;
+
+  // User home folder
+  share.strPath = "special://envhome/";
+  share.strName = g_localizeStrings.Get(21440);
+  share.m_ignore = true;
+  localDrives.push_back(share);
+
+  // iOS Inbox folder
+  share.strPath = "special://envhome/Documents/Inbox";
+  share.strName = "Inbox";
+  share.m_ignore = true;
+  localDrives.push_back(share);
+}
+
+std::vector<std::string> CIOSStorageProvider::GetDiskUsage()
+{
+  return {};
+}

--- a/xbmc/platform/darwin/osx/SDLMain.mm
+++ b/xbmc/platform/darwin/osx/SDLMain.mm
@@ -13,7 +13,7 @@
 
 #import "platform/darwin/osx/CocoaInterface.h"
 #import "platform/darwin/osx/HotKeyController.h"
-#import "platform/darwin/storage/DarwinStorageProvider.h"
+#import "platform/darwin/osx/storage/OSXStorageProvider.h"
 
 #import <SDL/SDL.h>
 #import <sys/param.h> /* for MAXPATHLEN */
@@ -402,7 +402,7 @@ static void setupWindowMenu(void)
     NSString* volumePath = [note.userInfo objectForKey:@"NSDevicePath"];
     const char* path = [volumePath UTF8String];
 
-    CDarwinStorageProvider::VolumeMountNotification(label, path);
+    COSXStorageProvider::VolumeMountNotification(label, path);
   }
 }
 
@@ -417,7 +417,7 @@ static void setupWindowMenu(void)
     NSString* volumePath = [note.userInfo objectForKey:@"NSDevicePath"];
     const char* path = [volumePath UTF8String];
 
-    CDarwinStorageProvider::VolumeUnmountNotification(label, path);
+    COSXStorageProvider::VolumeUnmountNotification(label, path);
   }
 }
 

--- a/xbmc/platform/darwin/osx/storage/CMakeLists.txt
+++ b/xbmc/platform/darwin/osx/storage/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES OSXStorageProvider.cpp)
+
+set(HEADERS OSXStorageProvider.h)
+
+core_add_library(platform_osx_storage)

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.h
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.h
@@ -14,11 +14,11 @@
 #include <utility>
 #include <vector>
 
-class CDarwinStorageProvider : public IStorageProvider
+class COSXStorageProvider : public IStorageProvider
 {
 public:
-  CDarwinStorageProvider();
-  virtual ~CDarwinStorageProvider() = default;
+  COSXStorageProvider();
+  virtual ~COSXStorageProvider() = default;
 
   virtual void Initialize() { }
   virtual void Stop() { }

--- a/xbmc/platform/darwin/storage/CMakeLists.txt
+++ b/xbmc/platform/darwin/storage/CMakeLists.txt
@@ -1,5 +1,0 @@
-set(SOURCES DarwinStorageProvider.cpp)
-
-set(HEADERS DarwinStorageProvider.h)
-
-core_add_library(platform_osx_storage)


### PR DESCRIPTION
## Description
Splits `DarwinStorageProvider` into OSX and iOS implementation and also adds free/total space display to iOS.

## Motivation and Context
iOS didn't show anything in System info - Storage.

## How Has This Been Tested?
* built project for arm64 and ran on iOS device
* verified that macOS code didn't become broken

## Screenshots (if appropriate):
![Screen Shot 2019-07-15 at 03 13 40](https://user-images.githubusercontent.com/1557784/61190179-945c2600-a6b1-11e9-8f55-1eb04fb31f14.png)


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
