### PR TITLE
Fix add-on setting references

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -571,9 +571,7 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(const TiXm
           }
         }
 
-        SettingWithConditions settingWithConditions = {
-          setting
-        };
+        SettingWithConditions settingWithConditions;
 
         // parse enable status
         const auto conditionEnable = XMLUtils::GetAttribute(settingElement, "enable");
@@ -593,9 +591,6 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(const TiXm
         else if (!conditionVisible.empty())
           settingWithConditions.visibleCondition = conditionVisible;
 
-        if (!settingWithConditions.enableCondition.empty() || !settingWithConditions.visibleCondition.empty())
-          settingsWithConditions.push_back(settingWithConditions);
-
         // check if there already is a setting with the setting identifier
         if (settingIds.find(settingId) != settingIds.end())
         {
@@ -606,6 +601,13 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(const TiXm
         {
           // add the setting's identifier to the list of all identifiers
           settingIds.insert(setting->GetId());
+        }
+
+        if (!settingWithConditions.enableCondition.empty() ||
+            !settingWithConditions.visibleCondition.empty())
+        {
+          settingWithConditions.setting = setting;
+          settingsWithConditions.push_back(settingWithConditions);
         }
 
         // add the setting to the list of settings from the same category

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -564,8 +564,8 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(const TiXm
 
           if (parentSetting != groupSettings.crend())
           {
-            if ((*parentSetting)->GetType() == SettingType::Reference)
-              setting->SetParent(std::static_pointer_cast<const CSettingReference>(*parentSetting)->GetReferencedId());
+            if ((*parentSetting)->IsReference())
+              setting->SetParent((*parentSetting)->GetReferencedId());
             else
               setting->SetParent((*parentSetting)->GetId());
           }
@@ -595,7 +595,7 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(const TiXm
         if (settingIds.find(settingId) != settingIds.end())
         {
           // turn the setting into a reference setting
-          setting = std::make_shared<CSettingReference>(settingId, GetSettingsManager());
+          setting->MakeReference();
         }
         else
         {
@@ -1377,14 +1377,7 @@ bool CAddonSettings::ParseOldCondition(std::shared_ptr<const CSetting> setting, 
     if (otherSetting == nullptr)
       return false;
 
-    std::string id = setting->GetId();
-    if (setting->GetType() == SettingType::Reference)
-      id = std::static_pointer_cast<const CSettingReference>(setting)->GetReferencedId();
-    std::string otherId = otherSetting->GetId();
-    if (otherSetting->GetType() == SettingType::Reference)
-      otherId = std::static_pointer_cast<const CSettingReference>(otherSetting)->GetReferencedId();
-
-    return id == otherId;
+    return setting->GetId() == otherSetting->GetId();
   });
   if (settingIt == settings.cend()) {
     CLog::Log(LOGWARNING, "CAddonSettings[%s]: failed to parse old setting conditions \"%s\" for \"%s\"",

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -332,6 +332,14 @@ SettingPtr CSettingList::Clone(const std::string &id) const
   return std::make_shared<CSettingList>(id, *this);
 }
 
+void CSettingList::MergeDetails(const CSetting& other)
+{
+  if (other.GetType() != SettingType::List)
+    return;
+
+  // TODO(smontellese)
+}
+
 bool CSettingList::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);
@@ -627,6 +635,18 @@ SettingPtr CSettingBool::Clone(const std::string &id) const
   return std::make_shared<CSettingBool>(id, *this);
 }
 
+void CSettingBool::MergeDetails(const CSetting& other)
+{
+  if (other.GetType() != SettingType::Boolean)
+    return;
+
+  const auto& boolSetting = static_cast<const CSettingBool&>(other);
+  if (m_value == false && boolSetting.m_value == true)
+    m_value = true;
+  if (m_default == false && boolSetting.m_default == true)
+    m_default = true;
+}
+
 bool CSettingBool::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);
@@ -774,6 +794,14 @@ CSettingInt::CSettingInt(const std::string &id, int label, int value, const Tran
 SettingPtr CSettingInt::Clone(const std::string &id) const
 {
   return std::make_shared<CSettingInt>(id, *this);
+}
+
+void CSettingInt::MergeDetails(const CSetting& other)
+{
+  if (other.GetType() != SettingType::Integer)
+    return;
+
+  // TODO(smontellese)
 }
 
 bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
@@ -1056,6 +1084,24 @@ SettingPtr CSettingNumber::Clone(const std::string &id) const
   return std::make_shared<CSettingNumber>(id, *this);
 }
 
+void CSettingNumber::MergeDetails(const CSetting& other)
+{
+  if (other.GetType() != SettingType::Number)
+    return;
+
+  const auto& numberSetting = static_cast<const CSettingNumber&>(other);
+  if (m_value == 0.0 && numberSetting.m_value != 0.0)
+    m_value = numberSetting.m_value;
+  if (m_default == 0.0 && numberSetting.m_default != 0.0)
+    m_default = numberSetting.m_default;
+  if (m_min == 0.0 && numberSetting.m_min != 0.0)
+    m_min = numberSetting.m_min;
+  if (m_step == 1.0 && numberSetting.m_step != 1.0)
+    m_step = numberSetting.m_step;
+  if (m_max == 0.0 && numberSetting.m_max != 0.0)
+    m_max = numberSetting.m_max;
+}
+
 bool CSettingNumber::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
   CExclusiveLock lock(m_critical);
@@ -1215,6 +1261,14 @@ CSettingString::CSettingString(const std::string &id, int label, const std::stri
 SettingPtr CSettingString::Clone(const std::string &id) const
 {
   return std::make_shared<CSettingString>(id, *this);
+}
+
+void CSettingString::MergeDetails(const CSetting& other)
+{
+  if (other.GetType() != SettingType::String)
+    return;
+
+  // TODO(smontellese)
 }
 
 bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false */)
@@ -1441,6 +1495,16 @@ CSettingAction::CSettingAction(const std::string &id, const CSettingAction &sett
 SettingPtr CSettingAction::Clone(const std::string &id) const
 {
   return std::make_shared<CSettingAction>(id, *this);
+}
+
+void CSettingAction::MergeDetails(const CSetting& other)
+{
+  if (other.GetType() != SettingType::Action)
+    return;
+
+  const auto& actionSetting = static_cast<const CSettingAction&>(other);
+  if (!HasData() && actionSetting.HasData())
+    SetData(actionSetting.GetData());
 }
 
 bool CSettingAction::Deserialize(const TiXmlNode *node, bool update /* = false */)

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -51,6 +51,7 @@ public:
 
   virtual std::shared_ptr<CSetting> Clone(const std::string &id) const = 0;
   void MergeBasics(const CSetting& other);
+  virtual void MergeDetails(const CSetting& other) = 0;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -153,6 +154,7 @@ public:
   ~CSettingList() override = default;
 
   std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -212,6 +214,7 @@ public:
   ~CSettingBool() override = default;
 
   std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -250,6 +253,7 @@ public:
   ~CSettingInt() override = default;
 
   std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -325,6 +329,7 @@ public:
   ~CSettingNumber() override = default;
 
   std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -372,6 +377,7 @@ public:
   ~CSettingString() override = default;
 
   std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -442,6 +448,7 @@ public:
   ~CSettingAction() override = default;
 
   std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -50,6 +50,7 @@ public:
   ~CSetting() override = default;
 
   virtual std::shared_ptr<CSetting> Clone(const std::string &id) const = 0;
+  void MergeBasics(const CSetting& other);
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -61,6 +62,7 @@ public:
   virtual void Reset() = 0;
 
   bool IsEnabled() const;
+  bool GetEnabled() const { return m_enabled; }
   void SetEnabled(bool enabled);
   bool IsDefault() const { return !m_changed; }
   const std::string& GetParent() const { return m_parentSetting; }
@@ -76,6 +78,12 @@ public:
 
   void SetCallback(ISettingCallback *callback) { m_callback = callback; }
 
+  bool IsReference() const { return !m_referencedId.empty(); }
+  const std::string& GetReferencedId() const { return m_referencedId; }
+  void SetReferencedId(const std::string& referencedId) { m_referencedId = referencedId; }
+  void MakeReference(const std::string& referencedId = "");
+
+  bool GetVisible() const { return ISetting::IsVisible(); }
   // overrides of ISetting
   bool IsVisible() const override;
 
@@ -106,6 +114,8 @@ protected:
   std::set<CSettingUpdate> m_updates;
   bool m_changed = false;
   mutable CSharedSection m_critical;
+
+  std::string m_referencedId;
 };
 
 template<typename TValue, SettingType TSettingType>
@@ -127,29 +137,6 @@ protected:
     : CSetting(id, setting)
   { }
   ~CTraitedSetting() override = default;
-};
-
-class CSettingReference : public CSetting
-{
-public:
-  CSettingReference(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingReference(const std::string &id, const CSettingReference &setting);
-  ~CSettingReference() override = default;
-
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
-
-  SettingType GetType() const override { return SettingType::Reference; }
-  bool FromString(const std::string &value) override { return false; }
-  std::string ToString() const override { return ""; }
-  bool Equals(const std::string &value) const override { return false; }
-  bool CheckValidity(const std::string &value) const override { return false; }
-  void Reset() override { }
-
-  const std::string& GetReferencedId() const { return m_referencedId; }
-  void SetReferencedId(const std::string& referencedId) { m_referencedId = referencedId; }
-
-private:
-  std::string m_referencedId;
 };
 
 /*!

--- a/xbmc/settings/lib/SettingType.h
+++ b/xbmc/settings/lib/SettingType.h
@@ -19,6 +19,5 @@ enum class SettingType {
   Number,
   String,
   Action,
-  List,
-  Reference
+  List
 };

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1323,7 +1323,11 @@ void CSettingsManager::ResolveReferenceSettings(std::shared_ptr<CSettingSection>
       continue;
 
     for (const auto& referenceSetting : groupedReferenceSetting.second.referenceSettings)
+    {
+      groupedReferenceSetting.second.referencedSetting->MergeDetails(*referenceSetting);
+
       itReferencedSetting->second.references.insert(referenceSetting->GetId());
+    }
   }
 
   // resolve any reference settings

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -16,6 +16,8 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <map>
+#include <unordered_set>
 #include <utility>
 
 const uint32_t CSettingsManager::Version = 2;
@@ -547,7 +549,11 @@ SettingPtr CSettingsManager::GetSetting(const std::string &id) const
 
   auto setting = FindSetting(id);
   if (setting != m_settings.end())
+  {
+    if (setting->second.setting->IsReference())
+      return GetSetting(setting->second.setting->GetReferencedId());
     return setting->second.setting;
+  }
 
   CLog::Log(LOGDEBUG, "CSettingsManager: requested setting (%s) was not found.", id.c_str());
   return nullptr;
@@ -769,7 +775,8 @@ bool CSettingsManager::Serialize(TiXmlNode *parent) const
 
   for (const auto& setting : m_settings)
   {
-    if (setting.second.setting->GetType() == SettingType::Action)
+    if (setting.second.setting->IsReference() ||
+        setting.second.setting->GetType() == SettingType::Action)
       continue;
 
     TiXmlElement settingElement(SETTING_XML_ELM_SETTING);
@@ -839,6 +846,38 @@ bool CSettingsManager::OnSettingChanging(std::shared_ptr<const CSetting> setting
   {
     if (!callback->OnSettingChanging(setting))
       return false;
+  }
+
+  // if this is a reference setting apply the same change to the referenced setting
+  if (setting->IsReference())
+  {
+    CSharedLock lock(m_settingsCritical);
+    auto referencedSettingIt = FindSetting(setting->GetReferencedId());
+    if (referencedSettingIt != m_settings.end())
+    {
+      Setting referencedSettingData = referencedSettingIt->second;
+      // now that we have a copy of the setting's data, we can leave the lock
+      lock.Leave();
+
+      referencedSettingData.setting->FromString(setting->ToString());
+    }
+  }
+  else if (!settingData.references.empty())
+  {
+    // if the changed setting is referenced by other settings apply the same change to the referencing settings
+    std::unordered_set<SettingPtr> referenceSettings;
+    CSharedLock lock(m_settingsCritical);
+    for (const auto& reference : settingData.references)
+    {
+      auto referenceSettingIt = FindSetting(reference);
+      if (referenceSettingIt != m_settings.end())
+        referenceSettings.insert(referenceSettingIt->second.setting);
+    }
+    // now that we have a copy of the setting's data, we can leave the lock
+    lock.Leave();
+
+    for (auto& referenceSetting : referenceSettings)
+      referenceSetting->FromString(setting->ToString());
   }
 
   return true;
@@ -953,8 +992,6 @@ SettingPtr CSettingsManager::CreateSetting(const std::string &settingType, const
     return std::make_shared<CSettingString>(settingId, const_cast<CSettingsManager*>(this));
   else if (StringUtils::EqualsNoCase(settingType, "action"))
     return std::make_shared<CSettingAction>(settingId, const_cast<CSettingsManager*>(this));
-  else if (StringUtils::EqualsNoCase(settingType, "reference"))
-    return std::make_shared<CSettingReference>(settingId, const_cast<CSettingsManager*>(this));
   else if (settingType.size() > 6 &&
            StringUtils::StartsWith(settingType, "list[") &&
            StringUtils::EndsWith(settingType, "]"))
@@ -1059,6 +1096,8 @@ bool CSettingsManager::LoadSetting(const TiXmlNode *node, SettingPtr setting, bo
     return false;
 
   auto settingId = setting->GetId();
+  if (setting->IsReference())
+    settingId = setting->GetReferencedId();
 
   const TiXmlElement* settingElement = nullptr;
   // try to split the setting identifier into category and subsetting identifer (v1-)
@@ -1160,7 +1199,10 @@ void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, c
 
 void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, SettingDependencyType dependencyType)
 {
-  SettingPtr setting = GetSetting(settingId);
+  auto settingIt = FindSetting(settingId);
+  if (settingIt == m_settings.end())
+    return;
+  SettingPtr setting = settingIt->second.setting;
   if (setting == nullptr)
     return;
 
@@ -1225,7 +1267,14 @@ void CSettingsManager::AddSetting(std::shared_ptr<CSetting> setting)
 
 void CSettingsManager::ResolveReferenceSettings(std::shared_ptr<CSettingSection> section)
 {
-  // resolve any reference settings
+  struct GroupedReferenceSettings
+  {
+    SettingPtr referencedSetting;
+    std::unordered_set<SettingPtr> referenceSettings;
+  };
+  std::map<std::string, GroupedReferenceSettings> groupedReferenceSettings;
+
+  // collect and group all reference(d) settings
   auto categories = section->GetCategories();
   for (const auto& category : categories)
   {
@@ -1233,29 +1282,80 @@ void CSettingsManager::ResolveReferenceSettings(std::shared_ptr<CSettingSection>
     for (auto& group : groups)
     {
       auto settings = group->GetSettings();
-      SettingList referenceSettings;
       for (const auto& setting : settings)
       {
-        if (setting->GetType() == SettingType::Reference)
-          referenceSettings.push_back(setting);
-      }
-
-      for (const auto& referenceSetting : referenceSettings)
-      {
-        auto referencedSettingId = std::static_pointer_cast<const CSettingReference>(referenceSetting)->GetReferencedId();
-        SettingPtr referencedSetting = nullptr;
-        auto itReferencedSetting = FindSetting(referencedSettingId);
-        if (itReferencedSetting == m_settings.end())
-          CLog::Log(LOGWARNING, "CSettingsManager: missing referenced setting \"%s\"", referencedSettingId.c_str());
-        else
+        if (setting->IsReference())
         {
-          referencedSetting = itReferencedSetting->second.setting;
-          itReferencedSetting = FindSetting(referenceSetting->GetId());
-          if (itReferencedSetting != m_settings.end())
-            m_settings.erase(itReferencedSetting);
-        }
+          auto referencedSettingId = setting->GetReferencedId();
+          auto itGroupedReferenceSetting = groupedReferenceSettings.find(referencedSettingId);
+          if (itGroupedReferenceSetting == groupedReferenceSettings.end())
+          {
+            SettingPtr referencedSetting = nullptr;
+            auto itReferencedSetting = FindSetting(referencedSettingId);
+            if (itReferencedSetting == m_settings.end())
+            {
+              CLog::Log(LOGWARNING, "CSettingsManager: missing referenced setting \"%s\"",
+                referencedSettingId.c_str());
+              continue;
+            }
 
-        group->ReplaceSetting(referenceSetting, referencedSetting);
+            GroupedReferenceSettings groupedReferenceSetting;
+            groupedReferenceSetting.referencedSetting = itReferencedSetting->second.setting;
+
+            itGroupedReferenceSetting = groupedReferenceSettings.insert(
+              std::make_pair(referencedSettingId, groupedReferenceSetting)).first;
+          }
+
+          itGroupedReferenceSetting->second.referenceSettings.insert(setting);
+        }
+      }
+    }
+  }
+
+  if (groupedReferenceSettings.empty())
+    return;
+
+  // merge all reference settings into the referenced setting
+  for (const auto& groupedReferenceSetting : groupedReferenceSettings)
+  {
+    auto itReferencedSetting = FindSetting(groupedReferenceSetting.first);
+    if (itReferencedSetting == m_settings.end())
+      continue;
+
+    for (const auto& referenceSetting : groupedReferenceSetting.second.referenceSettings)
+      itReferencedSetting->second.references.insert(referenceSetting->GetId());
+  }
+
+  // resolve any reference settings
+  for (const auto& category : categories)
+  {
+    auto groups = category->GetGroups();
+    for (auto& group : groups)
+    {
+      auto settings = group->GetSettings();
+      for (const auto& setting : settings)
+      {
+        if (setting->IsReference())
+        {
+          auto referencedSettingId = setting->GetReferencedId();
+          auto itGroupedReferenceSetting = groupedReferenceSettings.find(referencedSettingId);
+          if (itGroupedReferenceSetting != groupedReferenceSettings.end())
+          {
+            const auto referencedSetting = itGroupedReferenceSetting->second.referencedSetting;
+
+            // clone the referenced setting and copy the general properties of the reference setting
+            auto clonedReferencedSetting = referencedSetting->Clone(setting->GetId());
+            clonedReferencedSetting->SetReferencedId(referencedSettingId);
+            clonedReferencedSetting->MergeBasics(*setting);
+
+            group->ReplaceSetting(setting, clonedReferencedSetting);
+
+            // update the setting
+            auto itReferenceSetting = FindSetting(setting->GetId());
+            if (itReferenceSetting != m_settings.end())
+              itReferenceSetting->second.setting = clonedReferencedSetting;
+          }
+        }
       }
     }
   }
@@ -1270,11 +1370,6 @@ void CSettingsManager::CleanupIncompleteSettings()
     if (tmpIterator->second.setting == nullptr)
     {
       CLog::Log(LOGWARNING, "CSettingsManager: removing empty setting \"%s\"", tmpIterator->first.c_str());
-      m_settings.erase(tmpIterator);
-    }
-    else if (tmpIterator->second.setting->GetType() == SettingType::Reference)
-    {
-      CLog::Log(LOGWARNING, "CSettingsManager: removing missing reference setting \"%s\"", tmpIterator->first.c_str());
       m_settings.erase(tmpIterator);
     }
   }

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
 class CSettingCategory;
@@ -506,6 +507,7 @@ private:
     SettingDependencyMap dependencies;
     std::set<std::string> children;
     CallbackSet callbacks;
+    std::unordered_set<std::string> references;
   };
 
   using SettingMap = std::map<std::string, Setting>;


### PR DESCRIPTION
## Description
This should finally fix the issues with "reference settings" in add-on settings using the old style settings format introduced with the original rework. There were two issues with the initial implementation of "reference settings":
* I assumed that the first appearence of a setting is a full definition of the setting with all its properties. But in reality the "full definition" of the setting is often not the first appearance which leads to a more or less empty setting definition (apart from the ID)
* I assumed that all references of a setting would be hidden / invisible because they only reference another setting due to limitations in the old add-on settings system. But in reality they are not always hidden and they even have their own visibility / enable conditions independent of the referenced setting.

The initial implementation of "reference settings" consisted of a `CSettingReference` class which pointed to the referenced setting. During loading of the add-on settings definition we used `CSettingReference` wherever a setting ID was re-used. When actually showing the add-on settings dialog we replaced all `CSettingReference` instances with pointers to the referenced setting.

This new implementation adds the possibility to mark any setting as a reference to another setting. This allows every "reference setting" to have their own visibility / enable conditions etc. During execution `CSettingsManager` keeps a list of all references and automatically triggers updates / events / callbacks on all reference-connected setting instances. Furthermore there is a merging functionality which allows to merge all setting definition details to be merged into the "main referenced setting".

## Motivation and Context
It fixes #15252.

## How Has This Been Tested?
I've tested it manually using the different versions of the settings test add-on provided by @Zomboided and @Zomboided has tested it as well.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
