### PR TITLE
[videoplayer] allow ffmpeg options to be set/overidden by properties

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -812,6 +812,26 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
                   it->first.c_str());
       }
     }
+    // Allow ffmpeg options to be overidden by properties
+    static std::string optionPrefix = "inputstream.ffmpeg.";
+    static std::string ffmpegOptions[] =
+      {"user_agent", "referer", "seekable", "reconnect", "reconnect_at_eof",
+       "reconnect_streamed", "reconnect_delay_max", "icy", "icy_metadata_headers",
+       "icy_metadata_packet"};
+
+    for (const std::string optionName : ffmpegOptions)
+    {
+      CVariant optionValue = m_pInput->GetProperty(optionPrefix + optionName);
+      if (!optionValue.isNull())
+      {
+        CLog::Log(LOGDEBUG,
+                  "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() overriding ffmpeg option '%s: %s'",
+                  optionName.c_str(), optionValue.asString().c_str());
+        if (optionName == "user_agent")
+          hasUserAgent = true;
+        av_dict_set(&options, optionName.c_str(), optionValue.asString().c_str(), 0);
+      }
+    }
     if (!hasUserAgent)
     {
       // set default xbmc user-agent.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Allows setting stream properties in order to set ffmpeg options instead of having to pass via the URL options. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Easier for addons to send ffmpeg options instead of having to embed in URL protocol options.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On OSX using pvr.iptvsimple. Loaded numerous emote m3u8 files proving the values from the properties were passed to ffmpeg.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
