### PR TITLE
[Ios] mpnowplaying refactor and modernise code

### DIFF
--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.h
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.h
@@ -8,19 +8,22 @@
 
 #pragma once
 
-#import "interfaces/AnnouncementManager.h"
+#include "interfaces/AnnouncementManager.h"
 
 class CVariant;
 
 class CAnnounceReceiver : public ANNOUNCEMENT::IAnnouncer
 {
 public:
-  static  CAnnounceReceiver* GetInstance();
+  static CAnnounceReceiver* GetInstance();
 
-  void    Initialize();
-  void    DeInitialize();
+  void Initialize();
+  void DeInitialize();
 
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char* sender, const char* message, const CVariant& data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const char* sender,
+                const char* message,
+                const CVariant& data) override;
 
 private:
   CAnnounceReceiver() = default;

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -42,7 +42,7 @@ NSDictionary* dictionaryFromVariantMap(const CVariant& data)
     return nil;
   NSMutableDictionary* dict = [[NSMutableDictionary alloc] initWithCapacity:data.size()];
   for (CVariant::const_iterator_map itr = data.begin_map(); itr != data.end_map(); ++itr)
-    [dict setValue:objectFromVariant(itr->second) forKey:@(itr->first.c_str())];
+    dict[@(itr->first.c_str())] = objectFromVariant(itr->second);
 
   return dict;
 }
@@ -54,7 +54,8 @@ id objectFromVariant(const CVariant& data)
   if (data.isString())
     return @(data.asString().c_str());
   if (data.isWideString())
-    return [NSString stringWithCString:(const char*)data.asWideString().c_str() encoding:NSUnicodeStringEncoding];
+    return [NSString stringWithCString:reinterpret_cast<const char*>(data.asWideString().c_str())
+                              encoding:NSUnicodeStringEncoding];
   if (data.isInteger())
     return @(data.asInteger());
   if (data.isUnsignedInteger())
@@ -119,77 +120,76 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
     }
   }
 
-  //LOG(@"AnnounceBridge: [%s], [%s], [%s]", ANNOUNCEMENT::AnnouncementFlagToString(flag), sender, message);
-  NSDictionary* dict = dictionaryFromVariantMap(nonConstData);
-  //LOG(@"data: %@", dict.description);
+  auto dict = dictionaryFromVariantMap(nonConstData);
+
   if (msg == "OnPlay" || msg == "OnResume")
   {
-    NSDictionary* item = [dict valueForKey:@"item"];
-    NSDictionary* player = [dict valueForKey:@"player"];
-    [item setValue:[player valueForKey:@"speed"] forKey:@"speed"];
+    NSMutableDictionary* item = dict[@"item"];
+    NSDictionary* player = dict[@"player"];
+    item[@"speed"] = player[@"speed"];
     std::string thumb = g_application.CurrentFileItem().GetArt("thumb");
     if (!thumb.empty())
     {
       bool needsRecaching;
       std::string cachedThumb(CTextureCache::GetInstance().CheckCachedImage(thumb, needsRecaching));
-      //LOG("thumb: %s, %s", thumb.c_str(), cachedThumb.c_str());
       if (!cachedThumb.empty())
       {
         std::string thumbRealPath = CSpecialProtocol::TranslatePath(cachedThumb);
-        [item setValue:@(thumbRealPath.c_str()) forKey:@"thumb"];
+        item[@"thumb"] = @(thumbRealPath.c_str());
       }
     }
     double duration = g_application.GetTotalTime();
     if (duration > 0)
-      [item setValue:@(duration) forKey:@"duration"];
-    [item setValue:@(g_application.GetTime()) forKey:@"elapsed"];
+      item[@"duration"] = @(duration);
+    item[@"elapsed"] = @(g_application.GetTime());
     int current = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     if (current >= 0)
     {
-      [item setValue:@(current) forKey:@"current"];
-      [item setValue:@(CServiceBroker::GetPlaylistPlayer()
-                        .GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()
-              forKey:@"total"];
+      item[@"current"] = @(current);
+      item[@"total"] = @(CServiceBroker::GetPlaylistPlayer()
+                             .GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist())
+                             .size());
     }
     if (g_application.CurrentFileItem().HasMusicInfoTag())
     {
-      const std::vector<std::string>& genre =
-          g_application.CurrentFileItem().GetMusicInfoTag()->GetGenre();
+      const auto& genre = g_application.CurrentFileItem().GetMusicInfoTag()->GetGenre();
       if (!genre.empty())
       {
         NSMutableArray* genreArray = [[NSMutableArray alloc] initWithCapacity:genre.size()];
-        for (std::vector<std::string>::const_iterator it = genre.begin(); it != genre.end(); ++it)
+        for (auto genreItem : genre)
         {
-          [genreArray addObject:@(it->c_str())];
+          [genreArray addObject:@(genreItem.c_str())];
         }
-        [item setValue:genreArray forKey:@"genre"];
+        item[@"genre"] = genreArray;
       }
     }
-    //LOG(@"item: %@", item.description);
-    [g_xbmcController performSelectorOnMainThread:@selector(onPlay:)
-                                       withObject:item
-                                    waitUntilDone:NO];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [g_xbmcController.MPNPInfoManager onPlay:item];
+    });
   }
   else if (msg == "OnSpeedChanged" || msg == "OnPause")
   {
-    NSDictionary* item = [dict valueForKey:@"item"];
-    NSDictionary* player = [dict valueForKey:@"player"];
-    [item setValue:[player valueForKey:@"speed"] forKey:@"speed"];
-    [item setValue:@(g_application.GetTime()) forKey:@"elapsed"];
-    //LOG(@"item: %@", item.description);
-    [g_xbmcController performSelectorOnMainThread:@selector(OnSpeedChanged:)
-                                       withObject:item
-                                    waitUntilDone:NO];
+    NSMutableDictionary* item = dict[@"item"];
+    NSDictionary* player = dict[@"player"];
+    item[@"speed"] = player[@"speed"];
+    item[@"elapsed"] = @(g_application.GetTime());
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [g_xbmcController.MPNPInfoManager OnSpeedChanged:item];
+    });
     if (msg == "OnPause")
-      [g_xbmcController performSelectorOnMainThread:@selector(onPause:)
-                                         withObject:[dict valueForKey:@"item"]
-                                      waitUntilDone:NO];
+    {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [g_xbmcController.MPNPInfoManager onPause:item];
+      });
+    }
   }
   else if (msg == "OnStop")
   {
-    [g_xbmcController performSelectorOnMainThread:@selector(onStop:)
-                                       withObject:[dict valueForKey:@"item"]
-                                    waitUntilDone:NO];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [g_xbmcController.MPNPInfoManager onStop:dict[@"item"]];
+    });
   }
 }
 

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -8,24 +8,24 @@
 
 #import "platform/darwin/ios-common/AnnounceReceiver.h"
 
-#import "Application.h"
-#import "FileItem.h"
+#include "Application.h"
+#include "FileItem.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
-#import "TextureCache.h"
-#import "filesystem/SpecialProtocol.h"
-#import "music/MusicDatabase.h"
-#import "music/tags/MusicInfoTag.h"
-#import "playlists/PlayList.h"
-#import "utils/Variant.h"
+#include "TextureCache.h"
+#include "filesystem/SpecialProtocol.h"
+#include "music/MusicDatabase.h"
+#include "music/tags/MusicInfoTag.h"
+#include "playlists/PlayList.h"
+#include "utils/Variant.h"
 
 #import "platform/darwin/ios/XBMCController.h"
 
 #import <UIKit/UIKit.h>
 
-id objectFromVariant(const CVariant &data);
+id objectFromVariant(const CVariant& data);
 
-NSArray *arrayFromVariantArray(const CVariant &data)
+NSArray* arrayFromVariantArray(const CVariant& data)
 {
   if (!data.isArray())
     return nil;
@@ -36,7 +36,7 @@ NSArray *arrayFromVariantArray(const CVariant &data)
   return array;
 }
 
-NSDictionary *dictionaryFromVariantMap(const CVariant &data)
+NSDictionary* dictionaryFromVariantMap(const CVariant& data)
 {
   if (!data.isObject())
     return nil;
@@ -47,7 +47,7 @@ NSDictionary *dictionaryFromVariantMap(const CVariant &data)
   return dict;
 }
 
-id objectFromVariant(const CVariant &data)
+id objectFromVariant(const CVariant& data)
 {
   if (data.isNull())
     return nil;
@@ -71,7 +71,10 @@ id objectFromVariant(const CVariant &data)
   return nil;
 }
 
-void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag,
+                    const char* sender,
+                    const char* message,
+                    const CVariant& data)
 {
   int item_id = -1;
   std::string item_type = "";
@@ -117,12 +120,12 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
   }
 
   //LOG(@"AnnounceBridge: [%s], [%s], [%s]", ANNOUNCEMENT::AnnouncementFlagToString(flag), sender, message);
-  NSDictionary *dict = dictionaryFromVariantMap(nonConstData);
+  NSDictionary* dict = dictionaryFromVariantMap(nonConstData);
   //LOG(@"data: %@", dict.description);
   if (msg == "OnPlay" || msg == "OnResume")
   {
-    NSDictionary *item = [dict valueForKey:@"item"];
-    NSDictionary *player = [dict valueForKey:@"player"];
+    NSDictionary* item = [dict valueForKey:@"item"];
+    NSDictionary* player = [dict valueForKey:@"player"];
     [item setValue:[player valueForKey:@"speed"] forKey:@"speed"];
     std::string thumb = g_application.CurrentFileItem().GetArt("thumb");
     if (!thumb.empty())
@@ -144,15 +147,18 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
     if (current >= 0)
     {
       [item setValue:@(current) forKey:@"current"];
-      [item setValue:@(CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()) forKey:@"total"];
+      [item setValue:@(CServiceBroker::GetPlaylistPlayer()
+                        .GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()
+              forKey:@"total"];
     }
     if (g_application.CurrentFileItem().HasMusicInfoTag())
     {
-      const std::vector<std::string> &genre = g_application.CurrentFileItem().GetMusicInfoTag()->GetGenre();
+      const std::vector<std::string>& genre =
+          g_application.CurrentFileItem().GetMusicInfoTag()->GetGenre();
       if (!genre.empty())
       {
-        NSMutableArray *genreArray = [[NSMutableArray alloc] initWithCapacity:genre.size()];
-        for(std::vector<std::string>::const_iterator it = genre.begin(); it != genre.end(); ++it)
+        NSMutableArray* genreArray = [[NSMutableArray alloc] initWithCapacity:genre.size()];
+        for (std::vector<std::string>::const_iterator it = genre.begin(); it != genre.end(); ++it)
         {
           [genreArray addObject:@(it->c_str())];
         }
@@ -160,26 +166,34 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
       }
     }
     //LOG(@"item: %@", item.description);
-    [g_xbmcController performSelectorOnMainThread:@selector(onPlay:) withObject:item  waitUntilDone:NO];
+    [g_xbmcController performSelectorOnMainThread:@selector(onPlay:)
+                                       withObject:item
+                                    waitUntilDone:NO];
   }
   else if (msg == "OnSpeedChanged" || msg == "OnPause")
   {
-    NSDictionary *item = [dict valueForKey:@"item"];
-    NSDictionary *player = [dict valueForKey:@"player"];
+    NSDictionary* item = [dict valueForKey:@"item"];
+    NSDictionary* player = [dict valueForKey:@"player"];
     [item setValue:[player valueForKey:@"speed"] forKey:@"speed"];
     [item setValue:@(g_application.GetTime()) forKey:@"elapsed"];
     //LOG(@"item: %@", item.description);
-    [g_xbmcController performSelectorOnMainThread:@selector(OnSpeedChanged:) withObject:item  waitUntilDone:NO];
+    [g_xbmcController performSelectorOnMainThread:@selector(OnSpeedChanged:)
+                                       withObject:item
+                                    waitUntilDone:NO];
     if (msg == "OnPause")
-      [g_xbmcController performSelectorOnMainThread:@selector(onPause:) withObject:[dict valueForKey:@"item"]  waitUntilDone:NO];
+      [g_xbmcController performSelectorOnMainThread:@selector(onPause:)
+                                         withObject:[dict valueForKey:@"item"]
+                                      waitUntilDone:NO];
   }
   else if (msg == "OnStop")
   {
-    [g_xbmcController performSelectorOnMainThread:@selector(onStop:) withObject:[dict valueForKey:@"item"]  waitUntilDone:NO];
+    [g_xbmcController performSelectorOnMainThread:@selector(onStop:)
+                                       withObject:[dict valueForKey:@"item"]
+                                    waitUntilDone:NO];
   }
 }
 
-CAnnounceReceiver *CAnnounceReceiver::GetInstance()
+CAnnounceReceiver* CAnnounceReceiver::GetInstance()
 {
   static CAnnounceReceiver announceReceiverInstance;
   return &announceReceiverInstance;
@@ -195,7 +209,10 @@ void CAnnounceReceiver::DeInitialize()
   CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(GetInstance());
 }
 
-void CAnnounceReceiver::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void CAnnounceReceiver::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                                 const char* sender,
+                                 const char* message,
+                                 const CVariant& data)
 {
   // can be called from c++, we need an auto poll here.
   @autoreleasepool

--- a/xbmc/platform/darwin/ios-common/CMakeLists.txt
+++ b/xbmc/platform/darwin/ios-common/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(SOURCES AnnounceReceiver.mm
+            DarwinEmbedNowPlayingInfoManager.mm
             IOSKeyboard.mm
             IOSKeyboardView.mm)
 
 set(HEADERS AnnounceReceiver.h
+            DarwinEmbedNowPlayingInfoManager.h
             IOSKeyboard.h
             IOSKeyboardView.h)
 

--- a/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.h
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2010-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(unsigned int, DarwinEmbedPlaybackState) {
+  DARWINEMBED_PLAYBACK_STOPPED,
+  DARWINEMBED_PLAYBACK_PAUSED,
+  DARWINEMBED_PLAYBACK_PLAYING
+};
+
+@interface DarwinEmbedNowPlayingInfoManager : NSObject
+
+@property(nonatomic, copy) NSDictionary* nowPlayingInfo;
+@property(nonatomic) DarwinEmbedPlaybackState playbackState;
+
+- (void)onPlay:(NSDictionary*)item;
+- (void)OnSpeedChanged:(NSDictionary*)item;
+- (void)onPause:(NSDictionary*)item;
+- (void)onStop:(NSDictionary*)item;
+- (void)observeValueForKeyPath:(NSString*)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary*)change
+                       context:(void*)context;
+
+@end

--- a/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.mm
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.mm
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (C) 2010-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#import "DarwinEmbedNowPlayingInfoManager.h"
+
+#import "platform/darwin/ios/XBMCController.h"
+
+#import <MediaPlayer/MediaPlayer.h>
+
+@implementation DarwinEmbedNowPlayingInfoManager
+
+@synthesize nowPlayingInfo = m_nowPlayingInfo;
+@synthesize playbackState;
+
+#pragma mark - Now Playing routines
+
+- (void)onPlay:(NSDictionary*)item
+{
+  auto dict = [NSMutableDictionary new];
+
+  NSString* title = item[@"title"];
+  if (title && title.length > 0)
+    dict[MPMediaItemPropertyTitle] = title;
+  NSString* album = item[@"album"];
+  if (album && album.length > 0)
+    dict[MPMediaItemPropertyAlbumTitle] = album;
+  NSArray* artists = item[@"artist"];
+  if (artists && artists.count > 0)
+    dict[MPMediaItemPropertyArtist] = [artists componentsJoinedByString:@" "];
+  if (id track = item[@"track"])
+    dict[MPMediaItemPropertyAlbumTrackNumber] = track;
+  if (id duration = item[@"duration"])
+    dict[MPMediaItemPropertyPlaybackDuration] = duration;
+  NSArray* genres = item[@"genre"];
+  if (genres && genres.count > 0)
+    dict[MPMediaItemPropertyGenre] = [genres componentsJoinedByString:@" "];
+
+  NSString* thumb = item[@"thumb"];
+  if (thumb && thumb.length > 0)
+  {
+    if (auto image = [UIImage imageWithContentsOfFile:thumb])
+    {
+      if (auto mArt =
+          [[MPMediaItemArtwork alloc] initWithBoundsSize:image.size
+                                          requestHandler:^UIImage* _Nonnull(CGSize aSize) {
+                                            return image;}])
+      {
+        dict[MPMediaItemPropertyArtwork] = mArt;
+      }
+    }
+  }
+
+  if (id elapsed = item[@"elapsed"])
+    dict[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed;
+  if (id speed = item[@"speed"])
+    dict[MPNowPlayingInfoPropertyPlaybackRate] = speed;
+  if (id current = item[@"current"])
+    dict[MPNowPlayingInfoPropertyPlaybackQueueIndex] = current;
+  if (id total = item[@"total"])
+    dict[MPNowPlayingInfoPropertyPlaybackQueueCount] = total;
+
+  /*! @Todo additional properties?
+   other properities can be set:
+   MPMediaItemPropertyAlbumTrackCount
+   MPMediaItemPropertyComposer
+   MPMediaItemPropertyDiscCount
+   MPMediaItemPropertyDiscNumber
+   MPMediaItemPropertyPersistentID
+   Additional metadata properties:
+   MPNowPlayingInfoPropertyChapterNumber;
+   MPNowPlayingInfoPropertyChapterCount;
+   */
+
+  [self setNowPlayingInfo:dict];
+
+  self.playbackState = DARWINEMBED_PLAYBACK_PLAYING;
+
+  [g_xbmcController disableNetworkAutoSuspend];
+}
+
+- (void)OnSpeedChanged:(NSDictionary*)item
+{
+  NSMutableDictionary* dict = [self.nowPlayingInfo mutableCopy];
+  if (id elapsed = item[@"elapsed"])
+    dict[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed;
+  if (id speed = item[@"speed"])
+    dict[MPNowPlayingInfoPropertyPlaybackRate] = speed;
+
+  [self setNowPlayingInfo:dict];
+}
+
+- (void)onPause:(NSDictionary*)item
+{
+  self.playbackState = DARWINEMBED_PLAYBACK_PAUSED;
+
+  // schedule set network auto suspend state for save power if idle.
+  [g_xbmcController rescheduleNetworkAutoSuspend];
+}
+
+- (void)onStop:(NSDictionary*)item
+{
+  [self setNowPlayingInfo:nil];
+
+  self.playbackState = DARWINEMBED_PLAYBACK_STOPPED;
+
+  // delay set network auto suspend state in case we are switching playing item.
+  [g_xbmcController rescheduleNetworkAutoSuspend];
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary*)change
+                       context:(void*)context
+{
+  if ([keyPath isEqualToString:NSStringFromSelector(@selector(nowPlayingInfo))])
+    [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = m_nowPlayingInfo;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (!self)
+    return nil;
+
+  playbackState = DARWINEMBED_PLAYBACK_STOPPED;
+  [self addObserver:self
+         forKeyPath:NSStringFromSelector(@selector(nowPlayingInfo))
+            options:kNilOptions
+            context:nullptr];
+
+  return self;
+}
+
+- (void)dealloc
+{
+  [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(nowPlayingInfo))];
+}
+
+@end

--- a/xbmc/platform/darwin/ios/XBMCController.h
+++ b/xbmc/platform/darwin/ios/XBMCController.h
@@ -7,7 +7,9 @@
  */
 
 #include "input/XBMC_keysym.h"
-#import "windowing/XBMC_events.h"
+#include "windowing/XBMC_events.h"
+
+#import "platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.h"
 
 #import <AudioToolbox/AudioToolbox.h>
 #import <OpenGLES/EAGL.h>
@@ -15,13 +17,6 @@
 #import <UIKit/UIKit.h>
 
 @class IOSEAGLView;
-
-typedef enum
-{
-  IOS_PLAYBACK_STOPPED,
-  IOS_PLAYBACK_PAUSED,
-  IOS_PLAYBACK_PLAYING
-} IOSPlaybackState;
 
 @interface XBMCController : UIViewController <UIGestureRecognizerDelegate, UIKeyInput>
 {
@@ -41,8 +36,6 @@ typedef enum
   bool m_isPlayingBeforeInactive;
   UIBackgroundTaskIdentifier m_bgTask;
   NSTimer *m_networkAutoSuspendTimer;
-  IOSPlaybackState m_playbackState;
-  NSDictionary *nowPlayingInfo;
   bool nativeKeyboardActive;
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
@@ -52,7 +45,7 @@ typedef enum
 @property int  m_screenIdx;
 @property CGSize screensize;
 @property(nonatomic, strong) NSTimer* m_networkAutoSuspendTimer;
-@property(nonatomic, strong) NSDictionary* nowPlayingInfo;
+@property(nonatomic, strong) DarwinEmbedNowPlayingInfoManager* MPNPInfoManager;
 @property bool nativeKeyboardActive;
 
 // message from which our instance is obtained
@@ -63,7 +56,6 @@ typedef enum
 - (void) enterBackground;
 - (void) enterForeground;
 - (void) becomeInactive;
-- (void) setIOSNowPlayingInfo:(NSDictionary *)info;
 - (void) sendKey: (XBMCKey) key;
 - (void) observeDefaultCenterStuff: (NSNotification *) notification;
 - (CGRect)fullscreenSubviewFrame;
@@ -79,6 +71,7 @@ typedef enum
 
 - (void) disableNetworkAutoSuspend;
 - (void) enableNetworkAutoSuspend:(id)obj;
+- (void)rescheduleNetworkAutoSuspend;
 - (void) disableSystemSleep;
 - (void) enableSystemSleep;
 - (void) disableScreenSaver;

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -6,6 +6,8 @@
  *  See LICENSES/README.md for more information.
  */
 
+#import "XBMCController.h"
+
 #include "AppInboundProtocol.h"
 #include "Application.h"
 #include "CompileInfo.h"
@@ -30,7 +32,13 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "windowing/XBMC_events.h"
-#include "windowing/ios/WinSystemIOS.h"
+#import "windowing/ios/WinSystemIOS.h"
+
+#import "platform/darwin/NSLogDebugHelpers.h"
+#import "platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.h"
+#import "platform/darwin/ios/IOSEAGLView.h"
+#import "platform/darwin/ios/IOSScreenManager.h"
+#import "platform/darwin/ios/XBMCApplication.h"
 
 #define id _id
 #include "TextureCache.h"
@@ -39,6 +47,7 @@
 #include <math.h>
 #include <signal.h>
 
+#import <AVFoundation/AVAudioSession.h>
 #include <sys/resource.h>
 
 using namespace KODI::MESSAGING;
@@ -47,16 +56,6 @@ using namespace KODI::MESSAGING;
 #define M_PI 3.1415926535897932384626433832795028842
 #endif
 #define RADIANS_TO_DEGREES(radians) ((radians) * (180.0 / M_PI))
-
-#import <AVFoundation/AVAudioSession.h>
-#import <MediaPlayer/MPMediaItem.h>
-#import <MediaPlayer/MPNowPlayingInfoCenter.h>
-#import "IOSEAGLView.h"
-
-#import "XBMCController.h"
-#import "IOSScreenManager.h"
-#import "XBMCApplication.h"
-#import "platform/darwin/NSLogDebugHelpers.h"
 
 XBMCController *g_xbmcController;
 
@@ -142,7 +141,7 @@ public:
 @synthesize m_screenIdx;
 @synthesize screensize;
 @synthesize m_networkAutoSuspendTimer;
-@synthesize nowPlayingInfo;
+@synthesize MPNPInfoManager;
 @synthesize nativeKeyboardActive;
 //--------------------------------------------------------------
 - (void) sendKeypressEvent: (XBMC_Event) event
@@ -575,7 +574,6 @@ public:
 
   m_isPlayingBeforeInactive = NO;
   m_bgTask = UIBackgroundTaskInvalid;
-  m_playbackState = IOS_PLAYBACK_STOPPED;
 
   m_window = [[UIWindow alloc] initWithFrame:frame];
   [m_window setRootViewController:self];
@@ -595,6 +593,7 @@ public:
 
   [m_window makeKeyAndVisible];
   g_xbmcController = self;
+  MPNPInfoManager = [DarwinEmbedNowPlayingInfoManager new];
 
   return self;
 }
@@ -958,117 +957,11 @@ public:
 
   [m_glView stopAnimation];
 }
-//--------------------------------------------------------------
-- (void)setIOSNowPlayingInfo:(NSDictionary *)info
-{
-  self.nowPlayingInfo = info;
-  [[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:self.nowPlayingInfo];
-}
-//--------------------------------------------------------------
-- (void)onPlay:(NSDictionary *)item
-{
-  PRINT_SIGNATURE();
-  NSMutableDictionary * dict = [[NSMutableDictionary alloc] init];
 
-  NSString *title = [item objectForKey:@"title"];
-  if (title && title.length > 0)
-    [dict setObject:title forKey:MPMediaItemPropertyTitle];
-  NSString *album = [item objectForKey:@"album"];
-  if (album && album.length > 0)
-    [dict setObject:album forKey:MPMediaItemPropertyAlbumTitle];
-  NSArray *artists = [item objectForKey:@"artist"];
-  if (artists && artists.count > 0)
-    [dict setObject:[artists componentsJoinedByString:@" "] forKey:MPMediaItemPropertyArtist];
-  NSNumber *track = [item objectForKey:@"track"];
-  if (track)
-    [dict setObject:track forKey:MPMediaItemPropertyAlbumTrackNumber];
-  NSNumber *duration = [item objectForKey:@"duration"];
-  if (duration)
-    [dict setObject:duration forKey:MPMediaItemPropertyPlaybackDuration];
-  NSArray *genres = [item objectForKey:@"genre"];
-  if (genres && genres.count > 0)
-    [dict setObject:[genres componentsJoinedByString:@" "] forKey:MPMediaItemPropertyGenre];
-
-  NSString *thumb = [item objectForKey:@"thumb"];
-  if (thumb && thumb.length > 0)
-  {
-    UIImage *image = [UIImage imageWithContentsOfFile:thumb];
-    if (image)
-    {
-      MPMediaItemArtwork *mArt = [[MPMediaItemArtwork alloc] initWithImage:image];
-      if (mArt)
-      {
-        [dict setObject:mArt forKey:MPMediaItemPropertyArtwork];
-      }
-    }
-  }
-  NSNumber *elapsed = [item objectForKey:@"elapsed"];
-  if (elapsed)
-    [dict setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
-  NSNumber *speed = [item objectForKey:@"speed"];
-  if (speed)
-    [dict setObject:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
-  NSNumber *current = [item objectForKey:@"current"];
-  if (current)
-    [dict setObject:current forKey:MPNowPlayingInfoPropertyPlaybackQueueIndex];
-  NSNumber *total = [item objectForKey:@"total"];
-  if (total)
-    [dict setObject:total forKey:MPNowPlayingInfoPropertyPlaybackQueueCount];
-  /*
-   other properties can be set:
-   MPMediaItemPropertyAlbumTrackCount
-   MPMediaItemPropertyComposer
-   MPMediaItemPropertyDiscCount
-   MPMediaItemPropertyDiscNumber
-   MPMediaItemPropertyPersistentID
-
-   Additional metadata properties:
-   MPNowPlayingInfoPropertyChapterNumber;
-   MPNowPlayingInfoPropertyChapterCount;
-   */
-
-  [self setIOSNowPlayingInfo:dict];
-
-  m_playbackState = IOS_PLAYBACK_PLAYING;
-  [self disableNetworkAutoSuspend];
-}
-//--------------------------------------------------------------
-- (void)OnSpeedChanged:(NSDictionary *)item
-{
-  PRINT_SIGNATURE();
-  NSMutableDictionary *info = [self.nowPlayingInfo mutableCopy];
-  NSNumber *elapsed = [item objectForKey:@"elapsed"];
-  if (elapsed)
-    [info setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
-  NSNumber *speed = [item objectForKey:@"speed"];
-  if (speed)
-    [info setObject:speed forKey:MPNowPlayingInfoPropertyPlaybackRate];
-
-  [self setIOSNowPlayingInfo:info];
-}
-//--------------------------------------------------------------
-- (void)onPause:(NSDictionary *)item
-{
-  PRINT_SIGNATURE();
-  m_playbackState = IOS_PLAYBACK_PAUSED;
-  // schedule set network auto suspend state for save power if idle.
-  [self rescheduleNetworkAutoSuspend];
-}
-//--------------------------------------------------------------
-- (void)onStop:(NSDictionary *)item
-{
-  PRINT_SIGNATURE();
-  [self setIOSNowPlayingInfo:nil];
-
-  m_playbackState = IOS_PLAYBACK_STOPPED;
-  // delay set network auto suspend state in case we are switching playing item.
-  [self rescheduleNetworkAutoSuspend];
-}
-//--------------------------------------------------------------
 - (void)rescheduleNetworkAutoSuspend
 {
-  LOG(@"%s: playback state: %d", __PRETTY_FUNCTION__,  m_playbackState);
-  if (m_playbackState == IOS_PLAYBACK_PLAYING)
+  LOG(@"%s: playback state: %d", __PRETTY_FUNCTION__, MPNPInfoManager.playbackState);
+  if (MPNPInfoManager.playbackState == DARWINEMBED_PLAYBACK_PLAYING)
   {
     [self disableNetworkAutoSuspend];
     return;
@@ -1076,8 +969,14 @@ public:
   if (m_networkAutoSuspendTimer)
     [m_networkAutoSuspendTimer invalidate];
 
-  int delay = m_playbackState == IOS_PLAYBACK_PAUSED ? 60 : 30;  // wait longer if paused than stopped
-  self.m_networkAutoSuspendTimer = [NSTimer scheduledTimerWithTimeInterval:delay target:self selector:@selector(enableNetworkAutoSuspend:) userInfo:nil repeats:NO];
+  // wait longer if paused than stopped
+  int delay = MPNPInfoManager.playbackState == DARWINEMBED_PLAYBACK_PAUSED ? 60 : 30;
+  self.m_networkAutoSuspendTimer =
+      [NSTimer scheduledTimerWithTimeInterval:delay
+                                       target:self
+                                     selector:@selector(enableNetworkAutoSuspend:)
+                                     userInfo:nil
+                                      repeats:NO];
 }
 
 #pragma mark -


### PR DESCRIPTION
## Description
Factors out MPNowPlaying functions to ios-common.
Clang-Format run against Anouncereceiver.*
Fix warning about deprecated method (performSelectorOnMainThread )usage in AnnounceReceiver.mm

## Motivation and Context
MPNowPlaying functions will be common for TVOS. Rather than duplicate, ripped the common code out into ios-common.

## How Has This Been Tested?
Built/runtime tested on iPad, AppleTV

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
