### PR TITLE
AESinkAudioTrack: Fine-grain forced blocking depending on period_time and buffer

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -745,7 +745,8 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   else
   {
     // waiting should only be done if sink is not run dry
-    if (m_delay > (m_audiotrackbuffer_sec * 0.8))
+    double period_time = m_format.m_frames / static_cast<double>(m_sink_sampleRate);
+    if (m_delay >= (m_audiotrackbuffer_sec - period_time))
     {
       double time_should_ms = 1000.0 * written_frames / m_format.m_sampleRate;
       double time_off = time_should_ms - time_to_add_ms;


### PR DESCRIPTION
We can save more power and make recude the probability of Android's AudioTrack blocking for too long by adjusting forced sleeps with period_time, buffer and delay.

If there is space in buffer, don't additionally block
If buffer is nearly taken, block for AudioTrack