### PR TITLE
Cache - base filename on path with options and save with item for clearing on update

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2920,8 +2920,17 @@ bool CFileItemList::Save(int windowID)
   CLog::Log(LOGDEBUG,"Saving fileitems [%s]", CURL::GetRedacted(GetPath()).c_str());
 
   CFile file;
-  if (file.OpenForWrite(GetDiscFileCache(windowID), true)) // overwrite always
+  std::string cachefile = GetDiscFileCache(windowID);
+  if (file.OpenForWrite(cachefile, true)) // overwrite always
   {
+    // Before caching save simplified cache file name in every item so the cache file can be
+    // identifed and removed if the item is updated. List path and options (used for file
+    // name when list cached) can not be accurately derived from item path.
+    StringUtils::Replace(cachefile, "special://temp/archive_cache/", "");
+    StringUtils::Replace(cachefile, ".fi", "");
+    for (auto item : m_items)
+      item->SetProperty("cachefilename", cachefile);
+
     CArchive ar(&file, CArchive::store);
     ar << *this;
     CLog::Log(LOGDEBUG,"  -- items: %i, sort method: %i, ascending: %s", iSize, m_sortDescription.sortBy, m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
@@ -2935,7 +2944,11 @@ bool CFileItemList::Save(int windowID)
 
 void CFileItemList::RemoveDiscCache(int windowID) const
 {
-  std::string cacheFile(GetDiscFileCache(windowID));
+  RemoveDiscCache(GetDiscFileCache(windowID));
+}
+
+void CFileItemList::RemoveDiscCache(const std::string& cacheFile) const
+{
   if (CFile::Exists(cacheFile))
   {
     CLog::Log(LOGDEBUG,"Clearing cached fileitems [%s]", CURL::GetRedacted(GetPath()).c_str());
@@ -2943,10 +2956,16 @@ void CFileItemList::RemoveDiscCache(int windowID) const
   }
 }
 
+void CFileItemList::RemoveDiscCacheCRC(const std::string& crc) const
+{
+  std::string cachefile = StringUtils::Format("special://temp/archive_cache/%s.fi", crc);
+  RemoveDiscCache(cachefile);
+}
+
 std::string CFileItemList::GetDiscFileCache(int windowID) const
 {
   std::string strPath(GetPath());
-  strPath = CURL(strPath).GetWithoutOptions();
+  URIUtils::RemoveSlashAtEnd(strPath);
 
   uint32_t crc = Crc32::ComputeFromLowerCase(strPath);
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -725,6 +725,8 @@ public:
    \sa Save,Load
    */
   void RemoveDiscCache(int windowID = 0) const;
+  void RemoveDiscCache(const std::string& cachefile) const;
+  void RemoveDiscCacheCRC(const std::string& crc) const;
   bool AlwaysCache() const;
 
   void Swap(unsigned int item1, unsigned int item2);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -426,7 +426,15 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         { // need to remove the disc cache
           CFileItemList items;
           items.SetPath(URIUtils::GetDirectory(newItem->GetPath()));
-          items.RemoveDiscCache(GetID());
+          if (newItem->HasProperty("cachefilename"))
+          {
+            // Use stored cache file name
+            std::string crcfile = newItem->GetProperty("cachefilename").asString();
+            items.RemoveDiscCacheCRC(crcfile);
+          }
+          else
+            // No stored cache file name, attempt using truncated item path as list path
+            items.RemoveDiscCache(GetID());
         }
       }
       else if (message.GetParam1()==GUI_MSG_UPDATE_PATH)


### PR DESCRIPTION
Follow up to #16805 and needed to fix video library watched state issues #15251 and #16357 
Building cache filename using just path without options string has caused unintended consequnces for window navigation for items from plugins.  Also while it did solve cache identification and clearing issues for library item lists, it didn't do so for plugin items. Plugin lists all have the same base path, the option string is needed to differentiate between them!

The underlying problem that this solves (and that both #16805 and prior to that #14810 attempted to solve) was observed as follows: on playback of a video finishing, if the list of videos is subsequently read from cache (because it was slow to load as MySQL server over LAN or lots of items etc. ) then the watched state and playcount of that item is not updated on the GUI.

Looking at the  paths used to form cache file name reveals the source of this wrong behaviour. Say you have navigated to a list of episodes and are playing an episode. 
List path is `videodb://tvshows/titles/5/3?tvshowid=5&xsp...`
Item path is `videodb://tvshows/titles/5/3/68?season=3&tvshowid=5&xsp...`
A cache file is created for the list using the list path. When playback completes an update item message is sent and `CGUIMediaWindow` attempts to clear the cache for the list with this item. To get the name of the cache file it tries to recover the list path from the item path by trucating it to `videodb://tvshows/titles/5/3/` removing last parameter and options. This is not the list path, and the wrong cache filename is used and the cache for the list is not cleared.

Or say you were using the Netflix plugin
List path `plugin://plugin.video.netflix/?action=video_lists&profile_id=ZHX...`  gets cached
Item path ` plugin://plugin.video.netflix/?action=video_list&type=netflixOriginals&video_list_id=318...`
On item update the truncate approach to getting list path from item path would give incorrectly `plugin://plugin.video.netflix/` and again the cache is not cleared. User does not see updated watched state or playcount etc.

Cache filename needs to be based on path with options, and there is no easy way to get list path from the item path. Hence my solution is to store the cache filename as an item property for every item in the list, that way on item update the correct cache file can be found and removed.

In summary:
Base cache filename on itemlist path with options.
Save cache filename with each item in list  and use on item update to remove correct cache file.

@peak3d this should solve the plugin issues (original and new) @spiff for a saneity check
