### PR TITLE
[addon] fix ios runtime failure after PR 14908

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -541,11 +541,11 @@ const char* CAddonInfoBuilder::GetPlatformLibraryName(const TiXmlElement* elemen
 #elif defined(TARGET_WINDOWS_STORE)
   libraryName = element->Attribute("library_windowsstore");
 #elif defined(TARGET_DARWIN)
-#if defined(TARGET_DARWIN_IOS)
-  libraryName = element->Attribute("library_ios");
-  if (libraryName == nullptr)
-#endif
+#if defined(TARGET_DARWIN_EMBEDDED)
+  libraryName = element->Attribute("library_darwin_embedded");
+#else
   libraryName = element->Attribute("library_osx");
+#endif
 #endif
 
   return libraryName;


### PR DESCRIPTION
## Description
ios fails to run due to system addons not loading following cpluff removal PR https://github.com/xbmc/xbmc/pull/14908 +
darwin_embedded PR change https://github.com/xbmc/xbmc/pull/16039

failure to find library_darwin_embedded should not fall back to osx. different platforms that should be considered totally incompatible and not a fallback

## Motivation and Context
iOS fails to load due to system addons (audioencoder.kodi.builtin.aac etc) failing to load.
CORE_SYSTEM_NAME was renamed from ios to darwin_embedded in https://github.com/xbmc/xbmc/pull/16039

## How Has This Been Tested?
Runtime tested on ipad

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
