### PR TITLE
Fix + sign HTTP folder

### DIFF
--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -105,6 +105,18 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         strLinkOptions = strLinkBase.substr(pos);
         strLinkBase.erase(pos);
       }
+      
+      // encoding + and ; to URL encode if it is not already encoded by http server used on the remote server (example: Apache)
+      // more characters may be added here when required when required by certain http servers
+      pos = strLinkBase.find_first_of("+;");
+      while (pos != std::string::npos) 
+      {
+        std::stringstream convert;
+        convert << '%' << std::hex << int(strLinkBase.at(pos));
+        strLinkBase.replace(pos, 1, convert.str());
+        pos = strLinkBase.find_first_of("+;");
+      }
+
       std::string strLinkTemp = strLinkBase;
 
       URIUtils::RemoveSlashAtEnd(strLinkTemp);


### PR DESCRIPTION
## Description
When an HTTP or HTTPS folder had a '+' sign in the name, it did not appear in the XBMC folders

## Motivation and Context
If a user wants to browse his personal folders on his HTTP or HTTPS server, he will not be forced to change the '+' sign.

## How Has This Been Tested?

By importing a new source of HTTPS directory media.

## Screenshots (if appropriate):

![KodiPOC](https://user-images.githubusercontent.com/16168239/61840535-759f2180-ae5f-11e9-9e4c-5a85f3017a02.PNG)

![KodiPOCSign](https://user-images.githubusercontent.com/16168239/61840541-79cb3f00-ae5f-11e9-9f87-ff07dee186e0.PNG)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
