### PR TITLE
[videoplayer] allow custom headers to be sent to ffmpeg & inputstream class property

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -67,8 +67,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_PROPERTIES     20
 #define PVR_STREAM_PROPERTY_STREAMURL "streamurl" /*!< @brief the URL of the stream that should be played. */
 #define PVR_STREAM_PROPERTY_INPUTSTREAMADDON  "inputstreamaddon" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by PVR_STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities. */
+#define PVR_STREAM_PROPERTY_INPUTSTREAMCLASS  "inputstreamclass" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by PVR_STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities or to allow ffmpeg to handle directly set to `inputstream.ffmpeg`. */
 #define PVR_STREAM_PROPERTY_MIMETYPE "mimetype" /*!< @brief the MIME type of the stream that should be played. */
 #define PVR_STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream" /*!< @brief "true" to denote that the stream that should be played is a realtime stream. Any other value indicates that this is no realtime stream.*/
+#define PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG  "inputstream.ffmpeg" /*!< @brief special value for PVR_STREAM_PROPERTY_INPUTSTREAMCLASS to use ffmpeg to directly play a stream URL. */
 
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20

--- a/xbmc/cores/VideoPlayer/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/CMakeLists.txt
@@ -38,6 +38,7 @@ set(HEADERS AudioSinkAE.h
             Interface/StreamInfo.h
             Interface/Addon/DemuxPacket.h
             Interface/Addon/DemuxCrypto.h
+            Interface/Addon/InputStreamConstants.h
             Interface/Addon/TimingConstants.h)
 
 core_add_library(VideoPlayer)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -738,8 +738,16 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
       StringUtils::ToLower(name);
       const std::string &value = it->second;
 
-      if (name == "seekable")
-        av_dict_set(&options, "seekable", value.c_str(), 0);
+      // set any of these ffmpeg options
+      if (name == "seekable" || name == "reconnect" || name == "reconnect_at_eof" ||
+          name == "reconnect_streamed" || name == "reconnect_delay_max" ||
+          name == "icy" || name == "icy_metadata_headers" || name == "icy_metadata_packet")
+      {
+        CLog::Log(LOGDEBUG,
+                  "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option '%s: %s'",
+                  it->first.c_str(), value.c_str());
+        av_dict_set(&options, name.c_str(), value.c_str(), 0);
+      }
       // map some standard http headers to the ffmpeg related options
       else if (name == "user-agent")
       {
@@ -782,12 +790,22 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
         }
         headers.append(it->first).append(": ").append(value).append("\r\n");
       }
-      // we don't add blindly all options to headers anymore
-      // if anybody wants to pass options to ffmpeg, explicitly prefix those
-      // to be identified here
+      // Any other headers that need to be sent would be user defined and should be prefixed
+      // by a `!`. We mask these values so we don't log anything we shouldn't
+      else if (name.length() > 0 && name[0] == '!')
+      {
+        CLog::Log(LOGDEBUG,
+                  "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding user custom header option "
+                  "'%s: ***********'",
+                  it->first.c_str());
+        headers.append(it->first.substr(1)).append(": ").append(value).append("\r\n");
+      }
+      // for everything else we ignore the headers options if not specified above
       else
       {
-        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() ignoring header option '%s: %s'", it->first.c_str(), value.c_str());
+        CLog::Log(LOGDEBUG,
+                  "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() ignoring header option '%s'",
+                  it->first.c_str());
       }
     }
     if (!hasUserAgent)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -725,6 +725,10 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
   CURL url = m_pInput->GetURL();
   AVDictionary* options = nullptr;
 
+  // For a local file we need the following protocol whitelist
+  if (url.GetProtocol().empty() || url.IsProtocol("file"))
+    av_dict_set(&options, "protocol_whitelist", "file,http,https,tcp,tls,crypto", 0);
+
   if (url.IsProtocol("http") || url.IsProtocol("https"))
   {
     std::map<std::string, std::string> protocolOptions;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -7,29 +7,30 @@
  */
 
 #include "DVDFactoryInputStream.h"
+
 #include "DVDInputStream.h"
+#ifdef HAVE_LIBBLURAY
+#include "DVDInputStreamBluray.h"
+#endif
+#include "DVDInputStreamFFmpeg.h"
 #include "DVDInputStreamFile.h"
 #include "DVDInputStreamNavigator.h"
-#include "DVDInputStreamFFmpeg.h"
+#include "DVDInputStreamStack.h"
+#include "FileItem.h"
 #include "InputStreamAddon.h"
 #include "InputStreamMultiSource.h"
 #include "InputStreamPVRChannel.h"
 #include "InputStreamPVRRecording.h"
-#ifdef HAVE_LIBBLURAY
-#include "DVDInputStreamBluray.h"
-#endif
-#include "DVDInputStreamStack.h"
-#include "FileItem.h"
-#include "storage/MediaManager.h"
+#include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
+#include "addons/binary-addons/BinaryAddonManager.h"
 #include "cores/VideoPlayer/Interface/Addon/InputStreamConstants.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "filesystem/IFileTypes.h"
+#include "storage/MediaManager.h"
 #include "utils/URIUtils.h"
-#include "ServiceBroker.h"
-#include "addons/binary-addons/BinaryAddonManager.h"
-#include "Util.h"
 
 
 std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer, const CFileItem &fileitem, bool scanforextaudio)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -22,6 +22,7 @@
 #include "FileItem.h"
 #include "storage/MediaManager.h"
 #include "URL.h"
+#include "cores/VideoPlayer/Interface/Addon/InputStreamConstants.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "filesystem/IFileTypes.h"
@@ -56,6 +57,10 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
     if (CInputStreamAddon::Supports(addonInfo, fileitem))
       return std::shared_ptr<CInputStreamAddon>(new CInputStreamAddon(addonInfo, pPlayer, fileitem));
   }
+
+  if (fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAMCLASS).asString() ==
+      STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG)
+    return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(fileitem));
 
   if (fileitem.IsDiscImage())
   {
@@ -153,7 +158,9 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
     if (finalFileitem.IsType(".m3u8"))
       return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(finalFileitem));
 
-    if (finalFileitem.GetMimeType() == "application/vnd.apple.mpegurl")
+    // mime type for m3u8/hls streams
+    if (finalFileitem.GetMimeType() == "application/vnd.apple.mpegurl" ||
+        finalFileitem.GetMimeType() == "application/x-mpegURL")
       return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(finalFileitem));
 
     if (URIUtils::IsProtocol(finalFileitem.GetPath(), "udp"))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -9,12 +9,13 @@
 #include "DVDInputStream.h"
 
 #include "URL.h"
+#include "cores/VideoPlayer/Interface/Addon/InputStreamConstants.h"
 
 CDVDInputStream::CDVDInputStream(DVDStreamType streamType, const CFileItem& fileitem)
 {
   m_streamType = streamType;
   m_contentLookup = true;
-  m_realtime = fileitem.GetProperty("isrealtimestream").asBoolean(false);
+  m_realtime = fileitem.GetProperty(STREAM_PROPERTY_ISREALTIMESTREAM).asBoolean(false);
   m_item = fileitem;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -14,6 +14,7 @@
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemux.h"
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h"
 #include "cores/VideoPlayer/Interface/Addon/DemuxCrypto.h"
+#include "cores/VideoPlayer/Interface/Addon/InputStreamConstants.h"
 #include "cores/VideoPlayer/Interface/Addon/TimingConstants.h"
 #include "filesystem/SpecialProtocol.h"
 #include "utils/StringUtils.h"
@@ -65,7 +66,12 @@ CInputStreamAddon::~CInputStreamAddon()
 bool CInputStreamAddon::Supports(BinaryAddonBasePtr& addonBase, const CFileItem &fileitem)
 {
   // check if a specific inputstream addon is requested
-  CVariant addon = fileitem.GetProperty("inputstreamaddon");
+  CVariant addon = fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAMCLASS);
+  if (!addon.isNull())
+    return (addon.asString() == addonBase->ID());
+
+  // TODO: to be deprecated for the above - all addons must change
+  addon = fileitem.GetProperty("inputstreamaddon");
   if (!addon.isNull())
     return (addon.asString() == addonBase->ID());
 

--- a/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (C) 2017-2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#define STREAM_PROPERTY_INPUTSTREAMCLASS  "inputstreamclass" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities or to allow ffmpeg to handle directly set to STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG. */
+#define STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream" /*!< @brief "true" to denote that the stream that should be played is a realtime stream. Any other value indicates that this is not a realtime stream.*/
+#define STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG  "inputstream.ffmpeg" /*!< @brief special value for STREAM_PROPERTY_INPUTSTREAMCLASS to use ffmpeg to directly play a stream URL. */


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Currently all unknown headers are not allowed to be passed to ffmpeg. This PR includes a blacklist to stop certain headers ever being sent to ffmpeg ad a whitelist of other ffmpeg headers. This allows all other custom headers to be passed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On OSX, verifying that headers get/don't get passed from teh log.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
