### PR TITLE
Windowing: GBM - Fix refreshrate switch

### DIFF
--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -119,6 +119,7 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
   {
     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
     m_need_modeset = false;
+    CLog::Log(LOGDEBUG, "CDRMAtomic::%s - Execute modeset at next commit", __FUNCTION__);
   }
 
   DrmAtomicCommit(!drm_fb ? 0 : drm_fb->fb_id, flags, rendered, videoLayer);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -200,10 +200,7 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
   if (delay > 0)
-  {
-    m_delayDispReset = true;
     m_dispResetTimer.Set(delay * 100);
-  }
 
   return result;
 }
@@ -275,6 +272,7 @@ void CWinSystemGbm::Unregister(IDispResource *resource)
 void CWinSystemGbm::OnLostDevice()
 {
   CLog::Log(LOGDEBUG, "%s - notify display change event", __FUNCTION__);
+  m_dispReset = true;
 
   CSingleLock lock(m_resourceSection);
   for (auto resource : m_resources)

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -70,7 +70,7 @@ protected:
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*>  m_resources;
 
-  bool m_delayDispReset = false;
+  bool m_dispReset = false;
   XbmcThreads::EndTime m_dispResetTimer;
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
   std::unique_ptr<CLibInputHandler> m_libinput;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -92,14 +92,6 @@ bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
   CWinSystemGbm::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
 
-  if (!m_delayDispReset)
-  {
-    CSingleLock lock(m_resourceSection);
-
-    for (auto resource : m_resources)
-      resource->OnResetDisplay();
-  }
-
   return true;
 }
 
@@ -119,19 +111,21 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
       }
     }
     CWinSystemGbm::FlipPage(rendered, videoLayer);
+
+    if (m_dispReset && m_dispResetTimer.IsTimePast())
+    {
+      CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::%s - Sending display reset to all clients",
+                __FUNCTION__);
+      m_dispReset = false;
+      CSingleLock lock(m_resourceSection);
+
+      for (auto resource : m_resources)
+        resource->OnResetDisplay();
+    }
   }
   else
   {
     Sleep(10);
-  }
-
-  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
-  {
-    m_delayDispReset = false;
-    CSingleLock lock(m_resourceSection);
-
-    for (auto resource : m_resources)
-      resource->OnResetDisplay();
   }
 }
 


### PR DESCRIPTION
f## Description
We wake up the audio engine way too early.
In order to do it correctly, we need to wait until
the modeset has been executed by the atomic commit.
Otherwise there is a big chance that the audio engine
is trying to open the sound device while the ELD info
is broken.

## Motivation and Context
I often had the issue that we fell back to analog audio on a modeswitch when I used delay after refreshrate switch "off".
The reason was that the wakeup of the AudioEngine was done rather immediately and not after the actual modeset.

## How Has This Been Tested?
Running on some linux systems (gbm gl) for 2-3 weeks now.
Never lost audio so far.
Also runtime tested gbm gles.

Following enhanced debug log shows that it is correct now (you can also see that the atomic commit including the modeset takes 120ms while normal atomic commits seem to take ~10-40ms)
```
2019-12-18 21:48:24.137 T:32226  NOTICE: Whitelist search for: width: 1920, height: 1080, fps: 24.000, 3D: false
2019-12-18 21:48:24.137 T:32226   DEBUG: Trying to find exact refresh rate
2019-12-18 21:48:24.137 T:32226   DEBUG: Matched exact whitelisted Resolution 1920x1080 @ 24.000000 Hz (42)
2019-12-18 21:48:24.137 T:32226  NOTICE: Display resolution ADJUST : 1920x1080 @ 24.000000 Hz (42) (weight: 0.000)
2019-12-18 21:48:24.208 T:32225   DEBUG: Thread Timer 140437092292352 terminating
2019-12-18 21:48:24.233 T:32181   DEBUG: ------ Window Init (DialogBusy.xml) ------
2019-12-18 21:48:24.233 T:32181   DEBUG: Window DialogBusy.xml was already loaded
2019-12-18 21:48:24.233 T:32181   DEBUG: Alloc resources: 0.02ms
2019-12-18 21:48:24.235 T:32181   DEBUG: CWinSystemGbmGLContext::SetFullScreen - resolution changed, creating a new window
--> 2019-12-18 21:48:24.235 T:32181   DEBUG: OnLostDevice - notify display change event
2019-12-18 21:48:24.309 T:32207   DEBUG: CWebServer[8080]: request received for /jsonrpc
2019-12-18 21:48:24.429 T:32181   DEBUG: Previous line repeats 1 times.
2019-12-18 21:48:24.429 T:32181  NOTICE: VideoPlayer: OnLostDisplay received
2019-12-18 21:48:24.429 T:32181 WARNING: CDVDMessageQueue(audio)::Put MSGQ_NOT_INITIALIZED
2019-12-18 21:48:24.429 T:32181 WARNING: CDVDMessageQueue(video)::Put MSGQ_NOT_INITIALIZED
2019-12-18 21:48:24.429 T:32181   DEBUG: Flush - flushing renderer
2019-12-18 21:48:24.429 T:32181   DEBUG: CDRMUtils::DrmFbDestroyCallback - removing framebuffer: 105
2019-12-18 21:48:24.446 T:32181   DEBUG: CDRMUtils::DrmFbDestroyCallback - removing framebuffer: 109
2019-12-18 21:48:24.446 T:32181   DEBUG: CWinSystemGbmEGLContext::DestroyWindow - deinitialized GBM
2019-12-18 21:48:24.497 T:32181   DEBUG: CDRMUtils::SetMode - found crtc mode: 1920x1080 @ 24 Hz
2019-12-18 21:48:24.497 T:32181   DEBUG: CGBMUtils::CreateSurface - created surface with size 1920x1080
2019-12-18 21:48:24.498 T:32181   DEBUG: CWinSystemGbmEGLContext::CreateNewWindow - initialized GBM
2019-12-18 21:48:24.506 T:32181   DEBUG: OnLostDevice - notify display change event
2019-12-18 21:48:24.507 T:32181  NOTICE: VideoPlayer: OnLostDisplay received
2019-12-18 21:48:24.507 T:32181 WARNING: CDVDMessageQueue(audio)::Put MSGQ_NOT_INITIALIZED
2019-12-18 21:48:24.507 T:32181 WARNING: CDVDMessageQueue(video)::Put MSGQ_NOT_INITIALIZED
2019-12-18 21:48:24.507 T:32181   DEBUG: Flush - flushing renderer
2019-12-18 21:48:24.553 T:32181   DEBUG: CDRMUtils::SetMode - found crtc mode: 1920x1080 @ 24 Hz
2019-12-18 21:48:24.556 T:32181    INFO: GL: Maximum texture width: 16384
2019-12-18 21:48:24.566 T:32226  NOTICE: Creating video codec with codec id: 27
2019-12-18 21:48:24.566 T:32226  NOTICE: CDVDVideoCodecFFmpeg::Open() Using codec: H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
2019-12-18 21:48:24.566 T:32181   DEBUG: Keyboard: scancode: 0x1c, sym: 0x000d, unicode: 0x000d, modifier: 0x0
2019-12-18 21:48:24.566 T:32226   DEBUG: CDVDVideoCodecFFmpeg - Updated codec: ff-h264
2019-12-18 21:48:24.566 T:32226   DEBUG: CVideoPlayerVideo::OpenStream - open stream with codec id: 27
2019-12-18 21:48:24.566 T:32226  NOTICE: Creating video thread
2019-12-18 21:48:24.566 T:32229   DEBUG: Thread VideoPlayerVideo start, auto delete: false
2019-12-18 21:48:24.566 T:32229  NOTICE: running thread: video_thread
2019-12-18 21:48:24.566 T:32229   DEBUG: CVideoPlayerVideo - CDVDMsg::GENERAL_PAUSE: 1
2019-12-18 21:48:24.566 T:32226   DEBUG: ReadEditDecisionLists - Checking for edit decision lists (EDL) on local drive or remote share for: /home/a1rwulf/Videos/Youll_never_walk_alone.mkv
2019-12-18 21:48:24.566 T:32226  NOTICE: Opening stream: 1 source: 256
2019-12-18 21:48:24.566 T:32226  NOTICE: Finding audio codec for: 86020
2019-12-18 21:48:24.567 T:32226  NOTICE: CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder dca
2019-12-18 21:48:24.567 T:32226  NOTICE: Creating audio thread
2019-12-18 21:48:24.567 T:32230   DEBUG: Thread VideoPlayerAudio start, auto delete: false
2019-12-18 21:48:24.567 T:32230  NOTICE: running thread: CVideoPlayerAudio::Process()
2019-12-18 21:48:24.567 T:32230   DEBUG: CVideoPlayerAudio - CDVDMsg::GENERAL_PAUSE: 1
2019-12-18 21:48:24.567 T:32226  NOTICE: Opening stream: 4 source: 256
2019-12-18 21:48:24.567 T:32226   DEBUG: CVideoPlayer::SetCaching - caching state 2
2019-12-18 21:48:24.567 T:32230   DEBUG: CDVDAudio::Pause - pausing audio stream
2019-12-18 21:48:24.567 T:32226   DEBUG: CDVDClock::SetSpeedAdjust - adjusted:0.000000
2019-12-18 21:48:24.587 T:32181   DEBUG: EGL Debugging:
                                            Error: EGL_BAD_SURFACE
                                            Command: eglSwapBuffers
                                            Type: EGL_DEBUG_MSG_ERROR_KHR
                                            Message: dri2_swap_buffers
2019-12-18 21:48:24.587 T:32181   DEBUG: CDRMUtils::DrmFbGetFromBo - using modifier: 0x100000000000004
--> 2019-12-18 21:48:24.587 T:32181   DEBUG: CDRMAtomic::FlipPage - Execute modeset at next commit
--> 2019-12-18 21:48:24.587 T:32181   DEBUG: CDRMAtomic::FlipPage - START COMMIT
2019-12-18 21:48:24.590 T:32186   DEBUG: CALSAHControlMonitor - Monitored ALSA hctl value changed
2019-12-18 21:48:24.642 T:32207   DEBUG: CWebServer[8080]: request received for /jsonrpc
2019-12-18 21:48:24.664 T:32186   DEBUG: CALSAHControlMonitor - Monitored ALSA hctl value changed
--> 2019-12-18 21:48:24.706 T:32181   DEBUG: CDRMAtomic::FlipPage - FINISH COMMIT
2019-12-18 21:48:24.706 T:32181   DEBUG: CWinSystemGbmGLContext::PresentRender - Sending display reset to all clients
--> 2019-12-18 21:48:24.706 T:32184   DEBUG: CActiveAE - display reset event
2019-12-18 21:48:24.706 T:32181  NOTICE: VideoPlayer: OnResetDisplay received
2019-12-18 21:48:24.706 T:32230   DEBUG: CVideoPlayerAudio - CDVDMsg::GENERAL_PAUSE: 0
2019-12-18 21:48:24.706 T:32185    INFO: CActiveAESink::OpenSink - initialize sink
2019-12-18 21:48:24.706 T:32229   DEBUG: CVideoPlayerVideo - CDVDMsg::GENERAL_PAUSE: 0
2019-12-18 21:48:24.706 T:32185   DEBUG: CActiveAESink::OpenSink - trying to open device ALSA:hdmi:CARD=PCH,DEV=0
2019-12-18 21:48:24.706 T:32185    INFO: CAESinkALSA::Initialize - Attempting to open device "hdmi:CARD=PCH,DEV=0"
2019-12-18 21:48:24.708 T:32185    INFO: CAESinkALSA::Initialize - Opened device "hdmi:CARD=PCH,DEV=0,AES0=0x04,AES1=0x82,AES2=0x00,AES3=0x00"
2019-12-18 21:48:24.708 T:32185   DEBUG: CAESinkALSA::SelectALSAChannelMap - Selected ALSA map "FL FR"
2019-12-18 21:48:24.708 T:32185    INFO: CAESinkALSA::InitializeHW - Your hardware does not support AE_FMT_FLOAT, trying other formats
2019-12-18 21:48:24.708 T:32185    INFO: CAESinkALSA::InitializeHW - Using data format AE_FMT_S32NE
2019-12-18 21:48:24.708 T:32185   DEBUG: CAESinkALSA::InitializeHW - Request: periodSize 2048, bufferSize 8192
2019-12-18 21:48:24.709 T:32185   DEBUG: CAESinkALSA::InitializeHW - Got: periodSize 2048, bufferSize 8192
2019-12-18 21:48:24.709 T:32185   DEBUG: CAESinkALSA::InitializeHW - Setting timeout to 186 ms
2019-12-18 21:48:24.711 T:32185   DEBUG: CAESinkALSA::GetChannelLayout - Input Channel Count: 2 Output Channel Count: 2
2019-12-18 21:48:24.711 T:32185   DEBUG: CAESinkALSA::GetChannelLayout - Requested Layout: FL, FR
2019-12-18 21:48:24.711 T:32185   DEBUG: CAESinkALSA::GetChannelLayout - Got Layout: FL, FR (ALSA: FL FR)
2019-12-18 21:48:24.711 T:32185   DEBUG: CActiveAESink::OpenSink - ALSA Initialized:
2019-12-18 21:48:24.711 T:32185   DEBUG:   Output Device : HDA Intel PCH
2019-12-18 21:48:24.711 T:32185   DEBUG:   Sample Rate   : 44100
2019-12-18 21:48:24.711 T:32185   DEBUG:   Sample Format : AE_FMT_S32NE
2019-12-18 21:48:24.711 T:32185   DEBUG:   Channel Count : 2
2019-12-18 21:48:24.711 T:32185   DEBUG:   Channel Layout: FL, FR
2019-12-18 21:48:24.711 T:32185   DEBUG:   Frames        : 2048
2019-12-18 21:48:24.711 T:32185   DEBUG:   Frame Size    : 8

```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
