### PR TITLE
fixed: Cache forward size wasn't updated when source EOF was hit

### DIFF
--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -71,7 +71,6 @@ namespace XFILE
     unsigned m_writeRate;
     unsigned m_writeRateActual;
     int64_t m_forwardCacheSize;
-    int64_t m_forward;
     bool m_bFilling;
     bool m_bLowSpeedDetected;
     std::atomic<int64_t> m_fileSize;


### PR DESCRIPTION
Partial backport of #17081