### PR TITLE
[DemuxClient] Parse for mid stream changes (optional)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -64,7 +64,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
   }
 
   // platform specifig video decoders
-  if (!(hint.codecOptions & CODEC_FORCE_SOFTWARE))
+  if (!m_hwVideoCodecs.empty() && !(hint.codecOptions & CODEC_FORCE_SOFTWARE))
   {
     for (auto &codec : m_hwVideoCodecs)
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -235,6 +235,12 @@ public:
    */
   virtual void Reopen() {};
 
+  /**
+   * Return true, if codec parses stream to detect mid stream changes
+   * If false, demuxer tries to parse the stream and notifies VideoPlayer on changes.
+   */
+  virtual bool HasCodecParser() const { return true; }
+
 protected:
   CProcessInfo &m_processInfo;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1475,13 +1475,16 @@ void CDVDVideoCodecAndroidMediaCodec::ReleaseSurfaceTexture(void)
 void CDVDVideoCodecAndroidMediaCodec::UpdateFpsDuration()
 {
   if (m_hints.fpsrate > 0 && m_hints.fpsscale > 0)
-    m_fpsDuration = static_cast<uint32_t>(static_cast<uint64_t>(DVD_TIME_BASE) * m_hints.fpsscale /  m_hints.fpsrate);
+  {
+    m_fpsDuration =
+        static_cast<uint32_t>(static_cast<uint64_t>(DVD_TIME_BASE) * m_hints.fpsscale / m_hints.fpsrate);
+    m_processInfo.SetVideoFps(static_cast<float>(m_hints.fpsrate) / m_hints.fpsscale);
+  }
   else
     m_fpsDuration = 1;
-
-  m_processInfo.SetVideoFps(static_cast<float>(m_hints.fpsrate) / m_hints.fpsscale);
-
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::UpdateFpsDuration fpsRate:%u fpsscale:%u, fpsDur:%u", m_hints.fpsrate, m_hints.fpsscale, m_fpsDuration);
+  CLog::Log(LOGDEBUG,
+            "CDVDVideoCodecAndroidMediaCodec::UpdateFpsDuration fpsRate:%u fpsscale:%u, fpsDur:%u",
+            fpsRate, m_hints.fpsscale, m_fpsDuration);
 }
 
 void CDVDVideoCodecAndroidMediaCodec::surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -141,6 +141,7 @@ public:
   const char* GetName() override { return m_formatname.c_str(); };
   void SetCodecControl(int flags) override;
   unsigned GetAllowedReferences() override;
+  bool HasCodecParser() const override { return false; }
 
 protected:
   void Dispose();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -69,53 +69,37 @@ enum StreamSource
 class CDemuxStream
 {
 public:
-  CDemuxStream()
-  {
-    uniqueId = 0;
-    dvdNavId = 0;
-    demuxerId = -1;
-    codec = (AVCodecID)0; // AV_CODEC_ID_NONE
-    codec_fourcc = 0;
-    profile = FF_PROFILE_UNKNOWN;
-    level = FF_LEVEL_UNKNOWN;
-    type = STREAM_NONE;
-    source = STREAM_SOURCE_NONE;
-    iDuration = 0;
-    pPrivate = NULL;
-    ExtraData = NULL;
-    ExtraSize = 0;
-    disabled = false;
-    changes = 0;
-    flags = StreamFlags::FLAG_NONE;
-  }
-
+  CDemuxStream() = default;
   virtual ~CDemuxStream() { delete[] ExtraData; }
 
   virtual std::string GetStreamName();
 
-  int uniqueId; // unique stream id
-  int dvdNavId;
-  int64_t demuxerId; // id of the associated demuxer
-  AVCodecID codec;
-  unsigned int codec_fourcc; // if available
-  int profile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
-  int level; // encoder level of the stream reported by the decoder. used to qualify hw decoders.
-  StreamType type;
-  int source;
+  int uniqueId = 0; // unique stream id
+  int dvdNavId = 0;
+  int64_t demuxerId = -1; // id of the associated demuxer
+  AVCodecID codec = AV_CODEC_ID_NONE;
+  unsigned int codec_fourcc = 0; // if available
+  int profile =
+      FF_PROFILE_UNKNOWN; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
+  int level =
+      FF_LEVEL_UNKNOWN; // encoder level of the stream reported by the decoder. used to qualify hw decoders.
+  StreamType type = STREAM_NONE;
+  int source = STREAM_SOURCE_NONE;
 
-  int iDuration; // in mseconds
-  void* pPrivate; // private pointer for the demuxer
-  uint8_t* ExtraData; // extra data for codec to use
-  unsigned int ExtraSize; // size of extra data
+  int iDuration = 0; // in mseconds
+  void* pPrivate = nullptr; // private pointer for the demuxer
+  uint8_t* ExtraData = nullptr; // extra data for codec to use
+  unsigned int ExtraSize = 0; // size of extra data
 
-  StreamFlags flags;
+  StreamFlags flags = StreamFlags::FLAG_NONE;
   std::string language; // RFC 5646 language code (empty string if undefined)
-  bool disabled; // set when stream is disabled. (when no decoder exists)
+  bool disabled = false; // set when stream is disabled. (when no decoder exists)
 
   std::string name;
   std::string codecName;
 
-  int changes; // increment on change which player may need to know about
+  bool checkStreamChange = false;
+  int changes = 0; // increment on change which player may need to know about
 
   std::shared_ptr<DemuxCryptoSession> cryptoSession;
   std::shared_ptr<ADDON::IAddonProvider> externalInterfaces;
@@ -348,6 +332,11 @@ public:
    * adaptive demuxers like DASH can use this to choose best fitting video stream
    */
   virtual void SetVideoResolution(int width, int height){};
+
+  /*
+  * Enable ParsePacket to detect mid stream changes
+  */
+  virtual void EnableParsePacket(int64_t demuxerId, bool enable){};
 
   /*
   * return the id of the demuxer

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -43,10 +43,11 @@ public:
   void EnableStream(int id, bool enable) override;
   void OpenStream(int id) override;
   void SetVideoResolution(int width, int height) override;
+  void EnableParsePacket(int64_t demuxerId, bool enable) override;
 
 protected:
   void RequestStreams();
-  void SetStreamProps(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map, bool forceInit);
+  void SetStreamProps(CDemuxStream* stream, std::map<int, std::shared_ptr<CDemuxStream>>& map);
   bool ParsePacket(DemuxPacket* pPacket);
   void DisposeStreams();
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -344,6 +344,9 @@ void CInputStreamPVRBase::UpdateStreamMap()
       dStream = std::make_shared<CDemuxStream>();
 
     dStream->codec = (AVCodecID)stream.iCodecId;
+    if (dStream->codec == AV_CODEC_ID_MPEG2VIDEO)
+      dStream->checkStreamChange = true;
+
     dStream->uniqueId = stream.iPID;
     dStream->language = stream.strLanguage;
 

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -93,22 +93,23 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
   }
 
   // VIDEO
-  if( fpsscale != right.fpsscale
-  ||  fpsrate  != right.fpsrate
-  ||  height   != right.height
-  ||  width    != right.width
-  ||  stills   != right.stills
-  ||  level    != right.level
-  ||  profile  != right.profile
-  ||  ptsinvalid != right.ptsinvalid
-  ||  forced_aspect != right.forced_aspect
-  ||  bitsperpixel != right.bitsperpixel
-  ||  vfr      != right.vfr
-  ||  colorSpace != right.colorSpace
-  ||  colorRange != right.colorRange
-  ||  colorPrimaries != right.colorPrimaries
-  ||  colorTransferCharacteristic != right.colorTransferCharacteristic
-  ||  stereo_mode != right.stereo_mode ) return false;
+  if (fpsscale != right.fpsscale
+    || fpsrate != right.fpsrate
+    || height != right.height
+    || width != right.width
+    || stills != right.stills
+    || level != right.level
+    || profile != right.profile
+    || ptsinvalid != right.ptsinvalid
+    || forced_aspect != right.forced_aspect
+    || bitsperpixel != right.bitsperpixel
+    || vfr != right.vfr
+    || colorSpace != right.colorSpace
+    || colorRange != right.colorRange
+    || colorPrimaries != right.colorPrimaries
+    || colorTransferCharacteristic != right.colorTransferCharacteristic
+    || stereo_mode != right.stereo_mode)
+    return false;
 
   if (masteringMetadata && right.masteringMetadata)
   {

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -44,6 +44,7 @@ public:
   virtual bool IsInited() const = 0;
   virtual bool AcceptsData() const = 0;
   virtual bool IsStalled() const = 0;
+  virtual bool HasCodecParser() const { return true; }
 
   enum ESyncState
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3599,6 +3599,9 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   if(player == nullptr)
     return false;
 
+  if (m_pDemuxer)
+    m_pDemuxer->EnableParsePacket(hint.uniqueId, !player->HasCodecParser());
+
   if(m_CurrentVideo.id < 0 ||
      m_CurrentVideo.hint != hint)
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -66,6 +66,10 @@ public:
   double GetSubtitleDelay() override { return m_iSubtitleDelay; }
   void SetSubtitleDelay(double delay) override { m_iSubtitleDelay = delay; }
   bool IsStalled() const override { return m_stalled; }
+  bool HasCodecParser() const override
+  {
+    return m_pVideoCodec ? m_pVideoCodec->HasCodecParser() : false;
+  }
   bool IsRewindStalled() const override { return m_rewindStalled; }
   double GetCurrentPts() override;
   double GetOutputDelay() override; /* returns the expected delay, from that a packet is put in queue */


### PR DESCRIPTION
## Description
This PR implements the option to keep the ffmpeg parser alive even after codec extradata was found to track mid stream changes (@ksooo ). This happens only if the decoder don't have the capability to parse packets (curently only android mediacodec). For other decoders (e.g. ffmpeg) the demuxer will always stopp parsing after first extradata was found.

For PVR this implementation asks the demuxclient to continue parsing only for MPEG2 streams.
This is just for testing / showing what to do and should / could be implemented different.

## Motivation and Context
- solve mid stream changes

## How Has This Been Tested?
Play PVR SD MPEG2 channel on Windos (ffmpeg) and Android.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
