### PR TITLE
[backport]paplayer: avoid race condition that double fires OnPlaybackStarted

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -256,8 +256,10 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   m_isPlaying = true;
   m_startEvent.Set();
 
-  m_callback.OnPlayBackStarted(file);
+  // OnPlayBackStarted to be made only once.Callback processing may be slower than player process
+  // so clear signal flag first otherwise async stream processing could also make callback
   m_signalStarted = false;
+  m_callback.OnPlayBackStarted(file);
 
   return true;
 }


### PR DESCRIPTION
Backport of #17083
Avoid paplayer accidentally calling `CApplication::OnPlayBackStarted` twice when the player processing is faster than the application callback processing.
