### PR TITLE
[PVR] Recordings window: added support for ToggleWatched action

### DIFF
--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -202,6 +202,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
       item->SetLabel(strCurrent);
       item->SetLabelPreformatted(true);
       item->m_dateTime = recording->RecordingTimeAsLocalTime();
+      item->SetProperty("unwatchedepisodes", 0);
 
       // Assume all folders are watched, we'll change the overlay later
       item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED, false);
@@ -215,7 +216,10 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     }
 
     if (recording->GetPlayCount() == 0)
+    {
       unwatchedFolders.insert(item);
+      item->IncrementProperty("unwatchedepisodes", 1);
+    }
   }
 
   // Change the watched overlay to unwatched for folders containing unwatched entries

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -27,6 +27,7 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <memory>
@@ -99,6 +100,24 @@ bool CGUIWindowPVRRecordingsBase::OnAction(const CAction& action)
       return true;
     }
   }
+  else if (action.GetID() == ACTION_TOGGLE_WATCHED)
+  {
+    const std::shared_ptr<CFileItem> pItem = m_vecItems->Get(m_viewControl.GetSelectedItem());
+    if (!pItem || pItem->IsParentFolder())
+      return false;
+
+    bool bUnWatched = false;
+    if (pItem->HasPVRRecordingInfoTag())
+      bUnWatched = pItem->GetPVRRecordingInfoTag()->GetPlayCount() == 0;
+    else if (pItem->m_bIsFolder)
+      bUnWatched = pItem->GetProperty("unwatchedepisodes").asInteger() > 0;
+    else
+      return false;
+
+    CVideoLibraryQueue::GetInstance().MarkAsWatched(pItem, bUnWatched);
+    return true;
+  }
+
   return CGUIWindowPVRBase::OnAction(action);
 }
 


### PR DESCRIPTION
## Description
The ToggleWatched action currently has no effect in the PVR Recordings Window. This commit enables the ToggleWatched action to work for the PVR Recordings window when either a recording or folder (if items are grouped) is selected.

## Motivation and Context
The ToggleWatched action can be mapped to a remote button which is a very useful feature, but previously this had no effect in the PVR Recordings window.

## How Has This Been Tested?
Tested using pvr.hts with server-based play status.

In the PVR Recordings window I mapped a remote button to the ToggleWatched action. I tested this button on:
* items that were unwatched - they were marked as watched
* items that were partially watched - they were marked as watched
* items that were watched - they were marked as unwatched
In grouped view
* folders marked as unwatched - they were marked watched
* folders marked as watched - they wete marked unwatched
* within a folder on child items - marked watched/unwatched as expected
* within a folder, execute the action on parent folder (...) item - no effect as expected

Checked the playcount in the tvheadend admin interface after toggling watched flag to verify this was updated.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
