### PR TITLE
Allow DolbyVision streams passed from inputstream addons

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -493,8 +493,16 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       }
       break;
     case AV_CODEC_ID_HEVC:
-      m_mime = "video/hevc";
-      m_formatname = "amc-h265";
+      if (m_hints.codec_tag == MKTAG('d', 'v', 'h', 'e'))
+      {
+        m_mime = "video/dolby-vision";
+        m_formatname = "amc-dvhe";
+      }
+      else
+      {
+        m_mime = "video/hevc";
+        m_formatname = "amc-hevc";
+      }
       // check for hevc-hvcC and convert to h265-annex-b
       if (m_hints.extradata && !m_hints.cryptoSession)
       {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -581,6 +581,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
   toStream->uniqueId = stream->uniqueId;
   toStream->codec = stream->codec;
   toStream->codecName = stream->codecName;
+  toStream->codec_fourcc = stream->codec_fourcc;
   toStream->flags = stream->flags;
   toStream->cryptoSession = stream->cryptoSession;
   toStream->externalInterfaces = stream->externalInterfaces;


### PR DESCRIPTION
## Description
This PR implements the capability to view DV media (codec dvhe) on devices which have an DV decoder on board (for example some android devices like the new shield TV 2019 or AFTV 4K Gen2. 

From my current knowledge DV is not working correctly if the ffmpeg demuxer is used, because it splits stream and metadata and the MediaCodec API does not allow external DV metadata per frame.
Because of this DV is only working when inputstream.adaptive is used (could be used for all other demuxers except ffmpeg if I'm not wrong)  

DV decoder implementation is done in the second commit, for android only.

## Motivation and Context
More and more media providers support DV

## How Has This Been Tested?
Play the DASH stream from this site: https://developer.dolby.com/tools-media/sample-media/video-streams/dolby-vision-streams/

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
