### PR TITLE
[pvr/videoplayer] fix commercial skip (EDL's) from recordings and library sources

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -45,48 +45,8 @@ void CEdl::Clear()
   m_lastCutTime = 0;
 }
 
-bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFrameRate, const int iHeight)
+bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond)
 {
-  /*
-   * The frame rate hints returned from ffmpeg for the video stream do not appear to take into
-   * account whether the content is interlaced. This affects the calculation to time offsets based
-   * on frames per second as most commercial detection programs use full frames, which need two
-   * interlaced fields to calculate a single frame so the actual frame rate is half.
-   *
-   * Adjust the frame rate using the detected frame rate or height to determine typical interlaced
-   * content (obtained from http://en.wikipedia.org/wiki/Frame_rate)
-   *
-   * Note that this is a HACK and we should be able to get the frame rate from the source sending
-   * back frame markers. However, this doesn't seem possible for MythTV.
-   */
-  float fFramesPerSecond;
-  if (iHeight <= 480 && int(fFrameRate * 100) == 5994) // 59.940 fps = NTSC or 60i content except for 1280x720/60
-  {
-    fFramesPerSecond = fFrameRate / 2; // ~29.97f - division used to retain accuracy of original.
-    CLog::Log(LOGDEBUG, "%s - Assuming NTSC or 60i interlaced content. Adjusted frames per second from %.3f (~59.940 fps) to %.3f",
-              __FUNCTION__, fFrameRate, fFramesPerSecond);
-  }
-  else if (int(fFrameRate * 100) == 4795) // 47.952 fps = 24p -> NTSC conversion
-  {
-    fFramesPerSecond = fFrameRate / 2; // ~23.976f - division used to retain accuracy of original.
-    CLog::Log(LOGDEBUG, "%s - Assuming 24p -> NTSC conversion interlaced content. Adjusted frames per second from %.3f (~47.952 fps) to %.3f",
-              __FUNCTION__, fFrameRate, fFramesPerSecond);
-  }
-  else if (iHeight == 576 && fFrameRate > 30.0) // PAL @ 50.0fps rather than PAL @ 25.0 fps. Can't use direct fps check of 50.0 as this is valid for 720p
-  {
-    fFramesPerSecond = fFrameRate / 2; // ~25.0f - division used to retain accuracy of original.
-    CLog::Log(LOGDEBUG, "%s - Assuming PAL interlaced content. Adjusted frames per second from %.3f (~50.00 fps) to %.3f",
-              __FUNCTION__, fFrameRate, fFramesPerSecond);
-  }
-  else if (iHeight == 1080 && fFrameRate > 30.0) // Don't know of any 1080p content being broadcast at higher than 30.0 fps so assume 1080i
-  {
-    fFramesPerSecond = fFrameRate / 2;
-    CLog::Log(LOGDEBUG, "%s - Assuming 1080i interlaced content. Adjusted frames per second from %.3f to %.3f",
-              __FUNCTION__, fFrameRate, fFramesPerSecond);
-  }
-  else // Assume everything else is not interlaced, e.g. 720p.
-    fFramesPerSecond = fFrameRate;
-
   bool bFound = false;
 
   /*
@@ -231,7 +191,16 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       }
       else if (strFields[i][0] == '#') // #12345 format for frame number
       {
-        iCutStartEnd[i] = (int64_t)(atol(strFields[i].substr(1).c_str()) / fFramesPerSecond * 1000); // frame number to ms
+        if (fFramesPerSecond > 0.0f)
+        {
+          iCutStartEnd[i] = static_cast<int64_t>(std::atol(strFields[i].substr(1).c_str()) / fFramesPerSecond * 1000); // frame number to ms
+        }
+        else
+        {
+          CLog::Log(LOGERROR, "Edl::ReadEdl - Frame number not supported in EDL files when frame rate is unavailable (ts) - supplied frame number: %s",
+                    strFields[i].substr(1).c_str());
+          return false;
+        }
       }
       else // Plain old seconds in float format, e.g. 123.45
       {
@@ -341,9 +310,17 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
     /*
      * Not all generated Comskip files have the frame rate information.
      */
-    fFrameRate = fFramesPerSecond;
-    CLog::Log(LOGWARNING, "%s - Frame rate not in Comskip file. Using detected frames per second: %.3f",
-              __FUNCTION__, fFrameRate);
+    if (fFramesPerSecond > 0.0f)
+    {
+      fFrameRate = fFramesPerSecond;
+      CLog::Log(LOGWARNING, "Edl::ReadComskip - Frame rate not in Comskip file. Using detected frames per second: %.3f",
+                fFrameRate);
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "Edl::ReadComskip - Frame rate is unavailable and also not in Comskip file (ts).");
+      return false;
+    }
   }
   else
     fFrameRate /= 100; // Reduce by factor of 100 to get fps.

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -23,7 +23,7 @@ class CEdl
 public:
   CEdl();
 
-  bool ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond, const int iHeight);
+  bool ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesPerSecond);
   void Clear();
 
   bool HasCut() const;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3602,11 +3602,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
 
     // look for any EDL files
     m_Edl.Clear();
-    if (hint.fpsrate > 0 && hint.fpsscale > 0)
-    {
-      float fFramesPerSecond = (float)m_CurrentVideo.hint.fpsrate / (float)m_CurrentVideo.hint.fpsscale;
-      m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond, m_CurrentVideo.hint.height);
-    }
+    float fFramesPerSecond = 0.0f;
+    if (m_CurrentVideo.hint.fpsscale > 0.0f)
+      fFramesPerSecond = static_cast<float>(m_CurrentVideo.hint.fpsrate) / static_cast<float>(m_CurrentVideo.hint.fpsscale);
+    m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond);
     CServiceBroker::GetDataCacheCore().SetCutList(m_Edl.GetCutList());
 
     static_cast<IDVDStreamPlayerVideo*>(player)->SetSpeed(m_streamPlayerSpeed);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Fixes commercial skipping from both PVR recordings and library sources reported on 18.4.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Broken as per this issue:
https://github.com/xbmc/xbmc/issues/16564

Since commit e68bc9f22a576bc143014a7c3b46108a0388402f frame rate and scale are no longer loaded for PVR video when required to load the EDL file. Without these the file i skipped.

This can be worked around by setting a fallback framerate in `PVR Settings->Playback`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On OSX using latest master. Used a pvr recording with a valid EDL file and tested from both the recordings in PVR UI and as a library source. In both cases the EDL is loaded correctly.

Also tested using frame number in an EDL file and the the loading of the EDL fails as expected for a TS file.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed