### PR TITLE
Enable System.Exec to handle additiona parameters + crash fix

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2140,7 +2140,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
 #if defined(TARGET_DARWIN)
     CLog::Log(LOGNOTICE, "ExecWait is not implemented on this platform");
 #elif defined(TARGET_POSIX)
-    CUtil::RunCommandLine(pMsg->strParam.c_str(), (pMsg->param1 == 1));
+    CUtil::RunCommandLine(pMsg->params, (pMsg->param1 == 1));
 #elif defined(TARGET_WINDOWS)
     CWIN32Util::XBMCShellExecute(pMsg->strParam.c_str(), (pMsg->param1 == 1));
 #endif

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1575,10 +1575,8 @@ void CUtil::InitRandomSeed()
 }
 
 #ifdef TARGET_POSIX
-bool CUtil::RunCommandLine(const std::string& cmdLine, bool waitExit)
+bool CUtil::RunCommandLine(const std::vector<std::string> args, bool waitExit)
 {
-  std::vector<std::string> args = StringUtils::Split(cmdLine, ",");
-
   // Strip quotes and whitespace around the arguments, or exec will fail.
   // This allows the python invocation to be written more naturally with any amount of whitespace around the args.
   // But it's still limited, for example quotes inside the strings are not expanded, etc.
@@ -1632,6 +1630,8 @@ bool CUtil::Command(const std::vector<std::string>& arrArgs, bool waitExit)
       memset(args, 0, (sizeof(char *) * (arrArgs.size() + 3)));
       for (size_t i=0; i<arrArgs.size(); i++)
         args[i] = const_cast<char *>(arrArgs[i].c_str());
+      args[arrArgs.size()] = NULL;
+
       execvp(args[0], args);
     }
   }

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -177,7 +177,7 @@ public:
   //
   // Forks to execute an unparsed shell command line.
   //
-  static bool RunCommandLine(const std::string& cmdLine, bool waitExit = false);
+  static bool RunCommandLine(const std::vector<std::string> argArray, bool waitExit);
 #endif
   static std::string ResolveExecutablePath();
   static std::string GetFrameworksPath(bool forPython = false);

--- a/xbmc/interfaces/builtins/SystemBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SystemBuiltins.cpp
@@ -23,7 +23,7 @@ using namespace KODI::MESSAGING;
 static int Exec(const std::vector<std::string>& params)
 {
   CApplicationMessenger::GetInstance().PostMsg(TMSG_MINIMIZE);
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_OS, Wait, -1, nullptr, params[0]);
+  CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_OS, Wait, -1, nullptr, params[0], params);
 
   return 0;
 }


### PR DESCRIPTION
## Description
Enables additional arguments to be passed through to System.Exec()/ExecWait().
This also fixes Kodi from crashing if a user did pass multiple arguments to the System.exec() /ExecWait () commands

## Motivation and Context
Request on forums
https://forum.kodi.tv/showthread.php?tid=346358

Current behaviour is to split the input using the , delimiter. Have left this behaviour, but not sure if it needs to be documented somewhere. Feel free to point me to where if it is.

## How Has This Been Tested?
Ubuntu using kodi-send to send the following
```
kodi-send -a "System.Exec(/home/parallels/test.sh,--hide-menubar)"
```
Test script is a script that opens terminal, and passes any additional arguments through.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
