### PR TITLE
fix bad checksum fetching

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -133,8 +133,10 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo)
 
 bool CRepository::FetchChecksum(const std::string& url, std::string& checksum) noexcept
 {
-  CFile file;
-  if (!file.Open(url))
+  CCurlFile file;
+  CURL curlURL{url};
+    
+  if (!file.Open(curlURL))
     return false;
 
   // we intentionally avoid using file.GetLength() for


### PR DESCRIPTION
## Description
On XCode11 and Mac OSX 10.15, I was getting bad checksums when trying to click on the Kodi add-on repository.  It seems as if the checksum fetching didn't work?  (returning blank checksums) After putting breakpoints in, I noticed that the curl callback (write_callback) worked fine and read the data, which suggested reading from the circular buffer was being done incorrectly.

## Motivation and Context
Not sure how this code could have worked given I tested against master.  Once I changed to use CurlFile, the sha256 could be fetched.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
