### PR TITLE
[PVR] Cleanup: Replace Observer/Observable with EventSource/EventStream.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9639,9 +9639,6 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 
   m_infoProviders.InitCurrentItem(m_currentFile);
 
-  SetChanged();
-  NotifyObservers(ObservableMessageCurrentItem);
-  // @todo this should be handled by one of the observers above and forwarded
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "xbmc", "OnChanged");
 }
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -13,7 +13,6 @@
 #include "interfaces/info/SkinVariable.h"
 #include "messaging/IMessageTarget.h"
 #include "threads/CriticalSection.h"
-#include "utils/Observer.h"
 
 #include <map>
 #include <memory>
@@ -51,7 +50,7 @@ namespace MUSIC_INFO
  \ingroup strings
  \brief
  */
-class CGUIInfoManager : public Observable, public KODI::MESSAGING::IMessageTarget
+class CGUIInfoManager : public KODI::MESSAGING::IMessageTarget
 {
 public:
   CGUIInfoManager(void);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -115,7 +115,7 @@ void CPVRGUIInfo::Start(void)
 void CPVRGUIInfo::Stop(void)
 {
   StopThread();
-  CServiceBroker::GetPVRManager().UnregisterObserver(this);
+  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
 
   CGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
@@ -125,9 +125,9 @@ void CPVRGUIInfo::Stop(void)
   }
 }
 
-void CPVRGUIInfo::Notify(const Observable &obs, const ObservableMessage msg)
+void CPVRGUIInfo::Notify(const PVREvent& event)
 {
-  if (msg == ObservableMessageTimers || msg == ObservableMessageTimersReset)
+  if (event == PVREvent::Timers || event == PVREvent::TimersInvalidated)
     UpdateTimersCache();
 }
 
@@ -137,7 +137,7 @@ void CPVRGUIInfo::Process(void)
   int toggleInterval = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRInfoToggleInterval / 1000;
 
   /* updated on request */
-  CServiceBroker::GetPVRManager().RegisterObserver(this);
+  CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRGUIInfo::Notify);
   UpdateTimersCache();
 
   /* update the backend cache once initially */
@@ -273,6 +273,7 @@ void CPVRGUIInfo::UpdateTimeshiftData(void)
 
 bool CPVRGUIInfo::InitCurrentItem(CFileItem *item)
 {
+  CServiceBroker::GetPVRManager().PublishEvent(PVREvent::CurrentItem);
   return false;
 }
 

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -15,7 +15,6 @@
 #include "pvr/addons/PVRClients.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
-#include "utils/Observer.h"
 
 #include <atomic>
 #include <string>
@@ -36,7 +35,9 @@ namespace GUIINFO
 
 namespace PVR
 {
-  class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread, private Observer
+  enum class PVREvent;
+
+  class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
   {
   public:
     CPVRGUIInfo(void);
@@ -45,7 +46,11 @@ namespace PVR
     void Start(void);
     void Stop(void);
 
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
+    /*!
+     * @brief CEventStream callback for PVR events.
+     * @param event The event.
+     */
+    void Notify(const PVREvent& event);
 
     // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
     bool InitCurrentItem(CFileItem *item) override;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -18,7 +18,6 @@
 #include "threads/Event.h"
 #include "threads/Thread.h"
 #include "utils/EventStream.h"
-#include "utils/Observer.h"
 
 #include <memory>
 #include <string>
@@ -44,15 +43,32 @@ namespace PVR
     ManagerInterrupted,
     ManagerStarted,
 
+    // Channel events
+    ChannelPlaybackStopped,
+
+    // Channel group events
+    ChannelGroup,
+    ChannelGroupInvalidated,
+    ChannelGroupsInvalidated,
+    ChannelGroupsLoaded,
+
     // Recording events
     RecordingsInvalidated,
 
     // Timer events
-    TimersInvalidated,
     AnnounceReminder,
+    Timers,
+    TimersInvalidated,
 
-    // Channel events
-    ChannelGroupsInvalidated,
+    // EPG events
+    Epg,
+    EpgActiveItem,
+    EpgContainer,
+    EpgItemUpdate,
+    EpgUpdatePending,
+
+    // Item events
+    CurrentItem,
   };
 
   class CPVRManagerJobQueue
@@ -75,7 +91,7 @@ namespace PVR
     bool m_bStopped = true;
   };
 
-  class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer
+  class CPVRManager : private CThread, public ANNOUNCEMENT::IAnnouncer
   {
   public:
     /*!

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -171,7 +171,6 @@ bool CPVRChannel::UpdateFromClient(const CPVRChannelPtr &channel)
     m_bHasArchive             = channel->HasArchive();
 
     UpdateEncryptionName();
-    SetChanged();
   }
 
   // only update the channel name and icon if the user hasn't changed them manually
@@ -216,7 +215,6 @@ bool CPVRChannel::SetChannelID(int iChannelId)
     if (epg)
       epg->GetChannelData()->SetChannelId(m_iChannelId);
 
-    SetChanged();
     m_bChanged = true;
     return true;
   }
@@ -246,7 +244,6 @@ bool CPVRChannel::SetHidden(bool bIsHidden)
       epg->GetChannelData()->SetEPGEnabled(m_bEPGEnabled);
     }
 
-    SetChanged();
     m_bChanged = true;
     return true;
   }
@@ -266,7 +263,6 @@ bool CPVRChannel::SetLocked(bool bIsLocked)
     if (epg)
       epg->GetChannelData()->SetLocked(m_bIsLocked);
 
-    SetChanged();
     m_bChanged = true;
     return true;
   }
@@ -303,7 +299,6 @@ bool CPVRChannel::SetIconPath(const std::string &strIconPath, bool bIsUserSetIco
     if (epg)
       epg->GetChannelData()->SetIconPath(m_strIconPath);
 
-    SetChanged();
     m_bChanged = true;
     m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
     return true;
@@ -337,9 +332,7 @@ bool CPVRChannel::SetChannelName(const std::string &strChannelName, bool bIsUser
     if (epg)
       epg->GetChannelData()->SetChannelName(m_strChannelName);
 
-    SetChanged();
     m_bChanged = true;
-
     return true;
   }
 
@@ -382,7 +375,6 @@ bool CPVRChannel::SetClientID(int iClientId)
   if (m_iClientId != iClientId)
   {
     m_iClientId = iClientId;
-    SetChanged();
     m_bChanged = true;
     return true;
   }
@@ -398,10 +390,7 @@ void CPVRChannel::UpdatePath(const std::string& channelGroup)
     CSingleLock lock(m_critSection);
     const std::string strFileNameAndPath = CPVRChannelsPath(m_bIsRadio, channelGroup, client->ID(), m_iUniqueId);
     if (m_strFileNameAndPath != strFileNameAndPath)
-    {
       m_strFileNameAndPath = strFileNameAndPath;
-      SetChanged();
-    }
   }
 }
 
@@ -580,7 +569,6 @@ bool CPVRChannel::SetEPGEnabled(bool bEPGEnabled)
     if (epg)
       epg->GetChannelData()->SetEPGEnabled(m_bEPGEnabled);
 
-    SetChanged();
     m_bChanged = true;
 
     /* clear the previous EPG entries if needed */
@@ -602,7 +590,6 @@ bool CPVRChannel::SetEPGScraper(const std::string &strScraper)
     bool bCleanEPG = !m_strEPGScraper.empty() || strScraper.empty();
 
     m_strEPGScraper = StringUtils::Format("%s", strScraper.c_str());
-    SetChanged();
     m_bChanged = true;
 
     /* clear the previous EPG entries if needed */
@@ -781,7 +768,6 @@ void CPVRChannel::SetEpgID(int iEpgId)
   {
     m_iEpgId = iEpgId;
     m_epg.reset();
-    SetChanged();
     m_bChanged = true;
   }
 }

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -14,7 +14,6 @@
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
 #include "utils/ISortable.h"
-#include "utils/Observer.h"
 
 #include <memory>
 #include <string>
@@ -27,23 +26,16 @@ namespace PVR
   class CPVREpgInfoTag;
   class CPVRRadioRDSInfoTag;
 
-  /** PVR Channel class */
-  class CPVRChannel : public Observable,
-                      public ISerializable,
-                      public ISortable
+  class CPVRChannel : public ISerializable, public ISortable
   {
     friend class CPVRDatabase;
 
   public:
-    /*! @brief Create a new channel */
     explicit CPVRChannel(bool bRadio = false);
     CPVRChannel(const PVR_CHANNEL &channel, unsigned int iClientId);
 
-  private:
-    CPVRChannel(const CPVRChannel &tag) = delete;
-    CPVRChannel &operator=(const CPVRChannel &channel) = delete;
+    virtual ~CPVRChannel() = default;
 
-  public:
     bool operator ==(const CPVRChannel &right) const;
     bool operator !=(const CPVRChannel &right) const;
 
@@ -430,6 +422,9 @@ namespace PVR
 
     //@}
   private:
+    CPVRChannel(const CPVRChannel& tag) = delete;
+    CPVRChannel& operator=(const CPVRChannel& channel) = delete;
+
     /*!
      * @brief Update the encryption name after SetEncryptionSystem() has been called.
      */

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -568,10 +568,7 @@ bool CPVRChannelGroup::UpdateGroupEntries(const CPVRChannelGroup& channels, std:
 
     bReturn = Persist();
 
-    SetChanged();
-
-    lock.Leave();
-    NotifyObservers(HasNewChannels() || bRemoved || bRenumbered ? ObservableMessageChannelGroupReset : ObservableMessageChannelGroup);
+    m_events.Publish(HasNewChannels() || bRemoved || bRenumbered ? PVREvent::ChannelGroupInvalidated : PVREvent::ChannelGroup);
   }
   else
   {

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -13,7 +13,7 @@
 #include "pvr/channels/PVRChannelNumber.h"
 #include "pvr/channels/PVRChannelsPath.h"
 #include "settings/lib/ISettingCallback.h"
-#include "utils/Observer.h"
+#include "utils/EventStream.h"
 
 #include <map>
 #include <memory>
@@ -28,6 +28,8 @@ namespace PVR
 #define PVR_GROUP_TYPE_DEFAULT      0
 #define PVR_GROUP_TYPE_INTERNAL     1
 #define PVR_GROUP_TYPE_USER_DEFINED 2
+
+  enum class PVREvent;
 
   struct PVRChannelGroupMember
   {
@@ -51,9 +53,7 @@ namespace PVR
     EPG_LAST_DATE = 1
   };
 
-  /** A group of channels */
-  class CPVRChannelGroup : public Observable,
-                           public ISettingCallback
+  class CPVRChannelGroup : public ISettingCallback
   {
     friend class CPVRChannelGroupInternal;
     friend class CPVRDatabase;
@@ -87,6 +87,11 @@ namespace PVR
      * Empty group member
      */
     static PVRChannelGroupMember EmptyMember;
+
+    /*!
+     * @brief Query the events available for CEventStream
+     */
+    CEventStream<PVREvent>& Events() { return m_events; }
 
     /*!
      * @brief Load the channels from the database.
@@ -520,6 +525,7 @@ namespace PVR
     mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClientsForChannels;
     std::vector<int> m_failedClientsForChannelGroupMembers;
+    CEventSource<PVREvent> m_events;
 
   private:
     CDateTime GetEPGDate(EpgDateType epgDateType) const;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -12,14 +12,15 @@
 #include "pvr/PVRTypes.h"
 #include "pvr/dialogs/GUIDialogPVRItemsViewBase.h"
 #include "threads/SystemClock.h"
-#include "utils/Observer.h"
 
 #include <map>
 #include <string>
 
 namespace PVR
 {
-  class CGUIDialogPVRChannelsOSD : public CGUIDialogPVRItemsViewBase, public Observer, public CPVRChannelNumberInputHandler
+  enum class PVREvent;
+
+  class CGUIDialogPVRChannelsOSD : public CGUIDialogPVRItemsViewBase, public CPVRChannelNumberInputHandler
   {
   public:
     CGUIDialogPVRChannelsOSD(void);
@@ -27,8 +28,11 @@ namespace PVR
     bool OnMessage(CGUIMessage& message) override;
     bool OnAction(const CAction &action) override;
 
-    // Observer implementation
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
+    /*!
+     * @brief CEventStream callback for PVR events.
+     * @param event The event.
+     */
+    void Notify(const PVREvent& event);
 
     // CPVRChannelNumberInputHandler implementation
     void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -57,8 +57,7 @@ void CPVREpg::ForceUpdate(void)
     m_bUpdatePending = true;
   }
 
-  SetChanged(true);
-  NotifyObservers(ObservableMessageEpgUpdatePending);
+  m_events.Publish(PVREvent::EpgUpdatePending);
 }
 
 bool CPVREpg::HasValidEntries(void) const
@@ -193,7 +192,7 @@ bool CPVREpg::CheckPlayingEvent(void)
   bool bTagRemoved = !newTag && previousTag;
   if (bTagChanged || bTagRemoved)
   {
-    NotifyObservers(ObservableMessageEpgActiveItem);
+    m_events.Publish(PVREvent::EpgActiveItem);
     return true;
   }
   return false;
@@ -320,11 +319,7 @@ bool CPVREpg::UpdateEntries(const CPVREpg &epg, bool bStoreInDb /* = true */)
   m_lastScanTime = CDateTime::GetUTCDateTime();
   m_bUpdateLastScanTime = true;
 
-  SetChanged(true);
-
-  lock.Leave();
-  NotifyObservers(ObservableMessageEpg);
-
+  m_events.Publish(PVREvent::Epg);
   return true;
 }
 
@@ -414,10 +409,7 @@ bool CPVREpg::UpdateEntry(const CPVREpgInfoTagPtr &tag, EPG_EVENT_STATE newState
   }
 
   if (bRet && bNotify)
-  {
-    SetChanged();
-    NotifyObservers(ObservableMessageEpgItemUpdate);
-  }
+    m_events.Publish(PVREvent::EpgItemUpdate);
 
   return bRet;
 }

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -12,7 +12,7 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "pvr/PVRTypes.h"
 #include "threads/CriticalSection.h"
-#include "utils/Observer.h"
+#include "utils/EventStream.h"
 
 #include <map>
 #include <memory>
@@ -21,11 +21,13 @@
 
 namespace PVR
 {
+  enum class PVREvent;
+
   class CPVREpgChannelData;
   class CPVREpgDatabase;
   class CPVREpgInfoTag;
 
-  class CPVREpg : public Observable
+  class CPVREpg
   {
     friend class CPVREpgDatabase;
 
@@ -50,7 +52,7 @@ namespace PVR
     /*!
      * @brief Destroy this EPG instance.
      */
-    ~CPVREpg(void) override;
+    virtual ~CPVREpg();
 
     /*!
      * @brief Load all entries for this table from the given database.
@@ -245,6 +247,11 @@ namespace PVR
      */
     bool IsValid(void) const;
 
+    /*!
+     * @brief Query the events available for CEventStream
+     */
+    CEventStream<PVREvent>& Events() { return m_events; }
+
   private:
     CPVREpg(void) = delete;
     CPVREpg(const CPVREpg&) = delete;
@@ -312,5 +319,7 @@ namespace PVR
     bool                                m_bUpdateLastScanTime = false;
 
     std::shared_ptr<CPVREpgChannelData> m_channelData;
+
+    CEventSource<PVREvent> m_events;
   };
 }

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -15,7 +15,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
-#include "utils/Observer.h"
+#include "utils/EventStream.h"
 
 #include <list>
 #include <map>
@@ -33,7 +33,9 @@ namespace PVR
   class CPVREpgDatabase;
   class CPVREpgInfoTag;
 
-  class CPVREpgContainer : public Observer, public Observable, private CThread
+  enum class PVREvent;
+
+  class CPVREpgContainer : private CThread
   {
     friend class CPVREpgDatabase;
 
@@ -53,6 +55,11 @@ namespace PVR
      * @return A pointer to the database instance.
      */
     CPVREpgDatabasePtr GetEpgDatabase() const;
+
+    /*!
+     * @brief Query the events available for CEventStream
+     */
+    CEventStream<PVREvent>& Events() { return m_events; }
 
     /*!
      * @brief Start the EPG update thread.
@@ -85,11 +92,10 @@ namespace PVR
     bool DeleteEpg(const CPVREpgPtr &epg, bool bDeleteFromDatabase = false);
 
     /*!
-     * @brief Process a notification from an observable.
-     * @param obs The observable that sent the update.
-     * @param msg The update message.
+     * @brief CEventStream callback for PVR events.
+     * @param event The event.
      */
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
+    void Notify(const PVREvent& event);
 
     /*!
      * @brief Create the EPg for a given channel.
@@ -282,5 +288,6 @@ namespace PVR
 
     bool m_bUpdateNotificationPending = false; /*!< true while an epg updated notification to observers is pending. */
     CPVRSettings m_settings;
+    CEventSource<PVREvent> m_events;
   };
 }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -73,8 +73,6 @@ void CPVRRecordings::Update(void)
   m_bIsUpdating = false;
   lock.Leave();
 
-  CServiceBroker::GetPVRManager().SetChanged();
-  CServiceBroker::GetPVRManager().NotifyObservers(ObservableMessageRecordings);
   CServiceBroker::GetPVRManager().PublishEvent(PVREvent::RecordingsInvalidated);
 }
 

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -12,7 +12,6 @@
 #include "pvr/PVRSettings.h"
 #include "pvr/PVRTypes.h"
 #include "threads/Thread.h"
-#include "utils/Observer.h"
 
 #include <map>
 #include <memory>
@@ -22,6 +21,7 @@
 namespace PVR
 {
   enum class TimerOperationResult;
+  enum class PVREvent;
 
   class CPVRTimerInfoTag;
   class CPVRTimersPath;
@@ -61,7 +61,7 @@ namespace PVR
     MapTags m_tags;
   };
 
-  class CPVRTimers : public CPVRTimersContainer, public Observer, private CThread
+  class CPVRTimers : public CPVRTimersContainer, private CThread
   {
   public:
     CPVRTimers(void);
@@ -249,7 +249,11 @@ namespace PVR
      */
     void UpdateChannels(void);
 
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
+    /*!
+     * @brief CEventStream callback for PVR events.
+     * @param event The event.
+     */
+   void Notify(const PVREvent& event);
 
     /*!
      * @brief Get a timer tag given it's unique ID

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -11,7 +11,6 @@
 #include "pvr/PVRTypes.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
-#include "utils/Observer.h"
 #include "windows/GUIMediaWindow.h"
 
 #include <atomic>
@@ -38,6 +37,8 @@ class CGUIDialogProgressBarHandle;
 
 namespace PVR
 {
+  enum class PVREvent;
+
   enum EPGSelectAction
   {
     EPG_SELECT_ACTION_CONTEXT_MENU   = 0,
@@ -50,7 +51,7 @@ namespace PVR
 
   class CGUIPVRChannelGroupsSelector;
 
-  class CGUIWindowPVRBase : public CGUIMediaWindow, public Observer
+  class CGUIWindowPVRBase : public CGUIMediaWindow
   {
   public:
     ~CGUIWindowPVRBase(void) override;
@@ -62,9 +63,15 @@ namespace PVR
     void UpdateButtons(void) override;
     bool OnAction(const CAction &action) override;
     bool OnBack(int actionID) override;
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
     void SetInvalid() override;
     bool CanBeActivated() const override;
+
+    /*!
+     * @brief CEventStream callback for PVR events.
+     * @param event The event.
+     */
+    void Notify(const PVREvent& event);
+    virtual void NotifyEvent(const PVREvent& event);
 
     /*!
      * @brief Refresh window content.

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -22,6 +22,8 @@ class CGUIMessage;
 
 namespace PVR
 {
+  enum class PVREvent;
+
   class CGUIEPGGridContainer;
   class CPVRRefreshTimelineItemsThread;
 
@@ -38,9 +40,10 @@ namespace PVR
     void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
     void UpdateButtons(void) override;
-    void Notify(const Observable &obs, const ObservableMessage msg) override;
     void SetInvalid() override;
     bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+
+    void NotifyEvent(const PVREvent& event) override;
 
     bool RefreshTimelineItems();
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -42,13 +42,9 @@ CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio, int id, co
     CSettings::SETTING_MYVIDEOS_SELECTACTION
   })
 {
-  CServiceBroker::GetGUI()->GetInfoManager().RegisterObserver(this);
 }
 
-CGUIWindowPVRRecordingsBase::~CGUIWindowPVRRecordingsBase()
-{
-  CServiceBroker::GetGUI()->GetInfoManager().UnregisterObserver(this);
-}
+CGUIWindowPVRRecordingsBase::~CGUIWindowPVRRecordingsBase() = default;
 
 void CGUIWindowPVRRecordingsBase::OnWindowLoaded()
 {
@@ -297,25 +293,27 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage &message)
       }
       break;
     case GUI_MSG_REFRESH_LIST:
-      switch(message.GetParam1())
+    {
+      switch (static_cast<PVREvent>(message.GetParam1()))
       {
-        case ObservableMessageTimers:
-        case ObservableMessageEpg:
-        case ObservableMessageEpgContainer:
-        case ObservableMessageEpgActiveItem:
-        case ObservableMessageCurrentItem:
-        {
+        case PVREvent::CurrentItem:
+        case PVREvent::Epg:
+        case PVREvent::EpgActiveItem:
+        case PVREvent::EpgContainer:
+        case PVREvent::Timers:
           SetInvalid();
           break;
-        }
-        case ObservableMessageRecordings:
-        case ObservableMessageTimersReset:
-        {
+
+        case PVREvent::RecordingsInvalidated:
+        case PVREvent::TimersInvalidated:
           Refresh(true);
           break;
-        }
+
+        default:
+          break;
       }
       break;
+    }
   }
 
   return bReturn || CGUIWindowPVRBase::OnMessage(message);

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -31,13 +31,9 @@ using namespace PVR;
 CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string &xmlFile) :
   CGUIWindowPVRBase(bRadio, id, xmlFile)
 {
-  CServiceBroker::GetGUI()->GetInfoManager().RegisterObserver(this);
 }
 
-CGUIWindowPVRTimersBase::~CGUIWindowPVRTimersBase()
-{
-  CServiceBroker::GetGUI()->GetInfoManager().UnregisterObserver(this);
-}
+CGUIWindowPVRTimersBase::~CGUIWindowPVRTimersBase() = default;
 
 bool CGUIWindowPVRTimersBase::OnAction(const CAction &action)
 {
@@ -146,23 +142,26 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage &message)
       }
       break;
     case GUI_MSG_REFRESH_LIST:
-      switch(message.GetParam1())
+    {
+      switch (static_cast<PVREvent>(message.GetParam1()))
       {
-        case ObservableMessageTimers:
-        case ObservableMessageEpg:
-        case ObservableMessageEpgContainer:
-        case ObservableMessageEpgActiveItem:
-        case ObservableMessageCurrentItem:
-        {
+        case PVREvent::CurrentItem:
+        case PVREvent::Epg:
+        case PVREvent::EpgActiveItem:
+        case PVREvent::EpgContainer:
+        case PVREvent::Timers:
           SetInvalid();
           break;
-        }
-        case ObservableMessageTimersReset:
-        {
+
+        case PVREvent::TimersInvalidated:
           Refresh(true);
           break;
-        }
+
+        default:
+          break;
       }
+      break;
+    }
   }
 
   return bReturn || CGUIWindowPVRBase::OnMessage(message);

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -19,24 +19,9 @@ class ObservableMessageJob;
 typedef enum
 {
   ObservableMessageNone,
-  ObservableMessageCurrentItem,
-  ObservableMessageAddons,
-  ObservableMessageEpg,
-  ObservableMessageEpgContainer,
-  ObservableMessageEpgActiveItem,
-  ObservableMessageEpgItemUpdate,
-  ObservableMessageEpgUpdatePending,
-  ObservableMessageChannelGroup,
-  ObservableMessageChannelGroupReset,
-  ObservableMessageTimers,
-  ObservableMessageTimersReset,
-  ObservableMessageRecordings,
   ObservableMessagePeripheralsChanged,
-  ObservableMessageChannelGroupsLoaded,
-  ObservableMessageManagerStopped,
   ObservableMessageSettingsChanged,
   ObservableMessageButtonMapsChanged,
-  ObservableMessageChannelPlaybackStopped,
 } ObservableMessage;
 
 class Observer


### PR DESCRIPTION
Currently, for historical reasons, PVR uses both Observer/Observable and EventSource/EventStream to notify events to listeners.

Both implementations serve the same purpose with EventSource/EventStream being more flexible (events can carry more than just an int) and more reliable. Especially, there is no need to release instance locks before publishing an event (in opposite to Observer/Observable the event gets delivered in a separate thread).

This PR gets rid of Observer/Observable in favor of EventStream/EventSource.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish mind doing the review? Changes should be pretty forward and self-explaining.