### PR TITLE
fixed: File times for vfs addons (fixes #15426)

### DIFF
--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -345,7 +345,7 @@ static void VFSDirEntriesToCFileItemList(int num_entries,
     item->SetLabel(entries[i].label);
     item->SetPath(entries[i].path);
     item->m_dwSize = entries[i].size;
-    //item->m_dateTime = entries[i].mtime;
+    item->m_dateTime = entries[i].date_time;
     item->m_bIsFolder = entries[i].folder;
     if (entries[i].title)
       item->m_strTitle = entries[i].title;

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
@@ -612,6 +612,7 @@ static void CFileItemListToVFSDirEntries(VFSDirEntry* entries,
     entries[i].path = strdup(items[i]->GetPath().c_str());
     entries[i].size = items[i]->m_dwSize;
     entries[i].folder = items[i]->m_bIsFolder;
+    items[i]->m_dateTime.GetAsTime(entries[i].date_time);
   }
 }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -326,19 +326,22 @@ namespace vfs
     /// @ingroup cpp_kodi_vfs_CDirEntry
     /// @brief Constructor for VFS directory entry
     ///
-    /// @param[in] label   [opt] Name to use for entry
-    /// @param[in] path    [opt] Used path of the entry
-    /// @param[in] folder  [opt] If set entry used as folder
-    /// @param[in] size    [opt] If used as file, his size defined there
+    /// @param[in] label    [opt] Name to use for entry
+    /// @param[in] path     [opt] Used path of the entry
+    /// @param[in] folder   [opt] If set entry used as folder
+    /// @param[in] size     [opt] If used as file, his size defined there
+    /// @param[in] dateTime [opt] Date time of the entry
     ///
     CDirEntry(const std::string& label = "",
               const std::string& path = "",
               bool folder = false,
-              int64_t size = -1) :
+              int64_t size = -1,
+              time_t dateTime = 0):
       m_label(label),
       m_path(path),
       m_folder(folder),
-      m_size(size)
+      m_size(size),
+      m_dateTime(dateTime)
     {
     }
     //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
@@ -519,6 +519,7 @@ namespace addon
           entries[i].path = strdup(addonEntries[i].Path().c_str());
           entries[i].folder = addonEntries[i].IsFolder();
           entries[i].size = addonEntries[i].Size();
+          entries[i].date_time = addonEntries[i].DateTime();
 
           entries[i].num_props = 0;
           const std::map<std::string, std::string>& props = addonEntries[i].GetProperties();
@@ -582,6 +583,7 @@ namespace addon
           entries[i].path = strdup(addonEntries[i].Path().c_str());
           entries[i].folder = addonEntries[i].IsFolder();
           entries[i].size = addonEntries[i].Size();
+          entries[i].date_time = addonEntries[i].DateTime();
 
           entries[i].num_props = 0;
           const std::map<std::string, std::string>& props = addonEntries[i].GetProperties();

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
@@ -39,7 +39,7 @@ extern "C"
     char* label;             //!< item label
     char* title;             //!< item title
     char* path;              //!< item path
-    int num_props;           //!< Number of properties attached to item
+    unsigned int num_props;  //!< Number of properties attached to item
     VFSProperty* properties; //!< Properties
     time_t date_time;        //!< file creation date & time
     bool folder;             //!< Item is a folder

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
@@ -41,7 +41,7 @@ extern "C"
     char* path;              //!< item path
     int num_props;           //!< Number of properties attached to item
     VFSProperty* properties; //!< Properties
-    //FILETIME mtime;          //!< Mtime for file represented by item
+    time_t date_time;        //!< file creation date & time
     bool folder;             //!< Item is a folder
     uint64_t size;           //!< Size of file represented by item
   };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -55,8 +55,8 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_XML_ID       "kodi.binary.global.audioengine"
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.0.2"
-#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.0.2"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.0.3"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.0.3"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h"
 
@@ -111,8 +111,8 @@
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_XML_ID     "kodi.binary.instance.screensaver"
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "addon-instance/Screensaver.h"
 
-#define ADDON_INSTANCE_VERSION_VFS                    "2.0.0"
-#define ADDON_INSTANCE_VERSION_VFS_MIN                "2.0.0"
+#define ADDON_INSTANCE_VERSION_VFS                    "2.1.0"
+#define ADDON_INSTANCE_VERSION_VFS_MIN                "2.1.0"
 #define ADDON_INSTANCE_VERSION_VFS_XML_ID             "kodi.binary.instance.vfs"
 #define ADDON_INSTANCE_VERSION_VFS_DEPENDS            "addon-instance/VFS.h"
 


### PR DESCRIPTION
This fixes the missing file times in eg. the sftp vfs addon which also causes other problems like the videoscanner not working properly. Note that the sftp addon also requires a small fix to make this work, which will follow shortly.