### PR TITLE
[pvr] Update and persist channel group members from client on boot if…

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -114,10 +114,10 @@ JSONRPC_STATUS CPVROperations::GetChannels(const std::string &method, ITransport
     return InvalidParams;
 
   CFileItemList channels;
-  const std::vector<PVRChannelGroupMember> groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   for (const auto& groupMember : groupMembers)
   {
-    channels.Add(std::make_shared<CFileItem>(groupMember.channel));
+    channels.Add(std::make_shared<CFileItem>(groupMember->channel));
   }
 
   HandleFileItemList("channelid", false, "channels", channels, parameterObject, result, true);
@@ -284,10 +284,10 @@ void CPVROperations::FillChannelGroupDetails(const std::shared_ptr<CPVRChannelGr
   else
   {
     CFileItemList channels;
-    const std::vector<PVRChannelGroupMember> groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+    const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channelGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
     for (const auto& groupMember : groupMembers)
     {
-      channels.Add(std::make_shared<CFileItem>(groupMember.channel));
+      channels.Add(std::make_shared<CFileItem>(groupMember->channel));
     }
 
     object["channels"] = CVariant(CVariant::VariantTypeArray);

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1404,10 +1404,10 @@ namespace PVR
       if (channelGroup)
       {
         // try to start playback of first channel in this group
-        std::vector<PVRChannelGroupMember> groupMembers(channelGroup->GetMembers());
+        const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channelGroup->GetMembers();
         if (!groupMembers.empty())
         {
-          return SwitchToChannel(CFileItemPtr(new CFileItem((*groupMembers.begin()).channel)), true);
+          return SwitchToChannel(std::make_shared<CFileItem>((*groupMembers.begin())->channel), true);
         }
       }
     }
@@ -1445,7 +1445,7 @@ namespace PVR
       if (channels.empty())
         return false;
 
-      channel = channels.front().channel;
+      channel = channels.front()->channel;
     }
 
     CLog::Log(LOGNOTICE, "PVR is starting playback of channel '%s'", channel->ChannelName().c_str());

--- a/xbmc/pvr/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/PVRGUIChannelIconUpdater.cpp
@@ -58,23 +58,23 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
 
   for (const auto& group : m_groups)
   {
-    const std::vector<PVRChannelGroupMember> members = group->GetMembers();
+    const std::vector<std::shared_ptr<PVRChannelGroupMember>> members = group->GetMembers();
     int channelIndex = 0;
     for (const auto& member : members)
     {
-      progressHandler->UpdateProgress(member.channel->ChannelName(), channelIndex++, members.size());
+      progressHandler->UpdateProgress(member->channel->ChannelName(), channelIndex++, members.size());
 
       // skip if an icon is already set and exists
-      if (XFILE::CFile::Exists(member.channel->IconPath()))
+      if (XFILE::CFile::Exists(member->channel->IconPath()))
         continue;
 
       // reset icon before searching for a new one
-      member.channel->SetIconPath("");
+      member->channel->SetIconPath("");
 
-      const std::string strChannelUid = StringUtils::Format("%08d", member.channel->UniqueID());
-      std::string strLegalClientChannelName = CUtil::MakeLegalFileName(member.channel->ClientChannelName());
+      const std::string strChannelUid = StringUtils::Format("%08d", member->channel->UniqueID());
+      std::string strLegalClientChannelName = CUtil::MakeLegalFileName(member->channel->ClientChannelName());
       StringUtils::ToLower(strLegalClientChannelName);
-      std::string strLegalChannelName = CUtil::MakeLegalFileName(member.channel->ChannelName());
+      std::string strLegalChannelName = CUtil::MakeLegalFileName(member->channel->ChannelName());
       StringUtils::ToLower(strLegalChannelName);
 
       std::map<std::string, std::string>::iterator itItem;
@@ -82,11 +82,11 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
           (itItem = fileItemMap.find(strLegalChannelName)) != fileItemMap.end() ||
           (itItem = fileItemMap.find(strChannelUid)) != fileItemMap.end())
       {
-        member.channel->SetIconPath(itItem->second, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRAutoScanIconsUserSet);
+        member->channel->SetIconPath(itItem->second, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRAutoScanIconsUserSet);
       }
 
       if (m_bUpdateDb)
-        member.channel->Persist();
+        member->channel->Persist();
     }
   }
 

--- a/xbmc/pvr/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/PVRGUIDirectory.cpp
@@ -370,13 +370,13 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
 
       if (group)
       {
-        const std::vector<PVRChannelGroupMember> groupMembers = group->GetMembers();
+        const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers();
         for (const auto& groupMember : groupMembers)
         {
-          if (bShowHiddenChannels != groupMember.channel->IsHidden())
+          if (bShowHiddenChannels != groupMember->channel->IsHidden())
             continue;
 
-          results.Add(std::make_shared<CFileItem>(groupMember.channel));
+          results.Add(std::make_shared<CFileItem>(groupMember->channel));
         }
       }
       else

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -51,9 +51,6 @@ namespace PVR
     int iOrder = 0; // The value denoting the order of this member in the group
   };
 
-  typedef std::vector<PVRChannelGroupMember> PVR_CHANNEL_GROUP_SORTED_MEMBERS;
-  typedef std::map<std::pair<int, int>, PVRChannelGroupMember> PVR_CHANNEL_GROUP_MEMBERS;
-
   enum EpgDateType
   {
     EPG_FIRST_DATE = 0,
@@ -93,7 +90,7 @@ namespace PVR
     /**
      * Empty group member
      */
-    static PVRChannelGroupMember EmptyMember;
+    static std::shared_ptr<PVRChannelGroupMember> EmptyMember;
 
     /*!
      * @brief Query the events available for CEventStream
@@ -339,7 +336,7 @@ namespace PVR
      * @param eFilter A filter to apply.
      * @return The group members
      */
-    std::vector<PVRChannelGroupMember> GetMembers(Include eFilter = Include::ALL) const;
+    std::vector<std::shared_ptr<PVRChannelGroupMember>> GetMembers(Include eFilter = Include::ALL) const;
 
     /*!
      * @brief Get the list of active channel numbers in a group.
@@ -436,8 +433,8 @@ namespace PVR
      * @param id The storage id (a pair of client id and unique channel id).
      * @return A reference to the group member or an empty group member if it wasn't found.
      */
-    PVRChannelGroupMember& GetByUniqueID(const std::pair<int, int>& id);
-    const PVRChannelGroupMember& GetByUniqueID(const std::pair<int, int>& id) const;
+    std::shared_ptr<PVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id);
+    const std::shared_ptr<PVRChannelGroupMember>& GetByUniqueID(const std::pair<int, int>& id) const;
 
     void SetHidden(bool bHidden);
     bool IsHidden(void) const;
@@ -551,8 +548,8 @@ namespace PVR
     time_t           m_iLastWatched = 0;                /*!< last time group has been watched */
     bool             m_bHidden = false;                     /*!< true if this group is hidden, false otherwise */
     int              m_iPosition = 0;                   /*!< the position of this group within the group list */
-    PVR_CHANNEL_GROUP_SORTED_MEMBERS m_sortedMembers; /*!< members sorted by channel number */
-    PVR_CHANNEL_GROUP_MEMBERS        m_members;       /*!< members with key clientid+uniqueid */
+    std::vector<std::shared_ptr<PVRChannelGroupMember>> m_sortedMembers; /*!< members sorted by channel number */
+    std::map<std::pair<int, int>, std::shared_ptr<PVRChannelGroupMember>> m_members; /*!< members with key clientid+uniqueid */
     mutable CCriticalSection m_critSection;
     std::vector<int> m_failedClientsForChannels;
     std::vector<int> m_failedClientsForChannelGroupMembers;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -69,23 +69,23 @@ void CPVRChannelGroupInternal::UpdateChannelPaths(void)
 {
   CSingleLock lock(m_critSection);
   m_iHiddenChannels = 0;
-  for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = m_members.begin(); it != m_members.end(); ++it)
+  for (auto& groupMemberPair : m_members)
   {
-    if (it->second.channel->IsHidden())
+    if (groupMemberPair.second->channel->IsHidden())
       ++m_iHiddenChannels;
     else
-      it->second.channel->UpdatePath(GroupName());
+      groupMemberPair.second->channel->UpdatePath(GroupName());
   }
 }
 
 std::shared_ptr<CPVRChannel> CPVRChannelGroupInternal::UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber, int iOrder, const CPVRChannelNumber& clientChannelNumber /* = {} */)
 {
   CSingleLock lock(m_critSection);
-  const PVRChannelGroupMember& realChannel(GetByUniqueID(channel->StorageId()));
-  if (realChannel.channel)
+  const std::shared_ptr<PVRChannelGroupMember>& realMember = GetByUniqueID(channel->StorageId());
+  if (realMember->channel)
   {
-    realChannel.channel->UpdateFromClient(channel);
-    return realChannel.channel;
+    realMember->channel->UpdateFromClient(channel);
+    return realMember->channel;
   }
   else
   {
@@ -93,9 +93,9 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupInternal::UpdateFromClient(const st
     if (iChannelNumber == 0)
       iChannelNumber = static_cast<int>(m_sortedMembers.size()) + 1;
 
-    PVRChannelGroupMember newMember(channel, CPVRChannelNumber(iChannelNumber, channelNumber.GetSubChannelNumber()), 0, iOrder, clientChannelNumber);
     channel->UpdatePath(GroupName());
-    m_sortedMembers.push_back(newMember);
+    auto newMember = std::make_shared<PVRChannelGroupMember>(channel, CPVRChannelNumber(iChannelNumber, channelNumber.GetSubChannelNumber()), 0, iOrder, clientChannelNumber);
+    m_sortedMembers.emplace_back(newMember);
     m_members.insert(std::make_pair(channel->StorageId(), newMember));
     m_bChanged = true;
 
@@ -119,16 +119,16 @@ bool CPVRChannelGroupInternal::AddToGroup(const std::shared_ptr<CPVRChannel>& ch
   CSingleLock lock(m_critSection);
 
   /* get the group member, because we need the channel ID in this group, and the channel from this group */
-  PVRChannelGroupMember& groupMember = GetByUniqueID(channel->StorageId());
-  if (!groupMember.channel)
+  std::shared_ptr<PVRChannelGroupMember>& groupMember = GetByUniqueID(channel->StorageId());
+  if (!groupMember->channel)
     return bReturn;
 
   bool bSort = false;
 
   /* switch the hidden flag */
-  if (groupMember.channel->IsHidden())
+  if (groupMember->channel->IsHidden())
   {
-    groupMember.channel->SetHidden(false);
+    groupMember->channel->SetHidden(false);
     if (m_iHiddenChannels > 0)
       m_iHiddenChannels--;
 
@@ -139,9 +139,9 @@ bool CPVRChannelGroupInternal::AddToGroup(const std::shared_ptr<CPVRChannel>& ch
   if (!channelNumber.IsValid() || iChannelNumber > (m_members.size() - m_iHiddenChannels))
     iChannelNumber = m_members.size() - m_iHiddenChannels;
 
-  if (groupMember.channelNumber.GetChannelNumber() != iChannelNumber)
+  if (groupMember->channelNumber.GetChannelNumber() != iChannelNumber)
   {
-    groupMember.channelNumber = CPVRChannelNumber(iChannelNumber, channelNumber.GetSubChannelNumber());
+    groupMember->channelNumber = CPVRChannelNumber(iChannelNumber, channelNumber.GetSubChannelNumber());
     bSort = true;
   }
 
@@ -151,7 +151,7 @@ bool CPVRChannelGroupInternal::AddToGroup(const std::shared_ptr<CPVRChannel>& ch
   if (m_bLoaded)
   {
     bReturn = Persist();
-    groupMember.channel->Persist();
+    groupMember->channel->Persist();
   }
   return bReturn;
 }
@@ -225,29 +225,40 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup& chan
   CSingleLock lock(m_critSection);
 
   /* go through the channel list and check for updated or new channels */
-  for (PVR_CHANNEL_GROUP_MEMBERS::const_iterator it = channels.m_members.begin(); it != channels.m_members.end(); ++it)
+  for (auto& newMemberPair : channels.m_members)
   {
     /* check whether this channel is present in this container */
-    const PVRChannelGroupMember& existingChannel(GetByUniqueID(it->first));
-    if (existingChannel.channel)
+    std::shared_ptr<PVRChannelGroupMember>& existingMember = GetByUniqueID(newMemberPair.first);
+    const std::shared_ptr<PVRChannelGroupMember>& newMember = newMemberPair.second;
+    if (existingMember->channel)
     {
       /* if it's present, update the current tag */
-      if (existingChannel.channel->UpdateFromClient(it->second.channel))
+      if (existingMember->channel->UpdateFromClient(newMember->channel))
       {
         bReturn = true;
-        CLog::LogFC(LOGDEBUG, LOGPVR, "Updated {} channel '{}' from PVR client", IsRadio() ? "radio" : "TV", it->second.channel->ChannelName());
+        CLog::LogFC(LOGDEBUG, LOGPVR, "Updated {} channel '{}' from PVR client", IsRadio() ? "radio" : "TV", newMember->channel->ChannelName());
+      }
+
+      if (existingMember->channelNumber != newMember->channelNumber ||
+          existingMember->clientChannelNumber != newMember->clientChannelNumber ||
+          existingMember->iOrder != newMember->iOrder)
+      {
+        existingMember->channelNumber = newMember->channelNumber;
+        existingMember->clientChannelNumber = newMember->clientChannelNumber;
+        existingMember->iOrder = newMember->iOrder;
+        bReturn = true;
       }
     }
     else
     {
       /* new channel */
-      UpdateFromClient(it->second.channel, it->second.channelNumber, it->second.iOrder, it->second.clientChannelNumber);
-      if (it->second.channel->CreateEPG())
+      UpdateFromClient(newMember->channel, newMember->channelNumber, newMember->iOrder, newMember->clientChannelNumber);
+      if (newMember->channel->CreateEPG())
       {
-         CLog::LogFC(LOGDEBUG, LOGPVR, "Created EPG for {} channel '{}' from PVR client", IsRadio() ? "radio" : "TV", it->second.channel->ChannelName());
+        CLog::LogFC(LOGDEBUG, LOGPVR, "Created EPG for {} channel '{}' from PVR client", IsRadio() ? "radio" : "TV", newMember->channel->ChannelName());
       }
       bReturn = true;
-      CLog::LogFC(LOGDEBUG, LOGPVR, "Added {} channel '{}' from PVR client", IsRadio() ? "radio" : "TV", it->second.channel->ChannelName());
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Added {} channel '{}' from PVR client", IsRadio() ? "radio" : "TV", newMember->channel->ChannelName());
     }
   }
 
@@ -301,8 +312,8 @@ bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
 
   {
     CSingleLock lock(m_critSection);
-    for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = m_members.begin(); it != m_members.end(); ++it)
-      CreateChannelEpg(it->second.channel);
+    for (auto& groupMemberPair : m_members)
+      CreateChannelEpg(groupMemberPair.second->channel);
   }
 
   if (HasChangedChannels())

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -681,11 +681,11 @@ void CGUIDialogPVRChannelManager::Update()
   if(!channels)
     return;
 
-  std::vector<PVRChannelGroupMember> groupMembers(channels->GetMembers());
-  CFileItemPtr channelFile;
+  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = channels->GetMembers();
+  std::shared_ptr<CFileItem> channelFile;
   for (const auto& member : groupMembers)
   {
-    channelFile = CFileItemPtr(new CFileItem(member.channel));
+    channelFile = std::make_shared<CFileItem>(member->channel);
     if (!channelFile || !channelFile->HasPVRChannelInfoTag())
       continue;
     const std::shared_ptr<CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -173,10 +173,10 @@ void CGUIDialogPVRChannelsOSD::Update()
     const std::shared_ptr<CPVRChannelGroup> group = pvrMgr.GetPlayingGroup(channel->IsRadio());
     if (group)
     {
-      const std::vector<PVRChannelGroupMember> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : groupMembers)
       {
-        m_vecItems->Add(std::make_shared<CFileItem>(groupMember.channel));
+        m_vecItems->Add(std::make_shared<CFileItem>(groupMember->channel));
       }
 
       m_viewControl.SetItems(*m_vecItems);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -477,30 +477,30 @@ void CGUIDialogPVRGroupManager::Update()
     // Slightly different handling for "all" group...
     if (m_selectedGroup->IsInternalGroup())
     {
-      const std::vector<PVRChannelGroupMember> groupMembers = m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ALL);
+      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ALL);
       for (const auto& groupMember : groupMembers)
       {
-        if (groupMember.channel->IsHidden())
-          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember.channel));
+        if (groupMember->channel->IsHidden())
+          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->channel));
         else
-          m_groupMembers->Add(std::make_shared<CFileItem>(groupMember.channel));
+          m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->channel));
       }
     }
     else
     {
-      const std::vector<PVRChannelGroupMember> groupMembers = m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+      const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : groupMembers)
       {
-        m_groupMembers->Add(std::make_shared<CFileItem>(groupMember.channel));
+        m_groupMembers->Add(std::make_shared<CFileItem>(groupMember->channel));
       }
 
       /* for the center part, get all channels of the "all" channels group that are not in this group */
       const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
-      const std::vector<PVRChannelGroupMember> allGroupMembers = allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+      const std::vector<std::shared_ptr<PVRChannelGroupMember>> allGroupMembers = allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
       for (const auto& groupMember : allGroupMembers)
       {
-        if (!m_selectedGroup->IsGroupMember(groupMember.channel))
-          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember.channel));
+        if (!m_selectedGroup->IsGroupMember(groupMember->channel))
+          m_ungroupedChannels->Add(std::make_shared<CFileItem>(groupMember->channel));
       }
     }
     m_viewGroupMembers.SetItems(*m_groupMembers);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -70,17 +70,17 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin(void)
     group = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_searchFilter->IsRadio());
 
   m_channelNumbersMap.clear();
-  const std::vector<PVRChannelGroupMember> groupMembers(group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE));
+  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   int iIndex = 0;
   int iSelectedChannel = EPG_SEARCH_UNSET;
   for (const auto& groupMember : groupMembers)
   {
-    if (groupMember.channel)
+    if (groupMember->channel)
     {
-      labels.emplace_back(std::make_pair(groupMember.channel->ChannelName(), iIndex));
-      m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember.channelNumber));
+      labels.emplace_back(std::make_pair(groupMember->channel->ChannelName(), iIndex));
+      m_channelNumbersMap.insert(std::make_pair(iIndex, groupMember->channelNumber));
 
-      if (iSelectedChannel == EPG_SEARCH_UNSET && groupMember.channelNumber == m_searchFilter->GetChannelNumber())
+      if (iSelectedChannel == EPG_SEARCH_UNSET && groupMember->channelNumber == m_searchFilter->GetChannelNumber())
         iSelectedChannel = iIndex;
 
       ++iIndex;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -782,10 +782,10 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
 
   // Add regular channels
   const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
-  const std::vector<PVRChannelGroupMember> groupMembers = allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+  const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   for (const auto& groupMember : groupMembers)
   {
-    const std::shared_ptr<CPVRChannel> channel = groupMember.channel;
+    const std::shared_ptr<CPVRChannel> channel = groupMember->channel;
     const std::string channelDescription
       = StringUtils::Format("%s %s", channel->ChannelNumber().FormattedChannelNumber().c_str(), channel->ChannelName().c_str());
     m_channelEntries.insert({index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -708,13 +708,13 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
         m_bFirstOpen = false;
 
         // very first open of the window. come up with some data very fast...
-        const std::vector<PVRChannelGroupMember> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
+        const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
         for (const auto& groupMember : groupMembers)
         {
           // fake a channel without epg
 
           const std::shared_ptr<CPVREpgInfoTag> gapTag
-            = std::make_shared<CPVREpgInfoTag>(std::make_shared<CPVREpgChannelData>(*(groupMember.channel)), -1);
+            = std::make_shared<CPVREpgInfoTag>(std::make_shared<CPVREpgChannelData>(*(groupMember->channel)), -1);
           timeline->Add(std::make_shared<CFileItem>(gapTag));
         }
 


### PR DESCRIPTION
… changed

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Persists the channel group members after receiving the data from the PVR addons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

When the PVR addon loads if the channel group members change this was not persisted and the only to way to change it was to reset the PVR database (or have the addon trigger a channel/group) reload.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On Mac OSX, using both a v35 and v36 PVR DB.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
