### PR TITLE
[music] Fix thumb loader after #16444

### DIFF
--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -56,8 +56,7 @@ bool CMusicThumbLoader::LoadItemCached(CFileItem* pItem)
   if (pItem->m_bIsShareOrDrive)
     return false;
 
-  if (pItem->HasMusicInfoTag() && (pItem->GetArt().empty() ||
-    (pItem->GetArt().size() == 1 && pItem->HasArt("thumb"))))
+  if (pItem->HasMusicInfoTag() && !pItem->HasArt("thumb"))
   {
     if (FillLibraryArt(*pItem))
       return true;
@@ -66,7 +65,7 @@ bool CMusicThumbLoader::LoadItemCached(CFileItem* pItem)
       return false; // No fallback
   }
 
-  if (pItem->HasVideoInfoTag() && pItem->GetArt().empty())
+  if (pItem->HasVideoInfoTag() && !pItem->HasArt("thumb"))
   { // music video
     CVideoThumbLoader loader;
     if (loader.LoadItemCached(pItem))


### PR DESCRIPTION
#16444 introduced a regression which is fixed by this PR. 

In several places, like Estuary home screen and music navigation window, Artists, albums, songs did only showed default images instead of the real thumbs.

![screenshot003](https://user-images.githubusercontent.com/3226626/62776616-5fbe6d00-baab-11e9-9ea8-f0c3c7b8437f.png)
![screenshot002](https://user-images.githubusercontent.com/3226626/62776617-5fbe6d00-baab-11e9-832d-528689a73412.png)

Root cause for the regression: Formerly, icons were not stored in `CGUIListItem::m_art`, only in `CGUIListItem::m_strIcon`. The latter has been removed with #16444. Now, that icons are also stored in `CGUIListItem::m_art`, every piece of code making assumptions about the size of `CGUIListItem::m_art` (calls to `CGUIListItem::GetArt()` followed by decisions based on the returned size has to be reviewed carefully.

One of those code pieces, namely in `CMusicTumbLoader::LoadItemCached` did not work after #16444 and caused the problems fixed by this PR.

@DaveTBlake I do not fully understand the old logic, especially why `pItem->GetArt().size() == 1 && pItem->HasArt("thumb")` is a trigger to call `FillLibraryArt`, but for the fix I just templated it for icons and runtime-tests show that it work. 

I do guess that this condition is kind of a hack/workaround. What you really want to know here is whether you have a default thumb/icon only, but current `CGUIListItem`implementation has now clean way to get this information. `CGUIListItem::m_art`will be filled with real data as well as with default images (Default*.png) and there is now way to check for a default-only image. 

`CVideoThumbLoader` implementation looks very similar to `CMusicThumbLoader`, but uses a more simple condition to decide whether to call `FillLibraryArt`. It's just `!pItem->HasArt("thumb")`. Maybe that simple logic is also sufficient for `CMusicThumbLoader`? I don't know.

If you have a better idea for a fix, this would be appreciated.


