### PR TITLE
[python] Fix unicode decode errors

### DIFF
--- a/xbmc/interfaces/python/typemaps/python.string.outtm
+++ b/xbmc/interfaces/python/typemaps/python.string.outtm
@@ -7,5 +7,5 @@
  *  See LICENSES/README.md for more information.
  */
 %>${result} = <%
-  if(method.@feature_python_coerceToUnicode) { %>PyUnicode_DecodeUTF8(${api}.c_str(),${api}.size(),"replace");<% }
-  else { %>PyUnicode_FromStringAndSize(${api}.c_str(), ${api}.length());<% } %>
+  if(method.@feature_python_strictUnicode) { %>PyUnicode_DecodeUTF8(${api}.c_str(),${api}.size(),"strict");<% }
+  else { %>PyUnicode_DecodeUTF8(${api}.c_str(),${api}.size(),"surrogateescape");<% } %>

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -34,8 +34,6 @@ using namespace xbmc;
 
 %include "interfaces/legacy/swighelper.h"
 
-%feature("python:coerceToUnicode") XBMCAddon::xbmc::getLocalizedString "true"
-
 %include "interfaces/legacy/AddonString.h"
 %include "interfaces/legacy/ModuleXbmc.h"
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
@@ -31,6 +31,5 @@ using namespace xbmcaddon;
 %include "interfaces/legacy/swighelper.h"
 %include "interfaces/legacy/AddonString.h"
 
-%feature("python:coerceToUnicode") XBMCAddon::xbmcaddon::Addon::getLocalizedString "true"
 %include "interfaces/legacy/Addon.h"
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -49,8 +49,6 @@ using namespace xbmcgui;
 
 %include "interfaces/legacy/ListItem.h"
 
-%feature("python:coerceToUnicode") XBMCAddon::xbmcgui::ControlButton::getLabel "true"
-%feature("python:coerceToUnicode") XBMCAddon::xbmcgui::ControlButton::getLabel2 "true"
 %include "interfaces/legacy/Control.h"
 
 %include "interfaces/legacy/Dialog.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -29,6 +29,9 @@ using namespace xbmcvfs;
 
 %include "interfaces/legacy/swighelper.h"
 %include "interfaces/legacy/AddonString.h"
+
+%feature("python:strictUnicode") XBMCAddon::xbmcvfs::File::read "true"
+
 %include "interfaces/legacy/File.h"
 
 %rename ("st_atime") XBMCAddon::xbmcvfs::Stat::atime;


### PR DESCRIPTION
## Description

This PR changes the output typemap for `std::string` -> Python 3 `str`, and also removes python:coerceToUnicode feature in SWIG definitions.

## Motivation and Context

In certain cases Kodi API returns text in encodings other than UTF-8 which causes `UnicodeDecodeError` when converting this C++ `std::string` to Python 3 `str` that represents Unicode text. More info can be found here: https://github.com/romanvm/kodi.six/issues/3

Using `surrogateescape` error handler (see [PEP 383](https://www.python.org/dev/peps/pep-0383/)) serves 2 purposes:

1. Suppresses `UnicodeDecodeError` exceptions.
2. Allows to restore the original byte sequence from Python, e.g. to try to decode the text with different encoding.

For `xbmcvfs.File.read` `strict` error handler is used because `File` class has `readButes` method that allows to read a file in bytes format.

Also python:coerceToUnicode makes no sense in Python 3 because all strings are now returned as Unicode text.

## How Has This Been Tested?

The modified code was compiled on Ubuntu 18.04 and tested with non-UTF-8 strings returned from Kodi API.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
