### PR TITLE
fix clashing XBMCK_EJECT and XBMCK_FAVORITES

### DIFF
--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -222,7 +222,6 @@ typedef enum {
   // Add any other keys here
 
 	/* Media keys */
-  XBMCK_EJECT             = 333,
   XBMCK_STOP              = 337,
   XBMCK_RECORD            = 338,
   XBMCK_REWIND            = 339,
@@ -230,6 +229,7 @@ typedef enum {
   XBMCK_PLAY              = 341,
   XBMCK_SHUFFLE           = 342,
   XBMCK_FASTFORWARD       = 343,
+  XBMCK_EJECT = 344,
 
   XBMCK_LAST
 } XBMCKey;


### PR DESCRIPTION
The clash:  
  XBMCK_FAVORITES   = 0x14d,
  XBMCK_EJECT           = 333,
0x14d == 333

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
`XBMCK_EJECT` wrongly maps to `XBMCVK_FAVORITES`



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
