### PR TITLE
fixed: We should also clear resume bookmarks when marking as unwatched

### DIFF
--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -89,15 +89,16 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
   for (std::vector<CFileItemPtr>::const_iterator iter = markItems.begin(); iter != markItems.end(); ++iter)
   {
     CFileItemPtr item = *iter;
-    if (m_mark)
-    {
-      std::string path(item->GetPath());
-      if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->GetPath().empty())
-        path = item->GetVideoInfoTag()->GetPath();
 
-      db.ClearBookMarksOfFile(path, CBookmark::RESUME);
+    std::string path(item->GetPath());
+    if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->GetPath().empty())
+      path = item->GetVideoInfoTag()->GetPath();
+
+    // With both mark as watched and unwatched we want the resume bookmarks to be reset
+    db.ClearBookMarksOfFile(path, CBookmark::RESUME);
+
+    if (m_mark)
       db.IncrementPlayCount(*item);
-    }
     else
       db.SetPlayCount(*item, 0);
   }


### PR DESCRIPTION
Previously we would only reset the resume bookmarks when marking as watched. It's logical that we also do this when marking as unwatched. This allows people to start with a clean slate when they want to eg. watch a tv show all over again.