### PR TITLE
[Estuary] fallback to icon in poster view

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -72,6 +72,11 @@
 		<value condition="!String.IsEqual(listitem.dbtype,musicvideo) + !String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
+	<variable name="PosterThumbVar">
+		<value condition="!String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
+		<value condition="ListItem.IsParentFolder">DefaultFolderBackPoster.png</value>
+		<value>$INFO[ListItem.Icon]</value>
+	</variable>
 	<variable name="IconWallThumbVar">
 		<value condition="String.IsEqual(listitem.dbtype,genre) + System.HasAddon(resource.images.moviegenreicons.transparent)">$INFO[ListItem.Label,resource://resource.images.moviegenreicons.transparent/,.png]</value>
 		<value condition="String.IsEqual(listitem.dbtype,studio) + System.HasAddon(resource.images.studios.white)">$INFO[ListItem.Label,resource://resource.images.studios.white/,.png]</value>

--- a/addons/skin.estuary/xml/View_51_Poster.xml
+++ b/addons/skin.estuary/xml/View_51_Poster.xml
@@ -141,7 +141,7 @@
 				<height>716</height>
 				<fadetime>200</fadetime>
 				<aspectratio>scale</aspectratio>
-				<texture fallback="DefaultVideo.png" background="true">$VAR[PosterVar]</texture>
+				<texture fallback="DefaultMovies.png" background="true">$VAR[PosterThumbVar]</texture>
 			</control>
 			<control type="image">
 				<left>1</left>


### PR DESCRIPTION
unify the focused item & itemlayout in the poster view.
the focused item did not fallback to ListItem.Icon when ListItem.Art(poster) returned empty.

@sarbes 