### PR TITLE
fixed: Caching of small files (fixes regression of #17042)

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -90,7 +90,6 @@ CFileCache::CFileCache(const unsigned int flags)
   , m_writeRate(0)
   , m_writeRateActual(0)
   , m_forwardCacheSize(0)
-  , m_forward(0)
   , m_bFilling(false)
   , m_bLowSpeedDetected(false)
   , m_fileSize(0)
@@ -200,7 +199,6 @@ bool CFileCache::Open(const CURL& url)
   m_writePos = 0;
   m_writeRate = 1024 * 1024;
   m_writeRateActual = 0;
-  m_forward = 0;
   m_bFilling = true;
   m_bLowSpeedDetected = false;
   m_seekEvent.Reset();
@@ -268,7 +266,6 @@ void CFileCache::Process()
           CLog::Log(LOGDEBUG,
                     "CFileCache::Process - Cache completely reset for seek to position %" PRId64,
                     m_seekPos);
-          m_forward = 0;
           m_bFilling = true;
           m_bLowSpeedDetected = false;
         }
@@ -400,11 +397,11 @@ void CFileCache::Process()
     // avoid uncertainty at start of caching
     m_writeRateActual = average.Rate(m_writePos, 1000);
 
-    // Update forward cache size
-    m_forward = m_pCache->WaitForData(0, 0);
-
     // NOTE: Hysteresis (20-80%) for filling-logic
-    const float level = (m_forwardCacheSize == 0) ? 0.0 : (float) m_forward / m_forwardCacheSize;
+    const int64_t forward = m_pCache->WaitForData(0, 0);
+    const float level =
+        (m_forwardCacheSize == 0) ? 0.0 : static_cast<float>(forward / m_forwardCacheSize);
+
     if (level > 0.8f)
     {
      /* NOTE: We can only reliably test for low speed condition, when the cache is *really*
@@ -589,7 +586,7 @@ int CFileCache::IoControl(EIoControl request, void* param)
   if (request == IOCTRL_CACHE_STATUS)
   {
     SCacheStatus* status = (SCacheStatus*)param;
-    status->forward = m_forward;
+    status->forward = m_pCache->WaitForData(0, 0);
     status->maxrate = m_writeRate;
     status->currate = m_writeRateActual;
     status->lowspeed = m_bLowSpeedDetected;

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -69,7 +69,6 @@ namespace XFILE
     unsigned m_writeRate;
     unsigned m_writeRateActual;
     int64_t m_forwardCacheSize;
-    int64_t m_forward;
     bool m_bFilling;
     bool m_bLowSpeedDetected;
     std::atomic<int64_t> m_fileSize;


### PR DESCRIPTION
Also contains a fix for getting forward cache size properly when EOF is hit. Note that the EOF logic has always been wrong but we just didn't notice it before.