### PR TITLE
Fix "queue item" and "play next" for STRM files with Plugin URL [Backport]

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -480,7 +480,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     { // just queue the internet stream, it will be expanded on play
       queuedItems.Add(pItem);
     }
-    else if (pItem->IsPlugin() && pItem->GetProperty("isplayable") == "true")
+    else if (pItem->IsPlugin() && pItem->GetProperty("isplayable").asBoolean())
     {
       // python files can be played
       queuedItems.Add(pItem);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -553,7 +553,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     { // just queue the internet stream, it will be expanded on play
       queuedItems.Add(pItem);
     }
-    else if (pItem->IsPlugin() && pItem->GetProperty("isplayable") == "true")
+    else if (pItem->IsPlugin() && pItem->GetProperty("isplayable").asBoolean())
     { // a playable python files
       queuedItems.Add(pItem);
     }


### PR DESCRIPTION
This fixes issue #16597 and is a backport of https://github.com/xbmc/xbmc/pull/16604 

STRM files containing a plugin URL could not be added to the current playlist by clicking on "Queue item" or "Play Next" on the context menu, even though clicking on the item or "Play" on the context menu started playback without any problem.

This was tested just using STRM files with youtube URLs
e.g. plugin://plugin.video.youtube/play/?video_id=7LqaotiGWjQ