### PR TITLE
fixed: make archive files work via UPnP

### DIFF
--- a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
+++ b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
@@ -190,8 +190,7 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
     NPT_FileInfo             file_info;
     
     // prevent hackers from accessing files outside of our root
-    if ((file_path.Find("/..") >= 0) || (file_path.Find("\\..") >= 0) ||
-        NPT_FAILED(NPT_File::GetInfo(file_path, &file_info))) {
+    if ((file_path.Find("/..") >= 0) || (file_path.Find("\\..") >= 0)) {
         return NPT_ERROR_NO_SUCH_ITEM;
     }
     
@@ -201,7 +200,8 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
     // handle potential 304 only if range header not set
     NPT_DateTime  date;
     NPT_TimeStamp timestamp;
-    if (NPT_SUCCEEDED(PLT_UPnPMessageHelper::GetIfModifiedSince((NPT_HttpMessage&)request, date)) &&
+    if (NPT_SUCCEEDED(NPT_File::GetInfo(file_path, &file_info)) &&
+        NPT_SUCCEEDED(PLT_UPnPMessageHelper::GetIfModifiedSince((NPT_HttpMessage&)request, date)) &&
         !range_spec) {
         date.ToTimeStamp(timestamp);
         


### PR DESCRIPTION
## Description

This is the same as PR #16553, only for master.

## How Has This Been Tested?

I tested it on master with vfs.libarchive plugin on an LG webos 3.0 TV.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue) #16182
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change (There are no tests of NptXbmcFile.cpp)
- [X] All new and existing tests passed
