### PR TITLE
[addons] fix CAddon::HasSettings() for settings.xml files without any settings

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -53,7 +53,7 @@ CAddon::CAddon(const AddonInfoPtr& addonInfo, TYPE addonType)
  */
 bool CAddon::HasSettings()
 {
-  return LoadSettings(false);
+  return LoadSettings(false) && m_settings->HasSettings();
 }
 
 bool CAddon::SettingsInitialized() const

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -336,7 +336,7 @@ bool CAddonSettings::Save(CXBMCTinyXML& doc) const
 
 bool CAddonSettings::HasSettings() const
 {
-  return IsInitialized() && !GetSettingsManager()->GetSections().empty();
+  return IsInitialized() && GetSettingsManager()->HasSettings();
 }
 
 std::string CAddonSettings::GetSettingLabel(int label) const

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -541,6 +541,11 @@ void* CSettingsManager::GetSettingOptionsFiller(SettingConstPtr setting)
   return fillerIt->second.filler;
 }
 
+bool CSettingsManager::HasSettings() const
+{
+  return !m_settings.empty();
+}
+
 SettingPtr CSettingsManager::GetSetting(const std::string &id) const
 {
   CSharedLock lock(m_settingsCritical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -277,6 +277,12 @@ public:
   void* GetSettingOptionsFiller(std::shared_ptr<const CSetting> setting);
 
   /*!
+   \brief Checks whether any settings have been initialized.
+   
+   \return True if at least one setting has been initialized, false otherwise*/
+  bool HasSettings() const;
+
+  /*!
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier


### PR DESCRIPTION
## Description
This fix is coming from my media import work. I've noticed that if an add-on has either an empty `settings.xml` file or a `settings.xml` which only contains the root XML element in the UI it is possible to open the add-on's settings dialog even though there's nothing to configure.

## Motivation and Context
Don't show the `Configure` button in the add-on UI if there are no settings to configure.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
