### PR TITLE
Game add-ons: Architecture documentation

### DIFF
--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -39,6 +39,31 @@ class IGameInputCallback;
 /*!
  * \ingroup games
  * \brief Interface between Kodi and Game add-ons.
+ *
+ * The game add-on system is extremely large. To make the code more manageable,
+ * a subsystem pattern has been put in place. This pattern takes functionality
+ * that would normally be placed in this class, and puts it in another class
+ * (a "subsystem").
+ *
+ * The architecture is relatively simple. Subsystems are placed in a flat
+ * struct and accessed by calling the subsystem name. For example,
+ * historically, OpenJoystick() was a member of this class. Now, the function
+ * is called like Input().OpenJoystick().
+ *
+ * Although this pattern adds a layer of complexity, it enforces modularity and
+ * separation of concerns by making it very clear when one subsystem becomes
+ * dependent on another. Subsystems are all given access to each other by the
+ * calling mechanism. However, calling a subsystem creates a dependency on it,
+ * and an engineering decision must be made to justify the dependency.
+ *
+ * CONTRIBUTING
+ *
+ * If you wish to contribute, a beneficial task would be to refactor anything
+ * in this class into a new subsystem:
+ *
+ * Using line count as a heuristic, the subsystem pattern has shrunk the .cpp
+ * from 1,200 lines to just over 600. Reducing this further is the challenge.
+ * You must now choose whether to accept.
  */
 class CGameClient : public ADDON::CAddonDll
 {


### PR DESCRIPTION
## Description

This PR adds a doxygen comment to CGameClient, the main game add-on class, documenting the subsystem architecture used to manage the extremely large amount of code required by game add-ons.

The documentation is split in two parts. It begins with a few README paragraphs. Next, I borrow the CONTRIBUTING filename convention to highlight how a reader can become a contributor.

## Discussion

I'm extremely happy with the scalability and performance of the two systems I've built:

* Input I wrote over two years, and the extensive amount of documentation shows this.

* RetroPlayer I wrote in a summer with the GSoC '17 deadline hanging over my head. Documentation was kept light to bring the massive system to completion at an accelerated rate.

So, I'd like to extend the documentation going forward. This PR is kinda what I have in mind. I'd like feedback on the style, accessibility (reading level) and structure here. I'll gladly take no comments to mean that I should keep doing what I'm doing.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
