### PR TITLE
[Binary addons] Use VERSION_MIN for automated generated dependency requirements

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -108,7 +108,7 @@ macro (build_addon target prefix libs)
         if("${include_name}" MATCHES "_DEPENDS")
           # Use start definition name as base for other value type
           list(GET loop_var 0 list_name)
-          string(REPLACE "_DEPENDS" "" depends_name ${list_name})
+          string(REPLACE "_DEPENDS" "_MIN" depends_name ${list_name})
           string(REPLACE "_DEPENDS" "_XML_ID" xml_entry_name ${list_name})
           string(REPLACE "_DEPENDS" "_USED" used_type_name ${list_name})
 


### PR DESCRIPTION
## Description
kodi cmake process replaces @ADDON_DEPENDS@ inside addon.xml.in files of binary addons with a list of kodi API dependencies + version. Currently the interface version is taken instead interface min version what is wrong (https://github.com/peak3d/inputstream.adaptive/blob/master/inputstream.adaptive/addon.xml.in#L7).

When version of addon is increased (https://github.com/xbmc/xbmc/blob/master/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h) but VERSION_MIN stays untouched, the binary addon should be still compatible with kodi versions which support MIN_VERSION

## Motivation and Context
After bumping ADDON_INSTANCE_VERSION_INPUTSTREAM, building addon with this new version, kodi with previous version is unable to load the addon (incompatible). This is incorrect because VERSION_MIN was not changed.

## How Has This Been Tested?
- Bump ADDON_INSTANCE_VERSION_INPUTSTREAM
- build binary addon
- revert ADDON_INSTANCE_VERSION_INPUTSTREAM
- Launch kodi

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
