### PR TITLE
Filesystem: Add ability to carry origin

### DIFF
--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -101,7 +101,10 @@ bool CDirectoryNode::GetNodeInfo(const std::string& strPath,
 }
 
 //  Create a node object
-CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type,
+                                           const std::string& strName,
+                                           CDirectoryNode* pParent,
+                                           const std::string& strOrigin)
 {
   switch (Type)
   {
@@ -251,7 +254,8 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   if (CanCache() && items.Load())
     return true;
 
-  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this, m_origin));
+  std::unique_ptr<CDirectoryNode> pNode(
+      CDirectoryNode::CreateNode(GetChildType(), "", this, m_origin));
 
   bool bSuccess=false;
   if (pNode)

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -32,11 +32,11 @@
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
 //  Constructor is protected use ParseURL()
-CDirectoryNode::CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent)
+CDirectoryNode::CDirectoryNode(NODE_TYPE Type,
+                               const std::string& strName,
+                               CDirectoryNode* pParent,
+                               const std::string& strOrigin) : m_Type(Type), m_strName(strName), m_pParent(pParent), m_origin(strOrigin)
 {
-  m_Type=Type;
-  m_strName=strName;
-  m_pParent=pParent;
 }
 
 CDirectoryNode::~CDirectoryNode()
@@ -61,7 +61,7 @@ CDirectoryNode* CDirectoryNode::ParseURL(const std::string& strPath)
 
   for (int i=0; i < static_cast<int>(Path.size()); ++i)
   {
-    pNode = CreateNode(NodeType, Path[i], pParent);
+    pNode = CreateNode(NodeType, Path[i], pParent, url.GetProtocol());
     NodeType = pNode ? pNode->GetChildType() : NODE_TYPE_NONE;
     pParent = pNode;
   }
@@ -101,43 +101,43 @@ bool CDirectoryNode::GetNodeInfo(const std::string& strPath,
 }
 
 //  Create a node object
-CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent)
+CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
 {
   switch (Type)
   {
   case NODE_TYPE_ROOT:
-    return new CDirectoryNodeRoot(strName, pParent);
+    return new CDirectoryNodeRoot(strName, pParent, strOrigin);
   case NODE_TYPE_OVERVIEW:
-    return new CDirectoryNodeOverview(strName, pParent);
+    return new CDirectoryNodeOverview(strName, pParent, strOrigin);
   case NODE_TYPE_GENRE:
   case NODE_TYPE_SOURCE:
   case NODE_TYPE_ROLE:
   case NODE_TYPE_YEAR:
-    return new CDirectoryNodeGrouped(Type, strName, pParent);
+    return new CDirectoryNodeGrouped(Type, strName, pParent, strOrigin);
   case NODE_TYPE_ARTIST:
-    return new CDirectoryNodeArtist(strName, pParent);
+    return new CDirectoryNodeArtist(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM:
-    return new CDirectoryNodeAlbum(strName, pParent);
+    return new CDirectoryNodeAlbum(strName, pParent, strOrigin);
   case NODE_TYPE_SONG:
-    return new CDirectoryNodeSong(strName, pParent);
+    return new CDirectoryNodeSong(strName, pParent, strOrigin);
   case NODE_TYPE_SINGLES:
-    return new CDirectoryNodeSingles(strName, pParent);
+    return new CDirectoryNodeSingles(strName, pParent, strOrigin);
   case NODE_TYPE_TOP100:
-    return new CDirectoryNodeTop100(strName, pParent);
+    return new CDirectoryNodeTop100(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM_TOP100:
-    return new CDirectoryNodeAlbumTop100(strName, pParent);
+    return new CDirectoryNodeAlbumTop100(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM_TOP100_SONGS:
-    return new CDirectoryNodeAlbumTop100Song(strName, pParent);
+    return new CDirectoryNodeAlbumTop100Song(strName, pParent, strOrigin);
   case NODE_TYPE_SONG_TOP100:
-    return new CDirectoryNodeSongTop100(strName, pParent);
+    return new CDirectoryNodeSongTop100(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM_RECENTLY_ADDED:
-    return new CDirectoryNodeAlbumRecentlyAdded(strName, pParent);
+    return new CDirectoryNodeAlbumRecentlyAdded(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS:
-    return new CDirectoryNodeAlbumRecentlyAddedSong(strName, pParent);
+    return new CDirectoryNodeAlbumRecentlyAddedSong(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
-    return new CDirectoryNodeAlbumRecentlyPlayed(strName, pParent);
+    return new CDirectoryNodeAlbumRecentlyPlayed(strName, pParent, strOrigin);
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS:
-    return new CDirectoryNodeAlbumRecentlyPlayedSong(strName, pParent);
+    return new CDirectoryNodeAlbumRecentlyPlayedSong(strName, pParent, strOrigin);
   default:
     break;
   }
@@ -204,7 +204,7 @@ std::string CDirectoryNode::BuildPath() const
     pParent=pParent->GetParent();
   }
 
-  std::string strPath="musicdb://";
+  std::string strPath = m_origin.empty() ? "musicdb://" : m_origin + "://";
   for (int i = 0; i < static_cast<int>(array.size()); ++i)
     strPath+=array[i]+"/";
 
@@ -251,7 +251,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   if (CanCache() && items.Load())
     return true;
 
-  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this));
+  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this, m_origin));
 
   bool bSuccess=false;
   if (pNode)

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -67,8 +67,8 @@ namespace XFILE
       std::string BuildPath() const;
 
     protected:
-      CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
-      static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
 
       void AddOptions(const std::string &options);
       void CollectQueryParams(CQueryParams& params) const;
@@ -84,6 +84,7 @@ namespace XFILE
       std::string m_strName;
       CDirectoryNode* m_pParent;
       CUrlOptions m_options;
+      std::string m_origin;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -67,8 +67,14 @@ namespace XFILE
       std::string BuildPath() const;
 
     protected:
-      CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
-      static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNode(NODE_TYPE Type,
+                     const std::string& strName,
+                     CDirectoryNode* pParent,
+                     const std::string& strOrigin);
+      static CDirectoryNode* CreateNode(NODE_TYPE Type,
+                                        const std::string& strName,
+                                        CDirectoryNode* pParent,
+                                        const std::string& strOrigin);
 
       void AddOptions(const std::string &options);
       void CollectQueryParams(CQueryParams& params) const;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -14,8 +14,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbum::CDirectoryNodeAlbum(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM, strName, pParent)
+CDirectoryNodeAlbum::CDirectoryNodeAlbum(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -14,7 +14,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbum::CDirectoryNodeAlbum(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbum::CDirectoryNodeAlbum(const std::string& strName,
+                                         CDirectoryNode* pParent,
+                                         const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbum : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbum(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbum(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbum : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbum(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbum(const std::string& strName,
+                          CDirectoryNode* pParent,
+                          const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -15,8 +15,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyAdded::CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_ADDED, strName, pParent)
+CDirectoryNodeAlbumRecentlyAdded::CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_ADDED, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -15,7 +15,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyAdded::CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbumRecentlyAdded::CDirectoryNodeAlbumRecentlyAdded(const std::string& strName,
+                                                                   CDirectoryNode* pParent,
+                                                                   const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_ADDED, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyAdded : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyAdded : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyAdded(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbumRecentlyAdded(const std::string& strName,
+                                       CDirectoryNode* pParent,
+                                       const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
@@ -12,7 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyAddedSong::CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbumRecentlyAddedSong::CDirectoryNodeAlbumRecentlyAddedSong(
+    const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyAddedSong::CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS, strName, pParent)
+CDirectoryNodeAlbumRecentlyAddedSong::CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyAddedSong : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyAddedSong : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbumRecentlyAddedSong(const std::string& strName,
+                                           CDirectoryNode* pParent,
+                                           const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -15,8 +15,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyPlayed::CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_PLAYED, strName, pParent)
+CDirectoryNodeAlbumRecentlyPlayed::CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_PLAYED, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -15,7 +15,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyPlayed::CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbumRecentlyPlayed::CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName,
+                                                                     CDirectoryNode* pParent,
+                                                                     const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_PLAYED, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyPlayed : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyPlayed : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbumRecentlyPlayed(const std::string& strName,
+                                        CDirectoryNode* pParent,
+                                        const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
@@ -12,7 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyPlayedSong::CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbumRecentlyPlayedSong::CDirectoryNodeAlbumRecentlyPlayedSong(
+    const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumRecentlyPlayedSong::CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS, strName, pParent)
+CDirectoryNodeAlbumRecentlyPlayedSong::CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyPlayedSong : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbumRecentlyPlayedSong : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbumRecentlyPlayedSong(const std::string& strName,
+                                            CDirectoryNode* pParent,
+                                            const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -14,7 +14,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumTop100::CDirectoryNodeAlbumTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbumTop100::CDirectoryNodeAlbumTop100(const std::string& strName,
+                                                     CDirectoryNode* pParent,
+                                                     const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM_TOP100, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -14,8 +14,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumTop100::CDirectoryNodeAlbumTop100(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM_TOP100, strName, pParent)
+CDirectoryNodeAlbumTop100::CDirectoryNodeAlbumTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM_TOP100, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbumTop100 : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumTop100(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbumTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbumTop100 : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbumTop100(const std::string& strName,
+                                CDirectoryNode* pParent,
+                                const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumTop100Song::CDirectoryNodeAlbumTop100Song(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ALBUM_TOP100_SONGS, strName, pParent)
+CDirectoryNodeAlbumTop100Song::CDirectoryNodeAlbumTop100Song(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ALBUM_TOP100_SONGS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
@@ -12,7 +12,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeAlbumTop100Song::CDirectoryNodeAlbumTop100Song(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeAlbumTop100Song::CDirectoryNodeAlbumTop100Song(const std::string& strName,
+                                                             CDirectoryNode* pParent,
+                                                             const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ALBUM_TOP100_SONGS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeAlbumTop100Song : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumTop100Song(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeAlbumTop100Song(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeAlbumTop100Song : public CDirectoryNode
     {
     public:
-      CDirectoryNodeAlbumTop100Song(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeAlbumTop100Song(const std::string& strName,
+                                    CDirectoryNode* pParent,
+                                    const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -17,8 +17,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeArtist::CDirectoryNodeArtist(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ARTIST, strName, pParent)
+CDirectoryNodeArtist::CDirectoryNodeArtist(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ARTIST, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -17,7 +17,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeArtist::CDirectoryNodeArtist(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeArtist::CDirectoryNodeArtist(const std::string& strName,
+                                           CDirectoryNode* pParent,
+                                           const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ARTIST, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeArtist : public CDirectoryNode
     {
     public:
-      CDirectoryNodeArtist(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeArtist(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeArtist : public CDirectoryNode
     {
     public:
-      CDirectoryNodeArtist(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeArtist(const std::string& strName,
+                           CDirectoryNode* pParent,
+                           const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -12,7 +12,10 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type,
+                                             const std::string& strName,
+                                             CDirectoryNode* pParent,
+                                             const std::string& strOrigin)
   : CDirectoryNode(type, strName, pParent, strOrigin)
 { }
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(type, strName, pParent)
+CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(type, strName, pParent, strOrigin)
 { }
 
 NODE_TYPE CDirectoryNodeGrouped::GetChildType() const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeGrouped : public CDirectoryNode
     {
     public:
-      CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.h
@@ -17,7 +17,11 @@ namespace XFILE
     class CDirectoryNodeGrouped : public CDirectoryNode
     {
     public:
-      CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeGrouped(NODE_TYPE type,
+                            const std::string& strName,
+                            CDirectoryNode* pParent,
+                            const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -36,8 +36,8 @@ namespace XFILE
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent)
+CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -36,7 +36,9 @@ namespace XFILE
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName,
+                                               CDirectoryNode* pParent,
+                                               const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeOverview(const std::string& strName,
+                             CDirectoryNode* pParent,
+                             const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.cpp
@@ -10,8 +10,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ROOT, strName, pParent)
+CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ROOT, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.cpp
@@ -10,7 +10,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName,
+                                       CDirectoryNode* pParent,
+                                       const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ROOT, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeRoot : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeRoot : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeRoot(const std::string& strName,
+                         CDirectoryNode* pParent,
+                         const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeSingles::CDirectoryNodeSingles(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_SINGLES, strName, pParent)
+CDirectoryNodeSingles::CDirectoryNodeSingles(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_SINGLES, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -12,7 +12,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeSingles::CDirectoryNodeSingles(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeSingles::CDirectoryNodeSingles(const std::string& strName,
+                                             CDirectoryNode* pParent,
+                                             const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_SINGLES, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeSingles : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSingles(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeSingles(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeSingles : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSingles(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeSingles(const std::string& strName,
+                            CDirectoryNode* pParent,
+                            const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
@@ -17,7 +17,7 @@ using namespace XFILE::MUSICDATABASEDIRECTORY;
 CDirectoryNodeSong::CDirectoryNodeSong(const std::string& strName,
                                        CDirectoryNode* pParent,
                                        const std::string& strOrigin)
-    : CDirectoryNode(NODE_TYPE_SONG, strName, pParent, strOrigin)
+  : CDirectoryNode(NODE_TYPE_SONG, strName, pParent, strOrigin)
 {
 }
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
@@ -9,14 +9,16 @@
 #include "DirectoryNodeSong.h"
 
 #include "QueryParams.h"
+#include "ServiceBroker.h"
 #include "music/MusicDatabase.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeSong::CDirectoryNodeSong(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_SONG, strName, pParent)
+CDirectoryNodeSong::CDirectoryNodeSong(const std::string& strName,
+                                       CDirectoryNode* pParent,
+                                       const std::string& strOrigin)
+    : CDirectoryNode(NODE_TYPE_SONG, strName, pParent, strOrigin)
 {
-
 }
 
 bool CDirectoryNodeSong::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeSong : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSong(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeSong(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeSong : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSong(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeSong(const std::string& strEntryName,
+                         CDirectoryNode* pParent,
+                         const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeSongTop100::CDirectoryNodeSongTop100(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_SONG_TOP100, strName, pParent)
+CDirectoryNodeSongTop100::CDirectoryNodeSongTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_SONG_TOP100, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
@@ -12,7 +12,9 @@
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
-CDirectoryNodeSongTop100::CDirectoryNodeSongTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeSongTop100::CDirectoryNodeSongTop100(const std::string& strName,
+                                                   CDirectoryNode* pParent,
+                                                   const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_SONG_TOP100, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeSongTop100 : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSongTop100(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeSongTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeSongTop100 : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSongTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeSongTop100(const std::string& strName,
+                               CDirectoryNode* pParent,
+                               const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -19,8 +19,8 @@ Node Top100Children[] = {
                           { NODE_TYPE_ALBUM_TOP100, "albums",  10505 },
                         };
 
-CDirectoryNodeTop100::CDirectoryNodeTop100(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_TOP100, strName, pParent)
+CDirectoryNodeTop100::CDirectoryNodeTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_TOP100, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -19,7 +19,9 @@ Node Top100Children[] = {
                           { NODE_TYPE_ALBUM_TOP100, "albums",  10505 },
                         };
 
-CDirectoryNodeTop100::CDirectoryNodeTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeTop100::CDirectoryNodeTop100(const std::string& strName,
+                                           CDirectoryNode* pParent,
+                                           const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_TOP100, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeTop100 : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTop100(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeTop100 : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTop100(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeTop100(const std::string& strName,
+                           CDirectoryNode* pParent,
+                           const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -87,7 +87,10 @@ void CDirectoryNode::GetDatabaseInfo(const std::string& strPath, CQueryParams& p
 }
 
 //  Create a node object
-CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type,
+                                           const std::string& strName,
+                                           CDirectoryNode* pParent,
+                                           const std::string& strOrigin)
 {
   switch (Type)
   {
@@ -242,7 +245,8 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   if (CanCache() && items.Load())
     return true;
 
-  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this, m_origin));
+  std::unique_ptr<CDirectoryNode> pNode(
+      CDirectoryNode::CreateNode(GetChildType(), "", this, m_origin));
 
   bool bSuccess=false;
   if (pNode)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -32,11 +32,11 @@
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
 //  Constructor is protected use ParseURL()
-CDirectoryNode::CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent)
+CDirectoryNode::CDirectoryNode(NODE_TYPE Type,
+                               const std::string& strName,
+                               CDirectoryNode* pParent,
+                               const std::string& strOrigin) : m_Type(Type), m_strName(strName), m_pParent(pParent), m_origin(strOrigin)
 {
-  m_Type = Type;
-  m_strName = strName;
-  m_pParent = pParent;
 }
 
 CDirectoryNode::~CDirectoryNode()
@@ -63,7 +63,7 @@ CDirectoryNode* CDirectoryNode::ParseURL(const std::string& strPath)
   // if we hit a child type of NODE_TYPE_NONE, then we are done.
   for (size_t i = 0; i < Path.size() && NodeType != NODE_TYPE_NONE; ++i)
   {
-    pNode = CDirectoryNode::CreateNode(NodeType, Path[i], pParent);
+    pNode = CDirectoryNode::CreateNode(NodeType, Path[i], pParent, url.GetProtocol());
     NodeType = pNode ? pNode->GetChildType() : NODE_TYPE_NONE;
     pParent = pNode;
   }
@@ -87,14 +87,14 @@ void CDirectoryNode::GetDatabaseInfo(const std::string& strPath, CQueryParams& p
 }
 
 //  Create a node object
-CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent)
+CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
 {
   switch (Type)
   {
   case NODE_TYPE_ROOT:
-    return new CDirectoryNodeRoot(strName, pParent);
+    return new CDirectoryNodeRoot(strName, pParent, strOrigin);
   case NODE_TYPE_OVERVIEW:
-    return new CDirectoryNodeOverview(strName, pParent);
+    return new CDirectoryNodeOverview(strName, pParent, strOrigin);
   case NODE_TYPE_GENRE:
   case NODE_TYPE_COUNTRY:
   case NODE_TYPE_SETS:
@@ -104,31 +104,31 @@ CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const std::string& st
   case NODE_TYPE_DIRECTOR:
   case NODE_TYPE_STUDIO:
   case NODE_TYPE_MUSICVIDEOS_ALBUM:
-    return new CDirectoryNodeGrouped(Type, strName, pParent);
+    return new CDirectoryNodeGrouped(Type, strName, pParent, strOrigin);
   case NODE_TYPE_TITLE_MOVIES:
-    return new CDirectoryNodeTitleMovies(strName, pParent);
+    return new CDirectoryNodeTitleMovies(strName, pParent, strOrigin);
   case NODE_TYPE_TITLE_TVSHOWS:
-    return new CDirectoryNodeTitleTvShows(strName, pParent);
+    return new CDirectoryNodeTitleTvShows(strName, pParent, strOrigin);
   case NODE_TYPE_MOVIES_OVERVIEW:
-    return new CDirectoryNodeMoviesOverview(strName, pParent);
+    return new CDirectoryNodeMoviesOverview(strName, pParent, strOrigin);
   case NODE_TYPE_TVSHOWS_OVERVIEW:
-    return new CDirectoryNodeTvShowsOverview(strName, pParent);
+    return new CDirectoryNodeTvShowsOverview(strName, pParent, strOrigin);
   case NODE_TYPE_SEASONS:
-    return new CDirectoryNodeSeasons(strName, pParent);
+    return new CDirectoryNodeSeasons(strName, pParent, strOrigin);
   case NODE_TYPE_EPISODES:
-    return new CDirectoryNodeEpisodes(strName, pParent);
+    return new CDirectoryNodeEpisodes(strName, pParent, strOrigin);
   case NODE_TYPE_RECENTLY_ADDED_MOVIES:
-    return new CDirectoryNodeRecentlyAddedMovies(strName,pParent);
+    return new CDirectoryNodeRecentlyAddedMovies(strName, pParent, strOrigin);
   case NODE_TYPE_RECENTLY_ADDED_EPISODES:
-    return new CDirectoryNodeRecentlyAddedEpisodes(strName,pParent);
+    return new CDirectoryNodeRecentlyAddedEpisodes(strName, pParent, strOrigin);
   case NODE_TYPE_MUSICVIDEOS_OVERVIEW:
-    return new CDirectoryNodeMusicVideosOverview(strName,pParent);
+    return new CDirectoryNodeMusicVideosOverview(strName, pParent, strOrigin);
   case NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS:
-    return new CDirectoryNodeRecentlyAddedMusicVideos(strName,pParent);
+    return new CDirectoryNodeRecentlyAddedMusicVideos(strName, pParent, strOrigin);
   case NODE_TYPE_INPROGRESS_TVSHOWS:
-    return new CDirectoryNodeInProgressTvShows(strName,pParent);
+    return new CDirectoryNodeInProgressTvShows(strName, pParent, strOrigin);
   case NODE_TYPE_TITLE_MUSICVIDEOS:
-    return new CDirectoryNodeTitleMusicVideos(strName,pParent);
+    return new CDirectoryNodeTitleMusicVideos(strName, pParent, strOrigin);
   default:
     break;
   }
@@ -242,7 +242,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   if (CanCache() && items.Load())
     return true;
 
-  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this));
+  std::unique_ptr<CDirectoryNode> pNode(CDirectoryNode::CreateNode(GetChildType(), "", this, m_origin));
 
   bool bSuccess=false;
   if (pNode)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -73,8 +73,8 @@ namespace XFILE
 
       virtual bool CanCache() const;
     protected:
-      CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
-      static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
 
       void AddOptions(const std::string &options);
       void CollectQueryParams(CQueryParams& params) const;
@@ -91,6 +91,7 @@ namespace XFILE
       std::string m_strName;
       CDirectoryNode* m_pParent;
       CUrlOptions m_options;
+      std::string m_origin;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -73,8 +73,14 @@ namespace XFILE
 
       virtual bool CanCache() const;
     protected:
-      CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
-      static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNode(NODE_TYPE Type,
+                     const std::string& strName,
+                     CDirectoryNode* pParent,
+                     const std::string& strOrigin);
+      static CDirectoryNode* CreateNode(NODE_TYPE Type,
+                                        const std::string& strName,
+                                        CDirectoryNode* pParent,
+                                        const std::string& strOrigin);
 
       void AddOptions(const std::string &options);
       void CollectQueryParams(CQueryParams& params) const;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -13,7 +13,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeEpisodes::CDirectoryNodeEpisodes(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeEpisodes::CDirectoryNodeEpisodes(const std::string& strName,
+                                               CDirectoryNode* pParent,
+                                               const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_EPISODES, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -13,8 +13,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeEpisodes::CDirectoryNodeEpisodes(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_EPISODES, strName, pParent)
+CDirectoryNodeEpisodes::CDirectoryNodeEpisodes(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_EPISODES, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeEpisodes : public CDirectoryNode
     {
     public:
-      CDirectoryNodeEpisodes(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeEpisodes(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
       NODE_TYPE GetChildType() const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeEpisodes : public CDirectoryNode
     {
     public:
-      CDirectoryNodeEpisodes(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeEpisodes(const std::string& strEntryName,
+                             CDirectoryNode* pParent,
+                             const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
       NODE_TYPE GetChildType() const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -14,7 +14,10 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type,
+                                             const std::string& strName,
+                                             CDirectoryNode* pParent,
+                                             const std::string& strOrigin)
   : CDirectoryNode(type, strName, pParent, strOrigin)
 { }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -14,8 +14,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(type, strName, pParent)
+CDirectoryNodeGrouped::CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(type, strName, pParent, strOrigin)
 { }
 
 NODE_TYPE CDirectoryNodeGrouped::GetChildType() const

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeGrouped : public CDirectoryNode
     {
     public:
-      CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.h
@@ -17,7 +17,11 @@ namespace XFILE
     class CDirectoryNodeGrouped : public CDirectoryNode
     {
     public:
-      CDirectoryNodeGrouped(NODE_TYPE type, const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeGrouped(NODE_TYPE type,
+                            const std::string& strName,
+                            CDirectoryNode* pParent,
+                            const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeInProgressTvShows::CDirectoryNodeInProgressTvShows(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_INPROGRESS_TVSHOWS, strName, pParent)
+CDirectoryNodeInProgressTvShows::CDirectoryNodeInProgressTvShows(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_INPROGRESS_TVSHOWS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
@@ -12,7 +12,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeInProgressTvShows::CDirectoryNodeInProgressTvShows(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeInProgressTvShows::CDirectoryNodeInProgressTvShows(const std::string& strName,
+                                                                 CDirectoryNode* pParent,
+                                                                 const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_INPROGRESS_TVSHOWS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeInProgressTvShows : public CDirectoryNode
     {
     public:
-      CDirectoryNodeInProgressTvShows(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeInProgressTvShows(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeInProgressTvShows : public CDirectoryNode
     {
     public:
-      CDirectoryNodeInProgressTvShows(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeInProgressTvShows(const std::string& strEntryName,
+                                      CDirectoryNode* pParent,
+                                      const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -28,8 +28,8 @@ Node MovieChildren[] = {
                         { NODE_TYPE_TAGS,         "tags",       20459 }
                        };
 
-CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_MOVIES_OVERVIEW, strName, pParent)
+CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_MOVIES_OVERVIEW, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -28,7 +28,9 @@ Node MovieChildren[] = {
                         { NODE_TYPE_TAGS,         "tags",       20459 }
                        };
 
-CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const std::string& strName,
+                                                           CDirectoryNode* pParent,
+                                                           const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_MOVIES_OVERVIEW, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeMoviesOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeMoviesOverview(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeMoviesOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeMoviesOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeMoviesOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeMoviesOverview(const std::string& strName,
+                                   CDirectoryNode* pParent,
+                                   const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -26,8 +26,8 @@ Node MusicVideoChildren[] = {
                               { NODE_TYPE_TAGS,              "tags",      20459 }
                             };
 
-CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_MUSICVIDEOS_OVERVIEW, strName, pParent)
+CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_MUSICVIDEOS_OVERVIEW, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -26,7 +26,9 @@ Node MusicVideoChildren[] = {
                               { NODE_TYPE_TAGS,              "tags",      20459 }
                             };
 
-CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const std::string& strName,
+                                                                     CDirectoryNode* pParent,
+                                                                     const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_MUSICVIDEOS_OVERVIEW, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeMusicVideosOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeMusicVideosOverview(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeMusicVideosOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeMusicVideosOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeMusicVideosOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeMusicVideosOverview(const std::string& strName,
+                                        CDirectoryNode* pParent,
+                                        const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -29,8 +29,8 @@ Node OverviewChildren[] = {
                             { NODE_TYPE_INPROGRESS_TVSHOWS,         "inprogresstvshows",        626 },
                           };
 
-CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent)
+CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -29,7 +29,9 @@ Node OverviewChildren[] = {
                             { NODE_TYPE_INPROGRESS_TVSHOWS,         "inprogresstvshows",        626 },
                           };
 
-CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeOverview::CDirectoryNodeOverview(const std::string& strName,
+                                               CDirectoryNode* pParent,
+                                               const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeOverview(const std::string& strName,
+                             CDirectoryNode* pParent,
+                             const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRecentlyAddedEpisodes::CDirectoryNodeRecentlyAddedEpisodes(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_EPISODES, strName, pParent)
+CDirectoryNodeRecentlyAddedEpisodes::CDirectoryNodeRecentlyAddedEpisodes(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_EPISODES, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
@@ -12,7 +12,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRecentlyAddedEpisodes::CDirectoryNodeRecentlyAddedEpisodes(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeRecentlyAddedEpisodes::CDirectoryNodeRecentlyAddedEpisodes(
+    const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_EPISODES, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeRecentlyAddedEpisodes : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRecentlyAddedEpisodes(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeRecentlyAddedEpisodes(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeRecentlyAddedEpisodes : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRecentlyAddedEpisodes(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeRecentlyAddedEpisodes(const std::string& strEntryName,
+                                          CDirectoryNode* pParent,
+                                          const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -12,7 +12,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRecentlyAddedMovies::CDirectoryNodeRecentlyAddedMovies(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeRecentlyAddedMovies::CDirectoryNodeRecentlyAddedMovies(const std::string& strName,
+                                                                     CDirectoryNode* pParent,
+                                                                     const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_MOVIES, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRecentlyAddedMovies::CDirectoryNodeRecentlyAddedMovies(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_MOVIES, strName, pParent)
+CDirectoryNodeRecentlyAddedMovies::CDirectoryNodeRecentlyAddedMovies(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_MOVIES, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeRecentlyAddedMovies : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRecentlyAddedMovies(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeRecentlyAddedMovies(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeRecentlyAddedMovies : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRecentlyAddedMovies(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeRecentlyAddedMovies(const std::string& strEntryName,
+                                        CDirectoryNode* pParent,
+                                        const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
@@ -12,7 +12,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRecentlyAddedMusicVideos::CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeRecentlyAddedMusicVideos::CDirectoryNodeRecentlyAddedMusicVideos(
+    const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
@@ -12,8 +12,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRecentlyAddedMusicVideos::CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS, strName, pParent)
+CDirectoryNodeRecentlyAddedMusicVideos::CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeRecentlyAddedMusicVideos : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeRecentlyAddedMusicVideos : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeRecentlyAddedMusicVideos(const std::string& strEntryName,
+                                             CDirectoryNode* pParent,
+                                             const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.cpp
@@ -10,8 +10,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_ROOT, strName, pParent)
+CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_ROOT, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.cpp
@@ -10,7 +10,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeRoot::CDirectoryNodeRoot(const std::string& strName,
+                                       CDirectoryNode* pParent,
+                                       const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_ROOT, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeRoot : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeRoot : public CDirectoryNode
     {
     public:
-      CDirectoryNodeRoot(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeRoot(const std::string& strName,
+                         CDirectoryNode* pParent,
+                         const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -16,7 +16,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeSeasons::CDirectoryNodeSeasons(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeSeasons::CDirectoryNodeSeasons(const std::string& strName,
+                                             CDirectoryNode* pParent,
+                                             const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_SEASONS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -16,8 +16,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeSeasons::CDirectoryNodeSeasons(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_SEASONS, strName, pParent)
+CDirectoryNodeSeasons::CDirectoryNodeSeasons(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_SEASONS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeSeasons : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSeasons(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeSeasons(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeSeasons : public CDirectoryNode
     {
     public:
-      CDirectoryNodeSeasons(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeSeasons(const std::string& strName,
+                            CDirectoryNode* pParent,
+                            const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
@@ -13,8 +13,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeTitleMovies::CDirectoryNodeTitleMovies(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_TITLE_MOVIES, strName, pParent)
+CDirectoryNodeTitleMovies::CDirectoryNodeTitleMovies(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_TITLE_MOVIES, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
@@ -13,7 +13,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeTitleMovies::CDirectoryNodeTitleMovies(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeTitleMovies::CDirectoryNodeTitleMovies(const std::string& strName,
+                                                     CDirectoryNode* pParent,
+                                                     const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_TITLE_MOVIES, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeTitleMovies : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTitleMovies(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeTitleMovies(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeTitleMovies : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTitleMovies(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeTitleMovies(const std::string& strEntryName,
+                                CDirectoryNode* pParent,
+                                const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& items) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
@@ -13,8 +13,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeTitleMusicVideos::CDirectoryNodeTitleMusicVideos(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_TITLE_MUSICVIDEOS, strName, pParent)
+CDirectoryNodeTitleMusicVideos::CDirectoryNodeTitleMusicVideos(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_TITLE_MUSICVIDEOS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
@@ -13,7 +13,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeTitleMusicVideos::CDirectoryNodeTitleMusicVideos(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeTitleMusicVideos::CDirectoryNodeTitleMusicVideos(const std::string& strName,
+                                                               CDirectoryNode* pParent,
+                                                               const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_TITLE_MUSICVIDEOS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeTitleMusicVideos : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTitleMusicVideos(const std::string& strEntryName, CDirectoryNode* pParent);
+      CDirectoryNodeTitleMusicVideos(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       bool GetContent(CFileItemList& item) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeTitleMusicVideos : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTitleMusicVideos(const std::string& strEntryName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeTitleMusicVideos(const std::string& strEntryName,
+                                     CDirectoryNode* pParent,
+                                     const std::string& strOrigin);
+
     protected:
       bool GetContent(CFileItemList& item) const override;
     };

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -13,8 +13,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeTitleTvShows::CDirectoryNodeTitleTvShows(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_TITLE_TVSHOWS, strName, pParent)
+CDirectoryNodeTitleTvShows::CDirectoryNodeTitleTvShows(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_TITLE_TVSHOWS, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -13,7 +13,9 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
-CDirectoryNodeTitleTvShows::CDirectoryNodeTitleTvShows(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeTitleTvShows::CDirectoryNodeTitleTvShows(const std::string& strName,
+                                                       CDirectoryNode* pParent,
+                                                       const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_TITLE_TVSHOWS, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeTitleTvShows : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTitleTvShows(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeTitleTvShows(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeTitleTvShows : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTitleTvShows(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeTitleTvShows(const std::string& strName,
+                                 CDirectoryNode* pParent,
+                                 const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -24,8 +24,8 @@ Node TvShowChildren[] = {
                           { NODE_TYPE_TAGS,          "tags",     20459 }
                         };
 
-CDirectoryNodeTvShowsOverview::CDirectoryNodeTvShowsOverview(const std::string& strName, CDirectoryNode* pParent)
-  : CDirectoryNode(NODE_TYPE_TVSHOWS_OVERVIEW, strName, pParent)
+CDirectoryNodeTvShowsOverview::CDirectoryNodeTvShowsOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+  : CDirectoryNode(NODE_TYPE_TVSHOWS_OVERVIEW, strName, pParent, strOrigin)
 {
 
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -24,7 +24,9 @@ Node TvShowChildren[] = {
                           { NODE_TYPE_TAGS,          "tags",     20459 }
                         };
 
-CDirectoryNodeTvShowsOverview::CDirectoryNodeTvShowsOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin)
+CDirectoryNodeTvShowsOverview::CDirectoryNodeTvShowsOverview(const std::string& strName,
+                                                             CDirectoryNode* pParent,
+                                                             const std::string& strOrigin)
   : CDirectoryNode(NODE_TYPE_TVSHOWS_OVERVIEW, strName, pParent, strOrigin)
 {
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
@@ -17,7 +17,7 @@ namespace XFILE
     class CDirectoryNodeTvShowsOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTvShowsOverview(const std::string& strName, CDirectoryNode* pParent);
+      CDirectoryNodeTvShowsOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
@@ -17,7 +17,10 @@ namespace XFILE
     class CDirectoryNodeTvShowsOverview : public CDirectoryNode
     {
     public:
-      CDirectoryNodeTvShowsOverview(const std::string& strName, CDirectoryNode* pParent, const std::string& strOrigin);
+      CDirectoryNodeTvShowsOverview(const std::string& strName,
+                                    CDirectoryNode* pParent,
+                                    const std::string& strOrigin);
+
     protected:
       NODE_TYPE GetChildType() const override;
       bool GetContent(CFileItemList& items) const override;


### PR DESCRIPTION
## Description
This change adds the ability to keep the
vfs protocol for media paths (videodb/musicdb)
all the way from the skin until we query the
database.

## Motivation and Context
This the first step of my plan to extend our media support to come from services.

## How Has This Been Tested?
This is not intended to cause functional changes at this point.
But it should make sure that for example a `musicdb://albums/xyz` path
makes it's way from the skin into the db layer without losing the protocol information
in between and later hardcoding it from the DirectoryNode-Type.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
