### PR TITLE
[logging] Fix eventlog messages

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -472,10 +472,20 @@ namespace VIDEO
           mediaType = MediaTypeTvShow;
         else if (info2->Content() == CONTENT_MUSICVIDEOS)
           mediaType = MediaTypeMusicVideo;
-        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-          mediaType, pItem->GetPath(), 24145,
-          StringUtils::Format(g_localizeStrings.Get(24147).c_str(), mediaType.c_str(), URIUtils::GetFileName(pItem->GetPath()).c_str()),
-          pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));
+
+        if (info2->Content() == CONTENT_TVSHOWS)
+          CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
+            mediaType, pItem->GetPath(), 24145,
+            StringUtils::Format(g_localizeStrings.Get(24147).c_str(),
+            CMediaTypes::GetLocalization(mediaType), CURL::GetRedacted(pItem->GetPath())),
+            EventLevel::Warning)));
+        else if (info2->Content() == CONTENT_MOVIES || info2->Content() == CONTENT_MUSICVIDEOS)
+          CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
+            mediaType, pItem->GetPath(), 24145,
+            StringUtils::Format(g_localizeStrings.Get(24147).c_str(),
+            CMediaTypes::GetLocalization(mediaType),
+            URIUtils::GetFileName(pItem->GetPath()).c_str()),
+            pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));
       }
 
       pURL = NULL;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
`URIUtils::GetFileName(pItem->GetPath()).c_str())` is empty for TV-shows but will not be empty for movies. Therefore, if TV-shows failed to scrape, the eventlog message was pretty much useless. I changed it in a way that we have a difference between tv-shows and movies or musicvideos.

If the path gets too long, it will wrap the line, but the text will not scroll. But I guess the length generally enough. 

I'll create the backport if we think it should be backported. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes: #17027


## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested on Fedora with current Kodi master and some dummy files which failed to scrape. See screenshot below.

## Screenshots (if appropriate):
![eventlog](https://user-images.githubusercontent.com/7235787/71313775-cda57880-243d-11ea-8f66-1f6ca53bc0c7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed

Not too sure if my Code follows the code guidelines. I'm not a developer. But I guess it does. Otherwise point me to, please.