### PR TITLE
AudioTrack: Hack for Leia - workaround broken AMLogic firmware v23

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -882,6 +882,17 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities()
   m_info.m_wantsIECPassthrough = false;
   m_info.m_dataFormats.push_back(AE_FMT_RAW);
   m_info.m_streamTypes.clear();
+
+  // if hardware is amlogic but aml_present is false, means permissions are wrong in FW, we run on broken v23 firmware which should not have
+  // been sold to customers. Just add AC3 and return early
+  if (!aml_present() && (StringUtils::StartsWithNoCase(CJNIBuild::HARDWARE, "amlogic") &&
+                         CJNIAudioManager::GetSDKVersion() == 23))
+  {
+    m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+    CLog::Log(LOGNOTICE, "AMLogic v23 broken FW workaround in place - only AC3 supported");
+    return;
+  }
+
   if (CJNIAudioFormat::ENCODING_AC3 != -1)
   {
     if (VerifySinkConfiguration(48000, CJNIAudioFormat::CHANNEL_OUT_STEREO, CJNIAudioFormat::ENCODING_AC3))


### PR DESCRIPTION
This fixes: https://github.com/xbmc/xbmc/issues/16271

That's an insanely broken AMLogic firmware. Back at the time they switch to API v23, they had two versions. One that properly did standard Passthrough, another one that was "intermediate state" that did something non-deterministic.

As you see in the referenced issue, these boxes (vendor: amlogic, but not has_aml() and API == 23) segfault in a lower layer when you try to open E_AC3 format, though correctly returning a minBufferSize for it.

As I don't want Leia to fail even starting on all these shitty implementations - this will be Leia only. I don't plan to support such fuckup in Matrix, where AML special hacks are already removed.