### PR TITLE
[binary addons] support C-based compilers/tooling with headers

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -446,7 +446,7 @@ public:
     if (*addonInstance == nullptr)
       throw std::logic_error("kodi::addon::CAddonBase CreateInstanceEx returns a empty instance pointer!");
 
-    if (static_cast<::kodi::addon::IAddonInstance*>(*addonInstance)->m_type != instanceType)
+    if (static_cast< ::kodi::addon::IAddonInstance*>(*addonInstance)->m_type != instanceType)
       throw std::logic_error("kodi::addon::CAddonBase CreateInstanceEx with difference on given and returned instance type!");
 
     return status;
@@ -456,8 +456,8 @@ public:
   {
     if (CAddonBase::m_interface->globalSingleInstance == nullptr && instance != CAddonBase::m_interface->addonBase)
     {
-      if (static_cast<::kodi::addon::IAddonInstance*>(instance)->m_type == instanceType)
-        delete static_cast<::kodi::addon::IAddonInstance*>(instance);
+      if (static_cast< ::kodi::addon::IAddonInstance*>(instance)->m_type == instanceType)
+        delete static_cast< ::kodi::addon::IAddonInstance*>(instance);
       else
         throw std::logic_error("kodi::addon::CAddonBase DestroyInstance called with difference on given and present instance type!");
     }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -9,12 +9,18 @@
 #pragma once
 
 #include <stdarg.h>     /* va_list, va_start, va_arg, va_end */
+#ifdef __cplusplus
 #include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
+#else
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#endif
 
 #ifndef TARGET_WINDOWS
 #ifndef __cdecl
@@ -60,11 +66,15 @@
 
 #include "versions.h"
 
+#ifdef __cplusplus
 namespace kodi { namespace addon { class CAddonBase; }}
 namespace kodi { namespace addon { class IAddonInstance; }}
 namespace kodi { namespace gui { struct IRenderHelper; }}
+#endif
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 //==============================================================================
 /// Standard undefined pointer handle
@@ -140,7 +150,7 @@ struct ADDON_HANDLE_STRUCT
   void *dataAddress;    /*!< address to store data in */
   int   dataIdentifier; /*!< parameter to pass back when calling the callback */
 };
-typedef ADDON_HANDLE_STRUCT *ADDON_HANDLE;
+typedef struct ADDON_HANDLE_STRUCT *ADDON_HANDLE;
 
 /*
  * To have a on add-on and kodi itself handled string always on known size!
@@ -180,11 +190,11 @@ typedef struct AddonToKodiFuncTable_Addon
   bool (*set_setting_float)(void* kodiBase, const char* id, float value);
   bool (*set_setting_string)(void* kodiBase, const char* id, const char* value);
 
-  AddonToKodiFuncTable_kodi* kodi;
-  AddonToKodiFuncTable_kodi_audioengine* kodi_audioengine;
-  AddonToKodiFuncTable_kodi_filesystem* kodi_filesystem;
-  AddonToKodiFuncTable_kodi_gui* kodi_gui;
-  AddonToKodiFuncTable_kodi_network *kodi_network;
+  struct AddonToKodiFuncTable_kodi* kodi;
+  struct AddonToKodiFuncTable_kodi_audioengine* kodi_audioengine;
+  struct AddonToKodiFuncTable_kodi_filesystem* kodi_filesystem;
+  struct AddonToKodiFuncTable_kodi_gui* kodi_gui;
+  struct AddonToKodiFuncTable_kodi_network *kodi_network;
 
   void* (*get_interface)(void* kodiBase, const char *name, const char *version);
 } AddonToKodiFuncTable_Addon;
@@ -202,6 +212,7 @@ typedef struct KodiToAddonFuncTable_Addon
   ADDON_STATUS(*create_instance_ex)(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parent, const char* version);
 } KodiToAddonFuncTable_Addon;
 
+#ifdef __cplusplus
 /*
  * Main structure passed from kodi to addon with basic information needed to
  * create add-on.
@@ -232,9 +243,13 @@ typedef struct AddonGlobalInterface
   // Set from addon header!
   KodiToAddonFuncTable_Addon* toAddon;
 } AddonGlobalInterface;
+#endif
 
+#ifdef __cplusplus
 } /* extern "C" */
+#endif
 
+#ifdef __cplusplus
 //==============================================================================
 namespace kodi {
 namespace addon {
@@ -762,3 +777,4 @@ inline void* GetInterface(const std::string &name, const std::string &version)
   AddonGlobalInterface* kodi::addon::CAddonBase::m_interface = nullptr; \
   std::string kodi::addon::CAddonBase::m_strGlobalApiVersion;
 
+#endif

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -469,6 +469,7 @@ typedef struct game_controller_layout
 } ATTRIBUTE_PACKED game_controller_layout;
 
 struct game_input_port;
+typedef struct game_input_port game_input_port;
 
 /*!
  * \brief Device that can provide input
@@ -594,11 +595,11 @@ typedef struct game_input_event
 
 /// @name Environment types
 ///{
-struct game_system_timing
+typedef struct game_system_timing
 {
   double fps;                   // FPS of video content.
   double sample_rate;           // Sampling rate of audio.
-};
+} game_system_timing;
 ///}
 
 /*! Properties passed to the ADDON_Create() method of a game client */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
@@ -56,15 +56,15 @@ extern "C" {
 #endif
 
   /* EPG_TAG.iFlags values */
-  const unsigned int EPG_TAG_FLAG_UNDEFINED = 0x00000000; /*!< @brief nothing special to say about this entry */
-  const unsigned int EPG_TAG_FLAG_IS_SERIES = 0x00000001; /*!< @brief this EPG entry is part of a series */
+  static const unsigned int EPG_TAG_FLAG_UNDEFINED = 0x00000000; /*!< @brief nothing special to say about this entry */
+  static const unsigned int EPG_TAG_FLAG_IS_SERIES = 0x00000001; /*!< @brief this EPG entry is part of a series */
 
   /* Special EPG_TAG.iUniqueBroadcastId value */
 
   /*!
    * @brief special EPG_TAG.iUniqueBroadcastId value to indicate that a tag has not a valid EPG event uid.
    */
-  const unsigned int EPG_TAG_INVALID_UID = 0;
+  static const unsigned int EPG_TAG_INVALID_UID = 0;
 
   /*!
    * @brief EPG event states. Used with EpgEventStateChange callback.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -31,6 +31,7 @@
 #include "DemuxPacket.h"
 #else
 struct DemuxPacket;
+typedef struct DemuxPacket DemuxPacket;
 #endif
 
 #undef ATTRIBUTE_PACKED
@@ -627,6 +628,7 @@ extern "C" {
     xbmc_codec_t (*GetCodecByName)(const void* kodiInstance, const char* strCodecName);
   } AddonToKodiFuncTable_PVR;
 
+#ifdef __cplusplus
   /*!
    * @brief Structure to transfer the methods from xbmc_pvr_dll.h to Kodi
    */
@@ -715,6 +717,7 @@ extern "C" {
     AddonToKodiFuncTable_PVR toKodi;
     KodiToAddonFuncTable_PVR toAddon;
   } AddonInstance_PVR;
+#endif
 
 #ifdef __cplusplus
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -100,92 +100,92 @@ extern "C" {
   /*!
    * @brief numeric PVR timer type definitions (PVR_TIMER.iTimerType values)
    */
-  const unsigned int PVR_TIMER_TYPE_NONE = 0; /*!< @brief "Null" value for a numeric timer type. */
+  static const unsigned int PVR_TIMER_TYPE_NONE = 0; /*!< @brief "Null" value for a numeric timer type. */
 
   /*!
    * @brief special PVR_TIMER.iClientIndex value to indicate that a timer has not (yet) a valid client index.
    */
-  const unsigned int PVR_TIMER_NO_CLIENT_INDEX = 0; /*!< @brief timer has not (yet) a valid client index. */
+  static const unsigned int PVR_TIMER_NO_CLIENT_INDEX = 0; /*!< @brief timer has not (yet) a valid client index. */
 
   /*!
    * @brief special PVR_TIMER.iParentClientIndex value to indicate that a timer has no parent.
    */
-  const unsigned int PVR_TIMER_NO_PARENT = PVR_TIMER_NO_CLIENT_INDEX; /*!< @brief timer has no parent; it was not scheduled by a repeating timer. */
+  static const unsigned int PVR_TIMER_NO_PARENT = PVR_TIMER_NO_CLIENT_INDEX; /*!< @brief timer has no parent; it was not scheduled by a repeating timer. */
 
   /*!
    * @brief special PVR_TIMER.iEpgUid value to indicate that a timer has no EPG event uid.
    */
-  const unsigned int PVR_TIMER_NO_EPG_UID = EPG_TAG_INVALID_UID; /*!< @brief timer has no EPG event uid. */
+  static const unsigned int PVR_TIMER_NO_EPG_UID = EPG_TAG_INVALID_UID; /*!< @brief timer has no EPG event uid. */
 
   /*!
    * @brief special PVR_TIMER.iClientChannelUid value to indicate "any channel". Useful for some repeating timer types.
    */
-  const int PVR_TIMER_ANY_CHANNEL = -1; /*!< @brief denotes "any channel", not a specific one. */
+  static const int PVR_TIMER_ANY_CHANNEL = -1; /*!< @brief denotes "any channel", not a specific one. */
 
   /*!
    * @brief PVR timer type attributes (PVR_TIMER_TYPE.iAttributes values)
    */
-  const unsigned int PVR_TIMER_TYPE_ATTRIBUTE_NONE                    = 0x00000000;
+  static const unsigned int PVR_TIMER_TYPE_ATTRIBUTE_NONE                    = 0x00000000;
 
-  const unsigned int PVR_TIMER_TYPE_IS_MANUAL                         = 0x00000001; /*!< @brief defines whether this is a type for manual (time-based) or epg-based timers */
-  const unsigned int PVR_TIMER_TYPE_IS_REPEATING                      = 0x00000002; /*!< @brief defines whether this is a type for repeating or one-shot timers */
-  const unsigned int PVR_TIMER_TYPE_IS_READONLY                       = 0x00000004; /*!< @brief timers of this type must not be edited by Kodi */
-  const unsigned int PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES             = 0x00000008; /*!< @brief timers of this type must not be created by Kodi. All other operations are allowed, though */
+  static const unsigned int PVR_TIMER_TYPE_IS_MANUAL                         = 0x00000001; /*!< @brief defines whether this is a type for manual (time-based) or epg-based timers */
+  static const unsigned int PVR_TIMER_TYPE_IS_REPEATING                      = 0x00000002; /*!< @brief defines whether this is a type for repeating or one-shot timers */
+  static const unsigned int PVR_TIMER_TYPE_IS_READONLY                       = 0x00000004; /*!< @brief timers of this type must not be edited by Kodi */
+  static const unsigned int PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES             = 0x00000008; /*!< @brief timers of this type must not be created by Kodi. All other operations are allowed, though */
 
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE           = 0x00000010; /*!< @brief this type supports enabling/disabling of the timer (PVR_TIMER.state SCHEDULED|DISABLED) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_CHANNELS                 = 0x00000020; /*!< @brief this type supports channels (PVR_TIMER.iClientChannelUid) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_TIME               = 0x00000040; /*!< @brief this type supports a recording start time (PVR_TIMER.startTime) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH          = 0x00000080; /*!< @brief this type supports matching epg episode title using PVR_TIMER.strEpgSearchString */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH       = 0x00000100; /*!< @brief this type supports matching "more" epg data (not just episode title) using PVR_TIMER.strEpgSearchString. Setting FULLTEXT_EPG_MATCH implies TITLE_EPG_MATCH */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY                = 0x00000200; /*!< @brief this type supports a first day the timer gets active (PVR_TIMER.firstday) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS                 = 0x00000400; /*!< @brief this type supports weekdays for defining the recording schedule (PVR_TIMER.iWeekdays) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES = 0x00000800; /*!< @brief this type supports the "record only new episodes" feature (PVR_TIMER.iPreventDuplicateEpisodes) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN         = 0x00001000; /*!< @brief this type supports pre and post record time (PVR_TIMER.iMarginStart, PVR_TIMER.iMarginEnd) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_PRIORITY                 = 0x00002000; /*!< @brief this type supports recording priority (PVR_TIMER.iPriority) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_LIFETIME                 = 0x00004000; /*!< @brief this type supports recording lifetime (PVR_TIMER.iLifetime) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS        = 0x00008000; /*!< @brief this type supports placing recordings in user defined folders (PVR_TIMER.strDirectory) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP          = 0x00010000; /*!< @brief this type supports a list of recording groups (PVR_TIMER.iRecordingGroup) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_TIME                 = 0x00020000; /*!< @brief this type supports a recording end time (PVR_TIMER.endTime) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME            = 0x00040000; /*!< @brief enables an 'Any Time' over-ride option for startTime (using PVR_TIMER.bStartAnyTime) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME              = 0x00080000; /*!< @brief enables a separate 'Any Time' over-ride for endTime (using PVR_TIMER.bEndAnyTime) */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports specifying a maximum recordings setting' (PVR_TIMER.iMaxRecordings) */
-  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE        = 0x00200000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag */
-  const unsigned int PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE         = 0x00400000; /*!< @brief this type should not appear on any create menus which provide an associated EPG tag */
-  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE     = 0x00800000; /*!< @brief this type should not appear on any create menus unless associated with an EPG tag with 'series' attributes (EPG_TAG.iFlags & EPG_TAG_FLAG_IS_SERIES || EPG_TAG.iSeriesNumber > 0 || EPG_TAG.iEpisodeNumber > 0 || EPG_TAG.iEpisodePartNumber > 0). Implies PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL              = 0x01000000; /*!< @brief this type supports 'any channel', for example when defining a timer rule that should match any channel instaed of a particular channel */
-  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE = 0x02000000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag with a series link */
-  const unsigned int PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE          = 0x04000000; /*!< @brief this type allows deletion of an otherwise read-only timer */
-  const unsigned int PVR_TIMER_TYPE_IS_REMINDER                       = 0x08000000; /*!< @brief timers of this type do trigger a reminder if time is up by calling the Kodi callback 'ReminderNotification'. */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE           = 0x00000010; /*!< @brief this type supports enabling/disabling of the timer (PVR_TIMER.state SCHEDULED|DISABLED) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_CHANNELS                 = 0x00000020; /*!< @brief this type supports channels (PVR_TIMER.iClientChannelUid) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_TIME               = 0x00000040; /*!< @brief this type supports a recording start time (PVR_TIMER.startTime) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH          = 0x00000080; /*!< @brief this type supports matching epg episode title using PVR_TIMER.strEpgSearchString */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH       = 0x00000100; /*!< @brief this type supports matching "more" epg data (not just episode title) using PVR_TIMER.strEpgSearchString. Setting FULLTEXT_EPG_MATCH implies TITLE_EPG_MATCH */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY                = 0x00000200; /*!< @brief this type supports a first day the timer gets active (PVR_TIMER.firstday) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS                 = 0x00000400; /*!< @brief this type supports weekdays for defining the recording schedule (PVR_TIMER.iWeekdays) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES = 0x00000800; /*!< @brief this type supports the "record only new episodes" feature (PVR_TIMER.iPreventDuplicateEpisodes) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN         = 0x00001000; /*!< @brief this type supports pre and post record time (PVR_TIMER.iMarginStart, PVR_TIMER.iMarginEnd) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_PRIORITY                 = 0x00002000; /*!< @brief this type supports recording priority (PVR_TIMER.iPriority) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_LIFETIME                 = 0x00004000; /*!< @brief this type supports recording lifetime (PVR_TIMER.iLifetime) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS        = 0x00008000; /*!< @brief this type supports placing recordings in user defined folders (PVR_TIMER.strDirectory) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP          = 0x00010000; /*!< @brief this type supports a list of recording groups (PVR_TIMER.iRecordingGroup) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_TIME                 = 0x00020000; /*!< @brief this type supports a recording end time (PVR_TIMER.endTime) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME            = 0x00040000; /*!< @brief enables an 'Any Time' over-ride option for startTime (using PVR_TIMER.bStartAnyTime) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME              = 0x00080000; /*!< @brief enables a separate 'Any Time' over-ride for endTime (using PVR_TIMER.bEndAnyTime) */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports specifying a maximum recordings setting' (PVR_TIMER.iMaxRecordings) */
+  static const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE        = 0x00200000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag */
+  static const unsigned int PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE         = 0x00400000; /*!< @brief this type should not appear on any create menus which provide an associated EPG tag */
+  static const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE     = 0x00800000; /*!< @brief this type should not appear on any create menus unless associated with an EPG tag with 'series' attributes (EPG_TAG.iFlags & EPG_TAG_FLAG_IS_SERIES || EPG_TAG.iSeriesNumber > 0 || EPG_TAG.iEpisodeNumber > 0 || EPG_TAG.iEpisodePartNumber > 0). Implies PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL              = 0x01000000; /*!< @brief this type supports 'any channel', for example when defining a timer rule that should match any channel instaed of a particular channel */
+  static const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE = 0x02000000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag with a series link */
+  static const unsigned int PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE          = 0x04000000; /*!< @brief this type allows deletion of an otherwise read-only timer */
+  static const unsigned int PVR_TIMER_TYPE_IS_REMINDER                       = 0x08000000; /*!< @brief timers of this type do trigger a reminder if time is up by calling the Kodi callback 'ReminderNotification'. */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)
    */
-  const unsigned int PVR_WEEKDAY_NONE      = 0x00;
-  const unsigned int PVR_WEEKDAY_MONDAY    = 0x01;
-  const unsigned int PVR_WEEKDAY_TUESDAY   = 0x02;
-  const unsigned int PVR_WEEKDAY_WEDNESDAY = 0x04;
-  const unsigned int PVR_WEEKDAY_THURSDAY  = 0x08;
-  const unsigned int PVR_WEEKDAY_FRIDAY    = 0x10;
-  const unsigned int PVR_WEEKDAY_SATURDAY  = 0x20;
-  const unsigned int PVR_WEEKDAY_SUNDAY    = 0x40;
-  const unsigned int PVR_WEEKDAY_ALLDAYS   = PVR_WEEKDAY_MONDAY   | PVR_WEEKDAY_TUESDAY | PVR_WEEKDAY_WEDNESDAY |
+  static const unsigned int PVR_WEEKDAY_NONE      = 0x00;
+  static const unsigned int PVR_WEEKDAY_MONDAY    = 0x01;
+  static const unsigned int PVR_WEEKDAY_TUESDAY   = 0x02;
+  static const unsigned int PVR_WEEKDAY_WEDNESDAY = 0x04;
+  static const unsigned int PVR_WEEKDAY_THURSDAY  = 0x08;
+  static const unsigned int PVR_WEEKDAY_FRIDAY    = 0x10;
+  static const unsigned int PVR_WEEKDAY_SATURDAY  = 0x20;
+  static const unsigned int PVR_WEEKDAY_SUNDAY    = 0x40;
+  static const unsigned int PVR_WEEKDAY_ALLDAYS   = PVR_WEEKDAY_MONDAY   | PVR_WEEKDAY_TUESDAY | PVR_WEEKDAY_WEDNESDAY |
                                              PVR_WEEKDAY_THURSDAY | PVR_WEEKDAY_FRIDAY  | PVR_WEEKDAY_SATURDAY  |
                                              PVR_WEEKDAY_SUNDAY;
 
   /*!
    * @brief timeframe value for use with SetEPGTimeFrame function to indicate "no timeframe".
    */
-  const int EPG_TIMEFRAME_UNLIMITED = -1;
+  static const int EPG_TIMEFRAME_UNLIMITED = -1;
 
   /*!
    * @brief special PVR_TIMER.iClientChannelUid and PVR_RECORDING.iChannelUid value to indicate that no channel uid is available.
    */
-  const int PVR_CHANNEL_INVALID_UID = -1; /*!< @brief denotes that no channel uid is available. */
+  static const int PVR_CHANNEL_INVALID_UID = -1; /*!< @brief denotes that no channel uid is available. */
 
   /*!
    * @brief special PVR_DESCRAMBLE_INFO value to indicate that a struct member's value is not available.
    */
-  const int PVR_DESCRAMBLE_INFO_NOT_AVAILABLE = -1;
+  static const int PVR_DESCRAMBLE_INFO_NOT_AVAILABLE = -1;
 
   /*!
    * @brief PVR add-on error codes
@@ -390,7 +390,7 @@ extern "C" {
   /*!
    * @brief special PVR_CHANNEL.iOrder and PVR_CHANNEL_GROUP_MEMBER.iOrder value to indicate this channel has an unknown order
    */
-  const int PVR_CHANNEL_UNKNOWN_ORDER = 0; /*!< @brief channel has an unknown order. */
+  static const int PVR_CHANNEL_UNKNOWN_ORDER = 0; /*!< @brief channel has an unknown order. */
 
   /*!
    * @brief Representation of a TV or radio channel.


### PR DESCRIPTION
## Description
Makes the binary addons headers compatible with C compilers by ifdef out the C++ specific parts.

## Motivation and Context
I am experimenting with writing binary addons in higher level languages (i.e. Go, Rust, Nim, etc). Modern language runtimes typically provide C integration using some type of FFI. The way this usually works is by invoking a code generation utility that takes a C header and generates native bindings in the language you're working with.

See for instance https://doc.rust-lang.org/1.9.0/book/ffi.html or https://golang.org/cmd/cgo/ or https://github.com/JuliaInterop/Clang.jl 

## How Has This Been Tested?
I fed the various headers into clang (instead of clang++) and added ifdefs until all the errors went away.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
