### PR TITLE
[v19 Matrix] Windows HDR support

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -41,6 +41,8 @@
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 
+#include "rendering/dx/DeviceResources.h"
+#include "rendering/dx/RenderContext.h"
 #include "DVDDemuxers/DVDDemuxCC.h"
 #include "cores/FFmpeg.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
@@ -2385,6 +2387,14 @@ void CVideoPlayer::SendPlayerMessage(CDVDMsg* pMsg, unsigned int target)
 void CVideoPlayer::OnExit()
 {
   CLog::Log(LOGNOTICE, "CVideoPlayer::OnExit()");
+
+  bool hdr_capable, hdr_enabled;
+  DX::DeviceResources::Get()->DetectDisplayHDRcapable(hdr_capable, hdr_enabled);
+
+  if (hdr_enabled && DX::Windowing()->Is_10bitSwapchain())
+  {
+    DX::DeviceResources::Get()->Clear_HDR_MetaData();
+  }
 
   // set event to inform openfile something went wrong in case openfile is still waiting for this event
   SetCaching(CACHESTATE_DONE);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -505,9 +505,20 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
   if (SUCCEEDED(m_pVideoContext.As(&videoCtx1)))
   {
     const DXGI_COLOR_SPACE_TYPE source_color = GetDXGIColorSpace(views[2], m_bSupportHDR10);
-    const DXGI_COLOR_SPACE_TYPE target_color = DX::Windowing()->UseLimitedColor() 
-                                               ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709 
-                                               : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    DXGI_COLOR_SPACE_TYPE target_color;
+
+    if (DX::Windowing()->Is_10bitSwapchain() && (views[2]->hasLightMetadata || views[2]->primaries == AVCOL_PRI_BT2020))
+    {
+      target_color = DX::Windowing()->UseLimitedColor()
+                             ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
+                             : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+    }
+    else
+    {
+      target_color = DX::Windowing()->UseLimitedColor()
+                             ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709
+                             : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    }
 
     videoCtx1->VideoProcessorSetStreamColorSpace1(m_pVideoProcessor.Get(), DEFAULT_STREAM_INDEX, source_color);
     videoCtx1->VideoProcessorSetOutputColorSpace1(m_pVideoProcessor.Get(), target_color);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -525,6 +525,12 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
     // makes target available for processing in shaders
     videoCtx1->VideoProcessorSetOutputShaderUsage(m_pVideoProcessor.Get(), 1);
 
+//  Disabled because causes HDR image to dark.
+//  It is also not needed because it is only for dynamic HDR metadata (HDR10+).
+//  This code runs continuously during playback and this is only necessary for HDR10+.
+//  Static HDR metadata is configured only at the beginning.
+//  Probably there is some error with the change of scale (factor 50000) and data types conversions.
+/*
     if (m_bSupportHDR10)
     {
       ComPtr<ID3D11VideoContext2> videoCtx2;
@@ -556,6 +562,7 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
                                                       DXGI_HDR_METADATA_TYPE_HDR10, sizeof(hdr10), &hdr10);
       }
     }
+*/
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -162,6 +162,23 @@ bool CRendererBase::Configure(const VideoPicture& picture, float fps, unsigned o
   m_fps = fps;
   m_renderOrientation = orientation;
 
+  if (picture.hasDisplayMetadata || picture.color_primaries == AVCOL_PRI_BT2020)
+  {
+    bool hdr_capable, hdr_enabled;
+
+    DX::DeviceResources::Get()->DetectDisplayHDRcapable(hdr_capable, hdr_enabled);
+
+    if (hdr_enabled)
+    {
+      DX::DeviceResources::Get()->Set_HDR_MetaData(picture.displayMetadata, picture.lightMetadata);
+    }
+  }
+  else
+  {
+    if (DX::Windowing()->Is_10bitSwapchain())
+      DX::DeviceResources::Get()->Clear_HDR_MetaData();
+  }
+
   return true;
 }
 

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -14,7 +14,7 @@
 #if defined(TARGET_WINDOWS_STORE)
 #include <dxgi1_3.h>
 #else
-#include <dxgi1_2.h>
+#include <dxgi1_6.h>
 #include <easyhook/easyhook.h>
 #endif
 #include <functional>
@@ -22,6 +22,11 @@
 
 #include "DirectXHelper.h"
 #include "guilib/D3DResource.h"
+
+extern "C"
+{
+#include <libavutil/mastering_display_metadata.h>
+}
 
 struct RESOLUTION_INFO;
 
@@ -81,6 +86,10 @@ namespace DX
 
     bool SetFullScreen(bool fullscreen, RESOLUTION_INFO& res);
 
+    void DetectDisplayHDRcapable(bool& hdr_capable, bool& hdr_enabled) const;
+    void Set_HDR_MetaData(AVMasteringDisplayMetadata dm, AVContentLightMetadata lm) const;
+    void Clear_HDR_MetaData() const;
+
     // DX resources registration
     void Register(ID3DResource *resource);
     void Unregister(ID3DResource *resource);
@@ -131,6 +140,7 @@ namespace DX
     Microsoft::WRL::ComPtr<IDXGIFactory2> m_dxgiFactory;
     Microsoft::WRL::ComPtr<IDXGIAdapter1> m_adapter;
     Microsoft::WRL::ComPtr<IDXGIOutput1> m_output;
+    Microsoft::WRL::ComPtr<IDXGIOutput6> m_output6;
 
     Microsoft::WRL::ComPtr<ID3D11Device1> m_d3dDevice;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_d3dContext;

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -66,6 +66,9 @@ public:
 
   void FixRefreshRateIfNecessary(const D3D10DDIARG_CREATERESOURCE* pResource) const;
 
+  bool Is_10bitSwapchain() const { return m_10bit_swapchain; }
+  void Set10bitSwapchain(bool flag) { m_10bit_swapchain = flag; }
+
 protected:
   void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;
   void ReleaseBackBuffer() override;
@@ -77,5 +80,6 @@ protected:
 
   HMODULE m_hDriverModule;
   TRACED_HOOK_HANDLE m_hHook;
+  bool m_10bit_swapchain;
 };
 


### PR DESCRIPTION
## Description
Inspired on work of @fandangos, this implementation intends to be compatible with Intel HW and does not use proprietary APIs.

## Motivation and Context
Enable HDR on KODI in a stable and compatible way.

## How Has This Been Tested?
To use HDR features enable Windows HDR switch before open Kodi.
If video has HDR metadata enables proper rendering.
Can also play SDR content with Windows HDR switch ON and it is displayed correctly.
Only uses Microsoft Windows standard API to HDR passthrough.
If Windows HDR switch is turned OFF, it behaves like the normal Kodi edition.

Tested on Intel NUC 8i3BEK + Dennon AVX-1660H + Sony TV KD-55AG9 OLED.

Not tested on NVIDIA hardware but it should work too.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
