### PR TITLE
RendererMediaCodecSurface: Announce vertical shift as well

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -117,10 +117,9 @@ void CRendererMediaCodecSurface::ReleaseBuffer(int idx)
 
 bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
 {
-  if (feature == RENDERFEATURE_ZOOM ||
-    feature == RENDERFEATURE_STRETCH ||
-    feature == RENDERFEATURE_PIXEL_RATIO ||
-    feature == RENDERFEATURE_ROTATION)
+  if (feature == RENDERFEATURE_ZOOM || feature == RENDERFEATURE_STRETCH ||
+      feature == RENDERFEATURE_PIXEL_RATIO || feature == RENDERFEATURE_VERTICAL_SHIFT ||
+      feature == RENDERFEATURE_ROTATION)
     return true;
 
   return false;


### PR DESCRIPTION
This was disabled - I did not find any documentation why.