### PR TITLE
[Leia] ActiveAE: Prevent packets with zero samples from being passed to Visualization

### DIFF
--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -248,7 +248,7 @@ void CGUIVisualisationControl::OnInitialize(int channels, int samplesPerSec, int
 
 void CGUIVisualisationControl::OnAudioData(const float* audioData, unsigned int audioDataLength)
 {
-  if (!m_instance || !m_alreadyStarted)
+  if (!m_instance || !m_alreadyStarted || !audioData || audioDataLength == 0)
     return;
 
   // Save our audio data in the buffers


### PR DESCRIPTION
## Description
Backport of [PR 16963](https://github.com/xbmc/xbmc/pull/16963) for Leia branch, in the event that there is another dot release I believe this adds value for Leia users without causing any ill side-effects.

Certain circumstances can cause a packet with zero samples to be passed to an attached Visualization, which can cause that Visualization to enter an infinite loop.  Given that this concern can lock up/crash Kodi I thought it would be best to at least _propose_ something to bullet-proof that particular concern.

## Motivation and Context
Preventing packets with zero samples from being passed to an attached Visualization can avoid the issue without making any potentially breaking changes elsewhere. I would think that ideally the Visualization module(s) should protect itself from this, but many (including MilkDrop 2 and Waveform) do not.

Resolves Issue [19649](https://github.com/xbmc/xbmc/issues/16949) - "MPEG-TS audio stream can cause infinite loop in visualizations" on Leia branch

## How Has This Been Tested?
Tested on Kodi 18.5 Leia, Windows x64.  Prior to the change, the Issue described in [19649](https://github.com/xbmc/xbmc/issues/16949) was easily replicated.  After the change the attached Visualization never received the packet with zero samples and never entered an infinite loop.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
