### PR TITLE
Fix thumb loading on info dialogs

### DIFF
--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -120,6 +120,7 @@ void CGUIListItem::ClearArt()
 {
   m_art.clear();
   m_artFallbacks.clear();
+  SetProperty("libraryartfilled", false);
 }
 
 void CGUIListItem::AppendArt(const ArtMap &art, const std::string &prefix)


### PR DESCRIPTION
A follow up to #16508, itself a fix after  #16444 that moved storage of default icons to the item art map for v19. Unfortunately that broke the apperence of thumbs on the artist and season info dialog.

Now we are using a property ("libraryartfilled" ) to indicate that library art has been filled for an item, that property needs clearing when the item art map is cleared.

@DaVukovic since you reported this perhaps you could test this and confirm it is solved.

