### PR TITLE
Android: Skip HW acceleration if not needed

### DIFF
--- a/xbmc/platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.cpp
+++ b/xbmc/platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.cpp
@@ -15,6 +15,7 @@
 
 #include "MediaCodecDecoderFilterManager.h"
 
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <androidjni/MediaCodecList.h>
@@ -52,7 +53,17 @@ CMediaCodecDecoderFilterManager::CMediaCodecDecoderFilterManager()
       if (!strnicmp(*ptr, codecname.c_str(), strlen(*ptr)))
         flags = 0;
     }
-    add(CDecoderFilter(codecname, flags, 0));
+    std::string tmp(codecname);
+    StringUtils::ToLower(tmp);
+    int minheight = 0;
+    if (tmp.find("mpeg4") != std::string::npos)
+      minheight = 720;
+    else if (tmp.find("mpeg2") != std::string::npos)
+      minheight = 720;
+    else if (tmp.find("263") != std::string::npos)
+      minheight = 720;
+
+    add(CDecoderFilter(codecname, flags, minheight));
     CLog::Log(LOGNOTICE, "Mediacodec decoder: %s", codecname.c_str());
   }
   Save();


### PR DESCRIPTION
I am fedup with reports of non-working content especially for mpeg-4, h263. Therefore process files with height lower 720 with SW Decoder by default.

If someone needs it hw-decoded, a one-liner can be removed from decoderfilter.xml