### PR TITLE
[profiles] Do always stop PVR services on logoff. Restart PVR service…

### DIFF
--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -404,8 +404,9 @@ void CProfileManager::FinalizeLoadProfile()
   // Restart context menu manager
   contextMenuManager.Init();
 
-  // restart PVR services
-  pvrManager.Init();
+  // Restart PVR services if we are not just loading the master profile for the login screen
+  if (m_profileLoadedForLogin || m_currentProfile != 0 || m_lastUsedProfile == 0)
+    pvrManager.Init();
 
   favouritesManager.ReInit(GetProfileUserDataFolder());
 
@@ -442,6 +443,9 @@ void CProfileManager::LogOff()
 
   if (CVideoLibraryQueue::GetInstance().IsRunning())
     CVideoLibraryQueue::GetInstance().CancelAllJobs();
+
+  // Stop PVR services
+  CServiceBroker::GetPVRManager().Stop();
 
   networkManager.NetworkMessage(CNetwork::SERVICES_DOWN, 1);
 


### PR DESCRIPTION
…s only when not loading the master profile for the login screen.

It makes no sense to have PVR running when not logged in. Even worse, this can have "funny" side effects like PVR reminder dialogs (Matrix feature) may pop-up on the login screen:

![screenshot000](https://user-images.githubusercontent.com/3226626/67661619-f8a1ad80-f961-11e9-9514-1b06cb4834c0.png)

@garbear good to go?
