### PR TITLE
Fix playback and OSD naming of DVD folders

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2696,6 +2696,7 @@ void CFileItemList::StackFolders()
           {
             // NOTE: should this be done for the CD# folders too?
             item->m_bIsFolder = false;
+            item->SetLabel(CUtil::GetTitleFromPath(GetPath(), true));
             item->SetPath(dvdPath);
             item->SetLabel2("");
             item->SetLabelPreformatted(true);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -488,6 +488,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     if (!mediapath.empty())
     {
       CFileItemPtr item(new CFileItem(mediapath, false));
+      item->SetLabel(CUtil::GetTitleFromPath(pItem->GetPath(), true));
       queuedItems.Add(item);
       return;
     }
@@ -1126,6 +1127,16 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   {
     item.SetPath(pItem->GetVideoInfoTag()->m_strFileNameAndPath);
     item.SetProperty("original_listitem_url", pItem->GetPath());
+  }
+  if (pItem->m_bIsFolder) {
+    // check if it's a folder with dvd or bluray files, then just add the relevant file
+    std::string mediapath(pItem->GetOpticalMediaPath());
+    if (!mediapath.empty())
+    {
+      item.m_bIsFolder = false;
+      item.SetLabel(CUtil::GetTitleFromPath(pItem->GetPath(), true));
+      item.SetPath(mediapath);
+    }
   }
   CLog::Log(LOGDEBUG, "%s %s", __FUNCTION__, CURL::GetRedacted(item.GetPath()).c_str());
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1046,7 +1046,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     }
   }
 
-  if (pItem->m_bIsFolder)
+  if (pItem->m_bIsFolder && pItem->GetOpticalMediaPath().empty())
   {
     if ( pItem->m_bIsShareOrDrive )
     {


### PR DESCRIPTION
Currently, playing a folder-structured DVD has two particular problems:

1. Pressing the Select/OK/Enter button on pretty much anything else plays it, but for DVD folders it instead navigates into the folder. You must press a different Play button to actually play it. After navigating back a level because the first attempt did the wrong thing, of course. (Or open the context menu if you happen to have a mouse/keyboard attached, which I generally don't.) Navigating into a DVD folder is pretty much never a useful thing to do, the contents are not individually selectable and playable, the folder itself is a singular individual unit of playable stuff.

2. Once playing, the OSD always calls the current DVD "VIDEO_TS.IFO", because of the internal redirection it does to that file when the folder is played. This is... less than helpful.

For (1) we nobble the is-it-a-folder check to say not if it's a DVD (GetOpticalMediaPath() returns non-empty).

For (2) whenever GetOpticalMediaPath() identifies a DVD structure, we save away the original name of the item in its label, before redirecting to the VIDEO_TS.IFO file.