### PR TITLE
Code clarity: Separate GetVolumePercent() and GetVolumeRatio()

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3737,7 +3737,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         CServiceBroker::GetGUI()->GetWindowManager().Delete(WINDOW_SPLASH);
 
         // show the volumebar if the volume is muted
-        if (IsMuted() || GetVolume(false) <= VOLUME_MINIMUM)
+        if (IsMuted() || GetVolumeRatio() <= VOLUME_MINIMUM)
           ShowVolumeBar();
 
         if (!m_incompatibleAddons.empty())
@@ -4349,21 +4349,21 @@ void CApplication::SetHardwareVolume(float hardwareVolume)
     ae->SetVolume(hardwareVolume);
 }
 
-float CApplication::GetVolume(bool percentage /* = true */) const
+float CApplication::GetVolumePercent() const
 {
-  if (percentage)
-  {
-    // converts the hardware volume to a percentage
-    return m_volumeLevel * 100.0f;
-  }
+  // converts the hardware volume to a percentage
+  return m_volumeLevel * 100.0f;
+}
 
+float CApplication::GetVolumeRatio() const
+{
   return m_volumeLevel;
 }
 
 void CApplication::VolumeChanged()
 {
   CVariant data(CVariant::VariantTypeObject);
-  data["volume"] = GetVolume();
+  data["volume"] = GetVolumePercent();
   data["muted"] = m_muted;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Application, "xbmc", "OnVolumeChanged", data);
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -210,7 +210,8 @@ public:
   void Process() override;
   void ProcessSlow();
   void ResetScreenSaver();
-  float GetVolume(bool percentage = true) const;
+  float GetVolumePercent() const;
+  float GetVolumeRatio() const;
   void SetVolume(float iValue, bool isPercentage = true);
   bool IsMuted() const;
   bool IsMutedInternal() const { return m_muted; }

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -931,7 +931,7 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
   {
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(19021), g_localizeStrings.Get(29930));
     m_TA_TP_TrafficAdvisory = true;
-    m_TA_TP_TrafficVolume = g_application.GetVolume();
+    m_TA_TP_TrafficVolume = g_application.GetVolumePercent();
     float trafAdvVol = (float)CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("pvrplayback.trafficadvisoryvolume");
     if (trafAdvVol)
       g_application.SetVolume(m_TA_TP_TrafficVolume+trafAdvVol);

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -27,7 +27,7 @@ bool CGUIDialogVolumeBar::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN || action.GetID() == ACTION_VOLUME_SET || action.GetID() == ACTION_MUTE)
   {
-    if (g_application.IsMuted() || g_application.GetVolume(false) <= VOLUME_MINIMUM)
+    if (g_application.IsMuted() || g_application.GetVolumeRatio() <= VOLUME_MINIMUM)
     { // cancel the timer, dialog needs to stay visible
       CancelAutoClose();
       return true;

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -130,7 +130,7 @@ void CDialogGameVolume::OnStateChanged()
 
 float CDialogGameVolume::GetVolumePercent() const
 {
-  return g_application.GetVolume(true);
+  return g_application.GetVolumePercent();
 }
 
 std::string CDialogGameVolume::GetLabel()

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -183,7 +183,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       return true;
     }
     case PLAYER_VOLUME:
-      value = StringUtils::Format("%2.1f dB", CAEUtil::PercentToGain(g_application.GetVolume(false)));
+      value = StringUtils::Format("%2.1f dB", CAEUtil::PercentToGain(g_application.GetVolumeRatio()));
       return true;
     case PLAYER_SUBTITLE_DELAY:
       value = StringUtils::Format("%2.3f s", g_application.GetAppPlayer().GetVideoSettings().m_SubtitleDelay);
@@ -355,7 +355,7 @@ bool CPlayerGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
     // PLAYER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case PLAYER_VOLUME:
-      value = static_cast<int>(g_application.GetVolume());
+      value = static_cast<int>(g_application.GetVolumePercent());
       return true;
     case PLAYER_SUBTITLE_DELAY:
       value = g_application.GetSubtitleDelay();
@@ -407,7 +407,7 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = m_playerShowTime;
       return true;
     case PLAYER_MUTED:
-      value = (g_application.IsMuted() || g_application.GetVolume(false) <= VOLUME_MINIMUM);
+      value = (g_application.IsMuted() || g_application.GetVolumeRatio() <= VOLUME_MINIMUM);
       return true;
     case PLAYER_HAS_MEDIA:
       value = g_application.GetAppPlayer().IsPlaying();

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -93,7 +93,7 @@ static int NotifyAll(const std::vector<std::string>& params)
  */
 static int SetVolume(const std::vector<std::string>& params)
 {
-  float oldVolume = g_application.GetVolume();
+  float oldVolume = g_application.GetVolumePercent();
   float volume = (float)strtod(params[0].c_str(), nullptr);
 
   g_application.SetVolume(volume);

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -49,7 +49,7 @@ JSONRPC_STATUS CApplicationOperations::SetVolume(const std::string &method, ITra
   bool up = false;
   if (parameterObject["volume"].isInteger())
   {
-    int oldVolume = (int)g_application.GetVolume();
+    int oldVolume = (int)g_application.GetVolumePercent();
     int volume = (int)parameterObject["volume"].asInteger();
 
     g_application.SetVolume((float)volume, true);
@@ -104,7 +104,7 @@ JSONRPC_STATUS CApplicationOperations::Quit(const std::string &method, ITranspor
 JSONRPC_STATUS CApplicationOperations::GetPropertyValue(const std::string &property, CVariant &result)
 {
   if (property == "volume")
-    result = static_cast<int>(g_application.GetVolume());
+    result = static_cast<int>(g_application.GetVolumePercent());
   else if (property == "muted")
     result = g_application.IsMuted();
   else if (property == "name")

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -714,7 +714,7 @@ void CAirPlayServer::backupVolume()
   CSingleLock lock(ServerInstanceLock);
 
   if (ServerInstance && ServerInstance->m_origVolume == -1)
-    ServerInstance->m_origVolume = (int)g_application.GetVolume();
+    ServerInstance->m_origVolume = (int)g_application.GetVolumePercent();
 }
 
 void CAirPlayServer::restoreVolume()
@@ -824,7 +824,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
       }
       else if (volume >= 0 && volume <= 1)
       {
-        float oldVolume = g_application.GetVolume();
+        float oldVolume = g_application.GetVolumePercent();
         volume *= 100;
         if(oldVolume != volume && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_SERVICES_AIRPLAYVOLUMECONTROL))
         {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1184,7 +1184,7 @@ int CXBMCApp::WaitForActivityResult(const CJNIIntent &intent, int requestCode, C
 void CXBMCApp::onVolumeChanged(int volume)
 {
   // System volume was used; Reset Kodi volume to 100% if it isn't, already
-  if (g_application.GetVolume(false) != 1.0)
+  if (g_application.GetVolumeRatio() != 1.0)
     CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(
                                                  new CAction(ACTION_VOLUME_SET, static_cast<float>(CXBMCApp::GetMaxSystemVolume()))));
 }

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -52,7 +52,7 @@ CGUIDialogAudioSettings::~CGUIDialogAudioSettings() = default;
 void CGUIDialogAudioSettings::FrameMove()
 {
   // update the volume setting if necessary
-  float newVolume = g_application.GetVolume(false);
+  float newVolume = g_application.GetVolumeRatio();
   if (newVolume != m_volume)
     GetSettingsManager()->SetNumber(SETTING_AUDIO_VOLUME, newVolume);
 
@@ -233,7 +233,7 @@ void CGUIDialogAudioSettings::InitializeSettings()
 
   // audio settings
   // audio volume setting
-  m_volume = g_application.GetVolume(false);
+  m_volume = g_application.GetVolumeRatio();
   std::shared_ptr<CSettingNumber> settingAudioVolume = AddSlider(groupAudio, SETTING_AUDIO_VOLUME, 13376, SettingLevel::Basic, m_volume, 14054, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM);
   settingAudioVolume->SetDependencies(depsAudioOutputPassthroughDisabled);
   std::static_pointer_cast<CSettingControlSlider>(settingAudioVolume->GetControl())->SetFormatter(SettingFormatterPercentAsDecibel);


### PR DESCRIPTION
## Description
Volume is represented alternatively as a percent or a ratio throughout the code. Confusingly, these two representations share the same accessor, which uses a parameter to decide the behavior of the function. Furthermore, it's a default parameter, so in many cases it's hard to tell which behavior is even desired.

## Motivation and Context
Was working on a code clarity improvement for https://github.com/xbmc/xbmc/pull/16420, and this case jumped out at me as one that could use improving too.

## How Has This Been Tested?
Tested volume control keys. Volume slider still goes from empty to full.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
