### PR TITLE
[Android] Priorize timer instead HDMI_AUDIOPLUG on refreshrate switch

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -579,7 +579,8 @@ void CXBMCApp::SetRefreshRate(float rate)
   {
     m_displayChangeEvent.WaitMSec(5000);
     if (m_hdmiSource && g_application.GetAppPlayer().IsPlaying())
-      dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(false);
+      dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())
+          ->SetHDMIState(CWinSystemAndroid::HDMI_STATE_UNCONNECTED_TIMER);
   }
 }
 
@@ -607,7 +608,8 @@ void CXBMCApp::SetDisplayMode(int mode, float rate)
   {
     m_displayChangeEvent.WaitMSec(5000);
     if (m_hdmiSource && g_application.GetAppPlayer().IsPlaying())
-      dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())->SetHDMIState(false);
+      dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem())
+          ->SetHDMIState(CWinSystemAndroid::HDMI_STATE_UNCONNECTED_TIMER);
   }
 }
 
@@ -1022,7 +1024,9 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     {
       CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
       if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
-        dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHDMIState(m_hdmiPlugged);
+        dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHDMIState(
+            m_hdmiPlugged ? CWinSystemAndroid::HDMI_STATE_CONNECTED
+                          : CWinSystemAndroid::HDMI_STATE_UNCONNECTED);
     }
   }
   else if (action == "android.intent.action.SCREEN_OFF")

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -35,7 +35,7 @@ public:
   bool DestroyWindow() override;
   void UpdateResolutions() override;
 
-  void SetHDMIState(bool connected);
+  void SetHDMIState(uint8_t state);
 
   void UpdateDisplayModes();
 
@@ -52,6 +52,13 @@ public:
   bool MessagePump() override;
   bool IsHDRDisplay() override;
 
+  enum HDMISTATE : uint8_t
+  {
+    HDMI_STATE_UNCONNECTED = 0,
+    HDMI_STATE_CONNECTED = 1,
+    HDMI_STATE_UNCONNECTED_TIMER = 2,
+  };
+
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
   void OnTimeout() override;
@@ -66,14 +73,13 @@ protected:
 
   RENDER_STEREO_MODE m_stereo_mode;
 
-  enum RESETSTATE
+  enum RESETSTATE : uint8_t
   {
-    RESET_NOTWAITING,
-    RESET_WAITTIMER,
-    RESET_WAITEVENT
+    RESET_WAIT_TIMER = 1U << 0,
+    RESET_WAIT_HDMIPLUG = 1U << 1,
   };
 
-  RESETSTATE m_dispResetState;
+  uint8_t m_dispResetState;
   CTimer *m_dispResetTimer;
 
   CCriticalSection m_resourceSection;


### PR DESCRIPTION
## Description
In the current implementation a display mode change is finished, if the android device implements HDMI_AUDIO_PLUG event and if this intent arrives with state "connected", regardless what "delay after refreshrate" is set in kodi system settings.

This PR changes the behaviour in a way that timer has higher priority and the end of the mode switch is when the timer expires.

## Motivation and Context
Users need the timer because of:
- HDCP issues on NVIDIA Shield TV (OS 8.0.1+)
- Multi - HDMI connections (Box -> AVR -> TV)
- ...

## How Has This Been Tested?
Tested on "broken" NVIDIA Shield TV 8.0.1 playing DRM secure, which requires HDCP.
- Without this PR Vide starts, after about 2 seconds HDCP screen pops up and playback refuses
- With this PR and set delay to 5 seconds, stream starts later, but HDCP errors disappear.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
