### PR TITLE
[PVR] Address regression due to recent PVR recordings change

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -128,6 +128,8 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
       }
     }
   }
+
+  UpdatePath();
 }
 
 bool CPVRRecording::operator ==(const CPVRRecording& right) const


### PR DESCRIPTION
## Description
This PR addresses a regression caused by [PR 17140](https://github.com/xbmc/xbmc/pull/17140).  Proper initialization of the CPVRRecording class' m_strFileNameAndPath member is bypassed if the Update() method is never called for that instance to reinitialize all member variables.

## Motivation and Context
This regression was noted by @ksooo after the PR was merged to master branch, this is an oversight of the original PR testing in which I did not fully verify the state of all member variables before and after the change.

## How Has This Been Tested?
Tested on recent Matrix nightly (Jan 8, ref 13b724e), Windows x64 Desktop.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
