### PR TITLE
Override joystick controls per-keyname (fixes userdata config override)

### DIFF
--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -38,6 +38,15 @@ void CJoystickMapper::MapActions(int windowID, const TiXmlNode *pDevice)
   if (controllerId.empty())
     return;
 
+  // Update Controller IDs
+  if (std::find(m_controllerIds.begin(), m_controllerIds.end(), controllerId) == m_controllerIds.end())
+    m_controllerIds.emplace_back(controllerId);
+
+  // Create/overwrite keymap
+  auto& keymap = m_joystickKeymaps[controllerId];
+  if (!keymap)
+    keymap.reset(new CWindowKeymap(controllerId));
+
   const TiXmlElement *pButton = pDevice->FirstChildElement();
   while (pButton != nullptr)
   {
@@ -48,15 +57,6 @@ void CJoystickMapper::MapActions(int windowID, const TiXmlNode *pDevice)
     std::string actionString;
     if (DeserializeButton(pButton, feature, dir, holdtimeMs, hotkeys, actionString))
     {
-      // Update Controller IDs
-      if (std::find(m_controllerIds.begin(), m_controllerIds.end(), controllerId) == m_controllerIds.end())
-        m_controllerIds.emplace_back(controllerId);
-
-      // Find/create keymap
-      auto &keymap = m_joystickKeymaps[controllerId];
-      if (!keymap)
-        keymap.reset(new CWindowKeymap(controllerId));
-
       // Update keymap
       unsigned int actionId = ACTION_NONE;
       if (CActionTranslator::TranslateString(actionString, actionId))

--- a/xbmc/input/WindowKeymap.cpp
+++ b/xbmc/input/WindowKeymap.cpp
@@ -22,6 +22,14 @@ void CWindowKeymap::MapAction(int windowId, const std::string &keyName, JOYSTICK
   auto &actionGroup = m_windowKeymap[windowId][keyName];
 
   actionGroup.windowId = windowId;
+  auto it = actionGroup.actions.begin();
+  while (it != actionGroup.actions.end())
+  {
+    if (it->holdTimeMs == action.holdTimeMs && it->hotkeys == action.hotkeys)
+      it = actionGroup.actions.erase(it);
+    else
+      it++;
+  }
   actionGroup.actions.insert(std::move(action));
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR fixes a bug where the custom joystick configuration from the userdata folder was no longer being applied. This has been fixed by overriding the configuration per keyname. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This fixes a bug that no longer allowed user-provided joystick configuration. 

The custom configuration only needs to contain the modified controls and the default controls will still be used from the default configuration file. This might be slightly different from previous behavior but it seems like a reasonable solution. It was also the only solution that I could get to work correctly.

Fixes #15316.
Fixes PR #15347 (The change in that PR didn't work correctly. This PR is based on the code changes in that PR).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
This has been tested manually using a PS4 controller and the `peripheral.joystick` binary addon (master branch).

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed (Test 490: `TestWebServer.CanHeadFile` already failed before this change)
