### PR TITLE
Fix cosmetic style issues introduced by TrueHD fix

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -176,7 +176,8 @@ void CAEBitstreamPacker::PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size
 
   if (size > maxSize)
   {
-    CLog::Log(LOGERROR, "CAEBitstreamPacker::PackTrueHD - truncating TrueHD frame of %d bytes", size);
+    CLog::Log(LOGERROR, "CAEBitstreamPacker::PackTrueHD - truncating TrueHD frame of %d bytes",
+              size);
     size = maxSize;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -177,10 +177,12 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
     if (!m_trueHDoffset)
       memset(m_trueHDBuffer.get(), 0, TRUEHD_BUF_SIZE);
 
-    if (m_dataSize > 2560-2)
+    if (m_dataSize > 2560 - 2)
     {
-      CLog::Log(LOGERROR, "CDVDAudioCodecPassthrough::AddData - truncating TrueHD frame of %u bytes", m_dataSize);
-      m_dataSize = 2560-2;
+      CLog::Log(LOGERROR,
+                "CDVDAudioCodecPassthrough::AddData - truncating TrueHD frame of %u bytes",
+                m_dataSize);
+      m_dataSize = 2560 - 2;
     }
     memcpy(&(m_trueHDBuffer.get())[m_trueHDoffset], m_buffer, m_dataSize);
     uint8_t highByte = (m_dataSize >> 8) & 0xFF;


### PR DESCRIPTION
Commit 0e76bd058fbd8e3 ("Fix crashes due to missing TrueHD overrun
checks") introduced several style issues (too long lines and missing
whitespace).

Fix those.