### PR TITLE
[skin.estuary/pvr] Add year if populated and add genre to Guide, Timers and Recordings UIs

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -125,7 +125,7 @@
 				</control>
 			</control>
 			<include content="InfoDialogTopBarInfo">
-				<param name="main_label" value="$INFO[ListItem.Title]" />
+				<param name="main_label" value="$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]" />
 				<param name="sub_label" value="[COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white][B],[/B][/COLOR]]" />
 				<param name="posy" value="40" />
 			</include>

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -246,7 +246,7 @@
 				<width>830</width>
 				<height>262</height>
 				<font>font36_title</font>
-				<label>$INFO[ListItem.Title]</label>
+				<label>$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
 				<visible>!PVR.HasEpg</visible>
 			</control>
 			<control type="label">
@@ -254,7 +254,7 @@
 				<width>830</width>
 				<height>262</height>
 				<font>font36_title</font>
-				<label>$INFO[ListItem.EpgEventTitle]</label>
+				<label>$INFO[ListItem.EpgEventTitle] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
 				<visible>PVR.HasEpg</visible>
 			</control>
 			<control type="label">

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -259,9 +259,17 @@
 			</control>
 			<control type="label">
 				<top>435</top>
-				<width>830</width>
+				<width>40%</width>
 				<height>70</height>
 				<label>[I]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/I]</label>
+			</control>
+			<control type="label">
+				<top>435</top>
+				<right>30</right>
+				<width>60%</width>
+				<height>70</height>
+				<align>right</align>
+				<label>$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
 			</control>
 			<control type="textbox">
 				<top>490</top>

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -186,7 +186,7 @@
 						<control type="label">
 							<width>70%</width>
 							<height>30</height>
-							<label>[B]$INFO[ListItem.EpgEventTitle][/B]</label>
+							<label>[B]$INFO[ListItem.EpgEventTitle][/B] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
 						</control>
 						<control type="label">
 							<top>0</top>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Add year if available after title similar to videos to Guide, Timers, Recordings and Info UIs.

Add genre to main Timers and Recordings UIs similar to how it's populated in the Guide UI.

Thanks Dumyat from the forum for the guidance.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

No way to see year without this.

Genre could never be viewed for timers. It's not consistent regardless of screen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Runtime test on OSX, checking each UI screen.

## Screenshots (if appropriate):

<img width="1783" alt="Screenshot 2019-10-06 at 20 41 17" src="https://user-images.githubusercontent.com/4601187/66274781-f88a2280-e879-11e9-9b58-f86f593486be.png">
<img width="1773" alt="Screenshot 2019-10-06 at 20 41 37" src="https://user-images.githubusercontent.com/4601187/66274782-fcb64000-e879-11e9-9fdd-46994483fd9c.png">
<img width="1778" alt="Screenshot 2019-10-06 at 20 42 11" src="https://user-images.githubusercontent.com/4601187/66274788-0049c700-e87a-11e9-8e98-8c2dfd401009.png">
<img width="1777" alt="Screenshot 2019-10-06 at 20 43 00" src="https://user-images.githubusercontent.com/4601187/66274790-0475e480-e87a-11e9-83cc-d743346b2fcf.png">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
