### PR TITLE
[VideoThumbLoader] Do not replace the whole art map when getting item…

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -347,7 +347,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
       if (!art.empty())
         artwork.insert(std::make_pair(type, art));
     }
-    SetArt(*pItem, artwork);
+    pItem->AppendArt(artwork);
   }
 
   // hide thumb if episode is unwatched 
@@ -426,7 +426,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
       }
     }
   }
-  SetArt(*pItem, artwork);
+  pItem->AppendArt(artwork);
 
   // We can only extract flags/thumbs for file-like items
   if (!pItem->m_bIsFolder && pItem->IsVideo())
@@ -490,18 +490,6 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
   return true;
 }
 
-void CVideoThumbLoader::SetArt(CFileItem &item, const std::map<std::string, std::string> &artwork)
-{
-  item.SetArt(artwork);
-  if (artwork.find("thumb") == artwork.end())
-  { // set fallback for "thumb"
-    if (artwork.find("poster") != artwork.end())
-      item.SetArtFallback("thumb", "poster");
-    else if (artwork.find("banner") != artwork.end())
-      item.SetArtFallback("thumb", "banner");
-  }
-}
-
 bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
 {
   CVideoInfoTag &tag = *item.GetVideoInfoTag();
@@ -510,7 +498,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     std::map<std::string, std::string> artwork;
     m_videoDatabase->Open();
     if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
-      SetArt(item, artwork);
+      item.AppendArt(artwork);
     else if (tag.m_type == "actor" && !tag.m_artist.empty())
     { // we retrieve music video art from the music database (no backward compat)
       CMusicDatabase database;

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -113,13 +113,6 @@ public:
    */
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
-  /*! \brief set the artwork map for an item
-   In addition, sets the standard fallbacks.
-   \param item the item on which to set art.
-   \param artwork the artwork map.
-   */
-  static void SetArt(CFileItem &item, const std::map<std::string, std::string> &artwork);
-
   static bool GetEmbeddedThumb(const std::string& path,
                                const std::string& type,
                                EmbeddedArt& art);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1085,7 +1085,7 @@ void CGUIDialogVideoInfo::PlayTrailer()
   item.GetVideoInfoTag()->m_strTitle = StringUtils::Format("%s (%s)",
                                                            m_movieItem->GetVideoInfoTag()->m_strTitle.c_str(),
                                                            g_localizeStrings.Get(20410).c_str());
-  CVideoThumbLoader::SetArt(item, m_movieItem->GetArt());
+  item.SetArt(m_movieItem->GetArt());
   item.GetVideoInfoTag()->m_iDbId = -1;
   item.GetVideoInfoTag()->m_iFileId = -1;
 


### PR DESCRIPTION
…s from the library

## Description
Follow up to https://github.com/xbmc/xbmc/pull/16444. Since the default artwork is now stored in the artmap (instead of a member variable in `CFileItem`) if `setArt` is used on the ListItem with an art map, the whole map is replaced. Defaulticons were added to the map before getting the available artwork from the library so... make sure we add all the art in the library but do not replace the already existing art (unless it has the same type)

@DaveTBlake or @ksooo for review if possible. Sorry for closing the previous pull request - found a better place for the fix and the job was still in the jenkins queue.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/17034. @ronie please test for any regressions.

## How Has This Been Tested?
Manually with the db provided in the linked issue.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
