### PR TITLE
[addons] Add 'Search for Updates' item to addon browser.

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -203,6 +203,11 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
     InstallFromZip();
     return true;
   }
+  if (item->GetPath() == "addons://check_for_updates/")
+  {
+    CServiceBroker::GetRepositoryUpdater().CheckForUpdates(true);
+    return true;
+  }
   if (item->GetPath() == "addons://update_all/")
   {
     UpdateAddons updater;

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -198,7 +198,9 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
   {
     CURL url(item.GetPath());
     if (url.GetHostName() == "install")
-      execute = "installfromzip";
+      execute = "InstallFromZip";
+    else if (url.GetHostName() == "check_for_updates")
+      execute = "UpdateAddonRepos(showProgress)";
     else
       execute = StringUtils::Format("RunAddon(%s)", url.GetFileName().c_str());
   }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -615,6 +615,12 @@ static void RootDirectory(CFileItemList& items)
     item->SetArt("icon", "DefaultAddonsInstalled.png");
     items.Add(item);
   }
+  {
+    const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>("addons://check_for_updates/", false);
+    item->SetLabel(g_localizeStrings.Get(24034));
+    item->SetArt("icon", "DefaultAddonRepository.png");
+    items.Add(item);
+  }
   if (CServiceBroker::GetAddonMgr().HasAvailableUpdates())
   {
     CFileItemPtr item(new CFileItem("addons://outdated/", true));

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -283,9 +283,9 @@ static int AddonSettings(const std::vector<std::string>& params)
   return 0;
 }
 
-/*! \brief Open the settings for a given add-on.
-*  \param params The parameters.
-*/
+/*! \brief Open the install from zip dialog.
+ *  \param params The parameters.
+ */
 static int InstallFromZip(const std::vector<std::string>& params)
 {
   CGUIWindowAddonBrowser::InstallFromZip();
@@ -313,11 +313,13 @@ static int StopScript(const std::vector<std::string>& params)
 }
 
 /*! \brief Check add-on repositories for updates.
- *  \param params (ignored)
+ *  \param params The parameters.
+ *  \details params[0] = "showProgress" to show a progress indicator (optional).
  */
 static int UpdateRepos(const std::vector<std::string>& params)
 {
-  CServiceBroker::GetRepositoryUpdater().CheckForUpdates();
+  bool bShowProgress = params.size() > 0 && StringUtils::EqualsNoCase(params[0], "showProgress");
+  CServiceBroker::GetRepositoryUpdater().CheckForUpdates(bShowProgress);
 
   return 0;
 }
@@ -425,9 +427,10 @@ static int UpdateLocals(const std::vector<std::string>& params)
 ///     @param[in] id                    The URL of the script to stop.
 ///   }
 ///   \table_row2_l{
-///     <b>`UpdateAddonRepos`</b>
+///     <b>`UpdateAddonRepos([showprogress])`</b>
 ///     ,
 ///     Triggers a forced update of enabled add-on repositories.
+///     @param[in] showprogress          Add "showProgress" to show a progress indicator (optional).
 ///   }
 ///   \table_row2_l{
 ///     <b>`UpdateLocalAddons`</b>
@@ -444,7 +447,7 @@ CBuiltins::CommandMap CAddonBuiltins::GetOperations() const
            {"addon.default.set",          {"Open a select dialog to allow choosing the default addon of the given type", 1, SetDefaultAddon}},
            {"addon.opensettings",         {"Open a settings dialog for the addon of the given id", 1, AddonSettings}},
            {"installaddon",               {"Install the specified plugin/script", 1, InstallAddon}},
-           {"installfromzip",             { "Open the install from zip dialog", 0, InstallFromZip}},
+           {"installfromzip",             {"Open the install from zip dialog", 0, InstallFromZip}},
            {"runaddon",                   {"Run the specified plugin/script", 1, RunAddon}},
 #ifdef TARGET_DARWIN
            {"runapplescript",             {"Run the specified AppleScript command", 1, RunScript<true>}},


### PR DESCRIPTION
I find it quite annoying that "check for updates" is buried deep inside Estuary sideblade. Many klicks are needed to get there if you want to do a manual check for addon updates.

This PR places a check for updates button/menu item at a quite prominent place making it easy to trigger a manual addon update check.

![screenshot000](https://user-images.githubusercontent.com/3226626/63153547-d3fa9280-c00e-11e9-97d0-8d25a3a2f055.png)
![screenshot001](https://user-images.githubusercontent.com/3226626/63153550-da890a00-c00e-11e9-88c5-8d2912160a11.png)

@peak3d you are a good candidate for a code review, because you touched the code area affected by this PR back then when you fixed "install from zip"... 