### PR TITLE
[guiinfo]Fix Musicplayer.Property(Role.xxx) info labels - BACKPORT

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -326,6 +326,14 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     // MUSICPLAYER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case MUSICPLAYER_PROPERTY:
+      if (StringUtils::StartsWithNoCase(info.GetData3(), "Role.") && item->HasMusicInfoTag())
+      {
+        // "Role.xxxx" properties are held in music tag
+        std::string property = info.GetData3();
+        property.erase(0, 5); //Remove Role.
+        value = item->GetMusicInfoTag()->GetArtistStringForRole(property);
+        return true;
+      }
       value = item->GetProperty(info.GetData3()).asString();
       return true;
     case MUSICPLAYER_PLAYLISTLEN:


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/16784, a fix after https://github.com/xbmc/xbmc/pull/13754