### PR TITLE
Fix wrong sort order list for music playlists node

### DIFF
--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -453,6 +453,12 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
 
     SetSortOrder(SortOrderNone);
   }
+  else if (items.GetPath() == "special://musicplaylists/")
+  { // playlists list sorts by label only, ignoring folders
+    AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551,
+                  LABEL_MASKS("%F", "%D", "%L", "")); // Filename, Duration | Foldername, empty
+    SetSortMethod(SortByLabel);
+  }
   else
   {
     if (items.IsVideoDb() && items.Size() > (settings->GetBool(CSettings::SETTING_FILELISTS_SHOWPARENTDIRITEMS)?1:0))


### PR DESCRIPTION
The wrong sort orders have been availlable when listing playlists since #9886 removed `CGUIViewStateWindowMusicSongs`, and a necessary piece of code got lost with the switch to using the music nav window for music files as well as the library.

This reinstates that lost code - playliststs are listed in name order