### PR TITLE
[ios] fix overlapping drawing surface with the "safe area"

### DIFF
--- a/xbmc/platform/darwin/ios-common/IOSKeyboard.mm
+++ b/xbmc/platform/darwin/ios-common/IOSKeyboard.mm
@@ -38,9 +38,7 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
         return false;
 
       // assume we are only drawn on the mainscreen ever!
-      UIScreen* pCurrentScreen = [UIScreen mainScreen];
-      CGRect keyboardFrame =
-          CGRectMake(0, 0, pCurrentScreen.bounds.size.width, pCurrentScreen.bounds.size.height);
+      auto keyboardFrame = [g_xbmcController fullscreenSubviewFrame];
 
       //create the keyboardview
       m_impl->g_pIosKeyboard = [[KeyboardView alloc] initWithFrame:keyboardFrame];

--- a/xbmc/platform/darwin/ios/XBMCController.h
+++ b/xbmc/platform/darwin/ios/XBMCController.h
@@ -66,6 +66,7 @@ typedef enum
 - (void) setIOSNowPlayingInfo:(NSDictionary *)info;
 - (void) sendKey: (XBMCKey) key;
 - (void) observeDefaultCenterStuff: (NSNotification *) notification;
+- (CGRect)fullscreenSubviewFrame;
 - (void) setFramebuffer;
 - (bool) presentFramebuffer;
 - (CGSize) getScreenSize;

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -577,6 +577,12 @@ XBMCController *g_xbmcController;
   [super viewWillAppear:animated];
 }
 //--------------------------------------------------------------
+- (void)viewSafeAreaInsetsDidChange NS_AVAILABLE_IOS(11_0)
+{
+  [super viewSafeAreaInsetsDidChange];
+  m_glView.frame = UIEdgeInsetsInsetRect(self.view.bounds, self.view.safeAreaInsets);
+}
+//--------------------------------------------------------------
 -(void) viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -580,7 +580,7 @@ XBMCController *g_xbmcController;
 - (void)viewSafeAreaInsetsDidChange NS_AVAILABLE_IOS(11_0)
 {
   [super viewSafeAreaInsetsDidChange];
-  m_glView.frame = UIEdgeInsetsInsetRect(self.view.bounds, self.view.safeAreaInsets);
+  m_glView.frame = [self fullscreenSubviewFrame];
 }
 //--------------------------------------------------------------
 -(void) viewDidAppear:(BOOL)animated
@@ -637,6 +637,15 @@ XBMCController *g_xbmcController;
   [self resignFirstResponder];
 
 	[super viewDidUnload];
+}
+//--------------------------------------------------------------
+- (CGRect)fullscreenSubviewFrame
+{
+  auto rect = self.view.bounds;
+  if (@available(ios 11.0, *))
+    return UIEdgeInsetsInsetRect(rect, self.view.safeAreaInsets);
+  else
+    return rect;
 }
 //--------------------------------------------------------------
 - (void) setFramebuffer


### PR DESCRIPTION
## Description
UI no longer appears under the "notch" of new iPhones (X and later). Screenshots were taken from iPhone XR and framed with [fastlane](https://docs.fastlane.tools/actions/frameit/).

## Motivation and Context
Currently UI is partially cut by the notch, sometimes it cuts essential parts of the UI. See screenshots for examples.

## How Has This Been Tested?
- iPhone XR: to test new behavior
- iPhone 6+, iPhone 6s, iPhone 5, iPad Air 2: to verify that old behaviour still works the same way

## Screenshots (old vs new):
#### 1 left
![1force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66254034-61d63c80-e779-11e9-95a0-8612927daa6d.png) ![1new_force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66254037-6bf83b00-e779-11e9-89c7-3475661b322d.png)

#### 1 right
![1force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66254041-787c9380-e779-11e9-8f69-6a53413badd2.png) ![1new_force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66254042-79152a00-e779-11e9-86a8-9510cd25841d.png)

#### 2 left
![2force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66254053-94803500-e779-11e9-8f48-41533c9c36cb.png) ![2new_force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66254054-94803500-e779-11e9-917e-c8aafe8219fd.png)

#### 2 right
![2force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66254057-9f3aca00-e779-11e9-815a-42905086ac17.png) ![2new_force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66254058-9f3aca00-e779-11e9-9931-e45616f5b877.png)

#### 3 left
![3force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66254065-b679b780-e779-11e9-9660-7b0d9c91bbce.png) ![3new_force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66254066-b679b780-e779-11e9-9cf1-d42bf090a5f7.png)

#### 3 right
![3force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66254069-c09bb600-e779-11e9-88dc-f732c364dd07.png) ![3new_force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66254070-c09bb600-e779-11e9-8f06-4e0d0c1a57a2.png)

#### 4 left
![4_force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66266112-43c81500-e829-11e9-969c-fef0de872122.png) ![4new_force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/66266113-43c81500-e829-11e9-8082-89934f04ff4e.png)

#### 4 right
![4_force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66266116-517d9a80-e829-11e9-876d-1972e6405557.png) ![4new_force_landscaperight_framed](https://user-images.githubusercontent.com/1557784/66266118-517d9a80-e829-11e9-9833-8cb15ab02c1a.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
