### PR TITLE
[Visualizations] Prevent NULL/zero-length packets from being processed

### DIFF
--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -242,7 +242,7 @@ void CGUIVisualisationControl::OnInitialize(int channels, int samplesPerSec, int
 
 void CGUIVisualisationControl::OnAudioData(const float* audioData, unsigned int audioDataLength)
 {
-  if (!m_instance || !m_alreadyStarted)
+  if (!m_instance || !m_alreadyStarted || !audioData || audioDataLength == 0)
     return;
 
   // Save our audio data in the buffers


### PR DESCRIPTION
## Description
Second attempt to provide a reasonable quick-fix for Issue [19649](https://github.com/xbmc/xbmc/issues/16949).  Some circumstances (audio MUTE, audio ADJUST) can cause a packet with zero samples to be passed to a loaded Visualization, which can cause that Visualization to enter an infinite loop.

## Motivation and Context
The interface contract for Visualizations (\xbmc\addons\kodi-addon-dev-kit\include\kodi\addon-instance\Visualization.h) does not indicate that the **audioData** and **audioDataLength** parameters passed into the **AudioData()** callback may be NULL and/or zero-length respectively on input.

Preventing these conditions from being passed into the loaded Visualization module resolves Issue [19649](https://github.com/xbmc/xbmc/issues/16949) without any changes to how audio is currently processed in Kodi.

## How Has This Been Tested?
Tested on Kodi 18.4 Leia, 18.5 Leia, and a recent Matrix nightly on Windows x64.  Prior to the change, the Issue described in [19649](https://github.com/xbmc/xbmc/issues/16949) was easily replicated.  After the change the attached Visualization never received the packet with zero samples and never entered an infinite loop.

Steps to reproduce and sample file are available in Issue [19649](https://github.com/xbmc/xbmc/issues/16949).

## Screenshots (if appropriate):
N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
