### PR TITLE
[ios] fix broken touch input after closing keyboard on iOS 13

### DIFF
--- a/xbmc/platform/darwin/ios-common/IOSKeyboardView.mm
+++ b/xbmc/platform/darwin/ios-common/IOSKeyboardView.mm
@@ -239,18 +239,17 @@ static CEvent keyboardFinishedEvent;
   // give back the control to whoever
   [_textField resignFirstResponder];
 
-  // always called in the mainloop context
-  // detach the keyboard view from our main controller
-  [g_xbmcController deactivateKeyboard:self];
+  // delay closing view until text field finishes resigning first responder
+  dispatch_async(dispatch_get_main_queue(), ^{
+    // always called in the mainloop context
+    // detach the keyboard view from our main controller
+    [g_xbmcController deactivateKeyboard:self];
 
-  // until keyboard did hide, we let the calling thread break loop
-  if (0 == _keyboardIsShowing)
-  {
     // no more notification we want to receive.
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 
     keyboardFinishedEvent.Set();
-  }
+  });
 }
 
 - (void) deactivate


### PR DESCRIPTION
## Description
On iOS 13 (beta) touch input no longer works after closing keyboard and app appears frozen.

## Motivation and Context
Fixes bug reported in https://forum.kodi.tv/showthread.php?tid=347010

## How Has This Been Tested?
Tested behavior on iPhone 6s iOS 13.1 beta and iPhone 6+ iOS 12.4.1.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed