### PR TITLE
System.HasAddon() - return true for disabled addons

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1704,6 +1704,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
 ///                  _boolean_,
 ///     @return **True** if the specified addon is installed on the system.
 ///     @param id - the addon id
+///     @skinning_v19 **[Boolean Condition Updated]** \link System_HasAddon `System.HasAddon(id)`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`System.AddonIsEnabled(id)`</b>,

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -165,7 +165,7 @@ bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case SYSTEM_HAS_ADDON:
     {
       ADDON::AddonPtr addon;
-      value = CServiceBroker::GetAddonMgr().GetAddon(info.GetData3(), addon) && addon;
+      value = CServiceBroker::GetAddonMgr().IsAddonInstalled(info.GetData3());
       return true;
     }
     case SYSTEM_ADDON_IS_ENABLED:


### PR DESCRIPTION
the System.HasAddon() infobool is mainly used by skins to optionally install a missing addon, 
therefor it should also return true when an addon is already installed but disabled.