### PR TITLE
[PVR] Fix missing 'mark watched'/'mark unwatched' context menu entries for recordings folders.

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -65,7 +65,7 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
-      return URIUtils::IsPVRRecording(item.GetPath());
+      return StringUtils::StartsWith(item.GetPath(), "pvr://recordings/");
   }
   else if (!item.HasVideoInfoTag())
     return false;
@@ -91,7 +91,7 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
-      return URIUtils::IsPVRRecording(item.GetPath());
+      return StringUtils::StartsWith(item.GetPath(), "pvr://recordings/");
   }
   else if (!item.HasVideoInfoTag())
     return false;


### PR DESCRIPTION
Fixes a regression introduced with 7239c68e09043a9fd2785e9a2fb38d24aac2f835

Before:
![screenshot001](https://user-images.githubusercontent.com/3226626/69075144-1af28c80-0a31-11ea-9021-26f4fc6fbb59.png)

After:
![screenshot002](https://user-images.githubusercontent.com/3226626/69075148-1af28c80-0a31-11ea-9368-9f45d1dd9fc4.png)

@phunkyfish good to go?