### PR TITLE
VideoTagInfoLoaderFFmpeg: Resolve stack before trying to process

### DIFF
--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -13,6 +13,7 @@
 #include "addons/Scraper.h"
 #include "cores/FFmpeg.h"
 #include "filesystem/File.h"
+#include "filesystem/StackDirectory.h"
 #include "utils/StringUtils.h"
 #include "video/VideoInfoTag.h"
 
@@ -39,8 +40,12 @@ CVideoTagLoaderFFmpeg::CVideoTagLoaderFFmpeg(const CFileItem& item,
   : IVideoInfoTagLoader(item, info, lookInFolder)
   , m_info(info)
 {
+  std::string filename =
+      item.IsStack() ? CStackDirectory::GetFirstStackedFile(item.GetPath()) : item.GetPath();
+
   m_file = new CFile;
-  if (!m_file->Open(m_item.GetPath()))
+
+  if (!m_file->Open(filename))
   {
     delete m_file;
     m_file = nullptr;


### PR DESCRIPTION
## Description
Resolve a fileitems stack and use the first stackitem to initialize ffmpeg.

## Motivation and Context
Fixes: https://github.com/xbmc/xbmc/issues/15638

## How Has This Been Tested?
Tested to set art for normal movies and multifile movies on linux.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
