### PR TITLE
DVDSubtitleTagSami: Support SubRip (.srt) backslash escaped hard spaces and newlines

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -24,7 +24,7 @@ bool CDVDSubtitleTagSami::Init()
   delete m_tags;
   delete m_tagOptions;
   m_tags = new CRegExp(true);
-  if (!m_tags->RegComp("(<[^>]*>|\\{[^\\}]*\\})"))
+  if (!m_tags->RegComp("(<[^>]*>|\\{[^\\}]*\\})|\\[nh]"))
     return false;
 
   m_tagOptions = new CRegExp(true);
@@ -169,10 +169,17 @@ void CDVDSubtitleTagSami::ConvertLine(CDVDOverlayText* pOverlay, const char* lin
       pos = del_start;
       m_flag[FLAG_LANGUAGE] = false;
     }
-    else if (StringUtils::StartsWith(fullTag, "<br") && !strUTF8.empty())
+    else if ((fullTag == "\\n") || (StringUtils::StartsWith(fullTag, "<br") && !strUTF8.empty()))
     {
       strUTF8.insert(pos, "\n");
       pos += 1;
+    }
+    // SubRip (.srt) hard space
+    else if (fullTag == "\\h")
+    {
+      // Unicode no-break space
+      strUTF8.insert(pos, "\xC2\xA0");
+      pos += 2;
     }
   }
 


### PR DESCRIPTION
## Description

Support SubRip (.srt) hard spaces (`\h`). Also support newlines via `\n` instead of `<br/>`.

See <http://ale5000.altervista.org/subtitles.htm>. Note that `\n` and `\N` are identical—SubRip decides between the two based on whether the next line of text is completely uppercase (to maintain the style, I suppose). Can't see why it would affect rendering at all, which is good because we already lowercase `\N` to `\n` before parsing.

## Motivation and Context

A subtitle file I wanted to use has lines like `♪\hWE\hARE\hTHE\hCRYSTAL\hGEMS\h♪\h\h`, and I didn't want to deal with reading that. Fixing it didn't seem impossibly hard.

Finding documentation on SubRip's .srt format sucks.

Something I'm curious about, especially now that we're dealing with escaped space translation, are our trimming decisions. Currently, a `StringUtils::Trim(strUTF8)` is called before tag parsing happens, and after parsing, only a single trailing newline is checked for and trimmed. With the minimal changes in this PR currently, an escaped NBSP will not be trimmed like normal whitespace. Additionally, currently, the current subtitle conversions will happen: `" foo bar<br/> "` will be converted into `"foo bar"`, `" foo bar <br/>"` will be converted into `"foo bar "`, `"<br/>foo bar<br/>"` will be convered into `"\nfoo bar"`, and `"<b></b> foo bar <b></b>"` will be converted into `"[B][/B] foo bar [B][/B]"`. This seems not great. Why do we even bother trimming here, then?

For our subtitles to hit the screen, the `CVideoPlayer` in `CreatePlayers` creates a `CVideoPlayerSubtitle`, which in `OpenStream` creates a `CDVDFactorySubtitle`, which in `CreateParser` detects SubRip, returning a `CDVDSubtitleParserSubrip`, which in `Open` creates a `CDVDSubtitleTagSami TagConv` to parse body lines, and the `CVideoPlayer` passes in a reference to its `CDVDOverlayContainer` to that `CVideoPlayerSubtitle` constructor, which is filled by `CVideoPlayerSubtitle::Parse` with a `CDVDOverlayText` by `CDVDSubtitleParserSubrip::Open`. The `CRenderManager` will create an `OVERLAY::CRenderer` (`VideoRenderers/OverlayRenderer.cpp`) to display them, which takes `CDVDOverlay` instances in `AddOverlay` and in `Render` creates for each `CDVDOverlayText` an `OVERLAY::COverlayText *text` that's later ran through `text->Render` and `text->PrepareRender`. `OVERLAY::COverlayText` (`VideoRenderers/OverlayRendererGUI.cpp`) finally does things we care about in its constructor that takes a `CDVDOverlayText`, namely processing the text elements of that `CDVDOverlayText`. (It also displays the text and such, but that's more complex and we'll get to that later.)

`CDVDOverlayText`'s constructor collects all the `CDVDOverlayText::CElementText` texts into a single `std::string m_text`, which is:
1. trimmed of its trailing newlines
2. `StringUtils::Replace` processed (in order) for (case sensitive):
  a. `"\\r"` (backslash escaped carriage return) → `""` (no CR support, only NL)
  b. `"\r"` (literal carriage return) → `""` (no CR support, only NL)
  c. `"\\n"` (backslash escaped newline) → `"[CR]"`
  d. `"\n"` (newline) → "[CR]"
  e. `"<br>"` (exact `<br>` line break) → `"[CR]"`
  f. `"\\N"` (backslash escaped uppercase newline) → `"[CR]"`  
     (Hey, it shows up elsewhere!)
  g. `"<i>"` (exact `<i>` italics begin) → `"[I]"`
  h. `"</i>"` (exact `</i>` italics end) → `"[/I]"`
  i. `"<b>"` (exact `<b>` bold begin) → `"[B]"`
  j. `"</b>"` (exact `</b>` bold end) → `"[/B]"`
  k. `"<u>"` (exact `<u>` underline begin) → `""` (no underline)
  l. `"<p>"` (exact `<p>` paragraph end) → `""`
  m. `"<P>"` (exact `<P>` paragraph begin) → `""`
  n. `"&nbsp;"` (no-break space HTML entity escape) → `""` (empty string, not even a space)
  o. `"</u>"` (exact `</u>` underline end) → `""` (no underline)
  p. `"</i"` (exact `</i` italics end) → `"[/I]"`
  q. `"</b"` (exact `</b` bold end) → `"[/B]"`
  r. `"</u"` (exact `</u` underline end) → `""` (no underline)

This text is then fed into a `CGUITextLayout *m_layout` returned by `GetFontLayout` via `m_layout->Update`, and `m_layout->RenderOutline` draws the subs in `Render`. `CGUITextLayout` (`guilib/GUITextLayout.cpp`) interests us with `ParseText`, which is called in `Update` (via `UpdateCommon`) and produces the style information necessary for `RenderOutline` (via `UpdateStyled`, called at the end of `UpdateCommon`) and its `CGUIFont::DrawText` invocations, both of which don't significantly inspect the text (`CGUIFont::DrawText`: total number of characters is likely to effect truncation to elipses, total number of raw spaces (U+20) is likely to effect justification; `UpdateStyled`: either `WrapText` or `LineBreakText` is called). (Notes on other `CGUITextLayout` methods while I'm here: `inline bool CanWrapAtLetter(character_t letter)` only checks for U+20 spaces or characters occupying the CJK Unified Ideographs block (U+4E00..U+9FFF). `inline bool IsSpace(character_t letter)` only checks for U+20 spaces, not any other sort of Unicode whitespace. `WrapText` calls both of these in its algorithm and doesn't try to deal with other whitespace (en, em, figure, thin, hair, zero-width, no-break). `LineBreakText` trims one trailing newline. `WrapText` calls `LineBreakText` at the start and trims trailing `IsSpace` spaces when wrapping the following text into a new line.)

`CGUITextLayout::ParseText` parses exclusively for square bracketed control sequences.

It's rather late now after writing this addendum, so I'm not going to retool the PR to take all this into account yet, or even give that great of a writeup, but huh. :thinking:

`CGUITextLayout` could probably use better wrapping logic & Unicode support. `CDVDOverlayText` seems to be overeager and a good place to mask bugs, but I'd want to track down where else it's utilized first. I don't like how it wants to remove NBSPs when they're specified as entities when this PR adds support for them in traditional(?) SubRip form. `CDVDSubtitleTagSami` could use HTML entity handling, better trimming in the face of HTML entities, possibly extraction into general speedy HTML/XML logic, possibly escapes for literal square bracket control sequences in sub bodies (i.e. Kodi-specific `foo [B]bar[/B]` instead of the spec-approved `foo <b>bar</b>`) and a better idea of what it should handle. (I like it handling all the HTML and `CDVDOverlayText` not dealing with this, just passing the square bracket escapes down through.)

I'd love to hear what developers who actually work on these subsystems think about this.

New context comment, tracing Kodi's structure sucks. This wasn't quite spaghetti, but it's not fun to dig through big files grepping for potential class name fragments until you find a method call that seems about right. Graphing out (visually or textually) the connections between Kodi's different classes would be great, like a sort of atlas for Kodi development.

## How Has This Been Tested?

I have not tested it at all yet, because I'm lazy and/or busy. However, it's two new characters in a UTF-8 stream, so I'm not expecting issues. I'll leave a comment once I get this checked on desktop, but despite running into this on an Android build, I won't be checking there. The subtitle subsystem shouldn't be that platform dependent.

## Screenshots (if appropriate):

I'll take some once my testing build is done, both before (on stable Leia) and after (on this PR, rooted on master, unless a rebased Leia variant would be preferred). (On that note, a backport to Leia would always be appreciated.) I'll probably toss a VLC screenshot in here too for comparison.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

I mean, it's technically a breaking change, but at least `\n` is actually mentioned in the SubRip source. I have no idea where `\h` for NBSP came from. This will technically break text using `\n` and `\h` as actual text. Those subtitles are already broken in other media players, like VLC.

Also, all that new stuff I just found and talked about (but didn't touch) definitely strays closer into breaking change territory.

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xbmc/xbmc/16869)
<!-- Reviewable:end -->
