### PR TITLE
[addons] fix multiple usage

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -33,8 +33,9 @@ public:
   explicit CAddon(const AddonInfoPtr& addonInfo, TYPE addonType);
   ~CAddon() override = default;
 
-  TYPE Type() const override { return m_addonInfo->MainType(); }
-  bool IsType(TYPE type) const override { return type == m_addonInfo->MainType(); }
+  TYPE MainType() const override { return m_addonInfo->MainType(); }
+  TYPE Type() const override { return m_type; }
+  bool IsType(TYPE type) const override { return m_addonInfo->IsType(type); }
   const CAddonType* Type(TYPE type) const { return m_addonInfo->Type(type); }
 
   std::string ID() const override{ return m_addonInfo->ID(); }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -33,9 +33,52 @@ public:
   explicit CAddon(const AddonInfoPtr& addonInfo, TYPE addonType);
   ~CAddon() override = default;
 
+  /**
+   * @brief To get the main type of this addon
+   *
+   * This is the first type defined in **addon.xml** and can be different to the
+   * on @ref Type() defined type.
+   *
+   * @return The used main type of addon
+   */
   TYPE MainType() const override { return m_addonInfo->MainType(); }
+
+  /**
+   * @brief To get the on this CAddon class processed addon type
+   *
+   * @return For this class used addon type
+   */
   TYPE Type() const override { return m_type; }
+
+  /**
+   * @brief To check complete addon (not only this) contains a type
+   *
+   * @note This can be overridden by a child e.g. plugin to check for subtype
+   * e.g. video or music.
+   *
+   * @param[in] type The to checked type identifier
+   * @return true in case the wanted type is supported, false if not
+   */
   bool HasType(TYPE type) const override { return m_addonInfo->HasType(type); }
+
+  /**
+   * @brief The get for given addon type information and extension data
+   *
+   * @param[in] type The wanted type data
+   * @return addon type class with @ref CAddonExtensions as information
+   *
+   * @note This function return never a "nullptr", in case the wanted type is
+   * not supported, becomes a dummy of @ref CAddonType given.
+   *
+   * ------------------------------------------------------------------------
+   *
+   * **Example:**
+   * ~~~~~~~~~~~~~{.cpp}
+   * // To get e.g. <extension ... name="blablabla" /> from addon.xml
+   * std::string name = Type(ADDON_...)->GetValue("@name").asString();
+   * ~~~~~~~~~~~~~
+   *
+   */
   const CAddonType* Type(TYPE type) const { return m_addonInfo->Type(type); }
 
   std::string ID() const override{ return m_addonInfo->ID(); }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -34,7 +34,6 @@ public:
   ~CAddon() override = default;
 
   TYPE Type() const override { return m_addonInfo->MainType(); }
-  TYPE FullType() const override { return Type(); }
   bool IsType(TYPE type) const override { return type == m_addonInfo->MainType(); }
   const CAddonType* Type(TYPE type) const { return m_addonInfo->Type(type); }
 

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -35,7 +35,7 @@ public:
 
   TYPE MainType() const override { return m_addonInfo->MainType(); }
   TYPE Type() const override { return m_type; }
-  bool IsType(TYPE type) const override { return m_addonInfo->IsType(type); }
+  bool HasType(TYPE type) const override { return m_addonInfo->HasType(type); }
   const CAddonType* Type(TYPE type) const { return m_addonInfo->Type(type); }
 
   std::string ID() const override{ return m_addonInfo->ID(); }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -279,7 +279,7 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, const TYPE &type)
       bool bErase = false;
 
       // check if the addon matches the provided addon type
-      if (type != ADDON::ADDON_UNKNOWN && addon->Type() != type && !addon->IsType(type))
+      if (type != ADDON::ADDON_UNKNOWN && addon->Type() != type && !addon->HasType(type))
         bErase = true;
 
       if (!this->CanAddonBeInstalled(addon))
@@ -341,7 +341,7 @@ bool CAddonMgr::GetAddonsInternal(const TYPE &type, VECADDONS &addons, bool enab
 
   for (const auto& addonInfo : m_installedAddons)
   {
-    if (type != ADDON_UNKNOWN && !addonInfo.second->IsType(type))
+    if (type != ADDON_UNKNOWN && !addonInfo.second->HasType(type))
       continue;
 
     if (enabledOnly && IsAddonDisabled(addonInfo.second->ID()))
@@ -783,7 +783,7 @@ bool CAddonMgr::GetAddonInfos(AddonInfos& addonInfos, TYPE type)
   bool forUnknown = type == ADDON_UNKNOWN;
   for (auto& info : m_installedAddons)
   {
-    if (info.second->MainType() != ADDON_UNKNOWN && (forUnknown || info.second->IsType(type)))
+    if (info.second->MainType() != ADDON_UNKNOWN && (forUnknown || info.second->HasType(type)))
       addonInfos.push_back(info.second);
   }
 
@@ -796,7 +796,7 @@ const AddonInfoPtr CAddonMgr::GetAddonInfo(const std::string& id, TYPE type /*= 
 
   auto addon = m_installedAddons.find(id);
   if (addon != m_installedAddons.end())
-    if ((type == ADDON_UNKNOWN || addon->second->IsType(type)))
+    if ((type == ADDON_UNKNOWN || addon->second->HasType(type)))
       return addon->second;
 
   return nullptr;

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -423,7 +423,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
         bool matchesType = false;
         for (std::vector<ADDON::TYPE>::const_iterator type = validTypes.begin(); type != validTypes.end(); ++type)
         {
-          if (pAddon->IsType(*type))
+          if (pAddon->HasType(*type))
           {
             matchesType = true;
             break;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -33,6 +33,7 @@ namespace ADDON
   {
   public:
     virtual ~IAddon() = default;
+    virtual TYPE MainType() const = 0;
     virtual TYPE Type() const =0;
     virtual bool IsType(TYPE type) const =0;
     virtual std::string ID() const =0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -34,7 +34,6 @@ namespace ADDON
   public:
     virtual ~IAddon() = default;
     virtual TYPE Type() const =0;
-    virtual TYPE FullType() const =0;
     virtual bool IsType(TYPE type) const =0;
     virtual std::string ID() const =0;
     virtual std::string Name() const =0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -35,7 +35,7 @@ namespace ADDON
     virtual ~IAddon() = default;
     virtual TYPE MainType() const = 0;
     virtual TYPE Type() const =0;
-    virtual bool IsType(TYPE type) const =0;
+    virtual bool HasType(TYPE type) const = 0;
     virtual std::string ID() const =0;
     virtual std::string Name() const =0;
     virtual bool IsInUse() const =0;

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -80,22 +80,6 @@ CPluginSource::Content CPluginSource::Translate(const std::string &content)
     return CPluginSource::UNKNOWN;
 }
 
-TYPE CPluginSource::FullType() const
-{
-  if (Provides(VIDEO))
-    return ADDON_VIDEO;
-  if (Provides(AUDIO))
-    return ADDON_AUDIO;
-  if (Provides(IMAGE))
-    return ADDON_IMAGE;
-  if (Provides(GAME))
-    return ADDON_GAME;
-  if (Provides(EXECUTABLE))
-    return ADDON_EXECUTABLE;
-
-  return CAddon::FullType();
-}
-
 bool CPluginSource::IsType(TYPE type) const
 {
   return ((type == ADDON_VIDEO && Provides(VIDEO))

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -86,7 +86,8 @@ bool CPluginSource::IsType(TYPE type) const
        || (type == ADDON_AUDIO && Provides(AUDIO))
        || (type == ADDON_IMAGE && Provides(IMAGE))
        || (type == ADDON_GAME && Provides(GAME))
-       || (type == ADDON_EXECUTABLE && Provides(EXECUTABLE)));
+       || (type == ADDON_EXECUTABLE && Provides(EXECUTABLE))
+       || (type == CAddon::Type()));
 }
 
 } /*namespace ADDON*/

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -21,13 +21,19 @@ namespace ADDON
 CPluginSource::CPluginSource(const AddonInfoPtr& addonInfo, TYPE addonType) : CAddon(addonInfo, addonType)
 {
   std::string provides = addonInfo->Type(addonType)->GetValue("provides").asString();
-  if (!provides.empty())
-    addonInfo->AddExtraInfo("provides", provides);
-  else
+  if (provides.empty())
   {
+    /*
+     * If "provides" was empty, check about them in addon extra info. This become
+     * needed for addons from repo content where the addon is stored inside a
+     * database and the related type classes are not created on addon info.
+     * The database add then "provides" to there.
+     */
     const auto& i = addonInfo->ExtraInfo().find("provides");
     if (i != addonInfo->ExtraInfo().end())
       provides = i->second;
+    else
+      provides = "executable"; // if nothing fall back to "executable"
   }
 
   for (auto values : addonInfo->Type(addonType)->GetValues())

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -86,7 +86,7 @@ CPluginSource::Content CPluginSource::Translate(const std::string &content)
     return CPluginSource::UNKNOWN;
 }
 
-bool CPluginSource::IsType(TYPE type) const
+bool CPluginSource::HasType(TYPE type) const
 {
   return ((type == ADDON_VIDEO && Provides(VIDEO))
        || (type == ADDON_AUDIO && Provides(AUDIO))

--- a/xbmc/addons/PluginSource.h
+++ b/xbmc/addons/PluginSource.h
@@ -23,7 +23,7 @@ public:
 
   explicit CPluginSource(const AddonInfoPtr& addonInfo, TYPE addonType);
 
-  bool IsType(TYPE type) const override;
+  bool HasType(TYPE type) const override;
   bool Provides(const Content& content) const
   {
     return content == UNKNOWN ? false : m_providedContent.count(content) > 0;

--- a/xbmc/addons/PluginSource.h
+++ b/xbmc/addons/PluginSource.h
@@ -23,7 +23,6 @@ public:
 
   explicit CPluginSource(const AddonInfoPtr& addonInfo, TYPE addonType);
 
-  TYPE FullType() const override;
   bool IsType(TYPE type) const override;
   bool Provides(const Content& content) const
   {

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -150,7 +150,7 @@ const CAddonType* CAddonInfo::Type(TYPE type) const
   return &dummy;
 }
 
-bool CAddonInfo::IsType(TYPE type, bool mainOnly /*= false*/) const
+bool CAddonInfo::HasType(TYPE type, bool mainOnly /*= false*/) const
 {
   return (m_mainType == type || ProvidesSubContent(type, mainOnly ? m_mainType : ADDON_UNKNOWN));
 }

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -71,7 +71,7 @@ public:
   const std::string& ID() const { return m_id; }
 
   TYPE MainType() const { return m_mainType; }
-  bool IsType(TYPE type, bool mainOnly = false) const;
+  bool HasType(TYPE type, bool mainOnly = false) const;
   const std::vector<CAddonType>& Types() const { return m_types; }
   const CAddonType* Type(TYPE type) const;
 

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -70,9 +70,51 @@ public:
 
   const std::string& ID() const { return m_id; }
 
+  /**
+   * @brief To get the main type of this addon
+   *
+   * This is the first type defined in addon.xml.
+   *
+   * @return The used main type of addon
+   */
   TYPE MainType() const { return m_mainType; }
+
+  /**
+   * @brief To check addon contains a type
+   *
+   * @param[in] type The to checked type identifier
+   * @param[in] mainOnly to check only in first defined main addon inside addon.xml
+   * @return true in case the wanted type is supported, false if not
+   */
   bool HasType(TYPE type, bool mainOnly = false) const;
+
+  /**
+   * @brief To get all available types inside the addon
+   *
+   * To have all `<extension point="..." />` defined in addon.xml inside a list.
+   *
+   * @return List of all supported types
+   */
   const std::vector<CAddonType>& Types() const { return m_types; }
+
+  /**
+   * @brief The get for given addon type information and extension data
+   *
+   * @param[in] type The wanted type data
+   * @return addon type class with @ref CAddonExtensions as information
+   *
+   * @note This function return never a "nullptr", in case the wanted type is
+   * not supported, becomes a dummy of @ref CAddonType given.
+   *
+   * ------------------------------------------------------------------------
+   *
+   * **Example:**
+   * ~~~~~~~~~~~~~{.cpp}
+   * // To get <extension ... name="blablabla" /> from addon.xml
+   * std::string name = Type(ADDON_...)->GetValue("@name").asString();
+   * ~~~~~~~~~~~~~
+   *
+   */
   const CAddonType* Type(TYPE type) const;
 
   bool ProvidesSubContent(const TYPE& content, const TYPE& mainType = ADDON_UNKNOWN) const;

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -37,9 +37,9 @@ const std::string& CBinaryAddonBase::MainLibName() const
   return m_addonInfo->LibName();
 }
 
-bool CBinaryAddonBase::IsType(TYPE type) const
+bool CBinaryAddonBase::HasType(TYPE type) const
 {
-  return m_addonInfo->IsType(type);
+  return m_addonInfo->HasType(type);
 }
 
 const std::vector<CAddonType>& CBinaryAddonBase::Types() const

--- a/xbmc/addons/binary-addons/BinaryAddonBase.h
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.h
@@ -35,7 +35,7 @@ namespace ADDON
     TYPE MainType() const;
     const std::string& MainLibName() const;
 
-    bool IsType(TYPE type) const;
+    bool HasType(TYPE type) const;
     const std::vector<CAddonType>& Types() const;
     const CAddonType* Type(TYPE type) const;
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -61,7 +61,7 @@ bool CBinaryAddonManager::HasInstalledAddons(const TYPE &type) const
   CSingleLock lock(m_critSection);
   for (auto info : m_installedAddons)
   {
-    if (info.second->IsType(type))
+    if (info.second->HasType(type))
       return true;
   }
   return false;
@@ -72,7 +72,7 @@ bool CBinaryAddonManager::HasEnabledAddons(const TYPE &type) const
   CSingleLock lock(m_critSection);
   for (auto info : m_enabledAddons)
   {
-    if (info.second->IsType(type))
+    if (info.second->HasType(type))
       return true;
   }
   return false;
@@ -102,7 +102,7 @@ void CBinaryAddonManager::GetAddonInfos(BinaryAddonBaseList& addonInfos, bool en
 
   for (auto info : *addons)
   {
-    if (type == ADDON_UNKNOWN || info.second->IsType(type))
+    if (type == ADDON_UNKNOWN || info.second->HasType(type))
     {
       addonInfos.push_back(info.second);
     }
@@ -115,7 +115,7 @@ void CBinaryAddonManager::GetDisabledAddonInfos(BinaryAddonBaseList& addonInfos,
 
   for (auto info : m_installedAddons)
   {
-    if (type == ADDON_UNKNOWN || info.second->IsType(type))
+    if (type == ADDON_UNKNOWN || info.second->HasType(type))
     {
       if (!IsAddonEnabled(info.second->ID(), type))
         addonInfos.push_back(info.second);
@@ -128,7 +128,7 @@ const BinaryAddonBasePtr CBinaryAddonManager::GetInstalledAddonInfo(const std::s
   CSingleLock lock(m_critSection);
 
   auto addon = m_installedAddons.find(addonId);
-  if (addon != m_installedAddons.end() && (type == ADDON_UNKNOWN || addon->second->IsType(type)))
+  if (addon != m_installedAddons.end() && (type == ADDON_UNKNOWN || addon->second->HasType(type)))
     return addon->second;
 
   CLog::Log(LOGERROR, "CBinaryAddonManager::%s: Requested addon '%s' unknown as binary", __FUNCTION__, addonId.c_str());

--- a/xbmc/addons/test/TestAddonInfoBuilder.cpp
+++ b/xbmc/addons/test/TestAddonInfoBuilder.cpp
@@ -63,8 +63,8 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Id_Type)
   EXPECT_NE(nullptr, addon);
   EXPECT_EQ(addon->ID(), "foo.baz");
   EXPECT_EQ(addon->MainType(), ADDON_VIZ);
-  EXPECT_TRUE(addon->IsType(ADDON_VIZ));
-  EXPECT_FALSE(addon->IsType(ADDON_SCREENSAVER));
+  EXPECT_TRUE(addon->HasType(ADDON_VIZ));
+  EXPECT_FALSE(addon->HasType(ADDON_SCREENSAVER));
 }
 
 TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
@@ -79,13 +79,13 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
   EXPECT_EQ(addon->ID(), "metadata.blablabla.org");
 
   EXPECT_EQ(addon->MainType(), ADDON_SCRAPER_MOVIES);
-  EXPECT_TRUE(addon->IsType(ADDON_SCRAPER_MOVIES));
+  EXPECT_TRUE(addon->HasType(ADDON_SCRAPER_MOVIES));
   EXPECT_EQ(addon->Type(ADDON_SCRAPER_MOVIES)->LibName(), "blablabla.xml");
   EXPECT_EQ(addon->Type(ADDON_SCRAPER_MOVIES)->GetValue("@language").asString(), "en");
 
-  EXPECT_TRUE(addon->IsType(ADDON_SCRIPT_MODULE));
+  EXPECT_TRUE(addon->HasType(ADDON_SCRIPT_MODULE));
   EXPECT_EQ(addon->Type(ADDON_SCRIPT_MODULE)->LibName(), "lib.so");
-  EXPECT_FALSE(addon->IsType(ADDON_SCRAPER_ARTISTS));
+  EXPECT_FALSE(addon->HasType(ADDON_SCRAPER_ARTISTS));
 
   EXPECT_EQ(addon->Name(), "The Bla Bla Bla Addon");
   EXPECT_EQ(addon->Author(), "Team Kodi");
@@ -150,10 +150,10 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_DBEntry)
   EXPECT_EQ(addon->ID(), "video.blablabla.org");
 
   EXPECT_EQ(addon->MainType(), ADDON_PLUGIN);
-  EXPECT_TRUE(addon->IsType(ADDON_PLUGIN));
-  EXPECT_TRUE(addon->IsType(ADDON_VIDEO));
-  EXPECT_TRUE(addon->IsType(ADDON_AUDIO));
-  EXPECT_FALSE(addon->IsType(ADDON_GAME));
+  EXPECT_TRUE(addon->HasType(ADDON_PLUGIN));
+  EXPECT_TRUE(addon->HasType(ADDON_VIDEO));
+  EXPECT_TRUE(addon->HasType(ADDON_AUDIO));
+  EXPECT_FALSE(addon->HasType(ADDON_GAME));
 
   EXPECT_EQ(addon->Name(), "The Bla Bla Bla Addon");
   EXPECT_EQ(addon->Author(), "Team Kodi");

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -120,7 +120,7 @@ static bool IsEmulator(const AddonPtr& addon)
 
 static bool IsGameProvider(const AddonPtr& addon)
 {
-  return addon->Type() == ADDON_PLUGIN && addon->IsType(ADDON_GAME);
+  return addon->Type() == ADDON_PLUGIN && addon->HasType(ADDON_GAME);
 }
 
 static bool IsGameResource(const AddonPtr& addon)
@@ -152,7 +152,7 @@ static bool IsDependencyType(TYPE type)
 static bool IsUserInstalled(const AddonPtr& addon)
 {
   return std::find_if(dependencyTypes.begin(), dependencyTypes.end(),
-      [&](TYPE type){ return addon->IsType(type); }) == dependencyTypes.end();
+                      [&](TYPE type) { return addon->HasType(type); }) == dependencyTypes.end();
 }
 
 static bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)
@@ -178,7 +178,7 @@ static void GenerateTypeListing(const CURL& path, const std::set<TYPE>& types,
   {
     for (const auto& addon : addons)
     {
-      if (addon->IsType(type))
+      if (addon->HasType(type))
       {
         CFileItemPtr item(new CFileItem(CAddonInfo::TranslateType(type, true)));
         CURL itemPath = path;
@@ -419,7 +419,8 @@ static void GenerateCategoryListing(const CURL& path, VECADDONS& addons,
     TYPE type = CAddonInfo::TranslateType(category);
     items.SetProperty("addoncategory", CAddonInfo::TranslateType(type, true));
     addons.erase(std::remove_if(addons.begin(), addons.end(),
-        [type](const AddonPtr& addon){ return !addon->IsType(type); }), addons.end());
+                                [type](const AddonPtr& addon) { return !addon->HasType(type); }),
+                 addons.end());
     CAddonsDirectory::GenerateAddonListing(path, addons, items, CAddonInfo::TranslateType(type, true));
   }
 }
@@ -891,7 +892,7 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
     const bool bIsFolder = (addon->Type() == ADDON_PLUGIN);
 
     std::string path;
-    if (addon->IsType(ADDON_PLUGIN))
+    if (addon->HasType(ADDON_PLUGIN))
     {
       path = "plugin://" + addon->ID();
       PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
@@ -903,11 +904,11 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
         path = url.Get();
       }
     }
-    else if (addon->IsType(ADDON_SCRIPT))
+    else if (addon->HasType(ADDON_SCRIPT))
     {
       path = "script://" + addon->ID();
     }
-    else if (addon->IsType(ADDON_GAMEDLL))
+    else if (addon->HasType(ADDON_GAMEDLL))
     {
       // Kodi fails to launch games with empty path from home screen
       path = "game://" + addon->ID();

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -341,7 +341,16 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
   for (unsigned int i = ADDON_UNKNOWN + 1; i < ADDON_MAX - 1; ++i)
   {
     const TYPE type = (TYPE)i;
-    if (!IsInfoProviderType(type) && !IsLookAndFeelType(type) && !IsDependencyType(type) && !IsGameType(type))
+    /*
+     * Check and prevent insert for this cases:
+     * - By a provider, look and feel, dependency and game becomes given to
+     *   subdirectory to control the types
+     * - By ADDON_SCRIPT and ADDON_PLUGIN, them contains one of the possible
+     *   subtypes (audio, video, app or/and game) and not needed to show
+     *   together in a Script or Plugin list
+     */
+    if (!IsInfoProviderType(type) && !IsLookAndFeelType(type) && !IsDependencyType(type) &&
+        !IsGameType(type) && type != ADDON_SCRIPT && type != ADDON_PLUGIN)
       uncategorized.insert(static_cast<TYPE>(i));
   }
   GenerateTypeListing(path, uncategorized, addons, items);

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -891,34 +891,26 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
     const bool bIsFolder = (addon->Type() == ADDON_PLUGIN);
 
     std::string path;
-    switch (addon->Type())
+    if (addon->IsType(ADDON_PLUGIN))
     {
-      case ADDON_PLUGIN:
+      path = "plugin://" + addon->ID();
+      PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
+      if (plugin && plugin->ProvidesSeveral())
       {
-        path = "plugin://" + addon->ID();
-        PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
-        if (plugin && plugin->ProvidesSeveral())
-        {
-          CURL url(path);
-          std::string opt = StringUtils::Format("?content_type=%s", content.c_str());
-          url.SetOptions(opt);
-          path = url.Get();
-        }
-        break;
+        CURL url(path);
+        std::string opt = StringUtils::Format("?content_type=%s", content.c_str());
+        url.SetOptions(opt);
+        path = url.Get();
       }
-      case ADDON_SCRIPT:
-      {
-        path = "script://" + addon->ID();
-        break;
-      }
-      case ADDON_GAMEDLL:
-      {
-        // Kodi fails to launch games with empty path from home screen
-        path = "game://" + addon->ID();
-        break;
-      }
-      default:
-        break;
+    }
+    else if (addon->IsType(ADDON_SCRIPT))
+    {
+      path = "script://" + addon->ID();
+    }
+    else if (addon->IsType(ADDON_GAMEDLL))
+    {
+      // Kodi fails to launch games with empty path from home screen
+      path = "game://" + addon->ID();
     }
 
     items.Add(FileItemFromAddon(addon, path, bIsFolder));

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -785,8 +785,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL &path,
     itemPath.SetFileName(addon->ID());
     CFileItemPtr pItem = FileItemFromAddon(addon, itemPath.Get(), false);
 
-    AddonPtr localAddon;
-    bool installed = CServiceBroker::GetAddonMgr().GetAddon(addon->ID(), localAddon, ADDON_UNKNOWN, false);
+    bool installed = CServiceBroker::GetAddonMgr().IsAddonInstalled(addon->ID());
     bool disabled = CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
     bool hasUpdate = outdated.find(addon->ID()) != outdated.end();
 

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -228,7 +228,7 @@ bool CGameUtils::IsStandaloneGame(const ADDON::AddonPtr& addon)
     }
     case ADDON_SCRIPT:
     {
-      return addon->IsType(ADDON_GAME);
+      return addon->HasType(ADDON_GAME);
     }
     default:
       break;


### PR DESCRIPTION
## Description
If one addon defines several types inside, was before always only the first
possible to start, e.g. screensaver.atv4 has also a video addon inside,
but this was before not possible to start.

The view, control and start of addons where have more as one type inside are now fixed with this request.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
Now with more correct view:
![Bildschirmfoto von 2020-01-28 01-50-32](https://user-images.githubusercontent.com/6879739/73226743-6b910f00-4171-11ea-8cd9-1189ce09a1f5.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
