### PR TITLE
Add settings to flip video rendering.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9006,7 +9006,37 @@ msgctxt "#16336"
 msgid "IMX - Advanced"
 msgstr ""
 
-#empty strings from id 16337 to 16399
+#. Description of OSD video settings for flip #16337
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#16337"
+msgid "Off"
+msgstr ""
+
+#. Description of OSD video settings for flip #16337
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#16338"
+msgid "Flip Horizontally"
+msgstr ""
+
+#. Description of OSD video settings for flip #16337
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#16339"
+msgid "Flip Vertically"
+msgstr ""
+
+#. Description of OSD video settings for flip #16337
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#16340"
+msgid "Flip Both"
+msgstr ""
+
+#. Description of OSD video settings for flip #16337
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#16341"
+msgid "Flip Video"
+msgstr ""
+
+#empty strings from id 16341 to 16399
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16400"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -54,8 +54,6 @@ void CBaseRenderer::GetVideoRect(CRect &source, CRect &dest, CRect &view)
 
 inline void CBaseRenderer::ReorderDrawPoints()
 {
-
-
   float origMat[4][2] = {{m_destRect.x1, m_destRect.y1},
                          {m_destRect.x2, m_destRect.y1},
                          {m_destRect.x2, m_destRect.y2},

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -12,6 +12,7 @@
 #include "VideoShaders/ShaderFormats.h"
 #include "cores/IPlayer.h"
 #include "cores/VideoPlayer/Process/VideoBuffer.h"
+#include "cores/VideoSettings.h"
 #include "utils/Geometry.h"
 
 #include <utility>
@@ -105,6 +106,7 @@ protected:
 
   unsigned int m_sourceWidth = 720;
   unsigned int m_sourceHeight = 480;
+  unsigned int m_flipMode = VS_FLIP_OFF;
   float m_sourceFrameRatio = 1.0f;
   float m_fps = 0.0f;
 

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -36,6 +36,7 @@ CVideoSettings::CVideoSettings()
   m_StereoMode = 0;
   m_StereoInvert = false;
   m_VideoStream = -1;
+  m_VideoFlip = VS_FLIP_OFF;
 }
 
 bool CVideoSettings::operator!=(const CVideoSettings &right) const
@@ -67,6 +68,7 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_ToneMapParam != right.m_ToneMapParam) return true;
   if (m_Orientation != right.m_Orientation) return true;
   if (m_CenterMixLevel != right.m_CenterMixLevel) return true;
+  if (m_VideoFlip != right.m_VideoFlip) return true;
   return false;
 }
 

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -65,6 +65,14 @@ enum ETONEMAPMETHOD
   VS_TONEMAPMETHOD_MAX
 };
 
+enum FlipMode
+{
+  VS_FLIP_OFF=0,
+  VS_FLIP_HORIZONTAL,
+  VS_FLIP_VERTICAL,
+  VS_FLIP_BOTH	
+};
+
 enum ViewMode
 {
   ViewModeNormal = 0,
@@ -114,6 +122,7 @@ public:
   int m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
   float m_ToneMapParam = 1.0;
   int m_Orientation = 0;
+  int m_VideoFlip = VS_FLIP_OFF;
   int m_CenterMixLevel = 0; // relative to metadata or default
 };
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -44,6 +44,7 @@
 #define SETTING_VIDEO_TONEMAP_METHOD      "video.tonemapmethod"
 #define SETTING_VIDEO_TONEMAP_PARAM       "video.tonemapparam"
 #define SETTING_VIDEO_ORIENTATION         "video.orientation"
+#define SETTING_VIDEO_FLIP                "video.flip"
 
 #define SETTING_VIDEO_VDPAU_NOISE         "vdpau.noise"
 #define SETTING_VIDEO_VDPAU_SHARPNESS     "vdpau.sharpness"
@@ -197,6 +198,12 @@ void CGUIDialogVideoSettings::OnSettingChanged(std::shared_ptr<const CSetting> s
   {
     CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
     vs.m_StereoInvert = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
+    g_application.GetAppPlayer().SetVideoSettings(vs);
+  }
+  else if (settingId == SETTING_VIDEO_FLIP)
+  {
+    CVideoSettings vs = g_application.GetAppPlayer().GetVideoSettings();
+    vs.m_VideoFlip = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
     g_application.GetAppPlayer().SetVideoSettings(vs);
   }
 }
@@ -400,6 +407,14 @@ void CGUIDialogVideoSettings::InitializeSettings()
   if (g_application.GetAppPlayer().Supports(RENDERFEATURE_NONLINSTRETCH))
     AddToggle(groupVideo, SETTING_VIDEO_NONLIN_STRETCH, 659, SettingLevel::Basic, videoSettings.m_CustomNonLinStretch);
 
+  // Video flip settings
+  entries.clear();
+  entries.push_back(std::make_pair(16337, VS_FLIP_OFF));
+  entries.push_back(std::make_pair(16338, VS_FLIP_HORIZONTAL));
+  entries.push_back(std::make_pair(16339, VS_FLIP_VERTICAL));
+  entries.push_back(std::make_pair(16340, VS_FLIP_BOTH));
+  AddSpinner(groupVideo, SETTING_VIDEO_FLIP, 16341, SettingLevel::Basic, videoSettings.m_VideoFlip, entries);
+
   // tone mapping
   if (g_application.GetAppPlayer().Supports(RENDERFEATURE_TONEMAP))
   {
@@ -417,6 +432,7 @@ void CGUIDialogVideoSettings::InitializeSettings()
   entries.push_back(std::make_pair(36504, RENDER_STEREO_MODE_SPLIT_VERTICAL));
   AddSpinner(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICMODE, 36535, SettingLevel::Basic, videoSettings.m_StereoMode, entries);
   AddToggle(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICINVERT, 36536, SettingLevel::Basic, videoSettings.m_StereoInvert);
+
 
   // general settings
   AddButton(groupSaveAsDefault, SETTING_VIDEO_MAKE_DEFAULT, 12376, SettingLevel::Basic);

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -433,7 +433,6 @@ void CGUIDialogVideoSettings::InitializeSettings()
   AddSpinner(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICMODE, 36535, SettingLevel::Basic, videoSettings.m_StereoMode, entries);
   AddToggle(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICINVERT, 36536, SettingLevel::Basic, videoSettings.m_StereoInvert);
 
-
   // general settings
   AddButton(groupSaveAsDefault, SETTING_VIDEO_MAKE_DEFAULT, 12376, SettingLevel::Basic);
   AddButton(groupSaveAsDefault, SETTING_VIDEO_CALIBRATION, 214, SettingLevel::Basic);


### PR DESCRIPTION
## Add ability to flip video content

  This patch adds video settings to flip the video rendering. Depending on the 'Flip Video' setting the video will be flipped horizontally, vertically or both.

## Motivation and Context

  Allows for easily handle top-down, back projecting and such for devices that do not support it in hardware.

## How Has This Been Tested?

  Ran for several days in my own environment.

## Screenshots (if appropriate):

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
