### PR TITLE
Build cache filename using just path without options string

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2946,7 +2946,7 @@ void CFileItemList::RemoveDiscCache(int windowID) const
 std::string CFileItemList::GetDiscFileCache(int windowID) const
 {
   std::string strPath(GetPath());
-  URIUtils::RemoveSlashAtEnd(strPath);
+  strPath = CURL(strPath).GetWithoutOptions();
 
   uint32_t crc = Crc32::ComputeFromLowerCase(strPath);
 


### PR DESCRIPTION
This solves the issue that #14810 attempted to fix, and follows on from #16804 that reverted that PR because it was causing other problems.

The problem was that on playback of a video finishing,  if the list of videos is subsequently read from cache (because it was slow to load as MySQL server over LAN or lots of items etc. ) then the watched state and playcount of that item is not updated on the GUI. Because cache is not always used this lack of data display being refreshed is seen as intermittent and hard to repeat.

Messages to update the played item are sent correctly. The problem was that the disc cache file name was being formed inconsistently.  When cache is created the CRC is built from a item path without options, but when looking to clear cache (because the item has been updated) the CRC is built from path with options, hence a different CRC.

Hence the fix is to only use path and not option string when forming the cache file name.

Testing is best done in combination with #16804, needs either a slow system, lots of videos in a list,  or to run in debug and pause while reading data from the db. I have done that obviously.

Test builds with _both_ changes applied to v18 are on the mirrors e.g. win64 here http://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20191018-fc596118-Revert14810_Leia-x64.exe . 

This fix also goes towards ifixing video library watched state issues #15251 and #16357 