### PR TITLE
[Settings] CSettingInt: support pure string based labels for <option>

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -851,6 +851,16 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
             entry.second = strtol(optionElement->FirstChild()->Value(), nullptr, 10);
             m_translatableOptions.push_back(entry);
           }
+          else
+          {
+            std::string label;
+            if (optionElement->QueryStringAttribute(SETTING_XML_ATTR_LABEL, &label) ==
+                TIXML_SUCCESS)
+            {
+              int value = strtol(optionElement->FirstChild()->Value(), nullptr, 10);
+              m_options.emplace_back(label, value);
+            }
+          }
 
           optionElement = optionElement->NextSiblingElement(SETTING_XML_ELM_OPTION);
         }


### PR DESCRIPTION
support for pure strings was added in https://github.com/xbmc/xbmc/pull/16660/commits/f38d71ce519d0cf5156815b24ecce19198728602, but that only applies to string type settings.
this PR add it also for int type settings.

**motivation**
addons can use this (old style) setting:
`<setting label="32022" type="enum" id="foo" values="aa|bb|cc|dd" />`
(ref: https://kodi.wiki/view/Add-on_settings#type.3D.22enum.22_or_.22labelenum.22)

which would translate to (new-style):
```
<setting id="foo" label="32022" type="integer">
	<level>0</level>
	<default>0</default>
	<constraints>
		<options>
			<option label="aa">0</option>
			<option label="bb">1</option>
			<option label="cc">2</option>
			<option label="dd">3</option>
		</options>
	</constraints>
	<control type="spinner" format="string"/>
</setting>
```
but that currently does not work.. the setting is greyed out in the settings dialog.