### PR TITLE
[Estuary] fix studio icon name

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -136,7 +136,7 @@
 	</variable>
 	<variable name="WidgetStudioIconVar">
 		<value condition="System.HasAddon(resource.images.studios.white)">$INFO[ListItem.Label,resource://resource.images.studios.white/,.png]</value>
-		<value>DefaultStudio.png</value>
+		<value>DefaultStudios.png</value>
 	</variable>
 	<variable name="AddonsLabel2Var">
 		<value condition="ListItem.Property(addon.downloading)">$INFO[ListItem.Property(addon.status)]</value>


### PR DESCRIPTION
fix the filename of the default studios icon.

thanx to @ksooo for spotting this.