### PR TITLE
[VideoThumbLoader] Do not replace the whole art map when getting item…

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -510,7 +510,10 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     std::map<std::string, std::string> artwork;
     m_videoDatabase->Open();
     if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
-      SetArt(item, artwork);
+    {
+      for (const auto& arttype : artwork)
+        item.SetArt(arttype.first, arttype.second);
+    }
     else if (tag.m_type == "actor" && !tag.m_artist.empty())
     { // we retrieve music video art from the music database (no backward compat)
       CMusicDatabase database;


### PR DESCRIPTION
…s from the library

## Description
Follow up to https://github.com/xbmc/xbmc/pull/16444. Since the default artwork is now stored in the artmap (instead of a member variable in `CFileItem`) if `setArt` is used on the ListItem with an art map, the whole map is replaced. Defaulticons were added to the map before getting them from the library so make sure we add all the art in library but do not replace the item already existing art (unless they have the same type).

@DaveTBlake or @ksooo for review if possible.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/17034. @ronie please test for any regressions.

## How Has This Been Tested?
Manually with the db provided in the linked issue.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
