### PR TITLE
[PVR] Fix deadlock on PVR shutdown.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -299,8 +299,6 @@ void CPVRManager::Start()
   // lock here (m_startStopMutex), which only gets hold while starting/restarting pvr manager.
   Stop();
 
-  CSingleLock lock(m_critSection);
-
   if (!m_addons->HasCreatedClients())
     return;
 
@@ -338,8 +336,6 @@ void CPVRManager::Stop(void)
   StopThread();
 
   SetState(ManagerStateInterrupted);
-
-  CSingleLock lock(m_critSection);
 
   UnloadComponents();
   m_database->Close();


### PR DESCRIPTION
<pre>

* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fff7a61186a libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x000000010dac11b2 libsystem_pthread.dylib`_pthread_cond_wait + 722
    frame #2: 0x00007fff7770bb31 libc++.1.dylib`std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
    frame #3: 0x00000001001e4163 kodi.bin`std::__1::cv_status std::__1::condition_variable::wait_for<long long, std::__1::ratio<1l, 1000000000l> >(this=0x00000001110a01d8, __lk=0x00007ffeefbfe978, __d=0x00007ffeefbfe900) at __mutex_base:416:9
    frame #4: 0x00000001001e3d87 kodi.bin`std::__1::cv_status std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >(this=0x00000001110a01d8, __lk=0x00007ffeefbfe978, __t=0x00007ffeefbfe9e0) at __mutex_base:384:5
    frame #5: 0x00000001001e3b5b kodi.bin`std::__1::cv_status std::__1::condition_variable_any::wait_until<XbmcThreads::CRecursiveMutex, std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >(this=0x00000001110a01d8, __lock=0x00000001110a0228, __t=0x00007ffeefbfe9e0) at condition_variable:226:18
    frame #6: 0x00000001001e3a7f kodi.bin`std::__1::cv_status std::__1::condition_variable_any::wait_for<XbmcThreads::CRecursiveMutex, long long, std::__1::ratio<1l, 1000l> >(this=0x00000001110a01d8, __lock=0x00000001110a0228, __d=0x00007ffeefbfea28) at condition_variable:248:12
    frame #7: 0x00000001001e3963 kodi.bin`XbmcThreads::ConditionVariable::wait(this=0x00000001110a01d8, lock=0x00000001110a0228, milliseconds=4294967295) at Condition.h:47:33
    frame #8: 0x00000001001e3826 kodi.bin`bool XbmcThreads::TightConditionVariable<bool volatile&>::wait<CCriticalSection>(this=0x00000001110a0218, lock=0x00000001110a0228, milliseconds=4294967295) at Condition.h:100:18
    frame #9: 0x00000001001c5554 kodi.bin`CEvent::WaitMSec(this=0x00000001110a0180, milliSeconds=4294967295) at Event.h:79:50
    frame #10: 0x0000000101d044c2 kodi.bin`CThread::WaitForThreadExit(this=0x00000001110a0000, milliseconds=4294967295) at ThreadImpl.cpp:229:30
    frame #11: 0x0000000101d054a9 kodi.bin`CThread::StopThread(this=0x00000001110a0000, bWait=true) at Thread.cpp:160:5
==> thread never ends because worker function (T41) is waiting for PVR manager mutex which is owned by this thread!

    frame #12: 0x0000000101ad59ca kodi.bin`PVR::CPVRTimers::Unload(this=0x00000001110a0000) at PVRTimers.cpp:108:3
    frame #13: 0x0000000101975d27 kodi.bin`PVR::CPVRManager::UnloadComponents(this=0x0000000111096000) at PVRManager.cpp:596:13
    frame #14: 0x000000010197595b kodi.bin`PVR::CPVRManager::Stop(this=0x0000000111096000) at PVRManager.cpp:341:3
==> has CPVRManager mutex

    frame #15: 0x0000000101975d69 kodi.bin`PVR::CPVRManager::Unload(this=0x0000000111096000) at PVRManager.cpp:353:3
    frame #16: 0x0000000101975da5 kodi.bin`PVR::CPVRManager::Deinit(this=0x0000000111096000) at PVRManager.cpp:360:3
    frame #17: 0x0000000100334ca8 kodi.bin`CServiceManager::DeinitStageThree(this=0x000000010ddec810) at ServiceManager.cpp:190:17
    frame #18: 0x00000001001d195a kodi.bin`CApplication::Cleanup(this=0x000000010f004400) at Application.cpp:2430:25
    frame #19: 0x000000010037d5c4 kodi.bin`CXBApplicationEx::Destroy(this=0x000000010f004400) at XBApplicationEx.cpp:37:3
    frame #20: 0x000000010037d763 kodi.bin`CXBApplicationEx::Run(this=0x000000010f004400, params=0x00007ffeefbfef38) at XBApplicationEx.cpp:83:3
    frame #21: 0x000000010186fcd4 kodi.bin`::XBMC_Run(renderGUI=true, params=0x00007ffeefbfef38) at xbmc.cpp:72:26
    frame #22: 0x000000010000b38b kodi.bin`::SDL_main(argc=1, argv=0x000000010dd63fd0) at main.cpp:77:10
    frame #23: 0x000000010000a9f5 kodi.bin`main(argc=1, argv=0x00007ffeefbff030) at SDLMain.mm:561:12
    frame #24: 0x00007fff7a4d93d5 libdyld.dylib`start + 1



 thread #41, name = 'PVRTimers'
    frame #0: 0x00007fff7a610f06 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x000000010dabe83b libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 114
    frame #2: 0x000000010dabbe46 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 231
    frame #3: 0x0000000100117005 kodi.bin`XbmcThreads::CRecursiveMutex::lock(this=0x0000000111096c70) at RecursiveMutex.h:34:26
    frame #4: 0x0000000100116fd9 kodi.bin`XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock(this=0x0000000111096c70) at Lockables.h:49:32
    frame #5: 0x0000000100116fba kodi.bin`XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(this=0x00007000096b1508, lockable=0x0000000111096c70) at Lockables.h:118:83
    frame #6: 0x0000000100116f88 kodi.bin`CSingleLock::CSingleLock(this=0x00007000096b1508, cs=0x0000000111096c70) at SingleLock.h:27:55
    frame #7: 0x0000000100116f2d kodi.bin`CSingleLock::CSingleLock(this=0x00007000096b1508, cs=0x0000000111096c70) at SingleLock.h:27:101
==> wants CPVRManager mutex

    frame #8: 0x0000000101974538 kodi.bin`PVR::CPVRManager::ChannelGroups(this=0x0000000111096000) const at PVRManager.cpp:178:15
    frame #9: 0x0000000101ac37bd kodi.bin`PVR::CPVRTimerInfoTag::CreateFromEpg(tag=std::__1::shared_ptr<PVR::CPVREpgInfoTag>::element_type @ 0x0000000123f14590 strong=2 weak=2, bCreateRule=false, bCreateReminder=true, bReadOnly=true) at PVRTimerInfoTag.cpp:868:80
    frame #10: 0x0000000101ac4361 kodi.bin`PVR::CPVRTimerInfoTag::CreateReminderFromEpg(tag=std::__1::shared_ptr<PVR::CPVREpgInfoTag>::element_type @ 0x0000000123f14590 strong=2 weak=2, parent=std::__1::shared_ptr<PVR::CPVRTimerInfoTag>::element_type @ 0x00000001239cc490 strong=3 weak=1) at PVRTimerInfoTag.cpp:843:54
    frame #11: 0x0000000101ad8b31 kodi.bin`PVR::CPVRTimers::UpdateEntries(this=0x00000001110a0000, iMaxNotificationDelay=10) at PVRTimers.cpp:619:62
==> has CPVRTimers mutex

    frame #12: 0x0000000101ad79c5 kodi.bin`PVR::CPVRTimers::Process(this=0x00000001110a0000) at PVRTimers.cpp:158:5
    frame #13: 0x0000000101d051c4 kodi.bin`CThread::Action(this=0x00000001110a0000) at Thread.cpp:208:5
    frame #14: 0x0000000101d03fa8 kodi.bin`CThread::staticThread(data=0x00000001110a0000) at Thread.cpp:116:12
    frame #15: 0x000000010dabddc3 libsystem_pthread.dylib`_pthread_body + 126
    frame #16: 0x000000010dac0e8d libsystem_pthread.dylib`_pthread_start + 66
    frame #17: 0x000000010dabce11 libsystem_pthread.dylib`thread_start + 13
</pre>

Holding the mutex here is just plain wrong.