### PR TITLE
[Buildsteps] Fix URL for list of Kodi mirrors

### DIFF
--- a/tools/buildsteps/windows/download-dependencies.bat
+++ b/tools/buildsteps/windows/download-dependencies.bat
@@ -48,7 +48,7 @@ IF NOT EXIST %FORMED_OK_FLAG% (
   ECHO.
   ECHO I tried to get the packages from %KODI_MIRROR%;
   ECHO if this download mirror seems to be having problems, try choosing another from
-  ECHO the list on http://mirrors.kodi.tv/list.html, and setting %%KODI_MIRROR%% to
+  ECHO the list on http://mirrors.kodi.tv/timestamp.txt?mirrorlist, and setting %%KODI_MIRROR%% to
   ECHO point to it, like so:
   ECHO   C:\^> SET KODI_MIRROR=http://example.com/pub/xbmc/
   ECHO.


### PR DESCRIPTION
## Description

 - http://mirrors.kodi.tv/list.html does not exist anymore
 - http://mirrors.kodi.tv/timestamp.txt?mirrorlist should be used instead

See https://forum.kodi.tv/showthread.php?tid=347151

## Motivation and Context
`404 - Not Found` on old url

## How Has This Been Tested?
New URL has been opened (status code `200`)

## Screenshots (if appropriate):
n/a 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
