### PR TITLE
[Profiles] Perform operations only outside the login screen

### DIFF
--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -245,6 +245,7 @@ void CProfileManager::Clear()
   CSingleLock lock(m_critical);
   m_usingLoginScreen = false;
   m_profileLoadedForLogin = false;
+  m_previousProfileLoadedForLogin = false;
   m_lastUsedProfile = 0;
   m_nextProfileId = 0;
   SetCurrentProfileId(0);
@@ -297,7 +298,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   // save any settings of the currently used skin but only if the (master)
   // profile hasn't just been loaded as a temporary profile for login
-  if (g_SkinInfo != nullptr && !m_profileLoadedForLogin)
+  if (g_SkinInfo != nullptr && !m_previousProfileLoadedForLogin)
     g_SkinInfo->SaveSettings();
 
   // @todo: why is m_settings not used here?
@@ -307,7 +308,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
   settings->Unload();
 
   SetCurrentProfileId(index);
-  m_profileLoadedForLogin = false;
+  m_previousProfileLoadedForLogin = false;
 
   // load the new settings
   if (!settings->Load())
@@ -363,6 +364,8 @@ bool CProfileManager::LoadProfile(unsigned int index)
   Save();
   FinalizeLoadProfile();
 
+  m_profileLoadedForLogin = false;
+
   return true;
 }
 
@@ -407,14 +410,17 @@ void CProfileManager::FinalizeLoadProfile()
   contextMenuManager.Init();
 
   // Restart PVR services if we are not just loading the master profile for the login screen
-  if (m_profileLoadedForLogin || m_currentProfile != 0 || m_lastUsedProfile == 0)
+  if (m_previousProfileLoadedForLogin || m_currentProfile != 0 || m_lastUsedProfile == 0)
     pvrManager.Init();
 
   favouritesManager.ReInit(GetProfileUserDataFolder());
 
-  serviceAddons.Start();
-
-  g_application.UpdateLibraries();
+  // Start these operations only when a profile is loaded, not on the login screen
+  if (!m_profileLoadedForLogin || (m_profileLoadedForLogin && m_lastUsedProfile == 0))
+  {
+    serviceAddons.Start();
+    g_application.UpdateLibraries();
+  }
 
   stereoscopicsManager.Initialize();
 
@@ -602,10 +608,13 @@ void CProfileManager::LoadMasterProfileForLogin()
   m_lastUsedProfile = m_currentProfile;
   if (m_currentProfile != 0)
   {
+    // determines that the (master) profile has only been loaded for login
+    m_profileLoadedForLogin = true;
+
     LoadProfile(0);
 
     // remember that the (master) profile has only been loaded for login
-    m_profileLoadedForLogin = true;
+    m_previousProfileLoadedForLogin = true;
   }
 }
 

--- a/xbmc/profiles/ProfileManager.h
+++ b/xbmc/profiles/ProfileManager.h
@@ -200,6 +200,7 @@ private:
   std::vector<CProfile> m_profiles;
   bool m_usingLoginScreen = false;
   bool m_profileLoadedForLogin = false;
+  bool m_previousProfileLoadedForLogin = false;
   int m_autoLoginProfile = -1;
   unsigned int m_lastUsedProfile = 0;
   unsigned int m_currentProfile =


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Currently operations (such as addon services) are started in the login screen, and it shouldn't happen

If PR goes well, i ask permission to do a backport to Leia

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Every time you logout from other profiles, the addon services are started in the login screen,
this causes services to be started in an inappropriate context, which could cause unexpected behavior with the addons
Rif. https://github.com/xbmc/xbmc/issues/17136

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on latest Kodi 18.5 (ported to 19)
- One test performed with standard kodi settings (only master) and netflix add-on
- One test performed with more kodi profiles and netflix add-on on each kodi profile

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
