### PR TITLE
[python] add context manager support for xbmcvfs.File

### DIFF
--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -38,11 +38,20 @@ namespace XBMCAddon
     ///
     ///
     ///--------------------------------------------------------------------------
+    /// @python_v19 Added context manager support
     ///
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
     /// ..
     /// f = xbmcvfs.File(file, 'w')
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    /// **Example (v19 and up):**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// with xbmcvfs.File(file, 'w') as f:
+    ///   ..
     /// ..
     /// ~~~~~~~~~~~~~
     //
@@ -60,6 +69,11 @@ namespace XBMCAddon
       }
 
       inline ~File() override { delete file; }
+
+#if !defined(DOXYGEN_SHOULD_USE_THIS)
+      inline File* __enter__() { return this; };
+      inline void __exit__() { close(); };
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -81,6 +95,14 @@ namespace XBMCAddon
       /// f = xbmcvfs.File(file)
       /// b = f.read()
       /// f.close()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// with xbmcvfs.File(file) as file:
+      ///   b = f.read()
       /// ..
       /// ~~~~~~~~~~~~~
       ///
@@ -116,6 +138,14 @@ namespace XBMCAddon
       /// ..
       /// ~~~~~~~~~~~~~
       ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// with xbmcvfs.File(file) as f:
+      ///   b = f.readBytes()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
       readBytes(...);
 #else
       XbmcCommons::Buffer readBytes(unsigned long numBytes = 0);
@@ -143,6 +173,14 @@ namespace XBMCAddon
       /// ..
       /// ~~~~~~~~~~~~~
       ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// whith xbmcvfs.File(file, 'w') as f:
+      ///   result = f.write(buffer)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
       write(...);
 #else
       bool write(XbmcCommons::Buffer& buffer);
@@ -166,6 +204,14 @@ namespace XBMCAddon
       /// f = xbmcvfs.File(file)
       /// s = f.size()
       /// f.close()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// with xbmcvfs.File(file) as f:
+      ///   s = f.size()
       /// ..
       /// ~~~~~~~~~~~~~
       ///
@@ -198,6 +244,14 @@ namespace XBMCAddon
       /// ..
       /// ~~~~~~~~~~~~~
       ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// with xbmcvfs.File(file) as f:
+      ///   result = f.seek(8129, 0)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
       seek(...);
 #else
       inline long long seek(long long seekBytes, int iWhence = SEEK_SET) { DelayedCallGuard dg(languageHook); return file->Seek(seekBytes,iWhence); }
@@ -225,6 +279,14 @@ namespace XBMCAddon
       /// ..
       /// ~~~~~~~~~~~~~
       ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// with xbmcvfs.File(file) as f:
+      ///   s = f.tell()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
       tell();
 #else
       inline long long tell() { DelayedCallGuard dg(languageHook); return file->GetPosition(); }
@@ -245,6 +307,14 @@ namespace XBMCAddon
       /// ..
       /// f = xbmcvfs.File(file)
       /// f.close()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      /// **Example (v19 and up):**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// with xbmcvfs.File(file) as f:
+      ///   ..
       /// ..
       /// ~~~~~~~~~~~~~
       ///


### PR DESCRIPTION
## Description
This makes xbmcvfs.File usable in with statements.

```
with xbmcvfs.File(file) as file:
  pass
```

## Motivation and Context
make xbmcvfs.File usage more user-friendly

## How Has This Been Tested?
```
import os
import xbmc
import xbmcaddon
import xbmcvfs

profile = xbmcaddon.Addon().getAddonInfo("profile")
filepath = os.path.join(profile, "test.txt")

xbmcvfs.mkdir(profile)

with xbmcvfs.File(filepath, "w") as file:
    file.write("test")

with xbmcvfs.File(filepath) as file:
    xbmc.log(file.read())
```

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
