### PR TITLE
added: as.xml option to disable Curl HTTP2

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -628,9 +628,11 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   if (!m_cipherlist.empty())
     g_curlInterface.easy_setopt(h, CURLOPT_SSL_CIPHER_LIST, m_cipherlist.c_str());
 
-  // enable HTTP2 support. default: CURL_HTTP_VERSION_1_1. Curl >= 7.62.0 defaults to CURL_HTTP_VERSION_2TLS
-  g_curlInterface.easy_setopt(h, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
-
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_curlDisableHTTP2)
+    g_curlInterface.easy_setopt(h, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+  else
+    // enable HTTP2 support. default: CURL_HTTP_VERSION_1_1. Curl >= 7.62.0 defaults to CURL_HTTP_VERSION_2TLS
+    g_curlInterface.easy_setopt(h, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
 }
 
 void CCurlFile::SetRequestHeaders(CReadState* state)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -362,6 +362,7 @@ void CAdvancedSettings::Initialize()
   m_curlretries = 2;
   m_curlDisableIPV6 = false;      //Certain hardware/OS combinations have trouble
                                   //with ipv6.
+  m_curlDisableHTTP2 = false;
 
 #if defined(TARGET_DARWIN_EMBEDDED)
   m_startFullScreen = true;
@@ -844,7 +845,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "curlclienttimeout", m_curlconnecttimeout, 1, 1000);
     XMLUtils::GetInt(pElement, "curllowspeedtime", m_curllowspeedtime, 1, 1000);
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
-    XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
+    XMLUtils::GetBoolean(pElement, "disableipv6", m_curlDisableIPV6);
+    XMLUtils::GetBoolean(pElement, "disablehttp2", m_curlDisableHTTP2);
   }
 
   pElement = pRootElement->FirstChildElement("cache");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -298,6 +298,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_curllowspeedtime;
     int m_curlretries;
     bool m_curlDisableIPV6;
+    bool m_curlDisableHTTP2;
 
     bool m_fullScreen;
     bool m_startFullScreen;


### PR DESCRIPTION
Allows disabling HTTP2 for broken Curl / HTTP2 servers. Potentially fixes #15417