### PR TITLE
[Android] Use JNI instead NDK MediaCrypto for secure decoder check

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=25258a1e57414b46367ef367ef7291aeeb464d87
+VERSION=fc24c9cc507a244a587fa590f6882a588b9fc927
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -164,6 +164,7 @@ protected:
   int m_colorFormat;
   std::string m_formatname;
   bool m_opened;
+  bool m_needSecureDecoder = false;
   int m_codecControlFlags;
   int m_state;
   int m_noPictureLoop;


### PR DESCRIPTION
## Description
Use CJNIMediaCrypto instead AMediaNdkMediaCrypto when calling requiresSecureDecoderComponent(mime)

## Motivation and Context
The NDK implementation is not correct because it is implemented as a static call.
But the decision if secure decoder is required or not depends on the DRM instance.

JNI handles this case correct.

NDK issue ticket: https://github.com/android/ndk/issues/1093

## How Has This Been Tested?
Play secure content on Android P, for example N..X
Without this change only unsecure (SD) content is played correctly. 

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
