### PR TITLE
[Android] fetchDisplayMode only for SDK>=24

### DIFF
--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -309,7 +309,8 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
 
 bool CAndroidUtils::UpdateDisplayModes()
 {
-  fetchDisplayModes();
+  if (CJNIBase::GetSDKVersion() >= 24)
+    fetchDisplayModes();
   return true;
 }
 


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/16340 introduced fetchDisplayMode call when updating display resolution even for SDK < 24 what is wrong if modeAPI is not implemented.

## Motivation and Context
Refreshrate backswitch (to "current resolution")  on devices with SDK <24 could fail.

## How Has This Been Tested?
WETEK Hub
- launch kodi with 59.94Hz system::display.
- enable displaymode switch on start/end, leave whitelist empty
- play 25fps stream
- stop stream.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)