### PR TITLE
[PVR] EPG grid container: fix wrong timeline display on first grid page.

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -760,7 +760,7 @@ void CGUIEPGGridContainer::UpdateItems()
     }
   }
 
-  if (prevSelectedEpgTag && (oldChannelIndex != 0 || oldBlockIndex != 0))
+  if (prevSelectedEpgTag)
   {
     if (newChannelIndex >= m_gridModel->ChannelItemsSize() ||
         newBlockIndex >= m_gridModel->GridItemsSize() ||
@@ -2347,11 +2347,12 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
       int block = blockOffset;
       float posA2 = posA;
 
-      if (blockOffset > 0 && m_gridModel->IsSameGridItem(channel, block, blockOffset - 1))
+      const int startBlock = blockOffset == 0 ? 0 : blockOffset - 1;
+      if (startBlock == 0 || m_gridModel->IsSameGridItem(channel, block, startBlock))
       {
         // First program starts before current view
-        block = m_gridModel->GetGridItemStartBlock(channel, blockOffset - 1);
-        int missingSection = blockOffset - block;
+        block = m_gridModel->GetGridItemStartBlock(channel, startBlock);
+        const int missingSection = startBlock - block;
         posA2 -= missingSection * m_blockSize;
       }
 


### PR DESCRIPTION
An edge case, that can happen on first EPG grid page if the event to display starts before the start of the grid and leads to wrong timeline display. The following example is showing an event ending at 16:00 that is rendered like it would end at 17:00:

![screenshot000 15 12 42](https://user-images.githubusercontent.com/3226626/71683474-ed6c6300-2d92-11ea-8bf0-e1fd0b9668ef.png)
![screenshot000](https://user-images.githubusercontent.com/3226626/71683475-ee04f980-2d92-11ea-8977-e21cad0cdc34.png)

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish are you in the mood for a quick code review?