### PR TITLE
[ios][settings] share Kodi log with native sharing sheet

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21841,3 +21841,9 @@ msgstr ""
 msgctxt "#39117"
 msgid "Verbose logging for the [B]Announcer[/B] component"
 msgstr ""
+
+#. Label for action to present native iOS sharing sheet
+#: system/settings/darwin_ios.xml
+msgctxt "#39118"
+msgid "Share debug log"
+msgstr ""

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -70,6 +70,13 @@
         </setting>
       </group>
     </category>
+    <category id="logging">
+      <group id="1">
+        <setting id="debug.sharelog" type="action" label="39118">
+          <control type="button" format="action" />
+        </setting>
+      </group>
+    </category>
   </section>
   <section id="interface">
     <category id="skin">

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -381,6 +381,7 @@ using namespace KODI::MESSAGING;
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_startFullScreen = true;
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_canWindowed = false;
       xbmcAlive = TRUE;
+      [g_xbmcController onXbmcAlive];
       try
       {
         @autoreleasepool

--- a/xbmc/platform/darwin/ios/XBMCController.h
+++ b/xbmc/platform/darwin/ios/XBMCController.h
@@ -67,6 +67,7 @@ typedef enum
 - (void) sendKey: (XBMCKey) key;
 - (void) observeDefaultCenterStuff: (NSNotification *) notification;
 - (CGRect)fullscreenSubviewFrame;
+- (void)onXbmcAlive;
 - (void) setFramebuffer;
 - (bool) presentFramebuffer;
 - (CGSize) getScreenSize;

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -6,32 +6,34 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include <sys/resource.h>
-#include <signal.h>
-
-#include "ServiceBroker.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
-#include "FileItem.h"
-#include "music/tags/MusicInfoTag.h"
-#include "filesystem/SpecialProtocol.h"
-#include "playlists/PlayList.h"
-#include "messaging/ApplicationMessenger.h"
-#include "Application.h"
 #include "AppInboundProtocol.h"
-#include "input/touch/generic/GenericTouchActionHandler.h"
+#include "Application.h"
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "Util.h"
+#include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIControl.h"
 #include "input/Key.h"
-#include "windowing/ios/WinSystemIOS.h"
-#include "windowing/XBMC_events.h"
-#include "utils/log.h"
-#include "utils/TimeUtils.h"
-#include "Util.h"
+#include "input/touch/generic/GenericTouchActionHandler.h"
+#include "messaging/ApplicationMessenger.h"
+#include "music/tags/MusicInfoTag.h"
+#include "playlists/PlayList.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "threads/Event.h"
+#include "utils/TimeUtils.h"
+#include "utils/log.h"
+#include "windowing/XBMC_events.h"
+#include "windowing/ios/WinSystemIOS.h"
+
 #define id _id
 #include "TextureCache.h"
 #undef id
+
 #include <math.h>
+#include <signal.h>
+
+#include <sys/resource.h>
 
 using namespace KODI::MESSAGING;
 

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -8,6 +8,7 @@
 
 #include "AppInboundProtocol.h"
 #include "Application.h"
+#include "CompileInfo.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "Util.h"
@@ -20,8 +21,13 @@
 #include "playlists/PlayList.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "settings/lib/ISettingCallback.h"
+#include "settings/lib/Setting.h"
 #include "threads/Event.h"
+#include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "windowing/XBMC_events.h"
 #include "windowing/ios/WinSystemIOS.h"
@@ -54,10 +60,73 @@ using namespace KODI::MESSAGING;
 
 XBMCController *g_xbmcController;
 
+class DebugLogSharingPresenter : ISettingCallback
+{
+public:
+  DebugLogSharingPresenter() : ISettingCallback()
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(
+        this, std::set<std::string>{CSettings::SETTING_DEBUG_SHARE_LOG});
+  }
+  virtual ~DebugLogSharingPresenter()
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
+  }
+
+  void OnSettingAction(std::shared_ptr<const CSetting> setting) override
+  {
+    if (!setting || setting->GetId() != CSettings::SETTING_DEBUG_SHARE_LOG)
+      return;
+
+    auto lowerAppName = std::string{CCompileInfo::GetAppName()};
+    StringUtils::ToLower(lowerAppName);
+    auto path = URIUtils::AddFileToFolder(CSpecialProtocol::TranslatePath("special://logpath/"),
+                                          lowerAppName + ".log");
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      auto infoDic = NSBundle.mainBundle.infoDictionary;
+      auto subject = [NSString
+          stringWithFormat:@"iOS log - Kodi %@ %@", infoDic[@"CFBundleShortVersionString"],
+                           infoDic[static_cast<NSString*>(kCFBundleVersionKey)]];
+
+      auto activityVc = [[UIActivityViewController alloc]
+          initWithActivityItems:@[ [NSURL fileURLWithPath:@(path.c_str())] ]
+          applicationActivities:nil];
+      // hacky way to set email subject instead of providing UIActivityItemSource object
+      [activityVc setValue:subject forKey:@"subject"];
+
+      // make sure that the sharing sheet is displayed on iOS device's screen
+      auto iosDeviceScreen = UIScreen.mainScreen;
+      auto iosDeviceWindow = UIApplication.sharedApplication.keyWindow;
+      if (iosDeviceWindow.screen != iosDeviceScreen)
+      {
+        for (UIWindow* window in UIApplication.sharedApplication.windows)
+        {
+          if (window.screen == iosDeviceScreen)
+          {
+            iosDeviceWindow = window;
+            break;
+          }
+        }
+      }
+
+      auto rootVc = iosDeviceWindow.rootViewController;
+      [rootVc presentViewController:activityVc animated:YES completion:nil];
+
+      // iPad must present the sharing sheet in a popover
+      activityVc.popoverPresentationController.sourceView = rootVc.view;
+      activityVc.popoverPresentationController.sourceRect = CGRectMake(0.0, 0.0, 10.0, 10.0);
+    });
+  }
+};
+
 //--------------------------------------------------------------
 //
 
 @interface XBMCController ()
+{
+  std::unique_ptr<DebugLogSharingPresenter> m_debugLogSharingPresenter;
+}
 - (void)rescheduleNetworkAutoSuspend;
 @end
 
@@ -648,6 +717,11 @@ XBMCController *g_xbmcController;
     return UIEdgeInsetsInsetRect(rect, self.view.safeAreaInsets);
   else
     return rect;
+}
+//--------------------------------------------------------------
+- (void)onXbmcAlive
+{
+  m_debugLogSharingPresenter = std::make_unique<DebugLogSharingPresenter>();
 }
 //--------------------------------------------------------------
 - (void) setFramebuffer

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -379,6 +379,7 @@ const std::string CSettings::SETTING_DEBUG_SHOWLOGINFO = "debug.showloginfo";
 const std::string CSettings::SETTING_DEBUG_EXTRALOGGING = "debug.extralogging";
 const std::string CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL = "debug.setextraloglevel";
 const std::string CSettings::SETTING_DEBUG_SCREENSHOTPATH = "debug.screenshotpath";
+const std::string CSettings::SETTING_DEBUG_SHARE_LOG = "debug.sharelog";
 const std::string CSettings::SETTING_EVENTLOG_ENABLED = "eventlog.enabled";
 const std::string CSettings::SETTING_EVENTLOG_ENABLED_NOTIFICATIONS = "eventlog.enablednotifications";
 const std::string CSettings::SETTING_EVENTLOG_SHOW = "eventlog.show";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -345,6 +345,7 @@ public:
   static const std::string SETTING_DEBUG_EXTRALOGGING;
   static const std::string SETTING_DEBUG_SETEXTRALOGLEVEL;
   static const std::string SETTING_DEBUG_SCREENSHOTPATH;
+  static const std::string SETTING_DEBUG_SHARE_LOG;
   static const std::string SETTING_EVENTLOG_ENABLED;
   static const std::string SETTING_EVENTLOG_ENABLED_NOTIFICATIONS;
   static const std::string SETTING_EVENTLOG_SHOW;


### PR DESCRIPTION
## Description
Adds new iOS-only action to Logging settings that presents native sharing sheet with Kodi log file attached.

Wiki page: https://kodi.wiki/view/Log_file/iOS_native_sharing

## Motivation and Context
Currently there're 3 ways to get Kodi log:

1. Connect iOS device to PC/Mac, open device in iTunes, select Kodi in File Sharing and download log from there
2. From Xcode's Devices and Simulators window select iOS device, select Kodi, press "mechanism" button -> Download container (but it downloads the whole container, not just the log)
3. Use https://kodi.tv/addon/program-add-ons-scripts/kodi-logfile-uploader

1 and 2 require access to a computer first, with the third one you can see the log only in your browser.

By using sharing sheet the file can be sent anywhere you like in the form of a file. Also it's kind of an expected feature on iOS to be able to share stuff.

## How Has This Been Tested?
Tested on iPhone and iPad.

## Screenshots from iOS 13:
iPhone:
![Screen Shot 2019-10-09 at 17 08 33](https://user-images.githubusercontent.com/1557784/66489783-d4685480-eab8-11e9-9504-37240cc34abd.png)
![Screen Shot 2019-10-09 at 17 08 44](https://user-images.githubusercontent.com/1557784/66489784-d4685480-eab8-11e9-8744-ea973632fa03.png)

iPad:
![Screen Shot 2019-10-09 at 16 50 10](https://user-images.githubusercontent.com/1557784/66489806-db8f6280-eab8-11e9-9a82-011aa9359ec2.png)
![Screen Shot 2019-10-09 at 16 50 22](https://user-images.githubusercontent.com/1557784/66489807-db8f6280-eab8-11e9-9051-b9db575865e1.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
