### PR TITLE
[listproviders] Update addons list on repository updated

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -294,6 +294,15 @@ void CDirectoryProvider::OnAddonEvent(const ADDON::AddonEvent& event)
   }
 }
 
+void CDirectoryProvider::OnAddonRepositoryEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
+{
+  CSingleLock lock(m_section);
+  if (URIUtils::IsProtocol(m_currentUrl, "addons"))
+  {
+    m_updateState = INVALIDATED;
+  }
+}
+
 void CDirectoryProvider::OnPVRManagerEvent(const PVR::PVREvent& event)
 {
   CSingleLock lock(m_section);
@@ -337,6 +346,7 @@ void CDirectoryProvider::Reset()
     m_isAnnounced = false;
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
     CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
+    CServiceBroker::GetRepositoryUpdater().Events().Unsubscribe(this);
     CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
     CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
   }
@@ -461,6 +471,7 @@ bool CDirectoryProvider::UpdateURL()
     m_isAnnounced = true;
     CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
     CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
+    CServiceBroker::GetRepositoryUpdater().Events().Subscribe(this, &CDirectoryProvider::OnAddonRepositoryEvent);
     CServiceBroker::GetPVRManager().Events().Subscribe(this, &CDirectoryProvider::OnPVRManagerEvent);
     CServiceBroker::GetFavouritesService().Events().Subscribe(this, &CDirectoryProvider::OnFavouritesEvent);
   }

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -10,6 +10,7 @@
 
 #include "IListProvider.h"
 #include "addons/AddonEvents.h"
+#include "addons/RepositoryUpdater.h"
 #include "favourites/FavouritesService.h"
 #include "guilib/GUIStaticItem.h"
 #include "interfaces/IAnnouncer.h"
@@ -84,6 +85,7 @@ private:
   bool UpdateLimit();
   bool UpdateSort();
   void OnAddonEvent(const ADDON::AddonEvent& event);
+  void OnAddonRepositoryEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event);
   void OnPVRManagerEvent(const PVR::PVREvent& event);
   void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event);
   std::string GetTarget(const CFileItem& item) const;


### PR DESCRIPTION
If Estuary addons home page is visible (I mean the row of buttons on top of that page -> My add-ons, Install from repository, Install from zip file, ...) and an automatic (or programatically triggered) repository update occurs and updates are available, the button "Available Updates" does not appear in the addons home page button row.

This PR fixes this problem by making CDirectoryProvider react on RepositoryUpdated event.