### PR TITLE
[PVR] PVRManager: Factor out playback state functionality into its own class

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -199,7 +200,7 @@ JSONRPC_STATUS CPVROperations::Record(const std::string &method, ITransportLayer
   CVariant channel = parameterObject["channel"];
   if (channel.isString() && channel.asString() == "current")
   {
-    pChannel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+    pChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
     if (!pChannel)
       return InternalError;
   }
@@ -252,7 +253,7 @@ JSONRPC_STATUS CPVROperations::GetPropertyValue(const std::string &property, CVa
   else if (property == "recording")
   {
     if (started)
-      result = CServiceBroker::GetPVRManager().IsRecording();
+      result = CServiceBroker::GetPVRManager().PlaybackState()->IsRecording();
     else
       result = false;
   }

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES PVRActionListener.cpp
             PVRGUITimerInfo.cpp
             PVRGUITimesInfo.cpp
             PVRStreamProperties.cpp
+            PVRPlaybackState.cpp
             PVRThumbLoader.cpp)
 
 set(HEADERS PVRActionListener.h
@@ -34,6 +35,7 @@ set(HEADERS PVRActionListener.h
             PVRGUITimerInfo.h
             PVRGUITimesInfo.h
             PVRStreamProperties.h
+            PVRPlaybackState.h
             PVRThumbLoader.h)
 
 core_add_library(pvr)

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -19,6 +19,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
@@ -90,8 +91,8 @@ ChannelSwitchMode CPVRActionListener::GetChannelSwitchMode(int iAction)
 bool CPVRActionListener::OnAction(const CAction& action)
 {
   bool bIsJumpSMS = false;
-  bool bIsPlayingPVR(CServiceBroker::GetPVRManager().IsPlaying() &&
-                     g_application.CurrentFileItem().HasPVRChannelInfoTag());
+  bool bIsPlayingPVR = CServiceBroker::GetPVRManager().PlaybackState()->IsPlaying() &&
+                       g_application.CurrentFileItem().HasPVRChannelInfoTag();
 
   switch (action.GetID())
   {
@@ -244,7 +245,7 @@ bool CPVRActionListener::OnAction(const CAction& action)
       int iChannelNumber = static_cast<int>(action.GetAmount(0));
       int iSubChannelNumber = static_cast<int>(action.GetAmount(1));
 
-      const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+      const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
       const std::shared_ptr<CPVRChannelGroup> selectedGroup = CServiceBroker::GetPVRManager().ChannelGroups()->Get(currentChannel->IsRadio())->GetSelectedGroup();
       const std::shared_ptr<CPVRChannel> channel = selectedGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));
 

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -14,6 +14,7 @@
 #include "guilib/GUIComponent.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -117,12 +118,12 @@ namespace PVR
 
   std::shared_ptr<CPVRChannel> CPVRGUIChannelNavigator::GetNextOrPrevChannel(bool bNext)
   {
-    const bool bPlayingRadio = CServiceBroker::GetPVRManager().IsPlayingRadio();
-    const bool bPlayingTV = CServiceBroker::GetPVRManager().IsPlayingTV();
+    const bool bPlayingRadio = CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRadio();
+    const bool bPlayingTV = CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV();
 
     if (bPlayingTV || bPlayingRadio)
     {
-      const std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager().GetPlayingGroup(bPlayingRadio);
+      const std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(bPlayingRadio);
       if (group)
       {
         CSingleLock lock(m_critSection);

--- a/xbmc/pvr/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/PVRGUITimesInfo.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "cores/DataCacheCore.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
@@ -52,8 +53,8 @@ void CPVRGUITimesInfo::Reset()
 
 void CPVRGUITimesInfo::UpdatePlayingTag()
 {
-  const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().GetPlayingChannel();
-  std::shared_ptr<CPVREpgInfoTag> currentTag = CServiceBroker::GetPVRManager().GetPlayingEpgTag();
+  const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
+  std::shared_ptr<CPVREpgInfoTag> currentTag = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingEpgTag();
 
   if (currentChannel || currentTag)
   {
@@ -87,7 +88,7 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
   }
   else
   {
-    const std::shared_ptr<CPVRRecording> recording = CServiceBroker::GetPVRManager().GetPlayingRecording();
+    const std::shared_ptr<CPVRRecording> recording = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingRecording();
     if (recording)
     {
       CSingleLock lock(m_critSection);
@@ -99,7 +100,7 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
 
 void CPVRGUITimesInfo::UpdateTimeshiftData()
 {
-  if (!CServiceBroker::GetPVRManager().IsPlayingTV() && !CServiceBroker::GetPVRManager().IsPlayingRadio())
+  if (!CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV() && !CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRadio())
   {
     // If nothing is playing (anymore), there is no need to update data.
     Reset();
@@ -111,7 +112,7 @@ void CPVRGUITimesInfo::UpdateTimeshiftData()
   int64_t iPlayTime, iMinTime, iMaxTime;
   CServiceBroker::GetDataCacheCore().GetPlayTimes(iStartTime, iPlayTime, iMinTime, iMaxTime);
   bool bPlaying = CServiceBroker::GetDataCacheCore().GetSpeed() == 1.0;
-  const std::shared_ptr<CPVRChannel> playingChannel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+  const std::shared_ptr<CPVRChannel> playingChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
 
   CSingleLock lock(m_critSection);
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -37,6 +37,7 @@ namespace PVR
   class CPVRGUIInfo;
   class CPVRGUIProgressHandler;
   class CPVRManagerJobQueue;
+  class CPVRPlaybackState;
   class CPVRRecording;
   class CPVRRecordings;
   class CPVRTimers;
@@ -139,6 +140,12 @@ namespace PVR
     std::shared_ptr<CPVRGUIActions> GUIActions(void) const;
 
     /*!
+     * @brief Get access to the pvr playback state.
+     * @return The playback state.
+     */
+    std::shared_ptr<CPVRPlaybackState> PlaybackState() const;
+
+    /*!
      * @brief Get access to the epg container.
      * @return The epg container.
      */
@@ -186,33 +193,6 @@ namespace PVR
     std::shared_ptr<CPVRDatabase> GetTVDatabase(void) const;
 
     /*!
-     * @brief Check if a TV channel, radio channel or recording is playing.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlaying(void) const;
-
-    /*!
-     * @brief Check if the given channel is playing.
-     * @param channel The channel to check.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingChannel(const std::shared_ptr<CPVRChannel>& channel) const;
-
-    /*!
-     * @brief Check if the given recording is playing.
-     * @param recording The recording to check.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingRecording(const std::shared_ptr<CPVRRecording>& recording) const;
-
-    /*!
-     * @brief Check if the given epg tag is playing.
-     * @param epgTag The tag to check.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-
-    /*!
      * @return True while the PVRManager is initialising.
      */
     inline bool IsInitialising(void) const
@@ -248,62 +228,6 @@ namespace PVR
     }
 
     /*!
-     * @brief Check whether playing channel matches given uids.
-     * @param iClientID The client id.
-     * @param iUniqueChannelID The channel uid.
-     * @return True on match, false if there is no match or no channel is playing.
-     */
-    bool IsPlayingChannel(int iClientID, int iUniqueChannelID) const;
-
-    /*!
-     * @brief Return the channel that is currently playing.
-     * @return The channel or NULL if none is playing.
-     */
-    std::shared_ptr<CPVRChannel> GetPlayingChannel(void) const;
-
-    /*!
-     * @brief Return the recording that is currently playing.
-     * @return The recording or NULL if none is playing.
-     */
-    std::shared_ptr<CPVRRecording> GetPlayingRecording(void) const;
-
-    /*!
-     * @brief Return the epg tag that is currently playing.
-     * @return The tag or NULL if none is playing.
-     */
-    std::shared_ptr<CPVREpgInfoTag> GetPlayingEpgTag(void) const;
-
-    /*!
-     * @brief Get the name of the playing client, if there is one.
-     * @return The name of the client or an empty string if nothing is playing.
-     */
-    std::string GetPlayingClientName(void) const;
-
-    /*!
-     * @brief Get the ID of the playing client, if there is one.
-     * @return The ID or -1 if no client is playing.
-     */
-    int GetPlayingClientID(void) const;
-
-    /*!
-     * @brief Check whether there is an active recording on the currenlyt playing channel.
-     * @return True if there is a playing channel and there is an active recording on that channel, false otherwise.
-     */
-    bool IsRecordingOnPlayingChannel(void) const;
-
-    /*!
-     * @brief Check if an active recording is playing.
-     * @return True if an in-progress (active) recording is playing, false otherwise.
-     */
-    bool IsPlayingActiveRecording() const;
-
-    /*!
-     * @brief Check whether the currently playing channel can be recorded.
-     * @return True if there is a playing channel that can be recorded, false otherwise.
-     */
-    bool CanRecordOnPlayingChannel(void) const;
-
-    /*!
      * @brief Check whether EPG tags for channels have been created.
      * @return True if EPG tags have been created, false otherwise.
      */
@@ -332,19 +256,6 @@ namespace PVR
      * @return True if there are active recordings, false otherwise.
      */
     bool IsRecording(void) const;
-
-    /*!
-     * @brief Set the current playing group, used to load the right channel.
-     * @param group The new group.
-     */
-    void SetPlayingGroup(const std::shared_ptr<CPVRChannelGroup>& group);
-
-    /*!
-     * @brief Get the current playing group, used to load the right channel.
-     * @param bRadio True to get the current radio group, false to get the current TV group.
-     * @return The current group or the group containing all channels if it's not set.
-     */
-    std::shared_ptr<CPVRChannelGroup> GetPlayingGroup(bool bRadio = false) const;
 
     /*!
      * @brief Let the background thread create epg tags for all channels.
@@ -386,36 +297,6 @@ namespace PVR
      * @brief Check whether names are still correct after the language settings changed.
      */
     void LocalizationChanged(void);
-
-    /*!
-     * @brief Check if a TV channel is playing.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingTV(void) const;
-
-    /*!
-     * @brief Check if a radio channel is playing.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingRadio(void) const;
-
-    /*!
-     * @brief Check if a an encrypted TV or radio channel is playing.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingEncryptedChannel(void) const;
-
-    /*!
-     * @brief Check if a recording is playing.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingRecording(void) const;
-
-    /*!
-     * @brief Check if an epg tag is playing.
-     * @return True if it's playing, false otherwise.
-     */
-    bool IsPlayingEpgTag(void) const;
 
     /*!
      * @brief Check if parental lock is overridden at the given moment.
@@ -468,19 +349,6 @@ namespace PVR
     void Process(void) override;
 
   private:
-    /*!
-     * @brief Updates the last watched timestamps of the channel and group which are currently playing.
-     * @param channel The channel which is updated
-     * @param time The last watched time to set
-     */
-    void UpdateLastWatched(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& time);
-
-    /*!
-     * @brief Set the playing group to the first group the channel is in if the given channel is not part of the current playing group
-     * @param channel The channel
-     */
-    void SetPlayingGroup(const std::shared_ptr<CPVRChannel>& channel);
-
     /*!
      * @brief Executes "pvrpowermanagement.setwakeupcmd"
      */
@@ -562,17 +430,9 @@ namespace PVR
 
     CEventSource<PVREvent> m_events;
 
+    std::shared_ptr<CPVRPlaybackState> m_playbackState;
+
     CPVRActionListener m_actionListener;
     CPVRSettings m_settings;
-
-    std::shared_ptr<CPVRChannel> m_playingChannel;
-    std::shared_ptr<CPVRRecording> m_playingRecording;
-    std::shared_ptr<CPVREpgInfoTag> m_playingEpgTag;
-    std::string m_strPlayingClientName;
-    int m_playingClientId = -1;
-    int m_iplayingChannelUniqueID = -1;
-
-    class CLastWatchedUpdateTimer;
-    std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;
   };
 }

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -1,0 +1,330 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRPlaybackState.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "XBDateTime.h"
+#include "addons/PVRClient.h"
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroups.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
+#include "pvr/epg/EpgInfoTag.h"
+#include "pvr/recordings/PVRRecording.h"
+#include "pvr/timers/PVRTimers.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "threads/Timer.h"
+
+using namespace PVR;
+
+class CPVRPlaybackState::CLastWatchedUpdateTimer : public CTimer, private ITimerCallback
+{
+public:
+  CLastWatchedUpdateTimer(CPVRPlaybackState& state,
+                          const std::shared_ptr<CPVRChannel>& channel,
+                          const CDateTime& time)
+    : CTimer(this)
+    , m_state(state)
+    , m_channel(channel)
+    , m_time(time)
+  {
+  }
+
+  // ITimerCallback implementation
+  void OnTimeout() override
+  {
+    m_state.UpdateLastWatched(m_channel, m_time);
+  }
+
+private:
+  CLastWatchedUpdateTimer() = delete;
+
+  CPVRPlaybackState& m_state;
+  const std::shared_ptr<CPVRChannel> m_channel;
+  const CDateTime m_time;
+};
+
+
+CPVRPlaybackState::CPVRPlaybackState() = default;
+
+CPVRPlaybackState::~CPVRPlaybackState() = default;
+
+void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem> item)
+{
+  m_playingChannel.reset();
+  m_playingRecording.reset();
+  m_playingEpgTag.reset();
+  m_playingClientId = -1;
+  m_iplayingChannelUniqueID = -1;
+  m_strPlayingClientName.clear();
+
+  if (item->HasPVRChannelInfoTag())
+  {
+    const std::shared_ptr<CPVRChannel> channel = item->GetPVRChannelInfoTag();
+
+    m_playingChannel = channel;
+    m_playingClientId = m_playingChannel->ClientID();
+    m_iplayingChannelUniqueID = m_playingChannel->UniqueID();
+
+    SetPlayingGroup(channel);
+
+    int iLastWatchedDelay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_PVRPLAYBACK_DELAYMARKLASTWATCHED) * 1000;
+    if (iLastWatchedDelay > 0)
+    {
+      // Insert new / replace existing last watched update timer
+      if (m_lastWatchedUpdateTimer)
+        m_lastWatchedUpdateTimer->Stop(true);
+
+      m_lastWatchedUpdateTimer.reset(new CLastWatchedUpdateTimer(*this, channel, CDateTime::GetUTCDateTime()));
+      m_lastWatchedUpdateTimer->Start(iLastWatchedDelay);
+    }
+    else
+    {
+      // Store last watched timestamp immediately
+      UpdateLastWatched(channel, CDateTime::GetUTCDateTime());
+    }
+  }
+  else if (item->HasPVRRecordingInfoTag())
+  {
+    m_playingRecording = item->GetPVRRecordingInfoTag();
+    m_playingClientId = m_playingRecording->m_iClientId;
+  }
+  else if (item->HasEPGInfoTag())
+  {
+    m_playingEpgTag = item->GetEPGInfoTag();
+    m_playingClientId = m_playingEpgTag->ClientID();
+  }
+
+  if (m_playingClientId != -1)
+  {
+    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_playingClientId);
+    if (client)
+      m_strPlayingClientName = client->GetFriendlyName();
+  }
+}
+
+bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem> item)
+{
+  // Playback ended due to user interaction
+
+  bool bChanged = false;
+
+  if (item->HasPVRChannelInfoTag() && item->GetPVRChannelInfoTag() == m_playingChannel)
+  {
+    bool bUpdateLastWatched = true;
+
+    if (m_lastWatchedUpdateTimer)
+    {
+      if (m_lastWatchedUpdateTimer->IsRunning())
+      {
+        // If last watched timer is still running, cancel it. Channel was not watched long enough to store the value.
+        m_lastWatchedUpdateTimer->Stop(true);
+        bUpdateLastWatched = false;
+      }
+      m_lastWatchedUpdateTimer.reset();
+    }
+
+    if (bUpdateLastWatched)
+    {
+      // If last watched timer is not running (any more), channel was watched long enough to store the value.
+      UpdateLastWatched(m_playingChannel, CDateTime::GetUTCDateTime());
+    }
+
+    bChanged = true;
+    m_playingChannel.reset();
+    m_playingClientId = -1;
+    m_iplayingChannelUniqueID = -1;
+    m_strPlayingClientName.clear();
+  }
+  else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag() == m_playingRecording)
+  {
+    bChanged = true;
+    m_playingRecording.reset();
+    m_playingClientId = -1;
+    m_iplayingChannelUniqueID = -1;
+    m_strPlayingClientName.clear();
+  }
+  else if (item->HasEPGInfoTag() && item->GetEPGInfoTag() == m_playingEpgTag)
+  {
+    bChanged = true;
+    m_playingEpgTag.reset();
+    m_playingClientId = -1;
+    m_iplayingChannelUniqueID = -1;
+    m_strPlayingClientName.clear();
+  }
+
+  return bChanged;
+}
+
+void CPVRPlaybackState::OnPlaybackEnded(const std::shared_ptr<CFileItem> item)
+{
+  // Playback ended, but not due to user interaction
+  OnPlaybackStopped(item);
+}
+
+bool CPVRPlaybackState::IsPlaying() const
+{
+  return m_playingChannel != nullptr || m_playingRecording != nullptr || m_playingEpgTag != nullptr;
+}
+
+bool CPVRPlaybackState::IsPlayingTV() const
+{
+  return m_playingChannel && !m_playingChannel->IsRadio();
+}
+
+bool CPVRPlaybackState::IsPlayingRadio() const
+{
+  return m_playingChannel && m_playingChannel->IsRadio();
+}
+
+bool CPVRPlaybackState::IsPlayingEncryptedChannel() const
+{
+  return m_playingChannel && m_playingChannel->IsEncrypted();
+}
+
+bool CPVRPlaybackState::IsPlayingRecording() const
+{
+  return m_playingRecording != nullptr;
+}
+
+bool CPVRPlaybackState::IsPlayingEpgTag() const
+{
+  return m_playingEpgTag != nullptr;
+}
+
+bool CPVRPlaybackState::IsPlayingChannel(int iClientID, int iUniqueChannelID) const
+{
+  return m_playingChannel && m_playingClientId == iClientID && m_iplayingChannelUniqueID == iUniqueChannelID;
+}
+
+bool CPVRPlaybackState::IsPlayingChannel(const std::shared_ptr<CPVRChannel>& channel) const
+{
+  if (channel)
+  {
+    const std::shared_ptr<CPVRChannel> current = GetPlayingChannel();
+    if (current && *current == *channel)
+      return true;
+  }
+
+  return false;
+}
+
+bool CPVRPlaybackState::IsPlayingRecording(const std::shared_ptr<CPVRRecording>& recording) const
+{
+  if (recording)
+  {
+    const std::shared_ptr<CPVRRecording> current = GetPlayingRecording();
+    if (current && *current == *recording)
+      return true;
+  }
+
+  return false;
+}
+
+bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+{
+  if (epgTag)
+  {
+    const std::shared_ptr<CPVREpgInfoTag> current = GetPlayingEpgTag();
+    if (current && *current == *epgTag)
+      return true;
+  }
+
+  return false;
+}
+
+std::shared_ptr<CPVRChannel> CPVRPlaybackState::GetPlayingChannel() const
+{
+  return m_playingChannel;
+}
+
+std::shared_ptr<CPVRRecording> CPVRPlaybackState::GetPlayingRecording() const
+{
+  return m_playingRecording;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVRPlaybackState::GetPlayingEpgTag() const
+{
+  return m_playingEpgTag;
+}
+
+std::string CPVRPlaybackState::GetPlayingClientName() const
+{
+  return m_strPlayingClientName;
+}
+
+int CPVRPlaybackState::GetPlayingClientID() const
+{
+  return m_playingClientId;
+}
+
+bool CPVRPlaybackState::IsRecording() const
+{
+  return CServiceBroker::GetPVRManager().Timers()->IsRecording();
+}
+
+bool CPVRPlaybackState::IsRecordingOnPlayingChannel() const
+{
+  const std::shared_ptr<CPVRChannel> currentChannel = GetPlayingChannel();
+  return currentChannel && CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*currentChannel);
+}
+
+bool CPVRPlaybackState::IsPlayingActiveRecording() const
+{
+  const std::shared_ptr<CPVRRecording> currentRecording = GetPlayingRecording();
+  return currentRecording && currentRecording->IsInProgress();
+}
+
+bool CPVRPlaybackState::CanRecordOnPlayingChannel() const
+{
+  const std::shared_ptr<CPVRChannel> currentChannel = GetPlayingChannel();
+  return currentChannel && currentChannel->CanRecord();
+}
+
+void CPVRPlaybackState::SetPlayingGroup(const std::shared_ptr<CPVRChannelGroup>& group)
+{
+  if (group)
+    CServiceBroker::GetPVRManager().ChannelGroups()->Get(group->IsRadio())->SetSelectedGroup(group);
+}
+
+void CPVRPlaybackState::SetPlayingGroup(const std::shared_ptr<CPVRChannel>& channel)
+{
+  const std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager().ChannelGroups()->GetSelectedGroup(channel->IsRadio());
+  if (!group || !group->IsGroupMember(channel))
+  {
+    // The channel we'll switch to is not part of the current selected group.
+    // Set the first group as the selected group where the channel is a member.
+    CPVRChannelGroups* channelGroups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(channel->IsRadio());
+    const std::vector<std::shared_ptr<CPVRChannelGroup>> groups = channelGroups->GetGroupsByChannel(channel, true);
+    if (!groups.empty())
+      channelGroups->SetSelectedGroup(groups.front());
+  }
+}
+
+std::shared_ptr<CPVRChannelGroup> CPVRPlaybackState::GetPlayingGroup(bool bRadio) const
+{
+  return CServiceBroker::GetPVRManager().ChannelGroups()->GetSelectedGroup(bRadio);
+}
+
+void CPVRPlaybackState::UpdateLastWatched(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& time)
+{
+  time_t iTime;
+  time.GetAsTime(iTime);
+
+  channel->SetLastWatched(iTime);
+
+  // update last watched timestamp for group
+  const std::shared_ptr<CPVRChannelGroup> group = GetPlayingGroup(channel->IsRadio());
+  group->SetLastWatched(iTime);
+
+  CServiceBroker::GetPVRManager().ChannelGroups()->SetLastPlayedGroup(group);
+}

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -1,0 +1,212 @@
+/*
+ *  Copyright (C) 2012-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+class CDateTime;
+class CFileItem;
+
+namespace PVR
+{
+class CPVRChannel;
+class CPVRChannelGroup;
+class CPVREpgInfoTag;
+class CPVRRecording;
+
+class CPVRPlaybackState
+{
+public:
+  /*!
+   * @brief ctor.
+   */
+  CPVRPlaybackState();
+
+  /*!
+   * @brief dtor.
+   */
+  virtual ~CPVRPlaybackState();
+
+  /*!
+   * @brief Inform that playback of an item just started.
+   * @param item The item that started to play.
+   */
+  void OnPlaybackStarted(const std::shared_ptr<CFileItem> item);
+
+  /*!
+   * @brief Inform that playback of an item was stopped due to user interaction.
+   * @param item The item that stopped to play.
+   * @return True, if the state has changed, false otherwise
+   */
+  bool OnPlaybackStopped(const std::shared_ptr<CFileItem> item);
+
+  /*!
+   * @brief Inform that playback of an item has stopped without user interaction.
+   * @param item The item that ended to play.
+   */
+  void OnPlaybackEnded(const std::shared_ptr<CFileItem> item);
+
+  /*!
+   * @brief Check if a TV channel, radio channel or recording is playing.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlaying() const;
+
+  /*!
+   * @brief Check if a TV channel is playing.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingTV() const;
+
+  /*!
+   * @brief Check if a radio channel is playing.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingRadio() const;
+
+  /*!
+   * @brief Check if a an encrypted TV or radio channel is playing.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingEncryptedChannel() const;
+
+  /*!
+   * @brief Check if a recording is playing.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingRecording() const;
+
+  /*!
+   * @brief Check if an epg tag is playing.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingEpgTag() const;
+
+  /*!
+   * @brief Check whether playing channel matches given uids.
+   * @param iClientID The client id.
+   * @param iUniqueChannelID The channel uid.
+   * @return True on match, false if there is no match or no channel is playing.
+   */
+  bool IsPlayingChannel(int iClientID, int iUniqueChannelID) const;
+
+  /*!
+   * @brief Check if the given channel is playing.
+   * @param channel The channel to check.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingChannel(const std::shared_ptr<CPVRChannel>& channel) const;
+
+  /*!
+   * @brief Check if the given recording is playing.
+   * @param recording The recording to check.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingRecording(const std::shared_ptr<CPVRRecording>& recording) const;
+
+  /*!
+   * @brief Check if the given epg tag is playing.
+   * @param epgTag The tag to check.
+   * @return True if it's playing, false otherwise.
+   */
+  bool IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+
+  /*!
+   * @brief Return the channel that is currently playing.
+   * @return The channel or nullptr if none is playing.
+   */
+  std::shared_ptr<CPVRChannel> GetPlayingChannel() const;
+
+  /*!
+   * @brief Return the recording that is currently playing.
+   * @return The recording or nullptr if none is playing.
+   */
+  std::shared_ptr<CPVRRecording> GetPlayingRecording() const;
+
+  /*!
+   * @brief Return the epg tag that is currently playing.
+   * @return The tag or nullptr if none is playing.
+   */
+  std::shared_ptr<CPVREpgInfoTag> GetPlayingEpgTag() const;
+
+  /*!
+   * @brief Get the name of the playing client, if there is one.
+   * @return The name of the client or an empty string if nothing is playing.
+   */
+  std::string GetPlayingClientName() const;
+
+  /*!
+   * @brief Get the ID of the playing client, if there is one.
+   * @return The ID or -1 if no client is playing.
+   */
+  int GetPlayingClientID() const;
+
+  /*!
+   * @brief Check whether there are active recordings.
+   * @return True if there are active recordings, false otherwise.
+   */
+  bool IsRecording() const;
+
+  /*!
+   * @brief Check whether there is an active recording on the currenlyt playing channel.
+   * @return True if there is a playing channel and there is an active recording on that channel, false otherwise.
+   */
+  bool IsRecordingOnPlayingChannel() const;
+
+  /*!
+   * @brief Check if an active recording is playing.
+   * @return True if an in-progress (active) recording is playing, false otherwise.
+   */
+  bool IsPlayingActiveRecording() const;
+
+  /*!
+   * @brief Check whether the currently playing channel can be recorded.
+   * @return True if there is a playing channel that can be recorded, false otherwise.
+   */
+  bool CanRecordOnPlayingChannel() const;
+
+  /*!
+   * @brief Set the current playing group, used to load the right channel.
+   * @param group The new group.
+   */
+  void SetPlayingGroup(const std::shared_ptr<CPVRChannelGroup>& group);
+
+  /*!
+   * @brief Get the current playing group, used to load the right channel.
+   * @param bRadio True to get the current radio group, false to get the current TV group.
+   * @return The current group or the group containing all channels if it's not set.
+   */
+  std::shared_ptr<CPVRChannelGroup> GetPlayingGroup(bool bRadio) const;
+
+private:
+  /*!
+   * @brief Set the playing group to the first group the channel is in if the given channel is not part of the current playing group
+   * @param channel The channel
+   */
+  void SetPlayingGroup(const std::shared_ptr<CPVRChannel>& channel);
+
+  /*!
+   * @brief Updates the last watched timestamps of the channel and group which are currently playing.
+   * @param channel The channel which is updated
+   * @param time The last watched time to set
+   */
+  void UpdateLastWatched(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& time);
+
+  std::shared_ptr<CPVRChannel> m_playingChannel;
+  std::shared_ptr<CPVRRecording> m_playingRecording;
+  std::shared_ptr<CPVREpgInfoTag> m_playingEpgTag;
+  std::string m_strPlayingClientName;
+  int m_playingClientId = -1;
+  int m_iplayingChannelUniqueID = -1;
+
+  class CLastWatchedUpdateTimer;
+  std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;
+};
+} // namespace PVR

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -14,6 +14,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVREventLogJob.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
@@ -202,7 +203,7 @@ bool CPVRClients::RequestRestart(AddonPtr addon, bool bDataChanged)
 bool CPVRClients::StopClient(const AddonPtr& addon, bool bRestart)
 {
   // stop playback if needed
-  if (CServiceBroker::GetPVRManager().IsPlaying())
+  if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlaying())
     CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
 
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -13,6 +13,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/epg/EpgContainer.h"
@@ -162,7 +163,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const std::shared_ptr<CPVRChannel
     return false;
 
   /* check if this channel is currently playing if we are hiding it */
-  std::shared_ptr<CPVRChannel> currentChannel(CServiceBroker::GetPVRManager().GetPlayingChannel());
+  const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
   if (currentChannel && currentChannel == channel)
   {
     HELPERS::ShowOKDialogText(CVariant{19098}, CVariant{19102});

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/epg/EpgInfoTag.h"
 
@@ -34,7 +35,7 @@ void CGUIDialogPVRChannelGuide::OnInitWindow()
 {
   // no user-specific channel is set; use current playing channel
   if (!m_channel)
-    m_channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+    m_channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
 
   if (!m_channel)
   {

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -18,6 +18,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroups.h"
@@ -72,7 +73,7 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
 
 void CGUIDialogPVRChannelsOSD::OnInitWindow()
 {
-  if (!CServiceBroker::GetPVRManager().IsPlayingTV() && !CServiceBroker::GetPVRManager().IsPlayingRadio())
+  if (!CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV() && !CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRadio())
   {
     Close();
     return;
@@ -126,7 +127,7 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction& action)
       const std::shared_ptr<CPVRChannelGroup> nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP
                                                         ? groups->GetNextGroup(*m_group)
                                                         : groups->GetPreviousGroup(*m_group);
-      CServiceBroker::GetPVRManager().SetPlayingGroup(nextGroup);
+      CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(nextGroup);
       m_group = nextGroup;
       Init();
       Update();
@@ -167,10 +168,10 @@ void CGUIDialogPVRChannelsOSD::Update()
   pvrMgr.Events().Subscribe(this, &CGUIDialogPVRChannelsOSD::Notify);
   pvrMgr.EpgContainer().Events().Subscribe(this, &CGUIDialogPVRChannelsOSD::Notify);
 
-  const std::shared_ptr<CPVRChannel> channel = pvrMgr.GetPlayingChannel();
+  const std::shared_ptr<CPVRChannel> channel = pvrMgr.PlaybackState()->GetPlayingChannel();
   if (channel)
   {
-    const std::shared_ptr<CPVRChannelGroup> group = pvrMgr.GetPlayingGroup(channel->IsRadio());
+    const std::shared_ptr<CPVRChannelGroup> group = pvrMgr.PlaybackState()->GetPlayingGroup(channel->IsRadio());
     if (group)
     {
       const std::vector<std::shared_ptr<PVRChannelGroupMember>> groupMembers = group->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -22,6 +22,7 @@
 #include "messaging/helpers//DialogOKHelper.h"
 #include "pvr/PVRGUIDirectory.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -449,7 +450,7 @@ void CGUIDialogPVRGroupManager::Update()
   if (m_selectedGroup)
   {
     /* set this group in the pvrmanager, so it becomes the selected group in other dialogs too */
-    CServiceBroker::GetPVRManager().SetPlayingGroup(m_selectedGroup);
+    CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(m_selectedGroup);
     SET_CONTROL_LABEL(CONTROL_CURRENT_GROUP_LABEL, m_selectedGroup->GroupName());
     SET_CONTROL_SELECTED(GetID(), BUTTON_HIDE_GROUP, m_selectedGroup->IsHidden());
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
@@ -15,6 +15,7 @@
 #include "guilib/GUITextBox.h"
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
 
@@ -63,7 +64,7 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
     }
     else if (iControl == SPIN_CONTROL_INFO)
     {
-      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
       if (!channel)
         return false;
 
@@ -157,7 +158,7 @@ void CGUIDialogPVRRadioRDSInfo::InitInfoControls()
 
 void CGUIDialogPVRRadioRDSInfo::UpdateInfoControls()
 {
-  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
   if (!channel)
     return;
 

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -13,6 +13,7 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "cores/DataCacheCore.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgDatabase.h"
@@ -237,7 +238,7 @@ void CPVREpgInfoTag::ToSortable(SortItem& sortable, Field field) const
 
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
 {
-  if (CServiceBroker::GetPVRManager().IsPlayingChannel(ClientID(), UniqueChannelID()))
+  if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingChannel(ClientID(), UniqueChannelID()))
   {
     // start time valid?
     time_t startTime = CServiceBroker::GetDataCacheCore().GetStartTime();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -25,6 +25,7 @@
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRGUIDirectory.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -427,13 +428,13 @@ bool CGUIWindowPVRBase::InitChannelGroup()
   std::shared_ptr<CPVRChannelGroup> group;
   if (m_channelGroupPath.empty())
   {
-    group = CServiceBroker::GetPVRManager().GetPlayingGroup(m_bRadio);
+    group = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingGroup(m_bRadio);
   }
   else
   {
     group = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bRadio)->GetGroupByPath(m_channelGroupPath);
     if (group)
-      CServiceBroker::GetPVRManager().SetPlayingGroup(group);
+      CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(group);
     else
       CLog::LogF(LOGERROR, "Found no %s channel group with path '%s'!", m_bRadio ? "radio" : "TV", m_vecItems->GetPath().c_str());
   }
@@ -481,7 +482,7 @@ void CGUIWindowPVRBase::SetChannelGroup(std::shared_ptr<CPVRChannelGroup> &&grou
 
   if (updateChannelGroup)
   {
-    CServiceBroker::GetPVRManager().SetPlayingGroup(updateChannelGroup);
+    CServiceBroker::GetPVRManager().PlaybackState()->SetPlayingGroup(updateChannelGroup);
     Update(GetDirectoryPath());
   }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -24,6 +24,7 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -663,7 +664,8 @@ bool CGUIWindowPVRGuideBase::OnContextButtonNavigate(CONTEXT_BUTTON button)
       buttons.Add(&CGUIWindowPVRGuideBase::GotoEnd, 19064); // Last programme
       buttons.Add(&CGUIWindowPVRGuideBase::OpenDateSelectionDialog, 19288); // Date selector
       buttons.Add(&CGUIWindowPVRGuideBase::GotoFirstChannel, 19322); // First channel
-      if (CServiceBroker::GetPVRManager().IsPlayingTV() || CServiceBroker::GetPVRManager().IsPlayingRadio())
+      if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV() ||
+          CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRadio())
         buttons.Add(&CGUIWindowPVRGuideBase::GotoPlayingChannel, 19323); // Playing channel
       buttons.Add(&CGUIWindowPVRGuideBase::GotoLastChannel, 19324); // Last channel
       buttons.Add(&CGUIWindowPVRBase::ActivatePreviousChannelGroup, 19319); // Previous group
@@ -840,7 +842,7 @@ bool CGUIWindowPVRGuideBase::GotoLastChannel()
 
 bool CGUIWindowPVRGuideBase::GotoPlayingChannel()
 {
-  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().GetPlayingChannel();
+  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
   if (channel)
   {
     GetGridControl()->SetChannel(channel);


### PR DESCRIPTION
Another PVR refactoring PR. Idea is decoupling and separation of concerns.

In the distant future PVR shall no more know anything about any application playback states. So, this PR is a step into this direction.

Runtime-tested on macOS and Android, latest Kodi master.