### PR TITLE
fixed: Use exact matching for protocol in file+dir factories (fixes vfs.sftp addon issue #37)

### DIFF
--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -78,13 +78,13 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   if (!CWakeOnAccess::GetInstance().WakeUpHost(url))
     return NULL;
 
-  std::string strProtocol = url.GetProtocol();
-  if (!strProtocol.empty() && CServiceBroker::IsBinaryAddonCacheUp())
+  if (!url.GetProtocol().empty() && CServiceBroker::IsBinaryAddonCacheUp())
   {
-    StringUtils::ToLower(strProtocol);
     for (const auto& vfsAddon : CServiceBroker::GetVFSAddonCache().GetAddonInstances())
     {
-      if (vfsAddon->HasFiles() && vfsAddon->GetProtocols().find(strProtocol) != std::string::npos)
+      auto prots = StringUtils::Split(vfsAddon->GetProtocols(), "|");
+
+      if (vfsAddon->HasFiles() && std::find(prots.begin(), prots.end(), url.GetProtocol()) != prots.end())
         return new CVFSEntryIFileWrapper(vfsAddon);
     }
   }


### PR DESCRIPTION
Previously we did not use an exact match to compare the protocol in file/dir factory causing eg. "ftp" to be matched in "sftp". Furthermore we weren't consistent preferring internally supported protocols over addon provided protocols.

This fixes https://github.com/xbmc/vfs.sftp/issues/37