### PR TITLE
[scraper] Pass JSON serialized path settings to python scrapers

### DIFF
--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -148,6 +148,14 @@ private:
   std::string SearchStringEncoding() const
     { return m_parser.GetSearchStringEncoding(); }
 
+  /*! \brief Get the scraper settings for a particular path in the form of a JSON string
+   Loads the default and user settings (if not already loaded) and returns the user settings in the
+   form of an JSON string. It is used in Python scrapers.
+   \return a string containing the JSON settings
+   \sa SetPathSettings
+   */
+  std::string GetPathSettingsAsJSON();
+
   bool Load();
   std::vector<std::string> Run(const std::string& function,
                               const CScraperUrl& url,

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES AdvancedSettings.cpp
             SettingPath.cpp
             Settings.cpp
             SettingsBase.cpp
+            SettingsValueFlatJsonSerializer.cpp
             SettingsValueXmlSerializer.cpp
             SettingUtils.cpp
             SkinSettings.cpp
@@ -33,6 +34,7 @@ set(HEADERS AdvancedSettings.h
             SettingPath.h
             Settings.h
             SettingsBase.h
+            SettingsValueFlatJsonSerializer.h
             SettingsValueXmlSerializer.h
             SettingUtils.h
             SkinSettings.h

--- a/xbmc/settings/SettingsValueFlatJsonSerializer.cpp
+++ b/xbmc/settings/SettingsValueFlatJsonSerializer.cpp
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (C) 2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SettingsValueFlatJsonSerializer.h"
+
+#include "settings/lib/Setting.h"
+#include "settings/lib/SettingDefinitions.h"
+#include "settings/lib/SettingSection.h"
+#include "settings/lib/SettingType.h"
+#include "settings/lib/SettingsManager.h"
+#include "utils/JSONVariantWriter.h"
+#include "utils/log.h"
+
+CSettingsValueFlatJsonSerializer::CSettingsValueFlatJsonSerializer(bool compact /* = true */)
+  : m_compact(compact)
+{ }
+
+std::string CSettingsValueFlatJsonSerializer::SerializeValues(
+  const CSettingsManager* settingsManager) const
+{
+  if (settingsManager == nullptr)
+    return "";
+
+  CVariant root(CVariant::VariantTypeObject);
+
+  const auto sections = settingsManager->GetSections();
+  for (const auto& section : sections)
+    SerializeSection(root, section);
+
+  std::string result;
+  if (!CJSONVariantWriter::Write(root, result, m_compact))
+  {
+    CLog::Log(LOGWARNING,
+      "CSettingsValueFlatJsonSerializer: failed to serialize settings into JSON");
+    return "";
+  }
+
+  return result;
+}
+
+void CSettingsValueFlatJsonSerializer::SerializeSection(
+  CVariant& parent, std::shared_ptr<CSettingSection> section) const
+{
+  if (section == nullptr)
+    return;
+
+  const auto categories = section->GetCategories();
+  for (const auto& category : categories)
+    SerializeCategory(parent, category);
+}
+
+void CSettingsValueFlatJsonSerializer::SerializeCategory(
+  CVariant& parent, std::shared_ptr<CSettingCategory> category) const
+{
+  if (category == nullptr)
+    return;
+
+  const auto groups = category->GetGroups();
+  for (const auto& group : groups)
+    SerializeGroup(parent, group);
+}
+
+void CSettingsValueFlatJsonSerializer::SerializeGroup(
+  CVariant& parent, std::shared_ptr<CSettingGroup> group) const
+{
+  if (group == nullptr)
+    return;
+
+  const auto settings = group->GetSettings();
+  for (const auto& setting : settings)
+    SerializeSetting(parent, setting);
+}
+
+void CSettingsValueFlatJsonSerializer::SerializeSetting(
+  CVariant& parent, std::shared_ptr<CSetting> setting) const
+{
+  if (setting == nullptr)
+    return;
+
+  // ignore references and action settings (which don't have a value)
+  if (setting->IsReference() || setting->GetType() == SettingType::Action)
+    return;
+
+  const auto valueObj = SerializeSettingValue(setting);
+  if (valueObj.isNull())
+    return;
+
+  parent[setting->GetId()] = valueObj;
+}
+
+CVariant CSettingsValueFlatJsonSerializer::SerializeSettingValue(
+  std::shared_ptr<CSetting> setting) const
+{
+  switch (setting->GetType())
+  {
+    case SettingType::Action:
+      return CVariant::ConstNullVariant;
+
+    case SettingType::Boolean:
+      return CVariant(std::static_pointer_cast<CSettingBool>(setting)->GetValue());
+
+    case SettingType::Integer:
+      return CVariant(std::static_pointer_cast<CSettingInt>(setting)->GetValue());
+
+    case SettingType::Number:
+      return CVariant(std::static_pointer_cast<CSettingNumber>(setting)->GetValue());
+
+    case SettingType::String:
+      return CVariant(std::static_pointer_cast<CSettingString>(setting)->GetValue());
+
+    case SettingType::List:
+    {
+      const auto settingList = std::static_pointer_cast<CSettingList>(setting);
+
+      CVariant settingListValuesObj(CVariant::VariantTypeArray);
+      const auto settingListValues = settingList->GetValue();
+      for (const auto& settingListValue : settingListValues)
+      {
+        const auto valueObj = SerializeSettingValue(settingListValue);
+        if (!valueObj.isNull())
+          settingListValuesObj.push_back(valueObj);
+      }
+
+      return settingListValuesObj;
+    }
+
+    case SettingType::Unknown:
+    default:
+      CLog::Log(LOGWARNING,
+        "CSettingsValueFlatJsonSerializer: failed to serialize setting \"{}\" with value \"{}\" " \
+        "of unknown type", setting->GetId(), setting->ToString());
+      return CVariant::ConstNullVariant;
+  }
+}

--- a/xbmc/settings/SettingsValueFlatJsonSerializer.h
+++ b/xbmc/settings/SettingsValueFlatJsonSerializer.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "settings/lib/ISettingsValueSerializer.h"
+#include "utils/Variant.h"
+
+#include <memory>
+
+class CSetting;
+class CSettingCategory;
+class CSettingGroup;
+class CSettingSection;
+
+class CSettingsValueFlatJsonSerializer : public ISettingsValueSerializer
+{
+public:
+  explicit CSettingsValueFlatJsonSerializer(bool compact = true);
+  ~CSettingsValueFlatJsonSerializer() = default;
+
+  void SetCompact(bool compact = true) { m_compact = compact; }
+
+  // implementation of ISettingsValueSerializer
+  std::string SerializeValues(const CSettingsManager* settingsManager) const override;
+
+private:
+  void SerializeSection(CVariant& parent, std::shared_ptr<CSettingSection> section) const;
+  void SerializeCategory(CVariant& parent, std::shared_ptr<CSettingCategory> category) const;
+  void SerializeGroup(CVariant& parent, std::shared_ptr<CSettingGroup> group) const;
+  void SerializeSetting(CVariant& parent, std::shared_ptr<CSetting> setting) const;
+  CVariant SerializeSettingValue(std::shared_ptr<CSetting> setting) const;
+
+  bool m_compact;
+};


### PR DESCRIPTION
## Description
This is an alternative approach to #16964 and uses the newly introduce `ISettingsValueSerializerInterface` from #17062. It converts the scraper path settings to flat JSON like e.g.
```json
{
  "RatingS": 1,
  "absolutenumber": false,
  "dvdorder": false,
  "language": "en",
  "token": ""
}
```
and passes them to the python based scrapers.

This will need to be backported to Leia together with the following commit from #17062: 7fbb037d169790b0afd46c503585a842c0fa7687

## Motivation and Context
See #16964. I prefer to use a clean approach / solution.

## How Has This Been Tested?
Manually.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
