### PR TITLE
[Inputstream] Make API backwards compatible to old addons

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -394,7 +394,7 @@ namespace addon
 class CInstanceInputStream : public IAddonInstance
 {
 public:
-  explicit CInstanceInputStream(KODI_HANDLE instance, const std::string& kodiVersion)
+  explicit CInstanceInputStream(KODI_HANDLE instance, const std::string& kodiVersion = "0.0.0")
     : IAddonInstance(ADDON_INSTANCE_INPUTSTREAM)
   {
     if (CAddonBase::m_interface->globalSingleInstance != nullptr)


### PR DESCRIPTION
## Description
Currently Matrix inputstream addons doesn't build because of the API change introduced here: #16581 

## Motivation and Context
Allow nightly builds

## How Has This Been Tested?
Compiled win32

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
