### PR TITLE
Add ratings bubble also to "Shift" view

### DIFF
--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -89,6 +89,11 @@
 							<height>32</height>
 							<texture>$VAR[WallWatchedIconVar]</texture>
 						</control>
+						<control type="group">
+							<left>158</left>
+							<top>92</top>
+							<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
+						</control>
 					</itemlayout>
 					<focusedlayout width="370">
 						<control type="image">
@@ -118,6 +123,11 @@
 							<width>32</width>
 							<height>32</height>
 							<texture>$VAR[WallWatchedIconVar]</texture>
+						</control>
+						<control type="group">
+							<left>158</left>
+							<top>92</top>
+							<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
 						</control>
 					</focusedlayout>
 				</control>


### PR DESCRIPTION
## Description
"InfoWall", "Wall" and "Poster" views already have "ratings bubble", but for some reason it was missing from "Shift" view. Adding it.

## Motivation and Context
For consistency and usability it's good to have this feature supported on all (suitable) views.

## How Has This Been Tested?
Running local copy of modified Kodi. Browsing through Movie selection, with ratings on.
Tested with several screen resolutions.

## Screenshots (if appropriate):
![2019-10-07 19_08_35-Kodi](https://user-images.githubusercontent.com/24541264/66328975-4fedc880-e936-11e9-96f9-94a4431f4502.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
