### PR TITLE
Fix deadlock when stopping playback through json

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2025,6 +2025,14 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     m_appPlayer.FlushRenderer();
     break;
 
+  case TMSG_RENDERER_PREINIT:
+    m_appPlayer.PreInitRenderer();
+    break;
+
+  case TMSG_RENDERER_UNINIT:
+    m_appPlayer.UnInitRenderer();
+    break;
+
   case TMSG_HIBERNATE:
     CServiceBroker::GetPowerManager().Hibernate();
     break;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -54,6 +54,7 @@ class IActionListener;
 class CGUIComponent;
 class CAppInboundProtocol;
 class CSettingsComponent;
+class CJobQueue;
 
 namespace ADDON
 {
@@ -468,6 +469,8 @@ protected:
   */
   void HandleShutdownMessage();
 
+  void ClosePlayer();
+
   CInertialScrollingHandler *m_pInertialScrollingHandler;
 
   ReplayGainSettings m_replayGainSettings;
@@ -484,6 +487,8 @@ private:
   CApplicationPlayer m_appPlayer;
   CEvent m_playerEvent;
   CApplicationStackHelper m_stackHelper;
+  CEvent m_playerCloseEvent;
+  std::unique_ptr<CJobQueue> m_actionQueue;
 };
 
 XBMC_GLOBAL_REF(CApplication,g_application);

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -28,12 +28,7 @@ std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal() const
 void CApplicationPlayer::ClosePlayer()
 {
   m_nextItem.pItem.reset();
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-  {
-    CloseFile();
-    ResetPlayer();
-  }
+  CloseFile();
 }
 
 void CApplicationPlayer::ResetPlayer()

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -835,6 +835,20 @@ void CApplicationPlayer::FlushRenderer()
     player->FlushRenderer();
 }
 
+void CApplicationPlayer::PreInitRenderer()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->PreInitRenderer();
+}
+
+void CApplicationPlayer::UnInitRenderer()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->UnInitRenderer();
+}
+
 void CApplicationPlayer::SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -51,6 +51,8 @@ public:
   void FrameMove();
   void Render(bool clear, uint32_t alpha = 255, bool gui = true);
   void FlushRenderer();
+  void PreInitRenderer();
+  void UnInitRenderer();
   void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch);
   float GetRenderAspectRatio();
   void TriggerUpdateResolution();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -208,6 +208,8 @@ public:
    */
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) {};
   virtual void FlushRenderer() {};
+  virtual void PreInitRenderer() {};
+  virtual void UnInitRenderer() {};
   virtual void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch) {};
   virtual float GetRenderAspectRatio() { return 1.0; };
   virtual void TriggerUpdateResolution() {};

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -705,8 +705,6 @@ bool CVideoPlayer::CloseFile(bool reopen)
   if(m_pInputStream)
     m_pInputStream->Abort();
 
-  m_renderManager.UnInit();
-
   CLog::Log(LOGNOTICE, "VideoPlayer: waiting for threads to exit");
 
   // wait for the main thread to finish up
@@ -2385,6 +2383,9 @@ void CVideoPlayer::SendPlayerMessage(CDVDMsg* pMsg, unsigned int target)
 void CVideoPlayer::OnExit()
 {
   CLog::Log(LOGNOTICE, "CVideoPlayer::OnExit()");
+
+  if (m_bAbortRequest || m_error)
+    m_renderManager.UnInit();
 
   // set event to inform openfile something went wrong in case openfile is still waiting for this event
   SetCaching(CACHESTATE_DONE);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4755,6 +4755,16 @@ void CVideoPlayer::FlushRenderer()
   m_renderManager.Flush(true, true);
 }
 
+void CVideoPlayer::PreInitRenderer()
+{
+  m_renderManager.PreInit();
+}
+
+void CVideoPlayer::UnInitRenderer()
+{
+  m_renderManager.UnInit();
+}
+
 void CVideoPlayer::SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch)
 {
   m_processInfo->UpdateVideoSettings().SetViewMode(mode, zoom, par, shift, stretch);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -310,6 +310,8 @@ public:
   void FrameMove() override;
   void Render(bool clear, uint32_t alpha = 255, bool gui = true) override;
   void FlushRenderer() override;
+  void PreInitRenderer() override;
+  void UnInitRenderer() override;
   void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch) override;
   float GetRenderAspectRatio() override;
   void TriggerUpdateResolution() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -357,6 +357,12 @@ void CRenderManager::PreInit()
     if (!m_initEvent.WaitMSec(2000))
     {
       CLog::Log(LOGERROR, "%s - timed out waiting for renderer to preinit", __FUNCTION__);
+      return;
+    }
+    else
+    {
+      // Mainthread did it's work, we're done!
+      return;
     }
   }
 
@@ -379,6 +385,12 @@ void CRenderManager::PreInit()
 
 void CRenderManager::UnInit()
 {
+  {
+    CSingleLock lock(m_statelock);
+    if (m_renderState == STATE_UNCONFIGURED)
+      return;
+  }
+
   if (!g_application.IsCurrentThread())
   {
     m_initEvent.Reset();
@@ -386,6 +398,12 @@ void CRenderManager::UnInit()
     if (!m_initEvent.WaitMSec(2000))
     {
       CLog::Log(LOGERROR, "%s - timed out waiting for renderer to uninit", __FUNCTION__);
+      return;
+    }
+    else
+    {
+      // Mainthread did it's work, we're done!
+      return;
     }
   }
 


### PR DESCRIPTION
## Description
If you start playback and stop it fast (having refreshrate switching enabled) there is a high chance of a deadlock.
The fist approach was to make the resolution set asynchronous, which seems to be wrong.

See stacktrace:

```
libc.so.6!syscall() (/build/glibc-OTsEL5/glibc-2.27/sysdeps/unix/sysv/linux/x86_64/syscall.S:38)
Main Thread:
libstdc++.so.6!std::__atomic_futex_unsigned_base::_M_futex_wait_until(unsigned int*, unsigned int, bool, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000000000l> >) (Unknown Source:0)
std::__atomic_futex_unsigned<2147483648u>::_M_load_and_test_until(std::__atomic_futex_unsigned<2147483648> * const this, unsigned int __assumed, unsigned int __operand, bool __equal, std::memory_order __mo, bool __has_timeout, std::chrono::seconds __s, std::chrono::nanoseconds __ns) (/usr/include/c++/7/bits/atomic_futex.h:102)
std::__atomic_futex_unsigned<2147483648u>::_M_load_and_test_until_impl<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >(std::__atomic_futex_unsigned<2147483648> * const this, unsigned int __assumed, unsigned int __operand, bool __equal, std::memory_order __mo, const std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1, 1000000000> > > & __atime) (/usr/include/c++/7/bits/atomic_futex.h:140)
std::__atomic_futex_unsigned<2147483648u>::_M_load_when_equal_until<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >(std::memory_order __mo, unsigned int __val, std::__atomic_futex_unsigned<2147483648> * const this) (/usr/include/c++/7/bits/atomic_futex.h:199)
std::__atomic_futex_unsigned<2147483648u>::_M_load_when_equal_for<long, std::ratio<1l, 1000l> >(const std::chrono::duration<long, std::ratio<1, 1000> > & __rtime, std::memory_order __mo, unsigned int __val, std::__atomic_futex_unsigned<2147483648> * const this) (/usr/include/c++/7/bits/atomic_futex.h:172)
std::__future_base::_State_baseV2::wait_for<long, std::ratio<1l, 1000l> >(std::__future_base::_State_baseV2 * const this, const std::chrono::duration<long, std::ratio<1, 1000> > & __rel) (/usr/include/c++/7/future:351)
std::__basic_future<bool>::wait_for<long, std::ratio<1l, 1000l> >(const std::__basic_future<bool> * const this, const std::chrono::duration<long, std::ratio<1, 1000> > & __rel) (/usr/include/c++/7/future:700)
CThread::Join(CThread * const this, unsigned int milliseconds) (/home/a1rwulf/devel/kodi/xbmc/threads/Thread.cpp:253)
CThread::StopThread(CThread * const this, bool bWait) (/home/a1rwulf/devel/kodi/xbmc/threads/Thread.cpp:204)
CVideoPlayer::CloseFile(CVideoPlayer * const this, bool reopen) (/home/a1rwulf/devel/kodi/xbmc/cores/VideoPlayer/VideoPlayer.cpp:714)
CApplicationPlayer::CloseFile(CApplicationPlayer * const this, bool reopen) (/home/a1rwulf/devel/kodi/xbmc/ApplicationPlayer.cpp:56)
CApplicationPlayer::ClosePlayer(CApplicationPlayer * const this) (/home/a1rwulf/devel/kodi/xbmc/ApplicationPlayer.cpp:39)
CApplication::StopPlaying(CApplication * const this) (/home/a1rwulf/devel/kodi/xbmc/Application.cpp:3309)
PLAYLIST::CPlayListPlayer::OnApplicationMessage(PLAYLIST::CPlayListPlayer * const this, KODI::MESSAGING::ThreadMessage * pMsg) (/home/a1rwulf/devel/kodi/xbmc/PlayListPlayer.cpp:963)
KODI::MESSAGING::CApplicationMessenger::ProcessMessage(KODI::MESSAGING::CApplicationMessenger * const this, KODI::MESSAGING::ThreadMessage * pMsg) (/home/a1rwulf/devel/kodi/xbmc/messaging/ApplicationMessenger.cpp:242)
KODI::MESSAGING::CApplicationMessenger::ProcessMessages(KODI::MESSAGING::CApplicationMessenger * const this) (/home/a1rwulf/devel/kodi/xbmc/messaging/ApplicationMessenger.cpp:215)
CApplication::Process(CApplication * const this) (/home/a1rwulf/devel/kodi/xbmc/Application.cpp:4046)
CXBApplicationEx::Run(CXBApplicationEx * const this, const CAppParamParser & params) (/home/a1rwulf/devel/kodi/xbmc/XBApplicationEx.cpp:64)
XBMC_Run(bool renderGUI, const CAppParamParser & params) (/home/a1rwulf/devel/kodi/xbmc/platform/xbmc.cpp:72)
```

```
libpthread.so.0!futex_wait_cancelable(unsigned int expected, unsigned int * futex_word) (/build/glibc-OTsEL5/glibc-2.27/sysdeps/unix/sysv/linux/futex-internal.h:88)
libpthread.so.0!__pthread_cond_wait_common(pthread_mutex_t * mutex, pthread_cond_t * cond) (/build/glibc-OTsEL5/glibc-2.27/nptl/pthread_cond_wait.c:502)
libpthread.so.0!__pthread_cond_wait(pthread_cond_t * cond, pthread_mutex_t * mutex) (/build/glibc-OTsEL5/glibc-2.27/nptl/pthread_cond_wait.c:655)
libstdc++.so.6!std::condition_variable::wait(std::unique_lock<std::mutex>&) (Unknown Source:0)
std::_V2::condition_variable_any::wait<XbmcThreads::CRecursiveMutex>(std::_V2::condition_variable_any * const this, XbmcThreads::CRecursiveMutex & __lock) (/usr/include/c++/7/condition_variable:251)
XbmcThreads::ConditionVariable::wait(XbmcThreads::ConditionVariable * const this, CCriticalSection & lock) (/home/a1rwulf/devel/kodi/xbmc/threads/Condition.h:38)
XbmcThreads::TightConditionVariable<bool volatile&>::wait<CCriticalSection>(XbmcThreads::TightConditionVariable<bool volatile&> * const this, CCriticalSection & lock) (/home/a1rwulf/devel/kodi/xbmc/threads/Condition.h:83)
CEvent::Wait(CEvent * const this) (/home/a1rwulf/devel/kodi/xbmc/threads/Event.h:87)
KODI::MESSAGING::CApplicationMessenger::SendMsg(KODI::MESSAGING::CApplicationMessenger * const this, KODI::MESSAGING::ThreadMessage && message, bool wait) (/home/a1rwulf/devel/kodi/xbmc/messaging/ApplicationMessenger.cpp:146)
KODI::MESSAGING::CApplicationMessenger::SendMsg(KODI::MESSAGING::CApplicationMessenger * const this, uint32_t messageId, int param1, int param2, void * payload) (/home/a1rwulf/devel/kodi/xbmc/messaging/ApplicationMessenger.cpp:161)
CGraphicContext::SetVideoResolution(CGraphicContext * const this, RESOLUTION res, bool forceUpdate) (/home/a1rwulf/devel/kodi/xbmc/windowing/GraphicContext.cpp:390)
CVideoPlayer::OpenVideoStream(CVideoPlayer * const this, CDVDStreamInfo & hint, bool reset) (/home/a1rwulf/devel/kodi/xbmc/cores/VideoPlayer/VideoPlayer.cpp:3580)
CVideoPlayer::OpenStream(CVideoPlayer * const this, CCurrentStream & current, int64_t demuxerId, int iStream, int source, bool reset) (/home/a1rwulf/devel/kodi/xbmc/cores/VideoPlayer/VideoPlayer.cpp:3447)
CVideoPlayer::OpenDefaultStreams(CVideoPlayer * const this, bool reset) (/home/a1rwulf/devel/kodi/xbmc/cores/VideoPlayer/VideoPlayer.cpp:882)
CVideoPlayer::Prepare(CVideoPlayer * const this) (/home/a1rwulf/devel/kodi/xbmc/cores/VideoPlayer/VideoPlayer.cpp:1231)
CVideoPlayer::Process(CVideoPlayer * const this) (/home/a1rwulf/devel/kodi/xbmc/cores/VideoPlayer/VideoPlayer.cpp:1307)
CThread::Action(CThread * const this) (/home/a1rwulf/devel/kodi/xbmc/threads/Thread.cpp:282)
CThread::<lambda(CThread*, std::promise<bool>)>::operator()(CThread *, std::promise<bool>) const(const CThread::<lambda(CThread*, std::promise<bool>)> * const __closure, CThread * pThread, std::promise<bool> promise) (/home/a1rwulf/devel/kodi/xbmc/threads/Thread.cpp:140)
std::__invoke_impl<void, CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> >(std::__invoke_other, CThread::<lambda(CThread*, std::promise<bool>)> &&, CThread *&&, std::promise<bool> &&)(CThread::<lambda(CThread*, std::promise<bool>)> && __f,  __args#0,  __args#1) (/usr/include/c++/7/bits/invoke.h:60)
std::__invoke<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> >(CThread::<lambda(CThread*, std::promise<bool>)> &&, CThread *&&, std::promise<bool> &&)(CThread::<lambda(CThread*, std::promise<bool>)> && __fn,  __args#0,  __args#1) (/usr/include/c++/7/bits/invoke.h:95)
```



## How Has This Been Tested?
I've used following script to execute the deadlock case.
After the change it does not happen again.

```
#!/bin/bash
while true
do
    curl -s --data-binary '{"jsonrpc":"2.0","method":"Player.Open","sender":"xyz","id":1564573142676,"params":{"item":{"channelid":1}}}' -H 'content-type: application/json;' http://$1:8080/jsonrpc
    sleep $2
    curl -s --data-binary '{"jsonrpc":"2.0","method":"Player.Stop","sender":"xyz","id":1564573142430,"params":{"playerid":1}}' -H 'content-type: application/json;' http://$1:8080/jsonrpc
    sleep $2

    curl -s --data-binary '{"jsonrpc":"2.0","method":"Player.Open","sender":"xyz","id":1564573142676,"params":{"item":{"channelid":2}}}' -H 'content-type: application/json;' http://$1:8080/jsonrpc
    sleep $2
    curl -s --data-binary '{"jsonrpc":"2.0","method":"Player.Stop","sender":"xyz","id":1564573142430,"params":{"playerid":1}}' -H 'content-type: application/json;' http://$1:8080/jsonrpc
    sleep $2

    curl -s --data-binary '{"jsonrpc":"2.0","method":"Player.Open","sender":"xyz","id":1564573142676,"params":{"item":{"channelid":3}}}' -H 'content-type: application/json;' http://$1:8080/jsonrpc
    sleep $2
    curl -s --data-binary '{"jsonrpc":"2.0","method":"Player.Stop","sender":"xyz","id":1564573142430,"params":{"playerid":1}}' -H 'content-type: application/json;' http://$1:8080/jsonrpc
    sleep $2
done
```
Execute the script with the IP of the kodi instance and 1 sec sleeptime.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@FernetMenta Your opinion would be appreciated.