### PR TITLE
AESinkAudioTrack: Remove now superflous HeadSet check

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -309,7 +309,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
      }
   }
 
-  if (m_format.m_dataFormat == AE_FMT_RAW && !CXBMCApp::IsHeadsetPlugged())
+  if (m_format.m_dataFormat == AE_FMT_RAW)
   {
     m_passthrough = true;
     m_encoding = AEStreamFormatToATFormat(m_format.m_streamInfo.m_type);


### PR DESCRIPTION
With the removal of the headset check, we now properly enumerated PT capabilities of USB attached devices. Having that check though in there when opening them, is a clear programming error.

Therefore also remove this check there. If HeadSet is Plugged and unplugged XbmcApp will reenumerate and the underlaying driver can care for it.