### PR TITLE
[pvr] Support for starting EPG entries as live

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -70,6 +70,7 @@ struct DemuxPacket;
 #define PVR_STREAM_PROPERTY_INPUTSTREAMCLASS  "inputstreamclass" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by PVR_STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities or to allow ffmpeg to handle directly set to `inputstream.ffmpeg`. */
 #define PVR_STREAM_PROPERTY_MIMETYPE "mimetype" /*!< @brief the MIME type of the stream that should be played. */
 #define PVR_STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream" /*!< @brief "true" to denote that the stream that should be played is a realtime stream. Any other value indicates that this is no realtime stream.*/
+#define PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE "epgplaybackaslive" /*!< @brief "true" to denote that if the stream is from an EPG tag that it should be played is a live stream. Otherwise if it's a EPG tag it will play as normal video.*/
 #define PVR_STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG  "inputstream.ffmpeg" /*!< @brief special value for PVR_STREAM_PROPERTY_INPUTSTREAMCLASS to use ffmpeg to directly play a stream URL. */
 
 /* using the default avformat's MAX_STREAMS value to be safe */

--- a/xbmc/pvr/PVRStreamProperties.cpp
+++ b/xbmc/pvr/PVRStreamProperties.cpp
@@ -9,6 +9,7 @@
 #include "PVRStreamProperties.h"
 
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "utils/StringUtils.h"
 
 using namespace PVR;
 
@@ -30,4 +31,14 @@ std::string CPVRStreamProperties::GetStreamMimeType() const
       return prop.second;
   }
   return {};
+}
+
+bool CPVRStreamProperties::EPGPlaybackAsLive() const
+{
+  for (const auto& prop : *this)
+  {
+    if (prop.first == PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE)
+      return StringUtils::EqualsNoCase(prop.second, "true");
+  }
+  return false;
 }

--- a/xbmc/pvr/PVRStreamProperties.h
+++ b/xbmc/pvr/PVRStreamProperties.h
@@ -32,6 +32,12 @@ public:
    * @return The stream's MIME type or empty string, if not found.
    */
   std::string GetStreamMimeType() const;
+
+  /*!
+   * @brief If props are from an EPG tag indicates if playback should be as live playback would be
+   * @return true if it should be played back as live, false otherwise.
+   */
+  bool EPGPlaybackAsLive() const;
 };
 
 } // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -38,6 +38,7 @@ namespace PVR
   };
 
   class CPVRRecording;
+  class CPVRStreamProperties;
   class CPVRTimerInfoTag;
 
   class CPVRChannelSwitchingInputHandler : public CPVRChannelNumberInputHandler
@@ -514,9 +515,12 @@ namespace PVR
     /*!
      * @brief Start playback of the given item.
      * @param bFullscreen start playback fullscreen or not.
+     * @param epgProps propeties to be used instead of calling to the client if supplied.
      * @param item containing a channel or a recording.
      */
-    void StartPlayback(CFileItem* item, bool bFullscreen) const;
+    void StartPlayback(CFileItem* item,
+                       bool bFullscreen,
+                       CPVRStreamProperties* epgProps = nullptr) const;
 
     bool AllLocalBackendsIdle(std::shared_ptr<CPVRTimerInfoTag>& causingEvent) const;
     bool EventOccursOnLocalBackend(const std::shared_ptr<CFileItem>& item) const;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Currently it's not possible to play an EPG tag as if it's live, only as if it's a video.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

If using a catchup provider and the new inputstream.ffmpegdirect addon this is now a requirement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

MacOSX.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
