### PR TITLE
fixed: use first protocol from add-on in add network dialog

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1512,7 +1512,9 @@ bool CUtil::SupportsWriteFileOperations(const std::string& strPath)
     for (const auto& addon : CServiceBroker::GetVFSAddonCache().GetAddonInstances())
     {
       const auto& info = addon->GetProtocolInfo();
-      if (info.type == url.GetProtocol() && info.supportWrite)
+      auto prots = StringUtils::Split(info.type, "|");
+      if (info.supportWrite &&
+          std::find(prots.begin(), prots.end(), url.GetProtocol()) != prots.end())
         return true;
     }
   }

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -445,10 +445,14 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
     {
       const auto& info = addon->GetProtocolInfo();
       if (!addon->GetProtocolInfo().type.empty())
+      {
+        // only use first protocol
+        auto prots = StringUtils::Split(info.type, "|");
         m_protocols.emplace_back(Protocol{ info.supportPath, info.supportUsername,
           info.supportPassword, info.supportPort,
           info.supportBrowsing, info.defaultPort,
-          info.type, info.label });
+          prots.front(), info.label });
+      }
     }
   }
   // internals


### PR DESCRIPTION
## Description
Add-ons can supply multiple protocols. Using this verbatim leads to funky protocols in urls, such as sftp|ssh:// for vfs.sftp.