### PR TITLE
[Android] Implement 'HDR display enable' for ffmpeg decoded streams

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7075,7 +7075,10 @@ msgctxt "#13435"
 msgid "Enable HQ scalers for scaling above"
 msgstr ""
 
-#empty string with id 13436
+#: system/settings/settings.xml
+msgctxt "#13436"
+msgid "Use display HDR capabilities"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13437"
@@ -19055,7 +19058,13 @@ msgctxt "#36298"
 msgid "If enabled, a recording for the programme to remind will be scheduled when auto-closing the reminder popup, if supported by the PVR add-on and backend."
 msgstr ""
 
-#empty strings from id 36299 to 36301
+#. Description of setting with label #13436 "Use display HDR capabilities"
+#: system/settings/settings.xml
+msgctxt "#36299"
+msgid "Switch display into HDR mode if media with HDR information is played.\nIf disabled, HDR information are applied using kodi's internal HDR path"
+msgstr ""
+
+#empty strings from id 36300 to 36301
 
 #: system/settings/settings.xml
 msgctxt "#36302"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -143,6 +143,16 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="winsystem.ishdrdisplay" type="boolean" label="13436" help="36299">
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="ishdrdisplay" />
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="4" label="14232">
         <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">

--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=0c172c8869170d397dea3e3475a4bc1b5fe96345
+VERSION=62dabc1041fcf47aed483f8e2dea15c3cf0122db
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -539,7 +539,7 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
       attribs.Get());
     if (!texture->eglImage)
     {
-      CEGLUtils::LogError("Failed to import VA DRM surface into EGL image");
+      CEGLUtils::Log(LOGERROR, "Failed to import VA DRM surface into EGL image");
       return false;
     }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -202,6 +202,7 @@ protected:
   bool m_fullRange;
   AVColorPrimaries m_srcPrimaries;
   bool m_toneMap = false;
+  bool m_passthroughHDR = false;
   unsigned char* m_planeBuffer = nullptr;
   size_t m_planeBufferSize = 0;
 

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -83,6 +83,11 @@ bool IsFullscreen(const std::string &condition, const std::string &value, Settin
   return CServiceBroker::GetWinSystem()->IsFullScreen();
 }
 
+bool IsHDRDisplay(const std::string& condition, const std::string& value, SettingConstPtr setting, void* data)
+{
+  return CServiceBroker::GetWinSystem()->IsHDRDisplay();
+}
+
 bool IsMasterUser(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
   return g_passwordManager.bMasterUser;
@@ -333,6 +338,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblecontroller",           HasRumbleController));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("haspowerofffeature",            HasPowerOffFeature));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isfullscreen",                  IsFullscreen));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ishdrdisplay",                  IsHDRDisplay));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ismasteruser",                  IsMasterUser));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isusingttfsubtitles",           IsUsingTTFSubtitles));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilecanwritedatabase",       ProfileCanWriteDatabase));

--- a/xbmc/utils/EGLFence.cpp
+++ b/xbmc/utils/EGLFence.cpp
@@ -9,6 +9,7 @@
 #include "EGLFence.h"
 
 #include "EGLUtils.h"
+#include "utils/log.h"
 
 using namespace KODI::UTILS::EGL;
 
@@ -25,7 +26,7 @@ void CEGLFence::CreateFence()
   m_fence = m_eglCreateSyncKHR(m_display, EGL_SYNC_FENCE_KHR, nullptr);
   if (m_fence == EGL_NO_SYNC_KHR)
   {
-    CEGLUtils::LogError("failed to create egl sync fence");
+    CEGLUtils::Log(LOGERROR, "failed to create egl sync fence");
     throw std::runtime_error("failed to create egl sync fence");
   }
 }
@@ -39,7 +40,7 @@ void CEGLFence::DestroyFence()
 
   if (m_eglDestroySyncKHR(m_display, m_fence) != EGL_TRUE)
   {
-    CEGLUtils::LogError("failed to destroy egl sync fence");
+    CEGLUtils::Log(LOGERROR, "failed to destroy egl sync fence");
   }
 
   m_fence = EGL_NO_SYNC_KHR;
@@ -56,7 +57,7 @@ bool CEGLFence::IsSignaled()
   EGLint status = EGL_UNSIGNALED_KHR;
   if (m_eglGetSyncAttribKHR(m_display, m_fence, EGL_SYNC_STATUS_KHR, &status) != EGL_TRUE)
   {
-    CEGLUtils::LogError("failed to query egl sync fence");
+    CEGLUtils::Log(LOGERROR, "failed to query egl sync fence");
     return false;
   }
 

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -22,8 +22,8 @@ public:
   static std::set<std::string> GetClientExtensions();
   static std::set<std::string> GetExtensions(EGLDisplay eglDisplay);
   static bool HasExtension(EGLDisplay eglDisplay, std::string const & name);
-  static bool HasClientExtension(std::string const & name);
-  static void LogError(std::string const & what);
+  static bool HasClientExtension(std::string const& name);
+  static void Log(int logLevel, std::string const& what);
   template<typename T>
   static T GetRequiredProcAddress(const char * procname)
   {
@@ -187,10 +187,11 @@ public:
    */
   bool CreatePlatformDisplay(void* nativeDisplay, EGLNativeDisplayType nativeDisplayLegacy);
 
-  bool CreateSurface(EGLNativeWindowType nativeWindow);
+  void SurfaceAttrib(EGLint attribute, EGLint value);
+  bool CreateSurface(EGLNativeWindowType nativeWindow, EGLint HDRcolorSpace = EGL_NONE);
   bool CreatePlatformSurface(void* nativeWindow, EGLNativeWindowType nativeWindowLegacy);
   bool InitializeDisplay(EGLint renderingApi);
-  bool ChooseConfig(EGLint renderableType, EGLint visualId = 0);
+  bool ChooseConfig(EGLint renderableType, EGLint visualId = 0, bool hdr = false);
   bool CreateContext(CEGLAttributesVec contextAttribs);
   bool BindContext();
   void Destroy();
@@ -227,5 +228,5 @@ private:
   EGLDisplay m_eglDisplay{EGL_NO_DISPLAY};
   EGLSurface m_eglSurface{EGL_NO_SURFACE};
   EGLContext m_eglContext{EGL_NO_CONTEXT};
-  EGLConfig m_eglConfig{};
+  EGLConfig m_eglConfig{}, m_eglHDRConfig{};
 };

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -20,6 +20,8 @@
 #include "guilib/GUIFontTTFGL.h"
 #endif
 
+const char* CWinSystemBase::SETTING_WINSYSTEM_IS_HDR_DISPLAY = "winsystem.ishdrdisplay";
+
 CWinSystemBase::CWinSystemBase()
 {
   m_gfxContext.reset(new CGraphicContext());

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -36,6 +36,8 @@ class CGraphicContext;
 class CRenderSystemBase;
 class IRenderLoop;
 
+struct VideoPicture;
+
 class CWinSystemBase
 {
 public:
@@ -153,6 +155,10 @@ public:
   virtual void* GetHWContext() { return nullptr; }
 
   std::shared_ptr<CDPMSSupport> GetDPMSManager();
+  virtual bool SetHDR(const VideoPicture* videoPicture) { return false; };
+  virtual bool IsHDRDisplay() { return false; };
+
+  static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -194,7 +194,7 @@ CAndroidUtils::~CAndroidUtils()
 {
 }
 
-bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO *res) const
+bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO* res) const
 {
   EGLNativeWindowType nativeWindow = (EGLNativeWindowType)CXBMCApp::GetNativeWindow(30000);
   if (!nativeWindow)
@@ -234,7 +234,7 @@ bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO *res) const
   return true;
 }
 
-bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
+bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO& res)
 {
   CLog::Log(LOGNOTICE, "CAndroidUtils: SetNativeResolution: %s: %dx%d %dx%d@%f", res.strId.c_str(), res.iWidth, res.iHeight, res.iScreenWidth, res.iScreenHeight, res.fRefreshRate);
 
@@ -250,7 +250,7 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
   return true;
 }
 
-bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
+bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
 {
   RESOLUTION_INFO cur_res;
   bool ret = GetNativeResolution(&cur_res);
@@ -315,6 +315,25 @@ bool CAndroidUtils::UpdateDisplayModes()
 {
   fetchDisplayModes();
   return true;
+}
+
+bool CAndroidUtils::IsHDRDisplay()
+{
+  CJNIWindow window = CXBMCApp::getWindow();
+  bool ret = false;
+
+  if (window)
+  {
+    CJNIView view = window.getDecorView();
+    if (view)
+    {
+      CJNIDisplay display = view.getDisplay();
+      if (display)
+        ret = display.isHdr();
+    }
+  }
+  CLog::Log(LOGDEBUG, "CAndroidUtils: IsHDRDisplay: %s", ret ? "true" : "false");
+  return ret;
 }
 
 void  CAndroidUtils::OnSettingChanged(std::shared_ptr<const CSetting> setting)

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -21,10 +21,11 @@ class CAndroidUtils : public ISettingCallback
 public:
   CAndroidUtils();
   virtual ~CAndroidUtils();
-  virtual bool  GetNativeResolution(RESOLUTION_INFO *res) const;
-  virtual bool  SetNativeResolution(const RESOLUTION_INFO &res);
-  virtual bool  ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
-  virtual bool UpdateDisplayModes();
+  bool GetNativeResolution(RESOLUTION_INFO* res) const;
+  bool SetNativeResolution(const RESOLUTION_INFO& res);
+  bool ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions);
+  bool UpdateDisplayModes();
+  bool IsHDRDisplay();
 
   // Implementation of ISettingCallback
   static const std::string SETTING_LIMITGUI;

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -306,6 +306,11 @@ bool CWinSystemAndroid::MessagePump()
   return m_winEvents->MessagePump();
 }
 
+bool CWinSystemAndroid::IsHDRDisplay()
+{
+  return m_android->IsHDRDisplay();
+}
+
 std::unique_ptr<WINDOWING::IOSScreenSaver> CWinSystemAndroid::GetOSScreenSaverImpl()
 {
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> ret(new COSScreenSaverAndroid());

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -50,6 +50,7 @@ public:
 
   // winevents override
   bool MessagePump() override;
+  bool IsHDRDisplay() override;
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -8,11 +8,18 @@
 
 #include "WinSystemAndroidGLESContext.h"
 
+#include "ServiceBroker.h"
 #include "VideoSyncAndroid.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include "platform/android/activity/XBMCApp.h"
+
+#include <EGL/eglext.h>
+
 
 std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
 {
@@ -42,6 +49,14 @@ bool CWinSystemAndroidGLESContext::InitWindowSystem()
     return false;
   }
 
+  m_hasHDRConfig = m_pGLContext.ChooseConfig(EGL_OPENGL_ES2_BIT, 0, true);
+
+  m_hasEGLHDRExtensions = CEGLUtils::HasExtension(m_pGLContext.GetEGLDisplay(), "EGL_EXT_gl_colorspace_bt2020_pq")
+    && CEGLUtils::HasExtension(m_pGLContext.GetEGLDisplay(), "EGL_EXT_surface_SMPTE2086_metadata");
+
+  CLog::Log(LOGDEBUG, "CWinSystemAndroidGLESContext::InitWindowSystem: HDRConfig: %d, HDRExtensions: %d",
+    static_cast<int>(m_hasHDRConfig), static_cast<int>(m_hasEGLHDRExtensions));
+
   CEGLAttributesVec contextAttribs;
   contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
 
@@ -64,7 +79,7 @@ bool CWinSystemAndroidGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_pGLContext.CreateSurface(m_nativeWindow))
+  if (!CreateSurface())
   {
     return false;
   }
@@ -107,7 +122,7 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
   // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
   // we can't actually do anything about it
   if (rendered && !m_pGLContext.TrySwapBuffers())
-    CEGLUtils::LogError("eglSwapBuffers failed");
+    CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
   CXBMCApp::get()->WaitVSync(1000);
 }
 
@@ -142,3 +157,95 @@ std::unique_ptr<CVideoSync> CWinSystemAndroidGLESContext::GetVideoSync(void *clo
   return pVSync;
 }
 
+bool CWinSystemAndroidGLESContext::CreateSurface()
+{
+  if (!m_pGLContext.CreateSurface(m_nativeWindow, m_HDRColorSpace))
+  {
+    if (m_HDRColorSpace != EGL_NONE)
+    {
+      m_HDRColorSpace = EGL_NONE;
+      m_displayMetadata = nullptr;
+      m_lightMetadata = nullptr;
+      if (!m_pGLContext.CreateSurface(m_nativeWindow))
+        return false;
+    }
+    else
+      return false;
+  }
+
+#if EGL_EXT_surface_SMPTE2086_metadata
+  if (m_displayMetadata)
+  {
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_DISPLAY_PRIMARY_RX_EXT, static_cast<int>(av_q2d(m_displayMetadata->display_primaries[0][0]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_DISPLAY_PRIMARY_RY_EXT, static_cast<int>(av_q2d(m_displayMetadata->display_primaries[0][1]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_DISPLAY_PRIMARY_GX_EXT, static_cast<int>(av_q2d(m_displayMetadata->display_primaries[1][0]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_DISPLAY_PRIMARY_GY_EXT, static_cast<int>(av_q2d(m_displayMetadata->display_primaries[1][1]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_DISPLAY_PRIMARY_BX_EXT, static_cast<int>(av_q2d(m_displayMetadata->display_primaries[2][0]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_DISPLAY_PRIMARY_BY_EXT, static_cast<int>(av_q2d(m_displayMetadata->display_primaries[2][1]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_WHITE_POINT_X_EXT, static_cast<int>(av_q2d(m_displayMetadata->white_point[0]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_WHITE_POINT_Y_EXT, static_cast<int>(av_q2d(m_displayMetadata->white_point[1]) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_MAX_LUMINANCE_EXT, static_cast<int>(av_q2d(m_displayMetadata->max_luminance) * EGL_METADATA_SCALING_EXT + 0.5));
+    m_pGLContext.SurfaceAttrib(EGL_SMPTE2086_MIN_LUMINANCE_EXT, static_cast<int>(av_q2d(m_displayMetadata->min_luminance) * EGL_METADATA_SCALING_EXT + 0.5));
+  }
+  if (m_lightMetadata)
+  {
+    m_pGLContext.SurfaceAttrib(EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT, static_cast<int>(m_lightMetadata->MaxCLL * EGL_METADATA_SCALING_EXT));
+    m_pGLContext.SurfaceAttrib(EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT, static_cast<int>(m_lightMetadata->MaxFALL * EGL_METADATA_SCALING_EXT));
+  }
+#endif
+  return true;
+}
+
+bool CWinSystemAndroidGLESContext::IsHDRDisplay()
+{
+  return m_hasHDRConfig && m_hasEGLHDRExtensions && CWinSystemAndroid::IsHDRDisplay();
+}
+
+bool CWinSystemAndroidGLESContext::SetHDR(const VideoPicture* videoPicture)
+{
+  if (!CWinSystemAndroid::IsHDRDisplay() || !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(SETTING_WINSYSTEM_IS_HDR_DISPLAY))
+    return false;
+
+  EGLint HDRColorSpace = 0;
+
+#if EGL_EXT_gl_colorspace_bt2020_linear
+  if (m_hasHDRConfig && m_hasEGLHDRExtensions)
+  {
+    HDRColorSpace = EGL_NONE;
+    if (videoPicture && videoPicture->hasDisplayMetadata)
+    {
+      switch (videoPicture->color_space)
+      {
+      case AVCOL_SPC_BT2020_NCL:
+      case AVCOL_SPC_BT2020_CL:
+      case AVCOL_SPC_BT709:
+        HDRColorSpace = EGL_GL_COLORSPACE_BT2020_PQ_EXT;
+        break;
+      default:
+        m_displayMetadata = nullptr;
+        m_lightMetadata = nullptr;
+      }
+    }
+    else
+    {
+      m_displayMetadata = nullptr;
+      m_lightMetadata = nullptr;
+    }
+
+    if (HDRColorSpace != m_HDRColorSpace)
+    {
+      CLog::Log(LOGDEBUG, "CWinSystemAndroidGLESContext::SetHDR: ColorSpace: %d", HDRColorSpace);
+
+      m_HDRColorSpace = HDRColorSpace;
+      m_displayMetadata = m_HDRColorSpace == EGL_NONE ? nullptr : std::unique_ptr<AVMasteringDisplayMetadata>(new AVMasteringDisplayMetadata(videoPicture->displayMetadata));
+      // TODO: discuss with NVIDIA why this prevent turning HDR display off
+      //m_lightMetadata = !videoPicture || m_HDRColorSpace == EGL_NONE ? nullptr : std::unique_ptr<AVContentLightMetadata>(new AVContentLightMetadata(videoPicture->lightMetadata));
+      m_pGLContext.DestroySurface();
+      CreateSurface();
+      m_pGLContext.BindContext();
+    }
+  }
+#endif
+
+  return m_HDRColorSpace == HDRColorSpace;
+}

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.h
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.h
@@ -13,6 +13,9 @@
 #include "utils/EGLUtils.h"
 #include "utils/GlobalsHandling.h"
 
+struct AVMasteringDisplayMetadata;
+struct AVContentLightMetadata;
+
 class CWinSystemAndroidGLESContext : public CWinSystemAndroid, public CRenderSystemGLES
 {
 public:
@@ -32,6 +35,8 @@ public:
   virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 
   float GetFrameLatencyAdjustment() override;
+  bool IsHDRDisplay() override;
+  bool SetHDR(const VideoPicture* videoPicture) override;
 
   EGLDisplay GetEGLDisplay() const;
   EGLSurface GetEGLSurface() const;
@@ -42,6 +47,13 @@ protected:
   void PresentRenderImpl(bool rendered) override;
 
 private:
-  CEGLContextUtils m_pGLContext;
+  bool CreateSurface();
 
+  CEGLContextUtils m_pGLContext;
+  bool m_hasHDRConfig = false;
+
+  std::unique_ptr<AVMasteringDisplayMetadata> m_displayMetadata;
+  std::unique_ptr<AVContentLightMetadata> m_lightMetadata;
+  EGLint m_HDRColorSpace = EGL_NONE;
+  bool m_hasEGLHDRExtensions = false;
 };

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -74,7 +74,7 @@ bool CWinSystemGbmGLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res
 
   if (!m_eglContext.TrySwapBuffers())
   {
-    CEGLUtils::LogError("eglSwapBuffers failed");
+    CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
     throw std::runtime_error("eglSwapBuffers failed");
   }
 
@@ -103,7 +103,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
     {
       if (!m_eglContext.TrySwapBuffers())
       {
-        CEGLUtils::LogError("eglSwapBuffers failed");
+        CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
         throw std::runtime_error("eglSwapBuffers failed");
       }
     }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -85,7 +85,7 @@ bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
 
   if (!m_eglContext.TrySwapBuffers())
   {
-    CEGLUtils::LogError("eglSwapBuffers failed");
+    CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
     throw std::runtime_error("eglSwapBuffers failed");
   }
 
@@ -114,7 +114,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
     {
       if (!m_eglContext.TrySwapBuffers())
       {
-        CEGLUtils::LogError("eglSwapBuffers failed");
+        CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
         throw std::runtime_error("eglSwapBuffers failed");
       }
     }

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -156,7 +156,7 @@ void CWinSystemRpiGLESContext::PresentRenderImpl(bool rendered)
 
   if (!m_pGLContext.TrySwapBuffers())
   {
-    CEGLUtils::LogError("eglSwapBuffers failed");
+    CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
     throw std::runtime_error("eglSwapBuffers failed");
   }
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -129,7 +129,7 @@ void CWinSystemWaylandEGLContext::PresentFrame(bool rendered)
       // For now we just hard fail if this fails
       // Theoretically, EGL_CONTEXT_LOST could be handled, but it needs to be checked
       // whether egl implementations actually use it (mesa does not)
-      CEGLUtils::LogError("eglSwapBuffers failed");
+      CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
       throw std::runtime_error("eglSwapBuffers failed");
     }
     // eglSwapBuffers() (hopefully) calls commit on the surface and flushes


### PR DESCRIPTION
## Description
This PR implements switching HDR capable displays into HDR mode when playing HDR streams using LinuxRendererGLES GPU rendering.
When using this path, our internal HDR implementation is overriden and HDR calulation is done on GPU / display, its compareable to audio passthrough.

## Motivation and Context
VP9 profile 2 HDR streams are currently not supported on NVIDIA Shield TV, using this PR its from theory possible to play them. 1080p streams don't play smooth yet, but there are still ptions to optimize the render chain (e.g. YUV scanout instead our own YUV2RGB shader)

## How Has This Been Tested?
- NVIDIA Shield TV + youtube addon
enable vp9 dash in youtube addon settings
search for 'vp9 hdr' and play one stream.

- AFTV 4K (no GPU HDR extension)
HDR setting is not visible and internal HDR pipeline is used

- WETEK HUB (SDK version does not support HDR)
HDR setting is not visible and internal HDR pipeline is used

## For discussion
Solved: Should there be an settings option to disable this feature and use our shader HDR calulation instead?
There is now a setting which is only visible if display supports HDR and let users switch between display HDR and internal GL(ES) shader HDR

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
