### PR TITLE
[PVR] Add progress bar to reminders announcement dialog

### DIFF
--- a/addons/skin.estuary/xml/DialogConfirm.xml
+++ b/addons/skin.estuary/xml/DialogConfirm.xml
@@ -4,7 +4,7 @@
 	<depth>DepthDialog+</depth>
 	<controls>
 		<control type="group">
-			<height>390</height>
+			<height>400</height>
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
 			<width>915</width>
@@ -23,16 +23,16 @@
 				<autoscroll time="3000" delay="4000" repeat="5000">true</autoscroll>
 			</control>
 			<control type="progress" id="20">
-				<left>45</left>
-				<top>252</top>
-				<width>825</width>
+				<left>30</left>
+				<top>262</top>
+				<width>855</width>
 				<height>24</height>
 				<info>System.Progressbar</info>
 			</control>
 			<control type="grouplist" id="9000">
 				<orientation>horizontal</orientation>
 				<left>0</left>
-				<top>280</top>
+				<top>290</top>
 				<width>915</width>
 				<align>center</align>
 				<include content="DefaultDialogButton">

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -11,6 +11,8 @@
 #include "GUIDialogBoxBase.h"
 #include "IProgressCallback.h"
 
+#include <array>
+
 class CGUIDialogProgress :
       public CGUIDialogBoxBase, public IProgressCallback
 {
@@ -18,15 +20,22 @@ public:
   CGUIDialogProgress(void);
   ~CGUIDialogProgress(void) override;
 
+  void Reset();
   void Open(const std::string &param = "");
   bool OnMessage(CGUIMessage& message) override;
   bool OnBack(int actionID) override;
   void OnWindowLoaded() override;
   void Progress();
-  bool IsCanceled() const { return m_bCanceled; }
+  bool IsCanceled() const { return m_iChoice == CHOICE_CANCELED; }
   void SetPercentage(int iPercentage);
   int GetPercentage() const { return m_percentage; };
   void ShowProgressBar(bool bOnOff);
+
+  void ShowChoice(int iChoice, const CVariant& label);
+
+  static constexpr int CHOICE_NONE = -2;
+  static constexpr int CHOICE_CANCELED = -1;
+  int GetChoice() const;
 
   /*! \brief Wait for the progress dialog to be closed or canceled, while regularly
    rendering to allow for pointer movement or progress to be shown. Used when showing
@@ -57,13 +66,15 @@ protected:
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
 
   bool m_bCanCancel;
-  bool m_bCanceled;
 
   int  m_iCurrent;
   int  m_iMax;
   int m_percentage;
   bool m_showProgress;
 
+  std::array<bool, DIALOG_MAX_CHOICES> m_supportedChoices = {};
+  int m_iChoice = CHOICE_NONE;
+
 private:
-  void Reset();
+  void UpdateControls();
 };


### PR DESCRIPTION
... to visualize the time until dialog auto-closes. Progress starts at 100% and will continually decrease until 0% while the reminder is displayed.

![screenshot000](https://user-images.githubusercontent.com/3226626/61665567-9b98ba80-acd5-11e9-8fbd-796fc05126bc.png)


@Jalle19 mind taking a look at the code changes?