### PR TITLE
add support for xcode 11

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -331,7 +331,8 @@ case $host in
         esac
 
         # setup which sdk to use
-        found_sdk_version=[`$use_xcodebuild -showsdks | sed -E -n 's/.*macosx([0-9]+)\.([0-9]+)/\1.\2/p' | sort  -n -t. -k1,1 -k2,2 | tail -n 1`]
+        target_platform=macosx
+        found_sdk_version=[`$use_xcodebuild -showsdks | grep $target_platform | sort | tail -n 1 | awk '{ print $2}'`]
         use_sdk="${use_sdk:-$found_sdk_version}"
 
         # now that we know which sdk, error check sdk_name
@@ -342,10 +343,11 @@ case $host in
           10.12);;
           10.13);;
           10.14);;
+          10.15);;
           *)
             AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
         esac
-        sdk_name=macosx$use_sdk
+        sdk_name=$target_platform$use_sdk
         platform_min_version="macosx-version-min=10.9"
 
         use_sdk_path=[`$use_xcodebuild -version -sdk $sdk_name Path`]
@@ -384,6 +386,7 @@ case $host in
           case $use_sdk in
             11.*);;
             12.*);;
+            13.*);;
               *)
                 AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
               ;;
@@ -394,6 +397,7 @@ case $host in
             10.*);;
             11.*);;
             12.*);;
+            13.*);;
               *)
                 AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
               ;;


### PR DESCRIPTION
## Description

the output of `xcodebuild -showsdks` after upgrading to xcode 11 is:

```
$ xcodebuild -showsdks
iOS SDKs:
	iOS 13.0                      	-sdk iphoneos13.0

iOS Simulator SDKs:
	Simulator - iOS 13.0          	-sdk iphonesimulator13.0

macOS SDKs:
	DriverKit 19.0                	-sdk driverkit.macosx19.0
	macOS 10.15                   	-sdk macosx10.15

tvOS SDKs:
	tvOS 13.0                     	-sdk appletvos13.0

tvOS Simulator SDKs:
	Simulator - tvOS 13.0         	-sdk appletvsimulator13.0

watchOS SDKs:
	watchOS 6.0                   	-sdk watchos6.0

watchOS Simulator SDKs:
	Simulator - watchOS 6.0       	-sdk watchsimulator6.0
```
