### PR TITLE
CVideoInfoTag: fix behaviour of SetUniqueID(s) if no default unique ID has been previously set

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1418,7 +1418,11 @@ void CVideoInfoTag::SetUniqueIDs(std::map<std::string, std::string> uniqueIDs)
       uniqueIDs.erase(uniqueid.first);
   }
   if (uniqueIDs.find(m_strDefaultUniqueID) == uniqueIDs.end())
-    uniqueIDs[m_strDefaultUniqueID] = GetUniqueID();
+  {
+    const auto defaultUniqueId = GetUniqueID();
+    if (!defaultUniqueId.empty())
+      uniqueIDs[m_strDefaultUniqueID] = defaultUniqueId;
+  }
   m_uniqueIDs = std::move(uniqueIDs);
 }
 
@@ -1502,10 +1506,11 @@ void CVideoInfoTag::SetShowLink(std::vector<std::string> showLink)
 
 void CVideoInfoTag::SetUniqueID(const std::string& uniqueid, const std::string& type /* = "" */, bool isDefaultID /* = false */)
 {
+  if (uniqueid.empty())
+    return;
+
   if (type.empty())
-  {
     m_uniqueIDs[m_strDefaultUniqueID] = uniqueid;
-  }
   else
   {
     m_uniqueIDs[type] = uniqueid;


### PR DESCRIPTION
##  Description
This fix is coming from my media import work.  I've noticed that setting custom unique IDs on a video item without any previous unique IDs results in an additional entry `"unknown": `""` because the previous default unique ID is being forced into the list of unique IDs even though it doesn't have any meaning.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
