### PR TITLE
[scrapers] Pass path settings to Python scrapers as JSON

### DIFF
--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -95,6 +95,14 @@ public:
    */
   std::string GetPathSettings();
 
+  /*! \brief Get the scraper settings for a particular path in the form of a JSON string
+   Loads the default and user settings (if not already loaded) and returns the user settings in the
+   form of an JSON string. It is used in Python scrapers.
+   \return a string containing the JSON settings
+   \sa SetPathSettings
+   */
+  std::string GetPathSettingsAsJSON();
+
   /*! \brief Clear any previously cached results for this scraper
    Any previously cached files are cleared if they have been cached for longer than the specified
    cachepersistence.


### PR DESCRIPTION
## Description
This PR fixes the issue with Python scrapers not being able to access path-specific settings for different media sources.

## Motivation and Context
Currently Python scrapers do not have access to path-specific settings for different media sources that makes them less functional than XML-based scrapers. This PR addresses this issue by passing path-specific settings to Python scrapers via `pathSettings` parameter in a plugin call URL as a JSON object. Then path-specific settings can be accessed from Python code as the following:
```python
import sys
import json
from urllib.parse import parse_qsl

params = dict(parse_qsl(sys.argv[2][1:]))
path_settings = json.loads(params['pathSettings'])
```


## How Has This Been Tested?
The code was compiled on Ubuntu 18.04 and tested with different path-specific settings with a Python scraper (TVMaze scraper with fake settings.xml was used).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
