### PR TITLE
[Log] Use Thread ID instead NativeHandle for logging

### DIFF
--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -56,6 +56,7 @@ public:
   static int GetMaxPriority(void);
   static int GetNormalPriority(void);
   static std::uintptr_t GetCurrentThreadNativeHandle();
+  static uint64_t GetCurrentThreadNativeId();
 
   // Get and set the thread's priority
   int GetPriority(void);

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -139,6 +139,11 @@ std::uintptr_t CThread::GetCurrentThreadNativeHandle()
 #endif
 }
 
+uint64_t CThread::GetCurrentThreadNativeId()
+{
+  return static_cast<uint64_t>(GetCurrentThreadPid_());
+}
+
 int CThread::GetMinPriority(void)
 {
   // one level lower than application

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -50,6 +50,11 @@ std::uintptr_t CThread::GetCurrentThreadNativeHandle()
   return reinterpret_cast<std::uintptr_t>(::GetCurrentThread());
 }
 
+uint64_t CThread::GetCurrentThreadNativeId()
+{
+  return static_cast<uint64_t>(::GetCurrentThreadId());
+}
+
 int CThread::GetMinPriority(void)
 {
   return(THREAD_PRIORITY_IDLE);

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -206,7 +206,7 @@ bool CLog::WriteLogString(int logLevel, const std::string& logString)
                                   minute,
                                   second,
                                   static_cast<int>(millisecond),
-                                  static_cast<uint64_t>(CThread::GetCurrentThreadNativeHandle()),
+                                  static_cast<uint64_t>(CThread::GetCurrentThreadNativeId()),
                                   levelNames[logLevel]) + strData;
 
   return g_logState.m_platform.WriteStringToLog(strData);


### PR DESCRIPTION
## Description
Use Thread Thread ID instead NativeHandle for logging

## Motivation and Context
Using Thread ID helps analyzing debug log files, because they are a.) always the same for windows and b.) compareable with system logs / tools. 

## How Has This Been Tested?
Windows kodi 32 bit build

Before:
```
2019-09-21 21:50:58.251 T:4294967294  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.json v10.5.2 installed
2019-09-21 21:50:58.251 T:4294967294  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.metadata v2.1.0 installed
2019-09-21 21:50:58.251 T:4294967294  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.python v2.26.0 installed
2019-09-21 21:50:58.252 T:4294967294  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.webinterface v1.0.0 installed
2019-09-21 21:50:58.257 T:4294967294   DEBUG: CFavourites::Load - no system favourites found, skipping
2019-09-21 21:50:58.257 T:4294967294   DEBUG: CFavourites::Load - no userdata favourites found, skipping
2019-09-21 21:50:58.259 T:4294967294   DEBUG: Thread CWin32PowerStateWorker start, auto delete: false
2019-09-21 21:50:58.259 T:4294967294   DEBUG: Thread ActiveAE start, auto delete: false
```
Now:
```
2019-09-22 17:43:16.616 T:13160  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.json v10.5.2 installed
2019-09-22 17:43:16.616 T:13160  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.metadata v2.1.0 installed
2019-09-22 17:43:16.617 T:13160  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.python v2.26.0 installed
2019-09-22 17:43:16.617 T:13160  NOTICE: CAddonMgr::ADDON::CAddonMgr::FindAddons: xbmc.webinterface v1.0.0 installed
2019-09-22 17:43:16.625 T:13160   DEBUG: CFavourites::Load - no system favourites found, skipping
2019-09-22 17:43:16.629 T:15824   DEBUG: Thread CWin32PowerStateWorker start, auto delete: false
2019-09-22 17:43:16.630 T:940   DEBUG: Thread ActiveAE start, auto delete: false
2019-09-22 17:43:16.632 T:15456   DEBUG: Thread AESink start, auto delete: false
```
## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
