### PR TITLE
Resume paused ActiveAE stream while draining to avoid playback lapse

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -421,6 +421,9 @@ void CActiveAEStream::Drain(bool wait)
     m_currentBuffer = NULL;
   }
 
+  if (wait)
+    Resume();
+
   XbmcThreads::EndTime timer(2000);
   while (!timer.IsTimePast())
   {


### PR DESCRIPTION
## Description
Resolution for [Issue 17080](https://github.com/xbmc/xbmc/issues/17080), provided by @FernetMenta.

During MPEG-TS playback, an audio stream format change, for example from 6-channel to 2 channel, can cause a lapse of up to 2 seconds where no audio will be produced by the VideoPlayer.  When the format change is detected, the current stream is drained, but remains in a paused state until the drain operation is complete, causing this lapse

## Motivation and Context
Since the release of Kodi 18.0, I have experienced numerous MPEG-TS programs that exhibit this behavior, primarily during commercial breaks.  While the issue was generally present on specific PVR addon channels, pulling the MPEG-TS file out into the normal Videos library showed that it was not specific to just PVR addons.

[Issue 17080](https://github.com/xbmc/xbmc/issues/17080)

## How Has This Been Tested?
Tested on Windows x64 using build from Kodi 18.5 release tag.  Provided sample file from linked issue plays without the lapse now, and have not experienced audio lapses using PVR addon with known problematic channels.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

And for once, I finally have the clang-format stuff working so I don't think I'm going to get dinged on format.

Thank you @FernetMenta for providing the solution, this has been a problem spot for me for quite some time!!