### PR TITLE
[ios] fix sandbox check on iOS 13

### DIFF
--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -172,6 +172,8 @@ bool CDarwinUtils::IsIosSandboxed(void)
         @"/var/mobile/Containers/Bundle/",
         // since iOS later than 9.0.2 but before 9.3.5
         @"/var/containers/Bundle/",
+        // since iOS 13
+        @"/private/var/containers/Bundle/",
     };
     for (auto prefixPath : sandboxPrefixPaths)
     {


### PR DESCRIPTION
## Description
Refactors sandbox path checking and adds new path for iOS 13.

## Motivation and Context
`CDarwinUtils::GetAppRootFolder()` should point to Documents directory when Kodi is used on non-jailbroken device, `CDarwinUtils::IsIosSandboxed()` determines whether app is sandboxed or not which started returning `false` on iOS 13.

## How Has This Been Tested?
Verified that on iOS 13 device `CDarwinUtils::IsIosSandboxed()` return `true`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
