### PR TITLE
DTSHD-MA vs. DTSHD-HR

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -911,15 +911,20 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
       CLog::Log(LOGDEBUG, "AESinkAUDIOTrack: Using IEC PT mode: %d", CJNIAudioFormat::ENCODING_IEC61937);
       if (supports_192khz)
       {
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-        // Check for IEC 8 channel 192 khz PT
+        // Check for IEC 8 channel 192 khz PT DTS-HD-MA and TrueHD
         int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1);
         if (VerifySinkConfiguration(192000, atChannelMask, CJNIAudioFormat::ENCODING_IEC61937))
         {
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
           CLog::Log(LOGDEBUG, "8 Channel PT via IEC61937 is supported");
+        }
+        // Check for IEC 2 channel 192 khz PT DTS-HD-HR and E-AC3
+        if (VerifySinkConfiguration(192000, CJNIAudioFormat::CHANNEL_OUT_STEREO,
+                                    CJNIAudioFormat::ENCODING_IEC61937))
+        {
+          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
         }
       }
     }

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -337,7 +337,9 @@ double CAudioSinkAE::GetClockSpeed()
     return 1.0;
 }
 
-CAEStreamInfo::DataType CAudioSinkAE::GetPassthroughStreamType(AVCodecID codecId, int samplerate)
+CAEStreamInfo::DataType CAudioSinkAE::GetPassthroughStreamType(AVCodecID codecId,
+                                                               int samplerate,
+                                                               int profile)
 {
   AEAudioFormat format;
   format.m_dataFormat = AE_FMT_RAW;
@@ -356,7 +358,10 @@ CAEStreamInfo::DataType CAudioSinkAE::GetPassthroughStreamType(AVCodecID codecId
       break;
 
     case AV_CODEC_ID_DTS:
-      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
+      if (profile == FF_PROFILE_DTS_HD_HRA)
+        format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
+      else
+        format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
       format.m_streamInfo.m_sampleRate = samplerate;
       break;
 

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -59,7 +59,7 @@ public:
   double GetClock() override;
   double GetClockSpeed() override;
 
-  CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate);
+  CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
 protected:
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -81,7 +81,8 @@ bool CVideoPlayerAudio::OpenStream(CDVDStreamInfo hints)
   if (m_processInfo.IsRealtimeStream())
     allowpassthrough = false;
 
-  CAEStreamInfo::DataType streamType = m_audioSink.GetPassthroughStreamType(hints.codec, hints.samplerate);
+  CAEStreamInfo::DataType streamType =
+      m_audioSink.GetPassthroughStreamType(hints.codec, hints.samplerate, hints.profile);
   CDVDAudioCodec* codec = CDVDFactoryCodec::CreateAudioCodec(hints, m_processInfo,
                                                              allowpassthrough, m_processInfo.AllowDTSHDDecode(),
                                                              streamType);
@@ -607,7 +608,8 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
   if (m_processInfo.IsRealtimeStream() || m_synctype == SYNC_RESAMPLE)
     allowpassthrough = false;
 
-  CAEStreamInfo::DataType streamType = m_audioSink.GetPassthroughStreamType(m_streaminfo.codec, m_streaminfo.samplerate);
+  CAEStreamInfo::DataType streamType = m_audioSink.GetPassthroughStreamType(
+      m_streaminfo.codec, m_streaminfo.samplerate, m_streaminfo.profile);
   CDVDAudioCodec *codec = CDVDFactoryCodec::CreateAudioCodec(m_streaminfo, m_processInfo,
                                                              allowpassthrough, m_processInfo.AllowDTSHDDecode(),
                                                              streamType);

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -160,7 +160,8 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
 
   CDVDStreamInfo hint(*pStream, true);
 
-  CAEStreamInfo::DataType ptStreamTye = GetPassthroughStreamType(hint.codec, hint.samplerate);
+  CAEStreamInfo::DataType ptStreamTye =
+      GetPassthroughStreamType(hint.codec, hint.samplerate, hint.profile);
   m_pAudioCodec = CDVDFactoryCodec::CreateAudioCodec(hint, *m_processInfo, true, true, ptStreamTye);
   if (!m_pAudioCodec)
   {
@@ -491,7 +492,9 @@ bool VideoPlayerCodec::NeedConvert(AEDataFormat fmt)
   }
 }
 
-CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID codecId, int samplerate)
+CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID codecId,
+                                                                   int samplerate,
+                                                                   int profile)
 {
   AEAudioFormat format;
   format.m_dataFormat = AE_FMT_RAW;
@@ -510,7 +513,10 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
       break;
 
     case AV_CODEC_ID_DTS:
-      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
+      if (profile == FF_PROFILE_DTS_HD_HRA)
+        format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
+      else
+        format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
       format.m_streamInfo.m_sampleRate = samplerate;
       break;
 

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -39,7 +39,7 @@ public:
   void SetPassthroughStreamType(CAEStreamInfo::DataType streamType);
 
 private:
-  CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate);
+  CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
   CDVDDemux* m_pDemuxer;
   std::shared_ptr<CDVDInputStream> m_pInputStream;


### PR DESCRIPTION
Distinguish those two based on ffmpeg's profile. 

Use-Case: DTS-HD-HR passthrough on devices that cannot do DTS-HD-MA, like FireTV Stick 4k.

Succesfully tested DTS-HD-HR shipped with 192 khz and 2 channels.