### PR TITLE
Android: Fix waiting for display refresh

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -52,8 +52,7 @@ CWinSystemAndroid::CWinSystemAndroid()
 
   m_stereo_mode = RENDER_STEREO_MODE_OFF;
 
-  m_dispResetState = RESET_NOTWAITING;
-  m_dispResetTimer = new CTimer(this);
+  m_delayDispReset = false;
 
   m_android = nullptr;
 
@@ -64,7 +63,6 @@ CWinSystemAndroid::CWinSystemAndroid()
 CWinSystemAndroid::~CWinSystemAndroid()
 {
   m_nativeWindow = nullptr;
-  delete m_dispResetTimer, m_dispResetTimer = nullptr;
 }
 
 bool CWinSystemAndroid::InitWindowSystem()
@@ -132,9 +130,10 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
     return true;
   }
 
-  if (m_dispResetState != RESET_NOTWAITING)
+  if (m_delayDispReset)
   {
-    CLog::Log(LOGERROR, "CWinSystemAndroid::CreateNewWindow: cannot create window while resetting");
+    CLog::Log(LOGERROR,
+              "CWinSystemAndroid::CreateNewWindow: cannot create window while reset in progress");
     return false;
   }
 
@@ -217,46 +216,75 @@ void CWinSystemAndroid::UpdateResolutions(bool bUpdateDesktopRes)
   }
 }
 
-void CWinSystemAndroid::OnTimeout()
-{
-  m_dispResetState = RESET_WAITEVENT;
-  SetHDMIState(true);
-}
-
 void CWinSystemAndroid::SetHDMIState(bool connected)
 {
   CSingleLock lock(m_resourceSection);
-  CLog::Log(LOGDEBUG, "CWinSystemAndroid::SetHDMIState: connected: %d, dispResetState: %d", static_cast<int>(connected), m_dispResetState);
-  if (connected && m_dispResetState != RESET_NOTWAITING)
+  CLog::Log(LOGDEBUG, "CWinSystemAndroid::SetHDMIState: connected: %d",
+            static_cast<int>(connected));
+  if (connected)
   {
-    for (auto resource : m_resources)
-      resource->OnResetDisplay();
-    m_dispResetState = RESET_NOTWAITING;
-    m_dispResetTimer->Stop();
-  }
-  else if (!connected)
-  {
-    if (m_dispResetState == RESET_WAITTIMER)
+    // wake up if Timer is gone or not set
+    // else just do nothing
+    if (!m_delayDispReset)
     {
-      //HDMI_AUDIOPLUG arrived, use this
-      m_dispResetTimer->Stop();
-      m_dispResetState = RESET_WAITEVENT;
-      return;
+      CLog::Log(LOGDEBUG, "Waking up resources directly");
+      for (auto resource : m_resources)
+        resource->OnResetDisplay();
     }
-    else if (m_dispResetState != RESET_NOTWAITING)
-      return;
+    else
+    {
+      // we got a real hot plug event while waiting - means it's
+      // properly implemented - wakeup user if the time
+      // specified is gone already
+      if (!m_dispResetTimer.IsTimePast())
+      {
+        int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                        "videoscreen.delayrefreshchange") *
+                    100;
+        int waited = m_dispResetTimer.GetInitialTimeoutValue() - m_dispResetTimer.MillisLeft();
+        int userdelta = delay - waited;
+        if (userdelta < 0)
+        {
+          m_delayDispReset = false;
+          m_dispResetTimer.SetExpired();
+          // tell everyone we are going to wakeup now
+          for (auto resource : m_resources)
+            resource->OnResetDisplay();
+        }
+        else
+        {
+          CLog::Log(LOGDEBUG, "Received HDMI Intent - but user prefers sleeping longer");
+        }
+      }
+    }
+  }
+  else
+  {
+    // create new waiting timer if old delayed Timer was acked already
+    // This is called from Thread 1
+    if (!m_delayDispReset)
+    {
+      int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                      "videoscreen.delayrefreshchange") *
+                  100;
+      // tell everyone we are going to sleep now
+      for (auto resource : m_resources)
+        resource->OnLostDisplay();
 
-    int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange") * 100;
+      // we use a delay of 2000 ms to check if we get an HDMI Hotplug Event
+      // if we don't get it - the timer recovers us - else if user did not
+      // specify a delay and we get that event we will reset the delayed
+      // timer and compute the already waited time. This basically means:
+      // For devices without hot plug intent Refreshrate switching will
+      // last 2 seconds.
+      if (delay < 2000)
+        delay = 2000;
 
-    if (delay < 2000)
-      delay = 2000;
-
-    m_dispResetState = RESET_WAITTIMER;
-    m_dispResetTimer->Stop();
-    m_dispResetTimer->Start(delay);
-
-    for (auto resource : m_resources)
-      resource->OnLostDisplay();
+      m_delayDispReset = true;
+      m_dispResetTimer.Set(delay);
+    }
+    else
+      CLog::Log(LOGDEBUG, "HDMISet false called while delayed Display Reset in progress");
   }
 }
 

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -11,7 +11,7 @@
 #include "AndroidUtils.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "threads/CriticalSection.h"
-#include "threads/Timer.h"
+#include "threads/SystemClock.h"
 #include "windowing/WinSystem.h"
 
 #include <EGL/egl.h>
@@ -19,7 +19,7 @@
 class CDecoderFilterManager;
 class IDispResource;
 
-class CWinSystemAndroid : public CWinSystemBase, public ITimerCallback
+class CWinSystemAndroid : public CWinSystemBase
 {
 public:
   CWinSystemAndroid();
@@ -54,7 +54,6 @@ public:
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
-  void OnTimeout() override;
 
   CAndroidUtils *m_android;
 
@@ -66,15 +65,8 @@ protected:
 
   RENDER_STEREO_MODE m_stereo_mode;
 
-  enum RESETSTATE
-  {
-    RESET_NOTWAITING,
-    RESET_WAITTIMER,
-    RESET_WAITEVENT
-  };
-
-  RESETSTATE m_dispResetState;
-  CTimer *m_dispResetTimer;
+  bool m_delayDispReset;
+  XbmcThreads::EndTime m_dispResetTimer;
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -119,6 +119,14 @@ void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
     return;
   }
 
+  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
+  {
+    CSingleLock lock(m_resourceSection);
+    m_delayDispReset = false;
+    for (auto resource : m_resources)
+      resource->OnResetDisplay();
+  }
+
   // Ignore EGL_BAD_SURFACE: It seems to happen during/after mode changes, but
   // we can't actually do anything about it
   if (rendered && !m_pGLContext.TrySwapBuffers())


### PR DESCRIPTION
The intent has overwritten the wait timer. 

- Simplify code
- Don't interrupt wait timer when set
- Tested on FireTV 4K

Something to note: We only wait - timer based - means: Android itself can come back any time before the timer is passed - you will then shortly see the GUI before movie starts.