### PR TITLE
[Estuary] add scrollbar to settings dialogs

### DIFF
--- a/addons/skin.estuary/xml/DialogAddonSettings.xml
+++ b/addons/skin.estuary/xml/DialogAddonSettings.xml
@@ -50,8 +50,9 @@
 				<top>100</top>
 				<width>1060</width>
 				<height>700</height>
+				<pagecontrol>60</pagecontrol>
 				<onleft>3</onleft>
-				<onright>9000</onright>
+				<onright>60</onright>
 				<onup>5</onup>
 				<ondown>5</ondown>
 			</control>
@@ -141,6 +142,17 @@
 				<textureradioonnofocus>icons/settings.png</textureradioonnofocus>
 				<textureradioofffocus>icons/settings.png</textureradioofffocus>
 				<textureradiooffnofocus>icons/settings.png</textureradiooffnofocus>
+			</control>
+			<control type="scrollbar" id="60">
+				<left>1489</left>
+				<top>100</top>
+				<width>12</width>
+				<height>700</height>
+				<orientation>vertical</orientation>
+				<onleft>5</onleft>
+				<onright>9000</onright>
+				<animation effect="fade" start="0" end="100" delay="300" time="320">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.estuary/xml/DialogSettings.xml
+++ b/addons/skin.estuary/xml/DialogSettings.xml
@@ -28,8 +28,9 @@
 				<top>100</top>
 				<width>1160</width>
 				<height>750</height>
+				<pagecontrol>60</pagecontrol>
 				<onleft>9000</onleft>
-				<onright>9000</onright>
+				<onright>60</onright>
 				<onup>5</onup>
 				<ondown>5</ondown>
 			</control>
@@ -83,6 +84,17 @@
 					<param name="id" value="30" />
 					<param name="label" value="" />
 				</include>
+			</control>
+			<control type="scrollbar" id="60">
+				<left>1189</left>
+				<top>100</top>
+				<width>12</width>
+				<height>750</height>
+				<orientation>vertical</orientation>
+				<onleft>5</onleft>
+				<onright>9000</onright>
+				<animation effect="fade" start="0" end="100" delay="300" time="320">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
 			</control>
 		</control>
 	</controls>


### PR DESCRIPTION
both DialogSettings.xml and DialogAddonSettings.xml did not have a scrollbar.
now they do.

closes https://github.com/xbmc/xbmc/issues/16711

![scrollbar](https://user-images.githubusercontent.com/687265/66823530-bda58000-ef46-11e9-9413-df12f1e709e6.jpg)
