### PR TITLE
AESinkAudioTrack: Implement timestamp method for delay

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -12,6 +12,7 @@
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 
 #include <deque>
@@ -61,6 +62,7 @@ private:
   double                m_duration_written;
   unsigned int          m_min_buffer_size;
   uint64_t              m_headPos;
+  uint64_t m_timestampPos = 0;
   // Moving Average computes the weighted average delay over
   // a fixed size of delay values - current size: 20 values
   double                GetMovingAverageDelay(double newestdelay);
@@ -85,6 +87,9 @@ private:
   int                m_encoding;
   double m_pause_ms = 0.0;
   double m_delay = 0.0;
+  double m_hw_delay = 0.0;
+  CJNIAudioTimestamp m_timestamp;
+  XbmcThreads::EndTime m_stampTimer;
 
   std::vector<float> m_floatbuf;
   std::vector<int16_t> m_shortbuf;


### PR DESCRIPTION
This implements the suggest method since SDK version 19: GetTimeStamp.

See: https://developer.amazon.com/de/docs/fire-tv/audio-video-synchronization.html#21-audiotrackgettimestamp-api-level-19

With this implementation the delay in the processing pipeline can be estimated. For FireTV 4K - an additional delay (depending on content) for Stereo of about 180 ms is identified.

Needs testing, especially on legacy hw and such that use hackarounds.