### PR TITLE
AESinkAUDIOTRACK: Remove PT hack for volume

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -246,7 +246,6 @@ CAESinkAUDIOTRACK::CAESinkAUDIOTRACK()
   m_duration_written = 0;
   m_headPos = 0;
   m_timestampPos = 0;
-  m_volume = -1;
   m_sink_sampleRate = 0;
   m_passthrough = false;
   m_min_buffer_size = 0;
@@ -296,7 +295,6 @@ bool CAESinkAUDIOTRACK::IsSupported(int sampleRateInHz, int channelConfig, int e
 bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
 {
   m_format      = format;
-  m_volume      = -1;
   m_headPos = 0;
   m_timestampPos = 0;
   m_linearmovingaverage.clear();
@@ -527,27 +525,12 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   }
   format = m_format;
 
-  // Force volume to 100% for IEC passthrough
-  if (m_passthrough && m_info.m_wantsIECPassthrough)
-  {
-    CXBMCApp::get()->AcquireAudioFocus();
-    m_volume = CXBMCApp::GetSystemVolume();
-    CXBMCApp::SetSystemVolume(1.0);
-  }
-
   return true;
 }
 
 void CAESinkAUDIOTRACK::Deinitialize()
 {
   CLog::Log(LOGDEBUG, "CAESinkAUDIOTRACK::Deinitialize");
-
-  // Restore volume
-  if (m_volume != -1)
-  {
-    CXBMCApp::SetSystemVolume(m_volume);
-    CXBMCApp::get()->ReleaseAudioFocus();
-  }
 
   if (!m_at_jni)
     return;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -78,7 +78,6 @@ private:
   static bool m_sinkSupportsMultiChannelFloat;
 
   AEAudioFormat      m_format;
-  double             m_volume;
   int16_t           *m_alignedS16;
   unsigned int       m_sink_frameSize;
   unsigned int       m_sink_sampleRate;


### PR DESCRIPTION
With proper IEC61397 format available, we should not play the PCM games anymore.

Past:
When pseudo PT samples (16 bit) were sent out as hearable samples, the volume had to be forced to 100% so that those were not altered by Android internally. This was a nightmare at least since Float becamre a standard as well on Android.

Remove it.