### PR TITLE
[videolibrary] Add setting movie set information folder

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12566,7 +12566,13 @@ msgctxt "#20225"
 msgid "Where no local album cover exists, online art will be used. Where neither is available, cover images embedded in music files will be used"
 msgstr ""
 
-#empty strings from id 20226 to 20227
+#: system/settings/settings.xml
+#: xbmc/music/dialogs/GUIDialogVideoInfo.cpp
+msgctxt "#20226"
+msgid "Movie set information folder"
+msgstr ""
+
+#empty string id 20227
 
 #: system/settings/settings.xml
 msgctxt "#20228"
@@ -19155,7 +19161,16 @@ msgctxt "#36299"
 msgid "Switch display into HDR mode if media with HDR information is played.\nIf disabled, HDR information are applied using Kodi's internal HDR path."
 msgstr ""
 
-#empty strings from id 36300 to 36301
+#. Description of setting with label #20226 "Movie set information folder"
+#: system/settings/settings.xml
+msgctxt "#36300"
+msgid "Select the folder where movie set information (images) are saved locally."
+msgstr ""
+
+#: xbmc/interfaces/builtins/LibraryBuiltins.cpp
+msgctxt "#36301"
+msgid "No 'Movie set information folder' is configured to store movie set images so they will not be exported. Do you want to proceed?"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36302"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -989,6 +989,16 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.moviesetsfolder" type="path" label="20226" help="36300">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
+        </setting>
       </group>
     </category>
     <category id="music" label="14216" help="38108">

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -20,6 +20,8 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "music/MusicLibraryQueue.h"
 #include "settings/LibExportSettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -107,6 +109,20 @@ static int ExportLibrary(const std::vector<std::string>& params)
       HELPERS::DialogResponse result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{20430});
       cancelled = result == HELPERS::DialogResponse::CANCELLED;
       thumbs = result == HELPERS::DialogResponse::YES;
+    }
+  }
+
+  if (cancelled)
+    return -1;
+
+  if (thumbs && !singleFile && StringUtils::EqualsNoCase(params[0], "video"))
+  {
+    std::string movieSetsInfoPath = CServiceBroker::GetSettingsComponent()->GetSettings()->
+        GetString(CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER);
+    if (movieSetsInfoPath.empty())
+    {
+      auto result = HELPERS::ShowYesNoDialogText(CVariant{iHeading}, CVariant{36301});
+      cancelled = result != HELPERS::DialogResponse::YES;
     }
   }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -114,6 +114,7 @@ const std::string CSettings::SETTING_VIDEOLIBRARY_CLEANUP = "videolibrary.cleanu
 const std::string CSettings::SETTING_VIDEOLIBRARY_EXPORT = "videolibrary.export";
 const std::string CSettings::SETTING_VIDEOLIBRARY_IMPORT = "videolibrary.import";
 const std::string CSettings::SETTING_VIDEOLIBRARY_SHOWEMPTYTVSHOWS = "videolibrary.showemptytvshows";
+const std::string CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER = "videolibrary.moviesetsfolder";
 const std::string CSettings::SETTING_LOCALE_AUDIOLANGUAGE = "locale.audiolanguage";
 const std::string CSettings::SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG = "videoplayer.preferdefaultflag";
 const std::string CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM = "videoplayer.autoplaynextitem";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -80,6 +80,7 @@ public:
   static const std::string SETTING_VIDEOLIBRARY_EXPORT;
   static const std::string SETTING_VIDEOLIBRARY_IMPORT;
   static const std::string SETTING_VIDEOLIBRARY_SHOWEMPTYTVSHOWS;
+  static const std::string SETTING_VIDEOLIBRARY_MOVIESETSFOLDER;
   static const std::string SETTING_LOCALE_AUDIOLANGUAGE;
   static const std::string SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG;
   static const std::string SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1432,6 +1432,52 @@ namespace VIDEO
     return type;
   }
 
+  std::string CVideoInfoScanner::GetMovieSetInfoFolder(const std::string& setTitle)
+  {
+    if (setTitle.empty())
+      return "";
+    std::string path = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+        CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER);
+    if (path.empty())
+      return "";
+    path = URIUtils::AddFileToFolder(path, CUtil::MakeLegalFileName(setTitle, LEGAL_WIN32_COMPAT));
+    CLog::Log(LOGDEBUG,
+        "VideoInfoScanner: Looking for local artwork for movie set '{}' in folder '{}'",
+        setTitle,
+        CURL::GetRedacted(path));
+    return CDirectory::Exists(path) ? path : "";
+  }
+
+  void CVideoInfoScanner::GetLocalMovieSetArtwork(CGUIListItem::ArtMap& art,
+      const std::vector<std::string>& artTypes, const std::string& setTitle)
+  {
+    std::string path = GetMovieSetInfoFolder(setTitle);
+    if (path.empty())
+      return;
+
+    CFileItemList availableArtFiles;
+    CDirectory::GetDirectory(path, availableArtFiles,
+        CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+        DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+
+    for (const auto& artFile : availableArtFiles)
+    {
+      std::string candidate = URIUtils::GetFileName(artFile->GetPath());
+      URIUtils::RemoveExtension(candidate);
+      for (const auto& artType : artTypes)
+      {
+        if (!StringUtils::StartsWith(artType, "set."))
+          continue;
+        std::string realType = artType.substr(4);
+        if (StringUtils::EqualsNoCase(candidate, realType))
+        {
+          art[artType] = artFile->GetPath();
+          break;
+        }
+      }
+    }
+  }
+
   void CVideoInfoScanner::GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir, bool useLocal, const std::string &actorArtPath)
   {
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
@@ -1444,7 +1490,8 @@ namespace VIDEO
     std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(ContentToMediaType(content, pItem->m_bIsFolder));
     bool lookForThumb = find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end() &&
                         art.find("thumb") == art.end();
-    if (content == CONTENT_MOVIES)
+    bool moviePartOfSet = content == CONTENT_MOVIES && !movieDetails.m_set.title.empty();
+    if (moviePartOfSet)
     {
       for (std::string artType : CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection))
         artTypes.push_back("set." + artType);
@@ -1461,6 +1508,8 @@ namespace VIDEO
             art.insert(std::make_pair(*i, image));
         }
       }
+      if (moviePartOfSet)
+        GetLocalMovieSetArtwork(art, artTypes, movieDetails.m_set.title);
       // find and classify the local thumb (backcompat) if available
       if (lookForThumb)
       {

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -101,6 +101,8 @@ namespace VIDEO
 
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
 
+    static std::string GetMovieSetInfoFolder(const std::string& setTitle);
+
   protected:
     virtual void Process();
     bool DoScan(const std::string& strDirectory) override;
@@ -231,6 +233,10 @@ namespace VIDEO
     CVideoDatabase m_database;
     std::set<std::string> m_pathsToCount;
     std::set<int> m_pathsToClean;
+
+  private:
+    void GetLocalMovieSetArtwork(CGUIListItem::ArtMap& art,
+        const std::vector<std::string>& artTypes, const std::string& setTitle);
   };
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -41,6 +41,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "storage/MediaManager.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
@@ -1118,13 +1119,14 @@ std::string CGUIDialogVideoInfo::GetThumbnail() const
   return m_movieItem->GetArt("thumb");
 }
 
-void CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item)
+namespace
+{
+std::string GetItemPathForBrowserSource(const CFileItem& item)
 {
   if (!item.HasVideoInfoTag())
-    return;
+    return "";
 
   std::string itemDir = item.GetVideoInfoTag()->m_basePath;
-
   //season
   if (itemDir.empty())
     itemDir = item.GetVideoInfoTag()->GetPath();
@@ -1133,13 +1135,27 @@ void CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, c
   if (itemTmp.IsVideo())
     itemDir = URIUtils::GetParentPath(itemDir);
 
+  return itemDir;
+}
+
+void AddItemPathStringToFileBrowserSources(VECSOURCES& sources,
+    const std::string& itemDir, const std::string& label)
+{
   if (!itemDir.empty() && CDirectory::Exists(itemDir))
   {
     CMediaSource itemSource;
-    itemSource.strName = g_localizeStrings.Get(36041);
+    itemSource.strName = label;
     itemSource.strPath = itemDir;
     sources.push_back(itemSource);
   }
+}
+} // namespace
+
+void CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(VECSOURCES& sources,
+    const CFileItem& item)
+{
+  std::string itemDir = GetItemPathForBrowserSource(item);
+  AddItemPathStringToFileBrowserSources(sources, itemDir, g_localizeStrings.Get(36041));
 }
 
 int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
@@ -1840,6 +1856,29 @@ bool CGUIDialogVideoInfo::RemoveItemsFromTag(const CFileItemPtr &tagItem)
   return true;
 }
 
+namespace
+{
+std::string FindLocalMovieSetArtworkFile(const CFileItemPtr& item, const std::string& artType)
+{
+  std::string infoFolder = VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(item->GetLabel());
+  if (infoFolder.empty())
+    return "";
+
+  CFileItemList availableArtFiles;
+  CDirectory::GetDirectory(infoFolder, availableArtFiles,
+      CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+      DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+  for (const auto& artFile : availableArtFiles)
+  {
+    std::string candidate = URIUtils::GetFileName(artFile->GetPath());
+    URIUtils::RemoveExtension(candidate);
+    if (StringUtils::EqualsNoCase(candidate, artType))
+      return artFile->GetPath();
+  }
+  return "";
+}
+} // namespace
+
 bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const MediaType &type)
 {
   if (item == nullptr || !item->HasVideoInfoTag() || type.empty())
@@ -1885,7 +1924,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
     if (artType.empty())
       return false;
 
-    if (artType == "fanart")
+    if (artType == "fanart" && type != MediaTypeVideoCollection)
       return OnGetFanart(item);
 
     if (item->HasArt(artType))
@@ -1920,15 +1959,12 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
       std::string baseDir = StringUtils::Format("videodb://movies/sets/%d", item->GetVideoInfoTag()->m_iDbId);
       if (videodb.GetMoviesNav(baseDir, items))
       {
-        std::vector<std::string> allMovieThumbs;
         for (int i=0; i < items.Size(); i++)
         {
           CVideoInfoTag* pTag = items[i]->GetVideoInfoTag();
           pTag->m_strPictureURL.Parse();
-          pTag->m_strPictureURL.GetThumbURLs(allMovieThumbs, artType);
           pTag->m_strPictureURL.GetThumbURLs(thumbs, "set." + artType, -1, true);
         }
-        std::copy(allMovieThumbs.begin(), allMovieThumbs.end(), std::back_inserter(thumbs));
       }
     }
     else
@@ -1966,7 +2002,19 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
     }
 
     if (type == MediaTypeVideoCollection)
-      noneitem->SetArt("icon", "DefaultVideo.png");
+    {
+      std::string localFile = FindLocalMovieSetArtworkFile(item, artType);
+      if (!localFile.empty())
+      {
+        CFileItemPtr pItem(new CFileItem(localFile, false));
+        pItem->SetLabel(g_localizeStrings.Get(13514));
+        pItem->SetArt("thumb", localFile);
+        items.Add(pItem);
+        local = true;
+      }
+      else
+        noneitem->SetArt("icon", "DefaultVideo.png");
+    }
   }
   else
   {
@@ -2003,7 +2051,18 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
   std::string result;
   VECSOURCES sources=*CMediaSourceSettings::GetInstance().GetSources("video");
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
-  AddItemPathToFileBrowserSources(sources, *item);
+  if (type == MediaTypeVideoCollection)
+  {
+    AddItemPathStringToFileBrowserSources(sources,
+        VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(item->GetLabel()),
+        g_localizeStrings.Get(36041));
+    AddItemPathStringToFileBrowserSources(sources,
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+            CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER),
+        "* " + g_localizeStrings.Get(20226));
+  }
+  else
+    AddItemPathToFileBrowserSources(sources, *item);
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result))
     return false;   // user cancelled
 
@@ -2177,49 +2236,6 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
     items.Add(itemCurrent);
   }
 
-  std::vector<std::string> thumbs;
-  if (videoItem->GetVideoInfoTag()->m_type == MediaTypeVideoCollection)
-  {
-    CFileItemList movies;
-    std::string baseDir = StringUtils::Format("videodb://movies/sets/%d", videoItem->GetVideoInfoTag()->m_iDbId);
-    if (videodb.GetMoviesNav(baseDir, movies))
-    {
-      int iFanart = 0;
-      for (int i=0; i < movies.Size(); i++)
-      {
-        movies[i]->GetVideoInfoTag()->m_strPictureURL.Parse();
-        movies[i]->GetVideoInfoTag()->m_strPictureURL.GetThumbURLs(thumbs, "set.fanart", -1, true);
-      }
-      for (auto &fanart : thumbs)
-      {
-        CFileItemPtr item(new CFileItem(StringUtils::Format("fanart://Remote{0}", iFanart++), false));
-        item->SetArt("thumb", fanart);
-        item->SetArt("icon", "DefaultPicture.png");
-        item->SetLabel(g_localizeStrings.Get(20441)); // "Remote fanart"
-        items.Add(item);
-      }
-      for (int i=0; i < movies.Size(); i++)
-      {
-        // ensure the fanart is unpacked
-        movies[i]->GetVideoInfoTag()->m_fanart.Unpack();
-
-        // Grab the thumbnails from the web
-        for (unsigned int j = 0; j < movies[i]->GetVideoInfoTag()->m_fanart.GetNumFanarts(); j++)
-        {
-          std::string strItemPath = StringUtils::Format("fanart://Remote%i",iFanart++);
-          CFileItemPtr item(new CFileItem(strItemPath, false));
-          std::string thumb = movies[i]->GetVideoInfoTag()->m_fanart.GetPreviewURL(j);
-          item->SetArt("thumb", CTextureUtils::GetWrappedThumbURL(thumb));
-          item->SetArt("icon", "DefaultPicture.png");
-          item->SetLabel(g_localizeStrings.Get(20441));
-          thumbs.push_back(movies[i]->GetVideoInfoTag()->m_fanart.GetImageURL(j));
-
-          items.Add(item);
-        }
-      }
-    }
-  }
-
   // add the none option
   {
     CFileItemPtr itemNone(new CFileItem("fanart://None", false));
@@ -2237,11 +2253,6 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
       StringUtils::EqualsNoCase(result, "fanart://Current"))
     return false;
 
-  if (StringUtils::StartsWith(result, "fanart://Remote"))
-  {
-    int iFanart = atoi(result.substr(15).c_str());
-    result = thumbs[iFanart];
-  }
   else if (StringUtils::EqualsNoCase(result, "fanart://None") || !CFile::Exists(result))
     result.clear();
   if (!result.empty() && flip)


### PR DESCRIPTION
## Description
Add a "movie set information folder" setting to store artwork locally. Inspired by the artist information folder introduced in #12891.

For anyone familiar with Artwork Beef or the older MSAA, this only supports one layout for artwork like the "artist information folder" - the folder named as the collection title, and the artwork files inside exactly named as the artwork type in the library.

## Motivation and Context
Movie sets don't always have a single obvious place in a file system for artwork and other information to live. Now they do. This PR only supports artwork files.

The second commit stops assigning movie artwork to movie sets when there is no movie set artwork. This is less likely to happen now that they can be set from scrapers and local art, so we can treat them like other media types and simplify a bit.

Another commit exports cached movie set artwork to this folder when exporting the library to "separate files", much like other media artwork is exported next to the media. Exporting and importing to a "single file" is also supported.

## How Has This Been Tested?
Runtime tested.

## Screenshots (if appropriate):
Example file / folder layout.
![image](https://user-images.githubusercontent.com/260815/69696885-47944d00-109e-11ea-9918-0cc514ed5c00.png)

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)

The wiki will need some updates - I intend to do a quick pass over that when this is merged.