### PR TITLE
[ios] fix size of EAGL view and its layer for devices with "notch"

### DIFF
--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -60,7 +60,7 @@ using namespace KODI::MESSAGING;
 //--------------------------------------------------------------
 - (void) resizeFrameBuffer
 {
-  CGRect frame = [currentScreen bounds];
+  auto frame = self.bounds;
   CAEAGLLayer *eaglLayer = (CAEAGLLayer *)[self layer];
   //allow a maximum framebuffer size of 1080p
   //needed for tvout on iPad3/4 and iphone4/5 and maybe AppleTV3

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -534,7 +534,8 @@ XBMCController *g_xbmcController;
   self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.view.autoresizesSubviews = YES;
 
-  m_glView = [[IOSEAGLView alloc] initWithFrame:self.view.bounds withScreen:[UIScreen mainScreen]];
+  m_glView = [[IOSEAGLView alloc] initWithFrame:[self fullscreenSubviewFrame]
+                                     withScreen:UIScreen.mainScreen];
   [[IOSScreenManager sharedInstance] setView:m_glView];
   [m_glView setMultipleTouchEnabled:YES];
 
@@ -575,12 +576,6 @@ XBMCController *g_xbmcController;
   [self resumeAnimation];
 
   [super viewWillAppear:animated];
-}
-//--------------------------------------------------------------
-- (void)viewSafeAreaInsetsDidChange NS_AVAILABLE_IOS(11_0)
-{
-  [super viewSafeAreaInsetsDidChange];
-  m_glView.frame = [self fullscreenSubviewFrame];
 }
 //--------------------------------------------------------------
 -(void) viewDidAppear:(BOOL)animated
@@ -643,7 +638,7 @@ XBMCController *g_xbmcController;
 {
   auto rect = self.view.bounds;
   if (@available(ios 11.0, *))
-    return UIEdgeInsetsInsetRect(rect, self.view.safeAreaInsets);
+    return UIEdgeInsetsInsetRect(rect, m_window.safeAreaInsets);
   else
     return rect;
 }


### PR DESCRIPTION
## Description
Sets frame of EAGL view to correct value right from the start and sets size of its layer to the size of the view.

## Motivation and Context
After introducing reduced drawing surface size to account for the safe area in notched devices in #16719, UI of notched devices gets broken as soon as screensaver turns on.

## How Has This Been Tested?
Tested on iPhone XR (has notch) and 6+ (doesn't).

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
