### PR TITLE
fixed: No media flags were shown for DVDs (fixes #15929)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9685,6 +9685,7 @@ void CGUIInfoManager::UpdateAVInfo()
 {
   if (CServiceBroker::GetDataCacheCore().HasAVInfoChanges())
   {
+    printf("datache has AV changes\n");
     VideoStreamInfo video;
     AudioStreamInfo audio;
     SubtitleStreamInfo subtitle;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -323,6 +323,7 @@ public:
 
 void CSelectionStreams::Clear(StreamType type, StreamSource source)
 {
+  printf("clear selection streams %i from source %i\n", type, source);
   auto new_end = std::remove_if(m_Streams.begin(), m_Streams.end(),
                                 [type, source](const SelectionStream &stream)
                                 {
@@ -407,15 +408,19 @@ int CSelectionStreams::Source(StreamSource source, std::string filename)
 
 void CSelectionStreams::Update(SelectionStream& s)
 {
+                        // STREAM_VIDEO, , -1, 0)
+  printf("update type=%i source=%i demuxer=%i id=%i\n", s.type, s.source, s.demuxerId, s.id);
   int index = TypeIndexOf(s.type, s.source, s.demuxerId, s.id);
   if(index >= 0)
   {
+    printf("index update found\n");
     SelectionStream& o = Get(s.type, index);
     s.type_index = o.type_index;
     o = s;
   }
   else
   {
+    printf("pushback update\n");
     s.type_index = CountType(s.type);
     m_Streams.push_back(s);
   }
@@ -423,8 +428,10 @@ void CSelectionStreams::Update(SelectionStream& s)
 
 void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux* demuxer, std::string filename2)
 {
+  printf("Update\n");
   if(input && input->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
+    printf("Input update\n");
     std::shared_ptr<CDVDInputStreamNavigator> nav = std::static_pointer_cast<CDVDInputStreamNavigator>(input);
     std::string filename = nav->GetFileName();
     int source = Source(STREAM_SOURCE_NAV, filename);
@@ -486,8 +493,7 @@ void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux
       Update(s);
     }
   }
-
-  if (demuxer)
+  else if (demuxer)
   {
     std::string filename = demuxer->GetFileName();
     int source;
@@ -4902,6 +4908,7 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo &info)
 
   if (streamId < 0 || streamId > GetVideoStreamCount() - 1)
   {
+    printf("video invalid with id %i\n", streamId);
     info.valid = false;
     return;
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -850,6 +850,7 @@ bool CVideoPlayer::OpenDemuxStream()
 
   m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
   m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
+  printf("nav demux clear\n");
   m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
   m_pDemuxer->GetPrograms(m_programs);
   UpdateContent();
@@ -1021,6 +1022,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
       }
       if (stream->source == STREAM_SOURCE_NONE)
       {
+        printf("NULL stream\n");
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX_SUB);
         m_SelectionStreams.Update(NULL, m_pSubtitleDemuxer.get());
         UpdateContent();
@@ -1038,6 +1040,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
     // stream changed, update and open defaults
     if (packet->iStreamId == DMX_SPECIALID_STREAMCHANGE)
     {
+      printf("special stream change\n");
       m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
       m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
       m_pDemuxer->GetPrograms(m_programs);
@@ -1068,6 +1071,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
       }
       if(stream->source == STREAM_SOURCE_NONE)
       {
+        printf("no stream\n");
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
         m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
         UpdateContent();
@@ -1611,6 +1615,7 @@ void CVideoPlayer::CheckStreamChanges(CCurrentStream& current, CDemuxStream* str
 
     if (current.hint != CDVDStreamInfo(*stream, true))
     {
+      printf("check stram changes\n");
       m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
       m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
       UpdateContent();
@@ -2449,6 +2454,7 @@ void CVideoPlayer::OnExit()
 
   // clean up all selection streams
   m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NONE);
+  printf("cleanup all selection streams\n");
 
   m_messenger.End();
 
@@ -2481,6 +2487,7 @@ void CVideoPlayer::HandleMessages()
       IPlayerCallback *cb = &m_callback;
       CFileItem fileItem(m_item);
       UpdateFileItemStreamDetails(fileItem);
+      printf("##########Update File item stream details\n");
       CVideoSettings vs = m_processInfo->GetVideoSettings();
       m_outboundEvents->Submit([=]() {
         cb->StoreVideoSettings(fileItem, vs);
@@ -2520,6 +2527,7 @@ void CVideoPlayer::HandleMessages()
       m_pInputStream.reset();
 
       m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NONE);
+      printf("input stream reset\n");
 
       Prepare();
     }
@@ -3635,6 +3643,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   {
     m_pCCDemuxer = new CDVDDemuxCC(hint.codec);
     m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_VIDEOMUX);
+    printf("video is mpeg2\n");
   }
 
   return true;
@@ -4025,6 +4034,7 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
           m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
 
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
+        printf("dvdnav ts change\n");
         m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
         UpdateContent();
 
@@ -4861,11 +4871,12 @@ void CVideoPlayer::OnResetDisplay()
 
 void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item)
 {
-  if (!m_UpdateStreamDetails)
-    return;
+//  if (!m_UpdateStreamDetails)
+//    return;
   m_UpdateStreamDetails = false;
 
   CLog::Log(LOGDEBUG, "CVideoPlayer: updating file item stream details with current streams");
+  printf("updating file item stream details with current stream\n");
 
   VideoStreamInfo videoInfo;
   AudioStreamInfo audioInfo;
@@ -4897,6 +4908,7 @@ void CVideoPlayer::UpdateContentState()
                                                       m_CurrentAudio.demuxerId, m_CurrentAudio.id);
   m_content.m_subtitleIndex = m_SelectionStreams.TypeIndexOf(STREAM_SUBTITLE, m_CurrentSubtitle.source,
                                                          m_CurrentSubtitle.demuxerId, m_CurrentSubtitle.id);
+  printf("UPDATE contect state for m_videoindex %i source=%i muxid=%i curid=%i\n", m_content.m_videoIndex, m_CurrentVideo.source, m_CurrentVideo.demuxerId, m_CurrentVideo.id);
 }
 
 void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo &info)
@@ -4908,7 +4920,7 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo &info)
 
   if (streamId < 0 || streamId > GetVideoStreamCount() - 1)
   {
-    printf("video invalid with id %i\n", streamId);
+    printf("GetVideoStreamInfo: CURRENT_STREAM video invalid with id %i\n", streamId);
     info.valid = false;
     return;
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -439,6 +439,7 @@ void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux
       s.id       = i;
       s.flags    = StreamFlags::FLAG_NONE;
       s.filename = filename;
+      s.demuxerId = -1;
 
       AudioStreamInfo info = nav->GetAudioStreamInfo(i);
       s.name     = info.name;
@@ -457,6 +458,7 @@ void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux
       s.id       = i;
       s.filename = filename;
       s.channels = 0;
+      s.demuxerId = -1;
 
       SubtitleStreamInfo info = nav->GetSubtitleStreamInfo(i);
       s.name     = info.name;
@@ -479,11 +481,13 @@ void CSelectionStreams::Update(std::shared_ptr<CDVDInputStream> input, CDVDDemux
       s.width = info.width;
       s.height = info.height;
       s.codec = info.codecName;
+      s.demuxerId = -1;
       s.name = StringUtils::Format("%s %i", g_localizeStrings.Get(38032).c_str(), i);
       Update(s);
     }
   }
-  else if(demuxer)
+
+  if (demuxer)
   {
     std::string filename = demuxer->GetFileName();
     int source;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -8,6 +8,8 @@
 
 #include "guilib/guiinfo/VideoGUIInfo.h"
 
+#include "math.h"
+
 #include "Application.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
@@ -19,20 +21,19 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "guilib/WindowIDs.h"
-#include "guilib/guiinfo/GUIInfo.h"
-#include "guilib/guiinfo/GUIInfoHelper.h"
-#include "guilib/guiinfo/GUIInfoLabels.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "settings/lib/Setting.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoThumbLoader.h"
 
-#include <math.h>
+#include "guilib/guiinfo/GUIInfo.h"
+#include "guilib/guiinfo/GUIInfoHelper.h"
+#include "guilib/guiinfo/GUIInfoLabels.h"
 
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
@@ -401,6 +402,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_VIDEO_CODEC:
         value = tag->m_streamDetails.GetVideoCodec();
+        printf("codec is %s\n", value.c_str());
         return true;
       case LISTITEM_VIDEO_RESOLUTION:
         value = CStreamDetails::VideoDimsToResolutionDescription(tag->m_streamDetails.GetVideoWidth(), tag->m_streamDetails.GetVideoHeight());


### PR DESCRIPTION
The problem is that some stuff requires a demuxer id to be available (like media flags related code) in the available selectionstreams.

This also fixes the problem that the demuxer id was left uninitialised in the SelectionStream for the dvdnav part, which probably means that part never worked properly anyway.

Maybe the special casing for dvdnav in CSelectionStreams::Update() can completely go, not sure. Hopefully this fix is right. Perhaps people with some more insight can comment.