### PR TITLE
fixed: Chunk size logic for file cache (hopefully fixes #16975)

### DIFF
--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -119,7 +119,8 @@ int CSimpleFileCache::WriteToCache(const char *pBuffer, size_t iSize)
   size_t written = 0;
   while (iSize > 0)
   {
-    const ssize_t lastWritten = m_cacheFileWrite->Write(pBuffer, (iSize > SSIZE_MAX) ? SSIZE_MAX : iSize);
+    const ssize_t lastWritten =
+        m_cacheFileWrite->Write(pBuffer, std::min(iSize, static_cast<size_t>(SSIZE_MAX)));
     if (lastWritten <= 0)
     {
       CLog::LogF(LOGERROR, "failed to write to file");
@@ -145,14 +146,16 @@ int CSimpleFileCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
 {
   int64_t iAvailable = GetAvailableRead();
   if ( iAvailable <= 0 )
-    return m_bEndOfInput? 0 : CACHE_RC_WOULD_BLOCK;
+    return m_bEndOfInput ? 0 : CACHE_RC_WOULD_BLOCK;
 
-  size_t toRead = ((int64_t)iMaxSize > iAvailable) ? (size_t)iAvailable : iMaxSize;
+  size_t toRead = std::min(iMaxSize, static_cast<size_t>(iAvailable));
 
   size_t readBytes = 0;
   while (toRead > 0)
   {
-    const ssize_t lastRead = m_cacheFileRead->Read(pBuffer, (toRead > SSIZE_MAX) ? SSIZE_MAX : toRead);
+    const ssize_t lastRead =
+      m_cacheFileRead->Read(pBuffer, std::min(toRead, static_cast<size_t>(SSIZE_MAX)));
+
     if (lastRead == 0)
       break;
     if (lastRead < 0)

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -101,16 +101,7 @@ public:
   const std::vector<std::string> GetPropertyValues(XFILE::FileProperty type, const std::string &name = "") const;
   ssize_t LoadFile(const std::string &filename, auto_buffer& outputBuffer);
 
-
-  // will return a size, that is aligned to chunk size
-  // but always greater or equal to the file's chunk size
-  static int GetChunkSize(int chunk, int minimum)
-  {
-    if(chunk)
-      return chunk * ((minimum + chunk - 1) / chunk);
-    else
-      return minimum;
-  }
+  static int DetermineChunkSize(const int srcChunkSize, const int reqChunkSize);
 
   BitstreamStats* GetBitstreamStats() { return m_bitStreamStats; }
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -33,8 +33,6 @@
 
 using namespace XFILE;
 
-#define READ_CACHE_CHUNK_SIZE (128*1024)
-
 class CWriteRate
 {
 public:
@@ -137,7 +135,9 @@ bool CFileCache::Open(const CURL& url)
   m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
 
   // Determine the best chunk size we can use
-  m_chunkSize = CFile::DetermineChunkSize(m_source.GetChunkSize(), READ_CACHE_CHUNK_SIZE);
+  m_chunkSize = CFile::DetermineChunkSize(
+      m_source.GetChunkSize(),
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheChunkSize);
   CLog::Log(LOGDEBUG, "CFileCache::Open - Source chunk size is %i, setting cache chunk size to %i",
             m_source.GetChunkSize(), m_chunkSize);
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -244,7 +244,8 @@ void CFileCache::Process()
         m_nSeekResult = m_source.Seek(cacheMaxPos, SEEK_SET);
         if (m_nSeekResult != cacheMaxPos)
         {
-          CLog::Log(LOGERROR,"CFileCache::Process - Error %d seeking. Seek returned %" PRId64, (int)GetLastError(), m_nSeekResult);
+          CLog::Log(LOGERROR, "CFileCache::Process - Error %d seeking. Seek returned %" PRId64,
+                    static_cast<int>(GetLastError()), m_nSeekResult);
           m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
           sourceSeekFailed = true;
         }
@@ -260,6 +261,9 @@ void CFileCache::Process()
         m_nSeekResult = m_seekPos;
         if (bCompleteReset)
         {
+          CLog::Log(LOGDEBUG,
+                    "CFileCache::Process - Cache completely reset for seek to position %" PRId64,
+                    m_seekPos);
           m_forward = 0;
           m_bFilling = true;
           m_bLowSpeedDetected = false;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -381,8 +381,9 @@ void CAdvancedSettings::Initialize()
   m_iPVRTimeshiftThreshold = 10;
   m_bPVRTimeshiftSimpleOSD = true;
 
-  m_cacheMemSize = 1024 * 1024 * 20;
+  m_cacheMemSize = 1024 * 1024 * 20; // 20 MiB
   m_cacheBufferMode = CACHE_BUFFER_MODE_INTERNET; // Default (buffer all internet streams/filesystems)
+  m_cacheChunkSize = 128 * 1024; // 128 KiB
   // the following setting determines the readRate of a player data
   // as multiply of the default data read rate
   m_cacheReadFactor = 4.0f;
@@ -822,6 +823,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   {
     XMLUtils::GetUInt(pElement, "memorysize", m_cacheMemSize);
     XMLUtils::GetUInt(pElement, "buffermode", m_cacheBufferMode, 0, 4);
+    XMLUtils::GetUInt(pElement, "chunksize", m_cacheChunkSize, 256, 1024 * 1024);
     XMLUtils::GetFloat(pElement, "readfactor", m_cacheReadFactor);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -328,6 +328,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     unsigned int m_cacheMemSize;
     unsigned int m_cacheBufferMode;
+    unsigned int m_cacheChunkSize;
     float m_cacheReadFactor;
 
     bool m_jsonOutputCompact;


### PR DESCRIPTION
Also adds the option to make the default(!) chunksize configurable for filecache. Additionally it contains a few other (minor) tweaks.