### PR TITLE
[guiinfo]Fix Musicplayer.Property(Role.xxx) info labels

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -327,6 +327,14 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     // MUSICPLAYER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case MUSICPLAYER_PROPERTY:
+      if (StringUtils::StartsWithNoCase(info.GetData3(), "Role.") && item->HasMusicInfoTag())
+      {
+        // "Role.xxxx" properties are held in music tag
+        std::string property = info.GetData3();
+        property.erase(0, 5); //Remove Role.
+        value = item->GetMusicInfoTag()->GetArtistStringForRole(property);
+        return true;
+      }
       value = item->GetProperty(info.GetData3()).asString();
       return true;
     case MUSICPLAYER_PLAYLISTLEN:


### PR DESCRIPTION
Reported on forum https://forum.kodi.tv/showthread.php?tid=348405 the `Musicplayer.Property(Role.xxx)` info labels were broken by the major refactoring of CGUIInfoManager #13754

To test this needs music files with composer or other roles such as musicians or producer tagged and added to the library, and the skin adjusted to use this property (Estuary does not by default). 