### PR TITLE
[pvr] update channel number and client order for selected group when channel update triggered

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -237,6 +237,9 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
       RemoveFromAllGroups(channelsToRemove);
     }
 
+    if (bReturn && group == m_selectedGroup)
+      UpdateSelectedGroup();
+
     if (bReturn &&
         group->IsInternalGroup() &&
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bPVRChannelIconsAutoScan)
@@ -490,6 +493,13 @@ void CPVRChannelGroups::SetSelectedGroup(const std::shared_ptr<CPVRChannelGroup>
 
   for (auto& group : m_groups)
     group->SetSelectedGroup(group == m_selectedGroup);
+}
+
+void CPVRChannelGroups::UpdateSelectedGroup()
+{
+  CSingleLock lock(m_critSection);
+  m_selectedGroup->UpdateClientOrder();
+  m_selectedGroup->UpdateChannelNumbers();
 }
 
 bool CPVRChannelGroups::AddGroup(const std::string& strName)

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -157,6 +157,11 @@ namespace PVR
     void SetSelectedGroup(const std::shared_ptr<CPVRChannelGroup>& selectedGroup);
 
     /*!
+     * @brief Update the selected groups channel numbers and client order.
+     */
+    void UpdateSelectedGroup();
+
+    /*!
      * @brief Add a group to this container.
      * @param strName The name of the group.
      * @return True if the group was added, false otherwise.


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

When a PVR addon calls `TriggerChannel*Update()` the channel numbers and client order are updated. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Any new channels will present with number `0`;

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

OSX, using iptvsimple.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
