### PR TITLE
add CODEOWNERS file to help selecting reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,13 @@
 
 # Please try and keep the list in alphabetical order
 
+/xbmc/cores/RetroPlayer/ @garbear
 /xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVR*.* @ksooo
 /xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.* @lrusak
 /xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME* @lrusak
 /xbmc/filesystem/Music*.* @DaveTBlake
+/xbmc/games/ @garbear
+/xbmc/input/ @garbear
 /xbmc/interfaces/builtins/PVR*.* @ksooo
 /xbmc/interfaces/json-rpc/AudioLibrary.*  @DaveTBlake
 /xbmc/interfaces/json-rpc/PVR*.* @ksooo
@@ -15,6 +18,7 @@
 /xbmc/guilib/guiinfo/GUIInfoProviders.* @ksooo
 /xbmc/guilib/guiinfo/IGUIInfoProvider.h @ksooo
 /xbmc/music/ @DaveTBlake
+/xbmc/peripherals/ @garbear
 /xbmc/platform/linux/ @lrusak
 /xbmc/pvr/ @ksooo
 /xbmc/rendering/gles/ @lrusak

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# Please try and keep the list in alphabetical order
+
+/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.* @lrusak
+/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME* @lrusak
+/xbmc/platform/linux/ @lrusak
+/xbmc/rendering/gles/ @lrusak
+/xbmc/utils/EGL* @lrusak
+/xbmc/utils/GBMBufferObject.* @lrusak
+/xbmc/windowing/gbm/ @lrusak
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,19 @@
 
 # Please try and keep the list in alphabetical order
 
+/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVR*.* @ksooo
 /xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.* @lrusak
 /xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME* @lrusak
+/xbmc/interfaces/builtins/PVR*.* @ksooo
+/xbmc/interfaces/json-rpc/PVR*.* @ksooo
+/xbmc/guilib/GUIRangesControl.* @ksooo
+/xbmc/guilib/guiinfo/GUIInfoProvider.h @ksooo
+/xbmc/guilib/guiinfo/GUIInfoProviders.* @ksooo
+/xbmc/guilib/guiinfo/IGUIInfoProvider.h @ksooo
 /xbmc/platform/linux/ @lrusak
+/xbmc/pvr/ @ksooo
 /xbmc/rendering/gles/ @lrusak
+/xbmc/settings/SettingsComponent.* @ksooo
 /xbmc/utils/EGL* @lrusak
 /xbmc/utils/GBMBufferObject.* @lrusak
 /xbmc/windowing/gbm/ @lrusak

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,12 +6,15 @@
 /xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVR*.* @ksooo
 /xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.* @lrusak
 /xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME* @lrusak
+/xbmc/filesystem/Music*.* @DaveTBlake
 /xbmc/interfaces/builtins/PVR*.* @ksooo
+/xbmc/interfaces/json-rpc/AudioLibrary.*  @DaveTBlake
 /xbmc/interfaces/json-rpc/PVR*.* @ksooo
 /xbmc/guilib/GUIRangesControl.* @ksooo
 /xbmc/guilib/guiinfo/GUIInfoProvider.h @ksooo
 /xbmc/guilib/guiinfo/GUIInfoProviders.* @ksooo
 /xbmc/guilib/guiinfo/IGUIInfoProvider.h @ksooo
+/xbmc/music/ @DaveTBlake
 /xbmc/platform/linux/ @lrusak
 /xbmc/pvr/ @ksooo
 /xbmc/rendering/gles/ @lrusak

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,4 +26,5 @@
 /xbmc/utils/EGL* @lrusak
 /xbmc/utils/GBMBufferObject.* @lrusak
 /xbmc/windowing/gbm/ @lrusak
+/xbmc/windowing/wayland/ @yol
 


### PR DESCRIPTION
As discussed at devcon this adds the CODEOWNERS file. I encourage all core devs to add their relevant sections. There will be a lot of code that is missing maintainers.

this fixes https://github.com/xbmc/board/issues/114