### PR TITLE
CGUIDialogSelect: fix focusing list / buttons after 6d34db9900

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -126,7 +126,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     {
       if (m_viewControl.HasControl(message.GetControlId()))
       {
-        if (m_vecList->IsEmpty() || m_focusToButton)
+        if (m_vecList->IsEmpty())
         {
           if (m_bButtonEnabled)
             SET_CONTROL_FOCUS(CONTROL_EXTRA_BUTTON, 0);
@@ -334,6 +334,16 @@ void CGUIDialogSelect::OnInitWindow()
   SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
 
   CGUIDialogBoxBase::OnInitWindow();
+
+  // focus one of the buttons if explicitly requested
+  // ATTENTION: this must be done after calling CGUIDialogBoxBase::OnInitWindow()
+  if (m_focusToButton)
+  {
+    if (m_bButtonEnabled)
+      SET_CONTROL_FOCUS(CONTROL_EXTRA_BUTTON, 0);
+    else
+      SET_CONTROL_FOCUS(CONTROL_CANCEL_BUTTON, 0);
+  }
 
   // if nothing is selected, select first item
   m_viewControl.SetSelectedItem(std::max(GetSelectedItem(), 0));


### PR DESCRIPTION
## Description
In #16802 the possibility to pre-select the OK button in the select dialog (`CGUIDialogSelect`) has been introduced. Unfortunately this broke the possibility to change the focus to the list of dependencies and select one of them to view its details.

## Motivation and Context
Fix the possibility to change the focus to the list of dependencies and select one of them to view its details.

## How Has This Been Tested?
Manually.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
