### PR TITLE
add dual support for Artist Slideshow 2.x and 3.x

### DIFF
--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -20,6 +20,15 @@
 				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 				<texture background="true" colordiffuse="88FFFFFF">$INFO[Player.Art(fanart)]</texture>
+				<visible>String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))</visible>
+			</control>
+			<control type="image">
+				<aspectratio>scale</aspectratio>
+				<fadetime>400</fadetime>
+				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+				<texture background="true" colordiffuse="88FFFFFF">$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</texture>
+				<visible>!String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))</visible>
 			</control>
 			<control type="multiimage">
 				<aspectratio>scale</aspectratio>
@@ -28,7 +37,7 @@
 				<fadetime>600</fadetime>
 				<loop>yes</loop>
 				<imagepath background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow)]</imagepath>
-				<visible>System.HasAddon(script.artistslideshow)</visible>
+				<visible>!String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.ArtworkReady)</visible>
 			</control>
 		</control>
 		<control type="group">


### PR DESCRIPTION
## Description
With Artist Slideshow 3.x there is a change to the way AS passes image information to the skin. The multiimage control is being depreciated in favor of a regular image control that is updated programmatically.  This pull requests provides support for both the 2.x and 3.x image control methodology.

## Motivation and Context
for Artist Slideshow to properly support the Kodi 18 artist information folder, I needed to move from the multiimage control to a regular image control.  If there is another release of Kodi 18, I'm hoping to get this included so I can time the release of AS 3.x with the next Kodi 18 release (otherwise I may wait until Matrix is released with this change).

## How Has This Been Tested?
Tested both in my development environment (OSX, Windows, and OSMC) as well as by some forum users.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
