### PR TITLE
Reduce log spam produced by AnnouncementManager

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21741,3 +21741,9 @@ msgstr ""
 msgctxt "#39116"
 msgid "Episode plot"
 msgstr ""
+
+#. Label for component level debug logging setting
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#39117"
+msgid "Verbose logging for the [B]Announcer[/B] component"
+msgstr ""

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -44,6 +44,7 @@
 #define LOGWINDOWING  (1 << (LOGMASKBIT + 14))
 #define LOGPVR        (1 << (LOGMASKBIT + 15))
 #define LOGEPG        (1 << (LOGMASKBIT + 16))
+#define LOGANNOUNCE   (1 << (LOGMASKBIT + 17))
 
 #include "utils/params_check_macros.h"
 

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -110,7 +110,7 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
 
 void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
 {
-  CLog::Log(LOGDEBUG, "CAnnouncementManager - Announcement: %s from %s", message, sender);
+  CLog::Log(LOGDEBUG, LOGANNOUNCE, "CAnnouncementManager - Announcement: {} from {}", message, sender);
 
   CSingleLock lock(m_announcersCritSection);
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1440,6 +1440,7 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(SettingConstPtr se
   list.emplace_back(g_localizeStrings.Get(684), LOGWINDOWING);
   list.emplace_back(g_localizeStrings.Get(685), LOGPVR);
   list.emplace_back(g_localizeStrings.Get(686), LOGEPG);
+  list.emplace_back(g_localizeStrings.Get(39117), LOGANNOUNCE);
 #ifdef HAS_DBUS
   list.emplace_back(g_localizeStrings.Get(674), LOGDBUS);
 #endif

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -65,7 +65,7 @@ void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *s
 {
   int ra_flag = 0;
 
-  CLog::Log(LOGDEBUG, "GOT ANNOUNCEMENT, type: %i, from %s, message %s",(int)flag, sender, message);
+  CLog::Log(LOGDEBUG, LOGANNOUNCE, "GOT ANNOUNCEMENT, type: {}, from {}, message {}", flag, sender, message);
 
   // we are only interested in library changes
   if ((flag & (ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary)) == 0)


### PR DESCRIPTION
Got fed up with `CAnnouncementManager` cluttering up the debug log with 
```
DEBUG: CAnnouncementManager - Announcement: OnUpdate from xbmc
DEBUG: GOT ANNOUNCEMENT, type: 32, from xbmc, message OnUpdate
```
The number of entries depending on how many listeners registered, and bulked up debug of library scanning to no good use. But in case the logging was of use to some dev at a later point I have added a level of component logging for Annoucements and moved the log calls to that component.

I would like to backport too - removing log spam is useful for anyone looking at logs regualrly,  low risk, and not a new feature  to "sell" later to users. @ksooo what do you think?
