### PR TITLE
[macos] Improve and fix the fix for only quarter of screen rendered i…

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -791,14 +791,7 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   if (!view)
     return false;
 
-  if (CDisplaySettings::GetInstance().GetCurrentResolution() == RES_WINDOW)
-  {
-    // It seems, that in macOS 10.15 this defaults to YES, but we currently do not support
-    // Retina resolutions properly. Ensure that the view created by SDL uses a 1 pixel per
-    // point framebuffer.
-    view.wantsBestResolutionOpenGLSurface = NO;
-  }
-  else
+  if (CDisplaySettings::GetInstance().GetCurrentResolution() != RES_WINDOW)
   {
     // If we are not starting up windowed, then hide the initial SDL window
     // so we do not see it flash before the fade-out and switch to fullscreen.
@@ -879,6 +872,14 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   NSWindow* window;
 
   view = [context view];
+
+  if (view)
+  {
+    // It seems, that in macOS 10.15 this defaults to YES, but we currently do not support
+    // Retina resolutions properly. Ensure that the view uses a 1 pixel per point framebuffer.
+    view.wantsBestResolutionOpenGLSurface = NO;
+  }
+
   if (view && (newWidth > 0) && (newHeight > 0))
   {
     window = [view window];
@@ -1018,10 +1019,6 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     [windowedFullScreenwindow setContentSize:NSMakeSize(m_nWidth, m_nHeight)];
     [windowedFullScreenwindow update];
     [blankView setFrameSize:NSMakeSize(m_nWidth, m_nHeight)];
-
-    // It seems, that in macOS 10.15 this defaults to YES, but we currently do not support
-    // Retina resolutions properly. Thus, ensure that we get a 1 pixel per point framebuffer.
-    blankView.wantsBestResolutionOpenGLSurface = NO;
 
     // Obtain windowed pixel format and create a new context.
     newContext = CreateWindowedContext(cur_context);


### PR DESCRIPTION
…n windowed mode and certain fullscreen resolutions on macOS 10.15 (Catalina).

Followup to #16789 

Fix: switching from fullscreen to window did still result in rendering only a quarter of the window.
Improve: view attribute only needs to be set add one place (formerly two). 