### PR TITLE
[Estuary] Refactor Playlist Window + Views

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20600,6 +20600,7 @@ msgstr ""
 
 #. Values for setting with label #36621 and #36628 "Minimum/Maximum protocol version" - none means "no protocol version is forced"
 #: system/settings/settings.xml
+#: addons/skin.estuary/xml/View_50_List.xml
 msgctxt "#36623"
 msgid "None"
 msgstr ""

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -201,7 +201,10 @@ msgctxt "#31036"
 msgid "items"
 msgstr ""
 
-#empty string with id 31037
+#: /xml/Includes.xml
+msgctxt "#31037"
+msgid "Selected track"
+msgstr ""
 
 #: /xml/Variables.xml
 msgctxt "#31038"
@@ -349,7 +352,15 @@ msgctxt "#31072"
 msgid "Power Options"
 msgstr ""
 
-#empty strings from id 31073 to 31074
+#: /xml/MyPlaylist.xml
+msgctxt "#31073"
+msgid "Total length"
+msgstr ""
+
+#: /xml/MyPlaylist.xml
+msgctxt "#31074"
+msgid "Total duration"
+msgstr ""
 
 #: /xml/Home.xml
 msgctxt "#31075"

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -14,6 +14,7 @@
 	<include file="View_53_Shift.xml" />
 	<include file="View_54_InfoWall.xml" />
 	<include file="View_55_WideList.xml" />
+	<include file="View_503_NowPlaying.xml" />
 	<include file="View_500_Wall.xml" />
 	<include file="View_501_Banner.xml" />
 	<include file="View_502_FanArt.xml" />
@@ -34,7 +35,7 @@
 	<constant name="list_y_offset">0</constant>
 	<constant name="list_item_height">80</constant>
 	<expression name="infodialog_active">Window.IsActive(musicinformation) | Window.IsActive(songinformation) | Window.IsActive(movieinformation) | Window.IsActive(addoninformation) | Window.IsActive(pvrguideinfo) | Window.IsActive(pvrrecordinginfo) | Window.IsActive(pictureinfo) | Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml) | Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) | Window.IsVisible(script-script.extendedinfo-VideoList.xml)</expression>
-	<expression name="sidebar_visible">ControlGroup(9000).HasFocus | Control.HasFocus(6130) | Control.HasFocus(6131) | Window.IsActive(MyPlaylist.xml)</expression>
+	<expression name="sidebar_visible">ControlGroup(9000).HasFocus | Control.HasFocus(6130) | Control.HasFocus(6131)</expression>
 	<include name="CommonScrollbars">
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="150">WindowClose</animation>
@@ -50,8 +51,10 @@
 					<top>0</top>
 					<bottom>0</bottom>
 					<width>13</width>
-					<onleft>50</onleft>
-					<onright>50</onright>
+					<onleft condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onleft>
+					<onleft condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onleft>
+					<onright condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onright>
+					<onright condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onright>
 					<orientation>vertical</orientation>
 					<texturesliderbackground />
 					<animation effect="fade" start="0" end="100" time="200" delay="300">Visible</animation>
@@ -859,7 +862,7 @@
 					<animation effect="fade" time="150">VisibleChange</animation>
 					<control type="group">
 						<width>600</width>
-						<visible>Player.HasMedia + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
+						<visible>!Control.IsVisible(503) + Player.HasMedia + String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
 						<animation effect="fade" time="200">VisibleChange</animation>
 						<control type="grouplist">
 							<left>-75</left>

--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -337,7 +337,8 @@
 			<height>100%</height>
 			<onleft>9000</onleft>
 			<onup>9000</onup>
-			<onright>50</onright>
+			<onright condition="![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)]">50</onright>
+			<onright condition="Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist)">55</onright>
 			<ondown>9000</ondown>
 			<onback>50</onback>
 			<control type="label" id="200">

--- a/addons/skin.estuary/xml/MyPlaylist.xml
+++ b/addons/skin.estuary/xml/MyPlaylist.xml
@@ -1,163 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">50</defaultcontrol>
+	<defaultcontrol always="true">55</defaultcontrol>
 	<backgroundcolor>background</backgroundcolor>
-	<views>50</views>
+	<menucontrol>9000</menucontrol>
+	<views>55,503</views>
 	<controls>
 		<include>DefaultBackground</include>
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
+			<include>View_55_WideList</include>
+			<include condition="Window.IsActive(musicplaylist)">View_503_NowPlaying</include>
+			<include>CommonScrollbars</include>
 			<control type="group">
 				<include>OpenClose_Left</include>
-				<control type="fixedlist" id="50">
-					<left>410</left>
-					<top>list_y_offset</top>
-					<right>586</right>
-					<bottom>list_y_offset</bottom>
-					<scrolltime tween="cubic" easing="out">500</scrolltime>
-					<orientation>vertical</orientation>
-					<onleft>700</onleft>
-					<onright>60</onright>
-					<movement>5</movement>
-					<focusposition>6</focusposition>
-					<onup>50</onup>
-					<ondown>50</ondown>
-					<pagecontrol>60</pagecontrol>
-					<viewtype label="535">list</viewtype>
-					<preloaditems>1</preloaditems>
-					<focusedlayout height="list_item_height">
-						<control type="image">
-							<left>0</left>
-							<right>0</right>
-							<bottom>0</bottom>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.HasFocus(50)</visible>
-						</control>
-						<control type="label">
-							<left>30</left>
-							<bottom>0</bottom>
-							<right>30</right>
-							<aligny>center</aligny>
-							<font>font12</font>
-							<label>$VAR[PlaylistLabelVar]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>30</left>
-							<bottom>0</bottom>
-							<right>30</right>
-							<align>right</align>
-							<aligny>center</aligny>
-							<font>font12</font>
-							<label>$VAR[PlaylistLabel2Var]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</focusedlayout>
-					<itemlayout height="list_item_height">
-						<control type="label">
-							<left>30</left>
-							<bottom>0</bottom>
-							<right>30</right>
-							<aligny>center</aligny>
-							<font>font12</font>
-							<label>$VAR[PlaylistLabelVar]</label>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-						<control type="label">
-							<left>30</left>
-							<bottom>0</bottom>
-							<right>30</right>
-							<align>right</align>
-							<aligny>center</aligny>
-							<font>font12</font>
-							<label>$VAR[PlaylistLabel2Var]</label>
-							<textcolor>grey</textcolor>
-							<shadowcolor>text_shadow</shadowcolor>
-						</control>
-					</itemlayout>
-				</control>
-				<control type="group">
-					<depth>DepthContentPanel</depth>
-					<include content="ContentPanel">
-						<param name="width" value="470" />
-					</include>
-					<control type="grouplist" id="700">
-						<orientation>vertical</orientation>
-						<itemgap>0</itemgap>
-						<left>0</left>
-						<top>120</top>
-						<onup>700</onup>
-						<ondown>700</ondown>
-						<onleft>50</onleft>
-						<onright>50</onright>
-						<width>410</width>
-						<control type="radiobutton" id="20">
-							<width>410</width>
-							<height>110</height>
-							<align>left</align>
-							<aligny>top</aligny>
-							<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
-							<texturenofocus />
-							<radioposx>300</radioposx>
-							<textoffsetx>40</textoffsetx>
-							<textoffsety>35</textoffsety>
-							<label>$LOCALIZE[191]</label>
-						</control>
-						<include content="PlaylistWindowButton">
-							<param name="control_id" value="26" />
-							<param name="label" value="" />
-						</include>
-						<include content="PlaylistWindowButton">
-							<param name="control_id" value="21" />
-							<param name="label" value="$LOCALIZE[190]" />
-						</include>
-						<include content="PlaylistWindowButton">
-							<param name="control_id" value="22" />
-							<param name="label" value="$LOCALIZE[192]" />
-						</include>
-						<include content="MediaMenuNowPlaying">
-							<param name="left" value="-5" />
-						</include>
-					</control>
-				</control>
+				<include>Visible_Left</include>
+				<include>ListThumbInfoPanel</include>
 			</control>
+			<include content="TopBar" condition="Window.IsActive(videoplaylist)">
+				<param name="breadcrumbs_label" value="$LOCALIZE[31065]" />
+				<param name="sublabel">$LOCALIZE[31073] - $INFO[Container.TotalTime,,  ∙  ]$INFO[Container.CurrentItem,,/]$INFO[Container.NumItems]</param>
+			</include>
+			<include content="TopBar" condition="Window.IsActive(musicplaylist)">
+				<param name="breadcrumbs_label" value="$LOCALIZE[31066]" />
+				<param name="sublabel">$LOCALIZE[31074] - $INFO[Container.TotalTime]</param>
+			</include>
+			<include content="BottomBar">
+				<param name="info_visible" value="true" />
+			</include>
 			<control type="group">
-				<depth>DepthContentPanel</depth>
-				<right>0</right>
-				<width>593</width>
-				<include>OpenClose_Right</include>
-				<include content="ListThumbInfoPanel">
-					<param name="flip_bg" value="true" />
-				</include>
-				<control type="scrollbar" id="60">
-					<left>-20</left>
-					<top>0</top>
-					<width>12</width>
-					<bottom>0</bottom>
-					<onleft>50</onleft>
-					<texturesliderbackground />
-					<onright>700</onright>
-					<animation effect="zoom" end="50,100" time="300" tween="sine" center="-20,0" easing="inout" condition="!Control.HasFocus(60)">conditional</animation>
-					<orientation>vertical</orientation>
+				<visible>!Container.Content(songs)</visible>
+				<depth>DepthBars</depth>
+				<bottom>0</bottom>
+				<height>70</height>
+				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>
+			</control>
+			<include>MediaMenuMouseOverlay</include>
+			<control type="group">
+				<include>MediaMenuCommon</include>
+				<control type="grouplist" id="9000">
+					<top>50</top>
+					<include>MediaMenuListCommon</include>
+					<control type="label" id="203">
+						<description>Actions</description>
+						<include>MediaMenuLabelCommon</include>
+						<label>$LOCALIZE[31020]</label>
+					</control>
+					<control type="radiobutton" id="20">
+						<height>80</height>
+						<align>left</align>
+						<aligny>center</aligny>
+						<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+						<texturenofocus />
+						<radioposx>280</radioposx>
+						<textoffsetx>20</textoffsetx>
+						<label>$LOCALIZE[191]</label>
+					</control>
+					<control type="button" id="26">
+						<height>80</height>
+						<align>left</align>
+						<aligny>center</aligny>
+						<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+						<texturenofocus />
+						<radioposx>280</radioposx>
+						<textoffsetx>20</textoffsetx>
+						<label></label>
+					</control>
+					<control type="button" id="21">
+						<height>80</height>
+						<align>left</align>
+						<aligny>center</aligny>
+						<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+						<texturenofocus />
+						<radioposx>280</radioposx>
+						<textoffsetx>20</textoffsetx>
+						<label>$LOCALIZE[190]</label>
+					</control>
+					<control type="button" id="22">
+						<height>80</height>
+						<align>left</align>
+						<aligny>center</aligny>
+						<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+						<texturenofocus />
+						<radioposx>280</radioposx>
+						<textoffsetx>20</textoffsetx>
+						<label>$LOCALIZE[192]</label>
+					</control>
+					<include>MediaMenuNowPlaying</include>
 				</control>
 			</control>
-		</control>
-		<include content="TopBar" condition="Window.IsActive(videoplaylist)">
-			<param name="breadcrumbs_label" value="$LOCALIZE[31065]" />
-			<param name="sublabel">$INFO[Container.TotalTime,, - ] $INFO[Playlist.Position(video),, / ]$INFO[Playlist.Length(video)]</param>
-		</include>
-		<include content="TopBar" condition="Window.IsActive(musicplaylist)">
-			<param name="breadcrumbs_label" value="$LOCALIZE[31066]" />
-			<param name="sublabel">$INFO[Container.TotalTime,, - ] $INFO[Playlist.Position(music),, / ]$INFO[Playlist.Length(music)]</param>
-		</include>
-		<include>BottomBar</include>
-		<control type="group">
-			<depth>DepthBars</depth>
-			<bottom>0</bottom>
-			<height>70</height>
-			<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
-			<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
-			<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>
 		</control>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -8,15 +8,6 @@
 	<variable name="AutoCompletionContentVar">
 		<value condition="System.HasAddon(plugin.program.autocompletion) + !System.HasHiddenInput">plugin://plugin.program.autocompletion?info=autocomplete&amp;&amp;id=$INFO[Control.GetLabel(312).index(1)]&amp;&amp;limit=9</value>
 	</variable>
-	<variable name="PlaylistLabelVar">
-		<value condition="String.IsEqual(ListItem.DbType,episode)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
-		<value condition="String.IsEqual(ListItem.DbType,musicvideo)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>
-		<value>$INFO[ListItem.Label]</value>
-	</variable>
-	<variable name="PlaylistLabel2Var">
-		<value condition="Window.IsActive(musicplaylist)">$INFO[ListItem.Duration]</value>
-		<value>$INFO[ListItem.Duration,, $LOCALIZE[12391]]</value>
-	</variable>
 	<variable name="InfoListPathVar">
 		<value condition="String.IsEmpty(Container.PluginName)">$INFO[ListItem.FolderPath]</value>
 		<value></value>
@@ -79,10 +70,16 @@
 		<value condition="!String.isempty(ListItem.Thumb)">$INFO[ListItem.Thumb]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
+	<variable name="ListLabelVar">
+		<value condition="String.IsEqual(ListItem.DbType,episode) + Window.IsActive(videoplaylist)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
+		<value condition="String.IsEqual(ListItem.DbType,musicvideo) + Window.IsActive(videoplaylist)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>
+		<value>$INFO[ListItem.Label]</value>
+	</variable>
 	<variable name="ListLabel2Var">
 		<value condition="String.IsEmpty(Container.PluginName) + Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[556])">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
 		<value condition="String.IsEqual(Container.SortMethod,$LOCALIZE[556])">$INFO[ListItem.Year]</value>
 		<value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
+		<value condition="Window.IsActive(musicplaylist) | Window.IsActive(videoplaylist)">$INFO[ListItem.Duration]</value>
 		<value>$INFO[ListItem.Label2]</value>
 	</variable>
 	<variable name="ShiftLeftTextBoxVar">
@@ -123,12 +120,15 @@
 		<value condition="String.IsEqual(listitem.dbtype,musicvideo) | String.IsEqual(listitem.dbtype,video)">$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Plot]</value>
 		<value condition="String.IsEqual(listitem.dbtype,artist)">$INFO[ListItem.Property(artist_description)]</value>
 		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
-		<value condition="String.IsEqual(listitem.dbtype,song)">$VAR[MusicTrackInfo,[COLOR button_focus]$LOCALIZE[554]:[/COLOR],[CR]]$INFO[ListItem.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[listitem.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$INFO[ListItem.DiscNumber,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[ListItem.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Duration,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],[CR]]$INFO[ListItem.Playcount,[COLOR button_focus]$LOCALIZE[567]: [/COLOR],[CR]]</value>
+		<value condition="String.IsEqual(ListItem.DBType,song)">$VAR[MusicTrackInfo,[COLOR button_focus]$LOCALIZE[554]: [/COLOR],[CR]]$INFO[ListItem.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[listitem.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$INFO[ListItem.DiscNumber,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[ListItem.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[ListItem.Duration,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],[CR]]$INFO[ListItem.Playcount,[COLOR button_focus]$LOCALIZE[567]: [/COLOR],[CR]]$INFO[ListItem.LastPlayed,[COLOR button_focus]$LOCALIZE[568]: [/COLOR],]</value>
 		<value>$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]</value>
 	</variable>
+	<variable name="NowPlayingInfoVar">
+		<value>$INFO[MusicPlayer.Title,[COLOR button_focus]$LOCALIZE[554]: [/COLOR],[CR]]$INFO[MusicPlayer.Artist,[COLOR button_focus]$LOCALIZE[557]: [/COLOR],[CR]]$INFO[MusicPlayer.Album,[COLOR button_focus]$LOCALIZE[558]: [/COLOR],[CR]]$INFO[MusicPlayer.DiscNumber,[COLOR button_focus]$LOCALIZE[427]: [/COLOR],[CR]]$INFO[MusicPlayer.Year,[COLOR button_focus]$LOCALIZE[345]: [/COLOR],[CR]]$INFO[MusicPlayer.Genre,[COLOR button_focus]$LOCALIZE[515]: [/COLOR],[CR]]$INFO[MusicPlayer.Time,[COLOR button_focus]$LOCALIZE[180]: [/COLOR],/]$INFO[MusicPlayer.Duration,,[CR]]</value>
+	</variable>
 	<variable name="MusicTrackInfo">
-		<value condition="String.IsEmpty(listitem.Title)">$INFO[listitem.TrackNumber, ]</value>
-		<value>$INFO[listitem.TrackNumber, ,.]$INFO[listitem.Title, ]</value>
+		<value condition="String.IsEmpty(listitem.Title)">$INFO[listitem.TrackNumber]</value>
+		<value>$INFO[listitem.TrackNumber,,.]$INFO[listitem.Title, ]</value>
 	</variable>
 	<variable name="WidgetGenreIconVar">
 		<value condition="System.HasAddon(resource.images.moviegenreicons.transparent)">$INFO[ListItem.Label,resource://resource.images.moviegenreicons.transparent/,.png]</value>

--- a/addons/skin.estuary/xml/View_503_NowPlaying.xml
+++ b/addons/skin.estuary/xml/View_503_NowPlaying.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<includes>
+	<include name="View_503_NowPlaying">
+		<control type="group">
+			<include>OpenClose_Right</include>
+			<left>596</left>
+			<visible>Control.IsVisible(503)</visible>
+			<include>Visible_Right</include>
+			<include content="ListContainer">
+				<param name="list_id" value="503" />
+				<param name="right" value="594" />
+				<param name="viewtype_label" value="$LOCALIZE[31000]" />
+			</include>
+			<control type="group">
+				<depth>DepthContentPanel</depth>
+				<control type="group">
+					<right>-20</right>
+					<width>634</width>
+					<include content="ContentPanel">
+						<param name="left" value="0" />
+						<param name="top" value="-20" />
+						<param name="width" value="656" />
+						<param name="flipx" value="true" />
+					</include>
+					<include content="RightListPanel">
+						<param name="list_id" value="503" />
+					</include>
+				</control>
+			</control>
+		</control>
+	</include>
+</includes>

--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -22,35 +22,84 @@
 						<param name="width" value="656" />
 						<param name="flipx" value="true" />
 					</include>
-					<control type="scrollbar" id="50600">
-						<left>20</left>
-						<top>list_y_offset</top>
-						<width>12</width>
-						<bottom>list_y_offset</bottom>
-						<onleft>50</onleft>
-						<onright>50</onright>
-						<orientation>vertical</orientation>
-						<animation effect="zoom" end="50,100" time="300" tween="sine" center="20,0" easing="inout" condition="!Control.HasFocus(50600)">conditional</animation>
-					</control>
+					<include content="RightListPanel">
+						<param name="list_id" value="50" />
+					</include>
+				</control>
+			</control>
+		</control>
+	</include>
+	<include name="RightListPanel">
+		<control type="group">
+			<depth>DepthContentPanel</depth>
+			<control type="group">
+				<right>-32</right>
+				<include content="ContentPanel">
+					<param name="left" value="0" />
+					<param name="top" value="-20" />
+					<param name="width" value="656" />
+					<param name="flipx" value="true" />
+				</include>
+				<control type="group">
+					<visible>!Container.Content(songs)</visible>
 					<control type="image">
 						<depth>DepthContentPopout</depth>
-						<left>38</left>
-						<right>36</right>
+						<left>48</left>
 						<top>120</top>
+						<width>540</width>
+						<height>850</height>
 						<bottom>124</bottom>
 						<fadetime>200</fadetime>
-						<aspectratio aligny="center">keep</aspectratio>
+						<aspectratio align="center" aligny="center">keep</aspectratio>
 						<texture fallback="DefaultVideo.png" background="true">$VAR[InfoWallThumbVar]</texture>
 					</control>
 					<control type="group">
-						<left>310</left>
+						<left>318</left>
 						<top>936</top>
 						<include content="RatingCircle">
 							<param name="animation" value="True" />
 						</include>
 					</control>
 				</control>
+				<control type="group">
+					<visible>Control.IsVisible(503) + Window.IsActive(musicplaylist)</visible>
+					<control type="image">
+						<left>58</left>
+						<top>120</top>
+						<width>540</width>
+						<height>470</height>
+						<aspectratio aligny="bottom">keep</aspectratio>
+						<fadetime>300</fadetime>
+						<texture fallback="DefaultAudio.png" background="true">$INFO[Player.Icon]</texture>
+					</control>
+					<control type="textbox" id="15599">
+						<visible>Player.HasAudio + Window.IsActive(musicplaylist)</visible>
+						<left>58</left>
+						<top>600</top>
+						<width>540</width>
+						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
+						<label>[COLOR button_focus][B]$LOCALIZE[31000]: [/COLOR]$INFO[musicplayer.Playlistposition,]$INFO[musicplayer.Playlistlength,/][/B][CR]$VAR[NowPlayingInfoVar]</label>
+					</control>
+					<control type="textbox" id="15599">
+						<visible>!Player.HasAudio + Window.IsActive(musicplaylist)</visible>
+						<left>58</left>
+						<top>640</top>
+						<width>540</width>
+						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
+						<label>[COLOR button_focus][B]$LOCALIZE[31000]: [/COLOR]$LOCALIZE[36623][/B]</label>
+					</control>
+				</control>
 			</control>
+		</control>
+		<control type="scrollbar" id="$PARAM[list_id]600">
+			<left>20</left>
+			<top>list_y_offset</top>
+			<width>12</width>
+			<bottom>list_y_offset</bottom>
+			<onleft>$PARAM[list_id]</onleft>
+			<onright>$PARAM[list_id]</onright>
+			<orientation>vertical</orientation>
+			<animation effect="zoom" end="50,100" time="300" tween="sine" center="20,0" easing="inout" condition="!Control.HasFocus($PARAM[list_id]600)">conditional</animation>
 		</control>
 	</include>
 	<include name="ListContainer">
@@ -72,7 +121,7 @@
 				<onup>$PARAM[list_id]</onup>
 				<ondown>$PARAM[list_id]</ondown>
 				<viewtype label="$PARAM[viewtype_label]">list</viewtype>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(games) | Window.IsActive(MyPlaylist.xml)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)</visible>
 				<focusedlayout height="list_item_height">
 					<control type="image">
 						<left>0</left>
@@ -90,7 +139,7 @@
 						<aligny>center</aligny>
 						<scroll>true</scroll>
 						<font>font27</font>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ListLabelVar]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 					<control type="label">
@@ -132,7 +181,7 @@
 						<bottom>0</bottom>
 						<aligny>center</aligny>
 						<font>font27</font>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ListLabelVar]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 					<control type="label">
@@ -165,28 +214,38 @@
 			<control type="group">
 				<depth>DepthContentPanel</depth>
 				<include content="ContentPanel">
-					<param name="width" value="654" />
+					<param name="width" value="656" />
 					<param name="flipx" value="$PARAM[flip_bg]" />
 				</include>
 				<control type="image">
 					<left>30</left>
 					<top>140</top>
-					<width>530</width>
+					<width>540</width>
 					<height>470</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
 					<texture fallback="$PARAM[fallback_image]" background="true">$VAR[IconWallThumbVar]</texture>
-					<visible>!String.IsEqual(ListItem.DbType,episode)</visible>
+					<visible>!String.IsEqual(ListItem.DbType,episode) + !String.IsEqual(ListItem.DBType,song)</visible>
 				</control>
 				<control type="image">
 					<left>30</left>
 					<top>140</top>
-					<width>530</width>
+					<width>540</width>
 					<height>330</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
 					<texture background="true">$INFO[ListItem.Icon]</texture>
 					<visible>String.IsEqual(ListItem.DbType,episode)</visible>
+				</control>
+				<control type="image">
+					<left>30</left>
+					<top>120</top>
+					<width>540</width>
+					<height>470</height>
+					<aspectratio aligny="bottom">keep</aspectratio>
+					<fadetime>300</fadetime>
+					<texture fallback="DefaultAudio.png" background="true">$VAR[IconWallThumbVar]</texture>
+					<visible>String.IsEqual(ListItem.DBType,song)</visible>
 				</control>
 				<control type="group">
 					<left>273</left>
@@ -199,19 +258,27 @@
 					<left>30</left>
 					<control type="textbox" id="15500">
 						<top>640</top>
-						<width>525</width>
+						<width>540</width>
 						<bottom>117</bottom>
 						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>$VAR[ListBoxInfoVar]</label>
-						<visible>!String.IsEqual(ListItem.DbType,episode)</visible>
+						<visible>!String.IsEqual(ListItem.DbType,episode) + !String.IsEqual(ListItem.DBType,song)</visible>
 					</control>
 					<control type="textbox" id="15501">
 						<top>485</top>
-						<width>525</width>
+						<width>540</width>
 						<bottom>96</bottom>
 						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>$INFO[ListItem.Plot]</label>
 						<visible>String.IsEqual(ListItem.DbType,episode)</visible>
+					</control>
+					<control type="textbox" id="15502">
+						<top>600</top>
+						<width>540</width>
+						<height>410</height>
+						<autoscroll time="3000" delay="3000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
+						<label>[COLOR button_focus][B]$LOCALIZE[31037]: [/COLOR]$INFO[Container.CurrentItem,,/]$INFO[Container.NumItems][/B][CR]$VAR[ListBoxInfoVar]</label>
+						<visible>String.IsEqual(ListItem.DBType,song)</visible>
 					</control>
 				</control>
 				<control type="group">
@@ -231,7 +298,7 @@
 					<control type="textbox">
 						<left>30</left>
 						<top>460</top>
-						<width>530</width>
+						<width>540</width>
 						<height>413</height>
 						<align>center</align>
 						<aligny>center</aligny>

--- a/addons/skin.estuary/xml/View_55_WideList.xml
+++ b/addons/skin.estuary/xml/View_55_WideList.xml
@@ -20,7 +20,7 @@
 				<onup>55</onup>
 				<ondown>55</ondown>
 				<viewtype label="$LOCALIZE[31107]">list</viewtype>
-				<focusedlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games)">
+				<focusedlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)">
 					<control type="image">
 						<left>0</left>
 						<right>0</right>
@@ -42,7 +42,7 @@
 						<right>40</right>
 						<aligny>center</aligny>
 						<scroll>true</scroll>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ListLabelVar]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 					<control type="label">
@@ -56,7 +56,7 @@
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 				</focusedlayout>
-				<itemlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games)">
+				<itemlayout height="list_item_height" condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(movies) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content(games) | Window.IsActive(videoplaylist) | Window.IsActive(musicplaylist)">
 					<control type="image">
 						<left>35</left>
 						<centertop>50%</centertop>
@@ -70,7 +70,7 @@
 						<bottom>0</bottom>
 						<right>40</right>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ListLabelVar]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 					<control type="label">
@@ -134,7 +134,7 @@
 						<bottom>0</bottom>
 						<right>40</right>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
+						<label>$VAR[ListLabelVar]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 					<control type="label">
@@ -148,7 +148,6 @@
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 				</itemlayout>
-
 				<focusedlayout height="list_item_height" condition="Container.Content(playlists) | Container.Content()">
 					<control type="image">
 						<left>0</left>
@@ -215,7 +214,7 @@
 				<right>40</right>
 				<aligny>center</aligny>
 				<scroll>true</scroll>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ListLabelVar]</label>
 				<shadowcolor>text_shadow</shadowcolor>
 			</control>
 			<control type="label">
@@ -224,7 +223,7 @@
 				<right>40</right>
 				<align>right</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label2]</label>
+				<label>$VAR[ListLabel2Var]</label>
 				<shadowcolor>text_shadow</shadowcolor>
 			</control>
 		</focusedlayout>
@@ -234,7 +233,7 @@
 				<height>80</height>
 				<right>40</right>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label]</label>
+				<label>$VAR[ListLabelVar]</label>
 				<shadowcolor>text_shadow</shadowcolor>
 			</control>
 			<control type="label">
@@ -243,7 +242,7 @@
 				<right>40</right>
 				<align>right</align>
 				<aligny>center</aligny>
-				<label>$INFO[ListItem.Label2]</label>
+				<label>$VAR[ListLabel2Var]</label>
 				<textcolor>grey</textcolor>
 				<shadowcolor>text_shadow</shadowcolor>
 			</control>


### PR DESCRIPTION
## Description
This is a refactor of the Estuary Playlist window which presently looks like

**Image 1**
![image](https://user-images.githubusercontent.com/5781142/70375653-19153e00-18f8-11ea-8cb0-15ca709ea3b8.png)

## Motivation and Context
Make the Playlist window more like the other media views in terms of operation and features.

1. Introduce the sideblade in the Playlist windows as this allows:
* The controls can be moved from view onto sideblade. See Image 3 & 5
* Now possible to filter the playlist. See Image 6
* Now possible to have multiple view types if wanted as sideblade gives access to View Type selector. See Image 5

2. To minimise new code the default view for the playlist windows is Widelist (currently this is the only view for video playlists)

3. Add a new view for music playlists called "Now Playing" this was based on the List view to again minimise new code. The reasons for this new view are:
* Full screen music (visualisation window) only allows to see anything beyond next track, whereas plenty of users want to a full list of what's coming up next so prefer to remain within the Playlist window.
* For users who prefer to sit in the Playlist window this new view will provide media details for both the selected track (for browsing) and the currently playing track. thus giving a more jukebox type experience. See Image 7

## How Has This Been Tested?
To minimise new code this refactor reuses much of the code from the old **View_50_List** and **View_55_WideList** views and some of the includes that were contained in these View files has moved to a new **Includes_Views**.

Due to touching both **View_50_List** and **View_55_WideList**  I've tried testing all areas of Kodi that make use of these as far as I can, includes:
Music
Movies
TV Shows
PVR (could only test with PVR demo)
Pictures 

## Screenshots (if appropriate):

**Image 2 - Video playlist - TV Show**
![image](https://user-images.githubusercontent.com/5781142/70375767-eb30f900-18f9-11ea-8bf8-ca647aef3d7f.png)

**Image 2 - Video playlist - Movie**
![image](https://user-images.githubusercontent.com/5781142/70375777-fedc5f80-18f9-11ea-92e9-40b99eef53f1.png)

**Image 3 - Video playlist sideblade**
![image](https://user-images.githubusercontent.com/5781142/70375783-07cd3100-18fa-11ea-8107-9b719aca15ba.png)

**Image 4 - Music playlist**
![image](https://user-images.githubusercontent.com/5781142/70375791-26cbc300-18fa-11ea-878f-c5321fb92a62.png)

**Image 5 - Music playlist sideblade**
![image](https://user-images.githubusercontent.com/5781142/70375810-524ead80-18fa-11ea-8c74-927258a00251.png)

**Image 6 - Sideblade filter**
![image](https://user-images.githubusercontent.com/5781142/70375821-672b4100-18fa-11ea-9b19-24259ad6a11d.png)

**Image 7 - Music playlist - Now Playing view**
![image](https://user-images.githubusercontent.com/5781142/70375827-87f39680-18fa-11ea-866f-bcab9e7248a7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [x ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
