### PR TITLE
[settings] add some missing functionality required for add-on settings

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1074,9 +1074,10 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(const std::string& sett
   const auto settingEntries = StringUtils::Split(XMLUtils::GetAttribute(settingElement, "entries"), OldSettingValuesSeparator);
 
   // process sort
+  bool sortAscending = false;
   std::string sort = XMLUtils::GetAttribute(settingElement, "sort");
   if (sort == "true" || sort == "yes")
-    std::sort(values.begin(), values.end(), sortstringbyname());
+    sortAscending = true;
 
   SettingPtr setting = nullptr;
   if (settingType == "enum")
@@ -1113,6 +1114,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(const std::string& sett
 
       settingInt->SetTranslatableOptions(options);
     }
+
+    if (sortAscending)
+      settingInt->SetOptionsSort(SettingOptionsSort::Ascending);
 
     // set the default value
     if (settingInt->FromString(defaultValue))
@@ -1153,6 +1157,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(const std::string& sett
 
       settingString->SetTranslatableOptions(options);
     }
+
+    if (sortAscending)
+      settingString->SetOptionsSort(SettingOptionsSort::Ascending);
 
     // set the default value
     settingString->SetDefault(defaultValue);

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1513,7 +1513,7 @@ void CAddonSettings::FileEnumSettingOptionsFiller(std::shared_ptr<const CSetting
   if (settingPath->GetSources().empty())
     return;
 
-  const std::string& masking = settingPath->GetMasking();
+  const std::string& masking = settingPath->GetMasking(CServiceBroker::GetFileExtensionProvider());
 
   // fetch the matching files/directories
   CFileItemList items;

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1341,18 +1341,19 @@ bool CAddonSettings::ParseOldLabel(const TiXmlElement* element, const std::strin
   std::string labelString;
   element->QueryStringAttribute("label", &labelString);
 
+  bool parsed = !labelString.empty();
 
   // try to parse the label as a pure number, i.e. a localized string
-  char *endptr;
-  labelId = std::strtol(labelString.c_str(), &endptr, 10);
-  if (endptr == nullptr || *endptr == '\0')
-    return true;
-
-
-  // as a last resort use the setting's identifier as a label
-  bool parsed = !labelString.empty();
-  if (!parsed)
-    labelString = settingId;
+  if (parsed)
+  {
+    char* endptr;
+    labelId = std::strtol(labelString.c_str(), &endptr, 10);
+    if (endptr == nullptr || *endptr == '\0')
+      return true;
+  }
+  // make sure the label string is not empty
+  else
+    labelString = " ";
 
   labelId = m_unknownSettingLabelId;
   m_unknownSettingLabelId += 1;

--- a/xbmc/addons/settings/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.cpp
@@ -249,3 +249,11 @@ CSettingsManager* CGUIDialogAddonSettings::GetSettingsManager() const
 
   return m_addon->GetSettings()->GetSettingsManager();
 }
+
+void CGUIDialogAddonSettings::OnSettingAction(std::shared_ptr<const CSetting> setting)
+{
+  if (m_addon == nullptr || m_addon->GetSettings() == nullptr)
+    return;
+
+  m_addon->GetSettings()->OnSettingAction(setting);
+}

--- a/xbmc/addons/settings/GUIDialogAddonSettings.h
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.h
@@ -39,6 +39,9 @@ protected:
   void Save() override { }
   CSettingsManager* GetSettingsManager() const override;
 
+  // implementation of ISettingCallback
+  void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
+
 private:
   ADDON::AddonPtr m_addon;
   bool m_saveToDisk = false;

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -138,7 +138,13 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
   XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
   XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_HIDEVALUE, m_hideValue);
 
-  if (m_format == "addon")
+  if (m_format == "action")
+  {
+    bool closeDialog = false;
+    if (XMLUtils::GetBoolean(node, "close", closeDialog))
+      m_closeDialog = closeDialog;
+  }
+  else if (m_format == "addon")
   {
     std::string strShowAddons;
     if (XMLUtils::GetString(node, "show", strShowAddons) && !strShowAddons.empty())

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -260,19 +260,28 @@ bool CSettingControlSlider::Deserialize(const TiXmlNode *node, bool update /* = 
 
 bool CSettingControlSlider::SetFormat(const std::string &format)
 {
-  if (StringUtils::EqualsNoCase(format, "percentage"))
-    m_formatString = "%i %%";
-  else if (StringUtils::EqualsNoCase(format, "integer"))
-    m_formatString = "%d";
-  else if (StringUtils::EqualsNoCase(format, "number"))
-    m_formatString = "%.1f";
-  else
+  if (!StringUtils::EqualsNoCase(format, "percentage") &&
+      !StringUtils::EqualsNoCase(format, "integer") &&
+      !StringUtils::EqualsNoCase(format, "number"))
     return false;
 
   m_format = format;
   StringUtils::ToLower(m_format);
+  m_formatString = GetDefaultFormatString();
 
   return true;
+}
+
+std::string CSettingControlSlider::GetDefaultFormatString() const
+{
+  if (m_format == "percentage")
+    return "{} %";
+  if (m_format == "integer")
+    return "{:d}";
+  if (m_format == "number")
+    return "{:.1f}";
+
+  return "{}";
 }
 
 bool CSettingControlRange::Deserialize(const TiXmlNode *node, bool update /* = false */)

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -221,6 +221,7 @@ public:
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
   const std::string& GetFormatString() const { return m_formatString; }
   void SetFormatString(const std::string &formatString) { m_formatString = formatString; }
+  std::string GetDefaultFormatString() const;
 
   SettingControlSliderFormatter GetFormatter() const { return m_formatter; }
   void SetFormatter(SettingControlSliderFormatter formatter) { m_formatter = formatter; }
@@ -229,7 +230,7 @@ protected:
   int m_heading = -1;
   bool m_popup = false;
   int m_formatLabel = -1;
-  std::string m_formatString = "%i";
+  std::string m_formatString;
   SettingControlSliderFormatter m_formatter = nullptr;
 };
 

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -9,6 +9,7 @@
 #include "SettingPath.h"
 
 #include "settings/lib/SettingsManager.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -91,7 +92,40 @@ bool CSettingPath::SetValue(const std::string &value)
   return CSettingString::SetValue(value);
 }
 
-void CSettingPath::copy(const CSettingPath &setting)
+std::string CSettingPath::GetMasking(const CFileExtensionProvider& fileExtensionProvider) const
+{
+  if (m_masking.empty())
+    return m_masking;
+
+  // setup masking
+  const auto audioMask = fileExtensionProvider.GetMusicExtensions();
+  const auto videoMask = fileExtensionProvider.GetVideoExtensions();
+  const auto imageMask = fileExtensionProvider.GetPictureExtensions();
+  auto execMask = "";
+#if defined(TARGET_WINDOWS)
+  execMask = ".exe|.bat|.cmd|.py";
+#endif // defined(TARGET_WINDOWS)
+
+  std::string masking = m_masking;
+  if (masking == "video")
+    return videoMask;
+  if (masking == "audio")
+    return audioMask;
+  if (masking == "image")
+    return imageMask;
+  if (masking == "executable")
+    return execMask;
+
+  // convert mask qualifiers
+  StringUtils::Replace(masking, "$AUDIO", audioMask);
+  StringUtils::Replace(masking, "$VIDEO", videoMask);
+  StringUtils::Replace(masking, "$IMAGE", imageMask);
+  StringUtils::Replace(masking, "$EXECUTABLE", execMask);
+
+  return masking;
+}
+
+void CSettingPath::copy(const CSettingPath& setting)
 {
   CSettingString::Copy(setting);
 

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -45,7 +45,7 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
     return false;
 
   if (m_control != nullptr &&
-     (m_control->GetType() != "button" || (m_control->GetFormat() != "path" && m_control->GetFormat() != "file")))
+     (m_control->GetType() != "button" || (m_control->GetFormat() != "path" && m_control->GetFormat() != "file" && m_control->GetFormat() != "image")))
   {
     CLog::Log(LOGERROR, "CSettingPath: invalid <control> of \"%s\"", m_id.c_str());
     return false;

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 
+class CFileExtensionProvider;
+
 class CSettingPath : public CSettingString
 {
 public:
@@ -31,7 +33,7 @@ public:
   void SetSources(const std::vector<std::string> &sources) { m_sources = sources; }
   bool HideExtension() const { return m_hideExtension; }
   void SetHideExtension(bool hideExtension) { m_hideExtension = hideExtension; }
-  const std::string& GetMasking() const { return m_masking; }
+  std::string GetMasking(const CFileExtensionProvider& fileExtensionProvider) const;
   void SetMasking(const std::string& masking) { m_masking = masking; }
 
 private:

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -1218,6 +1218,15 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
             entry.second = optionElement->FirstChild()->Value();
             m_translatableOptions.push_back(entry);
           }
+          else
+          {
+            const std::string value = optionElement->FirstChild()->Value();
+            // if a specific "label" attribute is present use it otherwise use the value as label
+            std::string label = value;
+            optionElement->QueryStringAttribute(SETTING_XML_ATTR_LABEL, &label);
+
+            m_options.emplace_back(label, value);
+          }
 
           optionElement = optionElement->NextSiblingElement(SETTING_XML_ELM_OPTION);
         }

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -302,6 +302,8 @@ public:
     m_optionsFillerData = data;
   }
   IntegerSettingOptions UpdateDynamicOptions();
+  SettingOptionsSort GetOptionsSort() const { return m_optionsSort; }
+  void SetOptionsSort(SettingOptionsSort optionsSort) { m_optionsSort = optionsSort; }
 
 private:
   void copy(const CSettingInt &setting);
@@ -318,6 +320,7 @@ private:
   IntegerSettingOptionsFiller m_optionsFiller = nullptr;
   void *m_optionsFillerData = nullptr;
   IntegerSettingOptions m_dynamicOptions;
+  SettingOptionsSort m_optionsSort = SettingOptionsSort::NoSorting;
 };
 
 /*!
@@ -416,6 +419,8 @@ public:
     m_optionsFillerData = data;
   }
   StringSettingOptions UpdateDynamicOptions();
+  SettingOptionsSort GetOptionsSort() const { return m_optionsSort; }
+  void SetOptionsSort(SettingOptionsSort optionsSort) { m_optionsSort = optionsSort; }
 
 protected:
   virtual void copy(const CSettingString &setting);
@@ -429,6 +434,7 @@ protected:
   StringSettingOptionsFiller m_optionsFiller = nullptr;
   void *m_optionsFillerData = nullptr;
   StringSettingOptions m_dynamicOptions;
+  SettingOptionsSort m_optionsSort = SettingOptionsSort::NoSorting;
 };
 
 /*!

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -98,3 +98,10 @@ using StringSettingOptions = std::vector<StringSettingOption>;
 class CSetting;
 using IntegerSettingOptionsFiller = void (*)(std::shared_ptr<const CSetting> setting, IntegerSettingOptions &list, int &current, void *data);
 using StringSettingOptionsFiller = void (*)(std::shared_ptr<const CSetting> setting, StringSettingOptions &list, std::string &current, void *data);
+
+enum class SettingOptionsSort
+{
+  NoSorting,
+  Ascending,
+  Descending
+};

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -67,6 +67,18 @@ static CFileItemPtr GetFileItem(const std::string& label, const TValueType& valu
   return item;
 }
 
+template<class SettingOption>
+static bool CompareSettingOptionAseconding(const SettingOption& lhs, const SettingOption& rhs)
+{
+  return StringUtils::CompareNoCase(lhs.label, rhs.label) < 0;
+}
+
+template<class SettingOption>
+static bool CompareSettingOptionDeseconding(const SettingOption& lhs, const SettingOption& rhs)
+{
+  return StringUtils::CompareNoCase(lhs.label, rhs.label) > 0;
+}
+
 static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& options, std::set<int>& selectedOptions, ILocalizer* localizer)
 {
   std::shared_ptr<const CSettingInt> pSettingInt = NULL;
@@ -138,6 +150,21 @@ static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& op
     }
   }
 
+  switch (pSettingInt->GetOptionsSort())
+  {
+  case SettingOptionsSort::Ascending:
+    std::sort(options.begin(), options.end(), CompareSettingOptionAseconding<IntegerSettingOption>);
+    break;
+
+  case SettingOptionsSort::Descending:
+    std::sort(options.begin(), options.end(), CompareSettingOptionDeseconding<IntegerSettingOption>);
+    break;
+
+  case SettingOptionsSort::NoSorting:
+  default:
+    break;
+  }
+
   return true;
 }
 
@@ -194,6 +221,21 @@ static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& opti
     case SettingOptionsType::Unknown:
     default:
       return false;
+  }
+
+  switch (pSettingString->GetOptionsSort())
+  {
+  case SettingOptionsSort::Ascending:
+    std::sort(options.begin(), options.end(), CompareSettingOptionAseconding<StringSettingOption>);
+    break;
+
+  case SettingOptionsSort::Descending:
+    std::sort(options.begin(), options.end(), CompareSettingOptionDeseconding<StringSettingOption>);
+    break;
+
+  case SettingOptionsSort::NoSorting:
+  default:
+    break;
   }
 
   return true;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -817,7 +817,9 @@ bool CGUIControlButtonSetting::GetPath(std::shared_ptr<CSettingPath> pathSetting
   std::shared_ptr<const CSettingControlButton> control = std::static_pointer_cast<const CSettingControlButton>(pathSetting->GetControl());
   const auto heading = ::Localize(control->GetHeading(), localizer);
   if (control->GetFormat() == "file")
-    result = CGUIDialogFileBrowser::ShowAndGetFile(shares, pathSetting->GetMasking(), heading, path, control->UseImageThumbs(), control->UseFileDirectories());
+    result = CGUIDialogFileBrowser::ShowAndGetFile(
+      shares, pathSetting->GetMasking(CServiceBroker::GetFileExtensionProvider()), heading, path,
+      control->UseImageThumbs(), control->UseFileDirectories());
   else if (control->GetFormat() == "image")
     result = CGUIDialogFileBrowser::ShowAndGetImage(shares, heading, path);
   else

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -188,9 +188,11 @@ public:
   void Update(bool updateDisplayOnly = false) override;
   void Clear() override { m_pSlider = NULL; }
 
-  static std::string GetText(std::shared_ptr<const CSettingControlSlider> control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum, ILocalizer* localizer);
+  static std::string GetText(std::shared_ptr<CSetting> setting, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum, ILocalizer* localizer);
 
 private:
+  static bool FormatText(const std::string& formatString, const CVariant &value, const std::string& settingId, std::string& formattedText);
+
   CGUISettingsSliderControl *m_pSlider;
 };
 


### PR DESCRIPTION
## Description
Based on some feedback from @ronie quite a while ago I made some changes to the core's settings system to add some functionality supported by the old / outdated add-on settings system:
* support `<close>` property for action button `<control>`s
* support pure string based labels (non-translatable) for `<option>`
* extend supported `<masking>` format for path settings
* fix parsing of path setting with `<control type="button" format="image">`
* support `"sort"` attribute on `<options>` constraint of integer and string settings

## Motivation and Context
Make it easier for add-on authors to migrate from the old / outdated add-on settings system to the core's settings system.

## How Has This Been Tested?
I made some manual tests using the core's settings by changing some of the existing settings definitions. I was not able to test this with an actual add-on's settings. It would be great if someone could do that.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
