### PR TITLE
[Backport][Android] Update build (4.1 -> 5.4.1) and SDK (26 -> 28) versions

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -94,8 +94,8 @@ Before Android SDK can be used, you need to accept the licenses and configure it
 cd $HOME/android-tools/android-sdk-linux/tools/bin
 ./sdkmanager --licenses
 ./sdkmanager platform-tools
-./sdkmanager "platforms;android-26"
-./sdkmanager "build-tools;25.0.3"
+./sdkmanager "platforms;android-28"
+./sdkmanager "build-tools;28.0.3"
 ```
 
 ### 3.3. Set up the Android toolchain

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -163,7 +163,7 @@ java: res
 package: libs python java
 	@echo "Gradle build..."
 	ANDROID_HOME=$(SDKROOT) ./gradlew assemble$(BUILD_TYPE)Unsigned
-	@cp xbmc/build/outputs/apk/xbmc-$(BUILD_TYPE_LC)Unsigned-unsigned.apk images/@APP_NAME_LC@app-debug-$(CPU)-unaligned.apk
+	@cp xbmc/build/outputs/apk/$(BUILD_TYPE_LC)Unsigned/xbmc-$(BUILD_TYPE_LC)Unsigned-unsigned.apk images/@APP_NAME_LC@app-debug-$(CPU)-unaligned.apk
 
 apk-sign:
 	@echo "Signing..."

--- a/tools/android/packaging/build.gradle
+++ b/tools/android/packaging/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,10 +17,8 @@ allprojects {
     repositories {
         jcenter()
         google()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.1' //version required
-}
-

--- a/tools/android/packaging/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/android/packaging/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 

--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId "@APP_PACKAGE@"
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode @APP_VERSION_CODE_ANDROID@
         versionName "@APP_VERSION@"
     }
@@ -35,7 +35,9 @@ android {
             jniLibs.srcDirs = ['lib']
         }
     }
-
+    packagingOptions{
+      doNotStrip '**.setup'
+    }
 }
 
 project.afterEvaluate {
@@ -44,6 +46,6 @@ project.afterEvaluate {
 
 dependencies {
     // New support library to for channels/programs development.
-    compile 'com.android.support:support-tv-provider:26.0.1'
-    compile 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.android.support:support-tv-provider:28.0.0'
+    implementation 'com.google.code.gson:gson:2.8.0'
 }


### PR DESCRIPTION
Update gradle : 5.4.1
Update Android SDK: 28
Update build-tools: 28.0.3

## Description
Backport of https://github.com/xbmc/xbmc/pull/16559

## Motivation and Context
Get next Leia versions published in google playstore

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X ] **None of the above** (please explain below)
