### PR TITLE
Ensure that skin is reloaded when a profile is loaded

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3703,7 +3703,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         if (m_itemCurrentFile->IsOnDVD())
           StopPlaying();
       }
-      else if (message.GetParam1() == GUI_MSG_UI_READY)
+      else if (message.GetParam1() == GUI_MSG_UI_READY || message.GetParam1() == GUI_MSG_UI_READY_PROFILE)
       {
         // remove splash window
         CServiceBroker::GetGUI()->GetWindowManager().Delete(WINDOW_SPLASH);
@@ -3724,6 +3724,10 @@ bool CApplication::OnMessage(CGUIMessage& message)
         ShowAppMigrationMessage();
 
         m_bInitializing = false;
+
+        if (message.GetParam1() == GUI_MSG_UI_READY_PROFILE)
+          g_application.ReloadSkin(false);
+
       }
       else if (message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
       {

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -159,6 +159,7 @@
  */
 #define GUI_MSG_SUBTITLE_DOWNLOADED  52
 
+#define GUI_MSG_UI_READY_PROFILE 53
 
 #define GUI_MSG_USER         1000
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -423,12 +423,14 @@ void CProfileManager::FinalizeLoadProfile()
   // the startup window is considered part of the initialization as it most likely switches to the final window
   bool uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
 
+  uiInitializationFinished = true;
+
   CServiceBroker::GetGUI()->GetWindowManager().ChangeActiveWindow(firstWindow);
 
   // if the user interfaces has been fully initialized let everyone know
   if (uiInitializationFinished)
   {
-    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY_PROFILE);
     CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
   }
 }


### PR DESCRIPTION
## Description

As discussed briefly in Slack, this PR ensures that the skin is reloaded when a profile is loaded. 

## Motivation and Context

Presently, if a profile is loaded and a skin reload is needed, for example, when the Skin Shortcuts add-on is used to provide user configurable menus, the reload does not occur correctly and the user will have missing menu items. The issue (and workaround) is explained in more detail by @DaVukovic: 

https://kodi.wiki/view/Profiles#Missing_texts.2Fdifferent_skins_not_loading_while_using_profiles

<!--- Why is this change required? What problem does it solve? -->

This ensures that a reload of the skin occurs when a profile is loaded and ensures that all elements are displayed correctly. 

## How Has This Been Tested?

This has been tested on OSMC since early May and the issue has since been reported as fixed. This should be backported to Kodi v18. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed