### PR TITLE
[Backport][Android] Use JNI instead NDK MediaCrypto for secure decoder check

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=aa12538cc5090d061d34b5fd7385d939ea82ce8b
+VERSION=82f1a87f1d2397dd0340a9443d7feea70cc7ea3b
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -155,6 +155,7 @@ protected:
   int             m_colorFormat;
   std::string     m_formatname;
   bool            m_opened;
+  bool m_needSecureDecoder = false;
   int             m_codecControlFlags;
   int             m_state;
   int             m_noPictureLoop;


### PR DESCRIPTION
## Description
Backport of #16729 
