### PR TITLE
[cmake] check present "CPU" variable on PrepareEnv, if empty use CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/cmake/scripts/common/PrepareEnv.cmake
+++ b/cmake/scripts/common/PrepareEnv.cmake
@@ -34,6 +34,14 @@ endif()
 
 set(PLATFORM_TAG ${CORE_SYSTEM_NAME})
 
+# The CPU variable is given either by ./tools/depends or by the
+# ./cmake/scripts/common/ArchSetup.cmake (which refers to the Kodi building
+# itself). However, this file is only used by addons, so CPU can not always
+# be defined, so in this case, if empty, the base CPU will be used.
+if(NOT CPU)
+  set(CPU ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
 if(CORE_SYSTEM_NAME STREQUAL android)
   if (CPU MATCHES "v7a")
     set(PLATFORM_TAG ${PLATFORM_TAG}-armv7)


### PR DESCRIPTION
## Description
This is necessary to addons outside of "./tools/depends" to e.g. Mac to build because the variable "CPU" can only be given from there at the addon construction.

This is OK for cross platform addon construction like iOS or Android, but very cumbersome for building an addon to the same system (for testing purposes).

This is added:
```
if(NOT CPU)
  set(CPU ${CMAKE_SYSTEM_PROCESSOR})
endif()
```

Without comes:
```
<platform>osx-</platform>
```

With:
```
<platform>osx-x86_64</platform>
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Addon on Mac by:
```sh
cd visualization.spectrum # Where addon source is
mkdir build
cd build
/Users/Shared/xbmc-depends/x86_64-darwin18.5.0-native/bin/cmake \
   -DADDONS_TO_BUILD=visualization.spectrum \
   -DADDON_SRC_PREFIX=../..  \
   -DCMAKE_BUILD_TYPE=Release  \
   -DCMAKE_INSTALL_PREFIX="$HOME/Library/Application Support/Kodi/addons"  \
   -DPACKAGE_ZIP=1 ../../kodi/cmake/addons
make
```
>Note: In this way, it must be present under `./Cmake/addons/addons` (the content of https://github.com/xbmc/repo-binary-addons, which will be automatically downloaded), or if added subsequently there.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
