### PR TITLE
Fix CShoutcastFile's ability to set the stream's tag info on the UI

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -79,7 +79,6 @@ bool CShoutcastFile::Open(const CURL& url)
   m_buffer = new char[16*255];
   m_tagPos = 1;
   m_tagChange.Set();
-  Create();
 
   return result;
 }
@@ -178,16 +177,16 @@ void CShoutcastFile::ReadTruncated(char* buf2, int size)
 int CShoutcastFile::IoControl(EIoControl control, void* payload)
 {
   if (control == IOCTRL_SET_CACHE)
+  {
     m_cacheReader = (CFileCache*)payload;
+    Create();
+  }
 
   return IFile::IoControl(control, payload);
 }
 
 void CShoutcastFile::Process()
 {
-  if (!m_cacheReader)
-    return;
-
   while (!m_bStop)
   {
     if (m_tagChange.WaitMSec(500))

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -41,7 +41,6 @@ CShoutcastFile::CShoutcastFile() :
 
 CShoutcastFile::~CShoutcastFile()
 {
-  StopThread();
   Close();
 }
 
@@ -176,7 +175,7 @@ void CShoutcastFile::ReadTruncated(char* buf2, int size)
 
 int CShoutcastFile::IoControl(EIoControl control, void* payload)
 {
-  if (control == IOCTRL_SET_CACHE)
+  if (control == IOCTRL_SET_CACHE && m_cacheReader == nullptr)
   {
     m_cacheReader = (CFileCache*)payload;
     Create();


### PR DESCRIPTION

## Description
Fix a race condition in posting the stream's tag information to the GUI by moving the thread creation to after the condition is satisfied.

## Motivation and Context
Bug. See https://github.com/xbmc/xbmc/pull/13721#issuecomment-515754788

## How Has This Been Tested?
Ran several streams to make sure the issue's been resolved.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
