### PR TITLE
[Backport][Profiles] Perform operations only outside the login screen

### DIFF
--- a/xbmc/profiles/ProfileManager.h
+++ b/xbmc/profiles/ProfileManager.h
@@ -207,6 +207,7 @@ private:
   std::vector<CProfile> m_profiles;
   bool m_usingLoginScreen;
   bool m_profileLoadedForLogin;
+  bool m_previousProfileLoadedForLogin;
   int m_autoLoginProfile;
   unsigned int m_lastUsedProfile;
   unsigned int m_currentProfile; // do not modify directly, use SetCurrentProfileId() function instead


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This is a backport of https://github.com/xbmc/xbmc/pull/17138

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix operations performed in the login screen

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
