### PR TITLE
added: Missing protocol member for VFSURL struct

### DIFF
--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -116,6 +116,7 @@ class CVFSURLWrapper
       m_strings.push_back(url2.GetPassWord());
       m_strings.push_back(url2.GetRedacted());
       m_strings.push_back(url2.GetShareName());
+      m_strings.push_back(url2.GetProtocol());
 
       url.url = m_strings[0].c_str();
       url.domain = m_strings[1].c_str();
@@ -127,6 +128,7 @@ class CVFSURLWrapper
       url.password = m_strings[6].c_str();
       url.redacted = m_strings[7].c_str();
       url.sharename = m_strings[8].c_str();
+      url.protocol = m_strings[9].c_str();
     }
 
     VFSURL url;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
@@ -34,6 +34,7 @@ extern "C"
     const char* password;
     const char* redacted;
     const char* sharename;
+    const char* protocol;
   };
 
   typedef struct VFSGetDirectoryCallbacks /* internal */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
@@ -58,6 +58,7 @@ extern "C"
     const char* password;
     const char* redacted;
     const char* sharename;
+    const char* protocol;
   };
 
   struct VFSCallbacks

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -111,7 +111,7 @@
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_XML_ID     "kodi.binary.instance.screensaver"
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "addon-instance/Screensaver.h"
 
-#define ADDON_INSTANCE_VERSION_VFS                    "2.1.0"
+#define ADDON_INSTANCE_VERSION_VFS                    "2.2.0"
 #define ADDON_INSTANCE_VERSION_VFS_MIN                "2.1.0"
 #define ADDON_INSTANCE_VERSION_VFS_XML_ID             "kodi.binary.instance.vfs"
 #define ADDON_INSTANCE_VERSION_VFS_DEPENDS            "addon-instance/VFS.h"


### PR DESCRIPTION
I don't know if this is by design or simply forgotten, but currently the VFSURL struct is lacking a protocol-member. I stumbled onto this while looking into another SFTP VFS addon bug, where I need to obtain the protocol from the url. Instead of parsing it myself, I think it's more consistent to simply also have the protocol as a VFSURL member.