### PR TITLE
changed: By default enable filecache for all remote filesystems

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -382,8 +382,9 @@ void CAdvancedSettings::Initialize()
   m_bPVRTimeshiftSimpleOSD = true;
 
   m_cacheMemSize = 1024 * 1024 * 20; // 20 MiB
-  m_cacheBufferMode = CACHE_BUFFER_MODE_INTERNET; // Default (buffer all internet streams/filesystems)
+  m_cacheBufferMode = CACHE_BUFFER_MODE_REMOTE; // Default (buffer all remote filesystems)
   m_cacheChunkSize = 128 * 1024; // 128 KiB
+
   // the following setting determines the readRate of a player data
   // as multiply of the default data read rate
   m_cacheReadFactor = 4.0f;


### PR DESCRIPTION
This makes the default filecache buffer mode CACHE_BUFFER_MODE_REMOTE. By now most folks play stuff over (crappy) wifi-connections from network-shares for which this helps a lot. Furthermore devices have more ram and are more powerful by now, so that shouldn't be a problem anymore.