### PR TITLE
[skin.estuary] Improvement: 'Favourites' SideBlade Action (Leia branch)

### DIFF
--- a/addons/skin.estuary/xml/MyGames.xml
+++ b/addons/skin.estuary/xml/MyGames.xml
@@ -95,6 +95,12 @@
 						<label>$LOCALIZE[31020]</label>
 						<visible>Control.IsVisible(621) | Control.IsVisible(624)</visible>
 					</control>
+					<control type="button" id="309">
+						<description>Open Favorites</description>
+						<include>MediaMenuItemsCommon</include>
+						<label>1036</label>
+						<onclick>ActivateWindow(Favourites)</onclick>
+					</control>
 					<control type="button" id="621">
 						<description>Get more</description>
 						<include>MediaMenuItemsCommon</include>

--- a/addons/skin.estuary/xml/MyMusicNav.xml
+++ b/addons/skin.estuary/xml/MyMusicNav.xml
@@ -56,6 +56,12 @@
 						<onclick>ActivateWindow(musicplaylist)</onclick>
 						<visible>Integer.IsGreater(Playlist.Length(music),0)</visible>
 					</control>
+					<control type="button" id="309">
+						<description>Open Favorites</description>
+						<include>MediaMenuItemsCommon</include>
+						<label>1036</label>
+						<onclick>ActivateWindow(Favourites)</onclick>
+					</control>
 					<control type="button" id="621">
 						<include>MediaMenuItemsCommon</include>
 						<label>$LOCALIZE[21452]</label>

--- a/addons/skin.estuary/xml/MyPics.xml
+++ b/addons/skin.estuary/xml/MyPics.xml
@@ -238,6 +238,12 @@
 						<onclick>Addon.OpenSettings($INFO[Container.PluginName])</onclick>
 						<visible>!String.IsEmpty(Container.PluginName)</visible>
 					</control>
+					<control type="button" id="309">
+						<description>Open Favorites</description>
+						<include>MediaMenuItemsCommon</include>
+						<label>1036</label>
+						<onclick>ActivateWindow(Favourites)</onclick>
+					</control>
 					<control type="button" id="621">
 						<description>Get more</description>
 						<include>MediaMenuItemsCommon</include>

--- a/addons/skin.estuary/xml/MyPrograms.xml
+++ b/addons/skin.estuary/xml/MyPrograms.xml
@@ -43,6 +43,12 @@
 						<onclick>Addon.OpenSettings($INFO[Container.PluginName])</onclick>
 						<visible>!String.IsEmpty(Container.PluginName)</visible>
 					</control>
+					<control type="button" id="309">
+						<description>Open Favorites</description>
+						<include>MediaMenuItemsCommon</include>
+						<label>1036</label>
+						<onclick>ActivateWindow(Favourites)</onclick>
+					</control>
 					<control type="button" id="621">
 						<description>Get more</description>
 						<include>MediaMenuItemsCommon</include>

--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -140,6 +140,12 @@
 						<onclick>ActivateWindow(videoplaylist)</onclick>
 						<visible>Integer.IsGreater(Playlist.Length(video),0)</visible>
 					</control>
+					<control type="button" id="309">
+						<description>Open Favorites</description>
+						<include>MediaMenuItemsCommon</include>
+						<label>1036</label>
+						<onclick>ActivateWindow(Favourites)</onclick>
+					</control>
 					<control type="button" id="621">
 						<description>Get more</description>
 						<include>MediaMenuItemsCommon</include>


### PR DESCRIPTION
## Description
Favourites SideBlade action addition.

## Motivation and Context
I thought the SideBlade menu could use some more functionality. In my vision it is an always accessible sidemenu that could include shortcuts. Added a "Favourites" shortcut above the "Get more..." option. I will not be disappointed if it does not get included, but it is here to serve as food for thought for more sideblade actions.

## How Has This Been Tested?
Tested on x64 Android and Windows, both latest Leia and Matrix alpha. 

## Screenshots (if appropriate):
![Screenshot_20191210-034121](https://user-images.githubusercontent.com/43998058/70497064-87d1e180-1b1a-11ea-8ee3-9bc423290c63.jpg)

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 