### PR TITLE
[addons] fix repo addon install (<path> in addons.xml wasn't checked)

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -213,6 +213,18 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
     if (point == "kodi.addon.metadata" || point == "xbmc.addon.metadata")
     {
       /*
+       * Parse addon.xml "<path">...</path>" (special related to repository path),
+       * do first and if present override the default. Also set assetBasePath to
+       * find screenshots and icons.
+       */
+      element = child->FirstChildElement("path");
+      if (element && element->GetText() != nullptr && !repo.datadir.empty())
+      {
+        addon->m_path = URIUtils::AddFileToFolder(repo.datadir, element->GetText());
+        assetBasePath = URIUtils::GetDirectory(URIUtils::AddFileToFolder(repo.artdir, element->GetText()));
+      }
+
+      /*
        * Parse addon.xml "<summary lang="..">...</summary>"
        */
       GetTextList(child, "summary", addon->m_summary);


### PR DESCRIPTION
## Description
This fixes a problem that binary addons could not install from the Kodi repo.

From our repo a `<path>` is added to the big addons.xml. Unfortunately, this location is currently not being processed, so it works on script addons, but not on binaries, because the OS name is not added to them.

Error related to https://github.com/xbmc/xbmc/pull/14908, https://forum.kodi.tv/showthread.php?tid=345851 and https://forum.kodi.tv/showthread.php?tid=345994

This is the first round checked by `<extension point="xbmc.addon.metadata">` whether this exists in xml and if so used

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
To fix the use from repo and fault from me :smile:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
