### PR TITLE
Allow reading of the currently playing DVD title, and direct title play to a given DVD title

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2811,6 +2811,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   }
 
   options.starttime = CUtil::ConvertMilliSecsToSecs(item.m_lStartOffset);
+  options.starttitle = item.GetStartTitle();
 
   if (bRestart)
   {

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -171,6 +171,15 @@ int CApplicationPlayer::GetChapter()
     return -1;
 }
 
+int CApplicationPlayer::GetTitle()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->GetTitle();
+  else
+    return -1;
+}
+
 int CApplicationPlayer::GetChapterCount()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -81,6 +81,7 @@ public:
   float GetCachePercentage() const;
   int GetChapterCount();
   int GetChapter();
+  int GetTitle();
   void GetChapterName(std::string& strChapterName, int chapterIdx=-1);
   int64_t GetChapterPos(int chapterIdx=-1);
   float GetPercentage() const;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -455,6 +455,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
 
   m_lStartOffset = item.m_lStartOffset;
   m_lStartPartNumber = item.m_lStartPartNumber;
+  m_iStartTitle = item.m_iStartTitle;
   m_lEndOffset = item.m_lEndOffset;
   m_strDVDLabel = item.m_strDVDLabel;
   m_strTitle = item.m_strTitle;
@@ -487,6 +488,7 @@ void CFileItem::Initialize()
   m_iDriveType = CMediaSource::SOURCE_TYPE_UNKNOWN;
   m_lStartOffset = 0;
   m_lStartPartNumber = 1;
+  m_iStartTitle = -1;
   m_lEndOffset = 0;
   m_iprogramCount = 0;
   m_idepth = 1;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -254,6 +254,8 @@ public:
   void FillInDefaultIcon();
   void SetFileSizeLabel();
   void SetLabel(const std::string &strLabel) override;
+  void SetStartTitle(int tt) { m_iStartTitle = tt; }
+  int GetStartTitle() const { return m_iStartTitle; }
   int GetVideoContentType() const; /* return VIDEODB_CONTENT_TYPE, but don't want to include videodb in this header */
   bool IsLabelPreformatted() const { return m_bLabelPreformatted; }
   void SetLabelPreformatted(bool bYesNo) { m_bLabelPreformatted=bYesNo; }
@@ -531,6 +533,7 @@ public:
   int m_idepth;
   int64_t m_lStartOffset;
   int m_lStartPartNumber;
+  int m_iStartTitle;
   int64_t m_lEndOffset;
   LockType m_iLockMode;
   std::string m_strLockCode;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -34,12 +34,14 @@ public:
   {
     starttime = 0LL;
     startpercent = 0LL;
+    starttitle = -1;
     fullscreen = false;
     videoOnly = false;
     preferStereo = false;
   }
   double starttime; /* start time in seconds */
   double startpercent; /* start time in percent */
+  int starttitle; /* start title index */
   std::string state;  /* potential playerstate to restore to */
   bool fullscreen; /* player is allowed to switch to fullscreen */
   bool videoOnly; /* player is not allowed to play audio streams, video streams only */
@@ -149,6 +151,7 @@ public:
 
   virtual int  GetChapterCount()                               { return 0; }
   virtual int  GetChapter()                                    { return -1; }
+  virtual int GetTitle() { return -1; }
   virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) {}
   virtual int64_t GetChapterPos(int chapterIdx=-1)             { return 0; }
   virtual int  SeekChapter(int iChapter)                       { return -1; }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -252,6 +252,11 @@ public:
   virtual bool SeekChapter(int chapter, double* startpts = NULL) { return false; }
 
   /*
+   * Starts the specified title.
+   */
+  virtual bool SeekTitle(int title) { return false; }
+
+  /*
    * Get the number of chapters available
    */
   virtual int GetChapterCount() { return 0; }
@@ -260,6 +265,11 @@ public:
    * Get current chapter
    */
   virtual int GetChapter() { return 0; }
+
+  /*
+   * Get current title
+   */
+  virtual int GetTitle() { return 0; }
 
   /*
    * Get the name of a chapter

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1824,6 +1824,16 @@ int CDVDDemuxFFmpeg::GetChapter()
   return 0;
 }
 
+int CDVDDemuxFFmpeg::GetTitle()
+{
+  std::shared_ptr<CDVDInputStream::IChapter> ich =
+    std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
+  if (ich)
+    return ich->GetTitle();
+
+  return 0;
+}
+
 void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx)
 {
   if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
@@ -1887,6 +1897,25 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
   AVChapter* ch = m_pFormatContext->chapters[chapter - 1];
   double dts = ConvertTimestamp(ch->start, ch->time_base.den, ch->time_base.num);
   return SeekTime(DVD_TIME_TO_MSEC(dts), true, startpts);
+}
+
+bool CDVDDemuxFFmpeg::SeekTitle(int title)
+{
+  if (title < 1)
+    return false;
+
+  std::shared_ptr<CDVDInputStream::IChapter> ich =
+    std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
+  if (ich)
+  {
+    CLog::Log(LOGDEBUG, "%s - title seeking using input stream", __FUNCTION__);
+    if (!ich->SeekTitle(title))
+      return false;
+
+    return true;
+  }
+
+  return false;
 }
 
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -96,8 +96,10 @@ public:
   void SetProgram(int progId) override;
 
   bool SeekChapter(int chapter, double* startpts = NULL) override;
+  bool SeekTitle(int title) override;
   int GetChapterCount() override;
   int GetChapter() override;
+  int GetTitle() override;
   void GetChapterName(std::string& strChapterName, int chapterIdx=-1) override;
   int64_t GetChapterPos(int chapterIdx = -1) override;
   std::string GetStreamCodecName(int iStreamId) override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -83,11 +83,13 @@ public:
   {
   public:
     virtual ~IChapter() = default;
+    virtual int GetTitle() = 0;
     virtual int  GetChapter() = 0;
     virtual int  GetChapterCount() = 0;
     virtual void GetChapterName(std::string& name, int ch=-1) = 0;
     virtual int64_t GetChapterPos(int ch=-1) = 0;
     virtual bool SeekChapter(int ch) = 0;
+    virtual bool SeekTitle(int tt) = 0;
   };
 
   class IMenus

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -903,6 +903,14 @@ int CDVDInputStreamBluray::GetChapter()
     return 0;
 }
 
+int CDVDInputStreamBluray::GetTitle()
+{
+  if (m_titleInfo)
+    return static_cast<int>(bd_get_current_title(m_bd) + 1);
+  else
+    return 0;
+}
+
 bool CDVDInputStreamBluray::SeekChapter(int ch)
 {
   if(m_titleInfo && bd_seek_chapter(m_bd, ch-1) < 0)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -96,11 +96,13 @@ public:
   bool MouseMove(const CPoint &point);
   bool MouseClick(const CPoint &point);
 
+  int GetTitle() override;
   int GetChapter() override;
   int GetChapterCount() override;
   void GetChapterName(std::string& name, int ch=-1) override {};
   int64_t GetChapterPos(int ch) override;
   bool SeekChapter(int ch) override;
+  bool SeekTitle(int tt) override { return false; }
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
   int GetTotalTime() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1276,6 +1276,28 @@ bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
   return true;
 }
 
+bool CDVDInputStreamNavigator::SeekTitle(int iTitle)
+{
+  if (!m_dvdnav)
+    return false;
+
+  bool enabled = IsSubtitleStreamEnabled();
+  int audio = GetActiveAudioStream();
+  int subtitle = GetActiveSubtitleStream();
+
+  if (m_dll.dvdnav_title_play(m_dvdnav, iTitle) == DVDNAV_STATUS_ERR)
+  {
+    CLog::Log(LOGERROR, "dvdnav: dvdnav_title_play failed( %s )",
+              m_dll.dvdnav_err_to_string(m_dvdnav));
+    return false;
+  }
+
+  SetActiveSubtitleStream(subtitle);
+  SetActiveAudioStream(audio);
+  EnableSubtitleStream(enabled);
+  return true;
+}
+
 float CDVDInputStreamNavigator::GetVideoAspectRatio()
 {
   int iAspect = m_dll.dvdnav_get_video_aspect(m_dvdnav);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -96,11 +96,13 @@ public:
   bool GetState(std::string &xmlstate) override;
   bool SetState(const std::string &xmlstate) override;
 
+  int GetTitle() override { return m_iTitle; } // the current title
   int GetChapter() override { return m_iPart; } // the current part in the current title
   int GetChapterCount() override { return m_iPartCount; } // the number of parts in the current title
   void GetChapterName(std::string& name, int idx=-1) override {};
   int64_t GetChapterPos(int ch=-1) override;
   bool SeekChapter(int iChapter) override;
+  bool SeekTitle(int iTitle) override;
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
   int GetTotalTime() override; // the total time in milli seconds

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -522,6 +522,11 @@ CDVDInputStream::IChapter* CInputStreamAddon::GetIChapter()
   return this;
 }
 
+int CInputStreamAddon::GetTitle()
+{
+  return -1;
+}
+
 int CInputStreamAddon::GetChapter()
 {
   if (m_struct.toAddon.get_chapter)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -89,11 +89,13 @@ public:
 
   // IChapter
   CDVDInputStream::IChapter* GetIChapter() override;
+  int GetTitle() override;
   int GetChapter() override;
   int GetChapterCount() override;
   void GetChapterName(std::string& name, int ch = -1) override;
   int64_t GetChapterPos(int ch = -1) override;
   bool SeekChapter(int ch) override;
+  bool SeekTitle(int tt) override { return false; }
 
 protected:
   static int ConvertVideoCodecProfile(STREAMCODEC_PROFILE profile);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -838,6 +838,14 @@ bool CVideoPlayer::OpenDemuxStream()
     return false;
   }
 
+  if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) &&
+      m_playerOptions.starttitle > 0)
+  {
+    CLog::Log(LOGNOTICE, "Jumping to title %d", m_playerOptions.starttitle);
+    m_pDemuxer->SeekTitle(m_playerOptions.starttitle);
+    m_playerOptions.starttitle = -1;
+  }
+
   m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
   m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
   m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
@@ -4383,6 +4391,12 @@ int CVideoPlayer::GetChapter()
   return m_State.chapter;
 }
 
+int CVideoPlayer::GetTitle()
+{
+  CSingleLock lock(m_StateSection);
+  return m_State.title;
+}
+
 void CVideoPlayer::GetChapterName(std::string& strChapterName, int chapterIdx)
 {
   CSingleLock lock(m_StateSection);
@@ -4533,6 +4547,8 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   if (m_pDemuxer)
   {
+    state.title = m_pDemuxer->GetTitle();
+
     if (IsInMenuInternal())
       state.chapter = 0;
     else

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -45,6 +45,7 @@ struct SPlayerState
     player_state  = "";
     isInMenu = false;
     hasMenu = false;
+    title = 0;
     chapter = 0;
     chapters.clear();
     canpause = false;
@@ -74,6 +75,7 @@ struct SPlayerState
   bool hasMenu;
   bool streamsReady;
 
+  int title; // current title
   int chapter;              // current chapter
   std::vector<std::pair<std::string, int64_t>> chapters; // name and position for chapters
 
@@ -290,6 +292,7 @@ public:
 
   int  GetChapterCount() override;
   int  GetChapter() override;
+  int GetTitle() override;
   void GetChapterName(std::string& strChapterName, int chapterIdx=-1) override;
   int64_t GetChapterPos(int chapterIdx=-1) override;
   int  SeekChapter(int iChapter) override;

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -413,6 +413,10 @@ bool CFileItemHandler::FillFileItemList(const CVariant &parameterObject, CFileIt
     if (!added)
     {
       CFileItemPtr item = CFileItemPtr(new CFileItem(file, false));
+      if (parameterObject.isMember("title"))
+      {
+        item->SetStartTitle(parameterObject["title"].asInteger());
+      }
       if (item->IsPicture())
       {
         CPictureInfoTag picture;

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1370,6 +1370,21 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
         return FailedToExecute;
     }
   }
+  else if (property == "title")
+  {
+    switch (player)
+    {
+      case Video:
+        result = g_application.GetAppPlayer().GetTitle();
+        break;
+
+      case Audio:
+      case Picture:
+      default:
+        result = -1;
+        break;
+    }
+  }
   else if (property == "time")
   {
     switch (player)

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -954,6 +954,10 @@ bool CVideoLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
   CFileItemPtr fileItem(new CFileItem());
   if (FillFileItem(file, fileItem))
   {
+    if (parameterObject.isMember("title"))
+    {
+      fileItem->SetStartTitle(parameterObject["title"].asInteger());
+    }
     success = true;
     list.Add(fileItem);
   }

--- a/xbmc/interfaces/json-rpc/schema/types.json
+++ b/xbmc/interfaces/json-rpc/schema/types.json
@@ -152,7 +152,7 @@
   },
   "Playlist.Item": {
     "type": [
-      { "type": "object", "properties": { "file": { "type": "string", "description": "Path to a file (not a directory) to be added to the playlist", "required": true } }, "additionalProperties": false },
+      { "type": "object", "properties": { "file": { "type": "string", "description": "Path to a file (not a directory) to be added to the playlist", "required": true }, "title": { "type": "integer", "description": "Title on disc to play", "default": -1 } }, "additionalProperties": false },
       { "type": "object", "properties": { "directory": { "type": "string", "required": true }, "recursive": { "type": "boolean", "default": false }, "media": { "$ref": "Files.Media", "default": "files" } }, "additionalProperties": false },
       { "type": "object", "properties": { "movieid": { "$ref": "Library.Id", "required": true } }, "additionalProperties": false },
       { "type": "object", "properties": { "episodeid": { "$ref": "Library.Id", "required": true } }, "additionalProperties": false },
@@ -254,7 +254,7 @@
   },
   "Player.Property.Name": {
     "type": "string",
-    "enum": [ "type", "partymode", "speed", "time", "percentage",
+    "enum": [ "type", "partymode", "speed", "title", "time", "percentage",
               "totaltime", "playlistid", "position", "repeat", "shuffled",
               "canseek", "canchangespeed", "canmove", "canzoom", "canrotate",
               "canshuffle", "canrepeat", "currentaudiostream", "audiostreams",


### PR DESCRIPTION
This change provides a new Player.GetProperties property of "title", which indicates the currently playing DVD title.

It also provides a new Player.Open property of "title", which indicates that playback should start directly at that DVD title rather than the DVD menu.

Use case: having tagged all the title numbers on my TV series boxsets, my remote control app can now show the currently playing episode details, as well as start playing a particular episode directly.