### PR TITLE
[PVR] EPG grid container: fix regression after 2791691...

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -2352,7 +2352,7 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
       {
         // First program starts before current view
         block = m_gridModel->GetGridItemStartBlock(channel, startBlock);
-        const int missingSection = startBlock - block;
+        const int missingSection = blockOffset - block;
         posA2 -= missingSection * m_blockSize;
       }
 


### PR DESCRIPTION
... that prevented scrolling to next page if first item on page was not completely visible.

Followup to #17118 

Runtime-tested on macOS and Android, latest Kodi master.

No review needed. No-brainer (actually root cause was a typo).
