### PR TITLE
gui/texture/gl(es): Apply state block before rendering

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -351,6 +351,7 @@ void CGUIWindow::DoRender()
   CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(m_coordsRes, m_needsScaling);
 
   CServiceBroker::GetWinSystem()->GetGfxContext().AddGUITransform();
+  CServiceBroker::GetWinSystem()->GetGfxContext().ApplyStateBlock();
   CGUIControlGroup::DoRender();
   CServiceBroker::GetWinSystem()->GetGfxContext().RemoveTransform();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
There are OpenGL errors when `glVertexAttribute` is called in `CGUITextureGL::End` after starting up media (only tested on RetroPlayer, but it probably happens on VideoPlayer as well).

The cause of the error is that there's no VAO bound - or rather, VAO 0 is bound which is wrong - at least for core profile.
Not sure why rendering has worked up to this point, the issue seems to happen every frame.
This change asks the rendering context to apply any state necessary before rendering (part of which is binding the VAO).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Correct OpenGL usage.
- It fixes a GUI freeze issue on RetroPlayer with @KostasAndrianos 's shader work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
This is tested with GL core 4.6 profile, not sure about older or compatibility profiles.
Running apitrace doesn't show the related GL errors after this change.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
