### PR TITLE
[depends] build libplist static

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -154,7 +154,6 @@ foreach(lib IN LISTS required_dyload dyload_optional ITEMS Shairplay)
 endforeach()
 add_bundle_file(${ASS_LIBRARY} ${libdir} "")
 add_bundle_file(${BLURAY_LIBRARY} ${libdir} "")
-add_bundle_file(${PLIST_LIBRARY} ${libdir} "")
 add_bundle_file(${SHAIRPLAY_LIBRARY} ${libdir} "")
 add_bundle_file(${SMBCLIENT_LIBRARY} ${libdir} "")
 

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -3,7 +3,7 @@ include ../../depends/Makefile.include
 BUILD_TYPE:=@CMAKE_BUILD_TYPE@
 BUILD_TYPE_LC:=$(shell echo $(BUILD_TYPE) | tr A-Z a-z)
 
-OBJS = libplist.so libshairplay.so \
+OBJS = libshairplay.so \
   libass.so \
   libbluray.so libsmbclient.so
 

--- a/tools/depends/target/libplist/Makefile
+++ b/tools/depends/target/libplist/Makefile
@@ -7,16 +7,12 @@ VERSION=2.0.0
 SOURCE=$(LIBNAME)-$(VERSION)
 FILENAME=v$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
-ifeq (darwin, $(findstring darwin, $(HOST)))
-LIBDYLIB=$(PLATFORM)/src/.libs/libplist++.dylib
-else
-LIBDYLIB=$(PLATFORM)/src/.libs/libplist++.so
-endif
+LIBDYLIB=$(PLATFORM)/src/.libs/libplist++.a
 CFLAGS+=-fvisibility=default
 all: .installed-$(PLATFORM)
 
 # configuration settings
-CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; ./configure --prefix=$(PREFIX) --without-cython
+CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; CFLAGS="-Dlist_add=plist_list_add" ./configure --prefix=$(PREFIX) --disable-shared --without-cython
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
@@ -40,4 +36,3 @@ clean:
 
 distclean::
 	rm -rf $(PLATFORM) .installed-$(PLATFORM)
-


### PR DESCRIPTION
## Description
build libplist static

## Motivation and Context
libplist didn't link math lib, which caused errors on some android devices, after #16167
> cannot locate symbol "modf" referenced by "libplist.so"

## How Has This Been Tested?
tested by the user who reported the crash

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
