### PR TITLE
Fix abort due to double busy dialog

### DIFF
--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -73,6 +73,8 @@ private:
   bool StartScript(const std::string& strPath, bool retrievingDir, bool resume);
   bool WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir);
 
+  bool ProcessRenderLoop(bool renderOnly = false);
+
   static std::map<int,CPluginDirectory*> globalHandles;
   static int getNewHandle(CPluginDirectory *cp);
   static void reuseHandle(int handle, CPluginDirectory *cp);

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -214,6 +214,9 @@ public:
 #ifdef _DEBUG
   void DumpTextureUse();
 #endif
+
+  bool ProcessRenderLoop(bool renderOnly);
+
 private:
   void RenderPass() const;
 
@@ -243,8 +246,6 @@ private:
    * \param force True to ignore checks which refuses opening the window, otherwise false
    */
   void ActivateWindow_Internal(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool force = false);
-
-  bool ProcessRenderLoop(bool renderOnly);
 
   bool HandleAction(const CAction &action) const;
 


### PR DESCRIPTION
## Description
I've found this issue while using the TIDAL plugin without having `inputstream.rtmp` installed.

## Motivation and Context
While `inputstream.rtmp` seems to be necessary for playback, I still think it's not nice that we hardcrash in this situation.

The problem is that we are in a busy dialog of player open and because we fail to create a demuxer in `PAPlayer` the next item is queued, which is a `plugin://`-Path that is expanded by calling `WaitOnScriptResult` which opens a `BusyDialog` again.

## How Has This Been Tested?
Tested with the TIDAL plugin installed, `inputstream.rtmp` missing on Ubuntu.

The solution is taken from `GUIMediaWindow` which checks if a `BusyDialog` is already running before trying to open it again.
If there is already a busy dialog, afaik we can just directly wait for the event and progress the renderloop.

Possible nogo:
I had to make `ProcessRenderLoop` public in order to call it, I'm still puzzled how `GUIMediaWindow` can do this without being a friend class of `GUIWindowManager`, but maybe I just missed it.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@FernetMenta any objections (or hints on how to do it without making `ProcessRenderLoop` public)?