### PR TITLE
TexturePacker: fix for 32-bit systems

### DIFF
--- a/tools/depends/native/TexturePacker/CMakeLists.txt
+++ b/tools/depends/native/TexturePacker/CMakeLists.txt
@@ -51,4 +51,4 @@ target_link_libraries(TexturePacker
                               ${PNG_LIBRARIES}
                               ${JPEG_LIBRARIES}
                               ${LZO2_LIBRARIES})
-target_compile_options(TexturePacker PRIVATE ${ARCH_DEFINES})
+target_compile_options(TexturePacker PRIVATE ${ARCH_DEFINES} ${SYSTEM_DEFINES})

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -80,7 +80,7 @@ void CreateSkeletonHeaderImpl(CXBTFWriter& xbtfWriter, std::string fullPath, std
 
   if (dirp)
   {
-    while ((dp = readdir(dirp)) != NULL)
+    for (errno = 0; (dp = readdir(dirp)); errno = 0)
     {
       if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
       {
@@ -118,6 +118,8 @@ void CreateSkeletonHeaderImpl(CXBTFWriter& xbtfWriter, std::string fullPath, std
         }
       }
     }
+    if (errno)
+      fprintf(stderr, "Error reading directory %s (%s)\n", fullPath.c_str(), strerror(errno));
 
     closedir(dirp);
   }


### PR DESCRIPTION
## Description
This patch fixes TexturePacker failure on 32-bit systems (eg Raspberry Pi), which resulted in the built-in themes not having any textures (dialog boxes or cursors).

## Motivation and Context
TexturePacker build does not define `_FILE_OFFSET_BITS=64` or `_LARGEFILE64_SOURCE` macros, which can result in `readdir()` failing with `EOVERFLOW` on 32-bit systems.

Furthermore, there is no code to detect this failure, so it's silently ignored.

## How Has This Been Tested?
Built 32-bit version of Kodi in Raspbian chroot.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
