### PR TITLE
[settings] allow set of needed extensions for picture selection

### DIFF
--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -36,6 +36,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "storage/MediaManager.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -887,7 +888,20 @@ bool CGUIControlButtonSetting::GetPath(std::shared_ptr<CSettingPath> pathSetting
       shares, pathSetting->GetMasking(CServiceBroker::GetFileExtensionProvider()), heading, path,
       control->UseImageThumbs(), control->UseFileDirectories());
   else if (control->GetFormat() == "image")
-    result = CGUIDialogFileBrowser::ShowAndGetImage(shares, heading, path);
+  {
+    /* Check setting contains own masking, to filter required image type.
+     * e.g. png only needed
+     * <constraints>
+     *   <masking>*.png</masking>
+     * </constraints>
+     * <control type="button" format="image">
+     *   ...
+     */
+    std::string ext = pathSetting->GetMasking(CServiceBroker::GetFileExtensionProvider());
+    if (ext.empty())
+      ext = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
+    result = CGUIDialogFileBrowser::ShowAndGetFile(shares, ext, heading, path, true);
+  }
   else
     result = CGUIDialogFileBrowser::ShowAndGetDirectory(shares, heading, path, pathSetting->Writable());
 


### PR DESCRIPTION
## Description
Before was always all for Kodi available picture extensions present.
This allow to specialize the needed one.

Until now is only over normal format "file" the set of needed extensions
possible, but there on new settings version not possible to get a icon
of wanted files. On old was this done with special ways, where the backport
support set this.

But on newer settings.xml was it no more possible where `format="image"` is
needed, this change now also on new the setting about.

e.g.
```xml
        <setting id="texture0" type="path" label="30016" help="30017">
          <default></default>
          <dependencies>
            <dependency type="enable" setting="ownshader" operator="is">true</dependency>
            <dependency type="enable" setting="texture0-sound" operator="is">false</dependency>
          </dependencies>
          <constraints>
            <allowempty>true</allowempty>
            <masking>*.png</masking> <!-- HERE now possible to set for image -->
          </constraints>
          <control type="button" format="image">
            <heading>30016</heading>
          </control>
        </setting>
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
