### PR TITLE
[PVR] Add support for firstAired tag via PVR Recordings

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -59,6 +59,7 @@ struct DemuxPacket;
 #define PVR_ADDON_ATTRIBUTE_DESC_LENGTH       128
 #define PVR_ADDON_ATTRIBUTE_VALUES_ARRAY_SIZE 512
 #define PVR_ADDON_DESCRAMBLE_INFO_STRING_LENGTH 64
+#define PVR_ADDON_DATE_STRING_LENGTH          32
 
 #define XBMC_INVALID_CODEC_ID   0
 #define XBMC_INVALID_CODEC      { XBMC_CODEC_TYPE_UNKNOWN, XBMC_INVALID_CODEC_ID }
@@ -556,6 +557,7 @@ extern "C" {
     unsigned int iEpgEventId;                             /*!< @brief (optional) EPG event id associated with this recording. Valid ids must be greater than EPG_TAG_INVALID_UID. */
     int    iChannelUid;                                   /*!< @brief (optional) unique identifier of the channel for this recording. PVR_CHANNEL_INVALID_UID denotes that channel uid is not available. */
     PVR_RECORDING_CHANNEL_TYPE channelType;               /*!< @brief (optional) channel type. Set to PVR_RECORDING_CHANNEL_TYPE_UNKNOWN if the type cannot be determined. */
+    char   strFirstAired[PVR_ADDON_DATE_STRING_LENGTH];   /*!< @brief (optional) first aired date of this recording. Used only for display purposes. Specify in W3C date format "YYYY-MM-DD". */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -301,6 +301,9 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording, PV
   addonRecording.bIsDeleted = xbmcRecording.IsDeleted();
   addonRecording.iChannelUid = xbmcRecording.ChannelUid();
   addonRecording.channelType = xbmcRecording.IsRadio() ? PVR_RECORDING_CHANNEL_TYPE_RADIO : PVR_RECORDING_CHANNEL_TYPE_TV;
+  if (xbmcRecording.FirstAired().IsValid())
+    strncpy(addonRecording.strFirstAired, xbmcRecording.FirstAired().GetAsW3CDate().c_str(),
+            sizeof(addonRecording.strFirstAired) - 1);
 }
 
 /*!

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -426,6 +426,19 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         strValue = recording->IsRadio() ? m_strPlayingRadioGroup : m_strPlayingTVGroup;
         return true;
       }
+      case VIDEOPLAYER_PREMIERED:
+      case LISTITEM_PREMIERED:
+        if (recording->FirstAired().IsValid())
+        {
+          strValue = recording->FirstAired().GetAsLocalizedDate(true);
+          return true;
+        }
+        else if (recording->HasYear())
+        {
+          strValue = StringUtils::Format("%i", recording->GetYear());
+          return true;
+        }
+        return false;
     }
     return false;
   }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -94,6 +94,8 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
   m_bIsDeleted = recording.bIsDeleted;
   m_iEpgEventId = recording.iEpgEventId;
   m_iChannelUid = recording.iChannelUid;
+  if (strlen(recording.strFirstAired) > 0)
+    m_firstAired.SetFromW3CDateTime(recording.strFirstAired);
 
   SetGenre(recording.iGenreType, recording.iGenreSubType, recording.strGenreDescription);
   CVideoInfoTag::SetPlayCount(recording.iPlayCount);
@@ -159,7 +161,8 @@ bool CPVRRecording::operator ==(const CPVRRecording& right) const
        m_bRadio == right.m_bRadio &&
        m_genre == right.m_genre &&
        m_iGenreType == right.m_iGenreType &&
-       m_iGenreSubType == right.m_iGenreSubType);
+       m_iGenreSubType == right.m_iGenreSubType &&
+       m_firstAired == right.m_firstAired);
 }
 
 bool CPVRRecording::operator !=(const CPVRRecording& right) const
@@ -362,6 +365,7 @@ void CPVRRecording::Update(const CPVRRecording& tag)
   m_iEpgEventId = tag.m_iEpgEventId;
   m_iChannelUid = tag.m_iChannelUid;
   m_bRadio = tag.m_bRadio;
+  m_firstAired = tag.m_firstAired;
 
   CVideoInfoTag::SetPlayCount(tag.GetLocalPlayCount());
   CVideoInfoTag::SetResumePoint(tag.GetLocalResumePoint());
@@ -519,4 +523,9 @@ void CPVRRecording::SetGenre(int iGenreType, int iGenreSubType, const std::strin
 const std::string CPVRRecording::GetGenresLabel() const
 {
   return StringUtils::Join(m_genre, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+}
+
+CDateTime CPVRRecording::FirstAired() const
+{
+  return m_firstAired;
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -317,6 +317,12 @@ namespace PVR
      */
    const std::string GetGenresLabel() const;
 
+   /*!
+    * @brief Get the first air date of this event.
+    * @return The first air date.
+    */
+   CDateTime FirstAired() const;
+
   private:
     CDateTime m_recordingTime; /*!< start time of the recording */
     bool m_bGotMetaData;


### PR DESCRIPTION
## Description
This PR adds a new field to PVR_RECORDING that allows the addon to specify the original air date of a recording when available, so that value does not need to be derived by VideoInfoTag.

## Motivation and Context
Currently, the original air date will always be reported as January 1st of the Year specified in PVR_RECORDING, as it's being derived from just the year by VideoInfoTag.

This is a breaking API change, since the PVR_RECORDING structure is owned by the addon, an incorrect structure would have the new field initialized with garbage.

Since this is a breaking change, LMK if it would be more appropriate to move the new field higher up in the structure, it looks a little out of place at the end.

## How Has This Been Tested?
Tested on recent (Jan 6, ref e9806a39) nightly build of Matrix, Windows x64 Desktop.  HDHomeRun DVR backend timestamps were manually converted and confirmed to be accurate in the default Kodi skin (screenshots below). 

## Screenshots (if appropriate):
Prior to change (First aired is incorrect:)
![pr-before](https://user-images.githubusercontent.com/706055/71935489-ea97b680-3174-11ea-9465-cf021cff778c.png)

After change (First aired is now correct):
![pr-after](https://user-images.githubusercontent.com/706055/71935496-ed92a700-3174-11ea-8abd-80a11fb49cf5.png)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project *
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

* Code formatting note: I did not apply clang-format changes to every affected location as it would have drastically changed the formatting and clarity of these locations.  I'll probably get dinged on it, and will cycle back and apply them if so.
