### PR TITLE
[PVR] Guide window: Memory optimizations/Performance improvements

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -719,9 +719,6 @@ void CFileItem::ToSortable(SortItem &sortable, Field field) const
   if (HasPVRChannelInfoTag())
     GetPVRChannelInfoTag()->ToSortable(sortable, field);
 
-  if (HasEPGInfoTag())
-    GetEPGInfoTag()->ToSortable(sortable, field);
-
   if (HasAddonInfo())
   {
     switch (field)

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -295,10 +295,6 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
   {
     m_strIconPath = StringUtils::Format("%s", strIconPath.c_str());
 
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
-    if (epg)
-      epg->GetChannelData()->SetIconPath(m_strIconPath);
-
     m_bChanged = true;
     m_bIsUserSetIcon = bIsUserSetIcon && !m_strIconPath.empty();
     return true;
@@ -343,14 +339,7 @@ bool CPVRChannel::SetLastWatched(time_t iLastWatched)
 {
   {
     CSingleLock lock(m_critSection);
-    if (m_iLastWatched != iLastWatched)
-    {
-      m_iLastWatched = iLastWatched;
-
-      const std::shared_ptr<CPVREpg> epg = GetEPG();
-      if (epg)
-        epg->GetChannelData()->SetLastWatched(iLastWatched);
-    }
+    m_iLastWatched = iLastWatched;
   }
 
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
@@ -605,27 +594,13 @@ bool CPVRChannel::SetEPGScraper(const std::string& strScraper)
 void CPVRChannel::SetChannelNumber(const CPVRChannelNumber& channelNumber)
 {
   CSingleLock lock(m_critSection);
-  if (m_channelNumber != channelNumber)
-  {
-    m_channelNumber = channelNumber;
-
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
-    if (epg)
-      epg->GetChannelData()->SetSortableChannelNumber(m_channelNumber.SortableChannelNumber());
-  }
+  m_channelNumber = channelNumber;
 }
 
 void CPVRChannel::SetClientChannelNumber(const CPVRChannelNumber& clientChannelNumber)
 {
   CSingleLock lock(m_critSection);
-  if (m_clientChannelNumber != clientChannelNumber)
-  {
-    m_clientChannelNumber = clientChannelNumber;
-
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
-    if (epg)
-      epg->GetChannelData()->SetSortableClientChannelNumber(m_clientChannelNumber.SortableChannelNumber());
-  }
+  m_clientChannelNumber = clientChannelNumber;
 }
 
 void CPVRChannel::ToSortable(SortItem& sortable, Field field) const
@@ -806,12 +781,5 @@ bool CPVRChannel::CanRecord() const
 void CPVRChannel::SetClientOrder(int iOrder)
 {
   CSingleLock lock(m_critSection);
-  if (m_iOrder != iOrder)
-  {
-    m_iOrder = iOrder;
-
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
-    if (epg)
-      epg->GetChannelData()->SetClientOrder(iOrder);
-  }
+  m_iOrder = iOrder;
 }

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -507,6 +507,36 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEpgTags() const
   return epg->GetTags();
 }
 
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEPGTimeline(
+    const CDateTime& timelineStart,
+    const CDateTime& timelineEnd,
+    const CDateTime& minEventEnd,
+    const CDateTime& maxEventStart) const
+{
+  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  if (epg)
+  {
+    return epg->GetTimeline(timelineStart, timelineEnd, minEventEnd, maxEventStart);
+  }
+  else
+  {
+    // return single gap tag spanning whole timeline
+    return std::vector<std::shared_ptr<CPVREpgInfoTag>>{
+        CreateEPGGapTag(timelineStart, timelineEnd)};
+  }
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVRChannel::CreateEPGGapTag(const CDateTime& start,
+                                                             const CDateTime& end) const
+{
+  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  if (epg)
+    return std::make_shared<CPVREpgInfoTag>(epg->GetChannelData(), epg->EpgID(), start, end, true);
+  else
+    return std::make_shared<CPVREpgInfoTag>(std::make_shared<CPVREpgChannelData>(*this), -1, start,
+                                            end, true);
+}
+
 bool CPVRChannel::ClearEPG() const
 {
   const std::shared_ptr<CPVREpg> epg = GetEPG();

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -19,6 +19,8 @@
 #include <utility>
 #include <vector>
 
+class CDateTime;
+
 namespace PVR
 {
   class CPVREpg;
@@ -339,6 +341,29 @@ namespace PVR
      * @return The tags.
      */
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTags() const;
+
+    /*!
+     * @brief Get all EPG tags for the given time frame, including "gap" tags.
+     * @param timelineStart Start of time line.
+     * @param timelineEnd End of time line.
+     * @param minEventEnd The minimum end time of the events to return.
+     * @param maxEventStart The maximum start time of the events to return.
+     * @return The matching tags.
+     */
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGTimeline(
+        const CDateTime& timelineStart,
+        const CDateTime& timelineEnd,
+        const CDateTime& minEventEnd,
+        const CDateTime& maxEventStart) const;
+
+    /*!
+     * @brief Create a "gap" EPG tag.
+     * @param start Start of gap.
+     * @param end End of gap.
+     * @return The tag.
+     */
+    std::shared_ptr<CPVREpgInfoTag> CreateEPGGapTag(const CDateTime& start,
+                                                    const CDateTime& end) const;
 
     /*!
      * @brief Clear the EPG for this channel.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -923,46 +923,6 @@ void CPVRChannelGroup::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   }
 }
 
-std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannelGroup::GetEPGAll(bool bIncludeChannelsWithoutEPG /* = false */) const
-{
-  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
-
-  std::shared_ptr<CPVREpgInfoTag> epgTag;
-  std::shared_ptr<CPVRChannel> channel;
-  CSingleLock lock(m_critSection);
-
-  for (const auto& member : m_sortedMembers)
-  {
-    channel = member->channel;
-    if (!channel->IsHidden())
-    {
-      bool bEmpty = true;
-
-      std::shared_ptr<CPVREpg> epg = channel->GetEPG();
-      if (epg)
-      {
-        const std::vector<std::shared_ptr<CPVREpgInfoTag>> epgTags = epg->GetTags();
-        bEmpty = epgTags.empty();
-        if (!bEmpty)
-          tags.insert(tags.end(), epgTags.begin(), epgTags.end());
-      }
-
-      if (bIncludeChannelsWithoutEPG && bEmpty)
-      {
-        // Add dummy EPG tag associated with this channel
-        if (epg)
-          epgTag = std::make_shared<CPVREpgInfoTag>(epg->GetChannelData(), epg->EpgID());
-        else
-          epgTag = std::make_shared<CPVREpgInfoTag>(std::make_shared<CPVREpgChannelData>(*channel), -1);
-
-        tags.emplace_back(epgTag);
-      }
-    }
-  }
-
-  return tags;
-}
-
 CDateTime CPVRChannelGroup::GetEPGDate(EpgDateType epgDateType) const
 {
   CDateTime date;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -386,13 +386,6 @@ namespace PVR
     virtual bool CreateChannelEpgs(bool bForce = false);
 
     /*!
-     * @brief Get all EPG tags for all channels in this group.
-     * @param bIncludeChannelsWithoutEPG, for channels without EPG data, put an empty EPG tag associated with the channel into results
-     * @return The tags.
-     */
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGAll(bool bIncludeChannelsWithoutEPG = false) const;
-
-    /*!
      * @brief Get the start time of the first entry.
      * @return The start time.
      */

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -202,6 +202,19 @@ namespace PVR
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags() const;
 
     /*!
+     * @brief Get all EPG tags for the given time frame, including "gap" tags.
+     * @param timelineStart Start of time line
+     * @param timelineEnd End of time line
+     * @param minEventEnd The minimum end time of the events to return
+     * @param maxEventStart The maximum start time of the events to return
+     * @return The matching tags.
+     */
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTimeline(const CDateTime& timelineStart,
+                                                             const CDateTime& timelineEnd,
+                                                             const CDateTime& minEventEnd,
+                                                             const CDateTime& maxEventStart) const;
+
+    /*!
      * @brief Persist this table in the given database
      * @param database The database.
      * @return True if the table was persisted, false otherwise.
@@ -301,6 +314,15 @@ namespace PVR
      * @param iPastDays Delete entries with an end time before the given amount of days from now on.
      */
     void Cleanup(int iPastDays);
+
+    /*!
+     * @brief Create a "gap" tag
+     * @param start The start time of the gap.
+     * @param end The end time of the gap.
+     * @return The tag.
+     */
+    std::shared_ptr<CPVREpgInfoTag> CreateGapTag(const CDateTime& start,
+                                                 const CDateTime& end) const;
 
     std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>> m_tags;
     std::map<int, std::shared_ptr<CPVREpgInfoTag>> m_changedTags;

--- a/xbmc/pvr/epg/EpgChannelData.cpp
+++ b/xbmc/pvr/epg/EpgChannelData.cpp
@@ -20,20 +20,15 @@ CPVREpgChannelData::CPVREpgChannelData(int iClientId, int iUniqueClientChannelId
 }
 
 CPVREpgChannelData::CPVREpgChannelData(const CPVRChannel& channel)
-: m_bIsRadio(channel.IsRadio()),
-  m_iClientId(channel.ClientID()),
-  m_iUniqueClientChannelId(channel.UniqueID()),
-  m_bIsHidden(channel.IsHidden()),
-  m_bIsLocked(channel.IsLocked()),
-  m_bIsEPGEnabled(channel.EPGEnabled()),
-  m_iChannelId(channel.ChannelID()),
-  m_strIconPath(channel.IconPath()),
-  m_strChannelName(channel.ChannelName()),
-  m_strSortableChannelNumber(channel.ChannelNumber().SortableChannelNumber()),
-  m_strSortableClientChannelNumber(channel.ClientChannelNumber().SortableChannelNumber()),
-  m_iOrder(channel.ClientOrder())
+  : m_bIsRadio(channel.IsRadio()),
+    m_iClientId(channel.ClientID()),
+    m_iUniqueClientChannelId(channel.UniqueID()),
+    m_bIsHidden(channel.IsHidden()),
+    m_bIsLocked(channel.IsLocked()),
+    m_bIsEPGEnabled(channel.EPGEnabled()),
+    m_iChannelId(channel.ChannelID()),
+    m_strChannelName(channel.ChannelName())
 {
-  SetLastWatched(channel.LastWatched());
 }
 
 bool CPVREpgChannelData::IsRadio() const
@@ -91,16 +86,6 @@ void CPVREpgChannelData::SetChannelId(int iChannelId)
   m_iChannelId = iChannelId;
 }
 
-const std::string& CPVREpgChannelData::IconPath() const
-{
-  return m_strIconPath;
-}
-
-void CPVREpgChannelData::SetIconPath(const std::string& strIconPath)
-{
-  m_strIconPath = strIconPath;
-}
-
 const std::string& CPVREpgChannelData::ChannelName() const
 {
   return m_strChannelName;
@@ -109,48 +94,4 @@ const std::string& CPVREpgChannelData::ChannelName() const
 void CPVREpgChannelData::SetChannelName(const std::string& strChannelName)
 {
   m_strChannelName = strChannelName;
-}
-
-const std::string& CPVREpgChannelData::SortableChannelNumber() const
-{
-  return m_strSortableChannelNumber;
-}
-
-void CPVREpgChannelData::SetSortableChannelNumber(const std::string& strSortableChannelNumber)
-{
-  m_strSortableChannelNumber = strSortableChannelNumber;
-}
-
-const std::string& CPVREpgChannelData::SortableClientChannelNumber() const
-{
-  return m_strSortableClientChannelNumber;
-}
-
-void CPVREpgChannelData::SetSortableClientChannelNumber(const std::string& strSortableClientChannelNumber)
-{
-  m_strSortableClientChannelNumber = strSortableClientChannelNumber;
-}
-
-const std::string& CPVREpgChannelData::LastWatched() const
-{
-  return m_strLastWatched;
-}
-
-void CPVREpgChannelData::SetLastWatched(time_t iLastWatched)
-{
-  const CDateTime lastWatched(iLastWatched);
-  if (lastWatched.IsValid())
-    m_strLastWatched = lastWatched.GetAsDBDateTime();
-  else
-    m_strLastWatched.clear();
-}
-
-int CPVREpgChannelData::ClientOrder() const
-{
-  return m_iOrder;
-}
-
-void CPVREpgChannelData::SetClientOrder(int iOrder)
-{
-  m_iOrder = iOrder;
 }

--- a/xbmc/pvr/epg/EpgChannelData.h
+++ b/xbmc/pvr/epg/EpgChannelData.h
@@ -38,23 +38,8 @@ namespace PVR
     int ChannelId() const;
     void SetChannelId(int iChannelId);
 
-    const std::string& IconPath() const;
-    void SetIconPath(const std::string& strIconPath);
-
     const std::string& ChannelName() const;
     void SetChannelName(const std::string& strChannelName);
-
-    const std::string& SortableChannelNumber() const;
-    void SetSortableChannelNumber(const std::string& strSortableChannelNumber);
-
-    const std::string& SortableClientChannelNumber() const;
-    void SetSortableClientChannelNumber(const std::string& strSortableClientChannelNumber);
-
-    const std::string& LastWatched() const;
-    void SetLastWatched(time_t iLastWatched);
-
-    int ClientOrder() const;
-    void SetClientOrder(int iOrder);
 
   private:
     const bool m_bIsRadio = false;
@@ -65,11 +50,6 @@ namespace PVR
     bool m_bIsLocked = false;
     bool m_bIsEPGEnabled = true;
     int m_iChannelId = -1;
-    std::string m_strIconPath;
     std::string m_strChannelName;
-    std::string m_strSortableChannelNumber;
-    std::string m_strSortableClientChannelNumber;
-    std::string m_strLastWatched;
-    int m_iOrder = 0;
   };
 }

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -210,32 +210,6 @@ int CPVREpgInfoTag::ClientID() const
   return m_channelData->ClientId();
 }
 
-void CPVREpgInfoTag::ToSortable(SortItem& sortable, Field field) const
-{
-  CSingleLock lock(m_critSection);
-
-  switch (field)
-  {
-    case FieldChannelName:
-      sortable[FieldChannelName] = m_channelData->ChannelName();
-      break;
-    case FieldChannelNumber:
-      sortable[FieldChannelNumber] = m_channelData->SortableChannelNumber();
-      break;
-    case FieldClientChannelOrder:
-      if (m_channelData->ClientOrder())
-        sortable[FieldClientChannelOrder] = m_channelData->ClientOrder();
-      else
-        sortable[FieldClientChannelOrder] = m_channelData->SortableClientChannelNumber();
-      break;
-    case FieldLastPlayed:
-      sortable[FieldLastPlayed] = m_channelData->LastWatched();
-      break;
-    default:
-      break;
-  }
-}
-
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
 {
   if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingChannel(ClientID(), UniqueChannelID()))

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -37,15 +37,25 @@ CPVREpgInfoTag::CPVREpgInfoTag()
 {
 }
 
-CPVREpgInfoTag::CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData, int iEpgID)
-: m_iUniqueBroadcastID(EPG_TAG_INVALID_UID),
-  m_iFlags(EPG_TAG_FLAG_UNDEFINED),
-  m_iEpgID(iEpgID)
+CPVREpgInfoTag::CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData,
+                               int iEpgID,
+                               const CDateTime& start,
+                               const CDateTime& end,
+                               bool bIsGapTag)
+  : m_iUniqueBroadcastID(EPG_TAG_INVALID_UID),
+    m_iFlags(EPG_TAG_FLAG_UNDEFINED),
+    m_bIsGapTag(bIsGapTag),
+    m_iEpgID(iEpgID)
 {
   if (channelData)
     m_channelData = channelData;
   else
     m_channelData = std::make_shared<CPVREpgChannelData>();
+
+  const CDateTimeSpan correction(
+      0, 0, 0, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection);
+  m_startTime = start + correction;
+  m_endTime = end + correction;
 
   UpdatePath();
 }
@@ -677,6 +687,12 @@ bool CPVREpgInfoTag::IsParentalLocked() const
 {
   CSingleLock lock(m_critSection);
   return m_channelData->IsLocked();
+}
+
+bool CPVREpgInfoTag::IsGapTag() const
+{
+  CSingleLock lock(m_critSection);
+  return m_bIsGapTag;
 }
 
 const std::vector<std::string> CPVREpgInfoTag::Tokenize(const std::string& str)

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -11,7 +11,6 @@
 #include "XBDateTime.h"
 #include "threads/CriticalSection.h"
 #include "utils/ISerializable.h"
-#include "utils/ISortable.h"
 
 #include <memory>
 #include <string>
@@ -25,7 +24,8 @@ namespace PVR
   class CPVREpgChannelData;
   class CPVREpgDatabase;
 
-  class CPVREpgInfoTag final : public ISerializable, public ISortable, public std::enable_shared_from_this<CPVREpgInfoTag>
+  class CPVREpgInfoTag final : public ISerializable,
+                               public std::enable_shared_from_this<CPVREpgInfoTag>
   {
     friend class CPVREpg;
     friend class CPVREpgDatabase;
@@ -58,9 +58,6 @@ namespace PVR
 
     // ISerializable implementation
     void Serialize(CVariant& value) const override;
-
-    // ISortable implementation
-    void ToSortable(SortItem& sortable, Field field) const override;
 
     /*!
      * @brief Get the identifier of the client that serves this event.

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -44,8 +44,15 @@ namespace PVR
      * @brief Create a new EPG infotag.
      * @param channelData The channel data.
      * @param iEpgId The id of the EPG this tag belongs to.
+     * @param start The start time of the event
+     * @param end The end time of the event
+     * @param bIsGapTagTrue if this is a "gap" tag, false if this is a real EPG event
      */
-    CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData, int iEpgID);
+    CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData,
+                   int iEpgID,
+                   const CDateTime& start,
+                   const CDateTime& end,
+                   bool bIsGapTag);
 
     /*!
      * @brief Set data for the channel linked to this EPG infotag.
@@ -382,6 +389,12 @@ namespace PVR
     bool IsParentalLocked() const;
 
     /*!
+     * @brief Check whether this event is a real event or a gap in the EPG timeline.
+     * @return True if this event is a gap, false otherwise.
+     */
+    bool IsGapTag() const;
+
+    /*!
      * @brief Return the flags (EPG_TAG_FLAG_*) of this event as a bitfield.
      * @return the flags.
      */
@@ -452,6 +465,7 @@ namespace PVR
     CDateTime m_firstAired; /*!< first airdate */
     unsigned int m_iFlags = 0; /*!< the flags applicable to this EPG entry */
     std::string m_strSeriesLink; /*!< series link */
+    bool m_bIsGapTag = false;
 
     mutable CCriticalSection m_critSection;
     std::shared_ptr<CPVREpgChannelData> m_channelData;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -35,56 +35,64 @@ using namespace PVR;
 #define BLOCKJUMP    4 // how many blocks are jumped with each analogue scroll action
 static const int BLOCK_SCROLL_OFFSET = 60 / CGUIEPGGridContainerModel::MINSPERBLOCK; // how many blocks are jumped if we are at left/right edge of grid
 
-CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width, float height,
-                                           ORIENTATION orientation, int scrollTime, int preloadItems, int timeBlocks, int rulerUnit,
+CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID,
+                                           int controlID,
+                                           float posX,
+                                           float posY,
+                                           float width,
+                                           float height,
+                                           ORIENTATION orientation,
+                                           int scrollTime,
+                                           int preloadItems,
+                                           int timeBlocks,
+                                           int rulerUnit,
                                            const CTextureInfo& progressIndicatorTexture)
-: IGUIContainer(parentID, controlID, posX, posY, width, height),
-  m_orientation(orientation),
-  m_channelLayout(nullptr),
-  m_focusedChannelLayout(nullptr),
-  m_programmeLayout(nullptr),
-  m_focusedProgrammeLayout(nullptr),
-  m_rulerLayout(nullptr),
-  m_rulerDateLayout(nullptr),
-  m_pageControl(0),
-  m_rulerUnit(rulerUnit),
-  m_channelsPerPage(0),
-  m_programmesPerPage(0),
-  m_channelCursor(0),
-  m_channelOffset(0),
-  m_blocksPerPage(timeBlocks),
-  m_blockCursor(0),
-  m_blockOffset(0),
-  m_blockTravelAxis(0),
-  m_cacheChannelItems(preloadItems),
-  m_cacheProgrammeItems(preloadItems),
-  m_cacheRulerItems(preloadItems),
-  m_rulerDateHeight(0),
-  m_rulerDateWidth(0),
-  m_rulerPosX(0),
-  m_rulerPosY(0),
-  m_rulerHeight(0),
-  m_rulerWidth(0),
-  m_channelPosX(0),
-  m_channelPosY(0),
-  m_channelHeight(0),
-  m_channelWidth(0),
-  m_gridPosX(0),
-  m_gridPosY(0),
-  m_gridWidth(0),
-  m_gridHeight(0),
-  m_blockSize(0),
-  m_analogScrollCount(0),
-  m_guiProgressIndicatorTexture(posX, posY, width, height, progressIndicatorTexture),
-  m_scrollTime(scrollTime ? scrollTime : 1),
-  m_programmeScrollLastTime(0),
-  m_programmeScrollSpeed(0),
-  m_programmeScrollOffset(0),
-  m_channelScrollLastTime(0),
-  m_channelScrollSpeed(0),
-  m_channelScrollOffset(0),
-  m_gridModel(new CGUIEPGGridContainerModel),
-  m_item(nullptr)
+  : IGUIContainer(parentID, controlID, posX, posY, width, height),
+    m_orientation(orientation),
+    m_channelLayout(nullptr),
+    m_focusedChannelLayout(nullptr),
+    m_programmeLayout(nullptr),
+    m_focusedProgrammeLayout(nullptr),
+    m_rulerLayout(nullptr),
+    m_rulerDateLayout(nullptr),
+    m_pageControl(0),
+    m_rulerUnit(rulerUnit),
+    m_channelsPerPage(0),
+    m_programmesPerPage(0),
+    m_channelCursor(0),
+    m_channelOffset(0),
+    m_blocksPerPage(timeBlocks),
+    m_blockCursor(0),
+    m_blockOffset(0),
+    m_blockTravelAxis(0),
+    m_cacheChannelItems(preloadItems),
+    m_cacheProgrammeItems(preloadItems),
+    m_cacheRulerItems(preloadItems),
+    m_rulerDateHeight(0),
+    m_rulerDateWidth(0),
+    m_rulerPosX(0),
+    m_rulerPosY(0),
+    m_rulerHeight(0),
+    m_rulerWidth(0),
+    m_channelPosX(0),
+    m_channelPosY(0),
+    m_channelHeight(0),
+    m_channelWidth(0),
+    m_gridPosX(0),
+    m_gridPosY(0),
+    m_gridWidth(0),
+    m_gridHeight(0),
+    m_blockSize(0),
+    m_analogScrollCount(0),
+    m_guiProgressIndicatorTexture(posX, posY, width, height, progressIndicatorTexture),
+    m_scrollTime(scrollTime ? scrollTime : 1),
+    m_programmeScrollLastTime(0),
+    m_programmeScrollSpeed(0),
+    m_programmeScrollOffset(0),
+    m_channelScrollLastTime(0),
+    m_channelScrollSpeed(0),
+    m_channelScrollOffset(0),
+    m_gridModel(new CGUIEPGGridContainerModel)
 {
   ControlType = GUICONTAINER_EPGGRID;
 }
@@ -148,7 +156,6 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer& other)
     m_updatedGridModel(other.m_updatedGridModel
                            ? new CGUIEPGGridContainerModel(*other.m_updatedGridModel)
                            : nullptr),
-    m_item(other.m_item),
     m_itemStartBlock(other.m_itemStartBlock)
 {
 }
@@ -196,7 +203,7 @@ void CGUIEPGGridContainer::Process(unsigned int currentTime, CDirtyRegionList& d
       else
       {
         iItemsPerPage = m_blocksPerPage;
-        iTotalItems = m_gridModel->GetBlockCount();
+        iTotalItems = m_gridModel->GridItemsSize();
       }
 
       CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, iItemsPerPage, iTotalItems);
@@ -488,10 +495,11 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
     case ACTION_PAGE_DOWN:
       if (m_orientation == VERTICAL)
       {
-        if (m_channelOffset == m_gridModel->ChannelItemsSize() - m_channelsPerPage || m_gridModel->ChannelItemsSize() < m_channelsPerPage)
+        if (m_channelOffset == m_gridModel->ChannelItemsSize() - m_channelsPerPage ||
+            m_gridModel->ChannelItemsSize() < m_channelsPerPage)
         {
           // already at the last page, so move to the last item.
-          SetChannel(m_gridModel->ChannelItemsSize() - m_channelOffset - 1);
+          SetChannel(m_gridModel->GetLastChannel() - m_channelOffset);
         }
         else
         {
@@ -501,10 +509,11 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
       }
       else
       {
-        if (m_blockOffset == m_gridModel->GetBlockCount() - m_blocksPerPage || m_gridModel->GetBlockCount() < m_blocksPerPage)
+        if (m_blockOffset == m_gridModel->GridItemsSize() - m_blocksPerPage ||
+            m_gridModel->GridItemsSize() < m_blocksPerPage)
         {
           // already at the last page, so move to the last item.
-          SetBlock(m_gridModel->GetBlockCount() - m_blockOffset - 1);
+          SetBlock(m_gridModel->GetLastBlock() - m_blockOffset);
         }
         else
         {
@@ -574,9 +583,11 @@ bool CGUIEPGGridContainer::OnAction(const CAction& action)
           handled = true;
           m_analogScrollCount -= 0.4f;
 
-          if (m_blockOffset + m_blocksPerPage < m_gridModel->GetBlockCount() && m_blockCursor >= m_blocksPerPage / 2)
+          if (m_blockOffset + m_blocksPerPage < m_gridModel->GridItemsSize() &&
+              m_blockCursor >= m_blocksPerPage / 2)
             ProgrammesScroll(blocksToJump);
-          else if (m_blockCursor < m_blocksPerPage - blocksToJump && m_blockOffset + m_blockCursor < m_gridModel->GetBlockCount() - blocksToJump)
+          else if (m_blockCursor < m_blocksPerPage - blocksToJump &&
+                   m_blockOffset + m_blockCursor < m_gridModel->GridItemsSize() - blocksToJump)
             SetBlock(m_blockCursor + blocksToJump);
         }
         return handled;
@@ -656,10 +667,12 @@ void CGUIEPGGridContainer::UpdateItems()
   if (!m_updatedGridModel)
     return;
 
-  /* Safe currently selected epg tag and grid coordinates. Selection shall be restored after update. */
+  // Save currently selected epg tag and grid coordinates. Selection shall be restored after update.
   std::shared_ptr<CPVREpgInfoTag> prevSelectedEpgTag;
-  if (m_item)
-    prevSelectedEpgTag = m_item->GetEPGInfoTag();
+  if (HasData())
+    prevSelectedEpgTag =
+        m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset)
+            ->GetEPGInfoTag();
 
   const int oldChannelIndex = m_channelOffset + m_channelCursor;
   const int oldBlockIndex = m_blockOffset + m_blockCursor;
@@ -676,7 +689,7 @@ void CGUIEPGGridContainer::UpdateItems()
     eventOffset =
         oldBlockIndex - m_gridModel->GetGridItemStartBlock(oldChannelIndex, oldBlockIndex);
 
-    if (prevSelectedEpgTag->StartAsUTC().IsValid() && prevSelectedEpgTag->EndAsUTC().IsValid()) // "normal" tag selected
+    if (!prevSelectedEpgTag->IsGapTag()) // "normal" tag selected
     {
       if (oldGridStart >= prevSelectedEpgTag->StartAsUTC())
       {
@@ -701,7 +714,7 @@ void CGUIEPGGridContainer::UpdateItems()
       if (prevItem)
       {
         const std::shared_ptr<CPVREpgInfoTag> tag = prevItem->GetEPGInfoTag();
-        if (tag && tag->EndAsUTC().IsValid())
+        if (tag && !tag->IsGapTag())
         {
           if (oldGridStart >= tag->StartAsUTC())
           {
@@ -735,7 +748,7 @@ void CGUIEPGGridContainer::UpdateItems()
     {
       // grid start changed. block offset for selected event might have changed.
       newBlockIndex += m_gridModel->GetBlock(oldGridStart);
-      if (newBlockIndex < 0 || newBlockIndex + 1 > m_gridModel->GetBlockCount())
+      if (newBlockIndex < 0 || newBlockIndex > m_gridModel->GetLastBlock())
       {
         // previous selection is no longer in grid.
         SetInvalid();
@@ -749,8 +762,9 @@ void CGUIEPGGridContainer::UpdateItems()
   if (prevSelectedEpgTag && (oldChannelIndex != 0 || oldBlockIndex != 0))
   {
     if (newChannelIndex >= m_gridModel->ChannelItemsSize() ||
-        newBlockIndex >= m_gridModel->GetBlockCount() ||
-        m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag() != prevSelectedEpgTag)
+        newBlockIndex >= m_gridModel->GridItemsSize() ||
+        m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag() !=
+            prevSelectedEpgTag)
     {
       int iChannelIndex = CGUIEPGGridContainerModel::INVALID_INDEX;
       int iBlockIndex = CGUIEPGGridContainerModel::INVALID_INDEX;
@@ -772,7 +786,7 @@ void CGUIEPGGridContainer::UpdateItems()
       {
         newBlockIndex = iBlockIndex;
       }
-      else if (newBlockIndex >= m_gridModel->GetBlockCount())
+      else if (newBlockIndex > m_gridModel->GetLastBlock())
       {
         // default to now
         newBlockIndex = m_gridModel->GetNowBlock();
@@ -848,7 +862,7 @@ void CGUIEPGGridContainer::OnUp()
       if (offset < 0)
         offset = 0;
 
-      SetChannel(m_gridModel->ChannelItemsSize() - offset - 1);
+      SetChannel(m_gridModel->GetLastChannel() - offset);
       ScrollToChannelOffset(offset);
     }
     else
@@ -856,25 +870,20 @@ void CGUIEPGGridContainer::OnUp()
   }
   else
   {
-    if (m_item)
+    if (m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
+                                           m_blockCursor + m_blockOffset) > m_blockOffset)
     {
-      if (m_channelCursor + m_channelOffset >= 0 && m_blockOffset >= 0 &&
-          m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
-      {
-        // this is not first item on page
-        SetItem(GetPrevItem());
-        UpdateBlock();
-
-        return;
-      }
-      else if (m_blockCursor <= 0 && m_blockOffset && m_blockOffset - BLOCK_SCROLL_OFFSET >= 0)
-      {
-        // this is the first item on page
-        ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
-        UpdateBlock();
-
-        return;
-      }
+      // this is not first item on page
+      SetItem(GetPrevItem());
+      UpdateBlock();
+      return;
+    }
+    else if (m_blockCursor <= 0 && m_blockOffset && m_blockOffset - BLOCK_SCROLL_OFFSET >= 0)
+    {
+      // this is the first item on page
+      ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
+      UpdateBlock();
+      return;
     }
 
     CGUIControl::OnUp();
@@ -886,7 +895,7 @@ void CGUIEPGGridContainer::OnDown()
   if (m_orientation == VERTICAL)
   {
     CGUIAction action = GetAction(ACTION_MOVE_DOWN);
-    if (m_channelOffset + m_channelCursor + 1 < m_gridModel->ChannelItemsSize())
+    if (m_channelOffset + m_channelCursor < m_gridModel->GetLastChannel())
     {
       if (m_channelCursor + 1 < m_channelsPerPage)
       {
@@ -908,27 +917,23 @@ void CGUIEPGGridContainer::OnDown()
   }
   else
   {
-    if (m_item)
+    if (m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
+                                         m_blockCursor + m_blockOffset) <
+        (m_blockOffset + m_blocksPerPage - 1))
     {
-      if (m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset,
-                                             m_blocksPerPage + m_blockOffset - 1))
-      {
-        // this is not last item on page
-        SetItem(GetNextItem());
-        UpdateBlock();
-
-        return;
-      }
-      else if ((m_blockOffset != m_gridModel->GetBlockCount() - m_blocksPerPage) &&
-               m_gridModel->GetBlockCount() > m_blocksPerPage &&
-               m_blockOffset + BLOCK_SCROLL_OFFSET <= m_gridModel->GetBlockCount())
-      {
-        // this is the last item on page
-        ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
-        UpdateBlock();
-
-        return;
-      }
+      // this is not last item on page
+      SetItem(GetNextItem());
+      UpdateBlock();
+      return;
+    }
+    else if ((m_blockOffset != m_gridModel->GridItemsSize() - m_blocksPerPage) &&
+             m_gridModel->GridItemsSize() > m_blocksPerPage &&
+             m_blockOffset + BLOCK_SCROLL_OFFSET < m_gridModel->GetLastBlock())
+    {
+      // this is the last item on page
+      ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
+      UpdateBlock();
+      return;
     }
 
     CGUIControl::OnDown();
@@ -939,25 +944,20 @@ void CGUIEPGGridContainer::OnLeft()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_item)
+    if (m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
+                                           m_blockCursor + m_blockOffset) > m_blockOffset)
     {
-      if (m_channelCursor + m_channelOffset >= 0 && m_blockOffset >= 0 &&
-          m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
-      {
-        // this is not first item on page
-        SetItem(GetPrevItem());
-        UpdateBlock();
-
-        return;
-      }
-      else if (m_blockCursor <= 0 && m_blockOffset && m_blockOffset - BLOCK_SCROLL_OFFSET >= 0)
-      {
-        // this is the first item on page
-        ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
-        UpdateBlock();
-
-        return;
-      }
+      // this is not first item on page
+      SetItem(GetPrevItem());
+      UpdateBlock();
+      return;
+    }
+    else if (m_blockCursor <= 0 && m_blockOffset && m_blockOffset - BLOCK_SCROLL_OFFSET >= 0)
+    {
+      // this is the first item on page
+      ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
+      UpdateBlock();
+      return;
     }
 
     CGUIControl::OnLeft();
@@ -981,7 +981,7 @@ void CGUIEPGGridContainer::OnLeft()
       if (offset < 0)
         offset = 0;
 
-      SetChannel(m_gridModel->ChannelItemsSize() - offset - 1);
+      SetChannel(m_gridModel->GetLastChannel() - offset);
       ScrollToChannelOffset(offset);
     }
     else
@@ -993,27 +993,23 @@ void CGUIEPGGridContainer::OnRight()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_item)
+    if (m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
+                                         m_blockCursor + m_blockOffset) <
+        (m_blockOffset + m_blocksPerPage - 1))
     {
-      if (m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset,
-                                             m_blocksPerPage + m_blockOffset - 1))
-      {
-        // this is not last item on page
-        SetItem(GetNextItem());
-        UpdateBlock();
-
-        return;
-      }
-      else if ((m_blockOffset != m_gridModel->GetBlockCount() - m_blocksPerPage) &&
-               m_gridModel->GetBlockCount() > m_blocksPerPage &&
-               m_blockOffset + BLOCK_SCROLL_OFFSET <= m_gridModel->GetBlockCount())
-      {
-        // this is the last item on page
-        ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
-        UpdateBlock();
-
-        return;
-      }
+      // this is not last item on page
+      SetItem(GetNextItem());
+      UpdateBlock();
+      return;
+    }
+    else if ((m_blockOffset != m_gridModel->GridItemsSize() - m_blocksPerPage) &&
+             m_gridModel->GridItemsSize() > m_blocksPerPage &&
+             m_blockOffset + BLOCK_SCROLL_OFFSET < m_gridModel->GetLastBlock())
+    {
+      // this is the last item on page
+      ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
+      UpdateBlock();
+      return;
     }
 
     CGUIControl::OnRight();
@@ -1021,7 +1017,7 @@ void CGUIEPGGridContainer::OnRight()
   else
   {
     CGUIAction action = GetAction(ACTION_MOVE_RIGHT);
-    if (m_channelOffset + m_channelCursor + 1 < m_gridModel->ChannelItemsSize())
+    if (m_channelOffset + m_channelCursor < m_gridModel->GetLastChannel())
     {
       if (m_channelCursor + 1 < m_channelsPerPage)
       {
@@ -1077,11 +1073,10 @@ void CGUIEPGGridContainer::SetChannel(int channel)
 
   int channelIndex = channel + m_channelOffset;
   int blockIndex = m_blockCursor + m_blockOffset;
-  if (channelIndex < m_gridModel->ChannelItemsSize() && blockIndex < m_gridModel->GetBlockCount())
+  if (channelIndex < m_gridModel->ChannelItemsSize() && blockIndex < m_gridModel->GridItemsSize())
   {
-    SetItem(m_gridModel->GetGridItem(channelIndex, m_blockTravelAxis), channelIndex,
-            m_blockTravelAxis);
-    if (m_item)
+    if (SetItem(m_gridModel->GetGridItem(channelIndex, m_blockTravelAxis), channelIndex,
+                m_blockTravelAxis))
     {
       m_channelCursor = channel;
       MarkDirtyRegion();
@@ -1110,7 +1105,7 @@ void CGUIEPGGridContainer::SetBlock(int block, bool bUpdateBlockTravelAxis /* = 
 
 void CGUIEPGGridContainer::UpdateBlock(bool bUpdateBlockTravelAxis /* = true */)
 {
-  SetBlock(m_item ? m_itemStartBlock - m_blockOffset : 0, bUpdateBlockTravelAxis);
+  SetBlock(m_itemStartBlock > 0 ? m_itemStartBlock - m_blockOffset : 0, bUpdateBlockTravelAxis);
 }
 
 CGUIListItemLayout* CGUIEPGGridContainer::GetFocusedLayout() const
@@ -1147,7 +1142,7 @@ bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint& point, bool justGri
     channel = m_channelsPerPage - 1;
 
   if (channel >= m_gridModel->ChannelItemsSize())
-    channel = m_gridModel->ChannelItemsSize() - 1;
+    channel = m_gridModel->GetLastChannel();
 
   if (channel < 0)
     channel = 0;
@@ -1162,7 +1157,7 @@ bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint& point, bool justGri
   int blockIndex = block + m_blockOffset;
 
   // bail if out of range
-  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
+  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GridItemsSize())
     return false;
 
   // bail if block isn't occupied
@@ -1310,7 +1305,7 @@ CFileItemPtr CGUIEPGGridContainer::GetSelectedGridItem(int offset /*= 0*/) const
   CFileItemPtr item;
 
   if (m_channelCursor + m_channelOffset + offset < m_gridModel->ChannelItemsSize() &&
-      m_blockCursor + m_blockOffset < m_gridModel->GetBlockCount())
+      m_blockCursor + m_blockOffset < m_gridModel->GridItemsSize())
     item = m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 
   return item;
@@ -1376,17 +1371,21 @@ void CGUIEPGGridContainer::SetItem(const std::pair<std::shared_ptr<CFileItem>, i
   SetItem(itemInfo.first, m_channelCursor + m_channelOffset, itemInfo.second);
 }
 
-void CGUIEPGGridContainer::SetItem(const std::shared_ptr<CFileItem>& item,
+bool CGUIEPGGridContainer::SetItem(const std::shared_ptr<CFileItem>& item,
                                    int channelIndex,
                                    int blockIndex)
 {
   if (item && channelIndex < m_gridModel->ChannelItemsSize() &&
-      blockIndex < m_gridModel->GetBlockCount())
-    m_item = item;
+      blockIndex < m_gridModel->GridItemsSize())
+  {
+    m_itemStartBlock = m_gridModel->GetGridItemStartBlock(channelIndex, blockIndex);
+    return true;
+  }
   else
-    m_item.reset();
-
-  m_itemStartBlock = m_item ? m_gridModel->GetGridItemStartBlock(channelIndex, blockIndex) : 0;
+  {
+    m_itemStartBlock = 0;
+    return false;
+  }
 }
 
 std::shared_ptr<CFileItem> CGUIEPGGridContainer::GetItem() const
@@ -1394,7 +1393,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainer::GetItem() const
   const int channelIndex = m_channelCursor + m_channelOffset;
   const int blockIndex = m_blockCursor + m_blockOffset;
 
-  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
+  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GridItemsSize())
     return {};
 
   return m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
@@ -1404,7 +1403,7 @@ std::pair<std::shared_ptr<CFileItem>, int> CGUIEPGGridContainer::GetNextItem() c
 {
   int block = m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
                                                m_blockCursor + m_blockOffset);
-  if (block < m_gridModel->GetBlockCount())
+  if (block < m_gridModel->GridItemsSize())
   {
     // first block of next event is one block after end block of selected event
     block += 1;
@@ -1471,7 +1470,7 @@ void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
   CSingleLock lock(m_critSection);
 
   // make sure offset is in valid range
-  offset = std::max(0, std::min(offset, m_gridModel->GetBlockCount() - m_blocksPerPage));
+  offset = std::max(0, std::min(offset, m_gridModel->GridItemsSize() - m_blocksPerPage));
 
   float size = m_blockSize;
   int range = m_blocksPerPage / 1;
@@ -1506,7 +1505,8 @@ void CGUIEPGGridContainer::ValidateOffset()
   float pos = (m_orientation == VERTICAL) ? m_channelHeight : m_channelWidth;
 
   if (m_gridModel->ChannelItemsSize() &&
-      (m_channelOffset > m_gridModel->ChannelItemsSize() - m_channelsPerPage || m_channelScrollOffset > (m_gridModel->ChannelItemsSize() - m_channelsPerPage) * pos))
+      (m_channelOffset > m_gridModel->ChannelItemsSize() - m_channelsPerPage ||
+       m_channelScrollOffset > (m_gridModel->ChannelItemsSize() - m_channelsPerPage) * pos))
   {
     m_channelOffset = m_gridModel->ChannelItemsSize() - m_channelsPerPage;
     m_channelScrollOffset = m_channelOffset * pos;
@@ -1518,10 +1518,11 @@ void CGUIEPGGridContainer::ValidateOffset()
     m_channelScrollOffset = 0;
   }
 
-  if (m_gridModel->GetBlockCount() &&
-      (m_blockOffset > m_gridModel->GetBlockCount() - m_blocksPerPage || m_programmeScrollOffset > (m_gridModel->GetBlockCount() - m_blocksPerPage) * m_blockSize))
+  if (m_gridModel->GridItemsSize() &&
+      (m_blockOffset > m_gridModel->GridItemsSize() - m_blocksPerPage ||
+       m_programmeScrollOffset > (m_gridModel->GridItemsSize() - m_blocksPerPage) * m_blockSize))
   {
-    m_blockOffset = m_gridModel->GetBlockCount() - m_blocksPerPage;
+    m_blockOffset = m_gridModel->GridItemsSize() - m_blocksPerPage;
     m_programmeScrollOffset = m_blockOffset * m_blockSize;
   }
 
@@ -1606,9 +1607,9 @@ void CGUIEPGGridContainer::GoToBegin()
 void CGUIEPGGridContainer::GoToEnd()
 {
   const int blocksStart = m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
-                                                             m_gridModel->GetBlockCount() - 1);
+                                                             m_gridModel->GetLastBlock());
   const int blocksEnd = m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
-                                                         m_gridModel->GetBlockCount() - 1);
+                                                         m_gridModel->GetLastBlock());
 
   int blockOffset = 0;
   if (blocksEnd - blocksStart > m_blocksPerPage)
@@ -1641,7 +1642,7 @@ void CGUIEPGGridContainer::GoToFirstChannel()
 void CGUIEPGGridContainer::GoToLastChannel()
 {
   if (m_gridModel->ChannelItemsSize())
-    GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+    GoToChannel(m_gridModel->GetLastChannel());
   else
     GoToChannel(0);
 }
@@ -1663,14 +1664,14 @@ void CGUIEPGGridContainer::GoToBottom()
   if (m_orientation == VERTICAL)
   {
     if (m_gridModel->HasChannelItems())
-      GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+      GoToChannel(m_gridModel->GetLastChannel());
     else
       GoToChannel(0);
   }
   else
   {
-    if (m_gridModel->GetBlockCount() > 0)
-      GoToBlock(m_gridModel->GetBlockCount() - 1);
+    if (m_gridModel->GridItemsSize())
+      GoToBlock(m_gridModel->GetLastBlock());
     else
       GoToBlock(0);
   }
@@ -1692,15 +1693,15 @@ void CGUIEPGGridContainer::GoToMostRight()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_gridModel->GetBlockCount() > 0)
-      GoToBlock(m_gridModel->GetBlockCount() - 1);
+    if (m_gridModel->GridItemsSize())
+      GoToBlock(m_gridModel->GetLastBlock());
     else
       GoToBlock(0);
   }
   else
   {
     if (m_gridModel->HasChannelItems())
-      GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+      GoToChannel(m_gridModel->GetLastChannel());
     else
       GoToChannel(0);
   }
@@ -1768,7 +1769,7 @@ void CGUIEPGGridContainer::GoToChannel(int channelIndex)
 
 void CGUIEPGGridContainer::GoToBlock(int blockIndex)
 {
-  int lastPage = m_gridModel->GetBlockCount() - m_blocksPerPage;
+  int lastPage = m_gridModel->GridItemsSize() - m_blocksPerPage;
   if (blockIndex > lastPage)
   {
     // last page
@@ -2063,7 +2064,7 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender, unsigned int currentTime
   CGUIListItemPtr focusedItem;
 
   CFileItemPtr item;
-  int current = chanOffset;
+  int current = chanOffset - cacheBeforeChannel;
   while (pos < end && m_gridModel->HasChannelItems())
   {
     int itemNo = current;
@@ -2273,10 +2274,20 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
     GetChannelCacheOffsets(cacheBeforeChannel, cacheAfterChannel);
 
     // Free memory not used on screen
-    m_gridModel->FreeProgrammeMemory(chanOffset - cacheBeforeChannel,
-                                     chanOffset + m_channelsPerPage - 1 + cacheAfterChannel,
-                                     blockOffset - cacheBeforeProgramme,
-                                     blockOffset + m_programmesPerPage - 1 + cacheAfterProgramme);
+    int firstChannel = chanOffset - cacheBeforeChannel;
+    if (firstChannel < 0)
+      firstChannel = 0;
+    int lastChannel = chanOffset + m_channelsPerPage - 1 + cacheAfterChannel;
+    if (lastChannel > m_gridModel->GetLastChannel())
+      lastChannel = m_gridModel->GetLastChannel();
+    int firstBlock = blockOffset - cacheBeforeProgramme;
+    if (firstBlock < 0)
+      firstBlock = 0;
+    int lastBlock = blockOffset + m_programmesPerPage - 1 + cacheAfterProgramme;
+    if (lastBlock > m_gridModel->GetLastBlock())
+      lastBlock = m_gridModel->GetLastBlock();
+
+    m_gridModel->FreeProgrammeMemory(firstChannel, lastChannel, firstBlock, lastBlock);
   }
 
   CPoint originProgramme = CPoint(m_gridPosX, m_gridPosY) + m_renderOffset;
@@ -2307,88 +2318,91 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
   float drawOffsetB = (chanOffset - cacheBeforeProgramme) * m_channelLayout->Size(m_orientation) - m_channelScrollOffset;
   posB += drawOffsetB;
 
-  int channel = chanOffset;
+  int channel = chanOffset - cacheBeforeProgramme;
 
   float focusedPosX = 0;
   float focusedPosY = 0;
   CFileItemPtr focusedItem;
   CFileItemPtr item;
 
-  while (posB < endB && m_gridModel->HasChannelItems())
+  const int lastChannel = m_gridModel->GetLastChannel();
+  while (posB < endB && HasData() && channel <= lastChannel)
   {
-    if (channel >= m_gridModel->ChannelItemsSize())
-      break;
-
-    int block = blockOffset;
-    float posA2 = posA;
-
-    if (blockOffset > 0 && m_gridModel->GetGridItem(channel, block) ==
-                               m_gridModel->GetGridItem(channel, blockOffset - 1))
+    if (channel >= 0)
     {
-      // First program starts before current view
-      block = m_gridModel->GetGridItemStartBlock(channel, blockOffset - 1);
-      int missingSection = blockOffset - block;
-      posA2 -= missingSection * m_blockSize;
-    }
+      int block = blockOffset;
+      float posA2 = posA;
 
-    while (posA2 < endA && HasData())
-    {
-      if (block >= m_gridModel->GetBlockCount())
-        break;
-
-      item = m_gridModel->GetGridItem(channel, block);
-
-      if (!item || !item.get()->IsFileItem())
-        break;
-
-      bool focused = (channel == m_channelOffset + m_channelCursor) && (item == m_gridModel->GetGridItem(m_channelOffset + m_channelCursor, m_blockOffset + m_blockCursor));
-
-      if (bRender) //! @todo Why the functional difference wrt truncate here?
+      if (blockOffset > 0 && m_gridModel->IsSameGridItem(channel, block, blockOffset - 1))
       {
-        // reset to grid start position if first item is out of grid view
-        if (posA2 < posA)
-          posA2 = posA;
+        // First program starts before current view
+        block = m_gridModel->GetGridItemStartBlock(channel, blockOffset - 1);
+        int missingSection = blockOffset - block;
+        posA2 -= missingSection * m_blockSize;
+      }
 
-        // render our item
-        if (focused)
+      const int lastBlock = m_gridModel->GetLastBlock();
+      while (posA2 < endA && HasData() && block <= lastBlock)
+      {
+        item = m_gridModel->GetGridItem(channel, block);
+
+        bool focused = (channel == m_channelOffset + m_channelCursor) &&
+                       m_gridModel->IsSameGridItem(m_channelOffset + m_channelCursor,
+                                                   m_blockOffset + m_blockCursor, block);
+
+        if (bRender)
         {
-          focusedPosX = posA2;
-          focusedPosY = posB;
-          focusedItem = item;
-        }
-        else
-        {
-          if (m_orientation == VERTICAL)
-            RenderItem(posA2, posB, item.get(), focused);
+          // reset to grid start position if first item is out of grid view
+          if (posA2 < posA)
+            posA2 = posA;
+
+          // render our item
+          if (focused)
+          {
+            focusedPosX = posA2;
+            focusedPosY = posB;
+            focusedItem = item;
+          }
           else
-            RenderItem(posB, posA2, item.get(), focused);
+          {
+            if (m_orientation == VERTICAL)
+              RenderItem(posA2, posB, item.get(), focused);
+            else
+              RenderItem(posB, posA2, item.get(), focused);
+          }
         }
-      }
-      else
-      {
-        // calculate the size to truncate if item is out of grid view
-        float truncateSize = 0;
-        if (posA2 < posA)
-        {
-          truncateSize = posA - posA2;
-          posA2 = posA; // reset to grid start position
-        }
-
-        {
-          CSingleLock lock(m_critSection);
-          // truncate item's width
-          m_gridModel->SetGridItemWidth(channel, block, m_gridModel->GetGridItemOriginWidth(channel, block) - truncateSize);
-        }
-
-        if (m_orientation == VERTICAL)
-          ProcessItem(posA2, posB, item, m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridModel->GetGridItemWidth(channel, block));
         else
-          ProcessItem(posB, posA2, item, m_lastChannel, focused, m_programmeLayout, m_focusedProgrammeLayout, currentTime, dirtyregions, m_gridModel->GetGridItemWidth(channel, block));
-      }
+        {
+          // calculate the size to truncate if item is out of grid view
+          float truncateSize = 0;
+          if (posA2 < posA)
+          {
+            truncateSize = posA - posA2;
+            posA2 = posA; // reset to grid start position
+          }
 
-      // increment our X position
-      posA2 += m_gridModel->GetGridItemWidth(channel, block); // assumes focused & unfocused layouts have equal length
-      block += MathUtils::round_int(m_gridModel->GetGridItemOriginWidth(channel, block) / m_blockSize);
+          {
+            CSingleLock lock(m_critSection);
+            // truncate item's width
+            m_gridModel->DecreaseGridItemWidth(channel, block, truncateSize);
+          }
+
+          if (m_orientation == VERTICAL)
+            ProcessItem(posA2, posB, item, m_lastChannel, focused, m_programmeLayout,
+                        m_focusedProgrammeLayout, currentTime, dirtyregions,
+                        m_gridModel->GetGridItemWidth(channel, block));
+          else
+            ProcessItem(posB, posA2, item, m_lastChannel, focused, m_programmeLayout,
+                        m_focusedProgrammeLayout, currentTime, dirtyregions,
+                        m_gridModel->GetGridItemWidth(channel, block));
+        }
+
+        // increment our X position
+        posA2 += m_gridModel->GetGridItemWidth(
+            channel, block); // assumes focused & unfocused layouts have equal length
+        block +=
+            MathUtils::round_int(m_gridModel->GetGridItemOriginWidth(channel, block) / m_blockSize);
+      }
     }
 
     // increment our Y position

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -860,7 +860,7 @@ void CGUIEPGGridContainer::OnUp()
   }
   else
   {
-    if (m_gridModel->HasGridItems() && m_item)
+    if (m_item)
     {
       if (m_channelCursor + m_channelOffset >= 0 && m_blockOffset >= 0 &&
           m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
@@ -912,7 +912,7 @@ void CGUIEPGGridContainer::OnDown()
   }
   else
   {
-    if (m_gridModel->HasGridItems() && m_item)
+    if (m_item)
     {
       if (m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset,
                                              m_blocksPerPage + m_blockOffset - 1))
@@ -943,7 +943,7 @@ void CGUIEPGGridContainer::OnLeft()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_gridModel->HasGridItems() && m_item)
+    if (m_item)
     {
       if (m_channelCursor + m_channelOffset >= 0 && m_blockOffset >= 0 &&
           m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
@@ -997,7 +997,7 @@ void CGUIEPGGridContainer::OnRight()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_gridModel->HasGridItems() && m_item)
+    if (m_item)
     {
       if (m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset,
                                              m_blocksPerPage + m_blockOffset - 1))
@@ -1311,9 +1311,7 @@ CDateTime CGUIEPGGridContainer::GetSelectedDate() const
 
 int CGUIEPGGridContainer::GetSelectedItem() const
 {
-  if (!m_gridModel->HasGridItems() ||
-      !m_gridModel->HasChannelItems() ||
-      m_channelCursor + m_channelOffset >= m_gridModel->ChannelItemsSize() ||
+  if (m_channelCursor + m_channelOffset >= m_gridModel->ChannelItemsSize() ||
       m_blockCursor + m_blockOffset >= m_gridModel->GetBlockCount())
     return -1;
 
@@ -1324,9 +1322,7 @@ CFileItemPtr CGUIEPGGridContainer::GetSelectedGridItem(int offset /*= 0*/) const
 {
   CFileItemPtr item;
 
-  if (m_gridModel->HasGridItems() &&
-      m_gridModel->ChannelItemsSize() > 0 &&
-      m_channelCursor + m_channelOffset + offset < m_gridModel->ChannelItemsSize() &&
+  if (m_channelCursor + m_channelOffset + offset < m_gridModel->ChannelItemsSize() &&
       m_blockCursor + m_blockOffset < m_gridModel->GetBlockCount())
     item = m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -674,15 +674,8 @@ void CGUIEPGGridContainer::UpdateItems()
   if (prevSelectedEpgTag)
   {
     // get the block offset relative to the first block of the selected event
-    while (eventOffset > 0)
-    {
-      if (m_gridModel->GetGridItem(oldChannelIndex, eventOffset - 1) != m_gridModel->GetGridItem(oldChannelIndex, oldBlockIndex))
-        break;
-
-      eventOffset--;
-    }
-
-    eventOffset = oldBlockIndex - eventOffset;
+    eventOffset =
+        oldBlockIndex - m_gridModel->GetGridItemStartBlock(oldChannelIndex, oldBlockIndex);
 
     if (prevSelectedEpgTag->StartAsUTC().IsValid() && prevSelectedEpgTag->EndAsUTC().IsValid()) // "normal" tag selected
     {
@@ -871,7 +864,7 @@ void CGUIEPGGridContainer::OnUp()
       {
         // this is not first item on page
         m_item = GetPrevItem(m_channelCursor);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -879,7 +872,7 @@ void CGUIEPGGridContainer::OnUp()
       {
         // this is the first item on page
         ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -922,7 +915,7 @@ void CGUIEPGGridContainer::OnDown()
       {
         // this is not last item on page
         m_item = GetNextItem(m_channelCursor);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -932,7 +925,7 @@ void CGUIEPGGridContainer::OnDown()
       {
         // this is the last item on page
         ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -953,7 +946,7 @@ void CGUIEPGGridContainer::OnLeft()
       {
         // this is not first item on page
         m_item = GetPrevItem(m_channelCursor);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -961,7 +954,7 @@ void CGUIEPGGridContainer::OnLeft()
       {
         // this is the first item on page
         ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -1006,7 +999,7 @@ void CGUIEPGGridContainer::OnRight()
       {
         // this is not last item on page
         m_item = GetNextItem(m_channelCursor);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -1016,7 +1009,7 @@ void CGUIEPGGridContainer::OnRight()
       {
         // this is the last item on page
         ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item->item, m_channelCursor));
+        SetBlock(GetBlock(m_item));
 
         return;
       }
@@ -1090,7 +1083,7 @@ void CGUIEPGGridContainer::SetChannel(int channel)
     {
       m_channelCursor = channel;
       MarkDirtyRegion();
-      SetBlock(GetBlock(m_item->item, channel), false);
+      SetBlock(GetBlock(m_item), false);
     }
   }
 }
@@ -1384,23 +1377,9 @@ std::string CGUIEPGGridContainer::GetLabel(int info) const
   return label;
 }
 
-int CGUIEPGGridContainer::GetBlock(const CGUIListItemPtr& item, int channel)
+int CGUIEPGGridContainer::GetBlock(GridItem* gridItem)
 {
-  if (!item)
-    return 0;
-
-  return GetRealBlock(item, channel) - m_blockOffset;
-}
-
-int CGUIEPGGridContainer::GetRealBlock(const CGUIListItemPtr& item, int channel)
-{
-  int channelIndex = channel + m_channelOffset;
-  int block = 0;
-
-  while (block < m_gridModel->GetBlockCount() && m_gridModel->GetGridItem(channelIndex, block) != item)
-    block++;
-
-  return block;
+  return gridItem ? gridItem->startBlock - m_blockOffset : 0;
 }
 
 GridItem* CGUIEPGGridContainer::GetNextItem(int channel)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1602,18 +1602,12 @@ void CGUIEPGGridContainer::GoToBegin()
 
 void CGUIEPGGridContainer::GoToEnd()
 {
-  int blocksEnd = 0; // the end block of the last epg element for the selected channel
-  int blocksStart = 0; // the start block of the last epg element for the selected channel
-  int blockOffset = 0; // the block offset to scroll to
-  for (int blockIndex = m_gridModel->GetBlockCount() - 1; blockIndex >= 0 && (!blocksEnd || !blocksStart); blockIndex--)
-  {
-    if (!blocksEnd && m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, blockIndex))
-      blocksEnd = blockIndex;
+  const int blocksStart = m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
+                                                             m_gridModel->GetBlockCount() - 1);
+  const int blocksEnd = m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
+                                                         m_gridModel->GetBlockCount() - 1);
 
-    if (blocksEnd && m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, blocksEnd) != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, blockIndex))
-      blocksStart = blockIndex + 1;
-  }
-
+  int blockOffset = 0;
   if (blocksEnd - blocksStart > m_blocksPerPage)
     blockOffset = blocksStart;
   else if (blocksEnd > m_blocksPerPage)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1665,13 +1665,11 @@ void CGUIEPGGridContainer::GoToTop()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_gridModel->HasChannelItems())
-      GoToChannel(0);
+    GoToChannel(0);
   }
   else
   {
-    if (m_gridModel->HasProgrammeItems())
-      GoToBlock(0);
+    GoToBlock(0);
   }
 }
 
@@ -1681,11 +1679,15 @@ void CGUIEPGGridContainer::GoToBottom()
   {
     if (m_gridModel->HasChannelItems())
       GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+    else
+      GoToChannel(0);
   }
   else
   {
-    if (m_gridModel->HasProgrammeItems())
-      GoToBlock(m_gridModel->ProgrammeItemsSize() - 1);
+    if (m_gridModel->GetBlockCount() > 0)
+      GoToBlock(m_gridModel->GetBlockCount() - 1);
+    else
+      GoToBlock(0);
   }
 }
 
@@ -1693,13 +1695,11 @@ void CGUIEPGGridContainer::GoToMostLeft()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_gridModel->HasProgrammeItems())
-      GoToBlock(m_gridModel->ProgrammeItemsSize() - 1);
+    GoToBlock(0);
   }
   else
   {
-    if (m_gridModel->HasChannelItems())
-      GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+    GoToChannel(0);
   }
 }
 
@@ -1707,12 +1707,16 @@ void CGUIEPGGridContainer::GoToMostRight()
 {
   if (m_orientation == VERTICAL)
   {
-    if (m_gridModel->HasProgrammeItems())
+    if (m_gridModel->GetBlockCount() > 0)
+      GoToBlock(m_gridModel->GetBlockCount() - 1);
+    else
       GoToBlock(0);
   }
   else
   {
     if (m_gridModel->HasChannelItems())
+      GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+    else
       GoToChannel(0);
   }
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -90,63 +90,66 @@ CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float po
 }
 
 CGUIEPGGridContainer::CGUIEPGGridContainer(const CGUIEPGGridContainer& other)
-: IGUIContainer(other),
-  m_renderOffset(other.m_renderOffset),
-  m_orientation(other.m_orientation),
-  m_channelLayouts(other.m_channelLayouts),
-  m_focusedChannelLayouts(other.m_focusedChannelLayouts),
-  m_focusedProgrammeLayouts(other.m_focusedProgrammeLayouts),
-  m_programmeLayouts(other.m_programmeLayouts),
-  m_rulerLayouts(other.m_rulerLayouts),
-  m_rulerDateLayouts(other.m_rulerDateLayouts),
-  m_channelLayout(other.m_channelLayout),
-  m_focusedChannelLayout(other.m_focusedChannelLayout),
-  m_programmeLayout(other.m_programmeLayout),
-  m_focusedProgrammeLayout(other.m_focusedProgrammeLayout),
-  m_rulerLayout(other.m_rulerLayout),
-  m_rulerDateLayout(other.m_rulerDateLayout),
-  m_pageControl(other.m_pageControl),
-  m_rulerUnit(other.m_rulerUnit),
-  m_channelsPerPage(other.m_channelsPerPage),
-  m_programmesPerPage(other.m_programmesPerPage),
-  m_channelCursor(other.m_channelCursor),
-  m_channelOffset(other.m_channelOffset),
-  m_blocksPerPage(other.m_blocksPerPage),
-  m_blockCursor(other.m_blockCursor),
-  m_blockOffset(other.m_blockOffset),
-  m_blockTravelAxis(other.m_blockTravelAxis),
-  m_cacheChannelItems(other.m_cacheChannelItems),
-  m_cacheProgrammeItems(other.m_cacheProgrammeItems),
-  m_cacheRulerItems(other.m_cacheRulerItems),
-  m_rulerDateHeight(other.m_rulerDateHeight),
-  m_rulerDateWidth(other.m_rulerDateWidth),
-  m_rulerPosX(other.m_rulerPosX),
-  m_rulerPosY(other.m_rulerPosY),
-  m_rulerHeight(other.m_rulerHeight),
-  m_rulerWidth(other.m_rulerWidth),
-  m_channelPosX(other.m_channelPosX),
-  m_channelPosY(other.m_channelPosY),
-  m_channelHeight(other.m_channelHeight),
-  m_channelWidth(other.m_channelWidth),
-  m_gridPosX(other.m_gridPosX),
-  m_gridPosY(other.m_gridPosY),
-  m_gridWidth(other.m_gridWidth),
-  m_gridHeight(other.m_gridHeight),
-  m_blockSize(other.m_blockSize),
-  m_analogScrollCount(other.m_analogScrollCount),
-  m_guiProgressIndicatorTexture(other.m_guiProgressIndicatorTexture),
-  m_lastItem(other.m_lastItem),
-  m_lastChannel(other.m_lastChannel),
-  m_scrollTime(other.m_scrollTime),
-  m_programmeScrollLastTime(other.m_programmeScrollLastTime),
-  m_programmeScrollSpeed(other.m_programmeScrollSpeed),
-  m_programmeScrollOffset(other.m_programmeScrollOffset),
-  m_channelScrollLastTime(other.m_channelScrollLastTime),
-  m_channelScrollSpeed(other.m_channelScrollSpeed),
-  m_channelScrollOffset(other.m_channelScrollOffset),
-  m_gridModel(new CGUIEPGGridContainerModel(*other.m_gridModel)),
-  m_updatedGridModel(other.m_updatedGridModel ? new CGUIEPGGridContainerModel(*other.m_updatedGridModel) : nullptr),
-  m_item(GetItem(m_channelCursor)) // pointer to grid model internal data.
+  : IGUIContainer(other),
+    m_renderOffset(other.m_renderOffset),
+    m_orientation(other.m_orientation),
+    m_channelLayouts(other.m_channelLayouts),
+    m_focusedChannelLayouts(other.m_focusedChannelLayouts),
+    m_focusedProgrammeLayouts(other.m_focusedProgrammeLayouts),
+    m_programmeLayouts(other.m_programmeLayouts),
+    m_rulerLayouts(other.m_rulerLayouts),
+    m_rulerDateLayouts(other.m_rulerDateLayouts),
+    m_channelLayout(other.m_channelLayout),
+    m_focusedChannelLayout(other.m_focusedChannelLayout),
+    m_programmeLayout(other.m_programmeLayout),
+    m_focusedProgrammeLayout(other.m_focusedProgrammeLayout),
+    m_rulerLayout(other.m_rulerLayout),
+    m_rulerDateLayout(other.m_rulerDateLayout),
+    m_pageControl(other.m_pageControl),
+    m_rulerUnit(other.m_rulerUnit),
+    m_channelsPerPage(other.m_channelsPerPage),
+    m_programmesPerPage(other.m_programmesPerPage),
+    m_channelCursor(other.m_channelCursor),
+    m_channelOffset(other.m_channelOffset),
+    m_blocksPerPage(other.m_blocksPerPage),
+    m_blockCursor(other.m_blockCursor),
+    m_blockOffset(other.m_blockOffset),
+    m_blockTravelAxis(other.m_blockTravelAxis),
+    m_cacheChannelItems(other.m_cacheChannelItems),
+    m_cacheProgrammeItems(other.m_cacheProgrammeItems),
+    m_cacheRulerItems(other.m_cacheRulerItems),
+    m_rulerDateHeight(other.m_rulerDateHeight),
+    m_rulerDateWidth(other.m_rulerDateWidth),
+    m_rulerPosX(other.m_rulerPosX),
+    m_rulerPosY(other.m_rulerPosY),
+    m_rulerHeight(other.m_rulerHeight),
+    m_rulerWidth(other.m_rulerWidth),
+    m_channelPosX(other.m_channelPosX),
+    m_channelPosY(other.m_channelPosY),
+    m_channelHeight(other.m_channelHeight),
+    m_channelWidth(other.m_channelWidth),
+    m_gridPosX(other.m_gridPosX),
+    m_gridPosY(other.m_gridPosY),
+    m_gridWidth(other.m_gridWidth),
+    m_gridHeight(other.m_gridHeight),
+    m_blockSize(other.m_blockSize),
+    m_analogScrollCount(other.m_analogScrollCount),
+    m_guiProgressIndicatorTexture(other.m_guiProgressIndicatorTexture),
+    m_lastItem(other.m_lastItem),
+    m_lastChannel(other.m_lastChannel),
+    m_scrollTime(other.m_scrollTime),
+    m_programmeScrollLastTime(other.m_programmeScrollLastTime),
+    m_programmeScrollSpeed(other.m_programmeScrollSpeed),
+    m_programmeScrollOffset(other.m_programmeScrollOffset),
+    m_channelScrollLastTime(other.m_channelScrollLastTime),
+    m_channelScrollSpeed(other.m_channelScrollSpeed),
+    m_channelScrollOffset(other.m_channelScrollOffset),
+    m_gridModel(new CGUIEPGGridContainerModel(*other.m_gridModel)),
+    m_updatedGridModel(other.m_updatedGridModel
+                           ? new CGUIEPGGridContainerModel(*other.m_updatedGridModel)
+                           : nullptr),
+    m_item(other.m_item),
+    m_itemStartBlock(other.m_itemStartBlock)
 {
 }
 
@@ -660,7 +663,7 @@ void CGUIEPGGridContainer::UpdateItems()
   /* Safe currently selected epg tag and grid coordinates. Selection shall be restored after update. */
   std::shared_ptr<CPVREpgInfoTag> prevSelectedEpgTag;
   if (m_item)
-    prevSelectedEpgTag = m_item->item->GetEPGInfoTag();
+    prevSelectedEpgTag = m_item->GetEPGInfoTag();
 
   const int oldChannelIndex = m_channelOffset + m_channelCursor;
   const int oldBlockIndex = m_blockOffset + m_blockCursor;
@@ -694,14 +697,14 @@ void CGUIEPGGridContainer::UpdateItems()
     }
     else // "gap" tag selected
     {
-      const GridItem* currItem(GetItem(m_channelCursor));
+      const std::shared_ptr<CFileItem> currItem = GetItem();
       if (currItem)
-        channelUid = currItem->item->GetEPGInfoTag()->UniqueChannelID();
+        channelUid = currItem->GetEPGInfoTag()->UniqueChannelID();
 
-      const GridItem* prevItem(GetPrevItem(m_channelCursor));
+      const std::shared_ptr<CFileItem> prevItem = GetPrevItem().first;
       if (prevItem)
       {
-        const std::shared_ptr<CPVREpgInfoTag> tag(prevItem->item->GetEPGInfoTag());
+        const std::shared_ptr<CPVREpgInfoTag> tag = prevItem->GetEPGInfoTag();
         if (tag && tag->EndAsUTC().IsValid())
         {
           if (oldGridStart >= tag->StartAsUTC())
@@ -784,7 +787,7 @@ void CGUIEPGGridContainer::UpdateItems()
     if (newChannelIndex == oldChannelIndex && newBlockIndex == oldBlockIndex)
     {
       // same coordinates, keep current grid view port
-      m_item = GetItem(m_channelCursor);
+      UpdateItem();
     }
     else
     {
@@ -860,11 +863,11 @@ void CGUIEPGGridContainer::OnUp()
     if (m_gridModel->HasGridItems() && m_item)
     {
       if (m_channelCursor + m_channelOffset >= 0 && m_blockOffset >= 0 &&
-          m_item->item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
+          m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
       {
         // this is not first item on page
-        m_item = GetPrevItem(m_channelCursor);
-        SetBlock(GetBlock(m_item));
+        SetItem(GetPrevItem());
+        UpdateBlock();
 
         return;
       }
@@ -872,7 +875,7 @@ void CGUIEPGGridContainer::OnUp()
       {
         // this is the first item on page
         ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item));
+        UpdateBlock();
 
         return;
       }
@@ -911,11 +914,12 @@ void CGUIEPGGridContainer::OnDown()
   {
     if (m_gridModel->HasGridItems() && m_item)
     {
-      if (m_item->item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blocksPerPage + m_blockOffset - 1))
+      if (m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset,
+                                             m_blocksPerPage + m_blockOffset - 1))
       {
         // this is not last item on page
-        m_item = GetNextItem(m_channelCursor);
-        SetBlock(GetBlock(m_item));
+        SetItem(GetNextItem());
+        UpdateBlock();
 
         return;
       }
@@ -925,7 +929,7 @@ void CGUIEPGGridContainer::OnDown()
       {
         // this is the last item on page
         ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item));
+        UpdateBlock();
 
         return;
       }
@@ -942,11 +946,11 @@ void CGUIEPGGridContainer::OnLeft()
     if (m_gridModel->HasGridItems() && m_item)
     {
       if (m_channelCursor + m_channelOffset >= 0 && m_blockOffset >= 0 &&
-          m_item->item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
+          m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockOffset))
       {
         // this is not first item on page
-        m_item = GetPrevItem(m_channelCursor);
-        SetBlock(GetBlock(m_item));
+        SetItem(GetPrevItem());
+        UpdateBlock();
 
         return;
       }
@@ -954,7 +958,7 @@ void CGUIEPGGridContainer::OnLeft()
       {
         // this is the first item on page
         ScrollToBlockOffset(m_blockOffset - BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item));
+        UpdateBlock();
 
         return;
       }
@@ -995,11 +999,12 @@ void CGUIEPGGridContainer::OnRight()
   {
     if (m_gridModel->HasGridItems() && m_item)
     {
-      if (m_item->item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blocksPerPage + m_blockOffset - 1))
+      if (m_item != m_gridModel->GetGridItem(m_channelCursor + m_channelOffset,
+                                             m_blocksPerPage + m_blockOffset - 1))
       {
         // this is not last item on page
-        m_item = GetNextItem(m_channelCursor);
-        SetBlock(GetBlock(m_item));
+        SetItem(GetNextItem());
+        UpdateBlock();
 
         return;
       }
@@ -1009,7 +1014,7 @@ void CGUIEPGGridContainer::OnRight()
       {
         // this is the last item on page
         ScrollToBlockOffset(m_blockOffset + BLOCK_SCROLL_OFFSET);
-        SetBlock(GetBlock(m_item));
+        UpdateBlock();
 
         return;
       }
@@ -1078,12 +1083,13 @@ void CGUIEPGGridContainer::SetChannel(int channel)
   int blockIndex = m_blockCursor + m_blockOffset;
   if (channelIndex < m_gridModel->ChannelItemsSize() && blockIndex < m_gridModel->GetBlockCount())
   {
-    m_item = m_gridModel->GetGridItemPtr(channelIndex, m_blockTravelAxis);
+    SetItem(m_gridModel->GetGridItem(channelIndex, m_blockTravelAxis), channelIndex,
+            m_blockTravelAxis);
     if (m_item)
     {
       m_channelCursor = channel;
       MarkDirtyRegion();
-      SetBlock(GetBlock(m_item), false);
+      UpdateBlock(false);
     }
   }
 }
@@ -1102,8 +1108,13 @@ void CGUIEPGGridContainer::SetBlock(int block, bool bUpdateBlockTravelAxis /* = 
   if (bUpdateBlockTravelAxis)
     m_blockTravelAxis = m_blockOffset + m_blockCursor;
 
-  m_item = GetItem(m_channelCursor);
+  UpdateItem();
   MarkDirtyRegion();
+}
+
+void CGUIEPGGridContainer::UpdateBlock(bool bUpdateBlockTravelAxis /* = true */)
+{
+  SetBlock(m_item ? m_itemStartBlock - m_blockOffset : 0, bUpdateBlockTravelAxis);
 }
 
 CGUIListItemLayout* CGUIEPGGridContainer::GetFocusedLayout() const
@@ -1377,53 +1388,64 @@ std::string CGUIEPGGridContainer::GetLabel(int info) const
   return label;
 }
 
-int CGUIEPGGridContainer::GetBlock(GridItem* gridItem)
+void CGUIEPGGridContainer::SetItem(const std::pair<std::shared_ptr<CFileItem>, int>& itemInfo)
 {
-  return gridItem ? gridItem->startBlock - m_blockOffset : 0;
+  SetItem(itemInfo.first, m_channelCursor + m_channelOffset, itemInfo.second);
 }
 
-GridItem* CGUIEPGGridContainer::GetNextItem(int channel)
+void CGUIEPGGridContainer::SetItem(const std::shared_ptr<CFileItem>& item,
+                                   int channelIndex,
+                                   int blockIndex)
 {
-  const int channelIndex = channel + m_channelOffset;
-  const int blockIndex = m_blockCursor + m_blockOffset;
-  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
-    return nullptr;
+  if (item && channelIndex < m_gridModel->ChannelItemsSize() &&
+      blockIndex < m_gridModel->GetBlockCount())
+    m_item = item;
+  else
+    m_item.reset();
 
-  int block = m_gridModel->GetGridItemEndBlock(channelIndex, blockIndex);
+  m_itemStartBlock = m_item ? m_gridModel->GetGridItemStartBlock(channelIndex, blockIndex) : 0;
+}
+
+std::shared_ptr<CFileItem> CGUIEPGGridContainer::GetItem() const
+{
+  const int channelIndex = m_channelCursor + m_channelOffset;
+  const int blockIndex = m_blockCursor + m_blockOffset;
+
+  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
+    return {};
+
+  return m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
+}
+
+std::pair<std::shared_ptr<CFileItem>, int> CGUIEPGGridContainer::GetNextItem() const
+{
+  int block = m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
+                                               m_blockCursor + m_blockOffset);
   if (block < m_gridModel->GetBlockCount())
   {
     // first block of next event is one block after end block of selected event
     block += 1;
   }
 
-  return m_gridModel->GetGridItemPtr(channelIndex, block);
+  return {m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, block), block};
 }
 
-GridItem* CGUIEPGGridContainer::GetPrevItem(int channel)
+std::pair<std::shared_ptr<CFileItem>, int> CGUIEPGGridContainer::GetPrevItem() const
 {
-  const int channelIndex = channel + m_channelOffset;
-  const int blockIndex = m_blockCursor + m_blockOffset;
-  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
-    return nullptr;
-
-  int block = m_gridModel->GetGridItemStartBlock(channelIndex, blockIndex);
+  int block = m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
+                                                 m_blockCursor + m_blockOffset);
   if (block > 0)
   {
     // last block of previous event is one block before start block of selected event
     block -= 1;
   }
 
-  return m_gridModel->GetGridItemPtr(channelIndex, block);
+  return {m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, block), block};
 }
 
-GridItem* CGUIEPGGridContainer::GetItem(int channel)
+void CGUIEPGGridContainer::UpdateItem()
 {
-  int channelIndex = channel + m_channelOffset;
-  int blockIndex = m_blockCursor + m_blockOffset;
-  if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
-    return nullptr;
-
-  return m_gridModel->GetGridItemPtr(channelIndex, blockIndex);
+  SetItem(GetItem(), m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
 }
 
 void CGUIEPGGridContainer::SetFocus(bool focus)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -2320,17 +2320,11 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
     int block = blockOffset;
     float posA2 = posA;
 
-    item = m_gridModel->GetGridItem(channel, block);
-
-    if (blockOffset > 0 && item == m_gridModel->GetGridItem(channel, blockOffset - 1))
+    if (blockOffset > 0 && m_gridModel->GetGridItem(channel, block) ==
+                               m_gridModel->GetGridItem(channel, blockOffset - 1))
     {
-      /* first program starts before current view */
-      int startBlock = blockOffset - 1;
-
-      while (startBlock >= 0 && m_gridModel->GetGridItem(channel, startBlock) == item)
-        startBlock--;
-
-      block = startBlock + 1;
+      // First program starts before current view
+      block = m_gridModel->GetGridItemStartBlock(channel, blockOffset - 1);
       int missingSection = blockOffset - block;
       posA2 -= missingSection * m_blockSize;
     }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1401,17 +1401,19 @@ GridItem* CGUIEPGGridContainer::GetNextItem(int channel)
 
 GridItem* CGUIEPGGridContainer::GetPrevItem(int channel)
 {
-  int channelIndex = channel + m_channelOffset;
-  int blockIndex = m_blockCursor + m_blockOffset;
+  const int channelIndex = channel + m_channelOffset;
+  const int blockIndex = m_blockCursor + m_blockOffset;
   if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
     return nullptr;
 
-  int i = m_blockCursor;
+  int block = m_gridModel->GetGridItemStartBlock(channelIndex, blockIndex);
+  if (block > 0)
+  {
+    // last block of previous event is one block before start block of selected event
+    block -= 1;
+  }
 
-  while (i > 0 && m_gridModel->GetGridItem(channelIndex, i + m_blockOffset) == m_gridModel->GetGridItem(channelIndex, blockIndex))
-    i--;
-
-  return m_gridModel->GetGridItemPtr(channelIndex, i + m_blockOffset);
+  return m_gridModel->GetGridItemPtr(channelIndex, block);
 }
 
 GridItem* CGUIEPGGridContainer::GetItem(int channel)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1389,14 +1389,14 @@ GridItem* CGUIEPGGridContainer::GetNextItem(int channel)
   if (channelIndex >= m_gridModel->ChannelItemsSize() || blockIndex >= m_gridModel->GetBlockCount())
     return nullptr;
 
-  int i = m_blockCursor;
+  int block = m_gridModel->GetGridItemEndBlock(channelIndex, blockIndex);
+  if (block < m_gridModel->GetBlockCount())
+  {
+    // first block of next event is one block after end block of selected event
+    block += 1;
+  }
 
-  while (i < m_blocksPerPage &&
-         i + m_blockOffset + 1 < m_gridModel->GetBlockCount() &&
-         m_gridModel->GetGridItem(channelIndex, i + m_blockOffset) == m_gridModel->GetGridItem(channelIndex, blockIndex))
-    i++;
-
-  return m_gridModel->GetGridItemPtr(channelIndex, i + m_blockOffset);
+  return m_gridModel->GetGridItemPtr(channelIndex, block);
 }
 
 GridItem* CGUIEPGGridContainer::GetPrevItem(int channel)

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -30,6 +30,7 @@ class CGUIListItemLayout;
 namespace PVR
 {
   class CPVRChannel;
+  class CPVRChannelNumber;
 
   class CGUIEPGGridContainerModel;
 
@@ -98,8 +99,10 @@ namespace PVR
 
     void SetTimelineItems(const std::unique_ptr<CFileItemList>& items,
                           const CDateTime& gridStart,
-                          const CDateTime& gridEnd,
-                          bool bFirstOpen);
+                          const CDateTime& gridEnd);
+
+    std::unique_ptr<CFileItemList> GetCurrentTimeLineItems() const;
+
     /*!
      * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
      * @param channel the channel.
@@ -113,6 +116,13 @@ namespace PVR
      * @return true if the selection was set to the given channel, false otherwise.
      */
     bool SetChannel(const std::string& channel);
+
+    /*!
+     * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
+     * @param channelNumber the channel's number.
+     * @return true if the selection was set to the given channel, false otherwise.
+     */
+    bool SetChannel(const CPVRChannelNumber& channelNumber);
 
   private:
     bool OnClick(int actionID);

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -96,7 +96,10 @@ namespace PVR
     void GoToMostLeft();
     void GoToMostRight();
 
-    void SetTimelineItems(const std::unique_ptr<CFileItemList>& items, const CDateTime& gridStart, const CDateTime& gridEnd);
+    void SetTimelineItems(const std::unique_ptr<CFileItemList>& items,
+                          const CDateTime& gridStart,
+                          const CDateTime& gridEnd,
+                          bool bFirstOpen);
     /*!
      * @brief Set the control's selection to the given channel and set the control's view port to show the channel.
      * @param channel the channel.
@@ -194,8 +197,6 @@ namespace PVR
     float GetProgressIndicatorHeight() const;
 
     void UpdateItems();
-
-    int GetSelectedItem() const;
 
     int m_rulerUnit; //! number of blocks that makes up one element of the ruler
     int m_channelsPerPage;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -126,8 +126,7 @@ namespace PVR
     GridItem* GetNextItem(int channel);
     GridItem* GetPrevItem(int channel);
 
-    int GetBlock(const CGUIListItemPtr& item, int channel);
-    int GetRealBlock(const CGUIListItemPtr& item, int channel);
+    int GetBlock(GridItem* gridItem);
     void MoveToRow(int row);
 
     CGUIListItemLayout* GetFocusedLayout() const;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -129,7 +129,7 @@ namespace PVR
     void UpdateLayout();
 
     void SetItem(const std::pair<std::shared_ptr<CFileItem>, int>& itemInfo);
-    void SetItem(const std::shared_ptr<CFileItem>& item, int channelIndex, int blockIndex);
+    bool SetItem(const std::shared_ptr<CFileItem>& item, int channelIndex, int blockIndex);
     std::shared_ptr<CFileItem> GetItem() const;
     std::pair<std::shared_ptr<CFileItem>, int> GetNextItem() const;
     std::pair<std::shared_ptr<CFileItem>, int> GetPrevItem() const;
@@ -247,7 +247,6 @@ namespace PVR
     std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
     std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
 
-    std::shared_ptr<CFileItem> m_item;
     int m_itemStartBlock = 0;
   };
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 class CFileItem;
@@ -30,7 +31,6 @@ namespace PVR
 {
   class CPVRChannel;
 
-  struct GridItem;
   class CGUIEPGGridContainerModel;
 
   class CGUIEPGGridContainer : public IGUIContainer
@@ -111,22 +111,27 @@ namespace PVR
      */
     bool SetChannel(const std::string& channel);
 
-  protected:
+  private:
     bool OnClick(int actionID);
     bool SelectItemFromPoint(const CPoint& point, bool justGrid = true);
 
     void SetChannel(int channel);
+
     void SetBlock(int block, bool bUpdateBlockTravelAxis = true);
+    void UpdateBlock(bool bUpdateBlockTravelAxis = true);
+
     void ChannelScroll(int amount);
     void ProgrammesScroll(int amount);
     void ValidateOffset();
     void UpdateLayout();
 
-    GridItem* GetItem(int channel);
-    GridItem* GetNextItem(int channel);
-    GridItem* GetPrevItem(int channel);
+    void SetItem(const std::pair<std::shared_ptr<CFileItem>, int>& itemInfo);
+    void SetItem(const std::shared_ptr<CFileItem>& item, int channelIndex, int blockIndex);
+    std::shared_ptr<CFileItem> GetItem() const;
+    std::pair<std::shared_ptr<CFileItem>, int> GetNextItem() const;
+    std::pair<std::shared_ptr<CFileItem>, int> GetPrevItem() const;
+    void UpdateItem();
 
-    int GetBlock(GridItem* gridItem);
     void MoveToRow(int row);
 
     CGUIListItemLayout* GetFocusedLayout() const;
@@ -241,6 +246,7 @@ namespace PVR
     std::unique_ptr<CGUIEPGGridContainerModel> m_gridModel;
     std::unique_ptr<CGUIEPGGridContainerModel> m_updatedGridModel;
 
-    GridItem* m_item;
+    std::shared_ptr<CFileItem> m_item;
+    int m_itemStartBlock = 0;
   };
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -312,6 +312,7 @@ GridItem* CGUIEPGGridContainerModel::GetGridItemPtr(int iChannel, int iBlock) co
     m_gridIndex[iChannel][iBlock].width = fItemWidth;
     m_gridIndex[iChannel][iBlock].item = item;
     m_gridIndex[iChannel][iBlock].progIndex = progIndex;
+    m_gridIndex[iChannel][iBlock].startBlock = startBlock;
   }
   return &m_gridIndex[iChannel][iBlock];
 }
@@ -319,6 +320,11 @@ GridItem* CGUIEPGGridContainerModel::GetGridItemPtr(int iChannel, int iBlock) co
 std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetGridItem(int iChannel, int iBlock) const
 {
   return GetGridItemPtr(iChannel, iBlock)->item;
+}
+
+int CGUIEPGGridContainerModel::GetGridItemStartBlock(int iChannel, int iBlock) const
+{
+  return GetGridItemPtr(iChannel, iBlock)->startBlock;
 }
 
 float CGUIEPGGridContainerModel::GetGridItemWidth(int iChannel, int iBlock) const

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -308,11 +308,7 @@ GridItem* CGUIEPGGridContainerModel::GetGridItemPtr(int iChannel, int iBlock) co
     }
 
     const float fItemWidth = (endBlock - startBlock + 1) * m_fBlockSize;
-    m_gridIndex[iChannel][iBlock].originWidth = fItemWidth;
-    m_gridIndex[iChannel][iBlock].width = fItemWidth;
-    m_gridIndex[iChannel][iBlock].item = item;
-    m_gridIndex[iChannel][iBlock].progIndex = progIndex;
-    m_gridIndex[iChannel][iBlock].startBlock = startBlock;
+    m_gridIndex[iChannel][iBlock] = GridItem(item, fItemWidth, startBlock, endBlock, progIndex);
   }
   return &m_gridIndex[iChannel][iBlock];
 }
@@ -325,6 +321,11 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetGridItem(int iChannel, 
 int CGUIEPGGridContainerModel::GetGridItemStartBlock(int iChannel, int iBlock) const
 {
   return GetGridItemPtr(iChannel, iBlock)->startBlock;
+}
+
+int CGUIEPGGridContainerModel::GetGridItemEndBlock(int iChannel, int iBlock) const
+{
+  return GetGridItemPtr(iChannel, iBlock)->endBlock;
 }
 
 float CGUIEPGGridContainerModel::GetGridItemWidth(int iChannel, int iBlock) const

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -26,6 +26,7 @@ namespace PVR
     float originWidth = 0.0f;
     float width = 0.0f;
     int progIndex = -1;
+    int startBlock = 0;
   };
 
   class CPVREpgInfoTag;
@@ -64,6 +65,7 @@ namespace PVR
     bool HasGridItems() const { return !m_gridIndex.empty(); }
     GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
     std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
+    int GetGridItemStartBlock(int iChannel, int iBlock) const;
     float GetGridItemWidth(int iChannel, int iBlock) const;
     float GetGridItemOriginWidth(int iChannel, int iBlock) const;
     int GetGridItemIndex(int iChannel, int iBlock) const;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -63,15 +63,14 @@ namespace PVR
                     int iFirstBlock,
                     int iBlocksPerPage,
                     int iRulerUnit,
-                    float fBlockSize,
-                    bool bFirstOpen);
+                    float fBlockSize);
     void SetInvalid();
 
     static const int INVALID_INDEX = -1;
     void FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int& newChannelIndex, int& newBlockIndex) const;
 
     void FreeChannelMemory(int keepStart, int keepEnd);
-    void FreeProgrammeMemory(int firstChannel, int lastChannel, int firstBlock, int lastBlock);
+    bool FreeProgrammeMemory(int firstChannel, int lastChannel, int firstBlock, int lastBlock);
     void FreeRulerMemory(int keepStart, int keepEnd);
 
     std::shared_ptr<CFileItem> GetChannelItem(int iIndex) const { return m_channelItems[iIndex]; }
@@ -108,6 +107,8 @@ namespace PVR
     int GetFirstEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
     int GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
     bool IsEventMemberOfBlock(const std::shared_ptr<CPVREpgInfoTag>& event, int iBlock) const;
+
+    std::unique_ptr<CFileItemList> GetCurrentTimeLineItems() const;
 
   private:
     GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
@@ -168,7 +169,5 @@ namespace PVR
     int m_lastActiveChannel = 0;
     int m_firstActiveBlock = 0;
     int m_lastActiveBlock = 0;
-
-    bool m_bFirstOpen = true;
   };
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -10,8 +10,10 @@
 
 #include "XBDateTime.h"
 
+#include <functional>
 #include <map>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -77,7 +79,6 @@ namespace PVR
     int RulerItemsSize() const { return static_cast<int>(m_rulerItems.size()); }
 
     int GetBlockCount() const { return m_blocks; }
-    bool HasGridItems() const { return !m_gridIndex.empty(); }
     std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
     int GetGridItemStartBlock(int iChannel, int iBlock) const;
     int GetGridItemEndBlock(int iChannel, int iBlock) const;
@@ -118,7 +119,29 @@ namespace PVR
     std::vector<std::shared_ptr<CFileItem>> m_channelItems;
     std::vector<std::shared_ptr<CFileItem>> m_rulerItems;
     std::vector<ItemsPtr> m_epgItemsPtr;
-    mutable std::vector<std::vector<GridItem>> m_gridIndex;
+
+    struct GridCoordinates
+    {
+      GridCoordinates(int _channel, int _block) : channel(_channel), block(_block) {}
+
+      bool operator==(const GridCoordinates& other) const
+      {
+        return (channel == other.channel && block == other.block);
+      }
+
+      int channel = 0;
+      int block = 0;
+    };
+
+    struct GridCoordinatesHash
+    {
+      std::size_t operator()(const GridCoordinates& coordinates) const
+      {
+        return std::hash<int>()(coordinates.channel) ^ std::hash<int>()(coordinates.block);
+      }
+    };
+
+    mutable std::unordered_map<GridCoordinates, GridItem, GridCoordinatesHash> m_gridIndex;
     mutable std::map<std::pair<int, int>, std::shared_ptr<CFileItem>> m_gapItems;
 
     int m_blocks = 0;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -24,15 +24,10 @@ namespace PVR
 {
   struct GridItem
   {
-    GridItem(const std::shared_ptr<CFileItem>& _item,
-             float _width,
-             int _startBlock,
-             int _endBlock,
-             int _progIndex)
+    GridItem(const std::shared_ptr<CFileItem>& _item, float _width, int _startBlock, int _endBlock)
       : item(_item),
         originWidth(_width),
         width(_width),
-        progIndex(_progIndex),
         startBlock(_startBlock),
         endBlock(_endBlock)
     {
@@ -41,7 +36,6 @@ namespace PVR
     std::shared_ptr<CFileItem> item;
     float originWidth = 0.0f;
     float width = 0.0f;
-    int progIndex = -1;
     int startBlock = 0;
     int endBlock = 0;
   };
@@ -65,7 +59,8 @@ namespace PVR
                     int iFirstBlock,
                     int iBlocksPerPage,
                     int iRulerUnit,
-                    float fBlockSize);
+                    float fBlockSize,
+                    bool bFirstOpen);
     void SetInvalid();
 
     static const int INVALID_INDEX = -1;
@@ -74,10 +69,6 @@ namespace PVR
     void FreeChannelMemory(int keepStart, int keepEnd);
     void FreeProgrammeMemory(int firstChannel, int lastChannel, int firstBlock, int lastBlock);
     void FreeRulerMemory(int keepStart, int keepEnd);
-
-    std::shared_ptr<CFileItem> GetProgrammeItem(int iIndex) const { return m_programmeItems[iIndex]; }
-    bool HasProgrammeItems() const { return !m_programmeItems.empty(); }
-    int ProgrammeItemsSize() const { return static_cast<int>(m_programmeItems.size()); }
 
     std::shared_ptr<CFileItem> GetChannelItem(int iIndex) const { return m_channelItems[iIndex]; }
     bool HasChannelItems() const { return !m_channelItems.empty(); }
@@ -92,7 +83,6 @@ namespace PVR
     int GetGridItemEndBlock(int iChannel, int iBlock) const;
     float GetGridItemWidth(int iChannel, int iBlock) const;
     float GetGridItemOriginWidth(int iChannel, int iBlock) const;
-    int GetGridItemIndex(int iChannel, int iBlock) const;
     void SetGridItemWidth(int iChannel, int iBlock, float fWidth);
 
     bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }
@@ -109,24 +99,20 @@ namespace PVR
     int GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
 
   private:
-    void FreeItemsMemory();
     GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
     std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
     std::shared_ptr<CFileItem> GetGapItem(int iChannel, int iStartBlock) const;
 
-    struct ItemsPtr
-    {
-      long start;
-      long stop;
-    };
+    using EpgTagsMap = std::unordered_map<int, std::vector<std::shared_ptr<CFileItem>>>;
+    const EpgTagsMap::const_iterator GetChannelEpgTags(int iChannel) const;
+
+    mutable EpgTagsMap m_epgItems;
 
     CDateTime m_gridStart;
     CDateTime m_gridEnd;
 
-    std::vector<std::shared_ptr<CFileItem>> m_programmeItems;
     std::vector<std::shared_ptr<CFileItem>> m_channelItems;
     std::vector<std::shared_ptr<CFileItem>> m_rulerItems;
-    std::vector<ItemsPtr> m_epgItemsPtr;
 
     struct GridCoordinates
     {
@@ -159,5 +145,7 @@ namespace PVR
     int m_lastActiveChannel = 0;
     int m_firstActiveBlock = 0;
     int m_lastActiveBlock = 0;
+
+    bool m_bFirstOpen = true;
   };
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -22,11 +22,26 @@ namespace PVR
 {
   struct GridItem
   {
+    GridItem(const std::shared_ptr<CFileItem>& _item,
+             float _width,
+             int _startBlock,
+             int _endBlock,
+             int _progIndex)
+      : item(_item),
+        originWidth(_width),
+        width(_width),
+        progIndex(_progIndex),
+        startBlock(_startBlock),
+        endBlock(_endBlock)
+    {
+    }
+
     std::shared_ptr<CFileItem> item;
     float originWidth = 0.0f;
     float width = 0.0f;
     int progIndex = -1;
     int startBlock = 0;
+    int endBlock = 0;
   };
 
   class CPVREpgInfoTag;
@@ -66,6 +81,7 @@ namespace PVR
     GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
     std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
     int GetGridItemStartBlock(int iChannel, int iBlock) const;
+    int GetGridItemEndBlock(int iChannel, int iBlock) const;
     float GetGridItemWidth(int iChannel, int iBlock) const;
     float GetGridItemOriginWidth(int iChannel, int iBlock) const;
     int GetGridItemIndex(int iChannel, int iBlock) const;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -78,7 +78,6 @@ namespace PVR
 
     int GetBlockCount() const { return m_blocks; }
     bool HasGridItems() const { return !m_gridIndex.empty(); }
-    GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
     std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
     int GetGridItemStartBlock(int iChannel, int iBlock) const;
     int GetGridItemEndBlock(int iChannel, int iBlock) const;
@@ -102,6 +101,7 @@ namespace PVR
 
   private:
     void FreeItemsMemory();
+    GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
     std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
     std::shared_ptr<CFileItem> GetGapItem(int iChannel, int iStartBlock) const;
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -10,7 +10,9 @@
 
 #include "XBDateTime.h"
 
+#include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 class CFileItem;
@@ -83,6 +85,7 @@ namespace PVR
   private:
     void FreeItemsMemory();
     std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
+    std::shared_ptr<CFileItem> GetGapItem(int iChannel, int iStartBlock) const;
 
     struct ItemsPtr
     {
@@ -98,7 +101,9 @@ namespace PVR
     std::vector<std::shared_ptr<CFileItem>> m_rulerItems;
     std::vector<ItemsPtr> m_epgItemsPtr;
     mutable std::vector<std::vector<GridItem>> m_gridIndex;
+    mutable std::map<std::pair<int, int>, std::shared_ptr<CFileItem>> m_gapItems;
 
     int m_blocks = 0;
+    float m_fBlockSize = 0.0f;
   };
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -60,12 +60,12 @@ namespace PVR
 
     int GetBlockCount() const { return m_blocks; }
     bool HasGridItems() const { return !m_gridIndex.empty(); }
-    GridItem* GetGridItemPtr(int iChannel, int iBlock) { return &m_gridIndex[iChannel][iBlock]; }
-    std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].item; }
-    float GetGridItemWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].width; }
-    float GetGridItemOriginWidth(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].originWidth; }
-    int GetGridItemIndex(int iChannel, int iBlock) const { return m_gridIndex[iChannel][iBlock].progIndex; }
-    void SetGridItemWidth(int iChannel, int iBlock, float fWidth) { m_gridIndex[iChannel][iBlock].width = fWidth; }
+    GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
+    std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
+    float GetGridItemWidth(int iChannel, int iBlock) const;
+    float GetGridItemOriginWidth(int iChannel, int iBlock) const;
+    int GetGridItemIndex(int iChannel, int iBlock) const;
+    void SetGridItemWidth(int iChannel, int iBlock, float fWidth);
 
     bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }
     const CDateTime& GetGridStart() const { return m_gridStart; }
@@ -97,7 +97,7 @@ namespace PVR
     std::vector<std::shared_ptr<CFileItem>> m_channelItems;
     std::vector<std::shared_ptr<CFileItem>> m_rulerItems;
     std::vector<ItemsPtr> m_epgItemsPtr;
-    std::vector<std::vector<GridItem> > m_gridIndex;
+    mutable std::vector<std::vector<GridItem>> m_gridIndex;
 
     int m_blocks = 0;
   };

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -57,14 +57,22 @@ namespace PVR
     CGUIEPGGridContainerModel() = default;
     virtual ~CGUIEPGGridContainerModel() = default;
 
-    void Initialize(const std::unique_ptr<CFileItemList>& items, const CDateTime& gridStart, const CDateTime& gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
+    void Initialize(const std::unique_ptr<CFileItemList>& items,
+                    const CDateTime& gridStart,
+                    const CDateTime& gridEnd,
+                    int iFirstChannel,
+                    int iChannelsPerPage,
+                    int iFirstBlock,
+                    int iBlocksPerPage,
+                    int iRulerUnit,
+                    float fBlockSize);
     void SetInvalid();
 
     static const int INVALID_INDEX = -1;
     void FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int& newChannelIndex, int& newBlockIndex) const;
 
     void FreeChannelMemory(int keepStart, int keepEnd);
-    void FreeProgrammeMemory(int channel, int keepStart, int keepEnd);
+    void FreeProgrammeMemory(int firstChannel, int lastChannel, int firstBlock, int lastBlock);
     void FreeRulerMemory(int keepStart, int keepEnd);
 
     std::shared_ptr<CFileItem> GetProgrammeItem(int iIndex) const { return m_programmeItems[iIndex]; }
@@ -146,5 +154,10 @@ namespace PVR
 
     int m_blocks = 0;
     float m_fBlockSize = 0.0f;
+
+    int m_firstActiveChannel = 0;
+    int m_lastActiveChannel = 0;
+    int m_firstActiveBlock = 0;
+    int m_lastActiveBlock = 0;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -433,7 +433,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
         }
 
         const std::shared_ptr<CFileItem> pItem = GetCurrentListItem();
-        if (pItem && pItem->GetEPGInfoTag()->StartAsUTC().IsValid())
+        if (pItem && !pItem->GetEPGInfoTag()->IsGapTag())
         {
           switch (message.GetParam1())
           {
@@ -762,8 +762,8 @@ bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
         for (const auto& groupMember : groupMembers)
         {
           // fake a channel without epg
-          const std::shared_ptr<CPVREpgInfoTag> gapTag
-            = std::make_shared<CPVREpgInfoTag>(std::make_shared<CPVREpgChannelData>(*(groupMember->channel)), -1);
+          const std::shared_ptr<CPVREpgInfoTag> gapTag =
+              groupMember->channel->CreateEPGGapTag(startDate, endDate);
           timeline->Add(std::make_shared<CFileItem>(gapTag));
 
           channels->Add(std::make_shared<CFileItem>(groupMember->channel));

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -92,10 +92,8 @@ namespace PVR
     std::atomic_bool m_bSyncRefreshTimelineItems;
 
     std::shared_ptr<CPVRChannelGroup> m_cachedChannelGroup;
-    std::unique_ptr<CFileItemList> m_newTimeline;
 
     bool m_bChannelSelectionRestored;
-    std::atomic_bool m_bFirstOpen;
   };
 
   class CGUIWindowPVRTVGuide : public CGUIWindowPVRGuideBase

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -85,6 +85,8 @@ namespace PVR
 
     void RefreshView(CGUIMessage& message, bool bInitGridControl);
 
+    int GetCurrentListItemIndex(const std::shared_ptr<CFileItem>& item);
+
     std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
     std::atomic_bool m_bRefreshTimelineItems;
     std::atomic_bool m_bSyncRefreshTimelineItems;


### PR DESCRIPTION
Makes it possible to actually use the Guide window with > 1000 channels, 30 days of EPG data each, even on low power machines (like Raspi2).

Tested on macOS and Android (Shield).

I tried to separate these rather large changes in logical chunks to make review easier.

@MilhouseVH could you include this PR in your test builds? I would be really interested in some feedback, especially from Raspi users.