### PR TITLE
[Estuary][guiinfo][cpuinfo] Hide CPU usage if system does not provide this information

### DIFF
--- a/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
@@ -183,6 +183,16 @@
 					<label>$INFO[System.Memory(used.percent),[COLOR button_focus]$LOCALIZE[31030]:[/COLOR] ,       ]$INFO[System.CpuUsage,[COLOR button_focus]$LOCALIZE[13271][/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+				<control type="label">
+					<width>1600</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[System.Memory(used.percent),[COLOR button_focus]$LOCALIZE[31030]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>!System.SupportsCPUUsage</visible>
 				</control>
 			</control>
 			<control type="grouplist" id="5550">

--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -125,27 +125,12 @@
 					<left>420</left>
 					<orientation>vertical</orientation>
 					<control type="label">
-						<description>CPU Text</description>
-						<width>730</width>
-						<height>80</height>
-						<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
-						<aligny>top</aligny>
-						<textoffsety>40</textoffsety>
-						<shadowcolor>black</shadowcolor>
-						<font>font27</font>
-					</control>
-					<control type="progress">
-						<description>CPU BAR</description>
-						<width>730</width>
-						<height>16</height>
-						<info>System.CPUUsage</info>
-					</control>
-					<control type="label">
 						<description>Memory Text</description>
 						<width>730</width>
-						<height>40</height>
+						<height>80</height>
 						<label>$LOCALIZE[31030]: $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
-						<aligny>center</aligny>
+						<aligny>top</aligny>
+						<textoffsety>40</textoffsety>
 						<shadowcolor>black</shadowcolor>
 						<font>font27</font>
 					</control>
@@ -154,6 +139,23 @@
 						<width>730</width>
 						<height>16</height>
 						<info>system.memory(used)</info>
+					</control>
+					<control type="label">
+						<description>CPU Text</description>
+						<width>730</width>
+						<height>40</height>
+						<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
+						<aligny>center</aligny>
+						<shadowcolor>black</shadowcolor>
+						<font>font27</font>
+						<visible>System.SupportsCPUUsage</visible>
+					</control>
+					<control type="progress">
+						<description>CPU BAR</description>
+						<width>730</width>
+						<height>16</height>
+						<info>System.CPUUsage</info>
+						<visible>System.SupportsCPUUsage</visible>
 					</control>
 				</control>
 				<control type="label">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1629,6 +1629,14 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///     @skinning_v17 **[New Infolabel]** \link System_PrivacyPolicy `System.PrivacyPolicy`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`System.SupportsCPUUsage`</b>,
+///                  \anchor System_SupportsCPUUsage
+///                  _boolean_,
+///     @return **True** if the system can provide CPU usage information.
+///     <p><hr>
+///     @skinning_v19 **[New Boolean Condition]** \link  System_SupportsCPUUsage ` System.SupportsCPUUsage`\endlink
+///     <p>
+///   }
 const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACTIVE },
                                   { "hasmediadvd",      SYSTEM_MEDIA_DVD },
                                   { "hasmediaaudiocd",  SYSTEM_MEDIA_AUDIO_CD },
@@ -1696,7 +1704,8 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "stereoscopicmode", SYSTEM_STEREOSCOPIC_MODE },
                                   { "hascms",           SYSTEM_HAS_CMS },
                                   { "privacypolicy",    SYSTEM_PRIVACY_POLICY },
-                                  { "haspvraddon",      SYSTEM_HAS_PVR_ADDON }};
+                                  { "haspvraddon",      SYSTEM_HAS_PVR_ADDON },
+                                  { "supportscpuusage", SYSTEM_SUPPORTS_CPU_USAGE }};
 
 /// \page modules__infolabels_boolean_conditions
 ///   \table_row3{   <b>`System.HasAddon(id)`</b>,
@@ -1708,9 +1717,9 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`System.AddonIsEnabled(id)`</b>,
-///                  \anchor AddonIsEnabled
+///                  \anchor System_AddonIsEnabled
 ///                  _boolean_,
-///     @return **True** if the specified addon is enabled on the system..
+///     @return **True** if the specified addon is enabled on the system.
 ///     @param id - The addon Id
 ///     <p><hr>
 ///     @skinning_v19 **[New Boolean Condition]** \link System_AddonIsEnabled `System.AddonIsEnabled(id)`\endlink

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -104,6 +104,7 @@
 #define SYSTEM_MEDIA_DVD            127
 #define SYSTEM_DVDREADY             128
 #define SYSTEM_HAS_ALARM            129
+#define SYSTEM_SUPPORTS_CPU_USAGE   130
 #define SYSTEM_SCREEN_MODE          132
 #define SYSTEM_SCREEN_WIDTH         133
 #define SYSTEM_SCREEN_HEIGHT        134

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -71,11 +71,14 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
       text = StringUtils::Format("%i%%", m_fanSpeed * 2);
       break;
     case SYSTEM_CPU_USAGE:
+      if (CServiceBroker::GetCPUInfo()->SupportsCPUUsage())
 #if defined(TARGET_DARWIN) || defined(TARGET_WINDOWS)
-      text = StringUtils::Format("%d%%", CServiceBroker::GetCPUInfo()->GetUsedPercentage());
+        text = StringUtils::Format("%d%%", CServiceBroker::GetCPUInfo()->GetUsedPercentage());
 #else
-      text = StringUtils::Format("%s", CServiceBroker::GetCPUInfo()->GetCoresUsageString().c_str());
+        text = CServiceBroker::GetCPUInfo()->GetCoresUsageString();
 #endif
+      else
+        text = g_localizeStrings.Get(10005); // Not available
       break;
   }
   return text;
@@ -621,6 +624,9 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     }
     case SYSTEM_HAS_ALARM:
       value = g_alarmClock.HasAlarm(info.GetData3());
+      return true;
+    case SYSTEM_SUPPORTS_CPU_USAGE:
+      value = CServiceBroker::GetCPUInfo()->SupportsCPUUsage();
       return true;
     case SYSTEM_GET_BOOL:
       value = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(info.GetData3());

--- a/xbmc/platform/android/CPUInfoAndroid.h
+++ b/xbmc/platform/android/CPUInfoAndroid.h
@@ -18,6 +18,7 @@ public:
   CCPUInfoAndroid();
   ~CCPUInfoAndroid() = default;
 
+  bool SupportsCPUUsage() const override { return false; }
   int GetUsedPercentage() override { return 0; }
   float GetCPUFrequency() override { return 0; }
 };

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -38,21 +38,24 @@ std::string CCPUInfo::GetCoresUsageString() const
 {
   std::string strCores;
 
-  if (!m_cores.empty())
+  if (SupportsCPUUsage())
   {
-    for (const auto& core : m_cores)
+    if (!m_cores.empty())
     {
-      if (!strCores.empty())
-        strCores += ' ';
-      if (core.m_usagePercent < 10.0)
-        strCores += StringUtils::Format("#%d: %1.1f%%", core.m_id, core.m_usagePercent);
-      else
-        strCores += StringUtils::Format("#%d: %3.0f%%", core.m_id, core.m_usagePercent);
+      for (const auto& core : m_cores)
+      {
+        if (!strCores.empty())
+          strCores += ' ';
+        if (core.m_usagePercent < 10.0)
+          strCores += StringUtils::Format("#%d: %1.1f%%", core.m_id, core.m_usagePercent);
+        else
+          strCores += StringUtils::Format("#%d: %3.0f%%", core.m_id, core.m_usagePercent);
+      }
     }
-  }
-  else
-  {
-    strCores += StringUtils::Format("%3.0f%%", double(m_lastUsedPercentage));
+    else
+    {
+      strCores += StringUtils::Format("%3.0f%%", static_cast<double>(m_lastUsedPercentage));
+    }
   }
 
   return strCores;

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -75,6 +75,8 @@ public:
 
   static std::shared_ptr<CCPUInfo> GetCPUInfo();
 
+  virtual bool SupportsCPUUsage() const { return true; }
+
   virtual int GetUsedPercentage() = 0;
   virtual float GetCPUFrequency() = 0;
   virtual bool GetTemperature(CTemperature& temperature) = 0;

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -94,7 +94,11 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     KODI::MEMORY::MemoryStatus stat;
     KODI::MEMORY::GetMemoryStatus(&stat);
     std::string profiling = CGUIControlProfiler::IsRunning() ? " (profiling)" : "";
-    std::string strCores = CServiceBroker::GetCPUInfo()->GetCoresUsageString();
+    std::string strCores;
+    if (CServiceBroker::GetCPUInfo()->SupportsCPUUsage())
+      strCores = CServiceBroker::GetCPUInfo()->GetCoresUsageString();
+    else
+      strCores = "N/A";
     std::string lcAppName = CCompileInfo::GetAppName();
     StringUtils::ToLower(lcAppName);
 #if !defined(TARGET_POSIX)


### PR DESCRIPTION
Recent Android versions do not provide an API to obtain CPU usage information. Before this PR, it looked like this in Kodi GUI:

![112419131521](https://user-images.githubusercontent.com/3226626/69500358-b769d280-0efa-11ea-8e93-191d01c73fc9.png)
![112419131626](https://user-images.githubusercontent.com/3226626/69500359-b769d280-0efa-11ea-9d4c-805d1d4e9177.png)

This PR modifies `CCPUIInfo`, `CSystemGUIInfo` and the Estuary skin to show CPU usage information only if supported by the underlying system. `CGUIWindowDebugInfo` will display "N/A" if no CPU usage info is available.

@ronie: I added a new guiinfo bool. Could you please announce it in the forum after this PR got merged?