### PR TITLE
[backport][addons] add settings support for property condition (basic conditions only)

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -22,6 +22,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/SettingAddon.h"
+#include "settings/SettingConditions.h"
 #include "settings/SettingControl.h"
 #include "settings/SettingDateTime.h"
 #include "settings/SettingPath.h"
@@ -391,6 +392,13 @@ void CAddonSettings::InitializeControls()
 
 void CAddonSettings::InitializeConditions()
 {
+  CSettingConditions::Initialize();
+
+  // add basic conditions
+  const std::set<std::string>& simpleConditions = CSettingConditions::GetSimpleConditions();
+  for (const auto& condition : simpleConditions)
+    GetSettingsManager()->AddCondition(condition);
+
   GetSettingsManager()->AddDynamicCondition("InfoBool", InfoBool);
 }
 


### PR DESCRIPTION
## Description
Before was it not possible to get a for Kodi defined condition on addon
settings. With this are the basic conditions also available for addon,
to define OS related parts.

The more complex conditions are not added, not sure if this goes then
to far to allow addons also this.

Same as: https://github.com/xbmc/xbmc/pull/15803

Some addons need also on Leia to set the wanted OS on settings, without them is it there not usable.
See: 
- https://github.com/xbmc/visualization.waveform/pull/30
- https://github.com/xbmc/visualization.spectrum/blob/Leia/visualization.spectrum/resources/settings.xml#L30-L31

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
I just noticed where I tested addons on Leia.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
