### PR TITLE
Pulseaudio: Cleanup

### DIFF
--- a/cmake/modules/FindPulseAudio.cmake
+++ b/cmake/modules/FindPulseAudio.cmake
@@ -15,7 +15,7 @@
 #   PulseAudio::PulseAudio   - The PulseAudio library
 
 if(NOT PulseAudio_FIND_VERSION)
-  set(PulseAudio_FIND_VERSION 2.0.0)
+  set(PulseAudio_FIND_VERSION 11.0.0)
 endif()
 
 if(PKG_CONFIG_FOUND)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -391,7 +391,6 @@ static CAEChannelInfo PAChannelToAEChannelMap(const pa_channel_map& channels)
   return info;
 }
 
-#if PA_CHECK_VERSION(10,0,0)
 static void ModuleInfoCallback(pa_context* c, const pa_module_info *i, int eol, void *userdata)
 {
   ModuleInfoStruct *mis = static_cast<ModuleInfoStruct*>(userdata);
@@ -405,7 +404,7 @@ static void ModuleInfoCallback(pa_context* c, const pa_module_info *i, int eol, 
   }
   pa_threaded_mainloop_signal(mis->mainloop, 0);
 }
-#endif
+
 static void SinkInfoRequestCallback(pa_context *c, const pa_sink_info *i, int eol, void *userdata)
 {
 
@@ -635,38 +634,15 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     // can be set to "no". Therefore we give the choice back to user and let
     // him configure the soundserver the way he likes - this makes the pre 11
     // workaround obsolete
-#if PA_CHECK_VERSION(11,0,0)
     use_pa_mixing = true;
     map = AEChannelMapToPAChannel(format.m_channelLayout);
-#else
-    // as we mix for PA now to avoid default upmixing, we need to care for
-    // channel resolving
-    CAEChannelInfo target_layout = format.m_channelLayout;
-    CAEChannelInfo available_layout = PAChannelToAEChannelMap(sinkStruct.map);
-    target_layout.ResolveChannels(available_layout);
-
-    // if we cannot map all requested channels - tell PA to mix for us
-    if (target_layout.Count() != format.m_channelLayout.Count())
-    {
-      use_pa_mixing = true;
-      map = AEChannelMapToPAChannel(format.m_channelLayout);
-    }
-    else
-    {
-      // use our layout to update AE
-      map = AEChannelMapToPAChannel(target_layout);
-    }
-#endif
     format.m_channelLayout = PAChannelToAEChannelMap(map);
   }
   m_Channels = format.m_channelLayout.Count();
 
   // Pulse can resample everything between 1 hz and 192000 hz / 384000 hz (starting with 9.0)
   // Make sure we are in the range that we originally added
-  unsigned int max_pulse_sample_rate = 192000U;
-#if PA_CHECK_VERSION(9,0,0)
-  max_pulse_sample_rate = 384000U;
-#endif
+  unsigned int max_pulse_sample_rate = 384000U;
   format.m_sampleRate = std::max(5512U, std::min(format.m_sampleRate, max_pulse_sample_rate));
 
   pa_format_info *info[1];
@@ -1028,9 +1004,7 @@ void CAESinkPULSE::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   ModuleInfoStruct mis;
   mis.mainloop = mainloop;
 
-#if PA_CHECK_VERSION(10,0,0)
   WaitForOperation(pa_context_get_module_info_list(context, ModuleInfoCallback, &mis), mainloop, "Check PA Modules");
-#endif
   if (!mis.hasAllowPT)
   {
     CLog::Log(LOGWARNING, "Pulseaudio module module-allow-passthrough not loaded - opening PT devices might fail");


### PR DESCRIPTION
This removes some very oldish ifdeffery and requires pulseaudio 11.

Besides the maintenance burdon, version 11 got a nice feature that makes kodi's experience much better on the Desktop. It can now mix by itself, without upmxing everything to the speaker layout.

This would basically drop Ubuntu 16.04 LTS.

As it's only for master -> 2021 feels good to go :-)