### PR TITLE
add SUBTITLE, LANGUAGE keys 

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -385,6 +385,7 @@
       <right mod="alt">PlayerControl(tempoup)</right>
       <a>AudioDelay</a>
       <a mod="ctrl">AudioNextLanguage</a>
+      <language>AudioNextLanguage<language>
       <escape>Fullscreen</escape>
       <c>Playlist</c>
       <v>ActivateWindow(Teletext)</v>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -371,8 +371,10 @@
       <z>AspectRatio</z>
       <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
+      <subtitle>ShowSubtitles</subtitle>
       <t mod="ctrl">SubtitleAlign</t>
       <l>NextSubtitle</l>
+      <subtitle mod="longpress">NextSubtitle</subtitle>
       <left>StepBack</left>
       <right>StepForward</right>
       <up>ChapterOrBigStepForward</up>
@@ -571,7 +573,9 @@
       <z>AspectRatio</z>
       <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
+      <subtitle>ShowSubtitles</subtitle>
       <l>NextSubtitle</l>
+      <subtitle mod="longpress">NextSubtitle</subtitle>
       <a>AudioDelay</a>
       <escape>Fullscreen</escape>
       <return>Select</return>

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -233,6 +233,7 @@ typedef enum {
 
   // Remote control buttons
   XBMCK_SUBTITLE = 345,
+  XBMCK_LANGUAGE = 346,
 
   XBMCK_LAST
 } XBMCKey;

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -231,6 +231,9 @@ typedef enum {
   XBMCK_FASTFORWARD       = 343,
   XBMCK_EJECT = 344,
 
+  // Remote control buttons
+  XBMCK_SUBTITLE = 345,
+
   XBMCK_LAST
 } XBMCKey;
 

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -232,6 +232,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_HOMEPAGE ,              0,    0, XBMCVK_HOMEPAGE,      "homepage" }
 , { XBMCK_CONFIG,                 0,    0, XBMCVK_CONFIG,        "config" }
 , { XBMCK_EPG   ,                 0,    0, XBMCVK_EPG,           "epg" }
+, { XBMCK_SUBTITLE,               0,    0, XBMCVK_SUBTITLE,      "subtitle" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -233,6 +233,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_CONFIG,                 0,    0, XBMCVK_CONFIG,        "config" }
 , { XBMCK_EPG   ,                 0,    0, XBMCVK_EPG,           "epg" }
 , { XBMCK_SUBTITLE,               0,    0, XBMCVK_SUBTITLE,      "subtitle" }
+, { XBMCK_LANGUAGE,               0,    0, XBMCVK_LANGUAGE,      "language" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -210,6 +210,7 @@ typedef enum {
   XBMCVK_HOMEPAGE       = 0xEA,
   XBMCVK_CONFIG         = 0xEB,
   XBMCVK_EPG            = 0xEC,
+  XBMCVK_SUBTITLE       = 0xED,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -211,6 +211,7 @@ typedef enum {
   XBMCVK_CONFIG         = 0xEB,
   XBMCVK_EPG            = 0xEC,
   XBMCVK_SUBTITLE       = 0xED,
+  XBMCVK_LANGUAGE       = 0xEE,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -136,6 +136,7 @@ static const std::map<xkb_keysym_t, XBMCKey> xkbMap =
   { XKB_KEY_XF86HomePage, XBMCK_HOMEPAGE },
   // Unmapped: XBMCK_CONFIG, XBMCK_EPG
   { XKB_KEY_XF86Subtitle, XBMCK_SUBTITLE },
+  { XKB_KEY_XF86AudioCycleTrack, XBMCVK_LANGUAGE },
 
   // Media keys
   { XKB_KEY_XF86Eject, XBMCK_EJECT },

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -135,6 +135,7 @@ static const std::map<xkb_keysym_t, XBMCKey> xkbMap =
   { XKB_KEY_XF86Favorites, XBMCK_FAVORITES },
   { XKB_KEY_XF86HomePage, XBMCK_HOMEPAGE },
   // Unmapped: XBMCK_CONFIG, XBMCK_EPG
+  { XKB_KEY_XF86Subtitle, XBMCK_SUBTITLE },
 
   // Media keys
   { XKB_KEY_XF86Eject, XBMCK_EJECT },


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
add the XBMCVK_SUBTITLE,  XBMCK_LANGUAGE virtual keys and default mapping

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Dedicated virtual keys for Subtitles and Language are still missing.
The buttons are present on many remote controls handled as keyboard in the system, so it worth to have proper virtual keys for it.

The keys already has perfect match on all levels, so adding it to Kodi would be trivial:
Linux kernel: KEY_SUBTITLE, KEY_LANGUAGE
XKB: XKB_KEY_XF86Subtitle, XKB_KEY_XF86AudioCycleTrack

[Request -  add XBMCVK_SUBTITLE key](https://forum.kodi.tv/showthread.php?tid=349160)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@lrusak @davilla @sraue