### PR TITLE
Improve FreeBSD CPUInfo support

### DIFF
--- a/xbmc/platform/freebsd/CPUInfoFreebsd.h
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.h
@@ -20,4 +20,5 @@ public:
 
   int GetUsedPercentage() override;
   float GetCPUFrequency() override;
+  bool GetTemperature(CTemperature& temperature) override;
 };

--- a/xbmc/utils/Temperature.cpp
+++ b/xbmc/utils/Temperature.cpp
@@ -367,6 +367,11 @@ CTemperature CTemperature::CreateFromCelsius(double value)
   return CTemperature(value*1.8f+32.0f);
 }
 
+CTemperature CTemperature::CreateFromKelvin(double value)
+{
+  return CTemperature((value - 273.15) * 1.8 + 32.0);
+}
+
 void CTemperature::Archive(CArchive& ar)
 {
   if (ar.IsStoring())


### PR DESCRIPTION
## Description
Add CPU temperature reading.
Enable neon detection.

This patch from FreeBSD ports.


## Motivation and Context
Now on all FreeBSD hw platforms that support cpu temp sensor it will be available for user.
#16098 will require to include this feature.

## How Has This Been Tested?
I build and run kodi with this patch, it show CPU temp in info.
Tested on FreeBSD 11.2, 12.1 amd64
Other FreeBSD users use this patch during few years.
Other code not changed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
