### PR TITLE
[skin.estuary/pvr] Improve display of genre in PVR info dialog.

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -191,8 +191,30 @@
 	<include name="PVRInfoPanel">
 		<control type="group">
 			<visible>!ListItem.IsFolder</visible>
+			<control type="label">
+				<top>120</top>
+				<width>830</width>
+				<height>262</height>
+				<font>font36_title</font>
+				<label>$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
+				<visible>!PVR.HasEpg</visible>
+			</control>
+			<control type="label">
+				<top>120</top>
+				<width>830</width>
+				<height>262</height>
+				<font>font36_title</font>
+				<label>$INFO[ListItem.EpgEventTitle] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
+				<visible>PVR.HasEpg</visible>
+			</control>
+			<control type="label">
+				<top>165</top>
+				<width>830</width>
+				<height>70</height>
+				<label>[I]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/I]</label>
+			</control>
 			<control type="image">
-				<top>135</top>
+				<top>250</top>
 				<left>630</left>
 				<width>200</width>
 				<height>200</height>
@@ -201,24 +223,18 @@
 				<fadetime>200</fadetime>
 			</control>
 			<control type="group">
-				<top>120</top>
+				<top>235</top>
 				<left>0</left>
 				<width>590</width>
 				<control type="label">
-					<height>262</height>
-					<font>font45</font>
-					<label>$INFO[ListItem.ChannelName]</label>
-				</control>
-				<control type="label">
-					<top>60</top>
-					<height>200</height>
+					<height>150</height>
 					<wrapmultiline>true</wrapmultiline>
-					<label>$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]$VAR[ExpirationDateTimeLabel]</label>
+					<label>$INFO[ListItem.ChannelName,[B],[/B][CR]]$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]</label>
 				</control>
 				<control type="group">
 					<visible>Integer.IsGreater(ListItem.Progress,0)</visible>
-					<top>150</top>
-					<height>262</height>
+					<top>170</top>
+					<height>100</height>
 					<control type="label">
 						<label>$INFO[ListItem.StartTime]</label>
 					</control>
@@ -241,44 +257,12 @@
 					<visible>Integer.IsGreater(ListItem.PercentPlayed,0)</visible>
 				</control>
 			</control>
-			<control type="label">
-				<top>390</top>
-				<width>830</width>
-				<height>262</height>
-				<font>font36_title</font>
-				<label>$INFO[ListItem.Title] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-				<visible>!PVR.HasEpg</visible>
-			</control>
-			<control type="label">
-				<top>390</top>
-				<width>830</width>
-				<height>262</height>
-				<font>font36_title</font>
-				<label>$INFO[ListItem.EpgEventTitle] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-				<visible>PVR.HasEpg</visible>
-			</control>
-			<control type="label">
-				<top>435</top>
-				<width>830</width>
-				<height>70</height>
-				<label>[I]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/I]</label>
-			</control>
 			<control type="textbox">
 				<top>490</top>
 				<width>830</width>
 				<bottom>75</bottom>
-				<label>$INFO[ListItem.Plot]</label>
+				<label>$INFO[ListItem.TimerType,[COLOR grey]$LOCALIZE[803]:[/COLOR] ,[CR]]$VAR[ExpirationDateTimeLabel]$VAR[PremieredLabel]$INFO[ListItem.Rating,[COLOR grey]$LOCALIZE[563]:[/COLOR] ,[CR]]$INFO[ListItem.Writer,[COLOR grey]$LOCALIZE[20417]:[/COLOR] ,[CR]]$INFO[ListItem.Director,[COLOR grey]$LOCALIZE[20339]:[/COLOR] ,[CR]]$INFO[ListItem.Cast,[COLOR grey]$LOCALIZE[206]:[/COLOR] ,[CR]][CR]$INFO[ListItem.Plot]</label>
 				<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
-			</control>
-			<control type="textbox">
-				<top>530</top>
-				<width>830</width>
-				<height>340</height>
-				<align>center</align>
-				<font>font27</font>
-				<textcolor>80FFFFFF</textcolor>
-				<label>$LOCALIZE[19055]</label>
-				<visible>String.IsEmpty(Listitem.Plot) + String.IsEmpty(Listitem.Genre)</visible>
 			</control>
 		</control>
 		<control type="group">

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -259,17 +259,9 @@
 			</control>
 			<control type="label">
 				<top>435</top>
-				<width>40%</width>
+				<width>830</width>
 				<height>70</height>
 				<label>[I]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/I]</label>
-			</control>
-			<control type="label">
-				<top>435</top>
-				<right>30</right>
-				<width>60%</width>
-				<height>70</height>
-				<align>right</align>
-				<label>$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
 			</control>
 			<control type="textbox">
 				<top>490</top>


### PR DESCRIPTION
Followup to #16728 

Before #16728 (no genre displayed)

![screenshot000](https://user-images.githubusercontent.com/3226626/66297389-e0ed8100-e8ef-11e9-89bd-79c49218f178.png)

After #16728, before this PR (genre right to episode title, reducing space for episode title, which often leads to cut-off episode titles)

![screenshot001](https://user-images.githubusercontent.com/3226626/66297407-e8ad2580-e8ef-11e9-887f-0788b39a682f.png)

After this PR (genre displayed along with other extended data)

![screenshot001](https://user-images.githubusercontent.com/3226626/66304050-a8a06f80-e8fc-11e9-8543-401d5ff199e8.png)
