### PR TITLE
[Music]Language independant "various artists" album artist for compilations 

### DIFF
--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -159,6 +159,7 @@ typedef std::vector<CArtistCredit> VECARTISTCREDITS;
 const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
 const std::string BLANKARTIST_NAME = "[Missing Tag]";
 const long BLANKARTIST_ID = 1;
+const std::string VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
 #define ROLE_ARTIST 1  //Default role
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -711,24 +711,25 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
         !StringUtils::EqualsNoCase(artist, "various artists") &&
         !StringUtils::EqualsNoCase(artist, various)) // 3a
         compilation = false;
+      else
+        // Grab name for use in "various artist" artist
+        various = artists.begin()->first;
     }
     else if (hasAlbumArtist) // 3b
       compilation = false;
 
-    //Such a compilation album is stored with the localized value for "various artists" as the album artist
+    // Such a compilation album is stored under a unique artist that matches on Musicbrainz ID
+    // the "various artists" artist for music tagged with mbids.
     if (compilation)
     {
       CLog::Log(LOGDEBUG, "Album '%s' is a compilation as there's no overlapping tracks and %s",
                 songsByAlbumName.first.c_str(),
                 hasAlbumArtist ? "the album artist is 'Various'"
                                : "there is more than one unique artist");
+      // Clear song artists from artists map, put songs under "various artists" mbid entry
       artists.clear();
-      std::vector<std::string> va; va.push_back(various);
       for (auto& song : songs)
-      {
-        song.SetAlbumArtist(va);
-        artists[various].push_back(&song);
-      }
+        artists[VARIOUSARTISTS_MBID].push_back(&song);
     }
 
     /*
@@ -754,9 +755,10 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
      */
     for (auto& j : artists)
     {
-      /*
-       Find the common artist(s) for these songs. Take from albumartist tag when present, or use artist tag.
-       When from albumartist tag also check albumartistsort tag and take first non-empty value
+      /* Find the common artist(s) for these songs (grouped under primary artist).
+      Various artist compilations already under the unique "various artists" mbid.
+      Take from albumartist tag when present, or use artist tag.
+      When from albumartist tag also check albumartistsort tag and take first non-empty value
       */
       std::vector<CSong*>& artistSongs = j.second;
       std::vector<std::string> common;
@@ -787,6 +789,11 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
         }
         common.erase(common.begin() + match, common.end());
       }
+      if (j.first == VARIOUSARTISTS_MBID)
+      {
+        common.clear();
+        common.emplace_back(VARIOUSARTISTS_MBID);
+      }
 
       /*
        Step 4: Assign the album artist for each song that doesn't have it set
@@ -803,11 +810,22 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
 
       for (size_t i = 0; i < common.size(); i++)
       {
-        album.artistCredits.emplace_back(StringUtils::Trim(common[i]));
-        // Set artist sort name providing we have as many as we have artists,
-        // otherwise something is wrong with them so ignore rather than guess.
-        if (sortnames.size() == common.size())
-          album.artistCredits.back().SetSortName(StringUtils::Trim(sortnames[i]));
+        if (common[i] == VARIOUSARTISTS_MBID)
+          /* Treat "various", "various artists" and the localized equivalent name as the same
+          album artist as the artist with Musicbrainz ID 89ad4ac3-39f7-470e-963a-56509c546377. 
+          If adding this artist for the first time then the name will be set to either the primary
+          artist read from tags when 3a, or the localized value for "various artists" when not 3a.
+          This means that tag values are no longer translated into the current langauge.
+          */
+          album.artistCredits.emplace_back(various, VARIOUSARTISTS_MBID);
+        else
+        {
+          album.artistCredits.emplace_back(StringUtils::Trim(common[i]));
+          // Set artist sort name providing we have as many as we have artists,
+          // otherwise something is wrong with them so ignore rather than guess.
+          if (sortnames.size() == common.size())
+            album.artistCredits.back().SetSortName(StringUtils::Trim(sortnames[i]));
+        }
       }
       album.bCompilation = compilation;
       for (auto& k : artistSongs)


### PR DESCRIPTION
There has been a long standing problem with how the "various artists" album artist is implemented, especially impacting those who either use Kodi in a language other than English (even worse if they change language setting) or have music in other languages.  Users can end up with multiple language variations of "various artists" with compilations divided among them, when what they really want is the music all gathered together under one unique album artist. 

The original implementation went back to days before use of album artist tags was common and Musicbrainz IDs did not exist, but unfortunately made the results of tag processing dependant on both the language settings at the time, something that can be changed between scanning sessions, and the order in which music files are scanned. It means that Kodi translates some tag values, whereas it would be far better if the user got the tag value they entered. The situation is made worse by Picard optionally translating artist name, and doing so differently from Kodi. Hence a user could end up with "Various artists", "Diverse Interpreten", "Verschiedene Interpreten", 'Diverse Artiesten' and "Varios artists" etc.  as separate artists in their library

This improvement focuses on gathering these Various Artist compilations (and note that more widely "compilations" can include anthologies e.g. all having the same artist such as BobDylan Greatest Hit's) under a single consistent album artist. The name of that artist will be the first of the many possible language variants that is actually scanned.

It means that Various Artist compilations will be under one artist regardless of whether they are tagged with album artist of "various", "various artists", a localized equivalent (in current language), with the VA mbid (and whatever name) or if no album artist is specified at all but the song artists are mixed.

I look forward to getting some real-world testing from users with mixed language music libraries. 