### PR TITLE
[modernize] use-equals-default

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
+++ b/tools/EventClients/Clients/OSXRemote/xbmcclientwrapper.mm
@@ -30,7 +30,7 @@
 //helper class for easy EventSequence handling
 class XBMCClientEventSequence{
 public:
-  XBMCClientEventSequence(){}
+  XBMCClientEventSequence() = default;
 
   //implicit conversion
   XBMCClientEventSequence(eATVClientEvent f_event){

--- a/tools/EventClients/lib/c++/xbmcclient.h
+++ b/tools/EventClients/lib/c++/xbmcclient.h
@@ -140,8 +140,8 @@ public:
 class XBMCClientUtils
 {
 public:
-  XBMCClientUtils() {}
-  ~XBMCClientUtils() {}
+  XBMCClientUtils() = default;
+  ~XBMCClientUtils() = default;
   static unsigned int GetUniqueIdentifier()
   {
     static time_t id = time(NULL);
@@ -196,8 +196,7 @@ public:
   {
     m_PacketType = 0;
   }
-  virtual ~CPacket()
-  { }
+  virtual ~CPacket() = default;
 
   bool Send(int Socket, CAddress &Addr, unsigned int UID = XBMCClientUtils::GetUniqueIdentifier())
   {
@@ -595,8 +594,7 @@ public:
   {
     m_PacketType = PT_PING;
   }
-  virtual ~CPacketPING()
-  { }
+  virtual ~CPacketPING() = default;
 };
 
 class CPacketBYE : public CPacket
@@ -609,8 +607,7 @@ public:
   {
     m_PacketType = PT_BYE;
   }
-  virtual ~CPacketBYE()
-  { }
+  virtual ~CPacketBYE() = default;
 };
 
 class CPacketMOUSE : public CPacket
@@ -648,8 +645,7 @@ public:
     m_Payload.push_back( (m_Y & 0x00ff));
   }
 
-  virtual ~CPacketMOUSE()
-  { }
+  virtual ~CPacketMOUSE() = default;
 };
 
 class CPacketLOG : public CPacket
@@ -693,8 +689,7 @@ public:
     m_Payload.push_back('\0');
   }
 
-  virtual ~CPacketLOG()
-  { }
+  virtual ~CPacketLOG() = default;
 };
 
 class CPacketACTION : public CPacket
@@ -729,8 +724,7 @@ public:
     m_Payload.push_back('\0');
   }
 
-  virtual ~CPacketACTION()
-  { }
+  virtual ~CPacketACTION() = default;
 };
 
 class CXBMCClient

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -23,9 +23,7 @@ CAppParamParser::CAppParamParser()
 {
 }
 
-CAppParamParser::~CAppParamParser()
-{
-}
+CAppParamParser::~CAppParamParser() = default;
 
 void CAppParamParser::Parse(const char* const* argv, int nArgs)
 {

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -19,11 +19,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "settings/MediaSettings.h"
 
-CApplicationPlayer::CApplicationPlayer()
-{
-
-}
-
 std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal() const
 {
   CSingleLock lock(m_playerLock);

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -31,7 +31,7 @@ struct TextCacheStruct_t;
 class CApplicationPlayer
 {
 public:
-  CApplicationPlayer();
+  CApplicationPlayer() = default;
 
   // player management
   void ClosePlayer();

--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -24,10 +24,6 @@ CApplicationStackHelper::CApplicationStackHelper(void)
 {
 }
 
-CApplicationStackHelper::~CApplicationStackHelper(void)
-{
-}
-
 void CApplicationStackHelper::Clear()
 {
   m_currentStackPosition = 0;

--- a/xbmc/ApplicationStackHelper.h
+++ b/xbmc/ApplicationStackHelper.h
@@ -15,7 +15,7 @@ class CApplicationStackHelper
 {
 public:
   CApplicationStackHelper(void);
-  ~CApplicationStackHelper(void);
+  ~CApplicationStackHelper() = default;
 
   void Clear();
   void OnPlayBackStarted(const CFileItem& item);

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -35,9 +35,7 @@
 
 using namespace KODI;
 
-CServiceManager::CServiceManager()
-{
-}
+CServiceManager::CServiceManager() = default;
 
 CServiceManager::~CServiceManager()
 {

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -57,11 +57,5 @@ namespace ADDON
     static int CompareComponent(const char *a, const char *b);
   };
 
-  inline AddonVersion& AddonVersion::operator=(const AddonVersion& other)
-  {
-    mEpoch = other.mEpoch;
-    mUpstream = other.mUpstream;
-    mRevision = other.mRevision;
-    return *this;
-  }
+  inline AddonVersion& AddonVersion::operator=(const AddonVersion& other) = default;
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/PeripheralUtils.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/PeripheralUtils.h
@@ -150,9 +150,7 @@ namespace addon
   class PeripheralEvent
   {
   public:
-    PeripheralEvent(void)
-    {
-    }
+    PeripheralEvent() = default;
 
     PeripheralEvent(unsigned int peripheralIndex, unsigned int buttonIndex, JOYSTICK_STATE_BUTTON state) :
       m_type(PERIPHERAL_EVENT_TYPE_DRIVER_BUTTON),

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -132,8 +132,7 @@ namespace XbmcCommons
      * in the source buffer and vice/vrs. However, each buffer maintains
      * its own indexing.
      */
-    inline Buffer(const Buffer& buf) : bufferRef(buf.bufferRef), buffer(buf.buffer),
-      mposition(buf.mposition), mcapacity(buf.mcapacity), mlimit(buf.mlimit) { }
+    inline Buffer(const Buffer& buf) = default;
 
     /**
      * Copy another buffer. This is a "shallow copy" and therefore

--- a/xbmc/commons/Exception.h
+++ b/xbmc/commons/Exception.h
@@ -52,7 +52,7 @@ namespace XbmcCommons
 
     inline explicit Exception(const char* classname_) : classname(classname_) { }
     inline Exception(const char* classname_, const char* message_) : classname(classname_), message(message_) { }
-    inline Exception(const Exception& other) : classname(other.classname), message(other.message) { }
+    inline Exception(const Exception& other) = default;
 
     /**
      * This method is called from the constructor of subclasses. It

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -29,10 +29,6 @@ CSoundPacket::~CSoundPacket()
     CActiveAE::FreeSoundSample(data);
 }
 
-CSampleBuffer::CSampleBuffer()
-{
-}
-
 CSampleBuffer::~CSampleBuffer()
 {
   delete pkt;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -45,7 +45,7 @@ class CActiveAEBufferPool;
 class CSampleBuffer
 {
 public:
-  CSampleBuffer();
+  CSampleBuffer() = default;
   ~CSampleBuffer();
   CSampleBuffer *Acquire();
   void Return();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.h
@@ -29,7 +29,7 @@ public:
   virtual const char *GetName() { return "DARWINIOS"; }
 
   CAESinkDARWINIOS();
-  virtual ~CAESinkDARWINIOS();
+  virtual ~CAESinkDARWINIOS() = default;
 
   static void Register();
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -583,10 +583,6 @@ CAESinkDARWINIOS::CAESinkDARWINIOS()
 {
 }
 
-CAESinkDARWINIOS::~CAESinkDARWINIOS()
-{
-}
-
 void CAESinkDARWINIOS::Register()
 {
   AE::AESinkRegEntry reg;

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.h
@@ -40,7 +40,7 @@ public:
   */
   AEDeviceEnumerationOSX(AudioDeviceID deviceID);
   // d'tor
-  ~AEDeviceEnumerationOSX(){};
+  ~AEDeviceEnumerationOSX() = default;
 
   /*!
   * @brief Gets the device list which was enumerated by the last call to Enumerate

--- a/xbmc/cores/AudioEngine/Utils/AEAudioFormat.h
+++ b/xbmc/cores/AudioEngine/Utils/AEAudioFormat.h
@@ -66,16 +66,6 @@ struct AEAudioFormat
             m_streamInfo    ==  fmt.m_streamInfo;
   }
 
-  AEAudioFormat& operator=(const AEAudioFormat& fmt)
-  {
-    m_dataFormat = fmt.m_dataFormat;
-    m_sampleRate = fmt.m_sampleRate;
-    m_channelLayout = fmt.m_channelLayout;
-    m_frames = fmt.m_frames;
-    m_frameSize = fmt.m_frameSize;
-    m_streamInfo = fmt.m_streamInfo;
-
-    return *this;
-  }
+  AEAudioFormat& operator=(const AEAudioFormat& fmt) = default;
 };
 

--- a/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
@@ -24,7 +24,7 @@ namespace RETRO
   class IRenderBuffer
   {
   public:
-    virtual ~IRenderBuffer() { }
+    virtual ~IRenderBuffer() = default;
 
     // Pool functions
     virtual void Acquire() = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayText.h
@@ -66,11 +66,7 @@ public:
     {
     }
 
-    CElementText(CElementText& src)
-     : CElement(src),
-       m_text(src.m_text)
-    {
-    }
+    CElementText(CElementText& src) = default;
 
     const std::string& GetText()
     { return m_text; }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -66,7 +66,7 @@ class CMediaCodecVideoBuffer : public CVideoBuffer
 public:
   CMediaCodecVideoBuffer(int id)
     : CVideoBuffer(id){};
-  virtual ~CMediaCodecVideoBuffer(){};
+  virtual ~CMediaCodecVideoBuffer() = default;
 
   void Set(int internalId,
            int textureId,

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.cpp
@@ -15,10 +15,6 @@ CProcessInfo* CProcessInfoAndroid::Create()
   return new CProcessInfoAndroid();
 }
 
-CProcessInfoAndroid::CProcessInfoAndroid()
-{
-}
-
 void CProcessInfoAndroid::Register()
 {
   CProcessInfo::RegisterProcessControl("android", CProcessInfoAndroid::Create);

--- a/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
+++ b/xbmc/cores/VideoPlayer/Process/android/ProcessInfoAndroid.h
@@ -16,7 +16,7 @@ namespace VIDEOPLAYER
   class CProcessInfoAndroid : public CProcessInfo
   {
   public:
-    CProcessInfoAndroid();
+    CProcessInfoAndroid() = default;
     static CProcessInfo* Create();
     static void Register();
     EINTERLACEMETHOD GetFallbackDeintMethod() override;

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -20,10 +20,6 @@ void CProcessInfoGBM::Register()
   CProcessInfo::RegisterProcessControl("gbm", CProcessInfoGBM::Create);
 }
 
-CProcessInfoGBM::CProcessInfoGBM()
-{
-}
-
 EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
 {
 #if defined(__arm__)

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
@@ -17,7 +17,7 @@ namespace VIDEOPLAYER
 class CProcessInfoGBM : public CProcessInfo
 {
 public:
-  CProcessInfoGBM();
+  CProcessInfoGBM() = default;
   static CProcessInfo* Create();
   static void Register();
   EINTERLACEMETHOD GetFallbackDeintMethod() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -34,16 +34,18 @@ CColorManager::CColorManager()
 #endif  //defined(HAVE_LCMS2)
 }
 
+#if defined(HAVE_LCMS2)
 CColorManager::~CColorManager()
 {
-#if defined(HAVE_LCMS2)
   if (m_hProfile)
   {
     cmsCloseProfile(m_hProfile);
     m_hProfile = nullptr;
   }
-#endif  //defined(HAVE_LCMS2)
 }
+#else
+CColorManager::~CColorManager() = default;
+#endif //defined(HAVE_LCMS2)
 
 bool CColorManager::IsEnabled() const
 {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
@@ -36,10 +36,6 @@ bool CRendererVTB::Register()
   return true;
 }
 
-CRendererVTB::CRendererVTB()
-{
-}
-
 CRendererVTB::~CRendererVTB()
 {
   for (int i = 0; i < NUM_BUFFERS; ++i)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.h
@@ -14,7 +14,7 @@
 class CRendererVTB : public CLinuxRendererGL
 {
 public:
-  CRendererVTB();
+  CRendererVTB() = default;
   virtual ~CRendererVTB();
 
   static CBaseRenderer* Create(CVideoBuffer *buffer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -19,10 +19,6 @@
 
 using namespace VAAPI;
 
-CVaapi1Texture::CVaapi1Texture()
-{
-}
-
 void CVaapi1Texture::Init(InteropInfo &interop)
 {
   m_interop = interop;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -61,7 +61,7 @@ public:
 class CVaapi1Texture : public CVaapiTexture
 {
 public:
-  CVaapi1Texture();
+  CVaapi1Texture() = default;
 
   bool Map(CVaapiRenderPicture *pic) override;
   void Unmap() override;

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -209,9 +209,7 @@ typedef query_data::iterator qry_itor;
 class result_set
 {
 public:
-  result_set()
-  {
-  };
+  result_set() = default;
   ~result_set()
   {
     clear();

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -24,23 +24,7 @@
 class TestZipFile : public testing::Test
 {
 protected:
-  TestZipFile()
-  {
-    /* Add default settings for locale.
-     * Settings here are taken from CGUISettings::Initialize()
-     */
-    //! @todo implement
-    /*
-    CSettingsCategory *loc = CServiceBroker::GetSettingsComponent()->GetSettings()->AddCategory(7, "locale", 14090);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddString(loc, CSettings::SETTING_LOCALE_LANGUAGE,248,"english",
-                            SPIN_CONTROL_TEXT);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddString(loc, CSettings::SETTING_LOCALE_COUNTRY, 20026, "USA",
-                            SPIN_CONTROL_TEXT);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddString(loc, CSettings::SETTING_LOCALE_CHARSET, 14091, "DEFAULT",
-                            SPIN_CONTROL_TEXT); // charset is set by the
-                                                // language file
-    */
-  }
+  TestZipFile() = default;
 
   ~TestZipFile() override
   {

--- a/xbmc/games/controllers/types/ControllerGrid.cpp
+++ b/xbmc/games/controllers/types/ControllerGrid.cpp
@@ -17,16 +17,6 @@
 using namespace KODI;
 using namespace GAME;
 
-CControllerGrid::CControllerGrid()
-{
-}
-
-CControllerGrid::CControllerGrid(const CControllerGrid &other) :
-  m_grid(other.m_grid),
-  m_height(other.m_height)
-{
-}
-
 CControllerGrid::~CControllerGrid() = default;
 
 void CControllerGrid::SetControllerTree(const CControllerTree &controllerTree)

--- a/xbmc/games/controllers/types/ControllerGrid.h
+++ b/xbmc/games/controllers/types/ControllerGrid.h
@@ -50,8 +50,8 @@ namespace GAME
   class CControllerGrid
   {
   public:
-    CControllerGrid();
-    CControllerGrid(const CControllerGrid &other);
+    CControllerGrid() = default;
+    CControllerGrid(const CControllerGrid& other) = default;
     ~CControllerGrid();
 
     /*!

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -27,17 +27,6 @@ CTextureInfo::CTextureInfo(const std::string &file):
   useLarge = false;
 }
 
-CTextureInfo& CTextureInfo::operator=(const CTextureInfo &right)
-{
-  border = right.border;
-  orientation = right.orientation;
-  diffuse = right.diffuse;
-  filename = right.filename;
-  useLarge = right.useLarge;
-  diffuseColor = right.diffuseColor;
-  return *this;
-}
-
 CGUITextureBase::CGUITextureBase(float posX, float posY, float width, float height, const CTextureInfo& texture) :
   m_height(height), m_info(texture)
 {

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -56,7 +56,7 @@ class CTextureInfo
 public:
   CTextureInfo();
   explicit CTextureInfo(const std::string &file);
-  CTextureInfo& operator=(const CTextureInfo &right);
+  CTextureInfo& operator=(const CTextureInfo& right) = default;
   bool       useLarge;
   CRect      border;          // scaled  - unneeded if we get rid of scale on load
   int        orientation;     // orientation of the texture (0 - 7 == EXIForientation - 1)

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -121,12 +121,6 @@ CXBTFFile::CXBTFFile()
     m_frames()
 { }
 
-CXBTFFile::CXBTFFile(const CXBTFFile& ref)
-  : m_path(ref.m_path),
-    m_loop(ref.m_loop),
-    m_frames(ref.m_frames)
-{ }
-
 const std::string& CXBTFFile::GetPath() const
 {
   return m_path;

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -65,7 +65,7 @@ class CXBTFFile
 {
 public:
   CXBTFFile();
-  CXBTFFile(const CXBTFFile& ref);
+  CXBTFFile(const CXBTFFile& ref) = default;
 
   const std::string& GetPath() const;
   void SetPath(const std::string& path);

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -82,13 +82,9 @@ static const std::map<int, int> listitem2slideshow_map =
   { LISTITEM_PICTURE_GPS_ALT          , SLIDESHOW_EXIF_GPS_ALTITUDE }
 };
 
-CPicturesGUIInfo::CPicturesGUIInfo()
-{
-}
+CPicturesGUIInfo::CPicturesGUIInfo() = default;
 
-CPicturesGUIInfo::~CPicturesGUIInfo()
-{
-}
+CPicturesGUIInfo::~CPicturesGUIInfo() = default;
 
 void CPicturesGUIInfo::SetCurrentSlide(CFileItem *item)
 {

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -38,9 +38,7 @@ CPlayerGUIInfo::CPlayerGUIInfo()
 {
 }
 
-CPlayerGUIInfo::~CPlayerGUIInfo()
-{
-}
+CPlayerGUIInfo::~CPlayerGUIInfo() = default;
 
 int CPlayerGUIInfo::GetTotalPlayTime() const
 {

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -31,14 +31,6 @@
 
 using namespace KODI;
 
-CButtonTranslator::CButtonTranslator()
-{
-}
-
-CButtonTranslator::~CButtonTranslator()
-{
-}
-
 // Add the supplied device name to the list of connected devices
 bool CButtonTranslator::AddDevice(const std::string& strDevice)
 {

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -29,10 +29,10 @@ class CButtonTranslator
   friend class EVENTCLIENT::CEventButtonState;
 
 public:
-  CButtonTranslator();
+  CButtonTranslator() = default;
   CButtonTranslator(const CButtonTranslator&) = delete;
   CButtonTranslator const& operator=(CButtonTranslator const&) = delete;
-  virtual ~CButtonTranslator();
+  virtual ~CButtonTranslator() = default;
 
   // Add/remove a HID device with custom mappings
   bool AddDevice(const std::string& strDevice);

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -21,10 +21,6 @@
 #include <stdlib.h>
 #include <vector>
 
-CIRTranslator::CIRTranslator()
-{
-}
-
 void CIRTranslator::Load(const std::string &irMapName)
 {
   if (irMapName.empty())

--- a/xbmc/input/IRTranslator.h
+++ b/xbmc/input/IRTranslator.h
@@ -17,7 +17,7 @@ class TiXmlNode;
 class CIRTranslator
 {
 public:
-  CIRTranslator();
+  CIRTranslator() = default;
 
   /*!
    * \brief Loads Lircmap.xml/IRSSmap.xml

--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -27,10 +27,6 @@ using namespace KODI;
 #define JOYSTICK_XML_ATTR_HOLDTIME   "holdtime"
 #define JOYSTICK_XML_ATTR_HOTKEY     "hotkey"
 
-CJoystickMapper::~CJoystickMapper()
-{
-}
-
 void CJoystickMapper::MapActions(int windowID, const TiXmlNode *pDevice)
 {
   std::string controllerId;

--- a/xbmc/input/JoystickMapper.h
+++ b/xbmc/input/JoystickMapper.h
@@ -25,7 +25,7 @@ class CJoystickMapper : public IButtonMapper
 {
 public:
   CJoystickMapper() = default;
-  virtual ~CJoystickMapper();
+  virtual ~CJoystickMapper() = default;
 
   // implementation of IButtonMapper
   virtual void MapActions(int windowID, const TiXmlNode *pDevice) override;

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -762,8 +762,7 @@ namespace XBMCAddon
       void deallocating() override;
 
     public:
-
-      DialogBusy() {}
+      DialogBusy() = default;
       ~DialogBusy() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/Exception.h
+++ b/xbmc/interfaces/legacy/Exception.h
@@ -26,7 +26,7 @@ namespace XBMCAddon
   class UnimplementedException : public XbmcCommons::Exception
   {
   public:
-    inline UnimplementedException(const UnimplementedException& other) : Exception(other) { }
+    inline UnimplementedException(const UnimplementedException& other) = default;
     inline UnimplementedException(const char* classname, const char* methodname) :
       Exception("UnimplementedException")
     { SetMessage("Unimplemented method: %s::%s(...)", classname, methodname); }
@@ -39,7 +39,7 @@ namespace XBMCAddon
   class UnhandledException : public XbmcCommons::Exception
   {
   public:
-    inline UnhandledException(const UnhandledException& other) : Exception(other) { }
+    inline UnhandledException(const UnhandledException& other) = default;
     inline UnhandledException(const char* _message,...) : Exception("UnhandledException") { XBMCCOMMONS_COPYVARARGS(_message); }
   };
 }

--- a/xbmc/interfaces/legacy/Tuple.h
+++ b/xbmc/interfaces/legacy/Tuple.h
@@ -21,7 +21,7 @@ namespace XBMCAddon
   protected:
     int numValuesSet;
     explicit inline TupleBase(int pnumValuesSet) : numValuesSet(pnumValuesSet) {}
-    inline TupleBase(const TupleBase& o) : numValuesSet(o.numValuesSet) {}
+    inline TupleBase(const TupleBase& o) = default;
     inline void nvs(int newSize) { if(numValuesSet < newSize) numValuesSet = newSize; }
   public:
     inline int GetNumValuesSet() const { return numValuesSet; }

--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -133,13 +133,15 @@ namespace XBMCAddon
         P::SetLoadType(CGUIWindow::LOAD_ON_GUI_INIT);
       }
 
+#ifdef ENABLE_XBMC_TRACE_API
       ~Interceptor() override
       {
-#ifdef ENABLE_XBMC_TRACE_API
         XBMCAddonUtils::TraceGuard tg;
         CLog::Log(LOGDEBUG, "%sNEWADDON LIFECYCLE destroying %s 0x%lx", tg.getSpaces(),classname.c_str(), (long)(((void*)this)));
-#endif
       }
+#else
+      ~Interceptor() override = default;
+#endif
 
       bool OnMessage(CGUIMessage& message) override
       { XBMC_TRACE; return up() ? P::OnMessage(message) : checkedb(OnMessage(message)); }

--- a/xbmc/media/drm/CryptoSession.h
+++ b/xbmc/media/drm/CryptoSession.h
@@ -26,7 +26,7 @@ namespace DRM
   public:
     // Interface registration
     static CCryptoSession* GetCryptoSession(const std::string& UUID, const std::string& cipherAlgo, const std::string& macAlgo);
-    virtual ~CCryptoSession() {};
+    virtual ~CCryptoSession() = default;
 
     // Interface methods
     virtual XbmcCommons::Buffer GetKeyRequest(const XbmcCommons::Buffer& init, const std::string& mimeType, bool offlineKey, const std::map<std::string, std::string>& parameters) = 0;

--- a/xbmc/messaging/ThreadMessage.h
+++ b/xbmc/messaging/ThreadMessage.h
@@ -60,18 +60,7 @@ public:
   {
   }
 
-  ThreadMessage(const ThreadMessage& other)
-    : dwMessage(other.dwMessage),
-    param1(other.param1),
-    param2(other.param2),
-    param3(other.param3),
-    lpVoid(other.lpVoid),
-    strParam(other.strParam),
-    params(other.params),
-    waitEvent(other.waitEvent),
-    result(other.result)
-  {
-  }
+  ThreadMessage(const ThreadMessage& other) = default;
 
   ThreadMessage(ThreadMessage&& other)
     : dwMessage(other.dwMessage),

--- a/xbmc/platform/android/activity/AndroidJoyStick.h
+++ b/xbmc/platform/android/activity/AndroidJoyStick.h
@@ -16,8 +16,8 @@ struct AInputEvent;
 class CAndroidJoyStick
 {
 public:
-  CAndroidJoyStick() { }
-  ~CAndroidJoyStick() { }
+  CAndroidJoyStick() = default;
+  ~CAndroidJoyStick() = default;
 
   bool onJoyStickEvent(AInputEvent* event);
 };

--- a/xbmc/platform/android/activity/AndroidKey.h
+++ b/xbmc/platform/android/activity/AndroidKey.h
@@ -17,8 +17,8 @@
 class CAndroidKey
 {
 public:
-  CAndroidKey() {};
- ~CAndroidKey() {};
+  CAndroidKey() = default;
+  ~CAndroidKey() = default;
 
   bool onKeyboardEvent(AInputEvent *event);
 

--- a/xbmc/platform/android/activity/AndroidMouse.cpp
+++ b/xbmc/platform/android/activity/AndroidMouse.cpp
@@ -23,10 +23,6 @@ CAndroidMouse::CAndroidMouse()
 {
 }
 
-CAndroidMouse::~CAndroidMouse()
-{
-}
-
 bool CAndroidMouse::onMouseEvent(AInputEvent* event)
 {
   if (event == NULL)

--- a/xbmc/platform/android/activity/AndroidMouse.h
+++ b/xbmc/platform/android/activity/AndroidMouse.h
@@ -15,7 +15,7 @@ class CAndroidMouse
 
 public:
   CAndroidMouse();
-  virtual ~CAndroidMouse();
+  virtual ~CAndroidMouse() = default;
   bool onMouseEvent(AInputEvent* event);
 
 protected:

--- a/xbmc/platform/android/activity/DllGraphicBuffer.h
+++ b/xbmc/platform/android/activity/DllGraphicBuffer.h
@@ -13,7 +13,7 @@
 class DllGraphicBufferInterface
 {
 public:
-  virtual ~DllGraphicBufferInterface() {}
+  virtual ~DllGraphicBufferInterface() = default;
   virtual void    GraphicBufferCtor(void *, uint32_t w, uint32_t h, uint32_t format, gfxImageUsage usage)=0;
   virtual void    GraphicBufferDtor(void *)=0;
   virtual int     GraphicBufferLock(void*, uint32_t usage, void **addr)=0;

--- a/xbmc/platform/android/activity/JNIXBMCFile.h
+++ b/xbmc/platform/android/activity/JNIXBMCFile.h
@@ -22,7 +22,7 @@ namespace jni
   public:
     CJNIXBMCFile();
     CJNIXBMCFile(const jni::jhobject &object) : CJNIBase(object) {}
-    virtual ~CJNIXBMCFile() {}
+    virtual ~CJNIXBMCFile() = default;
 
     static void RegisterNatives(JNIEnv* env);
 

--- a/xbmc/platform/android/activity/JNIXBMCJsonHandler.h
+++ b/xbmc/platform/android/activity/JNIXBMCJsonHandler.h
@@ -25,7 +25,7 @@ namespace jni
 
 
   protected:
-    virtual ~CJNIXBMCJsonHandler() {}
+    virtual ~CJNIXBMCJsonHandler() = default;
 
     static jstring _requestJSON(JNIEnv* env, jobject thiz, jstring request);
 

--- a/xbmc/platform/android/activity/JNIXBMCMainView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.cpp
@@ -48,10 +48,6 @@ CJNIXBMCMainView::CJNIXBMCMainView(CJNISurfaceHolderCallback* callback)
   m_instance = this;
 }
 
-CJNIXBMCMainView::~CJNIXBMCMainView()
-{
-}
-
 void CJNIXBMCMainView::_attach(JNIEnv* env, jobject thiz)
 {
   (void)env;

--- a/xbmc/platform/android/activity/JNIXBMCMainView.h
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.h
@@ -20,7 +20,7 @@ class CJNIXBMCMainView : virtual public CJNIBase, public CJNISurfaceHolderCallba
 {
 public:
   CJNIXBMCMainView(CJNISurfaceHolderCallback* callback);
-  ~CJNIXBMCMainView();
+  ~CJNIXBMCMainView() = default;
 
   static void RegisterNatives(JNIEnv* env);
 

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -50,10 +50,6 @@ CJNIXBMCVideoView::CJNIXBMCVideoView(const jni::jhobject &object)
 {
 }
 
-CJNIXBMCVideoView::~CJNIXBMCVideoView()
-{
-}
-
 CJNIXBMCVideoView* CJNIXBMCVideoView::createVideoView(CJNISurfaceHolderCallback* callback)
 {
   std::string signature = "()L" + s_className + ";";

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.h
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.h
@@ -21,7 +21,7 @@ class CJNIXBMCVideoView : virtual public CJNIBase, public CJNISurfaceHolderCallb
 {
 public:
   CJNIXBMCVideoView(const jni::jhobject &object);
-  ~CJNIXBMCVideoView();
+  ~CJNIXBMCVideoView() = default;
 
   static void RegisterNatives(JNIEnv* env);
 

--- a/xbmc/platform/android/filesystem/APKDirectory.h
+++ b/xbmc/platform/android/filesystem/APKDirectory.h
@@ -14,10 +14,10 @@ namespace XFILE
 {
   class CAPKDirectory : public IFileDirectory
   {
-    public:
-    CAPKDirectory() {};
-    virtual ~CAPKDirectory() {};
-    virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+  public:
+    CAPKDirectory() = default;
+    virtual ~CAPKDirectory() = default;
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items);
     virtual bool ContainsFiles(const CURL& url);
     virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const;
     virtual bool Exists(const CURL& url);

--- a/xbmc/platform/android/filesystem/APKFile.cpp
+++ b/xbmc/platform/android/filesystem/APKFile.cpp
@@ -30,10 +30,6 @@ CAPKFile::CAPKFile()
   m_zip_archive = NULL;
 }
 
-CAPKFile::~CAPKFile()
-{
-}
-
 bool CAPKFile::Open(const CURL& url)
 {
   Close();

--- a/xbmc/platform/android/filesystem/APKFile.h
+++ b/xbmc/platform/android/filesystem/APKFile.h
@@ -20,7 +20,7 @@ namespace XFILE
   {
   public:
     CAPKFile();
-    virtual ~CAPKFile();
+    virtual ~CAPKFile() = default;
     virtual bool Open(const CURL& url);
     virtual void Close();
     virtual bool Exists(const CURL& url);

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.cpp
@@ -22,14 +22,6 @@
 
 using namespace XFILE;
 
-CAndroidAppDirectory::CAndroidAppDirectory(void)
-{
-}
-
-CAndroidAppDirectory::~CAndroidAppDirectory(void)
-{
-}
-
 bool CAndroidAppDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   std::string dirname = url.GetFileName();

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.h
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.h
@@ -17,8 +17,8 @@ class CAndroidAppDirectory :
       public IDirectory
 {
 public:
-  CAndroidAppDirectory(void);
-  virtual ~CAndroidAppDirectory(void);
+  CAndroidAppDirectory() = default;
+  virtual ~CAndroidAppDirectory() = default;
   virtual bool GetDirectory(const CURL& url, CFileItemList &items) override;
   virtual bool Exists(const CURL& url) override { return true; };
   virtual bool AllowAll() const override { return true; };

--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
@@ -20,12 +20,6 @@ void CAndroidPowerSyscall::Register()
   IPowerSyscall::RegisterPowerSyscall(CAndroidPowerSyscall::CreateInstance);
 }
 
-CAndroidPowerSyscall::CAndroidPowerSyscall()
-{ }
-
-CAndroidPowerSyscall::~CAndroidPowerSyscall()
-{ }
-
 int CAndroidPowerSyscall::BatteryLevel(void)
 {
   return CXBMCApp::GetBatteryLevel();

--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.h
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.h
@@ -13,8 +13,8 @@
 class CAndroidPowerSyscall : public CPowerSyscallWithoutEvents
 {
 public:
-  CAndroidPowerSyscall();
-  ~CAndroidPowerSyscall();
+  CAndroidPowerSyscall() = default;
+  ~CAndroidPowerSyscall() = default;
 
   static IPowerSyscall* CreateInstance();
   static void Register();

--- a/xbmc/platform/android/storage/AndroidStorageProvider.h
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.h
@@ -18,7 +18,7 @@ class CAndroidStorageProvider : public IStorageProvider
 {
 public:
   CAndroidStorageProvider();
-  virtual ~CAndroidStorageProvider() { }
+  virtual ~CAndroidStorageProvider() = default;
 
   virtual void Initialize() { }
   virtual void Stop() { }

--- a/xbmc/platform/darwin/PlatformDarwin.cpp
+++ b/xbmc/platform/darwin/PlatformDarwin.cpp
@@ -12,16 +12,6 @@
 
 #include <stdlib.h>
 
-CPlatformDarwin::CPlatformDarwin()
-{
-
-}
-
-CPlatformDarwin::~CPlatformDarwin()
-{
-
-}
-
 void CPlatformDarwin::Init()
 {
   CPlatformPosix::Init();

--- a/xbmc/platform/darwin/PlatformDarwin.h
+++ b/xbmc/platform/darwin/PlatformDarwin.h
@@ -14,10 +14,10 @@ class CPlatformDarwin : public CPlatformPosix
 {
   public:
     /**\brief C'tor */
-    CPlatformDarwin();
+    CPlatformDarwin() = default;
 
     /**\brief D'tor */
-    virtual ~CPlatformDarwin();
+    virtual ~CPlatformDarwin() = default;
 
     void Init() override;
 };

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.h
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.h
@@ -23,5 +23,5 @@ public:
   virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
 
 private:
-  CAnnounceReceiver() {};
+  CAnnounceReceiver() = default;
 };

--- a/xbmc/platform/darwin/storage/DarwinStorageProvider.h
+++ b/xbmc/platform/darwin/storage/DarwinStorageProvider.h
@@ -18,7 +18,7 @@ class CDarwinStorageProvider : public IStorageProvider
 {
 public:
   CDarwinStorageProvider();
-  virtual ~CDarwinStorageProvider() { }
+  virtual ~CDarwinStorageProvider() = default;
 
   virtual void Initialize() { }
   virtual void Stop() { }

--- a/xbmc/platform/overrides/android/PlatformAndroid.cpp
+++ b/xbmc/platform/overrides/android/PlatformAndroid.cpp
@@ -17,16 +17,6 @@ CPlatform* CPlatform::CreateInstance()
   return new CPlatformAndroid();
 }
 
-CPlatformAndroid::CPlatformAndroid()
-{
-
-}
-
-CPlatformAndroid::~CPlatformAndroid()
-{
-
-}
-
 void CPlatformAndroid::Init()
 {
   CPlatformPosix::Init();

--- a/xbmc/platform/overrides/android/PlatformAndroid.h
+++ b/xbmc/platform/overrides/android/PlatformAndroid.h
@@ -14,10 +14,10 @@ class CPlatformAndroid : public CPlatformPosix
 {
   public:
     /**\brief C'tor */
-    CPlatformAndroid();
+    CPlatformAndroid() = default;
 
     /**\brief D'tor */
-    virtual ~CPlatformAndroid();
+    virtual ~CPlatformAndroid() = default;
 
     void Init() override;
 };

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -87,9 +87,7 @@ CProfileManager::CProfileManager() :
 {
 }
 
-CProfileManager::~CProfileManager()
-{
-}
+CProfileManager::~CProfileManager() = default;
 
 void CProfileManager::Initialize(const std::shared_ptr<CSettings>& settings)
 {

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -50,10 +50,6 @@ CPVRGUIInfo::CPVRGUIInfo(void) :
   ResetProperties();
 }
 
-CPVRGUIInfo::~CPVRGUIInfo(void)
-{
-}
-
 void CPVRGUIInfo::ResetProperties(void)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -41,7 +41,7 @@ namespace PVR
   {
   public:
     CPVRGUIInfo(void);
-    ~CPVRGUIInfo(void) override;
+    ~CPVRGUIInfo() override = default;
 
     void Start(void);
     void Stop(void);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -90,10 +90,6 @@ CPVRTimers::CPVRTimers(void)
 {
 }
 
-CPVRTimers::~CPVRTimers(void)
-{
-}
-
 bool CPVRTimers::Load(void)
 {
   // unload previous timers

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -65,7 +65,7 @@ namespace PVR
   {
   public:
     CPVRTimers(void);
-    ~CPVRTimers(void) override;
+    ~CPVRTimers() override = default;
 
     /**
      * @brief (re)load the timers from the clients.

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -89,9 +89,7 @@ CGUIWindowPVRSearchBase::CGUIWindowPVRSearchBase(bool bRadio, int id, const std:
 {
 }
 
-CGUIWindowPVRSearchBase::~CGUIWindowPVRSearchBase()
-{
-}
+CGUIWindowPVRSearchBase::~CGUIWindowPVRSearchBase() = default;
 
 void CGUIWindowPVRSearchBase::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -30,10 +30,6 @@ CRenderSystemGLES::CRenderSystemGLES()
 {
 }
 
-CRenderSystemGLES::~CRenderSystemGLES()
-{
-}
-
 bool CRenderSystemGLES::InitRenderSystem()
 {
   GLint maxTextureSize;

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -36,7 +36,7 @@ class CRenderSystemGLES : public CRenderSystemBase
 {
 public:
   CRenderSystemGLES();
-  virtual ~CRenderSystemGLES();
+  virtual ~CRenderSystemGLES() = default;
 
   bool InitRenderSystem() override;
   bool DestroyRenderSystem() override;

--- a/xbmc/utils/ActorProtocol.h
+++ b/xbmc/utils/ActorProtocol.h
@@ -23,14 +23,14 @@ namespace Actor
 class CPayloadWrapBase
 {
 public:
-  virtual ~CPayloadWrapBase() {};
+  virtual ~CPayloadWrapBase() = default;
 };
 
 template<typename Payload>
 class CPayloadWrap : public CPayloadWrapBase
 {
 public:
-  ~CPayloadWrap() override {};
+  ~CPayloadWrap() override = default;
   CPayloadWrap(Payload *data) {m_pPayload.reset(data);};
   CPayloadWrap(Payload &data) {m_pPayload.reset(new Payload(data));};
   Payload *GetPlayload() {return m_pPayload.get();};

--- a/xbmc/utils/Digest.h
+++ b/xbmc/utils/Digest.h
@@ -106,8 +106,7 @@ struct TypedDigest
   CDigest::Type type{CDigest::Type::INVALID};
   std::string value;
 
-  TypedDigest()
-  {}
+  TypedDigest() = default;
 
   TypedDigest(CDigest::Type type, std::string const& value)
   : type(type), value(value)

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -182,10 +182,6 @@ void CEGLUtils::Log(int logLevel, const std::string& what)
   CLog::Log(logLevel, "{} ({})", what.c_str(), errorStr);
 }
 
-CEGLContextUtils::CEGLContextUtils()
-{
-}
-
 CEGLContextUtils::CEGLContextUtils(EGLenum platform, std::string const& platformExtension)
 : m_platform{platform}
 {

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -166,7 +166,7 @@ private:
 class CEGLContextUtils final
 {
 public:
-  CEGLContextUtils();
+  CEGLContextUtils() = default;
   /**
    * \param platform platform as constant from an extension building on EGL_EXT_platform_base
    */

--- a/xbmc/utils/test/TestJobManager.cpp
+++ b/xbmc/utils/test/TestJobManager.cpp
@@ -65,9 +65,7 @@ public:
 class TestJobManager : public testing::Test
 {
 protected:
-  TestJobManager()
-  {
-  }
+  TestJobManager() = default;
 
   ~TestJobManager() override
   {

--- a/xbmc/utils/test/TestLabelFormatter.cpp
+++ b/xbmc/utils/test/TestLabelFormatter.cpp
@@ -20,19 +20,7 @@
 class TestLabelFormatter : public testing::Test
 {
 protected:
-  TestLabelFormatter()
-  {
-    //! @todo implement
-    /* TODO
-    CSettingsCategory* fl = CServiceBroker::GetSettingsComponent()->GetSettings()->AddCategory(7, "filelists", 14081);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddBool(fl, CSettings::SETTING_FILELISTS_SHOWPARENTDIRITEMS, 13306, true);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddBool(fl, CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, 497, true);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddBool(fl, CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING, 13399, true);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddBool(fl, CSettings::SETTING_FILELISTS_ALLOWFILEDELETION, 14071, false);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddBool(fl, CSettings::SETTING_FILELISTS_SHOWADDSOURCEBUTTONS, 21382,  true);
-    CServiceBroker::GetSettingsComponent()->GetSettings()->AddBool(fl, CSettings::SETTING_FILELISTS_SHOWHIDDEN, 21330, false);
-    */
-  }
+  TestLabelFormatter() = default;
 
   ~TestLabelFormatter() override
   {

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -190,10 +190,6 @@ CAndroidUtils::CAndroidUtils()
   });
 }
 
-CAndroidUtils::~CAndroidUtils()
-{
-}
-
 bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO* res) const
 {
   EGLNativeWindowType nativeWindow = (EGLNativeWindowType)CXBMCApp::GetNativeWindow(30000);

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -20,7 +20,7 @@ class CAndroidUtils : public ISettingCallback
 {
 public:
   CAndroidUtils();
-  virtual ~CAndroidUtils();
+  virtual ~CAndroidUtils() = default;
   bool GetNativeResolution(RESOLUTION_INFO* res) const;
   bool SetNativeResolution(const RESOLUTION_INFO& res);
   bool ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions);

--- a/xbmc/windowing/android/OSScreenSaverAndroid.h
+++ b/xbmc/windowing/android/OSScreenSaverAndroid.h
@@ -13,7 +13,7 @@
 class COSScreenSaverAndroid : public KODI::WINDOWING::IOSScreenSaver
 {
 public:
-  explicit COSScreenSaverAndroid() {}
+  explicit COSScreenSaverAndroid() = default;
   void Inhibit() override;
   void Uninhibit() override;
 };

--- a/xbmc/windowing/osx/OSScreenSaverOSX.cpp
+++ b/xbmc/windowing/osx/OSScreenSaverOSX.cpp
@@ -10,10 +10,6 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
-COSScreenSaverOSX::COSScreenSaverOSX()
-{
-}
-
 void COSScreenSaverOSX::Inhibit()
 {
   // see Technical Q&A QA1340

--- a/xbmc/windowing/osx/OSScreenSaverOSX.h
+++ b/xbmc/windowing/osx/OSScreenSaverOSX.h
@@ -15,7 +15,7 @@
 class COSScreenSaverOSX : public KODI::WINDOWING::IOSScreenSaver
 {
 public:
-  COSScreenSaverOSX();
+  COSScreenSaverOSX() = default;
   void Inhibit() override;
   void Uninhibit() override;
 

--- a/xbmc/windowing/osx/WinEventsOSX.h
+++ b/xbmc/windowing/osx/WinEventsOSX.h
@@ -13,6 +13,6 @@
 class CWinEventsOSX : public CWinEventsSDL
 {
 public:
-  CWinEventsOSX();
-  ~CWinEventsOSX();
+  CWinEventsOSX() = default;
+  ~CWinEventsOSX() = default;
 };

--- a/xbmc/windowing/osx/WinEventsOSX.mm
+++ b/xbmc/windowing/osx/WinEventsOSX.mm
@@ -9,11 +9,3 @@
 #include "windowing/osx/WinEventsOSX.h"
 
 // place holder for future native osx event handler
-
-CWinEventsOSX::CWinEventsOSX()
-{
-}
-
-CWinEventsOSX::~CWinEventsOSX()
-{
-}

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -673,9 +673,7 @@ CWinSystemOSX::CWinSystemOSX()
   m_dpms = std::make_shared<CCocoaDPMSSupport>();
 }
 
-CWinSystemOSX::~CWinSystemOSX()
-{
-};
+CWinSystemOSX::~CWinSystemOSX() = default;
 
 void CWinSystemOSX::StartLostDeviceTimer()
 {

--- a/xbmc/windowing/osx/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/WinSystemOSXGL.h
@@ -14,8 +14,8 @@
 class CWinSystemOSXGL : public CWinSystemOSX, public CRenderSystemGL
 {
 public:
-  CWinSystemOSXGL();
-  virtual ~CWinSystemOSXGL();
+  CWinSystemOSXGL() = default;
+  virtual ~CWinSystemOSXGL() = default;
 
   // Implementation of CWinSystemBase via CWinSystemOSX
   CRenderSystemBase *GetRenderSystem() override { return this; }

--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -20,14 +20,6 @@ std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
   return winSystem;
 }
 
-CWinSystemOSXGL::CWinSystemOSXGL()
-{
-}
-
-CWinSystemOSXGL::~CWinSystemOSXGL()
-{
-}
-
 void CWinSystemOSXGL::PresentRenderImpl(bool rendered)
 {
   if (rendered)

--- a/xbmc/windowing/wayland/InputProcessorPointer.h
+++ b/xbmc/windowing/wayland/InputProcessorPointer.h
@@ -31,7 +31,7 @@ public:
   virtual void OnPointerLeave() {}
   virtual void OnPointerEvent(XBMC_Event& event) = 0;
 protected:
-  ~IInputHandlerPointer() {}
+  ~IInputHandlerPointer() = default;
 };
 
 class CInputProcessorPointer final : public IRawInputHandlerPointer

--- a/xbmc/windowing/wayland/Seat.h
+++ b/xbmc/windowing/wayland/Seat.h
@@ -40,7 +40,7 @@ public:
   virtual void OnKeyboardModifiers(CSeat* seat, std::uint32_t serial, std::uint32_t modsDepressed, std::uint32_t modsLatched, std::uint32_t modsLocked, std::uint32_t group) {}
   virtual void OnKeyboardRepeatInfo(CSeat* seat, std::int32_t rate, std::int32_t delay) {}
 protected:
-  ~IRawInputHandlerKeyboard() {}
+  ~IRawInputHandlerKeyboard() = default;
 };
 
 /**
@@ -57,7 +57,7 @@ public:
   virtual void OnPointerButton(CSeat* seat, std::uint32_t serial, std::uint32_t time, std::uint32_t button, wayland::pointer_button_state state) {}
   virtual void OnPointerAxis(CSeat* seat, std::uint32_t time, wayland::pointer_axis axis, double value) {}
 protected:
-  ~IRawInputHandlerPointer() {}
+  ~IRawInputHandlerPointer() = default;
 };
 
 /**
@@ -74,7 +74,7 @@ public:
   virtual void OnTouchCancel(CSeat* seat) {}
   virtual void OnTouchShape(CSeat* seat, std::int32_t id, double major, double minor) {}
 protected:
-  ~IRawInputHandlerTouch() {};
+  ~IRawInputHandlerTouch() = default;
 };
 
 /**

--- a/xbmc/windowing/wayland/Signals.h
+++ b/xbmc/windowing/wayland/Signals.h
@@ -23,7 +23,8 @@ using RegistrationIdentifierType = int;
 class ISignalHandlerData
 {
 protected:
-  ~ISignalHandlerData() {}
+  ~ISignalHandlerData() = default;
+
 public:
   virtual void Unregister(RegistrationIdentifierType id) = 0;
 };


### PR DESCRIPTION
## Description
run clang-tidy modernize-use-equals-default and applied the suggested fixes

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
