### PR TITLE
[VideoPlayer] Change avsync handling

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1903,29 +1903,38 @@ void CVideoPlayer::HandlePlaySpeed()
     if (m_pInputStream->IsRealtime())
       threshold = 40;
 
-    bool video = m_CurrentVideo.id < 0 || (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_WAITSYNC) ||
+    bool video = m_CurrentVideo.id < 0 ||
+                 (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_WAITSYNC) ||
+                 (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_INSYNC) ||
                  (m_CurrentVideo.packets == 0 && m_CurrentAudio.packets > threshold) ||
                  (!m_VideoPlayerAudio->AcceptsData() && m_processInfo->GetLevelVQ() < 10);
-    bool audio = m_CurrentAudio.id < 0 || (m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_WAITSYNC) ||
+    bool audio = m_CurrentAudio.id < 0 ||
+                 (m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_WAITSYNC) ||
+                 (m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_INSYNC) ||
                  (m_CurrentAudio.packets == 0 && m_CurrentVideo.packets > threshold) ||
                  (!m_VideoPlayerVideo->AcceptsData() && m_VideoPlayerAudio->GetLevel() < 10);
 
-    if (m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_WAITSYNC &&
-        (m_CurrentAudio.avsync == CCurrentStream::AV_SYNC_CONT ||
-         m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_INSYNC))
+    if (m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
     {
-      m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_INSYNC;
-      m_CurrentAudio.avsync = CCurrentStream::AV_SYNC_NONE;
-      m_VideoPlayerAudio->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, m_clock.GetClock()), 1);
+      if (m_CurrentAudio.avsync == CCurrentStream::AV_SYNC_CONT)
+      {
+        m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_INSYNC;
+        m_CurrentAudio.avsync = CCurrentStream::AV_SYNC_NONE;
+      }
+      else
+        audio = false;
     }
-    else if (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_WAITSYNC &&
-             m_CurrentVideo.avsync == CCurrentStream::AV_SYNC_CONT)
+    if (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
     {
-      m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_INSYNC;
-      m_CurrentVideo.avsync = CCurrentStream::AV_SYNC_NONE;
-      m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, m_clock.GetClock()), 1);
+      if (m_CurrentVideo.avsync == CCurrentStream::AV_SYNC_CONT)
+      {
+        m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_INSYNC;
+        m_CurrentVideo.avsync = CCurrentStream::AV_SYNC_NONE;
+      }
+      else
+        video = false;
     }
-    else if (video && audio)
+    if (video && audio)
     {
       double clock = 0;
       if (m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
@@ -2861,6 +2870,7 @@ void CVideoPlayer::HandleMessages()
       if (msg.player == VideoPlayer_AUDIO)
       {
         m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_WAITSYNC;
+        m_CurrentAudio.avsync = CCurrentStream::AV_SYNC_CONT;
         m_CurrentAudio.cachetime = msg.cachetime;
         m_CurrentAudio.cachetotal = msg.cachetotal;
         m_CurrentAudio.starttime = msg.timestamp;
@@ -2868,6 +2878,7 @@ void CVideoPlayer::HandleMessages()
       if (msg.player == VideoPlayer_VIDEO)
       {
         m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_WAITSYNC;
+        m_CurrentVideo.avsync = CCurrentStream::AV_SYNC_CONT;
         m_CurrentVideo.cachetime = msg.cachetime;
         m_CurrentVideo.cachetotal = msg.cachetotal;
         m_CurrentVideo.starttime = msg.timestamp;
@@ -3518,7 +3529,7 @@ bool CVideoPlayer::OpenAudioStream(CDVDStreamInfo& hint, bool reset)
 
   m_HasAudio = true;
 
-  static_cast<IDVDStreamPlayerAudio*>(player)->SendMessage(new CDVDMsg(CDVDMsg::PLAYER_REQUEST_STATE), 1);
+  static_cast<IDVDStreamPlayerAudio*>(player)->SendMessage(new CDVDMsg(CDVDMsg::PLAYER_REQUEST_STATE), 0);
 
   return true;
 }
@@ -3617,7 +3628,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
 
   m_HasVideo = true;
 
-  static_cast<IDVDStreamPlayerVideo*>(player)->SendMessage(new CDVDMsg(CDVDMsg::PLAYER_REQUEST_STATE), 1);
+  static_cast<IDVDStreamPlayerVideo*>(player)->SendMessage(new CDVDMsg(CDVDMsg::PLAYER_REQUEST_STATE), 0);
 
   // open CC demuxer if video is mpeg2
   if ((hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_H264) && !m_pCCDemuxer)


### PR DESCRIPTION
## Description
Even I'm not keen modifying things in VP code, my current issues with chapter playback using inputstream.adaptive leave me no other chance.

See this PR as discussion start, I hope that @FernetMenta jumps in here and brings some light in the magic of VP.

## Motivation and Context
inputstream.adaptive plays multi period manifests by sending a DMX_SPECIALID_STREAMCHANGE to the player between two periods / chapters. IMO it's not the simplest case for VP, because some streams come with audio, some others not, and there is a mix of very short and long sequences.

The stream I use for testing has 3 chapters:
1.) Advertisment (Video only, no audio), ~ 7 seconds duration
2.) Short channel logo (audio + video), ~ 3 seconds duration
3.) main video ( 12 Minutes)

After 2.) I see the first frame of 3.) but VP stalls for 7 seconds before it continues.
Manifest / strm file in separate post.

## Open questions:
From code I have not understood, how VP handles the situation, that first 7 seconds are without audio. There are ~ 8 seconds in buffer, means that I fill audio packets of stream 2 into an empty queue while video packets of stream2 are inserted after the packets of stream 1 (which is still playing). From what I see in log, it leads to a bunch of "WARNING: ActiveAE - large audio sync error" log lines. I see also issues when having subtitles not in all chapters, they usually start already during stream 1 / 2 even they belong to stream 3.

## How Has This Been Tested?
- copy the manifest file to a local webserver, allow .mpd mime types
- create a .strm file and copy the content (second post) into it.
- use inputstream.adaptive master, currently chapter changes are not merged into Matrix.
- play the strm file.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
