### PR TITLE
[subtitles] decode html escape characters

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -188,7 +188,7 @@ void CDVDSubtitleTagSami::ConvertLine(CDVDOverlayText* pOverlay, const char* lin
     strUTF8.erase(strUTF8.size()-1);
 
   std::wstring wStrHtml, wStr;
-  g_charsetConverter.utf8ToW(strUTF8, wStrHtml);
+  g_charsetConverter.utf8ToW(strUTF8, wStrHtml, false);
   HTML::CHTMLUtil::ConvertHTMLToW(wStrHtml, wStr);
   g_charsetConverter.wToUTF8(wStr, strUTF8);
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -10,6 +10,8 @@
 
 #include "DVDCodecs/Overlay/DVDOverlayText.h"
 #include "DVDSubtitleStream.h"
+#include "utils/CharsetConverter.h"
+#include "utils/HTMLUtil.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 
@@ -184,6 +186,11 @@ void CDVDSubtitleTagSami::ConvertLine(CDVDOverlayText* pOverlay, const char* lin
 
   if( strUTF8[strUTF8.size()-1] == '\n' )
     strUTF8.erase(strUTF8.size()-1);
+
+  std::wstring wStrHtml, wStr;
+  g_charsetConverter.utf8ToW(strUTF8, wStrHtml);
+  HTML::CHTMLUtil::ConvertHTMLToW(wStrHtml, wStr);
+  g_charsetConverter.wToUTF8(wStr, strUTF8);
 
   // add a new text element to our container
   pOverlay->AddElement(new CDVDOverlayText::CElementText(strUTF8.c_str()));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
As title

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Often subtitles like the WebVTT format, are supplied with html code (eg. netflix)
html tags are not a problem as they are filtered out
but the escapes like `&amp; &lt;` etc... are all displayed to kodi, 
this is necessary to not display them, see screenshot

Basically this revert an, oldest PR revert, https://github.com/xbmc/xbmc/pull/10885

@MartijnKaijser said he was having trouble with RTL language like hebrew,
it wasn't enough to disable the forced bidi flip instead revert all? (second commit)
for this purpose, i have tested an arabic right to left SRT file successfully without any problems, so no side effects due to this PR
Test made by Kodi library to netflix exported tv show Shtisel S01E01 and loaded the srt file
[Shtisel.S01E01.NF.srt.zip](https://github.com/xbmc/xbmc/files/4010166/Shtisel.S01E01.NF.srt.zip)

Builds for testing (builded 17/02/2020)
Build Matrix Win-x64 with PR:
https://www.mediafire.com/file/48v3mro8bxk5yms/Kodi19_x64_regular_PR.zip/file

Build Matrix Win-x64 with PR but without 249fceb commit of this PR:
https://www.mediafire.com/file/bx30aq8ash7i15v/Kodi19_x64_no_commit_249fceb.zip/file

Ref. Issue https://github.com/xbmc/xbmc/issues/15365

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Builded and tested on Kodi Leia, and also on Matrix
~(I can't test on Kodi 19 because currently there are missing python libraries on windows to run netflix addon)~
The movie tested is Suits, season 1 ep 1, Greek subtitles

## Screenshots (if appropriate):
Before:
![60296391-4c55a900-9926-11e9-884a-9c9912b53aaa](https://user-images.githubusercontent.com/3257156/71521335-96f9b300-28c0-11ea-8de6-5ffcad5b25a4.png)
After fix:
![Suits_result](https://user-images.githubusercontent.com/3257156/71521340-9c56fd80-28c0-11ea-8d9c-0fcf8020f41f.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
