### PR TITLE
xbmc.python bump to 3.0.0

### DIFF
--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.python" version="2.26.0" provider-name="Team Kodi">
+<addon id="xbmc.python" version="3.0.0" provider-name="Team Kodi">
   <backwards-compatibility abi="2.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -909,7 +909,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, "__author__", "Team Kodi <http://kodi.tv>");
    PyModule_AddStringConstant(module, "__date__", CCompileInfo::GetBuildDate().c_str());
-   PyModule_AddStringConstant(module, "__version__", "2.26.0");
+   PyModule_AddStringConstant(module, "__version__", "3.0.0");
    PyModule_AddStringConstant(module, "__credits__", "Team Kodi");
    PyModule_AddStringConstant(module, "__platform__", "ALL");
 


### PR DESCRIPTION
bump xbmc.python to 3.0.0 now that python 3 is in.
i've left the backwards-compatibility abi as is for now, i'll change that at a later date.