### PR TITLE
[ios] add setting to extend UI under the notch

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21901,3 +21901,15 @@ msgstr ""
 msgctxt "#39118"
 msgid "Share debug log"
 msgstr ""
+
+#. Label for skin setting whether to position UI under the notch
+#: system/settings/darwin_ios.xml
+msgctxt "#39119"
+msgid "Extend UI under the notch"
+msgstr ""
+
+#. Description of setting with label #39119 "Extend UI under the notch"
+#: system/settings/darwin_ios.xml
+msgctxt "#39120"
+msgid "Toggles whether UI is positioned within the 'safe area'. You might want to enable this setting and use \"Zoom\" setting to adjust UI manually. Takes effect after relaunching the app."
+msgstr ""

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -85,6 +85,7 @@
           <default>skin.estouchy</default>
         </setting>
         <setting id="lookandfeel.extenduiundernotch" type="boolean" label="39119" help="39120">
+          <requirement>DEVICE_HAS_NOTCH</requirement>
           <level>1</level>
           <default>false</default>
           <control type="toggle" />

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -84,6 +84,11 @@
         <setting id="lookandfeel.skin" type="addon">
           <default>skin.estouchy</default>
         </setting>
+        <setting id="lookandfeel.extenduiundernotch" type="boolean" label="39119" help="39120">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -84,7 +84,7 @@
         <setting id="lookandfeel.skin" type="addon">
           <default>skin.estouchy</default>
         </setting>
-        <setting id="lookandfeel.extenduiundernotch" type="boolean" label="39119" help="39120">
+        <setting id="lookandfeel.extenduiundernotch" type="boolean" label="39119" help="39120" before="lookandfeel.skin">
           <requirement>DEVICE_HAS_NOTCH</requirement>
           <level>1</level>
           <default>false</default>

--- a/xbmc/platform/darwin/DarwinUtils.h
+++ b/xbmc/platform/darwin/DarwinUtils.h
@@ -34,5 +34,6 @@ public:
   static bool        IsAliasShortcut(const std::string& path, bool isdirectory);
   static void        TranslateAliasShortcut(std::string& path);
   static bool        CreateAliasShortcut(const std::string& fromPath, const std::string& toPath);
+  static bool hasSafeArea(bool callOnMainThread = false);
 };
 

--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -378,3 +378,23 @@ bool CDarwinUtils::CreateAliasShortcut(const std::string& fromPath, const std::s
 #endif
   return ret;
 }
+
+bool CDarwinUtils::hasSafeArea(bool callOnMainThread)
+{
+#if defined(TARGET_DARWIN_IOS)
+  if (@available(ios 11.0, *))
+  {
+    bool __block result;
+    auto getResult = ^{
+      auto app = UIApplication.sharedApplication;
+      result = !UIEdgeInsetsEqualToEdgeInsets(app.keyWindow.safeAreaInsets, UIEdgeInsetsZero);
+    };
+    if (callOnMainThread)
+      dispatch_sync(dispatch_get_main_queue(), getResult);
+    else
+      getResult();
+    return result;
+  }
+#endif
+  return false;
+}

--- a/xbmc/platform/darwin/ios/CMakeLists.txt
+++ b/xbmc/platform/darwin/ios/CMakeLists.txt
@@ -2,12 +2,14 @@ set(SOURCES CPUInfoIos.cpp
             IOSEAGLView.mm
             IOSExternalTouchController.mm
             IOSScreenManager.mm
+            IOSSettingsHandler.mm
             XBMCController.mm)
 
 set(HEADERS CPUInfoIos.h
             IOSEAGLView.h
             IOSExternalTouchController.h
             IOSScreenManager.h
+            IOSSettingsHandler.h
             XBMCApplication.h
             XBMCController.h)
 

--- a/xbmc/platform/darwin/ios/IOSSettingsHandler.h
+++ b/xbmc/platform/darwin/ios/IOSSettingsHandler.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (C) 2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "settings/lib/ISettingCallback.h"
+
+class IOSSettingsHandler : public ISettingCallback
+{
+public:
+  IOSSettingsHandler();
+  virtual ~IOSSettingsHandler();
+
+  void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
+};

--- a/xbmc/platform/darwin/ios/IOSSettingsHandler.h
+++ b/xbmc/platform/darwin/ios/IOSSettingsHandler.h
@@ -8,6 +8,9 @@
 
 #include "settings/lib/ISettingCallback.h"
 
+@class NSString;
+extern NSString* const DisableSafeAreaDefaultsKey;
+
 class IOSSettingsHandler : public ISettingCallback
 {
 public:
@@ -15,4 +18,5 @@ public:
   virtual ~IOSSettingsHandler();
 
   void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
+  void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
 };

--- a/xbmc/platform/darwin/ios/IOSSettingsHandler.mm
+++ b/xbmc/platform/darwin/ios/IOSSettingsHandler.mm
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2019 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "IOSSettingsHandler.h"
+
+#include "CompileInfo.h"
+#include "ServiceBroker.h"
+#include "filesystem/SpecialProtocol.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+#import <UIKit/UIKit.h>
+
+IOSSettingsHandler::IOSSettingsHandler()
+{
+  std::set<std::string> watchedSettings{CSettings::SETTING_DEBUG_SHARE_LOG};
+  CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(this, watchedSettings);
+}
+
+IOSSettingsHandler::~IOSSettingsHandler()
+{
+  CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
+}
+
+void IOSSettingsHandler::OnSettingAction(std::shared_ptr<const CSetting> setting)
+{
+  if (!setting || setting->GetId() != CSettings::SETTING_DEBUG_SHARE_LOG)
+    return;
+
+  std::string lowerAppName{CCompileInfo::GetAppName()};
+  StringUtils::ToLower(lowerAppName);
+  auto path = URIUtils::AddFileToFolder(CSpecialProtocol::TranslatePath("special://logpath/"),
+                                        lowerAppName + ".log");
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    auto infoDic = NSBundle.mainBundle.infoDictionary;
+    auto subject =
+        [NSString stringWithFormat:@"iOS log - Kodi %@ %@", infoDic[@"CFBundleShortVersionString"],
+                                   infoDic[static_cast<NSString*>(kCFBundleVersionKey)]];
+
+    auto activityVc = [[UIActivityViewController alloc]
+        initWithActivityItems:@[ [NSURL fileURLWithPath:@(path.c_str())] ]
+        applicationActivities:nil];
+    // hacky way to set email subject instead of providing UIActivityItemSource object
+    [activityVc setValue:subject forKey:@"subject"];
+
+    // make sure that the sharing sheet is displayed on iOS device's screen
+    auto iosDeviceScreen = UIScreen.mainScreen;
+    auto iosDeviceWindow = UIApplication.sharedApplication.keyWindow;
+    if (iosDeviceWindow.screen != iosDeviceScreen)
+    {
+      for (UIWindow* window in UIApplication.sharedApplication.windows)
+      {
+        if (window.screen == iosDeviceScreen)
+        {
+          iosDeviceWindow = window;
+          break;
+        }
+      }
+    }
+
+    auto rootVc = iosDeviceWindow.rootViewController;
+    [rootVc presentViewController:activityVc animated:YES completion:nil];
+
+    // iPad must present the sharing sheet in a popover
+    activityVc.popoverPresentationController.sourceView = rootVc.view;
+    activityVc.popoverPresentationController.sourceRect = CGRectMake(0.0, 0.0, 10.0, 10.0);
+  });
+}

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -540,8 +540,10 @@ XBMCController *g_xbmcController;
   self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.view.autoresizesSubviews = YES;
 
-  m_glView = [[IOSEAGLView alloc] initWithFrame:[self fullscreenSubviewFrame]
-                                     withScreen:UIScreen.mainScreen];
+  auto frame = [NSUserDefaults.standardUserDefaults boolForKey:DisableSafeAreaDefaultsKey]
+                   ? self.view.bounds
+                   : [self fullscreenSubviewFrame];
+  m_glView = [[IOSEAGLView alloc] initWithFrame:frame withScreen:UIScreen.mainScreen];
   [[IOSScreenManager sharedInstance] setView:m_glView];
   [m_glView setMultipleTouchEnabled:YES];
 

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -15,6 +15,8 @@
 #include "addons/Skin.h"
 #if defined(TARGET_ANDROID)
 #include "platform/android/activity/AndroidFeatures.h"
+#elif defined(TARGET_DARWIN_IOS)
+#include "platform/darwin/DarwinUtils.h"
 #endif // defined(TARGET_ANDROID)
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h"
 #include "ServiceBroker.h"
@@ -327,6 +329,11 @@ void CSettingConditions::Initialize()
 #ifdef HAS_WEB_SERVER
   if(CWebServer::WebServerSupportsSSL())
     m_simpleConditions.insert("webserver_has_ssl");
+#endif
+
+#if defined(TARGET_DARWIN_IOS)
+  if (CDarwinUtils::hasSafeArea(true))
+    m_simpleConditions.insert("device_has_notch");
 #endif
 
   // add complex conditions

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -66,6 +66,8 @@ const std::string CSettings::SETTING_LOOKANDFEEL_SKINTHEME = "lookandfeel.skinth
 const std::string CSettings::SETTING_LOOKANDFEEL_SKINCOLORS = "lookandfeel.skincolors";
 const std::string CSettings::SETTING_LOOKANDFEEL_FONT = "lookandfeel.font";
 const std::string CSettings::SETTING_LOOKANDFEEL_SKINZOOM = "lookandfeel.skinzoom";
+const std::string CSettings::SETTING_LOOKANDFEEL_EXTENDUIUNDERNOTCH =
+    "lookandfeel.extenduiundernotch";
 const std::string CSettings::SETTING_LOOKANDFEEL_STARTUPACTION = "lookandfeel.startupaction";
 const std::string CSettings::SETTING_LOOKANDFEEL_STARTUPWINDOW = "lookandfeel.startupwindow";
 const std::string CSettings::SETTING_LOOKANDFEEL_SOUNDSKIN = "lookandfeel.soundskin";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -32,6 +32,7 @@ public:
   static const std::string SETTING_LOOKANDFEEL_SKINCOLORS;
   static const std::string SETTING_LOOKANDFEEL_FONT;
   static const std::string SETTING_LOOKANDFEEL_SKINZOOM;
+  static const std::string SETTING_LOOKANDFEEL_EXTENDUIUNDERNOTCH;
   static const std::string SETTING_LOOKANDFEEL_STARTUPACTION;
   static const std::string SETTING_LOOKANDFEEL_STARTUPWINDOW;
   static const std::string SETTING_LOOKANDFEEL_SOUNDSKIN;


### PR DESCRIPTION
## Description
Adds a new setting to devices that have "notch" (iPhone X and similar) to control UI size. The setting takes effect only after restarting the app because I couldn't achieve resizing `CAEAGLLayer` on the fly without bugs.

## Motivation and Context
Originally requested at https://forum.kodi.tv/showthread.php?tid=348671, builds on top of #16719 to control new behavior via Settings.

## How Has This Been Tested?
Tested on iPhone XR (has notch) and iPhone 6+ (no notch).

## Screenshots (if appropriate):
![Screen Shot 2020-01-06 at 19 18 09_framed](https://user-images.githubusercontent.com/1557784/71831409-e2c70c00-30b9-11ea-8515-0d1eeb9baf30.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
