### PR TITLE
[binary addons] use VERSION_MIN instead VERSION for dependency checks

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -108,7 +108,8 @@ macro (build_addon target prefix libs)
         if("${include_name}" MATCHES "_DEPENDS")
           # Use start definition name as base for other value type
           list(GET loop_var 0 list_name)
-          string(REPLACE "_DEPENDS" "" depends_name ${list_name})
+          string(REPLACE "_DEPENDS" "_MIN" depends_minver ${list_name})
+          string(REPLACE "_DEPENDS" "" depends_ver ${list_name})
           string(REPLACE "_DEPENDS" "_XML_ID" xml_entry_name ${list_name})
           string(REPLACE "_DEPENDS" "_USED" used_type_name ${list_name})
 
@@ -126,7 +127,7 @@ macro (build_addon target prefix libs)
                   list(GET loop_var 1 include_name)
                   string(REGEX REPLACE "[<>\"]|kodi/" "" include_name "${include_name}")
                   if(include_name MATCHES ${depend_header})
-                    set(ADDON_DEPENDS "${ADDON_DEPENDS}\n<import addon=\"${${xml_entry_name}}\" version=\"${${depends_name}}\"/>")
+                    set(ADDON_DEPENDS "${ADDON_DEPENDS}\n<import addon=\"${${xml_entry_name}}\" minversion=\"${${depends_minver}}\" version=\"${${depends_ver}}\"/>")
                     # Inform with them the addon header about used type
                     add_definitions(-D${used_type_name})
                     message(STATUS "Added usage definition: ${used_type_name}")

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -177,7 +177,10 @@ public:
    \param version the version to meet.
    \return true if  min_version <= version <= current_version, false otherwise.
    */
-  bool MeetsVersion(const AddonVersion &version) const override { return m_addonInfo->MeetsVersion(version); }
+  bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const override
+  {
+    return m_addonInfo->MeetsVersion(versionMin, version);
+  }
   bool ReloadSettings() override;
 
   /*! \brief retrieve the running instance of an add-on if it persists while running.

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -310,14 +310,15 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
   for (const auto& it : addon->GetDependencies())
   {
     const std::string &addonID = it.id;
-    const AddonVersion &version = it.requiredVersion;
+    const AddonVersion& versionMin = it.versionMin;
+    const AddonVersion& version = it.version;
     bool optional = it.optional;
     AddonPtr dep;
     bool haveAddon = CServiceBroker::GetAddonMgr().GetAddon(addonID, dep, ADDON_UNKNOWN, false);
-    if ((haveAddon && !dep->MeetsVersion(version)) || (!haveAddon && !optional))
+    if ((haveAddon && !dep->MeetsVersion(versionMin, version)) || (!haveAddon && !optional))
     {
       // we have it but our version isn't good enough, or we don't have it and we need it
-      if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(version))
+      if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(versionMin, version))
       {
         // we don't have it in a repo, or we have it but the version isn't good enough, so dep isn't satisfied.
         CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.asString().c_str());
@@ -733,11 +734,13 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
     if (it->id != "xbmc.metadata")
     {
       const std::string &addonID = it->id;
-      const AddonVersion &version = it->requiredVersion;
+      const AddonVersion& versionMin = it->versionMin;
+      const AddonVersion& version = it->version;
       bool optional = it->optional;
       AddonPtr dependency;
       bool haveAddon = CServiceBroker::GetAddonMgr().GetAddon(addonID, dependency, ADDON_UNKNOWN, false);
-      if ((haveAddon && !dependency->MeetsVersion(version)) || (!haveAddon && !optional))
+      if ((haveAddon && !dependency->MeetsVersion(versionMin, version)) ||
+          (!haveAddon && !optional))
       {
         // we have it but our version isn't good enough, or we don't have it and we need it
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -723,7 +723,7 @@ bool CAddonMgr::IsCompatible(const IAddon& addon)
       {
         AddonPtr addon;
         bool haveAddon = GetAddon(dependency.id, addon);
-        if (!haveAddon || !addon->MeetsVersion(dependency.requiredVersion))
+        if (!haveAddon || !addon->MeetsVersion(dependency.versionMin, dependency.version))
           return false;
       }
     }
@@ -753,7 +753,7 @@ std::vector<DependencyInfo> CAddonMgr::GetDepsRecursive(const std::string& id)
     auto added_it = std::find_if(added.begin(), added.end(), [&](const DependencyInfo& d){ return d.id == current_dep.id;});
     if (added_it != added.end())
     {
-      if (current_dep.requiredVersion < added_it->requiredVersion)
+      if (current_dep.version < added_it->version)
         continue;
 
       bool aopt = added_it->optional;

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -55,6 +55,11 @@ namespace ADDON
     }
   }
 
+  AddonVersion::AddonVersion(const char* version)
+    : AddonVersion(std::string(version ? version : ""))
+  {
+  }
+
   /**Compare two components of a Debian-style version.  Return -1, 0, or 1
    * if a is less than, equal to, or greater than b, respectively.
    */

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -29,6 +29,7 @@ namespace ADDON
   public:
     AddonVersion(const AddonVersion& other) { *this = other; }
     explicit AddonVersion(const std::string& version);
+    explicit AddonVersion(const char* version = nullptr);
     virtual ~AddonVersion() = default;
 
     int Epoch() const { return mEpoch; }

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -486,7 +486,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::Dependency
     {
       CFileItemPtr item(new CFileItem(info_addon->Name()));
       std::stringstream str;
-      str << it.id << " " << it.requiredVersion.asString();
+      str << it.id << " " << it.versionMin.asString() << " -> " << it.version.asString();
       if ((it.optional && !local_addon) || (!it.optional && local_addon))
         str << " " << StringUtils::Format(g_localizeStrings.Get(39022).c_str(),
                                           local_addon ? g_localizeStrings.Get(39019).c_str()

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -75,7 +75,8 @@ namespace ADDON
     virtual CAddonSettings* GetSettings() const =0;
     virtual const std::vector<DependencyInfo> &GetDependencies() const =0;
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
-    virtual bool MeetsVersion(const AddonVersion &version) const =0;
+    virtual bool MeetsVersion(const AddonVersion& versionMin,
+                              const AddonVersion& version) const = 0;
     virtual bool ReloadSettings() =0;
     virtual AddonPtr GetRunningInstance() const=0;
     virtual void OnPreInstall() =0;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -101,7 +101,7 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo)
   : CAddon(addonInfo, ADDON_REPOSITORY)
 {
   DirList dirs;
-  AddonVersion version("0.0.0");
+  AddonVersion version;
   AddonInfoPtr addonver = CServiceBroker::GetAddonMgr().GetAddonInfo("xbmc.addon");
   if (addonver)
     version = addonver->Version();

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -177,9 +177,21 @@ bool CAddonInfo::ProvidesSeveralSubContents() const
   return contents > 0 ? true : false;
 }
 
-bool CAddonInfo::MeetsVersion(const AddonVersion &version) const
+bool CAddonInfo::MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const
 {
-  return m_minversion <= version && version <= m_version;
+  return !(versionMin > m_version || version < m_minversion);
+}
+
+const AddonVersion& CAddonInfo::DependencyMinVersion(const std::string& dependencyID) const
+{
+  auto it = std::find_if(m_dependencies.begin(), m_dependencies.end(),
+                         [&](const DependencyInfo& other) { return other.id == dependencyID; });
+
+  if (it != m_dependencies.end())
+    return it->versionMin;
+
+  static AddonVersion emptyVersion;
+  return emptyVersion;
 }
 
 const AddonVersion& CAddonInfo::DependencyVersion(const std::string& dependencyID) const
@@ -187,9 +199,9 @@ const AddonVersion& CAddonInfo::DependencyVersion(const std::string& dependencyI
   auto it = std::find_if(m_dependencies.begin(), m_dependencies.end(), [&](const DependencyInfo& other) { return other.id == dependencyID; });
 
   if (it != m_dependencies.end())
-    return it->requiredVersion;
+    return it->version;
 
-  static AddonVersion emptyVersion("0.0.0");
+  static AddonVersion emptyVersion;
   return emptyVersion;
 }
 

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -29,16 +29,20 @@ typedef std::vector<AddonInfoPtr> AddonInfos;
 struct DependencyInfo
 {
   std::string id;
-  AddonVersion requiredVersion;
+  AddonVersion versionMin, version;
   bool optional;
-  DependencyInfo(std::string id, AddonVersion requiredVersion, bool optional)
-      : id(id), requiredVersion(requiredVersion), optional(optional) {}
+  DependencyInfo(std::string id, AddonVersion versionMin, AddonVersion version, bool optional)
+    : id(id)
+    , versionMin(versionMin.empty() ? version : versionMin)
+    , version(version)
+    , optional(optional)
+  {
+  }
 
   bool operator==(const DependencyInfo& rhs) const
   {
-    return id == rhs.id &&
-            requiredVersion == rhs.requiredVersion &&
-            optional == rhs.optional;
+    return id == rhs.id && versionMin == rhs.versionMin && version == rhs.version &&
+           optional == rhs.optional;
   }
 
   bool operator!=(const DependencyInfo& rhs) const
@@ -76,6 +80,7 @@ public:
 
   const AddonVersion& Version() const { return m_version; }
   const AddonVersion& MinVersion() const { return m_minversion; }
+  const AddonVersion& DependencyMinVersion(const std::string& dependencyID) const;
   const AddonVersion& DependencyVersion(const std::string& dependencyID) const;
   const std::string& Name() const { return m_name; }
   const std::string& License() const { return m_license; }
@@ -98,7 +103,7 @@ public:
   const std::string& Origin() const { return m_origin; }
   const InfoMap& ExtraInfo() const { return m_extrainfo; }
 
-  bool MeetsVersion(const AddonVersion& version) const;
+  bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const;
   uint64_t PackageSize() const { return m_packageSize; }
   CDateTime InstallDate() const { return m_installDate; }
   CDateTime LastUpdated() const { return m_lastUpdated; }
@@ -121,8 +126,8 @@ private:
   TYPE m_mainType = ADDON_UNKNOWN;
   std::vector<CAddonType> m_types;
 
-  AddonVersion m_version{"0.0.0"};
-  AddonVersion m_minversion{"0.0.0"};
+  AddonVersion m_version;
+  AddonVersion m_minversion;
   std::string m_name;
   std::string m_license;
   std::unordered_map<std::string, std::string> m_summary;

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -166,7 +166,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   /*
    * Parse addon.xml:
    * <requires>
-   *   <import addon="???" version="???" optional="???"/>
+   *   <import addon="???" minversion="???" version="???" optional="???"/>
    * </requires>
    */
   const TiXmlElement* requires = element->FirstChildElement("requires");
@@ -177,11 +177,13 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
       cstring = child->Attribute("addon");
       if (cstring)
       {
+        const char* versionMin = child->Attribute("minversion");
         const char* version = child->Attribute("version");
         bool optional = false;
         child->QueryBoolAttribute("optional", &optional);
 
-        addon->m_dependencies.emplace_back(cstring, AddonVersion(version ? version : "0.0.0"), optional);
+        addon->m_dependencies.emplace_back(cstring, AddonVersion(versionMin), AddonVersion(version),
+                                           optional);
       }
     }
   }

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -373,6 +373,16 @@ bool CAddonDll::DllLoaded(void) const
   return m_pDll != NULL;
 }
 
+AddonVersion CAddonDll::GetTypeVersionDll(int type) const
+{
+  return AddonVersion(m_pDll ? m_pDll->GetAddonTypeVersion(type) : nullptr);
+}
+
+AddonVersion CAddonDll::GetTypeMinVersionDll(int type) const
+{
+  return AddonVersion(m_pDll ? m_pDll->GetAddonTypeMinVersion(type) : nullptr);
+}
+
 ADDON_STATUS CAddonDll::GetStatus()
 {
   return m_pDll->GetStatus();
@@ -470,9 +480,9 @@ bool CAddonDll::CheckAPIVersion(int type)
     : addonVersion;
 
   /* Check the global usage from addon
-   * if not used from addon becomes "0.0.0" returned
+   * if not used from addon, empty version is returned
    */
-  if (type <= ADDON_GLOBAL_MAX && addonVersion == AddonVersion("0.0.0"))
+  if (type <= ADDON_GLOBAL_MAX && addonVersion.empty())
     return true;
 
   /* If a instance (not global) version becomes checked must be the version

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -42,6 +42,28 @@ namespace ADDON
     bool DllLoaded(void) const;
 
     /*!
+    * @brief Get api version of moduleType type
+    *
+    * @return The version of requested type, if dll is loaded and supported by addon.
+    *         If one of both do not match, an empty version is returned.
+    *
+    * @note This should only be called if the associated dll is loaded.
+    * Otherwise use @ref CAddonInfo::DependencyVersion(...)
+    */
+    AddonVersion GetTypeVersionDll(int type) const;
+
+    /*!
+    * @brief Get api min version of moduleType type
+    *
+    * @return The version of requested type, if dll is loaded and supported by addon.
+    *         If one of both do not match, an empty version is returned.
+    *
+    * @note This should only be called if the associated dll is loaded.
+    * Otherwise use @ref CAddonInfo::DependencyMinVersion(...)
+    */
+    AddonVersion GetTypeMinVersionDll(int type) const;
+
+    /*!
      * @brief Function to create a addon instance class
      *
      * @param[in] instanceType The wanted instance type class to open on addon

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
@@ -70,7 +70,7 @@ std::string IAddonInstanceHandler::Profile() const
 
 AddonVersion IAddonInstanceHandler::Version() const
 {
-  return m_addon ? m_addon->Version() : AddonVersion("0.0.0");
+  return m_addon ? m_addon->Version() : AddonVersion();
 }
 
 ADDON_STATUS IAddonInstanceHandler::CreateInstance(KODI_HANDLE instance)

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -107,9 +107,10 @@ const std::string& CBinaryAddonBase::Disclaimer() const
   return m_addonInfo->Disclaimer();
 }
 
-bool CBinaryAddonBase::MeetsVersion(const AddonVersion& version) const
+bool CBinaryAddonBase::MeetsVersion(const AddonVersion& versionMin,
+                                    const AddonVersion& version) const
 {
-  return m_addonInfo->MeetsVersion(version);
+  return m_addonInfo->MeetsVersion(versionMin, version);
 }
 
 AddonDllPtr CBinaryAddonBase::GetAddon(const IAddonInstanceHandler* handler)

--- a/xbmc/addons/binary-addons/BinaryAddonBase.h
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.h
@@ -51,7 +51,7 @@ namespace ADDON
     const ArtMap& Art() const;
     const std::string& Disclaimer() const;
 
-    bool MeetsVersion(const AddonVersion& version) const;
+    bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const;
 
     AddonDllPtr GetAddon(const IAddonInstanceHandler* handler);
     void ReleaseAddon(const IAddonInstanceHandler* handler);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -278,7 +278,7 @@ inline const char* GetTypeVersion(int type)
       return ADDON_INSTANCE_VERSION_VIDEOCODEC;
 #endif
   }
-  return "0.0.0";
+  return nullptr;
 }
 
 ///
@@ -331,7 +331,7 @@ inline const char* GetTypeMinVersion(int type)
     case ADDON_INSTANCE_VIDEOCODEC:
       return ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN;
   }
-  return "0.0.0";
+  return nullptr;
 }
 
 ///

--- a/xbmc/addons/test/TestAddonBuilder.cpp
+++ b/xbmc/addons/test/TestAddonBuilder.cpp
@@ -29,7 +29,7 @@ TEST_F(TestAddonBuilder, ShouldFailWhenEmpty)
 TEST_F(TestAddonBuilder, ShouldBuildDependencyAddons)
 {
   std::vector<DependencyInfo> deps;
-  deps.emplace_back("a", AddonVersion("1.0.0"), false);
+  deps.emplace_back("a", AddonVersion("1.0.0"), AddonVersion("1.0.10"), false);
 
   CAddonInfoBuilder::CFromDB builder;
   builder.SetId("aa");

--- a/xbmc/addons/test/TestAddonInfoBuilder.cpp
+++ b/xbmc/addons/test/TestAddonInfoBuilder.cpp
@@ -21,9 +21,9 @@ const std::string addonXML = R"xml(
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
-    <import addon="metadata.common.imdb.com" version="2.9.2"/>
-    <import addon="metadata.common.themoviedb.org" version="3.1.0"/>
-    <import addon="plugin.video.youtube" version="4.4.10" optional="true"/>
+    <import addon="metadata.common.imdb.com" minversion="2.9.2" version="2.9.2"/>
+    <import addon="metadata.common.themoviedb.org" minversion="3.1.0" version="3.1.0"/>
+    <import addon="plugin.video.youtube" minversion="4.4.0" version="4.4.10" optional="true"/>
   </requires>
   <extension point="xbmc.metadata.scraper.movies"
              language="en"
@@ -104,16 +104,20 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
   ASSERT_EQ(dependencies.size(), (long unsigned int)4);
   EXPECT_EQ(dependencies[0].id, "xbmc.metadata");
   EXPECT_EQ(dependencies[0].optional, false);
-  EXPECT_EQ(dependencies[0].requiredVersion.asString(), "2.1.0");
+  EXPECT_EQ(dependencies[0].versionMin.asString(), "2.1.0");
+  EXPECT_EQ(dependencies[0].version.asString(), "2.1.0");
   EXPECT_EQ(dependencies[1].id, "metadata.common.imdb.com");
   EXPECT_EQ(dependencies[1].optional, false);
-  EXPECT_EQ(dependencies[1].requiredVersion.asString(), "2.9.2");
+  EXPECT_EQ(dependencies[1].versionMin.asString(), "2.9.2");
+  EXPECT_EQ(dependencies[1].version.asString(), "2.9.2");
   EXPECT_EQ(dependencies[2].id, "metadata.common.themoviedb.org");
   EXPECT_EQ(dependencies[2].optional, false);
-  EXPECT_EQ(dependencies[2].requiredVersion.asString(), "3.1.0");
+  EXPECT_EQ(dependencies[2].versionMin.asString(), "3.1.0");
+  EXPECT_EQ(dependencies[2].version.asString(), "3.1.0");
   EXPECT_EQ(dependencies[3].id, "plugin.video.youtube");
   EXPECT_EQ(dependencies[3].optional, true);
-  EXPECT_EQ(dependencies[3].requiredVersion.asString(), "4.4.10");
+  EXPECT_EQ(dependencies[3].versionMin.asString(), "4.4.0");
+  EXPECT_EQ(dependencies[3].version.asString(), "4.4.10");
 
   auto info = addon->ExtraInfo().find("language");
   ASSERT_NE(info, addon->ExtraInfo().end());

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -357,12 +357,12 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
     videoStream->iBitRate = stream.m_BitRate;
     videoStream->profile = ConvertVideoCodecProfile(stream.m_codecProfile);
 
-    if (GetAddonBase()->DependencyVersion(ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID) >= AddonVersion("2.0.8"))
+    if (Addon()->GetTypeVersionDll(ADDON_TYPE::ADDON_INSTANCE_INPUTSTREAM) >= AddonVersion("2.0.8"))
     {
       videoStream->colorSpace = static_cast<AVColorSpace>(stream.m_colorSpace);
       videoStream->colorRange = static_cast<AVColorRange>(stream.m_colorRange);
     }
-    if (GetAddonBase()->DependencyVersion(ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID) >= AddonVersion("2.0.9"))
+    if (Addon()->GetTypeVersionDll(ADDON_TYPE::ADDON_INSTANCE_INPUTSTREAM) >= AddonVersion("2.0.9"))
     {
       videoStream->colorPrimaries = static_cast<AVColorPrimaries>(stream.m_colorPrimaries);
       videoStream->colorTransferCharacteristic = static_cast<AVColorTransferCharacteristic>(stream.m_colorTransferCharacteristic);

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -230,7 +230,8 @@ static CVariant Serialize(const AddonPtr& addon)
   {
     CVariant info(CVariant::VariantTypeObject);
     info["addonid"] = dep.id;
-    info["version"] = dep.requiredVersion.asString();
+    info["minversion"] = dep.versionMin.asString();
+    info["version"] = dep.version.asString();
     info["optional"] = dep.optional;
     variant["dependencies"].push_back(std::move(info));
   }


### PR DESCRIPTION
## Description
This PR follows up the discussion here: https://github.com/xbmc/xbmc/pull/16588 and provides a solution for @AlwinEsch 's comment about DependencyVersion.

Instead calling GetAddonBase()->DependencyVersion (based on addon.xml) we now call Addon()::GetTypeVersion into the shared lib to retrieve the api version of dependent api interface.

## Motivation and Context
In this PR: https://github.com/xbmc/xbmc/pull/16581/files#diff-4c2766e2feef12a473b0ec2d55da630bR372-R377 there have been some functions added which let kodi retrieve chapter information from inputstream addon.

To archive the goal, that inputstream addons compiled with this change are still compatible with kodi versions without IChapter implementation, this check was implemented: https://github.com/xbmc/xbmc/pull/16581/files#diff-4c2766e2feef12a473b0ec2d55da630bR372-R377

Even MIN_VERSION (https://github.com/xbmc/xbmc/blob/master/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h#L91-L92) remained unchanged (2.0.7) and only VERSION was set to 2.0.10 in the PR , the addon was rejected from kodi without the PR (2.0.7 -> 2.0.9).

Reason is that the dependency of kodi.inputstream (injected by AddonHelper.cmake into addon.xml.in) is set to 2.0.10 instead 2.0.7.

If kodi, which supports 2.0.7 -> 2.0.9) now tries to load an addon dependency with 2.0.10, this fails for sure. But it shouldn't because the new implementation (in addon) is compatible for kodi binaries beginning with 2.0.7. If kodi supports the MIN_VERSION of the addon, all should be fine.

## How Has This Been Tested?
- use this PR: https://github.com/xbmc/xbmc/pull/16581 which bumps ADDON_INSTANCE_VERSION_INPUTSTREAM from 2.0.9 to 2.0.10
- compile binary addon
- revert the PR, only rebuild kodi,
- start kodi, try to enable inputstream.adaptive binary addon (fails)
- apply this PR, rebuid only kodi
- start kodi again, enable inputstream.adaptive (succeeds)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
