### PR TITLE
fixed: Using absolute paths in combination with hosts in URLs caused …

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -463,7 +463,13 @@ std::string CURL::GetWithoutOptions() const
   if (m_strProtocol.empty())
     return m_strFileName;
 
-  return GetWithoutFilename() + m_strFileName;
+  std::string strGet = GetWithoutFilename();
+
+  // Prevent double slash when concatenating host part and filename part
+  if (m_strFileName.size() && (m_strFileName[0] == '/' || m_strFileName[0] == '\\') && URIUtils::HasSlashAtEnd(strGet))
+    URIUtils::RemoveSlashAtEnd(strGet);
+
+  return strGet + m_strFileName;
 }
 
 std::string CURL::GetWithoutUserDetails(bool redact) const


### PR DESCRIPTION
…double slashes (fixes #16413)

Backport of #16415