### PR TITLE
Revert setting playcount to PLAYCOUNT_NOT_SET on video items read from cache

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -470,8 +470,6 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strAlbum;
     ar >> m_artist;
     ar >> m_playCount;
-    //re-evaluate the playcount
-    m_playCount = PLAYCOUNT_NOT_SET;
     ar >> m_lastPlayed;
     ar >> m_iTop250;
     ar >> m_iSeason;


### PR DESCRIPTION
This reverts #14810 that caused the video library issues  #15251 and #16357 -  watched items not being hidden (or playcount updated)  when cached data was used for slower file item lists. Setting playcount to `PLAYCOUNT_NOT_SET` on read from cache does not cause it to be re-evaluated, it just retruns all items from cache as if they had not been played.

This has been tested by users and they confirm is resolves their issue.

A fix for the original issue that #14810 attempted to fix will be in another PR. Both neeed to be backported.
