### PR TITLE
[Music]Reduce repeated parsing of path to get node details

### DIFF
--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -93,6 +93,18 @@ NODE_TYPE CMusicDatabaseDirectory::GetDirectoryParentType(const std::string& str
   return pParentNode->GetChildType();
 }
 
+bool CMusicDatabaseDirectory::GetDirectoryNodeInfo(const std::string& strPath,
+                                                   MUSICDATABASEDIRECTORY::NODE_TYPE& type,
+                                                   MUSICDATABASEDIRECTORY::NODE_TYPE& childtype,
+                                                   MUSICDATABASEDIRECTORY::CQueryParams& params)
+{
+  std::string path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  if (!CDirectoryNode::GetNodeInfo(path, type, childtype, params))
+    return false;
+
+  return true;
+}
+
 bool CMusicDatabaseDirectory::IsArtistDir(const std::string& strDirectory)
 {
   NODE_TYPE node=GetDirectoryType(strDirectory);

--- a/xbmc/filesystem/MusicDatabaseDirectory.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory.h
@@ -25,6 +25,7 @@ namespace XFILE
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryChildType(const std::string& strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryType(const std::string& strPath);
     static MUSICDATABASEDIRECTORY::NODE_TYPE GetDirectoryParentType(const std::string& strPath);
+    static bool GetDirectoryNodeInfo(const std::string& strPath, MUSICDATABASEDIRECTORY::NODE_TYPE& type, MUSICDATABASEDIRECTORY::NODE_TYPE& childtype, MUSICDATABASEDIRECTORY::CQueryParams& params);
     bool IsArtistDir(const std::string& strDirectory);
     void ClearDirectoryCache(const std::string& strDirectory);
     static bool IsAllItem(const std::string& strDirectory);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -84,6 +84,22 @@ void CDirectoryNode::GetDatabaseInfo(const std::string& strPath, CQueryParams& p
   pNode->CollectQueryParams(params);
 }
 
+bool CDirectoryNode::GetNodeInfo(const std::string& strPath,
+                                 NODE_TYPE& type,
+                                 NODE_TYPE& childtype,
+                                 CQueryParams& params)
+{
+  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::ParseURL(strPath));
+  if (!pNode)
+    return false;
+
+  type = pNode->GetType();
+  childtype = pNode->GetChildType();
+  pNode->CollectQueryParams(params);
+
+  return true;
+}
+
 //  Create a node object
 CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent)
 {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -52,6 +52,7 @@ namespace XFILE
     public:
       static CDirectoryNode* ParseURL(const std::string& strPath);
       static void GetDatabaseInfo(const std::string& strPath, CQueryParams& params);
+      static bool GetNodeInfo(const std::string& strPath, NODE_TYPE& type, NODE_TYPE& childtype, CQueryParams& params);
       virtual ~CDirectoryNode();
 
       NODE_TYPE GetType() const;

--- a/xbmc/music/MusicDbUrl.cpp
+++ b/xbmc/music/MusicDbUrl.cpp
@@ -29,8 +29,13 @@ bool CMusicDbUrl::parse()
     return false;
 
   std::string path = m_url.Get();
-  NODE_TYPE dirType = CMusicDatabaseDirectory::GetDirectoryType(path);
-  NODE_TYPE childType = CMusicDatabaseDirectory::GetDirectoryChildType(path);
+
+  // Parse path for directory node types and query params
+  NODE_TYPE dirType;
+  NODE_TYPE childType;
+  CQueryParams queryParams;
+  if (!CMusicDatabaseDirectory::GetDirectoryNodeInfo(path, dirType, childType, queryParams))
+    return false;
 
   switch (dirType)
   {
@@ -108,10 +113,6 @@ bool CMusicDbUrl::parse()
 
   if (m_type.empty())
     return false;
-
-  // parse query params
-  CQueryParams queryParams;
-  CDirectoryNode::GetDatabaseInfo(path, queryParams);
 
   // retrieve and parse all options
   AddOptions(m_url.GetOptions());


### PR DESCRIPTION
`CMusicDbUrl` are created multiple times during music library navigation, and each time parsed the path 3 times creating nodes for each level. This adds methods to enable this to be done in one call.