### PR TITLE
[VideoPlayer] enable teletext support for inputstream addons

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -333,10 +333,15 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
     return nullptr;
 
   std::string codecName(stream.m_codecName);
-  StringUtils::ToLower(codecName);
-  AVCodec *codec = avcodec_find_decoder_by_name(codecName.c_str());
-  if (!codec)
-    return nullptr;
+  AVCodec* codec = nullptr;
+
+  if (stream.m_streamType != INPUTSTREAM_INFO::TYPE_TELETEXT)
+  {
+    StringUtils::ToLower(codecName);
+    codec = avcodec_find_decoder_by_name(codecName.c_str());
+    if (!codec)
+      return nullptr;
+  }
 
   CDemuxStream *demuxStream;
 
@@ -403,11 +408,19 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
     CDemuxStreamSubtitle *subtitleStream = new CDemuxStreamSubtitle();
     demuxStream = subtitleStream;
   }
+  else if (stream.m_streamType == INPUTSTREAM_INFO::TYPE_TELETEXT)
+  {
+    CDemuxStreamTeletext* teletextStream = new CDemuxStreamTeletext();
+    demuxStream = teletextStream;
+  }
   else
     return nullptr;
 
   demuxStream->name = stream.m_name;
-  demuxStream->codec = codec->id;
+  if (codec)
+    demuxStream->codec = codec->id;
+  else
+    demuxStream->codec = AV_CODEC_ID_DVB_TELETEXT;
   demuxStream->codecName = stream.m_codecInternalName;
   demuxStream->uniqueId = streamId;
   demuxStream->flags = static_cast<StreamFlags>(stream.m_flags);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Enable teletext support for inputstream addons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

It's was missing ;)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On a new inputstream addon based on ffmpeg.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
