### PR TITLE
AESinkAUDIOTRACK: Allow RAW and IEC distinguishing

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -233,6 +233,7 @@ int CAESinkAUDIOTRACK::AudioTrackWrite(char* audioData, int sizeInBytes, int64_t
 CAEDeviceInfo CAESinkAUDIOTRACK::m_info;
 CAEDeviceInfo CAESinkAUDIOTRACK::m_info_iec;
 CAEDeviceInfo CAESinkAUDIOTRACK::m_info_raw;
+bool CAESinkAUDIOTRACK::m_hasIEC = false;
 std::set<unsigned int> CAESinkAUDIOTRACK::m_sink_sampleRates;
 bool CAESinkAUDIOTRACK::m_sinkSupportsFloat = false;
 bool CAESinkAUDIOTRACK::m_sinkSupportsMultiChannelFloat = false;
@@ -298,7 +299,9 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
 {
 
   // try to recover used device
-  if (device == "Default" && !m_info.m_wantsIECPassthrough)
+  if (!m_hasIEC)
+    m_info = m_info_raw;
+  else if (device == "Default" && !m_info.m_wantsIECPassthrough)
     m_info = m_info_raw;
   else if (device == "AudioTrack (RAW)")
     m_info = m_info_raw;
@@ -914,8 +917,12 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
     UpdateAvailablePCMCapabilities();
     UpdateAvailablePassthroughCapabilities(isRaw);
 
-    m_info_iec = m_info;
-    list.push_back(m_info_iec);
+    if (!m_info.m_streamTypes.empty())
+    {
+      m_info_iec = m_info;
+      list.push_back(m_info_iec);
+      m_hasIEC = true;
+    }
   }
 
   // Query RAW capabilities

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -50,7 +50,7 @@ protected:
                                       int encoding,
                                       bool isRaw = false);
   static void UpdateAvailablePCMCapabilities();
-  static void UpdateAvailablePassthroughCapabilities();
+  static void UpdateAvailablePassthroughCapabilities(bool isRaw = false);
 
   int AudioTrackWrite(char* audioData, int offsetInBytes, int sizeInBytes);
   int AudioTrackWrite(char* audioData, int sizeInBytes, int64_t timestamp);
@@ -73,6 +73,8 @@ private:
   std::deque<double>   m_linearmovingaverage;
 
   static CAEDeviceInfo m_info;
+  static CAEDeviceInfo m_info_raw;
+  static CAEDeviceInfo m_info_iec;
   static std::set<unsigned int>       m_sink_sampleRates;
   static bool m_sinkSupportsFloat;
   static bool m_sinkSupportsMultiChannelFloat;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -75,6 +75,7 @@ private:
   static CAEDeviceInfo m_info;
   static CAEDeviceInfo m_info_raw;
   static CAEDeviceInfo m_info_iec;
+  static bool m_hasIEC;
   static std::set<unsigned int>       m_sink_sampleRates;
   static bool m_sinkSupportsFloat;
   static bool m_sinkSupportsMultiChannelFloat;


### PR DESCRIPTION
Reality did not work out.

IEC-Format with 8 channels and 192 khz is still not in the Android standard [1]. Work is ongoing but we have no timeline from google yet - even we asked them to add this specification for more than 2 years now. Devices like certain modern AML, Nvidia Shield and others implement it already - but most do not.

The main difference between IEC and RAW is, that in IEC case kodi's IEC packer is used. This uses:

2 channels / 44.1/ 48 khz for DTS and AC3
2 channels / 176.4 / 192 khz for E-AC3
2 channels / 192 khz for DTS-HD-HR
8 channels / 192 khz for DTS-HD-MA and TrueHD

Android's Packer has some limitations:
It only supports 48 khz DTS
It is highly device depenendend. On some E-AC3 works properly on others not.
On some devices E-AC3 works great with Android's Packer and Atmos while Kodi's Packer does not make it through the ARC [2].
Some firmwares don't implement e.g. DTS, but only AC-3 and E-AC3 while with IEC format from above, you can just send through whatever you like.
Additionally, and this was the main point for IEC, the SYNC implementation was horrible. Though to admit kodi's Delay Method was far from optimal and was fixed recently in v19 Matrix - during my testing it seemed to work okayish now (seek, a/v sync in general, etc.)

Long story. This PR adds an additional RAW sink so you can choose your PT device, be it RAW or IEC - the capabilities will be updated, when you swap the device.

There is one usability flaw here. There is currently no option that you can hide AE_TYPE_HDMI devices from general output devices, means there are also two PCM devices now, but both do the same.

Tested on FireTV 4K.

[1]: https://developer.android.com/reference/android/media/AudioFormat#ENCODING_IEC61937
[2]: https://forum.kodi.tv/showthread.php?tid=348500&pid=2913558#pid2913558