### PR TITLE
[videoplayer] Fix GetItemsToScan scan in sub-directories

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1875,7 +1875,7 @@ void CUtil::GetItemsToScan(const std::string& videoPath,
   for (std::vector<std::string>::const_iterator it = additionalPaths.begin(); it != additionalPaths.end(); ++it)
   {
     CFileItemList moreItems;
-    CDirectory::GetDirectory(*it, moreItems, CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions(), flags);
+    CDirectory::GetDirectory(*it, moreItems, item_exts, flags);
     items.Append(moreItems);
   }
 }


### PR DESCRIPTION
[`GetItemsToScan`](https://github.com/xbmc/xbmc/blob/c7e9b0b38c253612d145a905eba8b78fcd5e90b5/xbmc/Util.cpp#L1855-L1881) currently always scans for subtitles in additional directories. It should scan for requested extensions instead.

Fixes #17014 (technical details [here](https://github.com/xbmc/xbmc/issues/17014#issuecomment-565401483)). Verified on [this](http://mirrors.kodi.tv/test-builds/windows/win32/KodiSetup-20191216-4ce172e6-PR17036-merge-x86.exe) win32 test build
 
Also fixes scan for external audio tracks ([`ScanForExternalAudio`](https://github.com/xbmc/xbmc/blob/e5c32c4065eabbf421f9704c24bb78e5edf3db09/xbmc/Util.cpp#L2300-L2302)) and .sup subtitles ([`ScanForExternalDemuxSub`](https://github.com/xbmc/xbmc/blob/e5c32c4065eabbf421f9704c24bb78e5edf3db09/xbmc/Util.cpp#L2277-L2279)) in sub-directories for video