### PR TITLE
Fix PlayMedia builtin for playlists (.strm) and "artists" smart playlists 

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2648,7 +2648,11 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPl
       smartpl.OpenAndReadName(item.GetURL());
       CPlayList playlist;
       playlist.Add(items);
-      return ProcessAndStartPlaylist(smartpl.GetName(), playlist, (smartpl.GetType() == "songs" || smartpl.GetType() == "albums") ? PLAYLIST_MUSIC:PLAYLIST_VIDEO);
+      int iPlaylist = PLAYLIST_VIDEO;
+      if (smartpl.GetType() == "songs" || smartpl.GetType() == "albums" ||
+        smartpl.GetType() == "artists")
+        iPlaylist = PLAYLIST_MUSIC;
+      return ProcessAndStartPlaylist(smartpl.GetName(), playlist, iPlaylist);
     }
   }
   else if (item.IsPlayList() || item.IsInternetStream())

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -429,11 +429,14 @@ static int PlayMedia(const std::vector<std::string>& params)
     if ( CGUIWindowVideoBase::ShowResumeMenu(item) == false )
       return false;
   }
-  if (item.m_bIsFolder)
+  if (item.m_bIsFolder || item.IsPlayList())
   {
     CFileItemList items;
     std::string extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + "|" + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
-    XFILE::CDirectory::GetDirectory(item.GetPath(), items, extensions, XFILE::DIR_FLAG_DEFAULTS);
+    if (item.IsPlayList())
+      CUtil::GetRecursiveListing(item.GetPath(), items, extensions, XFILE::DIR_FLAG_DEFAULTS);
+    else
+      XFILE::CDirectory::GetDirectory(item.GetPath(), items, extensions, XFILE::DIR_FLAG_DEFAULTS);
 
     if (!items.IsEmpty()) // fall through on non expandable playlist
     {
@@ -471,7 +474,7 @@ static int PlayMedia(const std::vector<std::string>& params)
       return 0;
     }
   }
-  if ((item.IsAudio() || item.IsVideo()) && !item.IsPlayList() && !item.IsSmartPlayList())
+  if ((item.IsAudio() || item.IsVideo()) && !item.IsSmartPlayList())
     CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
   else
     g_application.PlayMedia(item, "", PLAYLIST_NONE);


### PR DESCRIPTION
A follow up for #16327 that solved some of the PlayMedia builtin regressions introduced in v18 but incorrectly caused .strm files to play without being in a player playlist. 

The fault was that `g_application.PlayMedia` was being called for .strm and other playlist files as it had been in v17, but with PLAYLIST_NONE (rather than defaulting to PLAYLIST_MUSIC the audio player playlist).  A better approach is to treat playlist files as folders (as  #14183 attempted),  but to fully restore v17 PlayMedia functionality they need to be recursively expanded before being added to the appropriate player playlist. This also ensures that .m3u playlist files containing music get played by the music player rather than the video player.

Smart playlists still need to be handled by ` g_application.PlayMedia` , rather than be passed directly to `CPlayListPlayer::Play`. However a small fix is needed here to ensure "artists" smart playlists are treated correctly as music playlists not as video.

Tested Playmedia with a variey of playlist files (.strm and .m3u) and smartplaylists of varied types, v17 funstionality correctly restored.
