### PR TITLE
DVDVideoCodecDRMPRIME: improve error messages and drain codec on reset

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -204,6 +204,9 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
   if (!m_pCodecContext)
     return true;
 
+  if (!packet.pData)
+    return true;
+
   AVPacket avpkt;
   av_init_packet(&avpkt);
   avpkt.data = packet.pData;
@@ -226,7 +229,7 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
     av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed: {} ({})", __FUNCTION__,
               err, ret);
-    if (ret != AVERROR_EOF)
+    if (ret != AVERROR_EOF && ret != AVERROR_INVALIDDATA)
       return false;
   }
 
@@ -238,9 +241,27 @@ void CDVDVideoCodecDRMPRIME::Reset()
   if (!m_pCodecContext)
     return;
 
+  Drain();
+
+  do
+  {
+    int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
+    if (ret == AVERROR_EOF)
+      break;
+    else if (ret)
+    {
+      char err[AV_ERROR_MAX_STRING_SIZE] = {};
+      av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
+      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed: {} ({})",
+                __FUNCTION__, err, ret);
+      break;
+    }
+    else
+      av_frame_unref(m_pFrame);
+  } while (true);
+
+  CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - flush buffers", __FUNCTION__);
   avcodec_flush_buffers(m_pCodecContext);
-  av_frame_unref(m_pFrame);
-  m_codecControlFlags = 0;
 }
 
 void CDVDVideoCodecDRMPRIME::Drain()
@@ -359,7 +380,15 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
   if (ret == AVERROR(EAGAIN))
     return VC_BUFFER;
   else if (ret == AVERROR_EOF)
+  {
+    if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
+    {
+      CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - flush buffers", __FUNCTION__);
+      avcodec_flush_buffers(m_pCodecContext);
+      SetCodecControl(m_codecControlFlags & ~DVD_CODEC_CTRL_DRAIN);
+    }
     return VC_EOF;
+  }
   else if (ret)
   {
     char err[AV_ERROR_MAX_STRING_SIZE] = {};
@@ -384,6 +413,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
   {
     CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
               av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
+    av_frame_unref(m_pFrame);
     return VC_ERROR;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -22,6 +22,7 @@
 extern "C"
 {
 #include <libavcodec/avcodec.h>
+#include <libavutil/error.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
 }
@@ -219,13 +220,14 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
   int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
   if (ret == AVERROR(EAGAIN))
     return false;
-  else if (ret == AVERROR_EOF)
-    return true;
   else if (ret)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed, ret:{}", __FUNCTION__,
-              ret);
-    return false;
+    char err[AV_ERROR_MAX_STRING_SIZE] = {};
+    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed: {} ({})", __FUNCTION__,
+              err, ret);
+    if (ret != AVERROR_EOF)
+      return false;
   }
 
   return true;
@@ -247,7 +249,14 @@ void CDVDVideoCodecDRMPRIME::Drain()
   av_init_packet(&avpkt);
   avpkt.data = nullptr;
   avpkt.size = 0;
-  avcodec_send_packet(m_pCodecContext, &avpkt);
+  int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
+  if (ret && ret != AVERROR_EOF)
+  {
+    char err[AV_ERROR_MAX_STRING_SIZE] = {};
+    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed: {} ({})", __FUNCTION__,
+              err, ret);
+  }
 }
 
 void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
@@ -353,8 +362,10 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
     return VC_EOF;
   else if (ret)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed, ret:{}", __FUNCTION__,
-              ret);
+    char err[AV_ERROR_MAX_STRING_SIZE] = {};
+    av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed: {} ({})", __FUNCTION__,
+              err, ret);
     return VC_ERROR;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -305,7 +305,7 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
   }
 
   pVideoPicture->color_range =
-      m_pFrame->color_range == AVCOL_RANGE_JPEG || m_hints.colorRange == AVCOL_RANGE_JPEG ? 1 : 0;
+      m_pFrame->color_range == AVCOL_RANGE_JPEG || m_hints.colorRange == AVCOL_RANGE_JPEG;
   pVideoPicture->color_primaries = m_pFrame->color_primaries == AVCOL_PRI_UNSPECIFIED
                                        ? m_hints.colorPrimaries
                                        : m_pFrame->color_primaries;

--- a/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/VideoBufferDRMPRIME.cpp
@@ -77,6 +77,7 @@ const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& pictur
 
 CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
 {
+  m_pixFormat = AV_PIX_FMT_DRM_PRIME;
 }
 
 CVideoBufferDRMPRIMEFFmpeg::CVideoBufferDRMPRIMEFFmpeg(IVideoBufferPool& pool, int id)


### PR DESCRIPTION
## Description
This PR improves ffmpeg error messages and make sure ffmpeg codec is drained of decoded frames when seeking.

Please note that this currently breaks seeking using the v4l2m2m decoder since that codec does not handle recovery from draining mode (it has no flush callback that restore state after draining has been triggered).

## Motivation and Context
Seeking sometime caused stalled video playback using drm prime video codec. When this happens there was usually a decoded frame with out of range pts "stuck" in kodi internal buffers.

With this change the codec is drained of decoded frames before being feed with new packets, this make codec only return decoded frames from the new seek position.

## How Has This Been Tested?
Seeking has been tested with v4l2 request hwaccel and sw decoding, usually there is 1-2 frames being drained before decoding continues.
With v4l2m2m decoder there usually is 3-5 frames being drained and after draining the v4l2m2m decoder drops any packet being feed (no recovery after flush buffers call).

~~This PR is marked as a draft because I want to do more testing using vaapi hwaccel and possibly look into a ffmpeg patch for the v4l2m2m decoder.~~

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
