### PR TITLE
[modernize] use-default-member-init

### DIFF
--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -30,11 +30,11 @@
 class Gifreader
 {
 public:
-  unsigned char* buffer;
-  unsigned int buffSize;
-  unsigned int readPosition;
+  unsigned char* buffer = nullptr;
+  unsigned int buffSize = 0;
+  unsigned int readPosition = 0;
 
-  Gifreader() : buffer(nullptr), buffSize(0), readPosition(0) {}
+  Gifreader() = default;
 };
 
 int ReadFromVfs(GifFileType* gif, GifByteType* gifbyte, int len)
@@ -43,14 +43,7 @@ int ReadFromVfs(GifFileType* gif, GifByteType* gifbyte, int len)
   return gifFile->Read(gifbyte, len);
 }
 
-GifHelper::GifHelper() :
-  m_imageSize(0),
-  m_pitch(0),
-  m_loops(0),
-  m_numFrames(0),
-  m_filename(""),
-  m_gif(nullptr),
-  m_pTemplate(nullptr)
+GifHelper::GifHelper()
 {
   m_gifFile = new CFile();
 }
@@ -472,27 +465,14 @@ void GifHelper::ClearFrameAreaToTransparency(unsigned char* dest, const GifFrame
   }
 }
 
-GifFrame::GifFrame() :
-  m_pImage(nullptr),
-  m_delay(0),
-  m_top(0),
-  m_left(0),
-  m_disposal(0),
-  m_height(0),
-  m_width(0),
-  m_imageSize(0)
-{}
-
-
-GifFrame::GifFrame(const GifFrame& src) :
-  m_pImage(nullptr),
-  m_delay(src.m_delay),
-  m_top(src.m_top),
-  m_left(src.m_left),
-  m_disposal(src.m_disposal),
-  m_height(src.m_height),
-  m_width(src.m_width),
-  m_imageSize(src.m_imageSize)
+GifFrame::GifFrame(const GifFrame& src)
+  : m_delay(src.m_delay),
+    m_top(src.m_top),
+    m_left(src.m_left),
+    m_disposal(src.m_disposal),
+    m_height(src.m_height),
+    m_width(src.m_width),
+    m_imageSize(src.m_imageSize)
 {
   if (src.m_pImage)
   {

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -60,21 +60,21 @@ class GifFrame
   friend class GifHelper;
 public:
 
-  GifFrame();
+  GifFrame() = default;
   virtual ~GifFrame();
 
-  unsigned char*  m_pImage;
-  unsigned int    m_delay;
+  unsigned char* m_pImage = nullptr;
+  unsigned int m_delay = 0;
 
 private:
   GifFrame(const GifFrame& src);
 
-  unsigned int    m_top;
-  unsigned int    m_left;
-  unsigned int    m_disposal;
-  unsigned int    m_height;
-  unsigned int    m_width;
-  unsigned int    m_imageSize;
+  unsigned int m_top = 0;
+  unsigned int m_left = 0;
+  unsigned int m_disposal = 0;
+  unsigned int m_height = 0;
+  unsigned int m_width = 0;
+  unsigned int m_imageSize = 0;
   std::vector<GifColor>   m_palette;
 };
 
@@ -101,15 +101,15 @@ public:
 
 private:
   std::vector<FramePtr> m_frames;
-  unsigned int    m_imageSize;
-  unsigned int    m_pitch;
-  unsigned int    m_loops;
-  unsigned int    m_numFrames;
+  unsigned int m_imageSize = 0;
+  unsigned int m_pitch = 0;
+  unsigned int m_loops = 0;
+  unsigned int m_numFrames = 0;
 
   std::string     m_filename;
-  GifFileType*    m_gif;
+  GifFileType* m_gif = nullptr;
   std::vector<GifColor> m_globalPalette;
-  unsigned char*  m_pTemplate;
+  unsigned char* m_pTemplate = nullptr;
   CFile*          m_gifFile;
 
   unsigned int m_width;

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -26,30 +26,30 @@
 class RGBAImage
 {
 public:
-  RGBAImage() : pixels(NULL), width(0), height(0), bbp(0), pitch(0) {}
+  RGBAImage() = default;
 
-  char *pixels;//image data
-  int width;// width
-  int height;// height
-  int bbp;// bits per pixel
-  int pitch;// rowsize in bytes
+  char* pixels = nullptr; // image data
+  int width = 0; // width
+  int height = 0; // height
+  int bbp = 0; // bits per pixel
+  int pitch = 0; // rowsize in bytes
 };
 
 class DecodedFrame
 {
-  public:
-   DecodedFrame() : delay(0) { }
-   RGBAImage	rgbaImage;				/* rgbaimage for this frame */
-   int				delay;					/* Frame delay in ms */
+public:
+  DecodedFrame() = default;
+  RGBAImage rgbaImage; /* rgbaimage for this frame */
+  int delay = 0; /* Frame delay in ms */
 };
 
 class DecodedFrames
 {
   public:
-    DecodedFrames(): user(NULL), destroyFN(nullptr) {}
+    DecodedFrames() = default;
     std::vector<DecodedFrame> frameList;
-    void     *user;         /* used internally*/
-    void (*destroyFN)(void *);
+    void* user = nullptr; /* used internally*/
+    void (*destroyFN)(void*) = nullptr;
 
     void clear()
     {

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -360,7 +360,6 @@ public:
 
   CStructHdl(C_STRUCT* cStructure)
     : m_cStructure(cStructure)
-    , m_owner(false)
   {
     assert(cStructure);
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -75,7 +75,7 @@ static float SineWaveGeneratorNextSampleFloat(SineWaveGenerator *ctx)
 class CAAudioUnitSink
 {
   public:
-    CAAudioUnitSink();
+    CAAudioUnitSink() = default;
    ~CAAudioUnitSink();
 
     bool         open(AudioStreamBasicDescription outputFormat);
@@ -110,10 +110,10 @@ class CAAudioUnitSink
                   AudioBufferList *ioData);
 
     bool                m_setup;
-    bool                m_activated;
+    bool m_activated = false;
     AudioUnit           m_audioUnit;
     AudioStreamBasicDescription m_outputFormat;
-    AERingBuffer       *m_buffer;
+    AERingBuffer* m_buffer = nullptr;
 
     bool                m_mute;
     Float32             m_outputVolume;
@@ -123,23 +123,13 @@ class CAAudioUnitSink
     unsigned int        m_sampleRate;
     unsigned int        m_frameSize;
 
-    bool                m_playing;
-    volatile bool       m_started;
+    bool m_playing = false;
+    volatile bool m_started = false;
 
     CAESpinSection      m_render_section;
-    volatile int64_t    m_render_timestamp;
-    volatile uint32_t   m_render_frames;
+    volatile int64_t m_render_timestamp = 0;
+    volatile uint32_t m_render_frames = 0;
 };
-
-CAAudioUnitSink::CAAudioUnitSink()
-: m_activated(false)
-, m_buffer(NULL)
-, m_playing(false)
-, m_started(false)
-, m_render_timestamp(0)
-, m_render_frames(0)
-{
-}
 
 CAAudioUnitSink::~CAAudioUnitSink()
 {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -129,16 +129,6 @@ OSStatus deviceChangedCB(AudioObjectID                       inObjectID,
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 CAESinkDARWINOSX::CAESinkDARWINOSX()
-: m_latentFrames(0),
-  m_outputBufferIndex(0),
-  m_outputBitstream(false),
-  m_planes(1),
-  m_frameSizePerPlane(0),
-  m_framesPerSecond(0),
-  m_buffer(NULL),
-  m_started(false),
-  m_render_tick(0),
-  m_render_delay(0.0)
 {
   // By default, kAudioHardwarePropertyRunLoop points at the process's main thread on SnowLeopard,
   // If your process lacks such a run loop, you can set kAudioHardwarePropertyRunLoop to NULL which

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -43,18 +43,20 @@ private:
 
   CCoreAudioDevice   m_device;
   CCoreAudioStream   m_outputStream;
-  unsigned int       m_latentFrames;
-  unsigned int       m_outputBufferIndex;
+  unsigned int m_latentFrames = 0;
+  unsigned int m_outputBufferIndex = 0;
 
-  bool               m_outputBitstream;   ///< true if we're bistreaming into a LinearPCM stream rather than AC3 stream.
-  unsigned int       m_planes;            ///< number of audio planes (1 if non-planar)
-  unsigned int       m_frameSizePerPlane; ///< frame size (per plane) in bytes
-  unsigned int       m_framesPerSecond;   ///< sample rate
+  bool m_outputBitstream =
+      false; ///< true if we're bistreaming into a LinearPCM stream rather than AC3 stream.
+  unsigned int m_planes = 1; ///< number of audio planes (1 if non-planar)
+  unsigned int m_frameSizePerPlane = 0; ///< frame size (per plane) in bytes
+  unsigned int m_framesPerSecond = 0; ///< sample rate
 
-  AERingBuffer      *m_buffer;
-  volatile bool      m_started;     // set once we get a callback from CoreAudio, which can take a little while.
+  AERingBuffer* m_buffer = nullptr;
+  volatile bool m_started =
+      false; // set once we get a callback from CoreAudio, which can take a little while.
 
   CAESpinSection         m_render_locker;
-  volatile int64_t       m_render_tick;
-  volatile double        m_render_delay;
+  volatile int64_t m_render_tick = 0;
+  volatile double m_render_delay = 0.0;
 };

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.h
@@ -50,7 +50,7 @@ private:
   CAEDeviceInfo m_info;
   AEAudioFormat m_format;
 
-  CAAudioUnitSink* m_audioSink;
+  CAAudioUnitSink* m_audioSink = nullptr;
 #if DO_440HZ_TONE_TEST
   SineWaveGenerator m_SineWaveGenerator;
 #endif

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -223,10 +223,10 @@ private:
                                  AudioBufferList* ioData);
 
   bool m_setup;
-  bool m_activated;
+  bool m_activated = false;
   AudioUnit m_audioUnit;
   AudioStreamBasicDescription m_outputFormat;
-  AERingBuffer* m_buffer;
+  AERingBuffer* m_buffer = nullptr;
 
   Float32 m_totalLatency;
   Float32 m_inputLatency;
@@ -242,8 +242,7 @@ private:
   std::atomic<int64_t> m_render_timestamp;
 };
 
-CAAudioUnitSink::CAAudioUnitSink()
-  : m_activated(false), m_buffer(nullptr), m_started(false), m_render_timestamp(0)
+CAAudioUnitSink::CAAudioUnitSink() : m_started(false), m_render_timestamp(0)
 {
 }
 
@@ -609,7 +608,7 @@ static void EnumerateDevices(AEDeviceInfoList& list)
 /***************************************************************************************/
 AEDeviceInfoList CAESinkDARWINTVOS::m_devices;
 
-CAESinkDARWINTVOS::CAESinkDARWINTVOS() : m_audioSink(nullptr)
+CAESinkDARWINTVOS::CAESinkDARWINTVOS()
 {
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -20,31 +20,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // CCoreAudioDevice
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-CCoreAudioDevice::CCoreAudioDevice()  :
-  m_Started             (false    ),
-  m_DeviceId            (0        ),
-  m_MixerRestore        (-1       ),
-  m_IoProc              (NULL     ),
-  m_ObjectListenerProc  (NULL     ),
-  m_SampleRateRestore   (0.0f     ),
-  m_HogPid              (-1       ),
-  m_frameSize           (0        ),
-  m_OutputBufferIndex   (0        ),
-  m_BufferSizeRestore   (0        )
-{
-}
-
-CCoreAudioDevice::CCoreAudioDevice(AudioDeviceID deviceId) :
-  m_Started             (false    ),
-  m_DeviceId            (deviceId ),
-  m_MixerRestore        (-1       ),
-  m_IoProc              (NULL     ),
-  m_ObjectListenerProc  (NULL     ),
-  m_SampleRateRestore   (0.0f     ),
-  m_HogPid              (-1       ),
-  m_frameSize           (0        ),
-  m_OutputBufferIndex   (0        ),
-  m_BufferSizeRestore   (0        )
+CCoreAudioDevice::CCoreAudioDevice(AudioDeviceID deviceId) : m_DeviceId(deviceId)
 {
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.h
@@ -24,7 +24,7 @@ class CCoreAudioChannelLayout;
 class CCoreAudioDevice
 {
 public:
-  CCoreAudioDevice();
+  CCoreAudioDevice() = default;
   explicit CCoreAudioDevice(AudioDeviceID deviceId);
   virtual ~CCoreAudioDevice();
 
@@ -70,18 +70,17 @@ public:
   bool          AddIOProc(AudioDeviceIOProc ioProc, void* pCallbackData);
   bool          RemoveIOProc();
 protected:
+  bool m_Started = false;
+  AudioDeviceID m_DeviceId = 0;
+  int m_MixerRestore = -1;
+  AudioDeviceIOProc m_IoProc = nullptr;
+  AudioObjectPropertyListenerProc m_ObjectListenerProc = nullptr;
 
-  bool              m_Started;
-  AudioDeviceID     m_DeviceId;
-  int               m_MixerRestore;
-  AudioDeviceIOProc m_IoProc;
-  AudioObjectPropertyListenerProc m_ObjectListenerProc;
-
-  Float64           m_SampleRateRestore;
-  pid_t             m_HogPid;
-  unsigned int      m_frameSize;
-  unsigned int      m_OutputBufferIndex;
-  unsigned int      m_BufferSizeRestore;
+  Float64 m_SampleRateRestore = 0.0f;
+  pid_t m_HogPid = -1;
+  unsigned int m_frameSize = 0;
+  unsigned int m_OutputBufferIndex = 0;
+  unsigned int m_BufferSizeRestore = 0;
 
   static XbmcThreads::EndTime m_callbackSuppressTimer;
   static AudioObjectPropertyListenerProc m_defaultOutputDeviceChangedCB;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.cpp
@@ -12,8 +12,7 @@
 #include "cores/AudioEngine/Sinks/darwin/CoreAudioHelpers.h"
 #include "utils/log.h"
 
-CCoreAudioStream::CCoreAudioStream() :
-  m_StreamId  (0    )
+CCoreAudioStream::CCoreAudioStream()
 {
   m_OriginalVirtualFormat.mFormatID = 0;
   m_OriginalPhysicalFormat.mFormatID = 0;

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioStream.h
@@ -51,7 +51,7 @@ protected:
   CEvent m_virtual_format_event;
   CEvent m_physical_format_event;
 
-  AudioStreamID m_StreamId;
+  AudioStreamID m_StreamId = 0;
   AudioStreamBasicDescription m_OriginalVirtualFormat;
   AudioStreamBasicDescription m_OriginalPhysicalFormat;
 };

--- a/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
+++ b/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
@@ -29,28 +29,9 @@
 class AERingBuffer {
 
 public:
-  AERingBuffer() :
-    m_iReadPos(0),
-    m_iWritePos(0),
-    m_iRead(0),
-    m_iWritten(0),
-    m_iSize(0),
-    m_planes(0),
-    m_Buffer(NULL)
-  {
-  }
+  AERingBuffer() = default;
 
-  AERingBuffer(unsigned int size, unsigned int planes = 1) :
-    m_iReadPos(0),
-    m_iWritePos(0),
-    m_iRead(0),
-    m_iWritten(0),
-    m_iSize(0),
-    m_planes(0),
-    m_Buffer(NULL)
-  {
-    Create(size, planes);
-  }
+  AERingBuffer(unsigned int size, unsigned int planes = 1) { Create(size, planes); }
 
   ~AERingBuffer()
   {
@@ -285,11 +266,11 @@ private:
     m_iRead+=size;
   }
 
-  unsigned int m_iReadPos;
-  unsigned int m_iWritePos;
-  unsigned int m_iRead;
-  unsigned int m_iWritten;
-  unsigned int m_iSize;
-  unsigned int m_planes;
-  unsigned char **m_Buffer;
+  unsigned int m_iReadPos = 0;
+  unsigned int m_iWritePos = 0;
+  unsigned int m_iRead = 0;
+  unsigned int m_iWritten = 0;
+  unsigned int m_iSize = 0;
+  unsigned int m_planes = 0;
+  unsigned char** m_Buffer = nullptr;
 };

--- a/xbmc/platform/android/activity/AndroidMouse.cpp
+++ b/xbmc/platform/android/activity/AndroidMouse.cpp
@@ -18,11 +18,6 @@
 
 //#define DEBUG_VERBOSE
 
-CAndroidMouse::CAndroidMouse()
-  : m_lastButtonState(0)
-{
-}
-
 bool CAndroidMouse::onMouseEvent(AInputEvent* event)
 {
   if (event == NULL)

--- a/xbmc/platform/android/activity/AndroidMouse.h
+++ b/xbmc/platform/android/activity/AndroidMouse.h
@@ -14,7 +14,7 @@ class CAndroidMouse
 {
 
 public:
-  CAndroidMouse();
+  CAndroidMouse() = default;
   virtual ~CAndroidMouse() = default;
   bool onMouseEvent(AInputEvent* event);
 
@@ -26,5 +26,5 @@ private:
   void MouseWheel(float x, float y, float value);
 
 private:
-  int32_t m_lastButtonState;
+  int32_t m_lastButtonState = 0;
 };

--- a/xbmc/platform/android/activity/AndroidTouch.cpp
+++ b/xbmc/platform/android/activity/AndroidTouch.cpp
@@ -13,7 +13,7 @@
 
 #include "platform/android/activity/XBMCApp.h"
 
-CAndroidTouch::CAndroidTouch() : m_dpi(160)
+CAndroidTouch::CAndroidTouch()
 {
   CGenericTouchInputHandler::GetInstance().RegisterHandler(&CGenericTouchActionHandler::GetInstance());
 }

--- a/xbmc/platform/android/activity/AndroidTouch.h
+++ b/xbmc/platform/android/activity/AndroidTouch.h
@@ -24,5 +24,5 @@ protected:
   virtual void setDPI(uint32_t dpi);
 
 private:
-  uint32_t m_dpi;
+  uint32_t m_dpi = 160;
 };

--- a/xbmc/platform/android/activity/JNIXBMCFile.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCFile.cpp
@@ -22,7 +22,6 @@ static std::string s_className = std::string(CCompileInfo::GetClass()) + "/XBMCF
 
 CJNIXBMCFile::CJNIXBMCFile()
   : CJNIBase()
-  , m_eof(true)
 {
 }
 

--- a/xbmc/platform/android/activity/JNIXBMCFile.h
+++ b/xbmc/platform/android/activity/JNIXBMCFile.h
@@ -27,7 +27,7 @@ namespace jni
     static void RegisterNatives(JNIEnv* env);
 
   protected:
-    bool m_eof;
+    bool m_eof = true;
     std::unique_ptr<XFILE::CFile> m_file;
 
     static jboolean _open(JNIEnv* env, jobject thiz, jstring path);

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
@@ -25,7 +25,6 @@ static std::string s_className = std::string(CCompileInfo::GetClass()) + "/XBMCM
 
 CJNIXBMCMediaSession::CJNIXBMCMediaSession()
   : CJNIBase(s_className)
-  , m_isActive(false)
 {
   m_object = new_object(CJNIContext::getClassLoader().loadClass(GetDotClassName(s_className)));
   m_object.setGlobal();

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.h
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.h
@@ -53,7 +53,7 @@ protected:
   static void _onSeekRequested(JNIEnv* env, jobject thiz, jlong pos);
   static bool _onMediaButtonEvent(JNIEnv* env, jobject thiz, jobject intent);
 
-  bool m_isActive;
+  bool m_isActive = false;
 };
 
 }

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -39,14 +39,8 @@ void CJNIXBMCVideoView::RegisterNatives(JNIEnv* env)
   }
 }
 
-CJNIXBMCVideoView::CJNIXBMCVideoView()
-  : m_callback(nullptr)
-{
-}
-
 CJNIXBMCVideoView::CJNIXBMCVideoView(const jni::jhobject &object)
   : CJNIBase(object)
-  , m_callback(nullptr)
 {
 }
 

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.h
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.h
@@ -47,10 +47,10 @@ public:
   bool isCreated() const;
 
 protected:
-  CJNISurfaceHolderCallback* m_callback;
+  CJNISurfaceHolderCallback* m_callback = nullptr;
   CEvent m_surfaceCreated;
   CRect m_surfaceRect;
 
 private:
-  CJNIXBMCVideoView();
+  CJNIXBMCVideoView() = default;
   };

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -64,10 +64,6 @@ static void MapAxisIds(int axisId, int primaryAxisId, int secondaryAxisId, std::
     axisIds.insert(axisIds.begin(), primaryAxisId);
 }
 
-CAndroidJoystickState::CAndroidJoystickState()
-  : m_deviceId(-1)
-{ }
-
 CAndroidJoystickState::CAndroidJoystickState(CAndroidJoystickState &&other) :
     m_deviceId(other.m_deviceId),
     m_buttons(std::move(other.m_buttons)),

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.h
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.h
@@ -23,7 +23,7 @@ namespace PERIPHERALS
   class CAndroidJoystickState
   {
   public:
-    CAndroidJoystickState();
+    CAndroidJoystickState() = default;
     CAndroidJoystickState(CAndroidJoystickState &&other);
     virtual ~CAndroidJoystickState();
 
@@ -82,7 +82,7 @@ namespace PERIPHERALS
     static bool ContainsAxis(int axisId, const JoystickAxes& axes);
     static bool GetAxesIndex(const std::vector<int>& axisIds, const JoystickAxes& axes, size_t& axesIndex);
 
-    int m_deviceId;
+    int m_deviceId = -1;
 
     JoystickAxes m_buttons;
     JoystickAxes m_axes;

--- a/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.cpp
@@ -109,7 +109,7 @@ namespace
   }
 }
 
-CZeroconfBrowserDarwin::CZeroconfBrowserDarwin():m_runloop(0)
+CZeroconfBrowserDarwin::CZeroconfBrowserDarwin()
 {
   //acquire the main threads event loop
   m_runloop = CFRunLoopGetMain();

--- a/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.h
+++ b/xbmc/platform/darwin/network/ZeroconfBrowserDarwin.h
@@ -52,7 +52,7 @@ private:
   void removeDiscoveredService(CFNetServiceBrowserRef browser, CFOptionFlags flags, ZeroconfService const &fcr_service);
 
   //CF runloop ref; we're using main-threads runloop
-  CFRunLoopRef m_runloop;
+  CFRunLoopRef m_runloop = nullptr;
 
   //shared variables (with guard)
   //! @todo split the guard for discovered, resolved access?

--- a/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
+++ b/xbmc/platform/darwin/network/ZeroconfDarwin.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <string>
 
-CZeroconfDarwin::CZeroconfDarwin():m_runloop(0)
+CZeroconfDarwin::CZeroconfDarwin()
 {
   //acquire the main threads event loop
   m_runloop = CFRunLoopGetMain();

--- a/xbmc/platform/darwin/network/ZeroconfDarwin.h
+++ b/xbmc/platform/darwin/network/ZeroconfDarwin.h
@@ -46,7 +46,7 @@ private:
   void cancelRegistration(CFNetServiceRef theService);
 
   //CF runloop ref; we're using main-threads runloop
-  CFRunLoopRef m_runloop;
+  CFRunLoopRef m_runloop = nullptr;
 
   //lock + data (accessed from runloop(main thread) + the rest)
   CCriticalSection m_data_guard;

--- a/xbmc/platform/darwin/osx/XBMCHelper.cpp
+++ b/xbmc/platform/darwin/osx/XBMCHelper.cpp
@@ -54,11 +54,6 @@ XBMCHelper::GetInstance()
 
 /////////////////////////////////////////////////////////////////////////////
 XBMCHelper::XBMCHelper()
-  : m_alwaysOn(false)
-  , m_mode(APPLE_REMOTE_DISABLED)
-  , m_sequenceDelay(0)
-  , m_port(0)
-  , m_errorStarting(false)
 {
   // Compute the KODI_HOME path.
   std::string homePath;

--- a/xbmc/platform/darwin/osx/XBMCHelper.h
+++ b/xbmc/platform/darwin/osx/XBMCHelper.h
@@ -56,11 +56,11 @@ private:
   std::string ReadFile(const char* fileName);
   void WriteFile(const char* fileName, const std::string& data);
 
-  bool m_alwaysOn;
-  int  m_mode;
-  int  m_sequenceDelay;
-  int  m_port;
-  bool m_errorStarting;
+  bool m_alwaysOn = false;
+  int m_mode = APPLE_REMOTE_DISABLED;
+  int m_sequenceDelay = 0;
+  int m_port = 0;
+  bool m_errorStarting = false;
 
   std::string m_configFile;
   std::string m_launchAgentLocalFile;

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSFile.h
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSFile.h
@@ -29,7 +29,7 @@ namespace XFILE
 class CTVOSFile : public IFile
 {
 public:
-  CTVOSFile() : m_position(-1), m_pFallbackFile(nullptr){};
+  CTVOSFile(){};
   ~CTVOSFile();
 
   bool static WantsFile(const CURL& url);
@@ -53,8 +53,8 @@ public:
 
 protected:
   CURL m_url;
-  int64_t m_position;
-  CPosixFile* m_pFallbackFile;
+  int64_t m_position = -1;
+  CPosixFile* m_pFallbackFile = nullptr;
   struct __stat64 m_cachedStat;
 
   int CacheStat(const CURL& url, struct __stat64* buffer);

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -76,14 +76,7 @@ using namespace XFILE;
 
 static CProfile EmptyProfile;
 
-CProfileManager::CProfileManager() :
-    m_usingLoginScreen(false),
-    m_profileLoadedForLogin(false),
-    m_autoLoginProfile(-1),
-    m_lastUsedProfile(0),
-    m_currentProfile(0),
-    m_nextProfileId(0),
-    m_eventLogs(new CEventLogManager)
+CProfileManager::CProfileManager() : m_eventLogs(new CEventLogManager)
 {
 }
 

--- a/xbmc/profiles/ProfileManager.h
+++ b/xbmc/profiles/ProfileManager.h
@@ -198,12 +198,14 @@ private:
   std::shared_ptr<CSettings> m_settings;
 
   std::vector<CProfile> m_profiles;
-  bool m_usingLoginScreen;
-  bool m_profileLoadedForLogin;
-  int m_autoLoginProfile;
-  unsigned int m_lastUsedProfile;
-  unsigned int m_currentProfile; // do not modify directly, use SetCurrentProfileId() function instead
-  int m_nextProfileId; // for tracking the next available id to give to a new profile to ensure id's are not re-used
+  bool m_usingLoginScreen = false;
+  bool m_profileLoadedForLogin = false;
+  int m_autoLoginProfile = -1;
+  unsigned int m_lastUsedProfile = 0;
+  unsigned int m_currentProfile =
+      0; // do not modify directly, use SetCurrentProfileId() function instead
+  int m_nextProfileId =
+      0; // for tracking the next available id to give to a new profile to ensure id's are not re-used
   mutable CCriticalSection m_critical;
 
   // Event properties

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -28,11 +28,10 @@
 using namespace PVR;
 
 CPVREpg::CPVREpg(int iEpgID, const std::string& strName, const std::string& strScraperName)
-: m_bChanged(false),
-  m_iEpgID(iEpgID),
-  m_strName(strName),
-  m_strScraperName(strScraperName),
-  m_channelData(new CPVREpgChannelData)
+  : m_iEpgID(iEpgID),
+    m_strName(strName),
+    m_strScraperName(strScraperName),
+    m_channelData(new CPVREpgChannelData)
 {
 }
 

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -41,15 +41,13 @@ CPVRTimersPath::CPVRTimersPath(const std::string& strPath, int iClientId, int iP
   }
 }
 
-CPVRTimersPath::CPVRTimersPath(bool bRadio, bool bTimerRules) :
-  m_path(StringUtils::Format(
-    "pvr://timers/%s/%s", bRadio ? "radio" : "tv", bTimerRules ? "rules" : "timers")),
-  m_bValid(true),
-  m_bRoot(true),
-  m_bRadio(bRadio),
-  m_bTimerRules(bTimerRules),
-  m_iClientId(-1),
-  m_iParentId(0)
+CPVRTimersPath::CPVRTimersPath(bool bRadio, bool bTimerRules)
+  : m_path(StringUtils::Format(
+        "pvr://timers/%s/%s", bRadio ? "radio" : "tv", bTimerRules ? "rules" : "timers")),
+    m_bValid(true),
+    m_bRoot(true),
+    m_bRadio(bRadio),
+    m_bTimerRules(bTimerRules)
 {
 }
 


### PR DESCRIPTION
## Description
run clang-tidy `modernize-use-default-member-init` check and applied the suggested fixes
run clang-tidy-diff with `modernize-use-nullptr` check and applied the suggested fixes
run clang-tidy `modernize-use-default-member-init` check and applied the suggested fixes
run clang-tidy-diff with `modernize-use-equals-default` check and applied the suggested fixes

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
