### PR TITLE
 [PVR] Fix CPVRChannelGroupInternal ctor - fixes #16386.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -55,27 +55,6 @@ CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
   OnInit();
 }
 
-CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelGroup& group)
-  : m_iGroupType(group.m_iGroupType)
-  , m_iGroupId(group.m_iGroupId)
-  , m_bLoaded(group.m_bLoaded)
-  , m_bChanged(group.m_bChanged)
-  , m_bUsingBackendChannelOrder(group.m_bUsingBackendChannelOrder)
-  , m_bUsingBackendChannelNumbers(group.m_bUsingBackendChannelNumbers)
-  , m_bPreventSortAndRenumber(group.m_bPreventSortAndRenumber)
-  , m_iLastWatched(group.m_iLastWatched)
-  , m_bHidden(group.m_bHidden)
-  , m_iPosition(group.m_iPosition)
-  , m_sortedMembers(group.m_sortedMembers)
-  , m_members(group.m_members)
-  , m_failedClientsForChannels(group.m_failedClientsForChannels)
-  , m_failedClientsForChannelGroupMembers(group.m_failedClientsForChannelGroupMembers)
-  , m_allChannelsGroup(group.m_allChannelsGroup)
-  , m_path(group.m_path)
-{
-  OnInit();
-}
-
 CPVRChannelGroup::~CPVRChannelGroup(void)
 {
   CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -77,12 +77,6 @@ namespace PVR
      */
     CPVRChannelGroup(const PVR_CHANNEL_GROUP& group, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
 
-    /*!
-     * @brief Copy constructor
-     * @param group Source group
-     */
-    CPVRChannelGroup(const CPVRChannelGroup &group);
-
     ~CPVRChannelGroup(void) override;
 
     bool operator ==(const CPVRChannelGroup &right) const;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -33,12 +33,6 @@ CPVRChannelGroupInternal::CPVRChannelGroupInternal(bool bRadio)
   m_iGroupType = PVR_GROUP_TYPE_INTERNAL;
 }
 
-CPVRChannelGroupInternal::CPVRChannelGroupInternal(const CPVRChannelGroup &group) :
-    CPVRChannelGroup(group),
-    m_iHiddenChannels(group.GetNumHiddenChannels())
-{
-}
-
 CPVRChannelGroupInternal::~CPVRChannelGroupInternal(void)
 {
   Unload();

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -27,9 +27,10 @@ using namespace PVR;
 using namespace KODI::MESSAGING;
 
 CPVRChannelGroupInternal::CPVRChannelGroupInternal(bool bRadio)
-: CPVRChannelGroup(CPVRChannelsPath(bRadio, g_localizeStrings.Get(19287)), PVR_GROUP_TYPE_INTERNAL)
-,  m_iHiddenChannels(0)
+  : CPVRChannelGroup(CPVRChannelsPath(bRadio, g_localizeStrings.Get(19287)))
+  , m_iHiddenChannels(0)
 {
+  m_iGroupType = PVR_GROUP_TYPE_INTERNAL;
 }
 
 CPVRChannelGroupInternal::CPVRChannelGroupInternal(const CPVRChannelGroup &group) :

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -30,8 +30,6 @@ namespace PVR
      */
     explicit CPVRChannelGroupInternal(bool bRadio);
 
-    explicit CPVRChannelGroupInternal(const CPVRChannelGroup &group);
-
     ~CPVRChannelGroupInternal(void) override;
 
     /**


### PR DESCRIPTION
Fixes #16386, introduced by #16368. 

@Jalle19 got some time for a code review? For #16368 I rewrote one of the two CPVRGroupInternal ctors and accidentally passed the group type as group id to the base class ctor... So, every internal group had the id "1", which can obviously lead to all kind of misbehavior. Compiler did not complain as both group id and group type values are ints... :-/

@MilhouseVH could you please include this PR into your next builds to get some feedback from the issue reporters?

@debutanker fyi

Note: This is Matrix-only. Leia is not affected by the issue.