### PR TITLE
add Library.HasNode infobool

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -8528,6 +8528,14 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 ///     @skinning_v19 **[New Boolean Condition]** \link Library_HasContent_Boxsets `Library.HasContent(boxsets)`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Library.HasNode(path)`</b>,
+///                  \anchor Library_HasNode
+///                  _boolean_,
+///     @return **True** if there the node is present in the library.
+///     <p><hr>
+///     @skinning_v19 **[New Boolean Condition]** \link Library_HasNode `Library.HasNode(path)`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
@@ -8946,6 +8954,12 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           return LIBRARY_HAS_BOXSETS;
         else if (cat == "role" && prop.num_params() > 1)
           return AddMultiInfo(CGUIInfo(LIBRARY_HAS_ROLE, prop.param(1), 0));
+      }
+      else if (prop.name == "hasnode" && prop.num_params())
+      {
+        std::string node = prop.param(0);
+        StringUtils::ToLower(node);
+        return AddMultiInfo(CGUIInfo(LIBRARY_HAS_NODE, prop.param(), 0));
       }
     }
     else if (cat.name == "musicplayer")

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -420,6 +420,7 @@
 #define LIBRARY_IS_SCANNING_MUSIC   730
 #define LIBRARY_HAS_ROLE            735
 #define LIBRARY_HAS_BOXSETS         736
+#define LIBRARY_HAS_NODE            737
 
 #define SYSTEM_PLATFORM_LINUX       741
 #define SYSTEM_PLATFORM_WINDOWS     742

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -9,10 +9,16 @@
 #include "guilib/guiinfo/LibraryGUIInfo.h"
 
 #include "Application.h"
+#include "ServiceBroker.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "music/MusicDatabase.h"
+#include "profiles/ProfileManager.h"
+#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
 
 using namespace KODI::GUILIB::GUIINFO;
@@ -240,6 +246,23 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
         }
       }
       value = artistcount > 0;
+      return true;
+    }
+    case LIBRARY_HAS_NODE:
+    {
+      const CURL url(info.GetData3());
+      const std::shared_ptr<CProfileManager> profileManager =
+            CServiceBroker::GetSettingsComponent()->GetProfileManager();
+      CFileItemList items;
+
+      std::string libDir = profileManager->GetLibraryFolder();
+      XFILE::CDirectory::GetDirectory(libDir, items, "", XFILE::DIR_FLAG_NO_FILE_DIRS);
+      if (items.Size() == 0)
+        libDir = "special://xbmc/system/library/";
+
+      std::string nodePath = URIUtils::AddFileToFolder(libDir, url.GetHostName() + "/");
+      nodePath = URIUtils::AddFileToFolder(nodePath, url.GetFileName());
+      value = XFILE::CFile::Exists(nodePath);
       return true;
     }
     case LIBRARY_IS_SCANNING:


### PR DESCRIPTION
xml based library nodes were added many moons ago.
however, most skins still use the builtin videodb:// and musicdb:// paths.

the main reason for not adopting xml based nodes is the lack of a way to check if a xml node may have been deleted.
this PR adds a Library.HasNode() infobool, which will return true if a xml node exists


skinning example: `<visible>Library.HasNode(library://video/movies/titles.xml)</visible>`