### PR TITLE
VAAPI: fix use after free in CVAAPIContext::DestroyContext

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -225,12 +225,19 @@ void CVAAPIContext::DestroyContext()
 {
   delete[] m_profiles;
   if (m_display)
-    CheckSuccess(vaTerminate(m_display), "vaTerminate");
-
+  {
+    if (CheckSuccess(vaTerminate(m_display), "vaTerminate"))
+    {
+      m_display = NULL;
+    }
+    else
+    {
 #if VA_CHECK_VERSION(1, 0, 0)
-  vaSetErrorCallback(m_display, nullptr, nullptr);
-  vaSetInfoCallback(m_display, nullptr, nullptr);
+      vaSetErrorCallback(m_display, nullptr, nullptr);
+      vaSetInfoCallback(m_display, nullptr, nullptr);
 #endif
+    }
+  }
 }
 
 void CVAAPIContext::QueryCaps()


### PR DESCRIPTION
Commit cfd59591f3f9 ("VAAPI: add error and info callbacks") added calls
into vaSetInfoCallback() and vaSetErrorCallback() in
CVAAPIContext::DestroyContext().

However, those calls are done after vaTerminate(m_display) which frees
the context, causing use after free.

Fix that by only performing the callback removal if vaTerminate() fails.

Also, set m_display to NULL after a successful vaTerminate() to avoid
similar issues being hidden in the future.
