### PR TITLE
FFmpeg: Bump to 4.0.4-Leia-18.4

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.0.3-Leia-18.2
+VERSION=4.0.4-Leia-18.4
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz


### PR DESCRIPTION
Version bump for FFmpeg. As we still plan to do a 18.04 release for Leia (at least I see patches going in), I did not change the version name, so that it can be seamlessly picked into Leia.