### PR TITLE
AESinkAudioTrack: Remove Headphone check - let Audiotrack handle it byself

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -825,11 +825,7 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   m_info.m_displayNameExtra = "audiotrack";
 
   UpdateAvailablePCMCapabilities();
-
-  if (!CXBMCApp::IsHeadsetPlugged())
-  {
-    UpdateAvailablePassthroughCapabilities();
-  }
+  UpdateAvailablePassthroughCapabilities();
   list.push_back(m_info);
 }
 


### PR DESCRIPTION
At the beginning of kodi on Android there was no real PT support available. At this time PCM16 bit in full volume was sent to the AVRs without knowing if a headphone / AVR / something else is behind.

With modern kodi we explicitely ask Audiotrack to open PT formats for us on enumeration. It will just fail if a real headphone is connected.