### PR TITLE
Announcements: Cleanup and remove hardcoded "xbmc" string in a lot of code

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2612,7 +2612,7 @@ void CApplication::Stop(int exitCode)
 
     CVariant vExitCode(CVariant::VariantTypeObject);
     vExitCode["exitcode"] = exitCode;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnQuit", vExitCode);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnQuit", vExitCode);
 
     // Abort any active screensaver
     WakeUpScreenSaverAndDPMS();
@@ -3117,7 +3117,8 @@ void CApplication::OnPlayBackEnded()
 
   CVariant data(CVariant::VariantTypeObject);
   data["end"] = true;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnStop", m_itemCurrentFile, data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnStop",
+                                                     m_itemCurrentFile, data);
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_ENDED, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
@@ -3239,7 +3240,8 @@ void CApplication::OnPlayBackStopped()
 
   CVariant data(CVariant::VariantTypeObject);
   data["end"] = false;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnStop", m_itemCurrentFile, data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnStop",
+                                                     m_itemCurrentFile, data);
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_STOPPED, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
@@ -3263,7 +3265,8 @@ void CApplication::OnPlayBackPaused()
   CVariant param;
   param["player"]["speed"] = 0;
   param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPause", m_itemCurrentFile, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPause",
+                                                     m_itemCurrentFile, param);
 }
 
 void CApplication::OnPlayBackResumed()
@@ -3275,7 +3278,8 @@ void CApplication::OnPlayBackResumed()
   CVariant param;
   param["player"]["speed"] = 1;
   param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnResume", m_itemCurrentFile, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnResume",
+                                                     m_itemCurrentFile, param);
 }
 
 void CApplication::OnPlayBackSpeedChanged(int iSpeed)
@@ -3287,7 +3291,8 @@ void CApplication::OnPlayBackSpeedChanged(int iSpeed)
   CVariant param;
   param["player"]["speed"] = iSpeed;
   param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnSpeedChanged", m_itemCurrentFile, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnSpeedChanged",
+                                                     m_itemCurrentFile, param);
 }
 
 void CApplication::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
@@ -3302,7 +3307,8 @@ void CApplication::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
   CJSONUtils::MillisecondsToTimeObject(seekOffset, param["player"]["seekoffset"]);
   param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   param["player"]["speed"] = (int)m_appPlayer.GetPlaySpeed();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnSeek", m_itemCurrentFile, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnSeek",
+                                                     m_itemCurrentFile, param);
   CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().SetDisplayAfterSeek(2500, static_cast<int>(seekOffset));
 }
 
@@ -3323,7 +3329,8 @@ void CApplication::OnAVStarted(const CFileItem &file)
   CVariant param;
   param["player"]["speed"] = 1;
   param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnAVStart", m_itemCurrentFile, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnAVStart",
+                                                     m_itemCurrentFile, param);
 }
 
 void CApplication::OnAVChange()
@@ -3338,7 +3345,8 @@ void CApplication::OnAVChange()
   CVariant param;
   param["player"]["speed"] = 1;
   param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnAVChange", m_itemCurrentFile, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnAVChange",
+                                                     m_itemCurrentFile, param);
 }
 
 void CApplication::RequestVideoSettings(const CFileItem &fileItem)
@@ -3456,7 +3464,7 @@ bool CApplication::ToggleDPMS(bool manual)
       m_dpmsIsManual = false;
       SetRenderGUI(true);
       CheckOSScreenSaverInhibitionSetting();
-      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "xbmc", "OnDPMSDeactivated");
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "OnDPMSDeactivated");
       return dpms->DisablePowerSaving();
     }
     else
@@ -3467,7 +3475,7 @@ bool CApplication::ToggleDPMS(bool manual)
         m_dpmsIsManual = manual;
         SetRenderGUI(false);
         CheckOSScreenSaverInhibitionSetting();
-        CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "xbmc", "OnDPMSActivated");
+        CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "OnDPMSActivated");
         return true;
       }
     }
@@ -3498,7 +3506,8 @@ bool CApplication::WakeUpScreenSaverAndDPMS(bool bPowerOffKeyPressed /* = false 
     // allow listeners to ignore the deactivation if it precedes a powerdown/suspend etc
     CVariant data(CVariant::VariantTypeObject);
     data["shuttingdown"] = bPowerOffKeyPressed;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "xbmc", "OnScreensaverDeactivated", data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI,
+                                                       "OnScreensaverDeactivated", data);
   }
 
   return result;
@@ -3706,7 +3715,7 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
   }
 
   m_screensaverActive = true;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "xbmc", "OnScreensaverActivated");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "OnScreensaverActivated");
 
   // disable screensaver lock from the login screen
   m_iScreenSaveLock = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_LOGIN_SCREEN ? 1 : 0;
@@ -3909,7 +3918,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
       CVariant param;
       param["player"]["speed"] = 1;
       param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", m_itemCurrentFile, param);
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
+                                                         m_itemCurrentFile, param);
 
       // we don't want a busy dialog when switching channels
       if (!m_itemCurrentFile->IsLiveTV())
@@ -4458,7 +4468,8 @@ void CApplication::VolumeChanged()
   CVariant data(CVariant::VariantTypeObject);
   data["volume"] = GetVolumePercent();
   data["muted"] = m_muted;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Application, "xbmc", "OnVolumeChanged", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Application, "OnVolumeChanged",
+                                                     data);
 
   // if player has volume control, set it.
   m_appPlayer.SetVolume(m_volumeLevel);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10614,7 +10614,7 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 
   m_infoProviders.InitCurrentItem(m_currentFile);
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "xbmc", "OnChanged");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "OnChanged");
 }
 
 void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -570,6 +570,7 @@ void CPartyModeManager::Announce()
 
     data["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
     data["property"]["partymode"] = m_bEnabled;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                       data);
   }
 }

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -764,7 +764,8 @@ void CPlayListPlayer::AnnouncePropertyChanged(int iPlaylist, const std::string &
   CVariant data;
   data["player"]["playerid"] = iPlaylist;
   data["property"][strProperty] = value;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                     data);
 }
 
 int PLAYLIST::CPlayListPlayer::GetMessageMask()

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -938,7 +938,7 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
 
     CVariant data(CVariant::VariantTypeObject);
     data["on"] = true;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTA", data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "RDSRadioTA", data);
   }
 
   if (!traffic_announcement && m_TA_TP_TrafficAdvisory && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool("pvrplayback.trafficadvisory"))
@@ -948,7 +948,7 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
 
     CVariant data(CVariant::VariantTypeObject);
     data["on"] = false;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTA", data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "RDSRadioTA", data);
   }
 
   return 4;
@@ -1173,7 +1173,7 @@ unsigned int CDVDRadioRDSData::DecodeRTC(uint8_t *msgElement)
 
   CVariant data(CVariant::VariantTypeObject);
   data["dateTime"] = (m_RTC_DateTime.IsValid()) ? m_RTC_DateTime.GetAsRFC1123DateTime() : "";
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioRTC", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "RDSRadioRTC", data);
 
   return 8;
 }
@@ -1730,6 +1730,6 @@ void CDVDRadioRDSData::SendTMCSignal(unsigned int flags, uint8_t *data)
     msg["y"]       = (unsigned int)(m_TMC_LastData[1]<<8 | m_TMC_LastData[2]);
     msg["z"]       = (unsigned int)(m_TMC_LastData[3]<<8 | m_TMC_LastData[4]);
 
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTMC", msg);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::PVR, "RDSRadioTMC", msg);
   }
 }

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -6,29 +6,30 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "interfaces/AnnouncementManager.h"
-#include "input/XBMC_vkeys.h"
-#include "input/InputCodingTable.h"
+#include "GUIDialogKeyboardGeneric.h"
+
+#include "GUIDialogNumeric.h"
+#include "GUIUserMessages.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "input/KeyboardLayoutManager.h"
-#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
-#include "GUIUserMessages.h"
-#include "GUIDialogNumeric.h"
-#include "GUIDialogKeyboardGeneric.h"
-#include "ServiceBroker.h"
+#include "input/InputCodingTable.h"
+#include "input/Key.h"
+#include "input/KeyboardLayoutManager.h"
+#include "input/XBMC_vkeys.h"
+#include "interfaces/AnnouncementManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/RegExp.h"
-#include "utils/Variant.h"
-#include "utils/StringUtils.h"
-#include "messaging/ApplicationMessenger.h"
 #include "utils/CharsetConverter.h"
-#include "windowing/WinSystem.h"
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
 #include "utils/log.h"
+#include "windowing/WinSystem.h"
 
 #ifdef TARGET_ANDROID
 #include <androidjni/Intent.h>
@@ -178,7 +179,7 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   data["title"] = m_strHeading;
   data["type"] = !m_hiddenInput ? "keyboard" : "password";
   data["value"] = GetText();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "OnInputRequested", data);
 }
 
 bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
@@ -511,7 +512,7 @@ void CGUIDialogKeyboardGeneric::OnDeinitWindow(int nextWindowID)
   // reset the heading (we don't always have this)
   m_strHeading = "";
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputFinished");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "OnInputFinished");
 }
 
 void CGUIDialogKeyboardGeneric::MoveCursor(int iAmount)

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -86,7 +86,7 @@ void CGUIDialogNumeric::OnInitWindow()
 
   data["value"] = GetOutputString();
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "OnInputRequested", data);
 }
 
 void CGUIDialogNumeric::OnDeinitWindow(int nextWindowID)
@@ -94,7 +94,7 @@ void CGUIDialogNumeric::OnDeinitWindow(int nextWindowID)
   // call base class
   CGUIDialog::OnDeinitWindow(nextWindowID);
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputFinished");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Input, "OnInputFinished");
 }
 
 bool CGUIDialogNumeric::OnAction(const CAction &action)

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -105,12 +105,9 @@ bool CDialogGameVolume::IsShown() const
   return m_active;
 }
 
-void CDialogGameVolume::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                                 const char* sender,
-                                 const char* message,
-                                 const CVariant& data)
+void CDialogGameVolume::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
-  if (flag == ANNOUNCEMENT::Application && strcmp(message, "OnVolumeChanged") == 0)
+  if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged")
   {
     const float volumePercent = static_cast<float>(data["volume"].asDouble());
 

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -105,7 +105,10 @@ bool CDialogGameVolume::IsShown() const
   return m_active;
 }
 
-void CDialogGameVolume::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CDialogGameVolume::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                 const std::string& sender,
+                                 const std::string& message,
+                                 const CVariant& data)
 {
   if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged")
   {

--- a/xbmc/games/dialogs/osd/DialogGameVolume.h
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.h
@@ -41,11 +41,8 @@ public:
   // implementation of IGUIVolumeBarCallback
   bool IsShown() const override;
 
-  // implementation of IAnnouncer
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                const char* sender,
-                const char* message,
-                const CVariant& data) override;
+    // implementation of IAnnouncer
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
 protected:
   // implementation of CGUIWindow via CGUIDialogSlider

--- a/xbmc/games/dialogs/osd/DialogGameVolume.h
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.h
@@ -42,7 +42,10 @@ public:
   bool IsShown() const override;
 
     // implementation of IAnnouncer
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const CVariant& data) override;
 
 protected:
   // implementation of CGUIWindow via CGUIDialogSlider

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -73,24 +73,24 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
   }
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message)
+void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message)
 {
   CVariant data;
   Announce(flag, sender, message, CFileItemPtr(), data);
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   Announce(flag, sender, message, CFileItemPtr(), data);
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, const std::shared_ptr<const CFileItem>& item)
+void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const std::shared_ptr<const CFileItem>& item)
 {
   CVariant data;
   Announce(flag, sender, message, item, data);
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, const char *message, const std::shared_ptr<const CFileItem>& item, const CVariant &data)
+void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const std::shared_ptr<const CFileItem>& item, const CVariant &data)
 {
   CAnnounceData announcement;
   announcement.flag = flag;
@@ -108,7 +108,7 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
   m_queueEvent.Set();
 }
 
-void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   CLog::Log(LOGDEBUG, LOGANNOUNCE, "CAnnouncementManager - Announcement: {} from {}", message, sender);
 
@@ -121,7 +121,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender,
     announcers[i]->Announce(flag, sender, message, data);
 }
 
-void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item, const CVariant &data)
+void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, CFileItemPtr item, const CVariant &data)
 {
   if (item == nullptr)
   {

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -25,6 +25,8 @@
 
 using namespace ANNOUNCEMENT;
 
+const std::string CAnnouncementManager::ANNOUNCEMENT_SENDER = "xbmc";
+
 CAnnouncementManager::CAnnouncementManager() : CThread("Announce")
 {
 }
@@ -72,6 +74,34 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
     }
   }
 }
+
+void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& message)
+{
+  Announce(flag, ANNOUNCEMENT_SENDER, message);
+}
+
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& message,
+                                    const CVariant& data)
+{
+  Announce(flag, ANNOUNCEMENT_SENDER, message, data);
+}
+
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& message,
+                                    const std::shared_ptr<const CFileItem>& item)
+{
+  Announce(flag, ANNOUNCEMENT_SENDER, message, item);
+}
+
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& message,
+                                    const std::shared_ptr<const CFileItem>& item,
+                                    const CVariant& data)
+{
+  Announce(flag, ANNOUNCEMENT_SENDER, message, item, data);
+}
+
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag,
                                     const std::string& sender,

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -77,21 +77,23 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& message)
 {
-  Announce(flag, ANNOUNCEMENT_SENDER, message);
+  CVariant data;
+  Announce(flag, ANNOUNCEMENT_SENDER, message, CFileItemPtr(), data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag,
                                     const std::string& message,
                                     const CVariant& data)
 {
-  Announce(flag, ANNOUNCEMENT_SENDER, message, data);
+  Announce(flag, ANNOUNCEMENT_SENDER, message, CFileItemPtr(), data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag,
                                     const std::string& message,
                                     const std::shared_ptr<const CFileItem>& item)
 {
-  Announce(flag, ANNOUNCEMENT_SENDER, message, item);
+  CVariant data;
+  Announce(flag, ANNOUNCEMENT_SENDER, message, item, data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag,
@@ -117,15 +119,6 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag,
                                     const CVariant& data)
 {
   Announce(flag, sender, message, CFileItemPtr(), data);
-}
-
-void CAnnouncementManager::Announce(AnnouncementFlag flag,
-                                    const std::string& sender,
-                                    const std::string& message,
-                                    const std::shared_ptr<const CFileItem>& item)
-{
-  CVariant data;
-  Announce(flag, sender, message, item, data);
 }
 
 void CAnnouncementManager::Announce(AnnouncementFlag flag,

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -73,24 +73,36 @@ void CAnnouncementManager::RemoveAnnouncer(IAnnouncer *listener)
   }
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message)
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& sender,
+                                    const std::string& message)
 {
   CVariant data;
   Announce(flag, sender, message, CFileItemPtr(), data);
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& sender,
+                                    const std::string& message,
+                                    const CVariant& data)
 {
   Announce(flag, sender, message, CFileItemPtr(), data);
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const std::shared_ptr<const CFileItem>& item)
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& sender,
+                                    const std::string& message,
+                                    const std::shared_ptr<const CFileItem>& item)
 {
   CVariant data;
   Announce(flag, sender, message, item, data);
 }
 
-void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const std::shared_ptr<const CFileItem>& item, const CVariant &data)
+void CAnnouncementManager::Announce(AnnouncementFlag flag,
+                                    const std::string& sender,
+                                    const std::string& message,
+                                    const std::shared_ptr<const CFileItem>& item,
+                                    const CVariant& data)
 {
   CAnnounceData announcement;
   announcement.flag = flag;
@@ -108,7 +120,10 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const std::string& se
   m_queueEvent.Set();
 }
 
-void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
+                                      const std::string& sender,
+                                      const std::string& message,
+                                      const CVariant& data)
 {
   CLog::Log(LOGDEBUG, LOGANNOUNCE, "CAnnouncementManager - Announcement: {} from {}", message, sender);
 
@@ -121,7 +136,11 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const std::string& 
     announcers[i]->Announce(flag, sender, message, data);
 }
 
-void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, CFileItemPtr item, const CVariant &data)
+void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
+                                      const std::string& sender,
+                                      const std::string& message,
+                                      CFileItemPtr item,
+                                      const CVariant& data)
 {
   if (item == nullptr)
   {

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -34,17 +34,17 @@ namespace ANNOUNCEMENT
     void AddAnnouncer(IAnnouncer *listener);
     void RemoveAnnouncer(IAnnouncer *listener);
 
-    void Announce(AnnouncementFlag flag, const char *sender, const char *message);
-    void Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
-    void Announce(AnnouncementFlag flag, const char *sender, const char *message,
+    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message);
+    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data);
+    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message,
         const std::shared_ptr<const CFileItem>& item);
-    void Announce(AnnouncementFlag flag, const char *sender, const char *message,
+    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message,
         const std::shared_ptr<const CFileItem>& item, const CVariant &data);
 
   protected:
     void Process() override;
-    void DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, CFileItemPtr item, const CVariant &data);
-    void DoAnnounce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
+    void DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, CFileItemPtr item, const CVariant &data);
+    void DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data);
 
     struct CAnnounceData
     {

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -35,16 +35,31 @@ namespace ANNOUNCEMENT
     void RemoveAnnouncer(IAnnouncer *listener);
 
     void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message);
-    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data);
-    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message,
-        const std::shared_ptr<const CFileItem>& item);
-    void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message,
-        const std::shared_ptr<const CFileItem>& item, const CVariant &data);
+    void Announce(AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const CVariant& data);
+    void Announce(AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const std::shared_ptr<const CFileItem>& item);
+    void Announce(AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const std::shared_ptr<const CFileItem>& item,
+                  const CVariant& data);
 
   protected:
     void Process() override;
-    void DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, CFileItemPtr item, const CVariant &data);
-    void DoAnnounce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data);
+    void DoAnnounce(AnnouncementFlag flag,
+                    const std::string& sender,
+                    const std::string& message,
+                    CFileItemPtr item,
+                    const CVariant& data);
+    void DoAnnounce(AnnouncementFlag flag,
+                    const std::string& sender,
+                    const std::string& message,
+                    const CVariant& data);
 
     struct CAnnounceData
     {

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -34,6 +34,16 @@ namespace ANNOUNCEMENT
     void AddAnnouncer(IAnnouncer *listener);
     void RemoveAnnouncer(IAnnouncer *listener);
 
+    void Announce(AnnouncementFlag flag, const std::string& message);
+    void Announce(AnnouncementFlag flag, const std::string& message, const CVariant& data);
+    void Announce(AnnouncementFlag flag,
+                  const std::string& message,
+                  const std::shared_ptr<const CFileItem>& item);
+    void Announce(AnnouncementFlag flag,
+                  const std::string& message,
+                  const std::shared_ptr<const CFileItem>& item,
+                  const CVariant& data);
+
     void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message);
     void Announce(AnnouncementFlag flag,
                   const std::string& sender,
@@ -48,6 +58,11 @@ namespace ANNOUNCEMENT
                   const std::string& message,
                   const std::shared_ptr<const CFileItem>& item,
                   const CVariant& data);
+
+    // The sender is not related to the application name.
+    // Also it's part of Kodi's API - changing it will break
+    // a big number of python addons and third party json consumers.
+    static const std::string ANNOUNCEMENT_SENDER;
 
   protected:
     void Process() override;

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -52,10 +52,6 @@ namespace ANNOUNCEMENT
     void Announce(AnnouncementFlag flag,
                   const std::string& sender,
                   const std::string& message,
-                  const std::shared_ptr<const CFileItem>& item);
-    void Announce(AnnouncementFlag flag,
-                  const std::string& sender,
-                  const std::string& message,
                   const std::shared_ptr<const CFileItem>& item,
                   const CVariant& data);
 

--- a/xbmc/interfaces/IAnnouncer.h
+++ b/xbmc/interfaces/IAnnouncer.h
@@ -72,6 +72,9 @@ namespace ANNOUNCEMENT
   public:
     IAnnouncer() = default;
     virtual ~IAnnouncer() = default;
-    virtual void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) = 0;
+    virtual void Announce(AnnouncementFlag flag,
+                          const std::string& sender,
+                          const std::string& message,
+                          const CVariant& data) = 0;
   };
 }

--- a/xbmc/interfaces/IAnnouncer.h
+++ b/xbmc/interfaces/IAnnouncer.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string>
+
 class CVariant;
 namespace ANNOUNCEMENT
 {
@@ -70,6 +72,6 @@ namespace ANNOUNCEMENT
   public:
     IAnnouncer() = default;
     virtual ~IAnnouncer() = default;
-    virtual void Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) = 0;
+    virtual void Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) = 0;
   };
 }

--- a/xbmc/interfaces/json-rpc/IJSONRPCAnnouncer.h
+++ b/xbmc/interfaces/json-rpc/IJSONRPCAnnouncer.h
@@ -20,7 +20,11 @@ namespace JSONRPC
     ~IJSONRPCAnnouncer() override = default;
 
   protected:
-    static std::string AnnouncementToJSONRPC(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& method, const CVariant &data, bool compactOutput)
+    static std::string AnnouncementToJSONRPC(ANNOUNCEMENT::AnnouncementFlag flag,
+                                             const std::string& sender,
+                                             const std::string& method,
+                                             const CVariant& data,
+                                             bool compactOutput)
     {
       CVariant root;
       root["jsonrpc"] = "2.0";

--- a/xbmc/interfaces/json-rpc/IJSONRPCAnnouncer.h
+++ b/xbmc/interfaces/json-rpc/IJSONRPCAnnouncer.h
@@ -20,7 +20,7 @@ namespace JSONRPC
     ~IJSONRPCAnnouncer() override = default;
 
   protected:
-    static std::string AnnouncementToJSONRPC(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *method, const CVariant &data, bool compactOutput)
+    static std::string AnnouncementToJSONRPC(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& method, const CVariant &data, bool compactOutput)
     {
       CVariant root;
       root["jsonrpc"] = "2.0";

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -214,13 +214,15 @@ JSONRPC_STATUS CJSONRPC::SetConfiguration(const std::string &method, ITransportL
 JSONRPC_STATUS CJSONRPC::NotifyAll(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant& parameterObject, CVariant &result)
 {
   if (parameterObject["data"].isNull())
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Other, parameterObject["sender"].asString().c_str(),
-      parameterObject["message"].asString().c_str());
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Other,
+                                                       parameterObject["sender"].asString(),
+                                                       parameterObject["message"].asString());
   else
   {
     CVariant data = parameterObject["data"];
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Other, parameterObject["sender"].asString().c_str(),
-      parameterObject["message"].asString().c_str(), data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Other,
+                                                       parameterObject["sender"].asString(),
+                                                       parameterObject["message"].asString(), data);
   }
 
   return ACK;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -67,43 +67,40 @@ XBPython::~XBPython()
 #define CHECK_FOR_ENTRY(l, v) \
   (l.hadSomethingRemoved ? (std::find(l.begin(), l.end(), v) != l.end()) : true)
 
-void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                        const char* sender,
-                        const char* message,
-                        const CVariant& data)
+void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   if (flag & ANNOUNCEMENT::VideoLibrary)
   {
-    if (strcmp(message, "OnScanFinished") == 0)
-      OnScanFinished("video");
-    else if (strcmp(message, "OnScanStarted") == 0)
-      OnScanStarted("video");
-    else if (strcmp(message, "OnCleanStarted") == 0)
-      OnCleanStarted("video");
-    else if (strcmp(message, "OnCleanFinished") == 0)
-      OnCleanFinished("video");
+   if (message == "OnScanFinished")
+     OnScanFinished("video");
+   else if (message == "OnScanStarted")
+     OnScanStarted("video");
+   else if (message == "OnCleanStarted")
+     OnCleanStarted("video");
+   else if (message == "OnCleanFinished")
+     OnCleanFinished("video");
   }
   else if (flag & ANNOUNCEMENT::AudioLibrary)
   {
-    if (strcmp(message, "OnScanFinished") == 0)
-      OnScanFinished("music");
-    else if (strcmp(message, "OnScanStarted") == 0)
-      OnScanStarted("music");
-    else if (strcmp(message, "OnCleanStarted") == 0)
-      OnCleanStarted("music");
-    else if (strcmp(message, "OnCleanFinished") == 0)
-      OnCleanFinished("music");
+   if (message == "OnScanFinished")
+     OnScanFinished("music");
+   else if (message == "OnScanStarted")
+     OnScanStarted("music");
+   else if (message == "OnCleanStarted")
+     OnCleanStarted("music");
+   else if (message == "OnCleanFinished")
+     OnCleanFinished("music");
   }
   else if (flag & ANNOUNCEMENT::GUI)
   {
-    if (strcmp(message, "OnScreensaverDeactivated") == 0)
-      OnScreensaverDeactivated();
-    else if (strcmp(message, "OnScreensaverActivated") == 0)
-      OnScreensaverActivated();
-    else if (strcmp(message, "OnDPMSDeactivated") == 0)
-      OnDPMSDeactivated();
-    else if (strcmp(message, "OnDPMSActivated") == 0)
-      OnDPMSActivated();
+   if (message == "OnScreensaverDeactivated")
+     OnScreensaverDeactivated();
+   else if (message == "OnScreensaverActivated")
+     OnScreensaverActivated();
+   else if (message == "OnDPMSDeactivated")
+     OnDPMSDeactivated();
+   else if (message == "OnDPMSActivated")
+     OnDPMSActivated();
   }
 
   std::string jsonData;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -67,40 +67,43 @@ XBPython::~XBPython()
 #define CHECK_FOR_ENTRY(l, v) \
   (l.hadSomethingRemoved ? (std::find(l.begin(), l.end(), v) != l.end()) : true)
 
-void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                        const std::string& sender,
+                        const std::string& message,
+                        const CVariant& data)
 {
   if (flag & ANNOUNCEMENT::VideoLibrary)
   {
-   if (message == "OnScanFinished")
-     OnScanFinished("video");
-   else if (message == "OnScanStarted")
-     OnScanStarted("video");
-   else if (message == "OnCleanStarted")
-     OnCleanStarted("video");
-   else if (message == "OnCleanFinished")
-     OnCleanFinished("video");
+    if (message == "OnScanFinished")
+      OnScanFinished("video");
+    else if (message == "OnScanStarted")
+      OnScanStarted("video");
+    else if (message == "OnCleanStarted")
+      OnCleanStarted("video");
+    else if (message == "OnCleanFinished")
+      OnCleanFinished("video");
   }
   else if (flag & ANNOUNCEMENT::AudioLibrary)
   {
-   if (message == "OnScanFinished")
-     OnScanFinished("music");
-   else if (message == "OnScanStarted")
-     OnScanStarted("music");
-   else if (message == "OnCleanStarted")
-     OnCleanStarted("music");
-   else if (message == "OnCleanFinished")
-     OnCleanFinished("music");
+    if (message == "OnScanFinished")
+      OnScanFinished("music");
+    else if (message == "OnScanStarted")
+      OnScanStarted("music");
+    else if (message == "OnCleanStarted")
+      OnCleanStarted("music");
+    else if (message == "OnCleanFinished")
+      OnCleanFinished("music");
   }
   else if (flag & ANNOUNCEMENT::GUI)
   {
-   if (message == "OnScreensaverDeactivated")
-     OnScreensaverDeactivated();
-   else if (message == "OnScreensaverActivated")
-     OnScreensaverActivated();
-   else if (message == "OnDPMSDeactivated")
-     OnDPMSDeactivated();
-   else if (message == "OnDPMSActivated")
-     OnDPMSActivated();
+    if (message == "OnScreensaverDeactivated")
+      OnScreensaverDeactivated();
+    else if (message == "OnScreensaverActivated")
+      OnScreensaverActivated();
+    else if (message == "OnDPMSDeactivated")
+      OnDPMSDeactivated();
+    else if (message == "OnDPMSActivated")
+      OnDPMSActivated();
   }
 
   std::string jsonData;

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -69,10 +69,7 @@ public:
   void OnPlayBackSeekChapter(int iChapter) override;
   void OnQueueNextItem() override;
 
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                const char* sender,
-                const char* message,
-                const CVariant& data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
   void RegisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void RegisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback);

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -69,7 +69,10 @@ public:
   void OnPlayBackSeekChapter(int iChapter) override;
   void OnQueueNextItem() override;
 
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
   void RegisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void RegisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback);

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -222,7 +222,10 @@ bool CDirectoryProvider::Update(bool forceRefresh)
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 
-void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                  const std::string& sender,
+                                  const std::string& message,
+                                  const CVariant& data)
 {
   // we are only interested in library, player and GUI changes
   if ((flag & (ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player | ANNOUNCEMENT::GUI)) == 0)
@@ -240,9 +243,7 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std
 
     if (flag & ANNOUNCEMENT::Player)
     {
-      if (message == "OnPlay" ||
-          message == "OnResume" ||
-          message == "OnStop")
+      if (message == "OnPlay" || message == "OnResume" || message == "OnStop")
       {
         if (m_currentSort.sortBy == SortByNone || // not nice, but many directories that need to be refreshed on start/stop have no special sort order (e.g. in progress movies)
             m_currentSort.sortBy == SortByLastPlayed ||
@@ -259,11 +260,8 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std
 
       // if there was a database update, we set the update state
       // to PENDING to fire off a new job in the next update
-      if (message == "OnScanFinished" ||
-          message == "OnCleanFinished" ||
-          message == "OnUpdate" ||
-          message == "OnRemove" ||
-          message == "OnRefresh")
+      if (message == "OnScanFinished" || message == "OnCleanFinished" || message == "OnUpdate" ||
+          message == "OnRemove" || message == "OnRefresh")
         m_updateState = INVALIDATED;
     }
   }

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -222,7 +222,7 @@ bool CDirectoryProvider::Update(bool forceRefresh)
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 
-void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   // we are only interested in library, player and GUI changes
   if ((flag & (ANNOUNCEMENT::VideoLibrary | ANNOUNCEMENT::AudioLibrary | ANNOUNCEMENT::Player | ANNOUNCEMENT::GUI)) == 0)
@@ -240,9 +240,9 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const cha
 
     if (flag & ANNOUNCEMENT::Player)
     {
-      if (strcmp(message, "OnPlay") == 0 ||
-          strcmp(message, "OnResume") == 0 ||
-          strcmp(message, "OnStop") == 0)
+      if (message == "OnPlay" ||
+          message == "OnResume" ||
+          message == "OnStop")
       {
         if (m_currentSort.sortBy == SortByNone || // not nice, but many directories that need to be refreshed on start/stop have no special sort order (e.g. in progress movies)
             m_currentSort.sortBy == SortByLastPlayed ||
@@ -259,11 +259,11 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const cha
 
       // if there was a database update, we set the update state
       // to PENDING to fire off a new job in the next update
-      if (strcmp(message, "OnScanFinished") == 0 ||
-          strcmp(message, "OnCleanFinished") == 0 ||
-          strcmp(message, "OnUpdate") == 0 ||
-          strcmp(message, "OnRemove") == 0 ||
-          strcmp(message, "OnRefresh") == 0)
+      if (message == "OnScanFinished" ||
+          message == "OnCleanFinished" ||
+          message == "OnUpdate" ||
+          message == "OnRemove" ||
+          message == "OnRefresh")
         m_updateState = INVALIDATED;
     }
   }

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -54,7 +54,10 @@ public:
   ~CDirectoryProvider() override;
 
   bool Update(bool forceRefresh) override;
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   void Reset() override;
   bool OnClick(const CGUIListItemPtr &item) override;

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -54,7 +54,7 @@ public:
   ~CDirectoryProvider() override;
 
   bool Update(bool forceRefresh) override;
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   void Reset() override;
   bool OnClick(const CGUIListItemPtr &item) override;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -85,7 +85,7 @@ static void AnnounceRemove(const std::string& content, int id)
   data["id"] = id;
   if (g_application.IsMusicScanning())
     data["transaction"] = true;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnRemove", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnRemove", data);
 }
 
 static void AnnounceUpdate(const std::string& content, int id, bool added = false)
@@ -97,7 +97,7 @@ static void AnnounceUpdate(const std::string& content, int id, bool added = fals
     data["transaction"] = true;
   if (added)
     data["added"] = true;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnUpdate", data);
 }
 
 CMusicDatabase::CMusicDatabase(void)
@@ -4080,7 +4080,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   int ret = ERROR_OK;
   unsigned int time = XbmcThreads::SystemClockMillis();
   CLog::Log(LOGINFO, "%s: Starting musicdatabase cleanup ..", __FUNCTION__);
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanStarted");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanStarted");
 
   SetLibraryLastCleaned();
 
@@ -4216,7 +4216,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   time = XbmcThreads::SystemClockMillis() - time;
   CLog::Log(LOGINFO, "%s: Cleaning musicdatabase done. Operation took %s", __FUNCTION__,
             StringUtils::SecondsToTimeString(time / 1000).c_str());
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanFinished");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanFinished");
 
   if (!Compress(false))
   {
@@ -4228,7 +4228,7 @@ error:
   RollbackTransaction();
   // Recreate DELETE triggers on song_artist and album_artist
   CreateRemovedLinkTriggers();
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanFinished");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanFinished");
   return ret;
 }
 
@@ -11155,7 +11155,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
       data["file"] = xmlFile;
       if (iFailCount > 0)
         data["failcount"] = iFailCount;
-      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnExport", data);
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnExport",
+                                                         data);
     }
   }
   catch (...)

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -76,7 +76,7 @@ CMusicInfoScanner::~CMusicInfoScanner() = default;
 void CMusicInfoScanner::Process()
 {
   m_bStop = false;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanStarted");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnScanStarted");
   try
   {
     if (m_showDialog && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
@@ -272,7 +272,7 @@ void CMusicInfoScanner::Process()
   CLog::Log(LOGDEBUG, "%s - Finished scan", __FUNCTION__);
 
   m_bRunning = false;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanFinished");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnScanFinished");
 
   // we need to clear the musicdb cache and update any active lists
   CUtil::DeleteMusicDatabaseDirectoryCache();

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -9,29 +9,31 @@
  *  from Airplayer. https://github.com/PascalW/Airplayer
  */
 
-#include "network/Network.h"
 #include "AirPlayServer.h"
 
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include "utils/log.h"
-#include "utils/StringUtils.h"
-#include "threads/SingleLock.h"
-#include "filesystem/File.h"
-#include "filesystem/Directory.h"
-#include "FileItem.h"
 #include "Application.h"
-#include "ServiceBroker.h"
-#include "messaging/ApplicationMessenger.h"
+#include "CompileInfo.h"
+#include "FileItem.h"
 #include "PlayListPlayer.h"
-#include "utils/Digest.h"
-#include "utils/Variant.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
-#include "input/Key.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "cores/IPlayer.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+#include "input/Key.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/ApplicationMessenger.h"
+#include "network/Network.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "threads/SingleLock.h"
+#include "utils/Digest.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #ifdef HAS_ZEROCONF
 #include "network/Zeroconf.h"
 #endif // HAS_ZEROCONF
@@ -157,7 +159,7 @@ void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
 {
   CSingleLock lock(ServerInstanceLock);
 
-  if ((flag & ANNOUNCEMENT::Player) && sender == "xbmc" && ServerInstance)
+  if ((flag & ANNOUNCEMENT::Player) && sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER && ServerInstance)
   {
     if (message == "OnStop")
     {

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -150,11 +150,14 @@ const char *eventStrings[] = {"playing", "paused", "loading", "stopped"};
 #define AUTH_REALM "AirPlay"
 #define AUTH_REQUIRED "WWW-Authenticate: Digest realm=\""  AUTH_REALM  "\", nonce=\"%s\"\r\n"
 
-void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                              const std::string& sender,
+                              const std::string& message,
+                              const CVariant& data)
 {
   CSingleLock lock(ServerInstanceLock);
 
-  if ( (flag & ANNOUNCEMENT::Player) && sender == "xbmc" && ServerInstance)
+  if ((flag & ANNOUNCEMENT::Player) && sender == "xbmc" && ServerInstance)
   {
     if (message == "OnStop")
     {

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -159,7 +159,8 @@ void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
 {
   CSingleLock lock(ServerInstanceLock);
 
-  if ((flag & ANNOUNCEMENT::Player) && sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER && ServerInstance)
+  if ((flag & ANNOUNCEMENT::Player) &&
+      sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER && ServerInstance)
   {
     if (message == "OnStop")
     {

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -150,13 +150,13 @@ const char *eventStrings[] = {"playing", "paused", "loading", "stopped"};
 #define AUTH_REALM "AirPlay"
 #define AUTH_REQUIRED "WWW-Authenticate: Digest realm=\""  AUTH_REALM  "\", nonce=\"%s\"\r\n"
 
-void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   CSingleLock lock(ServerInstanceLock);
 
-  if ( (flag & ANNOUNCEMENT::Player) && strcmp(sender, "xbmc") == 0 && ServerInstance)
+  if ( (flag & ANNOUNCEMENT::Player) && sender == "xbmc" && ServerInstance)
   {
-    if (strcmp(message, "OnStop") == 0)
+    if (message == "OnStop")
     {
       bool shouldRestoreVolume = true;
       if (data.isMember("player") && data["player"].isMember("playerid"))
@@ -167,11 +167,11 @@ void CAirPlayServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *s
 
       ServerInstance->AnnounceToClients(EVENT_STOPPED);
     }
-    else if (strcmp(message, "OnPlay") == 0 || strcmp(message, "OnResume") == 0)
+    else if (message == "OnPlay" || message == "OnResume")
     {
       ServerInstance->AnnounceToClients(EVENT_PLAYING);
     }
-    else if (strcmp(message, "OnPause") == 0)
+    else if (message == "OnPause")
     {
       ServerInstance->AnnounceToClients(EVENT_PAUSED);
     }

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -30,7 +30,10 @@ class CAirPlayServer : public CThread, public ANNOUNCEMENT::IAnnouncer
 {
 public:
   // IAnnouncer IF
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   //AirPlayServer impl.
   static bool StartServer(int port, bool nonlocal);

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -30,7 +30,7 @@ class CAirPlayServer : public CThread, public ANNOUNCEMENT::IAnnouncer
 {
 public:
   // IAnnouncer IF
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
   //AirPlayServer impl.
   static bool StartServer(int port, bool nonlocal);

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -161,9 +161,12 @@ void CAirTunesServer::SetMetadataFromBuffer(const char *buffer, unsigned int siz
   RefreshMetadata();
 }
 
-void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                               const std::string& sender,
+                               const std::string& message,
+                               const CVariant& data)
 {
-  if ( (flag & ANNOUNCEMENT::Player) && sender == "xbmc")
+  if ((flag & ANNOUNCEMENT::Player) && sender == "xbmc")
   {
     if ((message == "OnPlay" || message == "OnResume") && m_streamStarted)
     {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -161,11 +161,11 @@ void CAirTunesServer::SetMetadataFromBuffer(const char *buffer, unsigned int siz
   RefreshMetadata();
 }
 
-void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
-  if ( (flag & ANNOUNCEMENT::Player) && strcmp(sender, "xbmc") == 0)
+  if ( (flag & ANNOUNCEMENT::Player) && sender == "xbmc")
   {
-    if ((strcmp(message, "OnPlay") == 0 || strcmp(message, "OnResume") == 0) && m_streamStarted)
+    if ((message == "OnPlay" || message == "OnResume") && m_streamStarted)
     {
       RefreshMetadata();
       RefreshCoverArt();
@@ -174,14 +174,14 @@ void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *
         m_pDACP->Play();
     }
 
-    if (strcmp(message, "OnStop") == 0 && m_streamStarted)
+    if (message == "OnStop" && m_streamStarted)
     {
       CSingleLock lock(m_dacpLock);
       if (m_pDACP)
         m_pDACP->Stop();
     }
 
-    if (strcmp(message, "OnPause") == 0 && m_streamStarted)
+    if (message == "OnPause" && m_streamStarted)
     {
       CSingleLock lock(m_dacpLock);
       if (m_pDACP)

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -168,7 +168,8 @@ void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                                const std::string& message,
                                const CVariant& data)
 {
-  if ((flag & ANNOUNCEMENT::Player) && sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
+  if ((flag & ANNOUNCEMENT::Player) &&
+      sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
   {
     if ((message == "OnPlay" || message == "OnResume") && m_streamStarted)
     {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -11,35 +11,37 @@
 
 #include "AirTunesServer.h"
 
-#include <map>
-#include <string>
-#include <utility>
-
 #include "Application.h"
-#include "ServiceBroker.h"
-#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h"
+#include "CompileInfo.h"
 #include "FileItem.h"
+#include "GUIInfoManager.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h"
 #include "filesystem/File.h"
 #include "filesystem/PipeFile.h"
-#include "GUIInfoManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/tags/MusicInfoTag.h"
-#include "network/dacp/dacp.h"
 #include "network/Network.h"
 #include "network/Zeroconf.h"
 #include "network/ZeroconfBrowser.h"
+#include "network/dacp/dacp.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "URL.h"
 #include "utils/EndianSwap.h"
-#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
+
+#include <map>
+#include <string>
+#include <utility>
 
 #if !defined(TARGET_WINDOWS)
 #pragma GCC diagnostic ignored "-Wwrite-strings"
@@ -166,7 +168,7 @@ void CAirTunesServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                                const std::string& message,
                                const CVariant& data)
 {
-  if ((flag & ANNOUNCEMENT::Player) && sender == "xbmc")
+  if ((flag & ANNOUNCEMENT::Player) && sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
   {
     if ((message == "OnPlay" || message == "OnResume") && m_streamStarted)
     {

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -34,7 +34,10 @@ class CAirTunesServer : public ANNOUNCEMENT::IAnnouncer, public IActionListener,
 {
 public:
   // ANNOUNCEMENT::IAnnouncer
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   void RegisterActionListener(bool doRegister);
   static void EnableActionProcessing(bool enable);

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -34,7 +34,7 @@ class CAirTunesServer : public ANNOUNCEMENT::IAnnouncer, public IActionListener,
 {
 public:
   // ANNOUNCEMENT::IAnnouncer
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
   void RegisterActionListener(bool doRegister);
   static void EnableActionProcessing(bool enable);

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -222,7 +222,7 @@ int CTCPServer::GetCapabilities()
   return Response | Announcing;
 }
 
-void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   std::string str = IJSONRPCAnnouncer::AnnouncementToJSONRPC(flag, sender, message, data, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_jsonOutputCompact);
 

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -222,7 +222,10 @@ int CTCPServer::GetCapabilities()
   return Response | Announcing;
 }
 
-void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                          const std::string& sender,
+                          const std::string& message,
+                          const CVariant& data)
 {
   std::string str = IJSONRPCAnnouncer::AnnouncementToJSONRPC(flag, sender, message, data, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_jsonOutputCompact);
 

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -36,7 +36,11 @@ namespace JSONRPC
     bool Download(const char *path, CVariant &result) override;
     int GetCapabilities() override;
 
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string&message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const CVariant& data) override;
+
   protected:
     void Process() override;
   private:

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -36,7 +36,7 @@ namespace JSONRPC
     bool Download(const char *path, CVariant &result) override;
     int GetCapabilities() override;
 
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string&message, const CVariant &data) override;
   protected:
     void Process() override;
   private:

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -230,9 +230,9 @@ CUPnPRenderer::ProcessHttpGetRequest(NPT_HttpRequest&              request,
 |   CUPnPRenderer::Announce
 +---------------------------------------------------------------------*/
 void
-CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
-    if (strcmp(sender, "xbmc") != 0)
+    if (sender != "xbmc")
       return;
 
     NPT_AutoLock lock(m_state);
@@ -241,7 +241,7 @@ CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender,
     if (flag == ANNOUNCEMENT::Player) {
         if (NPT_FAILED(FindServiceByType("urn:schemas-upnp-org:service:AVTransport:1", avt)))
             return;
-        if (strcmp(message, "OnPlay") == 0 || strcmp(message, "OnResume") == 0 ) {
+        if (message == "OnPlay" || message == "OnResume") {
             avt->SetStateVariable("AVTransportURI", g_application.CurrentFile().c_str());
             avt->SetStateVariable("CurrentTrackURI", g_application.CurrentFile().c_str());
 
@@ -258,16 +258,16 @@ CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender,
             avt->SetStateVariable("NextAVTransportURI", "");
             avt->SetStateVariable("NextAVTransportURIMetaData", "");
         }
-        else if (strcmp(message, "OnPause") == 0) {
+        else if (message == "OnPause") {
             int64_t speed = data["player"]["speed"].asInteger();
             avt->SetStateVariable("TransportPlaySpeed", NPT_String::FromInteger(speed != 0 ? speed : 1));
             avt->SetStateVariable("TransportState", "PAUSED_PLAYBACK");
         }
-        else if (strcmp(message, "OnSpeedChanged") == 0) {
+        else if (message == "OnSpeedChanged") {
             avt->SetStateVariable("TransportPlaySpeed", NPT_String::FromInteger(data["player"]["speed"].asInteger()));
         }
     }
-    else if (flag == ANNOUNCEMENT::Application && strcmp(message, "OnVolumeChanged") == 0) {
+    else if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged") {
         if (NPT_FAILED(FindServiceByType("urn:schemas-upnp-org:service:RenderingControl:1", rct)))
             return;
 

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -31,6 +31,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "xbmc/interfaces/AnnouncementManager.h"
 
 #include <inttypes.h>
 
@@ -234,7 +235,7 @@ void CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                              const std::string& message,
                              const CVariant& data)
 {
-  if (sender != "xbmc")
+  if (sender != ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
     return;
 
   NPT_AutoLock lock(m_state);

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -245,6 +245,7 @@ void CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   {
     if (NPT_FAILED(FindServiceByType("urn:schemas-upnp-org:service:AVTransport:1", avt)))
       return;
+
     if (message == "OnPlay" || message == "OnResume")
     {
       avt->SetStateVariable("AVTransportURI", g_application.CurrentFile().c_str());
@@ -276,22 +277,22 @@ void CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
       avt->SetStateVariable("TransportPlaySpeed",
                             NPT_String::FromInteger(data["player"]["speed"].asInteger()));
     }
-    }
-    else if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged")
-    {
-      if (NPT_FAILED(FindServiceByType("urn:schemas-upnp-org:service:RenderingControl:1", rct)))
-        return;
+  }
+  else if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged")
+  {
+    if (NPT_FAILED(FindServiceByType("urn:schemas-upnp-org:service:RenderingControl:1", rct)))
+      return;
 
-      std::string buffer;
+    std::string buffer;
 
-      buffer = StringUtils::Format("%" PRId64, data["volume"].asInteger());
-      rct->SetStateVariable("Volume", buffer.c_str());
+    buffer = StringUtils::Format("%" PRId64, data["volume"].asInteger());
+    rct->SetStateVariable("Volume", buffer.c_str());
 
-      buffer = StringUtils::Format("%" PRId64, 256 * (data["volume"].asInteger() * 60 - 60) / 100);
-      rct->SetStateVariable("VolumeDb", buffer.c_str());
+    buffer = StringUtils::Format("%" PRId64, 256 * (data["volume"].asInteger() * 60 - 60) / 100);
+    rct->SetStateVariable("VolumeDb", buffer.c_str());
 
-      rct->SetStateVariable("Mute", data["muted"].asBoolean() ? "1" : "0");
-    }
+    rct->SetStateVariable("Mute", data["muted"].asBoolean() ? "1" : "0");
+  }
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -34,7 +34,7 @@ public:
 
     ~CUPnPRenderer() override;
 
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
     void UpdateState();
 
     // Http server handler

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -34,7 +34,10 @@ public:
 
     ~CUPnPRenderer() override;
 
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const CVariant& data) override;
     void UpdateState();
 
     // Http server handler

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -410,26 +410,30 @@ failure:
 /*----------------------------------------------------------------------
 |   CUPnPServer::Announce
 +---------------------------------------------------------------------*/
-void
-CUPnPServer::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CUPnPServer::Announce(AnnouncementFlag flag,
+                           const std::string& sender,
+                           const std::string& message,
+                           const CVariant& data)
 {
     NPT_String path;
     int item_id;
     std::string item_type;
 
     if (sender != "xbmc")
-        return;
+      return;
 
-    if (message != "OnUpdate" && message != "OnRemove"
-        && message != "OnScanStarted" && message != "OnScanFinished")
-        return;
+    if (message != "OnUpdate" && message != "OnRemove" && message != "OnScanStarted" &&
+        message != "OnScanFinished")
+      return;
 
     if (data.isNull()) {
-        if (message == "OnScanStarted" || message == "OnCleanStarted") {
-            m_scanning = true;
+      if (message == "OnScanStarted" || message == "OnCleanStarted")
+      {
+        m_scanning = true;
         }
-        else if (message == "OnScanFinished" || message == "OnCleanFinished") {
-            OnScanCompleted(flag);
+        else if (message == "OnScanFinished" || message == "OnCleanFinished")
+        {
+          OnScanCompleted(flag);
         }
     }
     else {

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -39,6 +39,7 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoThumbLoader.h"
 #include "view/GUIViewState.h"
+#include "xbmc/interfaces/AnnouncementManager.h"
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
@@ -419,7 +420,7 @@ void CUPnPServer::Announce(AnnouncementFlag flag,
     int item_id;
     std::string item_type;
 
-    if (sender != "xbmc")
+    if (sender != CAnnouncementManager::ANNOUNCEMENT_SENDER)
       return;
 
     if (message != "OnUpdate" && message != "OnRemove" && message != "OnScanStarted" &&
@@ -1089,7 +1090,8 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
               CVariant data;
               data["id"] = updated.GetVideoInfoTag()->m_iDbId;
               data["type"] = updated.GetVideoInfoTag()->m_type;
-              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                                 "OnUpdate", data);
             }
             updatelisting = true;
         }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -411,24 +411,24 @@ failure:
 |   CUPnPServer::Announce
 +---------------------------------------------------------------------*/
 void
-CUPnPServer::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+CUPnPServer::Announce(AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
     NPT_String path;
     int item_id;
     std::string item_type;
 
-    if (strcmp(sender, "xbmc"))
+    if (sender != "xbmc")
         return;
 
-    if (strcmp(message, "OnUpdate") && strcmp(message, "OnRemove")
-        && strcmp(message, "OnScanStarted") && strcmp(message, "OnScanFinished"))
+    if (message != "OnUpdate" && message != "OnRemove"
+        && message != "OnScanStarted" && message != "OnScanFinished")
         return;
 
     if (data.isNull()) {
-        if (!strcmp(message, "OnScanStarted") || !strcmp(message, "OnCleanStarted")) {
+        if (message == "OnScanStarted" || message == "OnCleanStarted") {
             m_scanning = true;
         }
-        else if (!strcmp(message, "OnScanFinished") || !strcmp(message, "OnCleanFinished")) {
+        else if (message == "OnScanFinished" || message == "OnCleanFinished") {
             OnScanCompleted(flag);
         }
     }

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -31,7 +31,7 @@ class CUPnPServer : public PLT_MediaConnect,
 public:
     CUPnPServer(const char* friendly_name, const char* uuid = NULL, int port = 0);
     ~CUPnPServer() override;
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
     // PLT_MediaServer methods
     NPT_Result OnBrowseMetadata(PLT_ActionReference&          action,

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -31,7 +31,10 @@ class CUPnPServer : public PLT_MediaConnect,
 public:
     CUPnPServer(const char* friendly_name, const char* uuid = NULL, int port = 0);
     ~CUPnPServer() override;
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const CVariant& data) override;
 
     // PLT_MediaServer methods
     NPT_Result OnBrowseMetadata(PLT_ActionReference&          action,

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -8,6 +8,7 @@
 
 #include "Peripherals.h"
 
+#include "CompileInfo.h"
 #include "EventScanner.h"
 #include "addons/AddonButtonMap.h"
 #include "addons/AddonManager.h"
@@ -1012,7 +1013,7 @@ void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                             const std::string& message,
                             const CVariant& data)
 {
-  if (flag == ANNOUNCEMENT::Player && sender == "xbmc")
+  if (flag == ANNOUNCEMENT::Player && sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
   {
     if (message == "OnQuit")
     {

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -1013,7 +1013,8 @@ void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                             const std::string& message,
                             const CVariant& data)
 {
-  if (flag == ANNOUNCEMENT::Player && sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
+  if (flag == ANNOUNCEMENT::Player &&
+      sender == ANNOUNCEMENT::CAnnouncementManager::ANNOUNCEMENT_SENDER)
   {
     if (message == "OnQuit")
     {

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -1007,14 +1007,11 @@ int CPeripherals::GetMessageMask()
   return TMSG_MASK_PERIPHERALS;
 }
 
-void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                            const char* sender,
-                            const char* message,
-                            const CVariant& data)
+void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
-  if (flag == ANNOUNCEMENT::Player && strcmp(sender, "xbmc") == 0)
+  if (flag == ANNOUNCEMENT::Player && sender == "xbmc")
   {
-    if (strcmp(message, "OnQuit") == 0)
+    if (message == "OnQuit")
     {
       if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
               CSettings::SETTING_INPUT_CONTROLLERPOWEROFF))

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -1007,7 +1007,10 @@ int CPeripherals::GetMessageMask()
   return TMSG_MASK_PERIPHERALS;
 }
 
-void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CPeripherals::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                            const std::string& sender,
+                            const std::string& message,
+                            const CVariant& data)
 {
   if (flag == ANNOUNCEMENT::Player && sender == "xbmc")
   {

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -326,10 +326,7 @@ public:
   int GetMessageMask() override;
 
   // implementation of IAnnouncer
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                const char* sender,
-                const char* message,
-                const CVariant& data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
   /*!
    * \brief Access the input manager passed to the constructor

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -326,7 +326,10 @@ public:
   int GetMessageMask() override;
 
   // implementation of IAnnouncer
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   /*!
    * \brief Access the input manager passed to the constructor

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -118,21 +118,16 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_configuration.Clear();
 }
 
-void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                                     const char* sender,
-                                     const char* message,
-                                     const CVariant& data)
+void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
-  if (flag == ANNOUNCEMENT::System && !strcmp(sender, "xbmc") && !strcmp(message, "OnQuit") &&
-      m_bIsReady)
+  if (flag == ANNOUNCEMENT::System && sender == "xbmc" && message == "OnQuit" && m_bIsReady)
   {
     CSingleLock lock(m_critSection);
     m_iExitCode = static_cast<int>(data["exitcode"].asInteger(EXITCODE_QUIT));
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
     StopThread(false);
   }
-  else if (flag == ANNOUNCEMENT::GUI && !strcmp(sender, "xbmc") &&
-           !strcmp(message, "OnScreensaverDeactivated") && m_bIsReady)
+  else if (flag == ANNOUNCEMENT::GUI && sender == "xbmc") && message == "OnScreensaverDeactivated" && m_bIsReady)
   {
     bool bIgnoreDeactivate(false);
     if (data["shuttingdown"].isBoolean())
@@ -150,8 +145,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
       ActivateSource();
     }
   }
-  else if (flag == ANNOUNCEMENT::GUI && !strcmp(sender, "xbmc") &&
-           !strcmp(message, "OnScreensaverActivated") && m_bIsReady)
+  else if (flag == ANNOUNCEMENT::GUI && sender == "xbmc" && message == "OnScreensaverActivated" && m_bIsReady)
   {
     // Don't put devices to standby if application is currently playing
     if (!g_application.GetAppPlayer().IsPlaying() && m_bPowerOffScreensaver)
@@ -161,7 +155,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
         StandbyDevices();
     }
   }
-  else if (flag == ANNOUNCEMENT::System && !strcmp(sender, "xbmc") && !strcmp(message, "OnSleep"))
+  else if (flag == ANNOUNCEMENT::System && sender == "xbmc" && message == "OnSleep")
   {
     // this will also power off devices when we're the active source
     {
@@ -170,7 +164,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     }
     StopThread();
   }
-  else if (flag == ANNOUNCEMENT::System && !strcmp(sender, "xbmc") && !strcmp(message, "OnWake"))
+  else if (flag == ANNOUNCEMENT::System && sender == "xbmc" && message == "OnWake")
   {
     CLog::Log(LOGDEBUG, "%s - reconnecting to the CEC adapter after standby mode", __FUNCTION__);
     if (ReopenConnection())
@@ -185,14 +179,13 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
         ActivateSource();
     }
   }
-  else if (flag == ANNOUNCEMENT::Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnStop"))
+  else if (flag == ANNOUNCEMENT::Player && sender == "xbmc" && message == "OnStop")
   {
     CSingleLock lock(m_critSection);
     m_preventActivateSourceOnPlay = CDateTime::GetCurrentDateTime();
     m_bOnPlayReceived = false;
   }
-  else if (flag == ANNOUNCEMENT::Player && !strcmp(sender, "xbmc") &&
-           (!strcmp(message, "OnPlay") || !strcmp(message, "OnResume")))
+  else if (flag == ANNOUNCEMENT::Player && sender == "xbmc" && (message == "OnPlay") || message == "OnResume"))
   {
     // activate the source when playback started, and the option is enabled
     bool bActivateSource(false);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -118,7 +118,10 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_configuration.Clear();
 }
 
-void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                     const std::string& sender,
+                                     const std::string& message,
+                                     const CVariant& data)
 {
   if (flag == ANNOUNCEMENT::System && sender == "xbmc" && message == "OnQuit" && m_bIsReady)
   {
@@ -145,7 +148,8 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const 
       ActivateSource();
     }
   }
-  else if (flag == ANNOUNCEMENT::GUI && sender == "xbmc" && message == "OnScreensaverActivated" && m_bIsReady)
+  else if (flag == ANNOUNCEMENT::GUI && sender == "xbmc" && message == "OnScreensaverActivated" &&
+           m_bIsReady)
   {
     // Don't put devices to standby if application is currently playing
     if (!g_application.GetAppPlayer().IsPlaying() && m_bPowerOffScreensaver)
@@ -185,7 +189,8 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const 
     m_preventActivateSourceOnPlay = CDateTime::GetCurrentDateTime();
     m_bOnPlayReceived = false;
   }
-  else if (flag == ANNOUNCEMENT::Player && sender == "xbmc" && (message == "OnPlay") || message == "OnResume"))
+  else if (flag == ANNOUNCEMENT::Player && sender == "xbmc" && (message == "OnPlay") ||
+           message == "OnResume"))
   {
     // activate the source when playback started, and the option is enabled
     bool bActivateSource(false);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -89,10 +89,7 @@ public:
                         CPeripheralBus* bus);
   ~CPeripheralCecAdapter(void) override;
 
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                const char* sender,
-                const char* message,
-                const CVariant& data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
   // audio control
   bool HasAudioControl(void);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -39,9 +39,6 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "view/GUIViewState.h"
-
-#define CONTROL_BTNVIEWASICONS      2
-#define CONTROL_BTNSORTBY           3
 #define CONTROL_BTNSORTASC          4
 #define CONTROL_LABELFILES         12
 
@@ -342,7 +339,8 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
     CVariant param;
     param["player"]["speed"] = 1;
     param["player"]["playerid"] = PLAYLIST_PICTURE;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", pSlideShow->GetCurrentSlide(), param);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
+                                                       pSlideShow->GetCurrentSlide(), param);
   }
 
   m_slideShowStarted = true;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -151,7 +151,7 @@ void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)
   CVariant param;
   param["player"]["speed"] = m_bSlideShow && !m_bPause ? 1 : 0;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", item, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay", item, param);
 }
 
 void CGUIWindowSlideShow::AnnouncePlayerPause(const CFileItemPtr& item)
@@ -159,7 +159,7 @@ void CGUIWindowSlideShow::AnnouncePlayerPause(const CFileItemPtr& item)
   CVariant param;
   param["player"]["speed"] = 0;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPause", item, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPause", item, param);
 }
 
 void CGUIWindowSlideShow::AnnouncePlayerStop(const CFileItemPtr& item)
@@ -167,14 +167,14 @@ void CGUIWindowSlideShow::AnnouncePlayerStop(const CFileItemPtr& item)
   CVariant param;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
   param["end"] = true;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnStop", item, param);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnStop", item, param);
 }
 
 void CGUIWindowSlideShow::AnnouncePlaylistClear()
 {
   CVariant data;
   data["playlistid"] = PLAYLIST_PICTURE;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnClear", data);
 }
 
 void CGUIWindowSlideShow::AnnouncePlaylistAdd(const CFileItemPtr& item, int pos)
@@ -182,7 +182,7 @@ void CGUIWindowSlideShow::AnnouncePlaylistAdd(const CFileItemPtr& item, int pos)
   CVariant data;
   data["playlistid"] = PLAYLIST_PICTURE;
   data["position"] = pos;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnAdd", item, data);
 }
 
 void CGUIWindowSlideShow::AnnouncePropertyChanged(const std::string &strProperty, const CVariant &value)
@@ -193,7 +193,8 @@ void CGUIWindowSlideShow::AnnouncePropertyChanged(const std::string &strProperty
   CVariant data;
   data["player"]["playerid"] = PLAYLIST_PICTURE;
   data["property"][strProperty] = value;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPropertyChanged",
+                                                     data);
 }
 
 bool CGUIWindowSlideShow::IsPlaying() const
@@ -1251,7 +1252,8 @@ void CGUIWindowSlideShow::RunSlideShow(const std::string &strPath,
     CVariant param;
     param["player"]["speed"] = 0;
     param["player"]["playerid"] = PLAYLIST_PICTURE;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", GetCurrentSlide(), param);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
+                                                       GetCurrentSlide(), param);
   }
 
   CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -167,34 +167,34 @@ CXBMCApp::~CXBMCApp()
   delete m_wakeLock;
 }
 
-void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
-  if (strcmp(sender, "xbmc") != 0)
+  if (sender != "xbmc")
     return;
 
   if (flag & Input)
   {
-    if (strcmp(message, "OnInputRequested") == 0)
+    if (message == "OnInputRequested")
       CAndroidKey::SetHandleSearchKeys(true);
-    else if (strcmp(message, "OnInputFinished") == 0)
+    else if (message == "OnInputFinished")
       CAndroidKey::SetHandleSearchKeys(false);
   }
   else if (flag & Player)
   {
-    if (strcmp(message, "OnPlay") == 0 || strcmp(message, "OnResume") == 0)
+    if (message == "OnPlay" || message == "OnResume")
       OnPlayBackStarted();
-    else if (strcmp(message, "OnPause") == 0)
+    else if (message == "OnPause")
       OnPlayBackPaused();
-    else if (strcmp(message, "OnStop") == 0)
+    else if (message == "OnStop")
       OnPlayBackStopped();
-    else if (strcmp(message, "OnSeek") == 0)
+    else if (message == "OnSeek")
       UpdateSessionState();
-    else if (strcmp(message, "OnSpeedChanged") == 0)
+    else if (message == "OnSpeedChanged")
       UpdateSessionState();
   }
   else if (flag & Info)
   {
-     if (strcmp(message, "OnChanged") == 0)
+     if (message == "OnChanged")
       UpdateSessionMetadata();
   }
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -167,7 +167,10 @@ CXBMCApp::~CXBMCApp()
   delete m_wakeLock;
 }
 
-void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                        const std::string& sender,
+                        const std::string& message,
+                        const CVariant& data)
 {
   if (sender != "xbmc")
     return;
@@ -194,7 +197,7 @@ void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& 
   }
   else if (flag & Info)
   {
-     if (message == "OnChanged")
+    if (message == "OnChanged")
       UpdateSessionMetadata();
   }
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -172,7 +172,7 @@ void CXBMCApp::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                         const std::string& message,
                         const CVariant& data)
 {
-  if (sender != "xbmc")
+  if (sender != CAnnouncementManager::ANNOUNCEMENT_SENDER)
     return;
 
   if (flag & Input)

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -90,7 +90,7 @@ public:
   static CXBMCApp* get() { return m_xbmcappinstance; }
 
   // IAnnouncer IF
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char* sender, const char* message, const CVariant& data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant& data) override;
 
   void onReceive(CJNIIntent intent) override;
   void onNewIntent(CJNIIntent intent) override;

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -90,7 +90,10 @@ public:
   static CXBMCApp* get() { return m_xbmcappinstance; }
 
   // IAnnouncer IF
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant& data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   void onReceive(CJNIIntent intent) override;
   void onNewIntent(CJNIIntent intent) override;

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.h
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.h
@@ -21,8 +21,8 @@ public:
   void DeInitialize();
 
   void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                const char* sender,
-                const char* message,
+                const std::string& sender,
+                const std::string& message,
                 const CVariant& data) override;
 
 private:

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -78,8 +78,8 @@ id objectFromVariant(const CVariant& data)
 }
 
 void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
-                    const char* sender,
-                    const char* message,
+                    const std::string& sender,
+                    const std::string& message,
                     const CVariant& data)
 {
   int item_id = -1;
@@ -215,8 +215,8 @@ void CAnnounceReceiver::DeInitialize()
 }
 
 void CAnnounceReceiver::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                                 const char* sender,
-                                 const char* message,
+                                 const std::string& sender,
+                                 const std::string& message,
                                  const CVariant& data)
 {
   // can be called from c++, we need an auto poll here.

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -49,7 +49,7 @@ void CPlayList::AnnounceRemove(int pos)
   CVariant data;
   data["playlistid"] = m_id;
   data["position"] = pos;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnRemove", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnRemove", data);
 }
 
 void CPlayList::AnnounceClear()
@@ -59,7 +59,7 @@ void CPlayList::AnnounceClear()
 
   CVariant data;
   data["playlistid"] = m_id;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnClear", data);
 }
 
 void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
@@ -70,7 +70,7 @@ void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
   CVariant data;
   data["playlistid"] = m_id;
   data["position"] = pos;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnAdd", item, data);
 }
 
 void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -124,7 +124,7 @@ bool CPowerManager::Reboot()
 
   if (success)
   {
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnRestart");
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnRestart");
 
     CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
     if (dialog)
@@ -169,7 +169,7 @@ void CPowerManager::ProcessEvents()
 
 void CPowerManager::OnSleep()
 {
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnSleep");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnSleep");
 
   CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
   if (dialog)
@@ -216,7 +216,7 @@ void CPowerManager::OnWake()
   CServiceBroker::GetPVRManager().OnWake();
   RestorePlayerState();
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnWake");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnWake");
 }
 
 void CPowerManager::OnLowBattery()
@@ -225,7 +225,7 @@ void CPowerManager::OnLowBattery()
 
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13050), "");
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnLowBattery");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnLowBattery");
 }
 
 void CPowerManager::StorePlayerState()

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -203,16 +203,16 @@ CPVRManager::~CPVRManager()
   CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager instance destroyed");
 }
 
-void CPVRManager::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char* sender, const char* message, const CVariant& data)
+void CPVRManager::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant& data)
 {
   if (!IsStarted())
     return;
 
   if ((flag & (ANNOUNCEMENT::GUI)))
   {
-    if (strcmp(message, "OnScreensaverActivated") == 0)
+    if (message == "OnScreensaverActivated")
       m_addons->OnPowerSavingActivated();
-    else if (strcmp(message, "OnScreensaverDeactivated") == 0)
+    else if (message == "OnScreensaverDeactivated")
       m_addons->OnPowerSavingDeactivated();
   }
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -203,7 +203,10 @@ CPVRManager::~CPVRManager()
   CLog::LogFC(LOGDEBUG, LOGPVR, "PVR Manager instance destroyed");
 }
 
-void CPVRManager::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant& data)
+void CPVRManager::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                           const std::string& sender,
+                           const std::string& message,
+                           const CVariant& data)
 {
   if (!IsStarted())
     return;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -97,7 +97,7 @@ namespace PVR
      */
     ~CPVRManager() override;
 
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char* sender, const char* message, const CVariant& data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant& data) override;
 
     /*!
      * @brief Get the channel groups container.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -97,7 +97,10 @@ namespace PVR
      */
     ~CPVRManager() override;
 
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant& data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                  const std::string& sender,
+                  const std::string& message,
+                  const CVariant& data) override;
 
     /*!
      * @brief Get the channel groups container.

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -349,7 +349,7 @@ void CMediaSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
     return;
 
   if (setting->GetId() == CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnRefresh");
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnRefresh");
 }
 
 int CMediaSettings::GetWatchedMode(const std::string &content) const

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -104,7 +104,8 @@ void CSaveFileState::DoWork(CFileItem& item,
                 CVariant data;
                 data["id"] = item.GetVideoInfoTag()->m_iDbId;
                 data["type"] = item.GetVideoInfoTag()->m_type;
-                CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+                CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                                   "OnUpdate", data);
               }
             }
           }
@@ -128,7 +129,8 @@ void CSaveFileState::DoWork(CFileItem& item,
               CVariant data;
               data["id"] = item.GetVideoInfoTag()->m_iDbId;
               data["type"] = item.GetVideoInfoTag()->m_type;
-              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+              CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                                 "OnUpdate", data);
             }
 
             updateListing = true;
@@ -195,7 +197,8 @@ void CSaveFileState::DoWork(CFileItem& item,
             CVariant data;
             data["id"] = item.GetMusicInfoTag()->GetDatabaseId();
             data["type"] = item.GetMusicInfoTag()->GetType();
-            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
+            CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary,
+                                                               "OnUpdate", data);
           }
         }
       }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5919,7 +5919,8 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
       // Only provide the "playcount" value if it has actually changed
       if (item.GetVideoInfoTag()->GetPlayCount() != count)
         data["playcount"] = count;
-      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", CFileItemPtr(new CFileItem(item)), data);
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnUpdate",
+                                                         CFileItemPtr(new CFileItem(item)), data);
     }
   }
   catch (...)
@@ -8972,7 +8973,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
     unsigned int time = XbmcThreads::SystemClockMillis();
     CLog::Log(LOGINFO, "%s: Starting videodatabase cleanup ..", __FUNCTION__);
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanStarted");
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                       "OnCleanStarted");
 
     BeginTransaction();
 
@@ -9083,7 +9085,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
         {
           progress->Close();
           m_pDS2->close();
-          CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+          CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                             "OnCleanFinished");
           return;
         }
       }
@@ -9325,7 +9328,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
   if (progress)
     progress->Close();
 
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnCleanFinished");
 }
 
 std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
@@ -10044,7 +10047,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       if (iFailCount > 0)
         data["failcount"] = iFailCount;
     }
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnExport", data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnExport",
+                                                       data);
   }
   catch (...)
   {
@@ -10455,7 +10459,7 @@ void CVideoDatabase::AnnounceRemove(std::string content, int id, bool scanning /
   data["id"] = id;
   if (scanning)
     data["transaction"] = true;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnRemove", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnRemove", data);
 }
 
 void CVideoDatabase::AnnounceUpdate(std::string content, int id)
@@ -10463,7 +10467,7 @@ void CVideoDatabase::AnnounceUpdate(std::string content, int id)
   CVariant data;
   data["type"] = content;
   data["id"] = id;
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnUpdate", data);
 }
 
 bool CVideoDatabase::GetItemsForPath(const std::string &content, const std::string &strPath, CFileItemList &items)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -105,7 +105,8 @@ namespace VIDEO
       m_bCanInterrupt = true;
 
       CLog::Log(LOGINFO, "VideoInfoScanner: Starting scan ..");
-      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanStarted");
+      CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                         "OnScanStarted");
 
       // Database operations should not be canceled
       // using Interrupt() while scanning as it could
@@ -165,7 +166,8 @@ namespace VIDEO
     }
 
     m_bRunning = false;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanFinished");
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
+                                                       "OnScanFinished");
 
     if (m_handle)
       m_handle->MarkFinished();
@@ -1407,7 +1409,8 @@ namespace VIDEO
     data["added"] = true;
     if (m_bRunning)
       data["transaction"] = true;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", itemCopy, data);
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnUpdate",
+                                                       itemCopy, data);
     return lResult;
   }
 

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -599,7 +599,7 @@ void CWinEventsWin10::OnSystemMediaButtonPressed(const SystemMediaTransportContr
   }
 }
 
-void CWinEventsWin10::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char * sender, const char * message, const CVariant & data)
+void CWinEventsWin10::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant & data)
 {
   if (flag & ANNOUNCEMENT::Player)
   {
@@ -610,22 +610,22 @@ void CWinEventsWin10::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *
     bool changed = false;
     MediaPlaybackStatus status = MediaPlaybackStatus::Changing;
 
-    if (strcmp(message, "OnPlay") == 0 || strcmp(message, "OnResume") == 0)
+    if (message == "OnPlay" || message == "OnResume")
     {
       changed = true;
       status = MediaPlaybackStatus::Playing;
     }
-    else if (strcmp(message, "OnStop") == 0)
+    else if (message == "OnStop")
     {
       changed = true;
       status = MediaPlaybackStatus::Stopped;
     }
-    else if (strcmp(message, "OnPause") == 0)
+    else if (message == "OnPause")
     {
       changed = true;
       status = MediaPlaybackStatus::Paused;
     }
-    else if (strcmp(message, "OnSpeedChanged") == 0)
+    else if (message == "OnSpeedChanged")
     {
       changed = true;
       status = speed != 0.0 ? MediaPlaybackStatus::Playing : MediaPlaybackStatus::Paused;

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -599,7 +599,10 @@ void CWinEventsWin10::OnSystemMediaButtonPressed(const SystemMediaTransportContr
   }
 }
 
-void CWinEventsWin10::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant & data)
+void CWinEventsWin10::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                               const std::string& sender,
+                               const std::string& message,
+                               const CVariant& data)
 {
   if (flag & ANNOUNCEMENT::Player)
   {

--- a/xbmc/windowing/win10/WinEventsWin10.h
+++ b/xbmc/windowing/win10/WinEventsWin10.h
@@ -57,7 +57,10 @@ public:
   static void OnSystemMediaButtonPressed(const winrt::Windows::Media::SystemMediaTransportControls&
                                        , const winrt::Windows::Media::SystemMediaTransportControlsButtonPressedEventArgs&);
   // IAnnouncer overrides
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
 private:
   friend class CWinSystemWin10;

--- a/xbmc/windowing/win10/WinEventsWin10.h
+++ b/xbmc/windowing/win10/WinEventsWin10.h
@@ -57,7 +57,7 @@ public:
   static void OnSystemMediaButtonPressed(const winrt::Windows::Media::SystemMediaTransportControls&
                                        , const winrt::Windows::Media::SystemMediaTransportControlsButtonPressedEventArgs&);
   // IAnnouncer overrides
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
 private:
   friend class CWinSystemWin10;

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -61,7 +61,7 @@ void CGUIWindowHome::OnInitWindow()
   CGUIWindow::OnInitWindow();
 }
 
-void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
 {
   int ra_flag = 0;
 
@@ -74,11 +74,11 @@ void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *s
   if (data.isMember("transaction") && data["transaction"].asBoolean())
     return;
 
-  if (strcmp(message, "OnScanStarted") == 0 ||
-      strcmp(message, "OnCleanStarted") == 0)
+  if (message == "OnScanStarted" ||
+      message == "OnCleanStarted")
     return;
 
-  bool onUpdate = strcmp(message, "OnUpdate") == 0;
+  bool onUpdate = message == "OnUpdate";
   // always update Totals except on an OnUpdate with no playcount update
   if (!onUpdate || data.isMember("playcount"))
     ra_flag |= Totals;

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -61,7 +61,10 @@ void CGUIWindowHome::OnInitWindow()
   CGUIWindow::OnInitWindow();
 }
 
-void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data)
+void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                              const std::string& sender,
+                              const std::string& message,
+                              const CVariant& data)
 {
   int ra_flag = 0;
 
@@ -74,8 +77,7 @@ void CGUIWindowHome::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::st
   if (data.isMember("transaction") && data["transaction"].asBoolean())
     return;
 
-  if (message == "OnScanStarted" ||
-      message == "OnCleanStarted")
+  if (message == "OnScanStarted" || message == "OnCleanStarted")
     return;
 
   bool onUpdate = message == "OnUpdate";

--- a/xbmc/windows/GUIWindowHome.h
+++ b/xbmc/windows/GUIWindowHome.h
@@ -23,7 +23,10 @@ public:
   CGUIWindowHome(void);
   ~CGUIWindowHome(void) override;
   void OnInitWindow() override;
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
 
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;

--- a/xbmc/windows/GUIWindowHome.h
+++ b/xbmc/windows/GUIWindowHome.h
@@ -23,7 +23,7 @@ public:
   CGUIWindowHome(void);
   ~CGUIWindowHome(void) override;
   void OnInitWindow() override;
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const std::string& sender, const std::string& message, const CVariant &data) override;
 
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;


### PR DESCRIPTION
## Description
In all Announcements "xbmc" was hardcoded as the sender.
Also the interface was using `const char*`.
This PR moves the interface to use `std::string` and introduces a constant
in `CAnnouncementManager`.
Additionally, as so much code just uses xbmc as a sender we offer new convenience methods
that imply the sender.

## Motivation and Context
Cleanup of const char* usage and getting rid of hardcoded "xbmc" strings.

## How Has This Been Tested?
Did a short test on linux.
Player notifications unchanged.
Actually no user facing functionality should change at all.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
