### PR TITLE
[skins] adjustments to support xml based library nodes

### DIFF
--- a/addons/skin.estouchy/xml/Home.xml
+++ b/addons/skin.estouchy/xml/Home.xml
@@ -16,7 +16,7 @@
 			<posy>10</posy>
 			<include>Window_OpenClose_Animation</include>
 			<animation effect="slide" start="0,0" end="250,0" time="0" condition="String.IsEqual(Skin.AspectRatio,4:3)">Conditional</animation>
-			<visible>[Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml/)] | [Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml/)] | [Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml/)] | Integer.IsGreater(Container(2400).NumItems,0)</visible>
+			<visible>[Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml)] | [Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml)] | [Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml)] | Integer.IsGreater(Container(2400).NumItems,0)</visible>
 			<control type="button">
 				<posx>0</posx>
 				<posy>120</posy>
@@ -107,7 +107,7 @@
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>
-						<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml/)</visible>
+						<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml)</visible>
 					</item>
 					<item id="2">
 						<label>$LOCALIZE[31011][CR]$LOCALIZE[31014]</label>
@@ -115,7 +115,7 @@
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>
-						<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml/)</visible>
+						<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml)</visible>
 					</item>
 					<item id="3">
 						<label>$LOCALIZE[31011][CR]$LOCALIZE[31016]</label>
@@ -123,7 +123,7 @@
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>
-						<visible>Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml/)</visible>
+						<visible>Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml)</visible>
 					</item>
 					<item id="4">
 						<label>24001</label>

--- a/addons/skin.estouchy/xml/Home.xml
+++ b/addons/skin.estouchy/xml/Home.xml
@@ -16,7 +16,7 @@
 			<posy>10</posy>
 			<include>Window_OpenClose_Animation</include>
 			<animation effect="slide" start="0,0" end="250,0" time="0" condition="String.IsEqual(Skin.AspectRatio,4:3)">Conditional</animation>
-			<visible>Library.HasContent(Movies) | Library.HasContent(TVShows) | Library.HasContent(Music) | Integer.IsGreater(Container(2400).NumItems,0)</visible>
+			<visible>[Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml/)] | [Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml/)] | [Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml/)] | Integer.IsGreater(Container(2400).NumItems,0)</visible>
 			<control type="button">
 				<posx>0</posx>
 				<posy>120</posy>
@@ -103,27 +103,31 @@
 				<content>
 					<item id="1">
 						<label>$LOCALIZE[31011][CR]$LOCALIZE[31013]</label>
+						<label2>item1</label2>
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>
-						<visible>Library.HasContent(Movies)</visible>
+						<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml/)</visible>
 					</item>
 					<item id="2">
 						<label>$LOCALIZE[31011][CR]$LOCALIZE[31014]</label>
+						<label2>item2</label2>
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>
-						<visible>Library.HasContent(TVShows)</visible>
+						<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml/)</visible>
 					</item>
 					<item id="3">
 						<label>$LOCALIZE[31011][CR]$LOCALIZE[31016]</label>
+						<label2>item3</label2>
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>
-						<visible>Library.HasContent(Music)</visible>
+						<visible>Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml/)</visible>
 					</item>
 					<item id="4">
 						<label>24001</label>
+						<label2>item4</label2>
 						<onclick>Control.Move(9010,1)</onclick>
 						<icon></icon>
 						<thumb></thumb>

--- a/addons/skin.estouchy/xml/Includes.xml
+++ b/addons/skin.estouchy/xml/Includes.xml
@@ -729,14 +729,14 @@
 						<label></label>
 						<onclick>ActivateWindow(Videos,MovieTitles,Return)</onclick>
 						<icon>icon_menu_movies.png</icon>
-						<visible>Library.HasContent(Movies)</visible>
+						<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/titles.xml/)</visible>
 						<visible>!Skin.HasSetting(HideHomeButtonMovies)</visible>
 					</item>
 					<item>
 						<label></label>
 						<onclick>ActivateWindow(Videos,TVShowTitles,Return)</onclick>
 						<icon>icon_menu_tvshows.png</icon>
-						<visible>Library.HasContent(TVShows)</visible>
+						<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/titles.xml/)</visible>
 						<visible>!Skin.HasSetting(HideHomeButtonTVShows)</visible>
 					</item>
 					<item>
@@ -881,7 +881,7 @@
 			<onclick>ActivateWindow(Videos,MovieTitles,Return)</onclick>
 			<icon>icon_menu_movies.png</icon>
 			<thumb></thumb>
-			<visible>Library.HasContent(Movies)</visible>
+			<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/titles.xml/)</visible>
 			<visible>!Skin.HasSetting(HideHomeButtonMovies)</visible>
 		</item>
 		<item>
@@ -889,7 +889,7 @@
 			<onclick>ActivateWindow(Videos,TVShowTitles,Return)</onclick>
 			<icon>icon_menu_tvshows.png</icon>
 			<thumb></thumb>
-			<visible>Library.HasContent(TVShows)</visible>
+			<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/titles.xml/)</visible>
 			<visible>!Skin.HasSetting(HideHomeButtonTVShows)</visible>
 		</item>
 		<item>

--- a/addons/skin.estouchy/xml/Includes.xml
+++ b/addons/skin.estouchy/xml/Includes.xml
@@ -729,14 +729,14 @@
 						<label></label>
 						<onclick>ActivateWindow(Videos,MovieTitles,Return)</onclick>
 						<icon>icon_menu_movies.png</icon>
-						<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/titles.xml/)</visible>
+						<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/titles.xml)</visible>
 						<visible>!Skin.HasSetting(HideHomeButtonMovies)</visible>
 					</item>
 					<item>
 						<label></label>
 						<onclick>ActivateWindow(Videos,TVShowTitles,Return)</onclick>
 						<icon>icon_menu_tvshows.png</icon>
-						<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/titles.xml/)</visible>
+						<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/titles.xml)</visible>
 						<visible>!Skin.HasSetting(HideHomeButtonTVShows)</visible>
 					</item>
 					<item>
@@ -881,7 +881,7 @@
 			<onclick>ActivateWindow(Videos,MovieTitles,Return)</onclick>
 			<icon>icon_menu_movies.png</icon>
 			<thumb></thumb>
-			<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/titles.xml/)</visible>
+			<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/titles.xml)</visible>
 			<visible>!Skin.HasSetting(HideHomeButtonMovies)</visible>
 		</item>
 		<item>
@@ -889,7 +889,7 @@
 			<onclick>ActivateWindow(Videos,TVShowTitles,Return)</onclick>
 			<icon>icon_menu_tvshows.png</icon>
 			<thumb></thumb>
-			<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/titles.xml/)</visible>
+			<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/titles.xml)</visible>
 			<visible>!Skin.HasSetting(HideHomeButtonTVShows)</visible>
 		</item>
 		<item>

--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -18,7 +18,7 @@
 				<width>630</width>
 				<height>660</height>
 				<control type="panel" id="2100">
-					<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml/) + String.IsEqual(Container(9010).ListItem.Label2,item1)</visible>
+					<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml) + String.IsEqual(Container(9010).ListItem.Label2,item1)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />
@@ -110,7 +110,7 @@
 					<content target="movies" limit="10">library://video/movies/recentlyaddedmovies.xml/</content>
 				</control>
 				<control type="panel" id="2200">
-					<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml/) + String.IsEqual(Container(9010).ListItem.Label2,item2)</visible>
+					<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml) + String.IsEqual(Container(9010).ListItem.Label2,item2)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />
@@ -229,7 +229,7 @@
 					<content target="video" limit="12">library://video/tvshows/recentlyaddedepisodes.xml/</content>
 				</control>
 				<control type="panel" id="2300">
-					<visible>Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml/) + String.IsEqual(Container(9010).ListItem.Label2,item3)</visible>
+					<visible>Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml) + String.IsEqual(Container(9010).ListItem.Label2,item3)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />

--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -18,7 +18,7 @@
 				<width>630</width>
 				<height>660</height>
 				<control type="panel" id="2100">
-					<visible>Library.HasContent(Movies) + Container(9010).HasFocus(1)</visible>
+					<visible>Library.HasContent(Movies) + Library.HasNode(library://video/movies/recentlyaddedmovies.xml/) + String.IsEqual(Container(9010).ListItem.Label2,item1)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />
@@ -107,10 +107,10 @@
 							<texture border="5">thumb_focus.png</texture>
 						</control>
 					</focusedlayout>
-				<content target="movies" limit="10">videodb://recentlyaddedmovies/</content>
+					<content target="movies" limit="10">library://video/movies/recentlyaddedmovies.xml/</content>
 				</control>
 				<control type="panel" id="2200">
-					<visible>Library.HasContent(TVShows) + Container(9010).HasFocus(2)</visible>
+					<visible>Library.HasContent(TVShows) + Library.HasNode(library://video/tvshows/recentlyaddedepisodes.xml/) + String.IsEqual(Container(9010).ListItem.Label2,item2)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />
@@ -226,10 +226,10 @@
 							<texture border="5">thumb_focus.png</texture>
 						</control>
 					</focusedlayout>
-				<content target="video" limit="12">videodb://recentlyaddedepisodes/</content>
+					<content target="video" limit="12">library://video/tvshows/recentlyaddedepisodes.xml/</content>
 				</control>
 				<control type="panel" id="2300">
-					<visible>Library.HasContent(Music) + Container(9010).HasFocus(3)</visible>
+					<visible>Library.HasContent(Music) + Library.HasNode(library://music/recentlyaddedalbums.xml/) + String.IsEqual(Container(9010).ListItem.Label2,item3)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />
@@ -318,10 +318,10 @@
 							<texture border="5">thumb_focus.png</texture>
 						</control>
 					</focusedlayout>
-				<content target="music" limit="15">musicdb://recentlyaddedalbums/</content>
+					<content target="music" limit="15">library://music/recentlyaddedalbums.xml/</content>
 				</control>
 				<control type="panel" id="2400">
-					<visible>Container(9010).HasFocus(4)</visible>
+					<visible>String.IsEqual(Container(9010).ListItem.Label2,item4)</visible>
 					<animation type="Visible" reversible="false">
 						<effect type="slide" start="400,0" end="0,0" delay="200" easing="out" tween="quadratic" time="400" />
 						<effect type="fade" start="0" end="100" delay="200" time="400" />

--- a/addons/skin.estuary/xml/Custom_1100_AddonLauncher.xml
+++ b/addons/skin.estuary/xml/Custom_1100_AddonLauncher.xml
@@ -23,14 +23,14 @@
 				<include content="AddonLauncherPanel">
 					<param name="group_id" value="500" />
 					<param name="id" value="video" />
-					<param name="container_path" value="addons://sources/video/" />
+					<param name="container_path" value="library://video/addons.xml" />
 					<param name="container_target" value="videos" />
 					<param name="imagewidget_onclick" value="ActivateWindow(addonbrowser,addons://all/xbmc.addon.video,return)" />
 				</include>
 				<include content="AddonLauncherPanel">
 					<param name="group_id" value="501" />
 					<param name="id" value="music" />
-					<param name="container_path" value="addons://sources/audio/" />
+					<param name="container_path" value="library://music/addons.xml/" />
 					<param name="container_target" value="music" />
 					<param name="imagewidget_onclick" value="ActivateWindow(addonbrowser,addons://all/xbmc.addon.audio,return)" />
 				</include>
@@ -152,19 +152,19 @@
 					<content>
 						<item id="1">
 							<label>$LOCALIZE[1037]</label>
-							<onclick>ActivateWindow(videos,addons://sources/video/,return)</onclick>
+							<onclick>ActivateWindow(videos,addons,return)</onclick>
 							<thumb>icons/sidemenu/videos.png</thumb>
 							<property name="id">video</property>
-							<property name="path">addons://sources/video/</property>
 							<property name="menu_id">$NUMBER[500]</property>
+							<visible>Library.HasNode(library://video/addons.xml)</visible>
 						</item>
 						<item id="2">
 							<label>$LOCALIZE[1038]</label>
-							<onclick>ActivateWindow(music,addons://sources/audio/,return)</onclick>
+							<onclick>ActivateWindow(music,addons,return)</onclick>
 							<thumb>icons/sidemenu/music.png</thumb>
 							<property name="id">music</property>
-							<property name="path">addons://sources/audio/</property>
 							<property name="menu_id">$NUMBER[501]</property>
+							<visible>Library.HasNode(library://music/addons.xml)</visible>
 						</item>
 						<item id="8">
 							<label>$LOCALIZE[35049]</label>
@@ -172,7 +172,6 @@
 							<onclick>ActivateWindow(games,addons://sources/game/,return)</onclick>
 							<thumb>icons/sidemenu/games.png</thumb>
 							<property name="id">game</property>
-							<property name="path">addons://sources/game/</property>
 							<property name="menu_id">$NUMBER[509]</property>
 						</item>
 						<item id="3">
@@ -180,7 +179,6 @@
 							<onclick>ActivateWindow(programs,addons://sources/executable/,return)</onclick>
 							<thumb>icons/sidemenu/programs.png</thumb>
 							<property name="id">addons</property>
-							<property name="path">addons://sources/executable/</property>
 							<property name="menu_id">$NUMBER[502]</property>
 						</item>
 						<item id="4">
@@ -188,7 +186,6 @@
 							<onclick>ActivateWindow(programs,androidapp://sources/apps/,return)</onclick>
 							<thumb>icons/sidemenu/android.png</thumb>
 							<property name="id">android</property>
-							<property name="path">androidapp://sources/apps/</property>
 							<property name="menu_id">$NUMBER[506]</property>
 							<visible>System.Platform.Android</visible>
 						</item>
@@ -197,7 +194,6 @@
 							<onclick>ActivateWindow(pictures,addons://sources/image/,return)</onclick>
 							<thumb>icons/sidemenu/pictures.png</thumb>
 							<property name="id">pictures</property>
-							<property name="path">addons://sources/image/</property>
 							<property name="menu_id">$NUMBER[503]</property>
 						</item>
 						<item id="7">
@@ -205,7 +201,6 @@
 							<onclick>ActivateWindow(addonbrowser,addons://user/,return)</onclick>
 							<thumb>icons/sidemenu/manage.png</thumb>
 							<property name="id">manage</property>
-							<property name="path">addons://user/</property>
 							<property name="menu_id">$NUMBER[508]</property>
 						</item>
 						<item id="6">
@@ -213,7 +208,6 @@
 							<onclick>ActivateWindow(addonbrowser,addons://all/,return)</onclick>
 							<thumb>icons/sidemenu/download.png</thumb>
 							<property name="id">download</property>
-							<property name="path">addons://all/</property>
 							<property name="menu_id">$NUMBER[507]</property>
 						</item>
 					</content>

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -51,7 +51,7 @@
 					<control type="grouplist" id="5001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>5010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(movies) + !Skin.HasSetting(home_no_categories_widget)">
+						<include content="WidgetListCategories" condition="Library.HasContent(movies) + Library.HasNode(library://video/movies/) + !Skin.HasSetting(home_no_categories_widget)">
 							<param name="content_path" value="library://video/movies/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
@@ -81,23 +81,23 @@
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5400"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(movies)">
-							<param name="content_path" value="videodb://movies/genres/"/>
+						<include content="WidgetListCategories" condition="Library.HasContent(movies) + Library.HasNode(library://video/movies/genres.xml)">
+							<param name="content_path" value="library://video/movies/genres.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[135]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="5500"/>
 							<param name="icon" value="$VAR[WidgetGenreIconVar]"/>
 							<param name="icon_height" value="70"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(movies)">
-							<param name="content_path" value="videodb://movies/sets/"/>
+						<include content="WidgetListPoster" condition="Library.HasContent(movies) + Library.HasNode(library://video/movies/sets.xml)">
+							<param name="content_path" value="library://video/movies/sets.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[31075]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="sortby" value="random"/>
 							<param name="list_id" value="5600"/>
 						</include>
 					</control>
-					<include content="ImageWidget" condition="!Library.HasContent(movies)">
+					<include content="ImageWidget" condition="!Library.HasContent(movies) + Library.HasNode(library://video/files.xml)">
 						<param name="text_label" value="$LOCALIZE[31104]" />
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,files,return)"/>
@@ -116,14 +116,14 @@
 					<control type="grouplist" id="6001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>6010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(tvshows) + !Skin.HasSetting(home_no_categories_widget)">
+						<include content="WidgetListCategories" condition="Library.HasContent(tvshows) + Library.HasNode(library://video/tvshows/) + !Skin.HasSetting(home_no_categories_widget)">
 							<param name="content_path" value="library://video/tvshows/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6900"/>
 						</include>
-						<include content="WidgetListPoster" condition="Library.HasContent(tvshows)">
-							<param name="content_path" value="videodb://inprogresstvshows"/>
+						<include content="WidgetListPoster" condition="Library.HasContent(tvshows) + Library.HasNode(library://video/tvshows/inprogresstvshows.xml)">
+							<param name="content_path" value="library://video/tvshows/inprogresstvshows.xml/"/>
 							<param name="sortby" value="lastplayed"/>
 							<param name="sortorder" value="descending"/>
 							<param name="widget_header" value="$LOCALIZE[626]"/>
@@ -142,16 +142,16 @@
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6300"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(tvshows)">
-							<param name="content_path" value="videodb://tvshows/genres/"/>
+						<include content="WidgetListCategories" condition="Library.HasContent(tvshows) + Library.HasNode(library://video/tvshows/genres.xml)">
+							<param name="content_path" value="library://video/tvshows/genres.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[135]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6400"/>
 							<param name="icon" value="$VAR[WidgetGenreIconVar]"/>
 							<param name="icon_height" value="70"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(tvshows)">
-							<param name="content_path" value="videodb://tvshows/studios/"/>
+						<include content="WidgetListCategories" condition="Library.HasContent(tvshows) + Library.HasNode(library://video/tvshows/studios.xml)">
+							<param name="content_path" value="library://video/tvshows/studios.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[20388]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6500"/>
@@ -159,7 +159,7 @@
 							<param name="icon_height" value="70"/>
 						</include>
 					</control>
-					<include content="ImageWidget" condition="!Library.HasContent(tvshows)">
+					<include content="ImageWidget" condition="!Library.HasContent(tvshows) + Library.HasNode(library://video/files.xml)">
 						<param name="text_label" value="$LOCALIZE[31104]" />
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,files,return)"/>
@@ -184,15 +184,15 @@
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7900"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
-							<param name="content_path" value="musicdb://recentlyplayedalbums"/>
+						<include content="WidgetListSquare" condition="Library.HasContent(music) + Library.HasNode(library://music/recentlyplayedalbums.xml)">
+							<param name="content_path" value="library://music/recentlyplayedalbums.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[517]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7100"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 						</include>
-						<include content="WidgetListSquare" condition="Library.HasContent(music)">
-							<param name="content_path" value="musicdb://recentlyaddedalbums/"/>
+						<include content="WidgetListSquare" condition="Library.HasContent(music) + Library.HasNode(library://music/recentlyaddedalbums.xml)">
+							<param name="content_path" value="library://music/recentlyaddedalbums.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[359]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7200"/>
@@ -229,7 +229,7 @@
 							<param name="sortorder" value="descending"/>
 						</include>
 					</control>
-					<include content="ImageWidget" condition="!Library.HasContent(music)">
+					<include content="ImageWidget" condition="!Library.HasContent(music) + Library.HasNode(library://music/files.xml)">
 						<param name="text_label" value="$LOCALIZE[31104]" />
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(music,files)"/>
@@ -255,8 +255,8 @@
 							<param name="list_id" value="8900"/>
 							<param name="visible" value="Integer.IsGreater(Container(8100).NumItems,0) | Integer.IsGreater(Container(8200).NumItems,0) | Integer.IsGreater(Container(8300).NumItems,0) | Integer.IsGreater(Container(8400).NumItems,0) | Integer.IsGreater(Container(8500).NumItems,0) | Integer.IsGreater(Container(8700).NumItems,0)"/>
 						</include>
-						<include content="WidgetListSquare">
-							<param name="content_path" value="addons://sources/video/"/>
+						<include content="WidgetListSquare" condition="Library.HasNode(library://video/addons.xml)">
+							<param name="content_path" value="library://video/addons.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[1037]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="sortby" value="lastused"/>
@@ -264,8 +264,8 @@
 							<param name="list_id" value="8100"/>
 							<param name="fallback_icon" value="DefaultAddon.png"/>
 						</include>
-						<include content="WidgetListSquare">
-							<param name="content_path" value="addons://sources/audio/"/>
+						<include content="WidgetListSquare" condition="Library.HasNode(library://music/addons.xml)">
+							<param name="content_path" value="library://music/addons.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[1038]"/>
 							<param name="widget_target" value="music"/>
 							<param name="sortby" value="lastused"/>
@@ -336,14 +336,14 @@
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="11900"/>
 						</include>
-						<include content="WidgetListCategories">
-							<param name="content_path" value="sources://video/"/>
+						<include content="WidgetListCategories" condition="Library.HasNode(library://video/files.xml)">
+							<param name="content_path" value="library://video/files.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[20094]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="11100"/>
 						</include>
-						<include content="WidgetListCategories">
-							<param name="content_path" value="special://videoplaylists/"/>
+						<include content="WidgetListCategories" condition="Library.HasNode(library://video/playlists.xml)">
+							<param name="content_path" value="library://video/playlists.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[136]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="11200"/>
@@ -683,14 +683,14 @@
 					<control type="grouplist" id="16001">
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>16010</pagecontrol>
-						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(home_no_categories_widget)">
+						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos) + Library.HasNode(library://video/musicvideos/) + !Skin.HasSetting(home_no_categories_widget)">
 							<param name="content_path" value="library://video/musicvideos/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="16900"/>
 						</include>
-						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos)">
-							<param name="content_path" value="videodb://recentlyaddedmusicvideos/"/>
+						<include content="WidgetListEpisodes" condition="Library.HasContent(musicvideos) + Library.HasNode(library://video/musicvideos/recentlyaddedmusicvideos.xml)">
+							<param name="content_path" value="library://video/musicvideos/recentlyaddedmusicvideos.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[20390]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="main_label" value="$INFO[ListItem.Label]" />
@@ -726,8 +726,8 @@
 							<param name="fallback_image" value="DefaultMusicSongs.png" />
 							<param name="list_id" value="16500"/>
 						</include>
-						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos)">
-							<param name="content_path" value="videodb://musicvideos/studios/"/>
+						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos) + Library.HasNode(library://video/musicvideos/studios.xml)">
+							<param name="content_path" value="library://video/musicvideos/studios.xml/"/>
 							<param name="widget_header" value="$LOCALIZE[20388]"/>
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="16600"/>
@@ -735,7 +735,7 @@
 							<param name="icon_height" value="70"/>
 						</include>
 					</control>
-					<include content="ImageWidget" condition="!Library.HasContent(musicvideos)">
+					<include content="ImageWidget" condition="!Library.HasContent(musicvideos) + Library.HasNode(library://video/files.xml)">
 						<param name="text_label" value="$LOCALIZE[31104]" />
 						<param name="button_label" value="$LOCALIZE[31110]" />
 						<param name="button_onclick" value="ActivateWindow(videos,files,return)"/>
@@ -897,23 +897,23 @@
 					<content>
 						<item>
 							<label>$LOCALIZE[342]</label>
-							<onclick condition="Library.HasContent(movies) + Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://movies/,return)</onclick>
-							<onclick condition="Library.HasContent(movies) + !Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://movies/titles/,return)</onclick>
-							<onclick condition="!Library.HasContent(movies)">ActivateWindow(Videos,sources://video/,return)</onclick>
+							<onclick condition="Library.HasContent(movies) + Library.HasNode(library://video/movies/) + Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,Movies,return)</onclick>
+							<onclick condition="Library.HasContent(movies) + Library.HasNode(library://video/movies/titles.xml) + !Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,MovieTitles,return)</onclick>
+							<onclick condition="!Library.HasContent(movies) + Library.HasNode(library://video/files.xml)">ActivateWindow(Videos,Files,return)</onclick>
 							<property name="menu_id">$NUMBER[5000]</property>
 							<thumb>icons/sidemenu/movies.png</thumb>
 							<property name="id">movies</property>
-							<visible>!Skin.HasSetting(HomeMenuNoMovieButton)</visible>
+							<visible>!Skin.HasSetting(HomeMenuNoMovieButton) + [Library.HasNode(library://video/movies/) | Library.HasNode(library://video/movies/titles.xml) | Library.HasNode(library://video/files.xml)]</visible>
 						</item>
 						<item>
 							<label>$LOCALIZE[20343]</label>
-							<onclick condition="Library.HasContent(tvshows) + Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://tvshows/,return)</onclick>
-							<onclick condition="Library.HasContent(tvshows) + !Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
-							<onclick condition="!Library.HasContent(tvshows)">ActivateWindow(Videos,sources://video/,return)</onclick>
+							<onclick condition="Library.HasContent(tvshows) + Library.HasNode(library://video/tvshows/) + Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,TvShows,return)</onclick>
+							<onclick condition="Library.HasContent(tvshows) + Library.HasNode(library://video/tvshows/titles.xml) + !Skin.HasSetting(home_no_categories_widget)">ActivateWindow(Videos,TvShowTitles,return)</onclick>
+							<onclick condition="!Library.HasContent(tvshows) + Library.HasNode(library://video/files.xml)">ActivateWindow(Videos,Files,return)</onclick>
 							<property name="menu_id">$NUMBER[6000]</property>
 							<thumb>icons/sidemenu/tv.png</thumb>
 							<property name="id">tvshows</property>
-							<visible>!Skin.HasSetting(HomeMenuNoTVShowButton)</visible>
+							<visible>!Skin.HasSetting(HomeMenuNoTVShowButton) + [Library.HasNode(library://video/tvshows/) | Library.HasNode(library://video/tvshows/titles.xml) | Library.HasNode(library://video/files.xml)]</visible>
 						</item>
 						<item>
 							<label>$LOCALIZE[2]</label>
@@ -937,7 +937,7 @@
 							<onclick>ActivateWindow(Videos,musicvideos,return)</onclick>
 							<thumb>icons/sidemenu/musicvideos.png</thumb>
 							<property name="id">musicvideos</property>
-							<visible>!Skin.HasSetting(HomeMenuNoMusicVideoButton)</visible>
+							<visible>!Skin.HasSetting(HomeMenuNoMusicVideoButton) + Library.HasNode(library://video/musicvideos/)</visible>
 						</item>
 						<item>
 							<label>$LOCALIZE[19020]</label>


### PR DESCRIPTION
changes to Estuary & Estouchy to add support for xml based nodes.
1) replace all videodb:// and musicdb:// (as well as some addons:// and special://) paths by library:// paths.
2) add Library.HasNode() checks where needed.

this PR depends on both https://github.com/xbmc/xbmc/pull/16993 and https://github.com/xbmc/xbmc/pull/16994, so please do not merge before those are in.