### PR TITLE
fixed: support shoutcast over https

### DIFF
--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -137,7 +137,7 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   ||  url.IsProtocol("http")
   ||  url.IsProtocol("https")) return new CCurlFile();
   else if (url.IsProtocol("dav") || url.IsProtocol("davs")) return new CDAVFile();
-  else if (url.IsProtocol("shout")) return new CShoutcastFile();
+  else if (url.IsProtocol("shout") || url.IsProtocol("shouts")) return new CShoutcastFile();
 #ifdef HAS_FILESYSTEM_SMB
 #ifdef TARGET_WINDOWS
   else if (url.IsProtocol("smb")) return new CWin32SMBFile();

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -57,7 +57,10 @@ bool CShoutcastFile::Open(const CURL& url)
 {
   CURL url2(url);
   url2.SetProtocolOptions(url2.GetProtocolOptions()+"&noshout=true&Icy-MetaData=1");
-  url2.SetProtocol("http");
+  if (url.GetProtocol() == "shouts")
+    url2.SetProtocol("https");
+  else if (url.GetProtocol() == "shout")
+    url2.SetProtocol("http");
 
   bool result = m_file.Open(url2);
   if (result)


### PR DESCRIPTION
we can no longer blindly replace protocol with http since
shoutcast over https is now a thing.

replace shout:// protocol with http
replace shouts://protocol with https

Backport of https://github.com/xbmc/xbmc/pull/16874