### PR TITLE
Disable "GIT_SHALLOW" option to clone the tree because the specified …

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -175,7 +175,7 @@ function(add_addon_depends addon searchpath)
                                   "${INSTALL_COMMAND}")
 
         if(CMAKE_VERSION VERSION_GREATER 3.5.9)
-          list(APPEND EXTERNALPROJECT_SETUP GIT_SHALLOW 1)
+          list(APPEND EXTERNALPROJECT_SETUP GIT_SHALLOW "")
         endif()
 
         # if there's an url defined we need to pass that to externalproject_add()


### PR DESCRIPTION
Disable "GIT_SHALLOW" option to clone the tree because the specified tag isn't a branch name, but a commit ref.

## Description
Unset cmake option GIT_SHALLOW in HandleDepends.cmake

## Motivation and Context
That fix the build with addon depends

## How Has This Been Tested?
Launch the pvr addons build

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
