### PR TITLE
[PVR] EPG grid container: Make CGUIEPGGridContainer::GoToEnd consistent with CGUIEPGGridContainer::GoToBegin behavior

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1622,19 +1622,8 @@ void CGUIEPGGridContainer::GoToBegin()
 
 void CGUIEPGGridContainer::GoToEnd()
 {
-  const int blocksStart = m_gridModel->GetGridItemStartBlock(m_channelCursor + m_channelOffset,
-                                                             m_gridModel->GetLastBlock());
-  const int blocksEnd = m_gridModel->GetGridItemEndBlock(m_channelCursor + m_channelOffset,
-                                                         m_gridModel->GetLastBlock());
-
-  int blockOffset = 0;
-  if (blocksEnd - blocksStart > m_blocksPerPage)
-    blockOffset = blocksStart;
-  else if (blocksEnd > m_blocksPerPage)
-    blockOffset = blocksEnd - m_blocksPerPage;
-
-  ScrollToBlockOffset(blockOffset); // scroll to the start point of the last epg element
-  SetBlock(m_blocksPerPage - 1); // select the last epg element
+  ScrollToBlockOffset(m_gridModel->GetLastBlock() - m_blocksPerPage + 1);
+  SetBlock(m_blocksPerPage - 1);
 }
 
 void CGUIEPGGridContainer::GoToNow()


### PR DESCRIPTION
`GoToBegin` always jumps to the first page of the EPG grid, regardless of the selected channel.

This PR makes `GoToEnd` behave consistent with `GoToBegin`. Now, the former will always jump to the last grid page, regardless of the selected channel.

Old `GoToEnd` behavior was to jump to the beginning of the last EPG tag of the selected channel. Often you ended up at the start of final "gap" (which is no actual event) that fills the grid from end of last real event to grid end. For channels without EPG this means, that selecting "goto end" will do the same as "goto begin" which is pretty irritating, IMO.

Runtime-tested on mackOS and ANdroid, latest Kodi master.

@phunkyfish for code review?