### PR TITLE
[Android] migrate to AndroidX

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -46,6 +46,6 @@ project.afterEvaluate {
 
 dependencies {
     // New support library to for channels/programs development.
-    implementation 'com.android.support:support-tv-provider:28.0.0'
-    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'androidx.tvprovider:tvprovider:1.0.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
 }

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -24,8 +24,8 @@ import android.app.job.JobService;
 import android.content.Context;
 import android.database.Cursor;
 import android.os.AsyncTask;
-import android.support.media.tv.TvContractCompat;
 import android.util.Log;
+import androidx.tvprovider.media.tv.TvContractCompat;
 
 import @APP_PACKAGE@.R;
 import @APP_PACKAGE@.XBMCJsonRPC;

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -22,11 +22,11 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.PersistableBundle;
-import android.support.annotation.NonNull;
-import android.support.media.tv.Channel;
-import android.support.media.tv.PreviewProgram;
-import android.support.media.tv.TvContractCompat;
 import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.tvprovider.media.tv.Channel;
+import androidx.tvprovider.media.tv.PreviewProgram;
+import androidx.tvprovider.media.tv.TvContractCompat;
 
 import @APP_PACKAGE@.Splash;
 import @APP_PACKAGE@.XBMCJsonRPC;

--- a/tools/android/packaging/xbmc/src/channels/model/XBMCDatabase.java.in
+++ b/tools/android/packaging/xbmc/src/channels/model/XBMCDatabase.java.in
@@ -16,8 +16,8 @@ package @APP_PACKAGE@.channels.model;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.Nullable;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.Nullable;
 
 import @APP_PACKAGE@.R;
 import @APP_PACKAGE@.channels.util.SharedPreferencesHelper;

--- a/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
@@ -30,12 +30,12 @@ import android.graphics.drawable.VectorDrawable;
 import android.media.tv.TvContract;
 import android.net.Uri;
 import android.os.PersistableBundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.WorkerThread;
-import android.support.media.tv.Channel;
-import android.support.media.tv.ChannelLogoUtils;
-import android.support.media.tv.TvContractCompat;
 import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+import androidx.tvprovider.media.tv.Channel;
+import androidx.tvprovider.media.tv.ChannelLogoUtils;
+import androidx.tvprovider.media.tv.TvContractCompat;
 
 import @APP_PACKAGE@.Splash;
 import @APP_PACKAGE@.channels.SyncChannelJobService;


### PR DESCRIPTION
## Description
This PR moves the dependency of android.support to androidx.

## Motivation and Context
Support Libraries are outdated and AndroidX is recommended instead. Read more here: https://developer.android.com/jetpack/androidx

## How Has This Been Tested?
On my Shield TV with custom kodi builds.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
