### PR TITLE
Sinks (Pulse / AudioTrack): Fix drain

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -792,6 +792,7 @@ void CAESinkAUDIOTRACK::Drain()
 
   CLog::Log(LOGDEBUG, "Draining Audio");
   m_at_jni->stop();
+  m_at_jni->pause();
   m_duration_written = 0;
   m_headPos = 0;
   m_linearmovingaverage.clear();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -545,10 +545,9 @@ void CAESinkAUDIOTRACK::Deinitialize()
   if (!m_at_jni)
     return;
 
-  uint64_t before = CurrentHostCounter();
   if (IsInitialized())
   {
-    m_at_jni->stop();
+    m_at_jni->pause();
     m_at_jni->flush();
   }
   m_at_jni->release();
@@ -560,14 +559,6 @@ void CAESinkAUDIOTRACK::Deinitialize()
 
   delete m_at_jni;
   m_at_jni = NULL;
-  uint64_t gone = CurrentHostCounter() - before;
-  uint64_t delta_ms = 1000 * gone / CurrentHostFrequency();
-  int64_t diff = m_audiotrackbuffer_sec * 1000 - delta_ms;
-  if (diff > 0)
-  {
-    CLog::Log(LOGDEBUG, "Flushing might not be properly implemented, sleeping: %d ms", diff);
-    usleep(diff * 1000);
-  }
   m_delay = 0.0;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -1151,6 +1151,8 @@ void CAESinkPULSE::Drain()
 
   pa_threaded_mainloop_lock(m_MainLoop);
   WaitForOperation(pa_stream_drain(m_Stream, NULL, NULL), m_MainLoop, "Drain");
+  WaitForOperation(pa_stream_cork(m_Stream, 1, NULL, NULL), m_MainLoop, "Pause");
+  m_IsStreamPaused = true;
   pa_threaded_mainloop_unlock(m_MainLoop);
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -1035,7 +1035,12 @@ void CAESinkPULSE::Deinitialize()
   m_maxLatency = 0.0;
 
   if (m_Stream)
-    Drain();
+  {
+    CSingleExit exit(m_sec);
+    pa_threaded_mainloop_lock(m_MainLoop);
+    WaitForOperation(pa_stream_flush(m_Stream, NULL, NULL), m_MainLoop, "Flush");
+    pa_threaded_mainloop_unlock(m_MainLoop);
+  }
 
   {
     CSingleExit exit(m_sec);


### PR DESCRIPTION
When draining the sink (on seek, stop, etc.) we playout all samples. To not run into an underrun, let's cork / pause the stream afterwards.

On ALSA this is already implemented with: https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html#ga788d05de75f2d536f8443cb0306754d0