### PR TITLE
[addon settings] parse action data

### DIFF
--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -143,6 +143,9 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
     bool closeDialog = false;
     if (XMLUtils::GetBoolean(node, "close", closeDialog))
       m_closeDialog = closeDialog;
+    std::string strActionData;
+    if (XMLUtils::GetString(node, SETTING_XML_ELM_DATA, strActionData))
+      m_actionData = strActionData;
   }
   else if (m_format == "addon")
   {


### PR DESCRIPTION
currently it's not possible to configure any weather addon in kodi due to multiple issues with the settings system.

this tends to fix the problem for weather addons that use the "new" settings system.
(fixes https://github.com/xbmc/xbmc/issues/16839)

weather addons that use the old-style addon settings remain broken
(ref https://github.com/xbmc/xbmc/issues/16833)