### PR TITLE
[PVR] Improve performance of TriggerRecordingUpdate/TriggerTimerUpdate

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -173,19 +173,17 @@ void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag)
       m_bDeletedTVRecordings = true;
   }
 
-  std::shared_ptr<CPVRRecording> newTag = GetById(tag->m_iClientId, tag->m_strRecordingId);
-  if (newTag)
+  std::shared_ptr<CPVRRecording> existingTag = GetById(tag->m_iClientId, tag->m_strRecordingId);
+  if (existingTag)
   {
-    newTag->Update(*tag);
+    existingTag->Update(*tag);
   }
   else
   {
-    newTag = std::shared_ptr<CPVRRecording>(new CPVRRecording);
-    newTag->Update(*tag);
-    newTag->UpdateMetadata(GetVideoDatabase());
-    newTag->m_iRecordingId = ++m_iLastId;
-    m_recordings.insert(std::make_pair(CPVRRecordingUid(newTag->m_iClientId, newTag->m_strRecordingId), newTag));
-    if (newTag->IsRadio())
+    tag->UpdateMetadata(GetVideoDatabase());
+    tag->m_iRecordingId = ++m_iLastId;
+    m_recordings.insert({CPVRRecordingUid(tag->m_iClientId, tag->m_strRecordingId), tag});
+    if (tag->IsRadio())
       ++m_iRadioRecordings;
     else
       ++m_iTVRecordings;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -37,14 +37,17 @@ bool CPVRTimersContainer::UpdateFromClient(const std::shared_ptr<CPVRTimerInfoTa
 {
   CSingleLock lock(m_critSection);
   std::shared_ptr<CPVRTimerInfoTag> tag = GetByClient(timer->m_iClientId, timer->m_iClientIndex);
-  if (!tag)
+  if (tag)
   {
-    tag.reset(new CPVRTimerInfoTag());
-    tag->m_iTimerId = ++m_iLastId;
-    InsertEntry(tag);
+    return tag->UpdateEntry(timer);
+  }
+  else
+  {
+    timer->m_iTimerId = ++m_iLastId;
+    InsertEntry(timer);
   }
 
-  return tag->UpdateEntry(timer);
+  return true;
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimersContainer::GetByClient(int iClientId, int iClientIndex) const


### PR DESCRIPTION
## Description
While doing some performance testing on my PVR addon, I noticed that TriggerRecordingUpdate() was taking longer than seemed necessary.  Digging into it a bit, I found that the data provided by the PVR addon was being duplicated unnecessarily by deep-copying a shared_ptr<> instance that has no need to be deep-copied.

I think this type of optimization may ultimately also be applicable to other PVR transfers (EPG, Channel Groups, Channels, Timers), but would prefer to see how this PR goes first before recommending any additional changes.  Each transfer function is different and may or may not benefit in the same way.

**edit:** The same type of change only affected EPG and Timers.  EPG is in the process of being refactored; so I only added a change for Timers.

## Motivation and Context
A measurable (> 40%) performance improvement transferring PVR_RECORDING information from a PVR addon to Kodi.  There was little to no associated improvement for the PVR_TIMER information as there will typically be a relatively small number of these.

## How Has This Been Tested?
Tested on Windows (Desktop) x64, using recent Kodi 19 "Matrix" nightly build.  No functionality issues were detected.  I compared the state of the original shared_ptr<> with the deep-copied one and found no discrepancies.  Performance increase (less addon overhead) for transferring 922 recording structures dropped from 171ms to 93ms, which is a 45% improvement.

I did not test this PR on Leia branch, and am of the opinion that even if accepted for master branch it's not worth a back-port since no defects have been addressed.

If accepted for master branch, I would be willing to look at the other PVR transfer operations to see if they may benefit some similar optimizations.

## Screenshots (if appropriate):
N/A

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Review by @ksooo is requested if PR builds successfully for all supported platforms.
