### PR TITLE
AudioEngine: Fix recovery in case of atempo filtergraph fails

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -220,6 +220,7 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
     {
       av_frame_free(&frame);
       CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - avcodec_fill_audio_frame failed");
+      m_filterEof = true;
       return -1;
     }
 
@@ -228,6 +229,7 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
     if (result < 0)
     {
       CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - av_buffersrc_add_frame failed");
+      m_filterEof = true;
       return -1;
     }
 
@@ -239,6 +241,7 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
     if (result < 0)
     {
       CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - av_buffersrc_add_frame");
+      m_filterEof = true;
       return -1;
     }
   }
@@ -265,6 +268,7 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
     else if (result < 0)
     {
       CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - av_buffersink_get_frame");
+      m_filterEof = true;
       return -1;
     }
 
@@ -281,6 +285,7 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
       if (result < 0)
       {
         CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - swr_convert_frame failed");
+        m_filterEof = true;
         return -1;
       }
     }
@@ -326,7 +331,7 @@ bool CActiveAEFilter::NeedData() const
 
 bool CActiveAEFilter::IsActive() const
 {
-  return m_pFilterGraph != nullptr;
+  return m_pFilterGraph != nullptr && !m_filterEof;
 }
 
 int CActiveAEFilter::GetBufferedSamples() const


### PR DESCRIPTION
## Description
ChangeFilter was never called when m_pTempoFilter->ProcessFilter
returns -1.
As a result we could never recover from this state.

## Motivation and Context
If CActiveAEFilter::ProcessFilter returns -1 for whatever reason (in my case failure in ffmpeg on live streams), we couldn't recover from this state for a long time (>=8sec).
This change immediately recreates the tempo-filter and subsequent calls worked, hence we could recover instantly.

## How Has This Been Tested?
Running on several linux systems for 2-3 weeks now, without any issues.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
