### PR TITLE
Fix hide watched by saving cache filename with each item for clear on item update [backport]

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -717,6 +717,8 @@ public:
    \sa Save,Load
    */
   void RemoveDiscCache(int windowID = 0) const;
+  void RemoveDiscCache(const std::string& cachefile) const;
+  void RemoveDiscCacheCRC(const std::string& crc) const;
   bool AlwaysCache() const;
 
   void Swap(unsigned int item1, unsigned int item2);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -469,8 +469,6 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strAlbum;
     ar >> m_artist;
     ar >> m_playCount;
-    //re-evaluate the playcount
-    m_playCount = PLAYCOUNT_NOT_SET;
     ar >> m_lastPlayed;
     ar >> m_iTop250;
     ar >> m_iSeason;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -427,7 +427,15 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         { // need to remove the disc cache
           CFileItemList items;
           items.SetPath(URIUtils::GetDirectory(newItem->GetPath()));
-          items.RemoveDiscCache(GetID());
+          if (newItem->HasProperty("cachefilename"))
+          {
+            // Use stored cache file name
+            std::string crcfile = newItem->GetProperty("cachefilename").asString();
+            items.RemoveDiscCacheCRC(crcfile);
+          }
+          else
+            // No stored cache file name, attempt using truncated item path as list path
+            items.RemoveDiscCache(GetID());
         }
       }
       else if (message.GetParam1()==GUI_MSG_UPDATE_PATH)


### PR DESCRIPTION
A backport of #16804 and #16848 that fixes issues with watched videos not being hidden (or playcount updated) for slower loading file item lists e.g when cache used, as reported in #15251 and #16357 

This reverts #14810 (that caused _all_ items read from cache to appear as unwatched) and also solves the original issue of the video watched state and playcount not being refreshed on the GUI when the list was cached.

Test builds for v18 are on the mirrors e.g. win64 here http://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20191030-90a7c73a-PR16806-merge-x64.exe