### PR TITLE
[darwin] modernize obj-c common darwin code

### DIFF
--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -39,9 +39,9 @@ const char* CDarwinUtils::getIosPlatformString(void)
 #if defined(TARGET_DARWIN_EMBEDDED)
     // Gets a string with the device model
     size_t size;
-    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+    sysctlbyname("hw.machine", nullptr, &size, nullptr, 0);
     char machine[size];
-    if (sysctlbyname("hw.machine", machine, &size, NULL, 0) == 0 && machine[0])
+    if (sysctlbyname("hw.machine", machine, &size, nullptr, 0) == 0 && machine[0])
       iOSPlatformString.assign(machine, size-1);
     else
 #endif
@@ -57,9 +57,9 @@ const char *CDarwinUtils::GetOSReleaseString(void)
   std::call_once(flag, []
   {
     size_t size;
-    sysctlbyname("kern.osrelease", NULL, &size, NULL, 0);
+    sysctlbyname("kern.osrelease", nullptr, &size, nullptr, 0);
     char osrelease[size];
-    sysctlbyname("kern.osrelease", osrelease, &size, NULL, 0);
+    sysctlbyname("kern.osrelease", osrelease, &size, nullptr, 0);
     osreleaseStr.assign(osrelease);
   });
   return osreleaseStr.c_str();
@@ -69,7 +69,7 @@ const char *CDarwinUtils::GetOSVersionString(void)
 {
   @autoreleasepool
   {
-    return [[[NSProcessInfo processInfo] operatingSystemVersionString] UTF8String];
+    return NSProcessInfo.processInfo.operatingSystemVersionString.UTF8String;
   }
 }
 
@@ -80,7 +80,7 @@ const char* CDarwinUtils::GetVersionString()
 #if defined(TARGET_DARWIN_EMBEDDED)
   std::call_once(flag, []
   {
-    versionString.assign([[[UIDevice currentDevice] systemVersion] UTF8String]);
+    versionString.assign(UIDevice.currentDevice.systemVersion.UTF8String);
   });
 #else
   std::call_once(flag, []
@@ -224,19 +224,19 @@ bool CFStringRefToStringWithEncoding(CFStringRef source, std::string &destinatio
   {
     CFIndex strLen = CFStringGetMaximumSizeForEncoding(CFStringGetLength(source) + 1,
                                                        encoding);
-    char *allocStr = (char*)malloc(strLen);
+    char* allocStr = static_cast<char*>(malloc(strLen));
 
     if(!allocStr)
       return false;
 
     if(!CFStringGetCString(source, allocStr, strLen, encoding))
     {
-      free((void*)allocStr);
+      free(static_cast<void*>(allocStr));
       return false;
     }
 
     destination = allocStr;
-    free((void*)allocStr);
+    free(static_cast<void*>(allocStr));
 
     return true;
   }
@@ -285,7 +285,7 @@ const std::string& CDarwinUtils::GetManufacturer(void)
             manufName = static_cast<const char*>([NSString stringWithString:(__bridge NSString*)manufacturer].UTF8String);
           else if (typeId == CFDataGetTypeID())
           {
-            manufName.assign((const char*)CFDataGetBytePtr((CFDataRef)manufacturer), CFDataGetLength((CFDataRef)manufacturer));
+            manufName.assign(reinterpret_cast<const char*>(CFDataGetBytePtr((CFDataRef)manufacturer)), CFDataGetLength((CFDataRef)manufacturer));
             if (!manufName.empty() && manufName[manufName.length() - 1] == 0)
               manufName.erase(manufName.length() - 1); // remove extra null at the end if any
           }

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -42,7 +42,7 @@ NSDictionary *dictionaryFromVariantMap(const CVariant &data)
     return nil;
   NSMutableDictionary* dict = [[NSMutableDictionary alloc] initWithCapacity:data.size()];
   for (CVariant::const_iterator_map itr = data.begin_map(); itr != data.end_map(); ++itr)
-    [dict setValue:objectFromVariant(itr->second) forKey:[NSString stringWithUTF8String:itr->first.c_str()]];
+    [dict setValue:objectFromVariant(itr->second) forKey:@(itr->first.c_str())];
 
   return dict;
 }
@@ -52,17 +52,17 @@ id objectFromVariant(const CVariant &data)
   if (data.isNull())
     return nil;
   if (data.isString())
-    return [NSString stringWithUTF8String:data.asString().c_str()];
+    return @(data.asString().c_str());
   if (data.isWideString())
-    return [NSString stringWithCString:(const char *)data.asWideString().c_str() encoding:NSUnicodeStringEncoding];
+    return [NSString stringWithCString:(const char*)data.asWideString().c_str() encoding:NSUnicodeStringEncoding];
   if (data.isInteger())
-    return [NSNumber numberWithLongLong:data.asInteger()];
+    return @(data.asInteger());
   if (data.isUnsignedInteger())
-    return [NSNumber numberWithUnsignedLongLong:data.asUnsignedInteger()];
+    return @(data.asUnsignedInteger());
   if (data.isBoolean())
-    return [NSNumber numberWithInt:data.asBoolean()?1:0];
+    return @(data.asBoolean() ? 1 : 0);
   if (data.isDouble())
-    return [NSNumber numberWithDouble:data.asDouble()];
+    return @(data.asDouble());
   if (data.isArray())
     return arrayFromVariantArray(data);
   if (data.isObject())
@@ -85,7 +85,7 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
     {
       if (!nonConstData["item"]["id"].isNull())
       {
-        item_id = (int)nonConstData["item"]["id"].asInteger();
+        item_id = static_cast<int>(nonConstData["item"]["id"].asInteger());
       }
 
       if (!nonConstData["item"]["type"].isNull())
@@ -133,18 +133,18 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
       if (!cachedThumb.empty())
       {
         std::string thumbRealPath = CSpecialProtocol::TranslatePath(cachedThumb);
-        [item setValue:[NSString stringWithUTF8String:thumbRealPath.c_str()] forKey:@"thumb"];
+        [item setValue:@(thumbRealPath.c_str()) forKey:@"thumb"];
       }
     }
     double duration = g_application.GetTotalTime();
     if (duration > 0)
-      [item setValue:[NSNumber numberWithDouble:duration] forKey:@"duration"];
-    [item setValue:[NSNumber numberWithDouble:g_application.GetTime()] forKey:@"elapsed"];
+      [item setValue:@(duration) forKey:@"duration"];
+    [item setValue:@(g_application.GetTime()) forKey:@"elapsed"];
     int current = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     if (current >= 0)
     {
-      [item setValue:[NSNumber numberWithInt:current] forKey:@"current"];
-      [item setValue:[NSNumber numberWithInt:CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()] forKey:@"total"];
+      [item setValue:@(current) forKey:@"current"];
+      [item setValue:@(CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()) forKey:@"total"];
     }
     if (g_application.CurrentFileItem().HasMusicInfoTag())
     {
@@ -154,7 +154,7 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
         NSMutableArray *genreArray = [[NSMutableArray alloc] initWithCapacity:genre.size()];
         for(std::vector<std::string>::const_iterator it = genre.begin(); it != genre.end(); ++it)
         {
-          [genreArray addObject:[NSString stringWithUTF8String:it->c_str()]];
+          [genreArray addObject:@(it->c_str())];
         }
         [item setValue:genreArray forKey:@"genre"];
       }
@@ -167,7 +167,7 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
     NSDictionary *item = [dict valueForKey:@"item"];
     NSDictionary *player = [dict valueForKey:@"player"];
     [item setValue:[player valueForKey:@"speed"] forKey:@"speed"];
-    [item setValue:[NSNumber numberWithDouble:g_application.GetTime()] forKey:@"elapsed"];
+    [item setValue:@(g_application.GetTime()) forKey:@"elapsed"];
     //LOG(@"item: %@", item.description);
     [g_xbmcController performSelectorOnMainThread:@selector(OnSpeedChanged:) withObject:item  waitUntilDone:NO];
     if (msg == "OnPause")


### PR DESCRIPTION
## Description
Applies xcode's modernize obj-c syntax conversion.

- Updates NULL to nullptr

- Modern C++ casts

- Uses . syntax as current recommended guidelines for objc code from Apple

## Motivation and Context
Modernize to current recommended code practices for obj-c code.

## How Has This Been Tested?
Runtime tested for ios/tvos for a few weeks.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
