### PR TITLE
Fix python crash when aborting script

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -52,6 +52,8 @@
 #include <osdefs.h>
 // clang-format on
 
+#include <cassert>
+
 #ifdef TARGET_WINDOWS
 extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);
 #else
@@ -436,6 +438,7 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
   // pending calls must be cleared out
   XBMCAddon::RetardedAsyncCallbackHandler::clearPendingCalls(m_threadState);
 
+  assert(m_threadState != nullptr);
   PyEval_ReleaseThread(m_threadState);
 
   setState(stateToSet);
@@ -558,7 +561,6 @@ bool CPythonInvoker::stop(bool abort)
       pulseGlobalEvent();
 
       PyEval_ReleaseThread(m_threadState);
-      m_threadState = nullptr;
     }
     lock.Leave();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Python calls abort if any of the thread functions
are called with a null parameter. Don't clear m_threadstate
to avoid crashing but also to properly clean up the interpreter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When cancelling a long running script Kodi crashes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
tested locally by cancelling an addon performing a long running task

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
