### PR TITLE
[platform][input] Fix keyboard layouts sort order.

### DIFF
--- a/xbmc/input/KeyboardLayoutManager.cpp
+++ b/xbmc/input/KeyboardLayoutManager.cpp
@@ -121,7 +121,7 @@ namespace
 {
   inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
   {
-    return (i.value > j.value);
+    return (i.value < j.value);
   }
 }
 

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -27,7 +27,7 @@ namespace
 {
   inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
   {
-    return (i.value > j.value);
+    return (i.value < j.value);
   }
 } // unnamed namespace
 


### PR DESCRIPTION
Fixes a regression introduced by #15467 

@ronie , @DaVukovic fyi

Runtime-tested on latest Kodi master, macOS.