### PR TITLE
[swig/python] fix vector output typemap for specialized std::vector<bool>

### DIFF
--- a/xbmc/interfaces/python/typemaps/python.vector.outtm
+++ b/xbmc/interfaces/python/typemaps/python.vector.outtm
@@ -22,9 +22,8 @@
 
       for (std::vector<${swigTypeParser.SwigType_str(vectype)}>::iterator iter = ${api}${accessor}begin(); iter != ${api}${accessor}end(); ++iter)
       {
-        ${swigTypeParser.SwigType_str(swigTypeParser.SwigType_ltype(vectype))}& entry${seq} = *iter;
         PyObject* pyentry${seq};
-        ${helper.getOutConversion(vectype,'result',method,[ 'result' : 'pyentry' + seq, 'api' : 'entry' + seq, 'sequence' : sequence ])}
+        ${helper.getOutConversion(vectype,'result',method,[ 'result' : 'pyentry' + seq, 'api' : '(*iter)', 'sequence' : sequence ])}
         PyList_Append(${result}, pyentry${seq});
         Py_DECREF(pyentry${seq});
       }


### PR DESCRIPTION
## Description
This fix is coming from my media import work.  There I've ran into the issue that trying to return a `std::vector<bool>` to a python add-on results in a compiler error in the code generated by swig. The problem is that the vector output typemap uses iterators to go through a `std::vector<>` value by value and convert every value to its python equivalent. But since `std::vector<bool>` has a specialized template implementation using a bitmap internally its iterators don't work the same as for other `std::vector<>` template instantiations.

## How Has This Been Tested?
By using `std::vector<bool>` as a return type of a python interface method, generating the proper python glue code and successfully compiling it.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
