### PR TITLE
Add mergeable config to check PR labels/milestones

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,18 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    validate:
+      - do: milestone
+        no_empty:
+          enabled: true
+        must_exclude:
+          regex: 'Abandoned'
+      - do: label
+        must_include:
+          regex: '^v|Infrastructure'
+          message: 'At least version label must be set'
+        must_exclude:
+          regex: '^(Don''t merge|On hold|No Jenkins|RFC|WIP)$'
+      - do: title
+        must_exclude:
+          regex: '\[(RFC|WIP)\]'


### PR DESCRIPTION
We should set labels and milestone on GitHub PRs before merging for release management and regression/bug chasing.

It is easy to forget though so I propose to configure the mergeable but (already added to the repo) to check this for us.

This PR is the config for the bot.