### PR TITLE
[cmake] fix generating addon.xmls to avoid "file COPY" failures, fixes #16000

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                                             -Dprefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                             -P ${CMAKE_SOURCE_DIR}/cmake/scripts/common/GenerateVersionedFiles.cmake
                    DEPENDS ${CMAKE_SOURCE_DIR}/version.txt
+                           export-files
                            ${ADDON_XML_DEPENDS}
                            ${CMAKE_SOURCE_DIR}/xbmc/CompileInfo.cpp.in)
 list(APPEND install_data ${ADDON_INSTALL_DATA})

--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -233,6 +233,7 @@ else()
       set(LIBDVD_TARGET_DIR dlls)
     endif()
     copy_file_to_buildtree(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/bin/libdvdnav.dll DIRECTORY ${LIBDVD_TARGET_DIR})
+    add_dependencies(export-files dvdnav)
   endif()
 
   set(LIBDVD_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include)

--- a/cmake/scripts/common/GenerateVersionedFiles.cmake
+++ b/cmake/scripts/common/GenerateVersionedFiles.cmake
@@ -24,9 +24,6 @@ foreach(loop_var ${ADDON_XML_IN_FILE})
   string(REPLACE ${CORE_SOURCE_DIR} ${CMAKE_BINARY_DIR} dest_dir ${source_dir})
   file(MAKE_DIRECTORY ${dest_dir})
 
-  # copy everything except addon.xml.in to build folder
-  file(COPY "${source_dir}" DESTINATION "${CMAKE_BINARY_DIR}/addons" REGEX ".xml.in" EXCLUDE)
-
   configure_file(${source_dir}/addon.xml.in ${dest_dir}/addon.xml @ONLY)
 
   unset(source_dir)


### PR DESCRIPTION
## Description

See #16000 - this fixes the random "file COPY" failures when building Kodi.

## Motivation and Context

Kodi failing randomly during a 3-4 hour (or longer) LibreELEC build is a PITA.

## How Has This Been Tested?

Extensively, see #16000. I have performed several thousand Kodi builds without this commit (multiple failures observed), and several thousand Kodi builds with this commit (zero failures).

This change has been proposed by @wsnipex. I have removed the "retry" support from the original version as that seems to be unnecessary.

## Screenshots (if appropriate):

N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
