### PR TITLE
paplayer: avoid race condition that double fires OnPlaybackStarted 

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -256,8 +256,10 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   m_isPlaying = true;
   m_startEvent.Set();
 
-  m_callback.OnPlayBackStarted(file);
+  // OnPlayBackStarted to be made only once. Callback processing may be slower than player process
+  // so clear signal flag first otherwise async stream processing could also make callback
   m_signalStarted = false;
+  m_callback.OnPlayBackStarted(file);
 
   return true;
 }


### PR DESCRIPTION
The intention is that the paplayer only fires OnPlaybackStarted once when playback of a file starts (see https://github.com/xbmc/xbmc/pull/13882 ) however sometimes `CApplication::OnPlayBackStarted` is accidentally called twice.

This was discovered on investigating a user report that starting playback of non-tagged (and hence not in library either) music files from apps using the JSON API, the audio "stuttered" - starting then dropping out briefly, almost starting twice. See https://forum.kodi.tv/showthread.php?tid=349909

The cause is that the OnPlaybackStarted callback can be a slow process and stream processing, that continues asynchronously, can happen before it completes and `m_signalStarted` is cleared (indicating that the start of playback does not have to be signelled by anywhere else). Hence OnPlaybackStarted is called twice by the paplayer.  Moving `m_signalStarted = false;` to before the callback in OpenFile avoids this double fire.

This race condition could have happened anytime, but timing conditions have to be just right for it to result in an noticeable gap in audio output. Hence why it was not noticed before, and why the user experiences were initialy difficult to reproduce. On playback of music files without metadata  the call to `IsGame` from `CApplication::OnPlayBackStarted` entails reading the addon database and lopping through the list of installed addons which can be particularly slow.
