### PR TITLE
Fix crashes due to missing TrueHD overrun checks

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -164,6 +164,22 @@ void CAEBitstreamPacker::PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size
   else
     offset = (m_trueHDPos * TRUEHD_FRAME_OFFSET) - BURST_HEADER_SIZE;
 
+  int maxSize = TRUEHD_FRAME_OFFSET;
+  if (m_trueHDPos == 0)
+    maxSize -= sizeof(mat_start_code) + BURST_HEADER_SIZE;
+  else if (m_trueHDPos == 11)
+    maxSize -= -MAT_MIDDLE_CODE_OFFSET;
+  else if (m_trueHDPos == 12)
+    maxSize -= sizeof(mat_middle_code) + MAT_MIDDLE_CODE_OFFSET;
+  else if (m_trueHDPos == 23)
+    maxSize -= sizeof(mat_end_code) + (24 * TRUEHD_FRAME_OFFSET - MAT_FRAME_SIZE);
+
+  if (size > maxSize)
+  {
+    CLog::Log(LOGERROR, "CAEBitstreamPacker::PackTrueHD - truncating TrueHD frame of %d bytes", size);
+    size = maxSize;
+  }
+
   memcpy(m_trueHD + offset, data, size);
 
   /* if we have a full frame */

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -177,6 +177,11 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
     if (!m_trueHDoffset)
       memset(m_trueHDBuffer.get(), 0, TRUEHD_BUF_SIZE);
 
+    if (m_dataSize > 2560-2)
+    {
+      CLog::Log(LOGERROR, "CDVDAudioCodecPassthrough::AddData - truncating TrueHD frame of %u bytes", m_dataSize);
+      m_dataSize = 2560-2;
+    }
     memcpy(&(m_trueHDBuffer.get())[m_trueHDoffset], m_buffer, m_dataSize);
     uint8_t highByte = (m_dataSize >> 8) & 0xFF;
     uint8_t lowByte = m_dataSize & 0xFF;


### PR DESCRIPTION
CAEBitstreamPacker and CDVDAudioCodecPassthrough copy TrueHD frames into
buffers without checking for overruns.

Fix that.

This should fix crashes of issue #16704.

However, audio dropouts still remain. To fix those, the TrueHD packet
offsets will need to be dynamically scaled based on the input_timing
field (TrueHD bytes 2-3) which allows determining the amount of time
required between the previous frame and the current frame.
