### PR TITLE
AESinkAudioTrack: Enable simple metric for format choosing

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -841,12 +841,14 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
   m_info.m_wantsIECPassthrough = false;
   m_info.m_dataFormats.push_back(AE_FMT_RAW);
   m_info.m_streamTypes.clear();
+  int rawcounter = 0;
   if (CJNIAudioFormat::ENCODING_AC3 != -1)
   {
     if (VerifySinkConfiguration(48000, CJNIAudioFormat::CHANNEL_OUT_STEREO, CJNIAudioFormat::ENCODING_AC3))
     {
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
       CLog::Log(LOGDEBUG, "Firmware implements AC3 RAW");
+      rawcounter++;
     }
   }
 
@@ -857,6 +859,7 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
     {
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
       CLog::Log(LOGDEBUG, "Firmware implements EAC3 RAW");
+      rawcounter += 2;
     }
   }
 
@@ -869,6 +872,7 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+      rawcounter++;
     }
   }
 
@@ -881,6 +885,7 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
         CLog::Log(LOGDEBUG, "Firmware implements DTS-HD RAW");
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
+        rawcounter += 6;
       }
     }
     if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)
@@ -889,6 +894,7 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
       {
         CLog::Log(LOGDEBUG, "Firmware implements TrueHD RAW");
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+        rawcounter += 3;
       }
     }
   }
@@ -900,32 +906,45 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
     if (supports_iec)
     {
       bool supports_192khz = m_sink_sampleRates.find(192000) != m_sink_sampleRates.end();
-      m_info.m_wantsIECPassthrough = true;
-      m_info.m_streamTypes.clear();
-      m_info.m_dataFormats.push_back(AE_FMT_RAW);
-      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
-      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
-      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
-      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
-      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
-      CLog::Log(LOGDEBUG, "AESinkAUDIOTrack: Using IEC PT mode: %d", CJNIAudioFormat::ENCODING_IEC61937);
+      CAEDeviceInfo iecinfo;
+      iecinfo.m_dataFormats.push_back(AE_FMT_RAW);
+      iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+      iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
+      iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
+      iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
+      iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+      int ieccounter = 2;
+      CLog::Log(LOGDEBUG, "AESinkAUDIOTrack: IEC PT mode supported: %d",
+                CJNIAudioFormat::ENCODING_IEC61937);
       if (supports_192khz)
       {
         // Check for IEC 8 channel 192 khz PT DTS-HD-MA and TrueHD
         int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1);
         if (VerifySinkConfiguration(192000, atChannelMask, CJNIAudioFormat::ENCODING_IEC61937))
         {
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+          iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
+          iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
           CLog::Log(LOGDEBUG, "8 Channel PT via IEC61937 is supported");
+          ieccounter += 6;
         }
         // Check for IEC 2 channel 192 khz PT DTS-HD-HR and E-AC3
         if (VerifySinkConfiguration(192000, CJNIAudioFormat::CHANNEL_OUT_STEREO,
                                     CJNIAudioFormat::ENCODING_IEC61937))
         {
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+          iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+          iecinfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+          CLog::Log(LOGDEBUG, "2 Channel 192 khz PT via IEC61937 is supported");
+          ieccounter += 5;
         }
+      }
+      // we prefer IEC but only if we have more capabilities
+      if (ieccounter >= rawcounter)
+      {
+        m_info.m_wantsIECPassthrough = true;
+        m_info.m_streamTypes = iecinfo.m_streamTypes;
+        m_info.m_dataFormats.push_back(AE_FMT_RAW);
+        CLog::Log(LOGNOTICE, "IEC Mode is used. Supported IEC: %d Supported RAW: %d", ieccounter,
+                  rawcounter);
       }
     }
   }


### PR DESCRIPTION
It seems that since we ~started~ stopped pushing, most modern box vendors have forgotten about the 8 channel IEC passthrough capabilitiy, which still did not make it into Android's Standard.

This code includes a very simple metric:
DTS / AC3 count 1
EAC3 counts 2
DTS-HD / TrueHD count 3

If we have 10 iec and 10 RAW -> IEC wins
If we have 2 IEC and 3 RAW -> RAW wins

Other than that: This is the last idea to avoid yet another 5 settings ...
