### PR TITLE
AESinkPulse: Implement Hotplug monitor

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -85,12 +85,15 @@ IAESink *CAESinkFactory::Create(std::string &device, AEAudioFormat &desiredForma
   return nullptr;
 }
 
-void CAESinkFactory::EnumerateEx(std::vector<AESinkInfo> &list, bool force)
+void CAESinkFactory::EnumerateEx(std::vector<AESinkInfo>& list, bool force, std::string driver)
 {
   AESinkInfo info;
 
   for(auto reg : m_AESinkRegEntry)
   {
+    if (!driver.empty() && driver != reg.second.sinkName)
+      continue;
+
     info.m_deviceInfoList.clear();
     info.m_sinkName = reg.second.sinkName;
     reg.second.enumerateFunc(info.m_deviceInfoList, force);

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -48,7 +48,7 @@ public:
 
   static void ParseDevice(std::string &device, std::string &driver);
   static IAESink *Create(std::string &device, AEAudioFormat &desiredFormat);
-  static void EnumerateEx(std::vector<AESinkInfo> &list, bool force);
+  static void EnumerateEx(std::vector<AESinkInfo>& list, bool force, std::string driver);
   static void Cleanup();
 
 protected:

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -448,6 +448,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             return;
 
           case CActiveAEControlProtocol::DEVICECHANGE:
+          case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
             LoadSettings();
             if (!m_settings.device.empty() && CAESinkFactory::HasSinks())
             {
@@ -494,7 +495,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
         {
         case CActiveAEControlProtocol::INIT:
           m_extError = false;
-          m_sink.EnumerateSinkList(false);
+          m_sink.EnumerateSinkList(false, "");
           LoadSettings();
           Configure();
           if (!m_isWinSysReg)
@@ -622,7 +623,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_extLastDeviceChange.push(now);
           UnconfigureSink();
           m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
-          m_sink.EnumerateSinkList(true);
+          m_sink.EnumerateSinkList(true, "");
           LoadSettings();
           m_extError = false;
           Configure();
@@ -635,6 +636,29 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           {
             m_state = AE_TOP_ERROR;
             m_extTimeout = 500;
+          }
+          return;
+        case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
+          const char* param;
+          param = reinterpret_cast<const char*>(msg->data);
+          CLog::Log(LOGDEBUG, "CActiveAE - device count change event from driver: %s", param);
+          m_sink.EnumerateSinkList(true, param);
+          if (!m_sink.DeviceExist(m_settings.driver, m_currDevice))
+          {
+            UnconfigureSink();
+            LoadSettings();
+            m_extError = false;
+            Configure();
+            if (!m_extError)
+            {
+              m_state = AE_TOP_CONFIGURED_PLAY;
+              m_extTimeout = 0;
+            }
+            else
+            {
+              m_state = AE_TOP_ERROR;
+              m_extTimeout = 500;
+            }
           }
           return;
         case CActiveAEControlProtocol::PAUSESTREAM:
@@ -835,7 +859,8 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!displayReset)
           {
             m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
-            m_sink.EnumerateSinkList(true);
+            m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECOUNTCHANGE);
+            m_sink.EnumerateSinkList(true, "");
             LoadSettings();
           }
           Configure();
@@ -855,6 +880,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_extDeferData = false;
           return;
         case CActiveAEControlProtocol::DEVICECHANGE:
+        case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
           return;
         default:
           break;
@@ -2859,6 +2885,13 @@ void CActiveAE::KeepConfiguration(unsigned int millis)
 void CActiveAE::DeviceChange()
 {
   m_controlPort.SendOutMessage(CActiveAEControlProtocol::DEVICECHANGE);
+}
+
+void CActiveAE::DeviceCountChange(std::string driver)
+{
+  const char* name = driver.c_str();
+  m_controlPort.SendOutMessage(CActiveAEControlProtocol::DEVICECOUNTCHANGE, name,
+                               driver.length() + 1);
 }
 
 bool CActiveAE::GetCurrentSinkFormat(AEAudioFormat &SinkFormat)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1381,12 +1381,12 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
 
         // input buffers
         m_vizBuffersInput = new CActiveAEBufferPool(m_internalFormat);
-        m_vizBuffersInput->Create(2000);
+        m_vizBuffersInput->Create(2000 + m_stats.GetMaxDelay() * 1000);
 
         // resample buffers
         m_vizBuffers = new CActiveAEBufferPoolResample(m_internalFormat, vizFormat, m_settings.resampleQuality);
         //! @todo use cache of sync + water level
-        m_vizBuffers->Create(2000, false, false);
+        m_vizBuffers->Create(2000 + m_stats.GetMaxDelay() * 1000, false, false);
         m_vizInitialized = false;
       }
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -73,6 +73,7 @@ public:
     RECONFIGURE,
     SUSPEND,
     DEVICECHANGE,
+    DEVICECOUNTCHANGE,
     MUTE,
     VOLUME,
     PAUSESTREAM,
@@ -254,6 +255,7 @@ public:
   bool IsSettingVisible(const std::string &settingId) override;
   void KeepConfiguration(unsigned int millis) override;
   void DeviceChange() override;
+  void DeviceCountChange(std::string driver) override;
   bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) override;
 
   void RegisterAudioCallback(IAudioCallback* pCallback) override;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -205,6 +205,26 @@ bool CActiveAESink::NeedIECPacking()
   return true;
 }
 
+bool CActiveAESink::DeviceExist(std::string driver, std::string device)
+{
+  if (driver.empty() && m_sink)
+    driver = m_sink->GetName();
+
+  for (const auto& itt : m_sinkInfoList)
+  {
+    if (itt.m_sinkName != driver)
+      continue;
+
+    for (auto itt2 : itt.m_deviceInfoList)
+    {
+      CAEDeviceInfo& info = itt2;
+      if (info.m_deviceName == device)
+        return true;
+    }
+  }
+  return false;
+}
+
 enum SINK_STATES
 {
   S_TOP = 0,                      // 0
@@ -661,7 +681,7 @@ void CActiveAESink::Process()
   }
 }
 
-void CActiveAESink::EnumerateSinkList(bool force)
+void CActiveAESink::EnumerateSinkList(bool force, std::string driver)
 {
   if (!m_sinkInfoList.empty() && !force)
     return;
@@ -669,25 +689,40 @@ void CActiveAESink::EnumerateSinkList(bool force)
   if (!CAESinkFactory::HasSinks())
     return;
 
+  std::vector<AE::AESinkInfo> tmpList(m_sinkInfoList);
+
   unsigned int c_retry = 4;
   m_sinkInfoList.clear();
-  CAESinkFactory::EnumerateEx(m_sinkInfoList, false);
+
+  if (!driver.empty())
+  {
+    for (auto const& info : tmpList)
+    {
+      if (info.m_sinkName != driver)
+        m_sinkInfoList.push_back(info);
+    }
+  }
+
+  CAESinkFactory::EnumerateEx(m_sinkInfoList, false, driver);
   while (m_sinkInfoList.empty() && c_retry > 0)
   {
     CLog::Log(LOGNOTICE, "No Devices found - retry: %d", c_retry);
     Sleep(1500);
     c_retry--;
     // retry the enumeration
-    CAESinkFactory::EnumerateEx(m_sinkInfoList, true);
+    CAESinkFactory::EnumerateEx(m_sinkInfoList, true, driver);
   }
   CLog::Log(LOGNOTICE, "Found %lu Lists of Devices", m_sinkInfoList.size());
-  PrintSinks();
+  PrintSinks(driver);
 }
 
-void CActiveAESink::PrintSinks()
+void CActiveAESink::PrintSinks(std::string& driver)
 {
   for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {
+    if (!driver.empty() && itt->m_sinkName != driver)
+      continue;
+
     CLog::Log(LOGNOTICE, "Enumerated %s devices:", itt->m_sinkName.c_str());
     int count = 0;
     for (auto itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
@@ -704,7 +739,7 @@ void CActiveAESink::PrintSinks()
 
 void CActiveAESink::EnumerateOutputDevices(AEDeviceList &devices, bool passthrough)
 {
-  EnumerateSinkList(false);
+  EnumerateSinkList(false, "");
 
   for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -83,20 +83,21 @@ class CActiveAESink : private CThread
 {
 public:
   explicit CActiveAESink(CEvent *inMsgEvent);
-  void EnumerateSinkList(bool force);
+  void EnumerateSinkList(bool force, std::string driver);
   void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough);
   void Start();
   void Dispose();
   AEDeviceType GetDeviceType(const std::string &device);
   bool HasPassthroughDevice();
   bool SupportsFormat(const std::string &device, AEAudioFormat &format);
+  bool DeviceExist(std::string driver, std::string device);
   CSinkControlProtocol m_controlPort;
   CSinkDataProtocol m_dataPort;
 
 protected:
   void Process() override;
   void StateMachine(int signal, Protocol *port, Message *msg);
-  void PrintSinks();
+  void PrintSinks(std::string& driver);
   void GetDeviceFriendlyName(std::string &device);
   void OpenSink();
   void ReturnBuffers();

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -223,6 +223,11 @@ public:
   virtual void DeviceChange() {}
 
   /**
+   * Instruct AE to re-initialize, e.g. after ELD change event
+   */
+  virtual void DeviceCountChange(std::string driver) {}
+
+  /**
    * Get the current sink data format
    *
    * @param Current sink data format. For more details see AEAudioFormat.

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -252,12 +252,12 @@ static void SinkCallback(pa_context* c,
       if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_NEW)
       {
         CLog::Log(LOGDEBUG, "Sink appeared");
-        CServiceBroker::GetActiveAE()->DeviceChange();
+        CServiceBroker::GetActiveAE()->DeviceCountChange("PULSE");
       }
       else if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_REMOVE)
       {
         CLog::Log(LOGDEBUG, "Sink removed");
-        CServiceBroker::GetActiveAE()->DeviceChange();
+        CServiceBroker::GetActiveAE()->DeviceCountChange("PULSE");
       }
       else if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_CHANGE)
       {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -13,8 +13,12 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/CriticalSection.h"
 
+#include <memory>
+
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
+
+class CDriverMonitor;
 
 class CAESinkPULSE : public IAESink
 {
@@ -27,6 +31,7 @@ public:
   static bool Register();
   static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
+  static void Cleanup();
 
   bool Initialize(AEAudioFormat &format, std::string &device) override;
   void Deinitialize() override;
@@ -47,7 +52,6 @@ public:
 private:
   void Pause(bool pause);
   static inline bool WaitForOperation(pa_operation *op, pa_threaded_mainloop *mainloop, const char *LogEntry);
-  static bool SetupContext(const char *host, pa_context **context, pa_threaded_mainloop **mainloop);
 
   bool m_IsAllocated;
   bool m_passthrough;
@@ -65,4 +69,6 @@ private:
 
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;
+
+  static std::unique_ptr<CDriverMonitor> m_pMonitor;
 };

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -66,6 +66,7 @@ private:
   unsigned int m_BytesPerSecond;
   unsigned int m_BufferSize;
   unsigned int m_Channels;
+  double m_maxLatency;
 
   pa_stream *m_Stream;
   pa_cvolume m_Volume;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -12,7 +12,9 @@
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/CriticalSection.h"
+#include "threads/Thread.h"
 
+#include <atomic>
 #include <memory>
 
 #include <pulse/pulseaudio.h>
@@ -48,7 +50,10 @@ public:
   bool IsInitialized();
   void UpdateInternalVolume(const pa_cvolume* nVol);
   pa_stream* GetInternalStream();
+  pa_threaded_mainloop* GetInternalMainLoop();
   CCriticalSection m_sec;
+  std::atomic<int> m_requestedBytes;
+
 private:
   void Pause(bool pause);
   static inline bool WaitForOperation(pa_operation *op, pa_threaded_mainloop *mainloop, const char *LogEntry);
@@ -69,6 +74,8 @@ private:
 
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;
+
+  XbmcThreads::EndTime m_extTimer;
 
   static std::unique_ptr<CDriverMonitor> m_pMonitor;
 };

--- a/xbmc/utils/ActorProtocol.cpp
+++ b/xbmc/utils/ActorProtocol.cpp
@@ -117,7 +117,10 @@ void Protocol::ReturnMessage(Message *msg)
   freeMessageQueue.push(msg);
 }
 
-bool Protocol::SendOutMessage(int signal, void *data /* = NULL */, size_t size /* = 0 */, Message *outMsg /* = NULL */)
+bool Protocol::SendOutMessage(int signal,
+                              const void* data /* = NULL */,
+                              size_t size /* = 0 */,
+                              Message* outMsg /* = NULL */)
 {
   Message *msg;
   if (outMsg)
@@ -168,7 +171,10 @@ bool Protocol::SendOutMessage(int signal, CPayloadWrapBase *payload, Message *ou
   return true;
 }
 
-bool Protocol::SendInMessage(int signal, void *data /* = NULL */, size_t size /* = 0 */, Message *outMsg /* = NULL */)
+bool Protocol::SendInMessage(int signal,
+                             const void* data /* = NULL */,
+                             size_t size /* = 0 */,
+                             Message* outMsg /* = NULL */)
 {
   Message *msg;
   if (outMsg)
@@ -219,7 +225,8 @@ bool Protocol::SendInMessage(int signal, CPayloadWrapBase *payload, Message *out
   return true;
 }
 
-bool Protocol::SendOutMessageSync(int signal, Message **retMsg, int timeout, void *data /* = NULL */, size_t size /* = 0 */)
+bool Protocol::SendOutMessageSync(
+    int signal, Message** retMsg, int timeout, const void* data /* = NULL */, size_t size /* = 0 */)
 {
   Message *msg = GetMessage();
   msg->isOut = true;

--- a/xbmc/utils/ActorProtocol.h
+++ b/xbmc/utils/ActorProtocol.h
@@ -78,11 +78,18 @@ public:
   ~Protocol();
   Message *GetMessage();
   void ReturnMessage(Message *msg);
-  bool SendOutMessage(int signal, void *data = nullptr, size_t size = 0, Message *outMsg = nullptr);
+  bool SendOutMessage(int signal,
+                      const void* data = nullptr,
+                      size_t size = 0,
+                      Message* outMsg = nullptr);
   bool SendOutMessage(int signal, CPayloadWrapBase *payload, Message *outMsg = nullptr);
-  bool SendInMessage(int signal, void *data = nullptr, size_t size = 0, Message *outMsg = nullptr);
+  bool SendInMessage(int signal,
+                     const void* data = nullptr,
+                     size_t size = 0,
+                     Message* outMsg = nullptr);
   bool SendInMessage(int signal, CPayloadWrapBase *payload, Message *outMsg = nullptr);
-  bool SendOutMessageSync(int signal, Message **retMsg, int timeout, void *data = nullptr, size_t size = 0);
+  bool SendOutMessageSync(
+      int signal, Message** retMsg, int timeout, const void* data = nullptr, size_t size = 0);
   bool SendOutMessageSync(int signal, Message **retMsg, int timeout, CPayloadWrapBase *payload);
   bool ReceiveOutMessage(Message **msg);
   bool ReceiveInMessage(Message **msg);


### PR DESCRIPTION
This implements hotplugging and device change functionality one level higher.

Use-Case:
Get device changes for pulseaudio even if kodi is idleing and not outputting audio

Reasoning:
Pulse-Sink is suspended and deinitialized after a longer idle period, especially if keep alive always is not used. While kodi is not outputting on the sink a new device is registered. As the ctx and the sink registration towards pulseaudio is not there - kodi does not get knowledge of this event and the new device won't be listed.

Implementation:
AESinkFactory has function ptrs for a long time to register an infrastructure / device whatever you want to call it. That way a sink can initialize its static DriverMonitor and register it with the SinkFactory. This DriverMonitor has its own pulse context and outlives the Sink itself.