### PR TITLE
WinSystem: Allow ALSA+PULSE in parallel

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -62,6 +62,11 @@ CWinSystemX11GLContext::CWinSystemX11GLContext()
   {
     OPTIONALS::SndioRegister();
   }
+  else if (StringUtils::EqualsNoCase(envSink, "ALSA+PULSE"))
+  {
+    OPTIONALS::ALSARegister();
+    OPTIONALS::PulseAudioRegister();
+  }
   else
   {
     if (!OPTIONALS::PulseAudioRegister())

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -54,6 +54,11 @@ CWinSystemGbm::CWinSystemGbm() :
   {
     OPTIONALS::SndioRegister();
   }
+  else if (StringUtils::EqualsNoCase(envSink, "ALSA+PULSE"))
+  {
+    OPTIONALS::ALSARegister();
+    OPTIONALS::PulseAudioRegister();
+  }
   else
   {
     if (!OPTIONALS::PulseAudioRegister())

--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -54,6 +54,11 @@ CWinSystemRpi::CWinSystemRpi() :
   {
     OPTIONALS::PulseAudioRegister();
   }
+  else if (StringUtils::EqualsNoCase(envSink, "ALSA+PULSE"))
+  {
+    OPTIONALS::ALSARegister();
+    OPTIONALS::PulseAudioRegister();
+  }
   else
   {
     OPTIONALS::ALSARegister();

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -156,6 +156,11 @@ CWinSystemWayland::CWinSystemWayland()
   {
     OPTIONALS::SndioRegister();
   }
+  else if (StringUtils::EqualsNoCase(envSink, "ALSA+PULSE"))
+  {
+    OPTIONALS::ALSARegister();
+    OPTIONALS::PulseAudioRegister();
+  }
   else
   {
     if (!OPTIONALS::PulseAudioRegister())


### PR DESCRIPTION
We have certain use-cases where ALSA + PULSE shall be used in combination. This is especially when a BT Headset is connected via PULSE and rest of the system is using e.g. ALSA for passthrough and audiophile setup.

The new environment var: ALSA+PULSE allows this for:

- GBM
- PI
- X11
- Wayland

A similar patch currently is in LE. This can be dropped by exposing KODI_AE_SINK=ALSA+PULSE in environment prior to starting kodi.