### PR TITLE
Always highlight the OK button when installing an add-on

### DIFF
--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -518,6 +518,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::Dependency
     for (auto& it : items)
       pDialog->Add(*it);
     pDialog->EnableButton(!reactivate, 186);
+    pDialog->SetButtonFocus(true);
     pDialog->Open();
 
     if (pDialog->IsButtonPressed())

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -126,7 +126,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     {
       if (m_viewControl.HasControl(message.GetControlId()))
       {
-        if (m_vecList->IsEmpty())
+        if (m_vecList->IsEmpty() || m_focusToButton)
         {
           if (m_bButtonEnabled)
             SET_CONTROL_FOCUS(CONTROL_EXTRA_BUTTON, 0);
@@ -168,6 +168,7 @@ void CGUIDialogSelect::Reset()
   m_bButtonPressed = false;
   m_useDetails = false;
   m_multiSelection = false;
+  m_focusToButton = false;
   m_selectedItem = nullptr;
   m_vecList->Clear();
   m_selectedItems.clear();
@@ -277,6 +278,11 @@ void CGUIDialogSelect::SetUseDetails(bool useDetails)
 void CGUIDialogSelect::SetMultiSelection(bool multiSelection)
 {
   m_multiSelection = multiSelection;
+}
+
+void CGUIDialogSelect::SetButtonFocus(bool buttonFocus)
+{
+  m_focusToButton = buttonFocus;
 }
 
 CGUIControl *CGUIDialogSelect::GetFirstFocusableControl(int id)

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -41,6 +41,7 @@ public:
   void SetSelected(const std::vector<std::string> &selectedLabels);
   void SetUseDetails(bool useDetails);
   void SetMultiSelection(bool multiSelection);
+  void SetButtonFocus(bool buttonFocus);
 
 protected:
   explicit CGUIDialogSelect(int windowid);
@@ -59,6 +60,7 @@ private:
   CFileItemPtr m_selectedItem;
   bool m_useDetails;
   bool m_multiSelection;
+  bool m_focusToButton{};
 
   std::vector<int> m_selectedItems;
   std::unique_ptr<CFileItemList> m_vecList;


### PR DESCRIPTION
## Description
This solves #16754. 
Admittedly this is somewhat of a personal opinion issue, although I think it is a valid one. It can *probably* be a better fix by highlighting the "cancel" button first, in order to prevent accidental clicks to the "OK" button.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
I tested on Linux Mint 19.2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
