### PR TITLE
CPUInfo fixes after #16098 

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -364,6 +364,8 @@ bool CApplication::Create(const CAppParamParser &params)
   m_bTestMode = params.m_testmode;
   m_bStandalone = params.m_standAlone;
 
+  CServiceBroker::RegisterCPUInfo(CCPUInfo::GetCPUInfo());
+
   m_pSettingsComponent.reset(new CSettingsComponent());
   m_pSettingsComponent->Init(params);
 

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -9,7 +9,6 @@
 #include "Platform.h"
 
 #include "ServiceBroker.h"
-#include "utils/CPUInfo.h"
 
 // Override for platform ports
 #if !defined(PLATFORM_OVERRIDE)
@@ -29,6 +28,5 @@ CPlatform::~CPlatform() = default;
 
 void CPlatform::Init()
 {
-  CServiceBroker::RegisterCPUInfo(CCPUInfo::GetCPUInfo());
 }
 

--- a/xbmc/platform/android/CPUInfoAndroid.h
+++ b/xbmc/platform/android/CPUInfoAndroid.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
 
-class CCPUInfoAndroid : public CCPUInfo
+#include "platform/posix/CPUInfoPosix.h"
+
+class CCPUInfoAndroid : public CCPUInfoPosix
 {
 public:
   CCPUInfoAndroid();

--- a/xbmc/platform/darwin/ios/CPUInfoIos.h
+++ b/xbmc/platform/darwin/ios/CPUInfoIos.h
@@ -8,14 +8,15 @@
 
 #pragma once
 
-#include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
+
+#include "platform/posix/CPUInfoPosix.h"
 
 #include <memory>
 
 class CPosixResourceCounter;
 
-class CCPUInfoIos : public CCPUInfo
+class CCPUInfoIos : public CCPUInfoPosix
 {
 public:
   CCPUInfoIos();

--- a/xbmc/platform/darwin/osx/CPUInfoOsx.h
+++ b/xbmc/platform/darwin/osx/CPUInfoOsx.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
-#include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
+
+#include "platform/posix/CPUInfoPosix.h"
 
 class CPosixResourceCounter;
 
-class CCPUInfoOsx : public CCPUInfo
+class CCPUInfoOsx : public CCPUInfoPosix
 {
 public:
   CCPUInfoOsx();

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.h
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
 
-class CCPUInfoFreebsd : public CCPUInfo
+#include "platform/posix/CPUInfoPosix.h"
+
+class CCPUInfoFreebsd : public CCPUInfoPosix
 {
 public:
   CCPUInfoFreebsd();

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -279,6 +279,8 @@ bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)
     temperature = CTemperature::CreateFromCelsius(value);
   else if (scale == 'F' || scale == 'f')
     temperature = CTemperature::CreateFromFahrenheit(value);
+  else
+    return false;
 
   temperature.SetValid(true);
 

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <vector>
 
-#if defined(HAS_NEON)
+#if (defined(__arm__) && defined(HAS_NEON)) || defined(__aarch64__)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
-#else
+#elif defined(__i386__) || defined(__x86_64__)
 #include <cpuid.h>
 #endif
 
@@ -94,7 +94,7 @@ CCPUInfoLinux::CCPUInfoLinux()
     m_cores.emplace_back(coreInfo);
   }
 
-#if !defined(HAS_NEON)
+#if defined(__i386__) || defined(__x86_64__)
   unsigned int eax;
   unsigned int ebx;
   unsigned int ecx;
@@ -184,10 +184,8 @@ CCPUInfoLinux::CCPUInfoLinux()
   }
 #endif
 
-#if defined(HAS_NEON) && !defined(__LP64__)
+#if defined(HAS_NEON) && defined(__arm__)
   if (getauxval(AT_HWCAP) & HWCAP_NEON)
-#endif
-#if defined(HAS_NEON)
     m_cpuFeatures |= CPU_FEATURE_NEON;
 #endif
 

--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -264,7 +264,7 @@ float CCPUInfoLinux::GetCPUFrequency()
 bool CCPUInfoLinux::GetTemperature(CTemperature& temperature)
 {
   if (!SysfsUtils::Has("/sys/class/hwmon/hwmon0/temp1_input"))
-    return CCPUInfo::GetTemperature(temperature);
+    return CCPUInfoPosix::GetTemperature(temperature);
 
   int value{-1};
   char scale{'c'};

--- a/xbmc/platform/linux/CPUInfoLinux.h
+++ b/xbmc/platform/linux/CPUInfoLinux.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
 
-class CCPUInfoLinux : public CCPUInfo
+#include "platform/posix/CPUInfoPosix.h"
+
+class CCPUInfoLinux : public CCPUInfoPosix
 {
 public:
   CCPUInfoLinux();

--- a/xbmc/platform/posix/CMakeLists.txt
+++ b/xbmc/platform/posix/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES ConvUtils.cpp
+            CPUInfoPosix.cpp
             Filesystem.cpp
             MessagePrinter.cpp
             PlatformPosix.cpp
@@ -10,6 +11,7 @@ set(SOURCES ConvUtils.cpp
             XTimeUtils.cpp)
 
 set(HEADERS ConvUtils.h
+            CPUInfoPosix.h
             PlatformDefs.h
             PlatformPosix.h
             PosixMountProvider.h

--- a/xbmc/platform/posix/CPUInfoPosix.cpp
+++ b/xbmc/platform/posix/CPUInfoPosix.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CPUInfoPosix.h"
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+
+bool CCPUInfoPosix::GetTemperature(CTemperature& temperature)
+{
+  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
+
+  temperature.SetValid(false);
+
+  int value{-1};
+  char scale{'c'};
+
+  if (!cmd.empty())
+  {
+    auto p = popen(cmd.c_str(), "r");
+    if (p)
+    {
+      int ret = fscanf(p, "%d %c", &value, &scale);
+      pclose(p);
+
+      if (ret < 2)
+        return false;
+    }
+  }
+
+  if (scale == 'C' || scale == 'c')
+    temperature = CTemperature::CreateFromCelsius(value);
+  else if (scale == 'F' || scale == 'f')
+    temperature = CTemperature::CreateFromFahrenheit(value);
+  else
+    return false;
+
+  temperature.SetValid(true);
+
+  return true;
+}

--- a/xbmc/platform/posix/CPUInfoPosix.h
+++ b/xbmc/platform/posix/CPUInfoPosix.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/CPUInfo.h"
+
+class CCPUInfoPosix : public CCPUInfo
+{
+public:
+  virtual bool GetTemperature(CTemperature& temperature) override;
+
+protected:
+  CCPUInfoPosix() = default;
+  virtual ~CCPUInfoPosix() = default;
+};

--- a/xbmc/platform/win10/CPUInfoWin10.cpp
+++ b/xbmc/platform/win10/CPUInfoWin10.cpp
@@ -117,3 +117,9 @@ int CCPUInfoWin10::GetUsedPercentage()
 
   return static_cast<int>(m_lastUsedPercentage);
 }
+
+bool CCPUInfoWin10::GetTemperature(CTemperature& temperature)
+{
+  temperature.SetValid(false);
+  return false;
+}

--- a/xbmc/platform/win10/CPUInfoWin10.h
+++ b/xbmc/platform/win10/CPUInfoWin10.h
@@ -19,4 +19,5 @@ public:
 
   int GetUsedPercentage() override;
   float GetCPUFrequency() override { return 0; }
+  bool GetTemperature(CTemperature& temperature) override;
 };

--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -285,3 +285,9 @@ float CCPUInfoWin32::GetCPUFrequency()
 
   return 0;
 }
+
+bool CCPUInfoWin32::GetTemperature(CTemperature& temperature)
+{
+  temperature.SetValid(false);
+  return false;
+}

--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -125,7 +125,6 @@ CCPUInfoWin32::CCPUInfoWin32()
   else
     m_cpuQueryLoad = nullptr;
 
-#ifndef _M_ARM
   int CPUInfo[4]; // receives EAX, EBX, ECD and EDX in that order
 
   __cpuid(CPUInfo, 0);
@@ -164,7 +163,6 @@ CCPUInfoWin32::CCPUInfoWin32()
     if (CPUInfo[CPUINFO_EDX] & CPUID_80000001_EDX_3DNOWEXT)
       m_cpuFeatures |= CPU_FEATURE_3DNOWEXT;
   }
-#endif // ! _M_ARM
 
   // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
   if (m_cpuFeatures & CPU_FEATURE_SSE)

--- a/xbmc/platform/win32/CPUInfoWin32.h
+++ b/xbmc/platform/win32/CPUInfoWin32.h
@@ -19,6 +19,7 @@ public:
 
   int GetUsedPercentage() override;
   float GetCPUFrequency() override;
+  bool GetTemperature(CTemperature& temperature) override;
 
 private:
   // avoid inclusion of <windows.h> and others

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -8,9 +8,6 @@
 
 #include "CPUInfo.h"
 
-#include "ServiceBroker.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 
 bool CCPUInfo::HasCoreId(int coreId) const
@@ -59,36 +56,4 @@ std::string CCPUInfo::GetCoresUsageString() const
   }
 
   return strCores;
-}
-
-bool CCPUInfo::GetTemperature(CTemperature& temperature)
-{
-  std::string cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd;
-
-  temperature.SetValid(false);
-
-  int value{-1};
-  char scale{'c'};
-
-  if (!cmd.empty())
-  {
-    auto p = popen(cmd.c_str(), "r");
-    if (p)
-    {
-      int ret = fscanf(p, "%d %c", &value, &scale);
-      pclose(p);
-
-      if (ret < 2)
-        return false;
-    }
-  }
-
-  if (scale == 'C' || scale == 'c')
-    temperature = CTemperature::CreateFromCelsius(value);
-  else if (scale == 'F' || scale == 'f')
-    temperature = CTemperature::CreateFromFahrenheit(value);
-
-  temperature.SetValid(true);
-
-  return true;
 }

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -77,7 +77,7 @@ public:
 
   virtual int GetUsedPercentage() = 0;
   virtual float GetCPUFrequency() = 0;
-  virtual bool GetTemperature(CTemperature& temperature);
+  virtual bool GetTemperature(CTemperature& temperature) = 0;
 
   bool HasCoreId(int coreId) const;
   const CoreInfo GetCoreInfo(int coreId);

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -44,7 +44,11 @@ TEST_F(TestCPUInfo, GetCPUFrequency)
   EXPECT_GE(CServiceBroker::GetCPUInfo()->GetCPUFrequency(), 0.f);
 }
 
+#if defined(TARGET_WINDOWS)
+TEST_F(TestCPUInfo, DISABLED_GetTemperature)
+#else
 TEST_F(TestCPUInfo, GetTemperature)
+#endif
 {
   CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cpuTempCmd = "echo '50 c'";
   CTemperature t;


### PR DESCRIPTION
#16098 introduced a few issues with various platforms (some that jenkins doesn't even build)

This should fix some of them and some other issues that were found.

----
#### CPUInfoWin32: remove _M_ARM gaurd
 - not sure why this even existed in the past

----
#### CPUInfoLinux: return false if temperature units aren't valid
 - if a valid temperature isn't passed then we need to return false as the temperature won't be valid

----
#### CPUInfoLinux: fix ifdefs for non neon platforms

 this attempts to fix the build for all the following paths:
  - arm (without neon, ie RPi0/1)
  - arm (with neon, ie RPI2+)
  - aarch64 (doesn't need neon ?)
  - x86

----
#### CPUInfo: split posix functions into specific class to allow windows to build
 - this introduces an intermediate class CCPUInfoPosix which include posix specific commands to allow windows to build properly.

----
#### CCPUInfo: move servicebroker registration earlier in app startup
 - this fixes startup on RPi where it wants cpuinfo before the settingscomponent initialization