### PR TITLE
DRMPRIME: Cleanup and improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -32,7 +32,7 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
   : CDVDVideoCodec(processInfo)
 {
   m_pFrame = av_frame_alloc();
-  m_videoBufferPool = std::make_shared<CVideoBufferPoolDRMPRIME>();
+  m_videoBufferPool = std::make_shared<CVideoBufferPoolDRMPRIMEFFmpeg>();
 }
 
 CDVDVideoCodecDRMPRIME::~CDVDVideoCodecDRMPRIME()
@@ -336,7 +336,8 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
 
   if (m_pFrame->format == AV_PIX_FMT_DRM_PRIME)
   {
-    CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_videoBufferPool->Get());
+    CVideoBufferDRMPRIMEFFmpeg* buffer =
+        dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(m_videoBufferPool->Get());
     buffer->SetRef(m_pFrame);
     pVideoPicture->videoBuffer = buffer;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -338,6 +338,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
   {
     CVideoBufferDRMPRIMEFFmpeg* buffer =
         dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(m_videoBufferPool->Get());
+    buffer->SetPictureParams(*pVideoPicture);
     buffer->SetRef(m_pFrame);
     pVideoPicture->videoBuffer = buffer;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -281,7 +281,6 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
   pVideoPicture->iFlags = 0;
   pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
   pVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST : 0;
-  pVideoPicture->iFlags |= m_pFrame->data[0] ? 0 : DVP_FLAG_DROPPED;
 
   int64_t pts = m_pFrame->pts;
   if (pts == AV_NOPTS_VALUE)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -130,6 +130,8 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   if (!m_pCodecContext)
     return false;
 
+  m_hints = hints;
+
   const AVCodecHWConfig* pConfig = FindHWConfig(pCodec);
   if (pConfig && (pConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
       pConfig->device_type == AV_HWDEVICE_TYPE_DRM)
@@ -272,10 +274,16 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
         (static_cast<int>(lrint(pVideoPicture->iWidth / aspect_ratio))) & -3;
   }
 
-  pVideoPicture->color_range = m_pFrame->color_range == AVCOL_RANGE_JPEG ? 1 : 0;
-  pVideoPicture->color_primaries = m_pFrame->color_primaries;
-  pVideoPicture->color_transfer = m_pFrame->color_trc;
-  pVideoPicture->color_space = m_pFrame->colorspace;
+  pVideoPicture->color_range =
+      m_pFrame->color_range == AVCOL_RANGE_JPEG || m_hints.colorRange == AVCOL_RANGE_JPEG ? 1 : 0;
+  pVideoPicture->color_primaries = m_pFrame->color_primaries == AVCOL_PRI_UNSPECIFIED
+                                       ? m_hints.colorPrimaries
+                                       : m_pFrame->color_primaries;
+  pVideoPicture->color_transfer = m_pFrame->color_trc == AVCOL_TRC_UNSPECIFIED
+                                      ? m_hints.colorTransferCharacteristic
+                                      : m_pFrame->color_trc;
+  pVideoPicture->color_space =
+      m_pFrame->colorspace == AVCOL_SPC_UNSPECIFIED ? m_hints.colorSpace : m_pFrame->colorspace;
 
   pVideoPicture->iRepeatPicture = 0;
   pVideoPicture->iFlags = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -284,6 +284,16 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
                                       : m_pFrame->color_trc;
   pVideoPicture->color_space =
       m_pFrame->colorspace == AVCOL_SPC_UNSPECIFIED ? m_hints.colorSpace : m_pFrame->colorspace;
+  pVideoPicture->chroma_position = m_pFrame->chroma_location;
+
+  pVideoPicture->colorBits = 8;
+  if (m_pCodecContext->codec_id == AV_CODEC_ID_HEVC &&
+      m_pCodecContext->profile == FF_PROFILE_HEVC_MAIN_10)
+    pVideoPicture->colorBits = 10;
+  else if (m_pCodecContext->codec_id == AV_CODEC_ID_H264 &&
+           (m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10 ||
+            m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10_INTRA))
+    pVideoPicture->colorBits = 10;
 
   pVideoPicture->iRepeatPicture = 0;
   pVideoPicture->iFlags = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -297,6 +297,12 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
   if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
     Drain();
 
+  if (pVideoPicture->videoBuffer)
+  {
+    pVideoPicture->videoBuffer->Release();
+    pVideoPicture->videoBuffer = nullptr;
+  }
+
   int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
   if (ret == AVERROR(EAGAIN))
     return VC_BUFFER;
@@ -308,10 +314,6 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
               ret);
     return VC_ERROR;
   }
-
-  if (pVideoPicture->videoBuffer)
-    pVideoPicture->videoBuffer->Release();
-  pVideoPicture->videoBuffer = nullptr;
 
   SetPictureParams(pVideoPicture);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -110,11 +110,11 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   const AVCodec* pCodec = FindDecoder(hints);
   if (!pCodec)
   {
-    CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::%s - unable to find decoder for codec %d", __FUNCTION__, hints.codec);
+    CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - unable to find decoder for codec {}", __FUNCTION__, hints.codec);
     return false;
   }
 
-  CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - using decoder %s", __FUNCTION__, pCodec->long_name ? pCodec->long_name : pCodec->name);
+  CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::{} - using decoder {}", __FUNCTION__, pCodec->long_name ? pCodec->long_name : pCodec->name);
 
   m_pCodecContext = avcodec_alloc_context3(pCodec);
   if (!m_pCodecContext)
@@ -128,7 +128,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
     CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
     if (av_hwdevice_ctx_create(&m_pCodecContext->hw_device_ctx, AV_HWDEVICE_TYPE_DRM, drmGetDeviceNameFromFd2(winSystem->GetDrm()->GetFileDescriptor()), nullptr, 0) < 0)
     {
-      CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unable to create hwdevice context", __FUNCTION__);
+      CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::{} - unable to create hwdevice context", __FUNCTION__);
       avcodec_free_context(&m_pCodecContext);
       return false;
     }
@@ -153,7 +153,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
 
   if (avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0)
   {
-    CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unable to open codec", __FUNCTION__);
+    CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::{} - unable to open codec", __FUNCTION__);
     avcodec_free_context(&m_pCodecContext);
     return false;
   }
@@ -200,7 +200,7 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
     return true;
   else if (ret)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::%s - send packet failed, ret:%d", __FUNCTION__, ret);
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed, ret:{}", __FUNCTION__, ret);
     return false;
   }
 
@@ -277,7 +277,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
     return VC_EOF;
   else if (ret)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::%s - receive frame failed, ret:%d", __FUNCTION__, ret);
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed, ret:{}", __FUNCTION__, ret);
     return VC_ERROR;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -9,6 +9,7 @@
 #include "DVDVideoCodecDRMPRIME.h"
 
 #include "ServiceBroker.h"
+#include "cores/VideoPlayer/DVDCodecs/DVDCodecs.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h"
 #include "settings/Settings.h"
@@ -21,6 +22,7 @@
 extern "C"
 {
 #include <libavcodec/avcodec.h>
+#include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
 }
 
@@ -161,6 +163,9 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
         static_cast<uint8_t*>(av_mallocz(hints.extrasize + AV_INPUT_BUFFER_PADDING_SIZE));
     memcpy(m_pCodecContext->extradata, hints.extradata, hints.extrasize);
   }
+
+  for (auto&& option : options.m_keys)
+    av_opt_set(m_pCodecContext, option.m_name.c_str(), option.m_value.c_str(), 0);
 
   if (avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -14,8 +14,7 @@
 
 #include <memory>
 
-class CDVDVideoCodecDRMPRIME
-  : public CDVDVideoCodec
+class CDVDVideoCodecDRMPRIME : public CDVDVideoCodec
 {
 public:
   explicit CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo);
@@ -28,9 +27,9 @@ public:
   bool AddData(const DemuxPacket& packet) override;
   void Reset() override;
   CDVDVideoCodec::VCReturn GetPicture(VideoPicture* pVideoPicture) override;
-  const char* GetName() override { return m_name.c_str(); };
-  unsigned GetAllowedReferences() override { return 5; };
-  void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
+  const char* GetName() override { return m_name.c_str(); }
+  unsigned GetAllowedReferences() override { return 5; }
+  void SetCodecControl(int flags) override { m_codecControlFlags = flags; }
 
 protected:
   void Drain();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -39,6 +39,7 @@ protected:
 
   std::string m_name;
   int m_codecControlFlags = 0;
+  CDVDStreamInfo m_hints;
   AVCodecContext* m_pCodecContext = nullptr;
   AVFrame* m_pFrame = nullptr;
   std::shared_ptr<IVideoBufferPool> m_videoBufferPool;

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -16,33 +16,33 @@ extern "C"
 #include <libavutil/pixdesc.h>
 }
 
-IVideoBufferDRMPRIME::IVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
+CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
 {
 }
 
-CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
-  : IVideoBufferDRMPRIME(id)
+CVideoBufferDRMPRIMEFFmpeg::CVideoBufferDRMPRIMEFFmpeg(IVideoBufferPool& pool, int id)
+  : CVideoBufferDRMPRIME(id)
 {
   m_pFrame = av_frame_alloc();
 }
 
-CVideoBufferDRMPRIME::~CVideoBufferDRMPRIME()
+CVideoBufferDRMPRIMEFFmpeg::~CVideoBufferDRMPRIMEFFmpeg()
 {
   Unref();
   av_frame_free(&m_pFrame);
 }
 
-void CVideoBufferDRMPRIME::SetRef(AVFrame* frame)
+void CVideoBufferDRMPRIMEFFmpeg::SetRef(AVFrame* frame)
 {
   av_frame_move_ref(m_pFrame, frame);
 }
 
-void CVideoBufferDRMPRIME::Unref()
+void CVideoBufferDRMPRIMEFFmpeg::Unref()
 {
   av_frame_unref(m_pFrame);
 }
 
-int CVideoBufferDRMPRIME::GetColorEncoding() const
+int CVideoBufferDRMPRIMEFFmpeg::GetColorEncoding() const
 {
   switch (m_pFrame->colorspace)
   {
@@ -65,7 +65,7 @@ int CVideoBufferDRMPRIME::GetColorEncoding() const
   }
 }
 
-int CVideoBufferDRMPRIME::GetColorRange() const
+int CVideoBufferDRMPRIMEFFmpeg::GetColorRange() const
 {
   switch (m_pFrame->color_range)
   {
@@ -77,23 +77,23 @@ int CVideoBufferDRMPRIME::GetColorRange() const
   }
 }
 
-bool CVideoBufferDRMPRIME::IsValid() const
+bool CVideoBufferDRMPRIMEFFmpeg::IsValid() const
 {
   AVDRMFrameDescriptor* descriptor = GetDescriptor();
   return descriptor && descriptor->nb_layers;
 }
 
-CVideoBufferPoolDRMPRIME::~CVideoBufferPoolDRMPRIME()
+CVideoBufferPoolDRMPRIMEFFmpeg::~CVideoBufferPoolDRMPRIMEFFmpeg()
 {
   for (auto buf : m_all)
     delete buf;
 }
 
-CVideoBuffer* CVideoBufferPoolDRMPRIME::Get()
+CVideoBuffer* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
 {
   CSingleLock lock(m_critSection);
 
-  CVideoBufferDRMPRIME* buf = nullptr;
+  CVideoBufferDRMPRIMEFFmpeg* buf = nullptr;
   if (!m_free.empty())
   {
     int idx = m_free.front();
@@ -104,7 +104,7 @@ CVideoBuffer* CVideoBufferPoolDRMPRIME::Get()
   else
   {
     int id = m_all.size();
-    buf = new CVideoBufferDRMPRIME(*this, id);
+    buf = new CVideoBufferDRMPRIMEFFmpeg(*this, id);
     m_all.push_back(buf);
     m_used.push_back(id);
   }
@@ -113,7 +113,7 @@ CVideoBuffer* CVideoBufferPoolDRMPRIME::Get()
   return buf;
 }
 
-void CVideoBufferPoolDRMPRIME::Return(int id)
+void CVideoBufferPoolDRMPRIMEFFmpeg::Return(int id)
 {
   CSingleLock lock(m_critSection);
 

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -16,6 +16,41 @@ extern "C"
 #include <libavutil/pixdesc.h>
 }
 
+namespace DRMPRIME
+{
+
+int GetColorEncoding(const VideoPicture& picture)
+{
+  switch (picture.color_space)
+  {
+    case AVCOL_SPC_BT2020_CL:
+    case AVCOL_SPC_BT2020_NCL:
+      return DRM_COLOR_YCBCR_BT2020;
+    case AVCOL_SPC_SMPTE170M:
+    case AVCOL_SPC_BT470BG:
+    case AVCOL_SPC_FCC:
+      return DRM_COLOR_YCBCR_BT601;
+    case AVCOL_SPC_BT709:
+      return DRM_COLOR_YCBCR_BT709;
+    case AVCOL_SPC_RESERVED:
+    case AVCOL_SPC_UNSPECIFIED:
+    default:
+      if (picture.iWidth > 1024 || picture.iHeight >= 600)
+        return DRM_COLOR_YCBCR_BT709;
+      else
+        return DRM_COLOR_YCBCR_BT601;
+  }
+}
+
+int GetColorRange(const VideoPicture& picture)
+{
+  if (picture.color_range)
+    return DRM_COLOR_YCBCR_FULL_RANGE;
+  return DRM_COLOR_YCBCR_LIMITED_RANGE;
+}
+
+} // namespace DRMPRIME
+
 CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
 {
 }
@@ -40,41 +75,6 @@ void CVideoBufferDRMPRIMEFFmpeg::SetRef(AVFrame* frame)
 void CVideoBufferDRMPRIMEFFmpeg::Unref()
 {
   av_frame_unref(m_pFrame);
-}
-
-int CVideoBufferDRMPRIMEFFmpeg::GetColorEncoding() const
-{
-  switch (m_pFrame->colorspace)
-  {
-    case AVCOL_SPC_BT2020_CL:
-    case AVCOL_SPC_BT2020_NCL:
-      return DRM_COLOR_YCBCR_BT2020;
-    case AVCOL_SPC_SMPTE170M:
-    case AVCOL_SPC_BT470BG:
-    case AVCOL_SPC_FCC:
-      return DRM_COLOR_YCBCR_BT601;
-    case AVCOL_SPC_BT709:
-      return DRM_COLOR_YCBCR_BT709;
-    case AVCOL_SPC_RESERVED:
-    case AVCOL_SPC_UNSPECIFIED:
-    default:
-      if (m_pFrame->width > 1024 || m_pFrame->height >= 600)
-        return DRM_COLOR_YCBCR_BT709;
-      else
-        return DRM_COLOR_YCBCR_BT601;
-  }
-}
-
-int CVideoBufferDRMPRIMEFFmpeg::GetColorRange() const
-{
-  switch (m_pFrame->color_range)
-  {
-    case AVCOL_RANGE_JPEG:
-      return DRM_COLOR_YCBCR_FULL_RANGE;
-    case AVCOL_RANGE_MPEG:
-    default:
-      return DRM_COLOR_YCBCR_LIMITED_RANGE;
-  }
 }
 
 bool CVideoBufferDRMPRIMEFFmpeg::IsValid() const

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -16,8 +16,7 @@ extern "C"
 #include <libavutil/pixdesc.h>
 }
 
-IVideoBufferDRMPRIME::IVideoBufferDRMPRIME(int id)
-  : CVideoBuffer(id)
+IVideoBufferDRMPRIME::IVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
 {
 }
 
@@ -47,22 +46,22 @@ int CVideoBufferDRMPRIME::GetColorEncoding() const
 {
   switch (m_pFrame->colorspace)
   {
-  case AVCOL_SPC_BT2020_CL:
-  case AVCOL_SPC_BT2020_NCL:
-    return DRM_COLOR_YCBCR_BT2020;
-  case AVCOL_SPC_SMPTE170M:
-  case AVCOL_SPC_BT470BG:
-  case AVCOL_SPC_FCC:
-    return DRM_COLOR_YCBCR_BT601;
-  case AVCOL_SPC_BT709:
-    return DRM_COLOR_YCBCR_BT709;
-  case AVCOL_SPC_RESERVED:
-  case AVCOL_SPC_UNSPECIFIED:
-  default:
-    if (m_pFrame->width > 1024 || m_pFrame->height >= 600)
-      return DRM_COLOR_YCBCR_BT709;
-    else
+    case AVCOL_SPC_BT2020_CL:
+    case AVCOL_SPC_BT2020_NCL:
+      return DRM_COLOR_YCBCR_BT2020;
+    case AVCOL_SPC_SMPTE170M:
+    case AVCOL_SPC_BT470BG:
+    case AVCOL_SPC_FCC:
       return DRM_COLOR_YCBCR_BT601;
+    case AVCOL_SPC_BT709:
+      return DRM_COLOR_YCBCR_BT709;
+    case AVCOL_SPC_RESERVED:
+    case AVCOL_SPC_UNSPECIFIED:
+    default:
+      if (m_pFrame->width > 1024 || m_pFrame->height >= 600)
+        return DRM_COLOR_YCBCR_BT709;
+      else
+        return DRM_COLOR_YCBCR_BT601;
   }
 }
 
@@ -70,11 +69,11 @@ int CVideoBufferDRMPRIME::GetColorRange() const
 {
   switch (m_pFrame->color_range)
   {
-  case AVCOL_RANGE_JPEG:
-    return DRM_COLOR_YCBCR_FULL_RANGE;
-  case AVCOL_RANGE_MPEG:
-  default:
-    return DRM_COLOR_YCBCR_LIMITED_RANGE;
+    case AVCOL_RANGE_JPEG:
+      return DRM_COLOR_YCBCR_FULL_RANGE;
+    case AVCOL_RANGE_MPEG:
+    default:
+      return DRM_COLOR_YCBCR_LIMITED_RANGE;
   }
 }
 

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -29,11 +29,11 @@ enum drm_color_range
   DRM_COLOR_YCBCR_FULL_RANGE,
 };
 
-class IVideoBufferDRMPRIME : public CVideoBuffer
+class CVideoBufferDRMPRIME : public CVideoBuffer
 {
 public:
-  IVideoBufferDRMPRIME() = delete;
-  ~IVideoBufferDRMPRIME() override = default;
+  CVideoBufferDRMPRIME() = delete;
+  ~CVideoBufferDRMPRIME() override = default;
 
   virtual AVDRMFrameDescriptor* GetDescriptor() const = 0;
   virtual uint32_t GetWidth() const = 0;
@@ -49,14 +49,14 @@ public:
   uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
 
 protected:
-  explicit IVideoBufferDRMPRIME(int id);
+  explicit CVideoBufferDRMPRIME(int id);
 };
 
-class CVideoBufferDRMPRIME : public IVideoBufferDRMPRIME
+class CVideoBufferDRMPRIMEFFmpeg : public CVideoBufferDRMPRIME
 {
 public:
-  CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id);
-  ~CVideoBufferDRMPRIME() override;
+  CVideoBufferDRMPRIMEFFmpeg(IVideoBufferPool& pool, int id);
+  ~CVideoBufferDRMPRIMEFFmpeg() override;
   void SetRef(AVFrame* frame);
   void Unref();
 
@@ -75,16 +75,16 @@ protected:
   AVFrame* m_pFrame = nullptr;
 };
 
-class CVideoBufferPoolDRMPRIME : public IVideoBufferPool
+class CVideoBufferPoolDRMPRIMEFFmpeg : public IVideoBufferPool
 {
 public:
-  ~CVideoBufferPoolDRMPRIME() override;
+  ~CVideoBufferPoolDRMPRIMEFFmpeg() override;
   void Return(int id) override;
   CVideoBuffer* Get() override;
 
 protected:
   CCriticalSection m_critSection;
-  std::vector<CVideoBufferDRMPRIME*> m_all;
+  std::vector<CVideoBufferDRMPRIMEFFmpeg*> m_all;
   std::deque<int> m_used;
   std::deque<int> m_free;
 };

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.h
@@ -38,24 +38,12 @@ public:
   virtual AVDRMFrameDescriptor* GetDescriptor() const = 0;
   virtual uint32_t GetWidth() const = 0;
   virtual uint32_t GetHeight() const = 0;
-  virtual int GetColorEncoding() const
-  {
-    return DRM_COLOR_YCBCR_BT709;
-  };
-  virtual int GetColorRange() const
-  {
-    return DRM_COLOR_YCBCR_LIMITED_RANGE;
-  };
+  virtual int GetColorEncoding() const { return DRM_COLOR_YCBCR_BT709; }
+  virtual int GetColorRange() const { return DRM_COLOR_YCBCR_LIMITED_RANGE; }
 
-  virtual bool IsValid() const
-  {
-    return true;
-  };
-  virtual bool Map()
-  {
-    return true;
-  };
-  virtual void Unmap() {};
+  virtual bool IsValid() const { return true; }
+  virtual bool Map() { return true; }
+  virtual void Unmap() {}
 
   uint32_t m_fb_id = 0;
   uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
@@ -76,14 +64,8 @@ public:
   {
     return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]);
   }
-  uint32_t GetWidth() const override
-  {
-    return m_pFrame->width;
-  }
-  uint32_t GetHeight() const override
-  {
-    return m_pFrame->height;
-  }
+  uint32_t GetWidth() const override { return m_pFrame->width; }
+  uint32_t GetHeight() const override { return m_pFrame->height; }
   int GetColorEncoding() const override;
   int GetColorRange() const override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -10,6 +10,8 @@
 
 #include "utils/log.h"
 
+using namespace DRMPRIME;
+
 void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
 {
   m_eglImage.reset(new CEGLImage(eglDisplay));
@@ -45,8 +47,8 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
     attribs.width = m_texWidth;
     attribs.height = m_texHeight;
     attribs.format = layer->format;
-    attribs.colorSpace = GetColorSpace(buffer->GetColorEncoding());
-    attribs.colorRange = GetColorRange(buffer->GetColorRange());
+    attribs.colorSpace = GetColorSpace(DRMPRIME::GetColorEncoding(buffer->GetPicture()));
+    attribs.colorRange = GetColorRange(DRMPRIME::GetColorRange(buffer->GetPicture()));
     attribs.planes = planes;
 
     if (!m_eglImage->CreateImage(attribs))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -15,7 +15,7 @@ void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
   m_eglImage.reset(new CEGLImage(eglDisplay));
 }
 
-bool CDRMPRIMETexture::Map(IVideoBufferDRMPRIME* buffer)
+bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
 {
   if (m_primebuffer)
     return true;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -94,7 +94,7 @@ int CDRMPRIMETexture::GetColorSpace(int colorSpace)
     case DRM_COLOR_YCBCR_BT709:
       return EGL_ITU_REC709_EXT;
     default:
-      CLog::Log(LOGERROR, "CEGLImage::%s - failed to get colorspace for: %d", __FUNCTION__, colorSpace);
+      CLog::Log(LOGERROR, "CDRMPRIMETexture::{} - failed to get colorspace for: {}", __FUNCTION__, colorSpace);
       break;
   }
 
@@ -110,7 +110,7 @@ int CDRMPRIMETexture::GetColorRange(int colorRange)
     case DRM_COLOR_YCBCR_LIMITED_RANGE:
       return EGL_YUV_NARROW_RANGE_EXT;
     default:
-      CLog::Log(LOGERROR, "CEGLImage::%s - failed to get colorrange for: %d", __FUNCTION__, colorRange);
+      CLog::Log(LOGERROR, "CDRMPRIMETexture::{} - failed to get colorrange for: {}", __FUNCTION__, colorRange);
       break;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -85,34 +85,26 @@ void CDRMPRIMETexture::Unmap()
 
 int CDRMPRIMETexture::GetColorSpace(int colorSpace)
 {
-  switch(colorSpace)
+  switch (colorSpace)
   {
     case DRM_COLOR_YCBCR_BT2020:
       return EGL_ITU_REC2020_EXT;
     case DRM_COLOR_YCBCR_BT601:
       return EGL_ITU_REC601_EXT;
     case DRM_COLOR_YCBCR_BT709:
-      return EGL_ITU_REC709_EXT;
     default:
-      CLog::Log(LOGERROR, "CDRMPRIMETexture::{} - failed to get colorspace for: {}", __FUNCTION__, colorSpace);
-      break;
+      return EGL_ITU_REC709_EXT;
   }
-
-  return -1;
 }
 
 int CDRMPRIMETexture::GetColorRange(int colorRange)
 {
-  switch(colorRange)
+  switch (colorRange)
   {
     case DRM_COLOR_YCBCR_FULL_RANGE:
       return EGL_YUV_FULL_RANGE_EXT;
     case DRM_COLOR_YCBCR_LIMITED_RANGE:
-      return EGL_YUV_NARROW_RANGE_EXT;
     default:
-      CLog::Log(LOGERROR, "CDRMPRIMETexture::{} - failed to get colorrange for: {}", __FUNCTION__, colorRange);
-      break;
+      return EGL_YUV_NARROW_RANGE_EXT;
   }
-
-  return -1;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -22,7 +22,7 @@ public:
   void Init(EGLDisplay eglDisplay);
 
   GLuint GetTexture() { return m_texture; }
-  CSizeInt GetTextureSize() { return { m_texWidth, m_texHeight }; }
+  CSizeInt GetTextureSize() { return {m_texWidth, m_texHeight}; }
 
 protected:
   IVideoBufferDRMPRIME* m_primebuffer{nullptr};
@@ -36,5 +36,4 @@ protected:
 private:
   static int GetColorSpace(int colorSpace);
   static int GetColorRange(int colorRange);
-
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -17,7 +17,7 @@
 class CDRMPRIMETexture
 {
 public:
-  bool Map(IVideoBufferDRMPRIME* buffer);
+  bool Map(CVideoBufferDRMPRIME* buffer);
   void Unmap();
   void Init(EGLDisplay eglDisplay);
 
@@ -25,7 +25,7 @@ public:
   CSizeInt GetTextureSize() { return {m_texWidth, m_texHeight}; }
 
 protected:
-  IVideoBufferDRMPRIME* m_primebuffer{nullptr};
+  CVideoBufferDRMPRIME* m_primebuffer{nullptr};
   std::unique_ptr<CEGLImage> m_eglImage;
 
   const GLenum m_textureTarget{GL_TEXTURE_EXTERNAL_OES};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -35,7 +35,7 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 {
-  if (buffer && dynamic_cast<IVideoBufferDRMPRIME*>(buffer) &&
+  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer) &&
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
           SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
@@ -137,7 +137,7 @@ bool CRendererDRMPRIME::NeedBuffer(int index)
   if (m_iLastRenderBuffer == index)
     return true;
 
-  IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
+  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
   if (buffer && buffer->m_fb_id)
     return true;
 
@@ -168,7 +168,7 @@ void CRendererDRMPRIME::RenderUpdate(
     return;
   }
 
-  IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
+  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
   if (!buffer || !buffer->IsValid())
     return;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -211,6 +211,7 @@ bool CRendererDRMPRIME::Supports(ERENDERFEATURE feature)
   {
     case RENDERFEATURE_STRETCH:
     case RENDERFEATURE_ZOOM:
+    case RENDERFEATURE_VERTICAL_SHIFT:
     case RENDERFEATURE_PIXEL_RATIO:
       return true;
     default:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -36,7 +36,8 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 {
   if (buffer && dynamic_cast<IVideoBufferDRMPRIME*>(buffer) &&
-      CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
     CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
     if (winSystem && winSystem->GetDrm()->GetVideoPlane()->plane &&
@@ -53,7 +54,10 @@ void CRendererDRMPRIME::Register()
   if (winSystem && winSystem->GetDrm()->GetVideoPlane()->plane &&
       std::dynamic_pointer_cast<CDRMAtomic>(winSystem->GetDrm()))
   {
-    CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)->SetVisible(true);
+    CServiceBroker::GetSettingsComponent()
+        ->GetSettings()
+        ->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)
+        ->SetVisible(true);
     VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
     return;
   }
@@ -155,7 +159,8 @@ void CRendererDRMPRIME::Update()
   ManageRenderArea();
 }
 
-void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
+void CRendererDRMPRIME::RenderUpdate(
+    int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
   if (m_iLastRenderBuffer == index && m_videoLayerBridge)
   {
@@ -170,7 +175,8 @@ void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned
   if (!m_videoLayerBridge)
   {
     CWinSystemGbm* winSystem = static_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-    m_videoLayerBridge = std::dynamic_pointer_cast<CVideoLayerBridgeDRMPRIME>(winSystem->GetVideoLayerBridge());
+    m_videoLayerBridge =
+        std::dynamic_pointer_cast<CVideoLayerBridgeDRMPRIME>(winSystem->GetVideoLayerBridge());
     if (!m_videoLayerBridge)
       m_videoLayerBridge = std::make_shared<CVideoLayerBridgeDRMPRIME>(winSystem->GetDrm());
     winSystem->RegisterVideoLayerBridge(m_videoLayerBridge);
@@ -201,12 +207,15 @@ bool CRendererDRMPRIME::ConfigChanged(const VideoPicture& picture)
 
 bool CRendererDRMPRIME::Supports(ERENDERFEATURE feature)
 {
-  if (feature == RENDERFEATURE_ZOOM ||
-      feature == RENDERFEATURE_STRETCH ||
-      feature == RENDERFEATURE_PIXEL_RATIO)
-    return true;
-
-  return false;
+  switch (feature)
+  {
+    case RENDERFEATURE_STRETCH:
+    case RENDERFEATURE_ZOOM:
+    case RENDERFEATURE_PIXEL_RATIO:
+      return true;
+    default:
+      return false;
+  }
 }
 
 bool CRendererDRMPRIME::Supports(ESCALINGMETHOD method)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -13,8 +13,7 @@
 class CVideoBuffer;
 class CVideoLayerBridgeDRMPRIME;
 
-class CRendererDRMPRIME
-  : public CBaseRenderer
+class CRendererDRMPRIME : public CBaseRenderer
 {
 public:
   CRendererDRMPRIME() = default;
@@ -26,21 +25,22 @@ public:
 
   // Player functions
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
-  bool IsConfigured() override { return m_bConfigured; };
+  bool IsConfigured() override { return m_bConfigured; }
   void AddVideoPicture(const VideoPicture& picture, int index) override;
-  void UnInit() override {};
+  void UnInit() override {}
   bool Flush(bool saveBuffers) override;
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
-  bool IsGuiLayer() override { return false; };
+  bool IsGuiLayer() override { return false; }
   CRenderInfo GetRenderInfo() override;
   void Update() override;
-  void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
+  void RenderUpdate(
+      int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   bool RenderCapture(CRenderCapture* capture) override;
   bool ConfigChanged(const VideoPicture& picture) override;
 
   // Feature support
-  bool SupportsMultiPassRendering() override { return false; };
+  bool SupportsMultiPassRendering() override { return false; }
   bool Supports(ERENDERFEATURE feature) override;
   bool Supports(ESCALINGMETHOD method) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -25,7 +25,7 @@ CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 
 CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
 {
-  if (buffer && dynamic_cast<IVideoBufferDRMPRIME*>(buffer))
+  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer))
     return new CRendererDRMPRIMEGLES();
 
   return nullptr;
@@ -102,7 +102,7 @@ bool CRendererDRMPRIMEGLES::UploadTexture(int index)
 {
   CPictureBuffer& buf = m_buffers[index];
 
-  IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(buf.videoBuffer);
+  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
 
   if (!buffer || !buffer->IsValid())
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -103,7 +103,7 @@ bool CRendererDRMPRIMEGLES::UploadTexture(int index)
 
   if (!buffer || !buffer->IsValid())
   {
-    CLog::Log(LOGNOTICE, "CRendererDRMPRIMEGLES::%s - no buffer", __FUNCTION__);
+    CLog::Log(LOGNOTICE, "CRendererDRMPRIMEGLES::{} - no buffer", __FUNCTION__);
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -36,13 +36,16 @@ void CRendererDRMPRIMEGLES::Register()
   VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime_gles", CRendererDRMPRIMEGLES::Create);
 }
 
-bool CRendererDRMPRIMEGLES::Configure(const VideoPicture &picture, float fps, unsigned int orientation)
+bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
+                                      float fps,
+                                      unsigned int orientation)
 {
-  CWinSystemGbmGLESContext* winSystem = dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
+  CWinSystemGbmGLESContext* winSystem =
+      dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return false;
 
-  for (auto &texture : m_DRMPRIMETextures)
+  for (auto& texture : m_DRMPRIMETextures)
     texture.Init(winSystem->GetEGLDisplay());
 
   for (auto& fence : m_fences)
@@ -68,9 +71,9 @@ bool CRendererDRMPRIMEGLES::NeedBuffer(int index)
 
 bool CRendererDRMPRIMEGLES::CreateTexture(int index)
 {
-  CPictureBuffer &buf = m_buffers[index];
-  YuvImage &im = buf.image;
-  CYuvPlane &plane = buf.fields[0][0];
+  CPictureBuffer& buf = m_buffers[index];
+  YuvImage& im = buf.image;
+  CYuvPlane& plane = buf.fields[0][0];
 
   DeleteTexture(index);
 
@@ -78,7 +81,7 @@ bool CRendererDRMPRIMEGLES::CreateTexture(int index)
   plane = {};
 
   im.height = m_sourceHeight;
-  im.width  = m_sourceWidth;
+  im.width = m_sourceWidth;
   im.cshift_x = 1;
   im.cshift_y = 1;
 
@@ -91,13 +94,13 @@ void CRendererDRMPRIMEGLES::DeleteTexture(int index)
 {
   ReleaseBuffer(index);
 
-  CPictureBuffer &buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
   buf.fields[0][0].id = 0;
 }
 
 bool CRendererDRMPRIMEGLES::UploadTexture(int index)
 {
-  CPictureBuffer &buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
 
   IVideoBufferDRMPRIME* buffer = dynamic_cast<IVideoBufferDRMPRIME*>(buf.videoBuffer);
 
@@ -109,10 +112,10 @@ bool CRendererDRMPRIMEGLES::UploadTexture(int index)
 
   m_DRMPRIMETextures[index].Map(buffer);
 
-  CYuvPlane &plane = buf.fields[0][0];
+  CYuvPlane& plane = buf.fields[0][0];
 
   auto size = m_DRMPRIMETextures[index].GetTextureSize();
-  plane.texwidth  = size.Width();
+  plane.texwidth = size.Width();
   plane.texheight = size.Height();
   plane.pixpertex_x = 1;
   plane.pixpertex_y = 1;
@@ -134,10 +137,11 @@ bool CRendererDRMPRIMEGLES::LoadShadersHook()
 
 bool CRendererDRMPRIMEGLES::RenderHook(int index)
 {
-  CRenderSystemGLES *renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+  CRenderSystemGLES* renderSystem =
+      dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
   assert(renderSystem);
 
-  CYuvPlane &plane = m_buffers[index].fields[0][0];
+  CYuvPlane& plane = m_buffers[index].fields[0][0];
 
   glDisable(GL_DEPTH_TEST);
 
@@ -186,14 +190,17 @@ bool CRendererDRMPRIMEGLES::RenderHook(int index)
   vertex[3].y = m_rotatedDestCoords[3].y;
   vertex[3].z = 0.0f;
   vertex[3].u1 = plane.rect.x1;
-  vertex[3].v1 = plane.rect.y2;;
+  vertex[3].v1 = plane.rect.y2;
 
   glGenBuffers(1, &vertexVBO);
   glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * vertex.size(), vertex.data(), GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * vertex.size(), vertex.data(),
+               GL_STATIC_DRAW);
 
-  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
-  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
 
   glEnableVertexAttribArray(vertLoc);
   glEnableVertexAttribArray(loc);
@@ -228,14 +235,14 @@ bool CRendererDRMPRIMEGLES::Supports(ERENDERFEATURE feature)
 {
   switch (feature)
   {
-  case RENDERFEATURE_STRETCH:
-  case RENDERFEATURE_ZOOM:
-  case RENDERFEATURE_VERTICAL_SHIFT:
-  case RENDERFEATURE_PIXEL_RATIO:
-  case RENDERFEATURE_ROTATION:
-    return true;
-  default:
-    return false;
+    case RENDERFEATURE_STRETCH:
+    case RENDERFEATURE_ZOOM:
+    case RENDERFEATURE_VERTICAL_SHIFT:
+    case RENDERFEATURE_PIXEL_RATIO:
+    case RENDERFEATURE_ROTATION:
+      return true;
+    default:
+      return false;
   }
 }
 
@@ -243,9 +250,9 @@ bool CRendererDRMPRIMEGLES::Supports(ESCALINGMETHOD method)
 {
   switch (method)
   {
-  case VS_SCALINGMETHOD_LINEAR:
-    return true;
-  default:
-    return false;
+    case VS_SCALINGMETHOD_LINEAR:
+      return true;
+    default:
+      return false;
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -22,8 +22,8 @@ namespace EGL
 {
 class CEGLFence;
 }
-}
-}
+} // namespace UTILS
+} // namespace KODI
 
 class CRendererDRMPRIMEGLES : public CLinuxRendererGLES
 {
@@ -36,7 +36,7 @@ public:
   static void Register();
 
   // CLinuxRendererGLES overrides
-  bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
+  bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
   void ReleaseBuffer(int index) override;
   bool NeedBuffer(int index) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -32,7 +32,7 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
 }
 
-void CVideoLayerBridgeDRMPRIME::Acquire(IVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
 {
   // release the buffer that is no longer presented on screen
   Release(m_prev_buffer);
@@ -45,7 +45,7 @@ void CVideoLayerBridgeDRMPRIME::Acquire(IVideoBufferDRMPRIME* buffer)
   m_buffer->Acquire();
 }
 
-void CVideoLayerBridgeDRMPRIME::Release(IVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
 {
   if (!buffer)
     return;
@@ -54,7 +54,7 @@ void CVideoLayerBridgeDRMPRIME::Release(IVideoBufferDRMPRIME* buffer)
   buffer->Release();
 }
 
-bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
+bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
 {
   if (buffer->m_fb_id)
     return true;
@@ -115,7 +115,7 @@ bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
   return true;
 }
 
-void CVideoLayerBridgeDRMPRIME::Unmap(IVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
 {
   if (buffer->m_fb_id)
   {
@@ -136,7 +136,7 @@ void CVideoLayerBridgeDRMPRIME::Unmap(IVideoBufferDRMPRIME* buffer)
   buffer->Unmap();
 }
 
-void CVideoLayerBridgeDRMPRIME::Configure(IVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
   struct plane* plane = m_DRM->GetVideoPlane();
   if (m_DRM->SupportsProperty(plane, "COLOR_ENCODING") &&
@@ -147,7 +147,7 @@ void CVideoLayerBridgeDRMPRIME::Configure(IVideoBufferDRMPRIME* buffer)
   }
 }
 
-void CVideoLayerBridgeDRMPRIME::SetVideoPlane(IVideoBufferDRMPRIME* buffer, const CRect& destRect)
+void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)
 {
   if (!Map(buffer))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -13,6 +13,7 @@
 #include "windowing/gbm/DRMUtils.h"
 
 using namespace KODI::WINDOWING::GBM;
+using namespace DRMPRIME;
 
 CVideoLayerBridgeDRMPRIME::CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm) : m_DRM(drm)
 {
@@ -138,12 +139,14 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
 
 void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
+  const VideoPicture& picture = buffer->GetPicture();
+
   struct plane* plane = m_DRM->GetVideoPlane();
   if (m_DRM->SupportsProperty(plane, "COLOR_ENCODING") &&
       m_DRM->SupportsProperty(plane, "COLOR_RANGE"))
   {
-    m_DRM->AddProperty(plane, "COLOR_ENCODING", buffer->GetColorEncoding());
-    m_DRM->AddProperty(plane, "COLOR_RANGE", buffer->GetColorRange());
+    m_DRM->AddProperty(plane, "COLOR_ENCODING", GetColorEncoding(picture));
+    m_DRM->AddProperty(plane, "COLOR_RANGE", GetColorRange(picture));
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -74,7 +74,7 @@ bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
     ret = drmPrimeFDToHandle(m_DRM->GetFileDescriptor(), descriptor->objects[object].fd, &buffer->m_handles[object]);
     if (ret < 0)
     {
-      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to convert prime fd %d to gem handle %u, ret = %d",
+      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to convert prime fd {} to gem handle {}, ret = {}",
                 __FUNCTION__, descriptor->objects[object].fd, buffer->m_handles[object], ret);
       return false;
     }
@@ -103,7 +103,7 @@ bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
                                    handles, pitches, offsets, modifier, &buffer->m_fb_id, flags);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::%s - failed to add fb %d, ret = %d", __FUNCTION__, buffer->m_fb_id, ret);
+    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}", __FUNCTION__, buffer->m_fb_id, ret);
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -14,8 +14,7 @@
 
 using namespace KODI::WINDOWING::GBM;
 
-CVideoLayerBridgeDRMPRIME::CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm)
-  : m_DRM(drm)
+CVideoLayerBridgeDRMPRIME::CVideoLayerBridgeDRMPRIME(std::shared_ptr<CDRMUtils> drm) : m_DRM(drm)
 {
 }
 
@@ -71,10 +70,13 @@ bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
   // convert Prime FD to GEM handle
   for (int object = 0; object < descriptor->nb_objects; object++)
   {
-    ret = drmPrimeFDToHandle(m_DRM->GetFileDescriptor(), descriptor->objects[object].fd, &buffer->m_handles[object]);
+    ret = drmPrimeFDToHandle(m_DRM->GetFileDescriptor(), descriptor->objects[object].fd,
+                             &buffer->m_handles[object]);
     if (ret < 0)
     {
-      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to convert prime fd {} to gem handle {}, ret = {}",
+      CLog::Log(LOGERROR,
+                "CVideoLayerBridgeDRMPRIME::{} - failed to convert prime fd {} to gem handle {}, "
+                "ret = {}",
                 __FUNCTION__, descriptor->objects[object].fd, buffer->m_handles[object], ret);
       return false;
     }
@@ -99,11 +101,13 @@ bool CVideoLayerBridgeDRMPRIME::Map(IVideoBufferDRMPRIME* buffer)
     flags = DRM_MODE_FB_MODIFIERS;
 
   // add the video frame FB
-  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(), buffer->GetHeight(), layer->format,
-                                   handles, pitches, offsets, modifier, &buffer->m_fb_id, flags);
+  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(),
+                                   buffer->GetHeight(), layer->format, handles, pitches, offsets,
+                                   modifier, &buffer->m_fb_id, flags);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}", __FUNCTION__, buffer->m_fb_id, ret);
+    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",
+              __FUNCTION__, buffer->m_fb_id, ret);
     return false;
   }
 
@@ -123,7 +127,7 @@ void CVideoLayerBridgeDRMPRIME::Unmap(IVideoBufferDRMPRIME* buffer)
   {
     if (buffer->m_handles[i])
     {
-      struct drm_gem_close gem_close = { .handle = buffer->m_handles[i] };
+      struct drm_gem_close gem_close = {.handle = buffer->m_handles[i]};
       drmIoctl(m_DRM->GetFileDescriptor(), DRM_IOCTL_GEM_CLOSE, &gem_close);
       buffer->m_handles[i] = 0;
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -19,15 +19,14 @@ namespace WINDOWING
 {
 namespace GBM
 {
-  class CDRMUtils;
+class CDRMUtils;
 }
-}
-}
+} // namespace WINDOWING
+} // namespace KODI
 
 class IVideoBufferDRMPRIME;
 
-class CVideoLayerBridgeDRMPRIME
-  : public KODI::WINDOWING::GBM::CVideoLayerBridge
+class CVideoLayerBridgeDRMPRIME : public KODI::WINDOWING::GBM::CVideoLayerBridge
 {
 public:
   CVideoLayerBridgeDRMPRIME(std::shared_ptr<KODI::WINDOWING::GBM::CDRMUtils> drm);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -24,7 +24,7 @@ class CDRMUtils;
 } // namespace WINDOWING
 } // namespace KODI
 
-class IVideoBufferDRMPRIME;
+class CVideoBufferDRMPRIME;
 
 class CVideoLayerBridgeDRMPRIME : public KODI::WINDOWING::GBM::CVideoLayerBridge
 {
@@ -33,19 +33,19 @@ public:
   ~CVideoLayerBridgeDRMPRIME() override;
   void Disable() override;
 
-  virtual void Configure(IVideoBufferDRMPRIME* buffer);
-  virtual void SetVideoPlane(IVideoBufferDRMPRIME* buffer, const CRect& destRect);
+  virtual void Configure(CVideoBufferDRMPRIME* buffer);
+  virtual void SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect);
   virtual void UpdateVideoPlane();
 
 protected:
   std::shared_ptr<KODI::WINDOWING::GBM::CDRMUtils> m_DRM;
 
 private:
-  void Acquire(IVideoBufferDRMPRIME* buffer);
-  void Release(IVideoBufferDRMPRIME* buffer);
-  bool Map(IVideoBufferDRMPRIME* buffer);
-  void Unmap(IVideoBufferDRMPRIME* buffer);
+  void Acquire(CVideoBufferDRMPRIME* buffer);
+  void Release(CVideoBufferDRMPRIME* buffer);
+  bool Map(CVideoBufferDRMPRIME* buffer);
+  void Unmap(CVideoBufferDRMPRIME* buffer);
 
-  IVideoBufferDRMPRIME* m_buffer = nullptr;
-  IVideoBufferDRMPRIME* m_prev_buffer = nullptr;
+  CVideoBufferDRMPRIME* m_buffer = nullptr;
+  CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
 };


### PR DESCRIPTION
## Description
This PR contains cleanup and refactored code for the DRM PRIME video codec, renderer and video buffer.

- Format code with clang-format
- Use Python-like format string syntax for logging
- Use of hints as a fallback for video picture params
- Rename `CVideoBufferDRMPRIME` to `CVideoBufferDRMPRIMEFFmpeg`
- Rename `IVideoBufferDRMPRIME` to `CVideoBufferDRMPRIME`
- Decouple `GetColorEncoding` and `GetColorRange` from `CVideoBufferDRMPRIME` and make use of a `VideoPicture` for picture params
- Minor changes and fixes discovered while experimenting with VA-API

## Motivation and Context
Cleanup, improvements and trying to address some remarks made in #16103 and #16089

## How Has This Been Tested?
The LibreELEC build used during the DRM PRIME presentation at DevCon contained an earlier iteration of these patches.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
