### PR TITLE
WIP - [remote] Allow longpress mod for remote keymaps

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -15,6 +15,10 @@
 <!--  eg <B>ActivateWindow(Music)</B>                                                     -->
 <!-- would automatically go to Music on the press of the B button.                        -->
 <!--                                                                                      -->
+<!--  Long presses                                                                        -->
+<!--   A limitation is that if a single press is mapped in a section, a global "longpress"-->
+<!--   will be ignored. The workaround is to duplicate the long mapping in the section.   -->
+<!--                                                                                      -->
 <!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
 <!-- This is different from a "noop" action, which disables a button.                     -->
 <!--                                                                                      -->
@@ -23,6 +27,7 @@
   <global>
     <remote>
       <play>PlayPause</play>
+      <play mod="longpress">PlayPause</play>
       <pause>Pause</pause>
       <stop>Stop</stop>
       <forward>FastForward</forward>
@@ -32,10 +37,12 @@
       <up>Up</up>
       <down>Down</down>
       <select>Select</select>
+      <select mod="longpress">ContextMenu</select>
       <enter>FullScreen</enter>
       <pageplus>PageUp</pageplus>
       <pageminus>PageDown</pageminus>
       <back>Back</back>
+      <back mod="longpress">Stop</back>
       <menu>ContextMenu</menu>
       <contentsmenu>PreviousMenu</contentsmenu>
       <rootmenu>PreviousMenu</rootmenu>

--- a/xbmc/input/keyboard/Key.cpp
+++ b/xbmc/input/keyboard/Key.cpp
@@ -44,6 +44,14 @@ CKey::CKey(uint32_t buttonCode, unsigned int held)
   m_held = held;
 }
 
+CKey::CKey(uint32_t buttonCode, unsigned int held, uint32_t modifiers)
+{
+  Reset();
+  m_buttonCode = buttonCode;
+  m_held = held;
+  m_modifiers = modifiers;
+}
+
 CKey::CKey(uint32_t keycode,
            uint8_t vkey,
            wchar_t unicode,

--- a/xbmc/input/keyboard/Key.h
+++ b/xbmc/input/keyboard/Key.h
@@ -27,6 +27,7 @@ public:
        float rightThumbY = 0.0f,
        float repeat = 0.0f);
   CKey(uint32_t buttonCode, unsigned int held);
+  CKey(uint32_t buttonCode, unsigned int held, uint32_t modifiers);
   CKey(uint32_t keycode,
        uint8_t vkey,
        wchar_t unicode,

--- a/xbmc/input/keymaps/ButtonTranslator.cpp
+++ b/xbmc/input/keymaps/ButtonTranslator.cpp
@@ -314,9 +314,9 @@ void CButtonTranslator::MapWindowActions(const tinyxml2::XMLNode* pWindow, int w
         if (type == "gamepad")
           buttonCode = CGamepadTranslator::TranslateString(pButton->Value());
         else if (type == "remote")
-          buttonCode = CIRTranslator::TranslateString(pButton->Value());
+          buttonCode = CIRTranslator::TranslateButton(pButton);
         else if (type == "universalremote")
-          buttonCode = CIRTranslator::TranslateUniversalRemoteString(pButton->Value());
+          buttonCode = CIRTranslator::TranslateUniversalRemoteButton(pButton);
         else if (type == "keyboard")
           buttonCode = CKeyboardTranslator::TranslateButton(pButton);
         else if (type == "mouse")

--- a/xbmc/input/keymaps/remote/IRTranslator.cpp
+++ b/xbmc/input/keymaps/remote/IRTranslator.cpp
@@ -9,6 +9,7 @@
 #include "IRTranslator.h"
 
 #include "ServiceBroker.h"
+#include "input/keyboard/Key.h"
 #include "input/keymaps/remote/IRRemoteIDs.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
@@ -137,6 +138,16 @@ void CIRTranslator::MapRemote(tinyxml2::XMLNode* pRemote, const std::string& szD
 void CIRTranslator::Clear()
 {
   m_irRemotesMap.clear();
+}
+
+uint32_t CIRTranslator::TranslateButton(const tinyxml2::XMLElement* pButton)
+{
+  return ApplyModifiersToButton(pButton, TranslateString(pButton->Value()));
+}
+
+uint32_t CIRTranslator::TranslateUniversalRemoteButton(const tinyxml2::XMLElement* pButton)
+{
+  return ApplyModifiersToButton(pButton, TranslateUniversalRemoteString(pButton->Value()));
 }
 
 uint32_t CIRTranslator::TranslateButton(const std::string& szDevice, const std::string& szButton)
@@ -320,4 +331,29 @@ uint32_t CIRTranslator::TranslateUniversalRemoteString(const std::string& szButt
     buttonCode = 0;
 
   return buttonCode;
+}
+
+uint32_t CIRTranslator::ApplyModifiersToButton(const tinyxml2::XMLElement* pButton,
+                                               uint32_t iButtonCode)
+{
+  // Process the longpress modifier
+  std::string strMod;
+  if (pButton->Attribute("mod"))
+  {
+    strMod = pButton->Attribute("mod");
+    StringUtils::ToLower(strMod);
+
+    std::vector<std::string> modArray = StringUtils::Split(strMod, ",");
+    for (auto substr : modArray)
+    {
+      StringUtils::Trim(substr);
+
+      if (substr == "longpress")
+        iButtonCode |= CKey::MODIFIER_LONG;
+      else
+        CLog::Log(LOGERROR, "Remote Translator: Unknown key modifier {} in {}", substr, strMod);
+    }
+  }
+
+  return iButtonCode;
 }

--- a/xbmc/input/keymaps/remote/IRTranslator.h
+++ b/xbmc/input/keymaps/remote/IRTranslator.h
@@ -15,8 +15,9 @@
 
 namespace tinyxml2
 {
+class XMLElement;
 class XMLNode;
-}
+} // namespace tinyxml2
 
 namespace KODI
 {
@@ -42,12 +43,15 @@ public:
 
   uint32_t TranslateButton(const std::string& szDevice, const std::string& szButton);
 
+  static uint32_t TranslateButton(const tinyxml2::XMLElement* pButton);
+  static uint32_t TranslateUniversalRemoteButton(const tinyxml2::XMLElement* pButton);
   static uint32_t TranslateString(std::string strButton);
   static uint32_t TranslateUniversalRemoteString(const std::string& szButton);
 
 private:
   bool LoadIRMap(const std::string& irMapPath);
   void MapRemote(tinyxml2::XMLNode* pRemote, const std::string& szDevice);
+  static uint32_t ApplyModifiersToButton(const tinyxml2::XMLElement* pButton, uint32_t iButtonCode);
 
   using IRButtonMap = std::map<std::string, std::string>;
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -305,7 +305,11 @@ std::optional<CKey> CPeripheralCecAdapter::GetCecKey()
   if (buttonCode <= 0)
     return {};
 
-  std::optional<CKey> key = CKey{static_cast<uint32_t>(buttonCode), holdTime};
+  std::optional<CKey> key;
+  if (holdTime > HOLD_THRESHOLD_MS)
+    key = CKey{static_cast<uint32_t>(buttonCode | CKey::MODIFIER_LONG), holdTime, CKey::MODIFIER_LONG};
+  else
+    key = CKey{static_cast<uint32_t>(buttonCode), holdTime};
 
   ResetButton();
   return key;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -132,6 +132,8 @@ public:
   bool ToggleDeviceState(CecStateChange mode = STATE_SWITCH_TOGGLE, bool forceType = false);
 
 private:
+  static const unsigned int HOLD_THRESHOLD_MS = 250;
+
   bool InitialiseFeature(const PeripheralFeature feature) override;
   void ResetMembers(void);
   void Process(void) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

The longpress mod does not work for remote keymaps (only keyboard keymaps).

This PR is an attempt at adding this to remote keymaps. Need to get it into a librelec build so I can test.

If I hold the ok button I get many of these:
```
2019-10-08 15:29:38.477 T:742   DEBUG: PushCecKeypress - received key  b duration 0
2019-10-08 15:29:38.509 T:707   DEBUG: HandleKey: 11 (0x0b, obc244) pressed, action is Select
```

Followed by:
```
2019-10-08 15:29:44.514 T:742   DEBUG: PushCecKeypress - received key  b duration 0
2019-10-08 15:29:44.521 T:707   DEBUG: HandleKey: 11 (0x0b, obc244) pressed, action is Select
2019-10-08 15:29:44.620 T:742   DEBUG: PushCecKeypress - received key  b duration 1326
```

Keypresses are logged from: peripherals/devices/PeripheralCecAdapter.cpp

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

New PVR Guide nav controls are not accessible to CEC users that can only use remote keymaps. In addition this would be really useful for low button remotes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
