### PR TITLE
[music]Fix display of discs or songs sublist for selected album

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4849,6 +4849,14 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
 
   return false;
 }
+int CMusicDatabase::GetDiscsCount(const std::string& baseDir, const Filter& filter /* = Filter() */)
+{
+  int iDiscTotal = -1;
+  CFileItemList itemscount;
+  if (GetDiscsByWhere(baseDir, filter, itemscount, SortDescription(), true))
+    iDiscTotal = itemscount.GetProperty("total").asInteger();
+  return iDiscTotal;
+}
 
 bool CMusicDatabase::GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */, bool artistData /* = false*/)
 {

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -478,6 +478,7 @@ public:
                        const SortDescription& sortDescription = SortDescription(),
                        bool countOnly = false);
   bool GetArtistsByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
+  int GetDiscsCount(const std::string& baseDir, const Filter& filter = Filter());
   int GetSongsCount(const Filter &filter = Filter());
   bool GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription &sorting) override;
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -371,58 +371,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
   if (strDirectory.empty())
     AddSearchFolder();
 
-  bool bResult = false;
-  if (URIUtils::IsMusicDb(strDirectory))
-  {
-    XFILE::CMusicDatabaseDirectory dir;
-    CQueryParams params;
-    MUSICDATABASEDIRECTORY::NODE_TYPE type;
-    MUSICDATABASEDIRECTORY::NODE_TYPE childtype;
-    dir.GetDirectoryNodeInfo(strDirectory, type, childtype, params);
-
-    //Control navigation from albums to discs or directly to songs
-    if (childtype == NODE_TYPE_DISC)
-    {
-      bool bFlatten = false;
-
-      if (params.GetAlbumId() < 0)
-        bFlatten = true; // Showing *all albums next always songs
-      else
-      {
-        // Option to show discs for ordinary albums (not just boxed sets)
-        bFlatten = !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MUSICLIBRARY_SHOWDISCS);
-        CMusicDatabase musicdatabase;
-        if (musicdatabase.Open())
-        {
-          if (bFlatten) // Check for boxed set
-            bFlatten = !musicdatabase.IsAlbumBoxset(params.GetAlbumId());
-          if (!bFlatten)
-          { // Check we will get more than 1 disc when filter applied
-            int iDiscTotal = -1;
-            if (musicdatabase.GetDiscsByWhere(strDirectory, CDatabase::Filter(), items,
-                                              SortDescription(), true))
-              iDiscTotal = items.GetProperty("total").asInteger();
-            bFlatten = iDiscTotal <= 1;
-          }
-        }
-        musicdatabase.Close();
-      }
-      if (bFlatten)
-      { // Skip discs level and show songs
-        CMusicDbUrl musicUrl;
-        if (!musicUrl.FromString(strDirectory))
-          return false;
-
-        musicUrl.AppendPath("-2/"); // Flattened so adjust list label etc.
-        bResult = CGUIWindowMusicBase::GetDirectory(musicUrl.ToString(), items);
-      }
-    }
-  }
-
-  if (!bResult)
-    bResult = CGUIWindowMusicBase::GetDirectory(strDirectory, items);
-
+  bool bResult = CGUIWindowMusicBase::GetDirectory(strDirectory, items);
   if (bResult)
   {
     if (items.IsPlayList())


### PR DESCRIPTION
A follow-up to #16915 the addition of multi-disc and boxset handling, which fixes a regression for skins that show the songs for the currently selected album as a sublist on a panel on the albms node. 

Reported (with screen shots) for Estuary here https://forum.kodi.tv/showthread.php?tid=349695&pid=2905879#pid2905879 but could effect other skins.

Since the addition of the multi-disc and boxset feature, the deafult children of an album are discs not songs. Navigation directly from an album to songs was implemented to allow for when the album had only one disc, the possibily of filtered results being on only one disc, or if the user only wanted to see a disc level for albums flagged as boxsets. This conditional control of what kind of children to fetch - songs or discs - needed to be applied to all places where fileitem lists are populated not just navigation between library screens. 

The solution is to move the conditional child node processing (the decidson to "flatten" the display to just songs, rather than split into discs) from `CGUIWindowMusicNav::GetDirectory` to `CMusicDatabaseDirectory::GetDirectory`

@the-black-eagle I think this is a slightly more comprehensive solution than the processing in `CDirectoryNodeAlbum::GetChildType` that you proposed. That couldn't allow for showing songs when the filtered results are only one disc, because CDirectoryNodeAlbum doesn't know what path it is created from. An example of this would be to navigate artist > album from a list of song artists to a multi-disc album where the artist is only a song artist on some of the tracks on one of the discs.

Thanks for spotting this @jjd-uk, I hope you both will give this a good testing