### PR TITLE
[PlaylistPlayer] Do not attempt to further resolve plugin paths for failing entries

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -899,7 +899,8 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
           // resolve only for a maximum of 5 times to avoid deadlocks (plugin:// paths can resolve to plugin:// paths)
           for (int i = 0; URIUtils::IsPlugin(item->GetDynPath()) && i < 5; ++i)
           {
-            XFILE::CPluginDirectory::GetPluginResult(item->GetDynPath(), *item, true);
+            if (!XFILE::CPluginDirectory::GetPluginResult(item->GetDynPath(), *item, true))
+              return;
           }
           if (item->IsAudio() || item->IsVideo())
             Play(item, pMsg->strParam);


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/16192 early resolved plugin paths so that the infotags are properly filled. However, even if a plugin fails to resolve, Kodi will continue trying to resolve it to a playable path in a 5 times loop. This PR fixes the behaviour returning early in case Kodi could not resolve the path. Thanks to @basrieter for the time.

@notspiff mind reviewing?

## Motivation and Context
Fix https://github.com/xbmc/xbmc/issues/16385

## How Has This Been Tested?
Runtime tested

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
