### PR TITLE
[WindowManager] Stop bypassing lockcode of mediasources

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5730,7 +5730,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogGamepad.cpp
 #: xbmc/dialogs/GUIDialogNumeric.cpp
 msgctxt "#12343"
-msgid "retries left "
+msgid "retries left"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogGamepad.cpp

--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -65,6 +65,7 @@ set(HEADERS AppParamParser.h
             IProgressCallback.h
             InfoScanner.h
             LangInfo.h
+            LockType.h
             MediaSource.h
             NfoFile.h
             PartyModeManager.h

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -441,9 +441,13 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       break;
     case WINDOW_MUSIC_NAV:      // Music
       bCheckPW = profileManager->GetCurrentProfile().musicLocked();
+      if (!bCheckPW && strMediasourcePath != "") // check mediasource by path
+        return g_passwordManager.IsMediaPathUnlocked(strMediasourcePath, "music");
       break;
     case WINDOW_VIDEO_NAV:      // Video
       bCheckPW = profileManager->GetCurrentProfile().videoLocked();
+      if (!bCheckPW && strMediasourcePath != "") // check mediasource by path
+        return g_passwordManager.IsMediaPathUnlocked(strMediasourcePath, "video");
       break;
     case WINDOW_PICTURES:       // Pictures
       bCheckPW = profileManager->GetCurrentProfile().picturesLocked();

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -29,6 +29,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
 #include <utility>
@@ -42,41 +43,32 @@ CGUIPassword::CGUIPassword(void)
 }
 CGUIPassword::~CGUIPassword(void) = default;
 
-bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
+template<typename T>
+bool CGUIPassword::IsItemUnlocked(T pItem,
+                                  const std::string& strType,
+                                  const std::string& strLabel,
+                                  const std::string& strHeading)
 {
-  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
-
-  // \brief Tests if the user is allowed to access the share folder
-  // \param pItem The share folder item to access
-  // \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
-  // \return If access is granted, returns \e true
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
   if (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   while (pItem->m_iHasLock > LOCK_STATE_LOCK_BUT_UNLOCKED)
   {
-    std::string strLockCode = pItem->m_strLockCode;
-    std::string strLabel = pItem->GetLabel();
-    int iResult = 0;  // init to user succeeded state, doing this to optimize switch statement below
-    char buffer[33]; // holds 32 places plus sign character
-    if(g_passwordManager.bMasterUser)// Check if we are the MasterUser!
+    const std::string strLockCode = pItem->m_strLockCode;
+    int iResult = 0; // init to user succeeded state, doing this to optimize switch statement below
+    if (!g_passwordManager.bMasterUser) // Check if we are the MasterUser!
     {
-      iResult = 0;
-    }
-    else
-    {
-      if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES) && pItem->m_iBadPwdCount >= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES))
+      if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                   CSettings::SETTING_MASTERLOCK_MAXRETRIES) &&
+          pItem->m_iBadPwdCount >= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                       CSettings::SETTING_MASTERLOCK_MAXRETRIES))
       { // user previously exhausted all retries, show access denied error
         HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
-        return false;
+        return false; //             "Access denied"      "Password retry limit exceeded."
       }
       // show the appropriate lock dialog
-      std::string strHeading = "";
-      if (pItem->m_bIsFolder)
-        strHeading = g_localizeStrings.Get(12325);
-      else
-        strHeading = g_localizeStrings.Get(12348);
-
       iResult = VerifyPassword(pItem->m_iLockMode, strLockCode, strHeading);
     }
     switch (iResult)
@@ -91,19 +83,20 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
         // password entry succeeded
         pItem->m_iBadPwdCount = 0;
         pItem->m_iHasLock = LOCK_STATE_LOCK_BUT_UNLOCKED;
-        g_passwordManager.LockSource(strType,strLabel,false);
-        sprintf(buffer,"%i",pItem->m_iBadPwdCount);
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount", buffer);
+        g_passwordManager.LockSource(strType, strLabel, false);
+        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
+                                                         std::to_string(pItem->m_iBadPwdCount));
         CMediaSourceSettings::GetInstance().Save();
         break;
       }
     case 1:
       {
         // password entry failed
-        if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES))
+        if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                     CSettings::SETTING_MASTERLOCK_MAXRETRIES))
           pItem->m_iBadPwdCount++;
-        sprintf(buffer,"%i",pItem->m_iBadPwdCount);
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount", buffer);
+        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
+                                                         std::to_string(pItem->m_iBadPwdCount));
         CMediaSourceSettings::GetInstance().Save();
         break;
       }
@@ -118,12 +111,32 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
   return true;
 }
 
+bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string& strType)
+{
+  const std::string strLabel = pItem->GetLabel();
+  std::string strHeading;
+  if (pItem->m_bIsFolder)
+    strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
+  else
+    strHeading = g_localizeStrings.Get(12348); // "Item locked"
+
+  return IsItemUnlocked<CFileItem*>(pItem, strType, strLabel, strHeading);
+}
+
+bool CGUIPassword::IsItemUnlocked(CMediaSource* pItem, const std::string& strType)
+{
+  const std::string strLabel = pItem->strName;
+  std::string strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
+
+  return IsItemUnlocked<CMediaSource*>(pItem, strType, strLabel, strHeading);
+}
+
 bool CGUIPassword::CheckStartUpLock()
 {
   // prompt user for mastercode if the mastercode was set b4 or by xml
   int iVerifyPasswordResult = -1;
 
-  std::string strHeader = g_localizeStrings.Get(20075);
+  std::string strHeader = g_localizeStrings.Get(20075); // "Enter master lock code"
 
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
@@ -145,13 +158,13 @@ bool CGUIPassword::CheckStartUpLock()
       if (iVerifyPasswordResult != 0 )
       {
         std::string strLabel1;
-        strLabel1 = g_localizeStrings.Get(12343);
+        strLabel1 = g_localizeStrings.Get(12343); // "retries left"
         int iLeft = g_passwordManager.iMasterLockRetriesLeft-i;
         std::string strLabel = StringUtils::Format("%i %s", iLeft, strLabel1.c_str());
 
         // PopUp OK and Display: MasterLock mode has changed but no new Mastercode has been set!
         HELPERS::ShowOKDialogLines(CVariant{12360}, CVariant{12367}, CVariant{strLabel}, CVariant{""});
-      }
+      } //                             "Master lock"    "Master code is not valid..."
       else
         i=g_passwordManager.iMasterLockRetriesLeft;
     }
@@ -178,7 +191,7 @@ bool CGUIPassword::SetMasterLockMode(bool bDetails)
   {
     CProfile::CLock locks = profile->GetLocks();
     if (CGUIDialogLockSettings::ShowAndGetLock(locks, 12360, true, bDetails))
-    {
+    { //                                          "Master lock"
       profile->SetLocks(locks);
       return true;
     }
@@ -227,7 +240,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
     {
       if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         return CheckLock(profile->getLockMode(),profile->getLockCode(),20095,bCanceled);
-    }
+    } //                                                          "Enter profile lock code"
   }
 
   return true;
@@ -303,16 +316,15 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
         g_passwordManager.iMasterLockRetriesLeft = 0;
         // Tell the user they ran out of retry attempts
         HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
-        return ;
+        return; //                    "Access denied"    "Password retry limit exceeded."
       }
     }
     std::string dlgLine1 = "";
     if (0 < g_passwordManager.iMasterLockRetriesLeft)
-      dlgLine1 = StringUtils::Format("%d %s",
-                                     g_passwordManager.iMasterLockRetriesLeft,
-                                     g_localizeStrings.Get(12343).c_str());
+      dlgLine1 = StringUtils::Format("%d %s", g_passwordManager.iMasterLockRetriesLeft,
+                                     g_localizeStrings.Get(12343).c_str()); // "retries left"
     HELPERS::ShowOKDialogLines(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
-  }
+  } //                    "Enter master lock code"     "Access denied"
   else
     g_passwordManager.iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES); // user entered correct mastercode, reset retries to max allowed
 }
@@ -501,7 +513,9 @@ void CGUIPassword::RemoveSourceLocks()
       {
         it->m_iHasLock = LOCK_STATE_NO_LOCK;
         it->m_iLockMode = LOCK_MODE_EVERYONE;
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, it->strName, "lockmode", "0"); // removes locks from xml
+
+        // remove locks from xml
+        CMediaSourceSettings::GetInstance().UpdateSource(strType, it->strName, "lockmode", "0");
       }
   }
   CMediaSourceSettings::GetInstance().Save();
@@ -520,11 +534,38 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES
   bool bName = false;
   int iIndex = CUtil::GetMatchingSource(strPath, vecSources, bName);
 
-  if (iIndex > -1 && iIndex < (int)vecSources.size())
+  if (iIndex > -1 && iIndex < static_cast<int>(vecSources.size()))
     if (vecSources[iIndex].m_iHasLock < LOCK_STATE_LOCKED)
       return true;
 
   return false;
+}
+
+bool CGUIPassword::IsMediaPathUnlocked(const std::string& strPath, const std::string& strType)
+{
+  if (StringUtils::StartsWithNoCase(strPath, "root") ||
+      StringUtils::StartsWithNoCase(strPath, "library://"))
+  {
+    // no mediasource-lookup needed
+    CLog::Log(LOGDEBUG, "CGUIPassword::IsMediaPathUnlocked - entering from {}", strPath);
+    return true;
+  }
+
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  if (g_passwordManager.bMasterUser ||
+      profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+    return true;
+
+  VECSOURCES& vecSources = *CMediaSourceSettings::GetInstance().GetSources(strType);
+  bool bName = false;
+  int iIndex = CUtil::GetMatchingSource(strPath, vecSources, bName);
+  if (iIndex > -1 && iIndex < static_cast<int>(vecSources.size()))
+    return g_passwordManager.IsItemUnlocked(&vecSources[iIndex], strType);
+
+  // need to add a missing filter (root/library.. etc.)
+  CLog::Log(LOGERROR, "CGUIPassword::IsMediaPathUnlocked - missing filter: {}", strPath);
+  return true;
 }
 
 void CGUIPassword::OnSettingAction(std::shared_ptr<const CSetting> setting)

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -25,7 +25,22 @@ class CGUIPassword : public ISettingCallback
 public:
   CGUIPassword(void);
   ~CGUIPassword(void) override;
+  template<typename T>
+  bool IsItemUnlocked(T pItem,
+                      const std::string& strType,
+                      const std::string& strLabel,
+                      const std::string& strHeading);
+  /* \brief Tests if the user is allowed to access the share folder
+   \param pItem The share folder item to access
+   \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
+   \return If access is granted, returns \e true
+   */
   bool IsItemUnlocked(CFileItem* pItem, const std::string &strType);
+  /* \brief Tests if the user is allowed to access the Mediasource
+   \param pItem The share folder item to access
+   \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
+   \return If access is granted, returns \e true
+   */
   bool IsItemUnlocked(CMediaSource* pItem, const std::string &strType);
   bool CheckLock(LockType btnType, const std::string& strPassword, int iHeading);
   bool CheckLock(LockType btnType, const std::string& strPassword, int iHeading, bool& bCanceled);
@@ -49,6 +64,12 @@ public:
   void LockSources(bool lock);
   void RemoveSourceLocks();
   bool IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources);
+  /* \brief Tests if the user is allowed to access the path by looking up the matching Mediasource
+   \param strPath The folder path to access
+   \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
+   \return If access is granted, returns \e true
+   */
+  bool IsMediaPathUnlocked(const std::string& strPath, const std::string& strType);
 
   void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -75,6 +75,7 @@ public:
 
   bool bMasterUser;
   int iMasterLockRetriesLeft;
+  std::string strMediasourcePath;
 
 private:
   int VerifyPassword(LockType btnType, const std::string& strPassword, const std::string& strHeading);

--- a/xbmc/LockType.h
+++ b/xbmc/LockType.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -771,9 +771,18 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   // debug
   CLog::Log(LOGDEBUG, "Activating window ID: %i", iWindowID);
 
+  // make sure we check mediasources from home
+  if (GetActiveWindow() == WINDOW_HOME)
+    g_passwordManager.strMediasourcePath = !params.empty() ? params[0] : "";
+  else
+    g_passwordManager.strMediasourcePath = "";
+
   if (!g_passwordManager.CheckMenuLock(iWindowID))
   {
-    CLog::Log(LOGERROR, "MasterCode is Wrong: Window with id %d will not be loaded! Enter a correct MasterCode!", iWindowID);
+    CLog::Log(LOGERROR,
+              "MasterCode or Mediasource-code is wrong: Window with id {} will not be loaded! "
+              "Enter a correct code!",
+              iWindowID);
     if (GetActiveWindow() == WINDOW_INVALID && iWindowID != WINDOW_HOME)
       ActivateWindow(WINDOW_HOME);
     return;

--- a/xbmc/media/CMakeLists.txt
+++ b/xbmc/media/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES MediaType.cpp)
 
-set(HEADERS MediaType.h)
+set(HEADERS MediaLockState.h
+            MediaType.h)
 
 core_add_library(media)

--- a/xbmc/media/MediaLockState.h
+++ b/xbmc/media/MediaLockState.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+typedef enum
+{
+  LOCK_STATE_NO_LOCK = 0,
+  LOCK_STATE_LOCK_BUT_UNLOCKED = 1,
+  LOCK_STATE_LOCKED = 2,
+} MediaLockState;


### PR DESCRIPTION
## Description
this is related to #17110 
locked mediasources can be accessed (bypassing the lock) directly from home on estuary.
security hole, imho
krypton, leia and master are affected.
you can bypass the lock by adding the locked source to favourites and opening from there, too.

## Motivation and Context
i accidently hit a locked mediasource on home-screen and came in.

## How Has This Been Tested?
tested on linux, rbpi and win64

## Screenshots (if appropriate):
![screenshot003](https://user-images.githubusercontent.com/58829855/71772252-a0ca8880-2f48-11ea-80b5-f22e50ad4b4b.png)

**you can get in just by hitting the button!**

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
