### PR TITLE
bump androidjni sha (fix Display::isHdr()

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=62dabc1041fcf47aed483f8e2dea15c3cf0122db
+VERSION=25258a1e57414b46367ef367ef7291aeeb464d87
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc


### PR DESCRIPTION
## Description
Set libandroidjni SHA to current master HEAD

## Motivation and Context
Android kodi aarch64 version currently segfaults with "method not found" exception because of wrong signature of the return type in Display::isHdr.
This PR forces current libandroidjni HEAD which solves the issue.

## How Has This Been Tested?
- Start kodi on e.g. NVIDIA Shield TV with aarch64 kodi.
- Play a movie with HDR information or open player video settings section.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
