### PR TITLE
[Inputstream Addon] Add missing breaks

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -93,12 +93,16 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
       break;
     case FF_PROFILE_VP9_0:
       initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile0;
+      break;
     case FF_PROFILE_VP9_1:
       initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile1;
+      break;
     case FF_PROFILE_VP9_2:
       initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile2;
+      break;
     case FF_PROFILE_VP9_3:
       initData.codecProfile = STREAMCODEC_PROFILE::VP9CodecProfile3;
+      break;
     default:
       return false;
     }


### PR DESCRIPTION
## Description
This PR adds missing breaks when evaluating VP9 codec profile for playback with AddonVideoCodec (e.g. DRM protected / secured content using widevine shared library)

## Motivation and Context
Coverity scan report

## How Has This Been Tested?
not tested

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
