### PR TITLE
[ios] fix returned file system sizes before iOS 12

### DIFF
--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
@@ -38,8 +38,8 @@ void CIOSStorageProvider::GetLocalDrives(VECSOURCES& localDrives)
 std::vector<std::string> CIOSStorageProvider::GetDiskUsage()
 {
   std::vector<std::string> result;
-  auto fileSystemAttributes = [NSFileManager.defaultManager attributesOfFileSystemForPath:@"/"
-                                                                                    error:nil];
+  auto fileSystemAttributes =
+      [NSFileManager.defaultManager attributesOfFileSystemForPath:NSHomeDirectory() error:nil];
 
   auto formatter = [NSByteCountFormatter new];
   formatter.includesActualByteCount = YES;


### PR DESCRIPTION
## Description
Fixes retrieving free and total disk space on iOS 9 and 10.

## Motivation and Context
Retrieving free and total disk space in #16374 reports incorrect results on iOS 9 and 10 (not sure about iOS 11). With the new approach results are correct on all supported iOS versions.

## How Has This Been Tested?
Tested on devices running iOS 9, 10, 12, 13.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
