### PR TITLE
DVDAudioCodecPassthrough: Properly check for DTSHD_MA as well after HR change

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -43,6 +43,10 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
       m_codecName = "pt-eac3";
       break;
 
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
+      m_codecName = "pt-dtshd";
+      break;
+
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
       m_codecName = "pt-dtshd";
       break;


### PR DESCRIPTION
Minor change. Now that we distinguish between DTS-HD-HR and DTS-HD-MA we need to make sure that our CDVDCodecPassthrough still understands it.