### PR TITLE
Add support for ListItem.OriginalTitle

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -75,8 +75,12 @@
 		<value condition="!String.isempty(ListItem.Thumb)">$INFO[ListItem.Thumb]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
+	<variable name="ListTitleVar">
+		<value condition="!String.IsEmpty(ListItem.OriginalTitle)">$INFO[ListItem.OriginalTitle]</value>
+		<value>$INFO[ListItem.Title]</value>
+	</variable>
 	<variable name="ListLabelVar">
-		<value condition="String.IsEqual(ListItem.DbType,episode) + Window.IsActive(videoplaylist)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + Window.IsActive(videoplaylist)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$VAR[ListTitleVar]</value>
 		<value condition="String.IsEqual(ListItem.DbType,musicvideo) + Window.IsActive(videoplaylist)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
@@ -276,8 +280,9 @@
 		<value>[COLOR grey]$INFO[ListItem.Year, (,)][/COLOR]</value>
 	</variable>
 	<variable name="VideoInfoMainLabelVar">
-		<value condition="String.IsEqual(ListItem.DBType,set)">$INFO[ListItem.Title]</value>
+		<value condition="String.IsEqual(ListItem.DBType,set)">$VAR[ListTitleVar]</value>
 		<value condition="!String.IsEmpty(ListItem.TVShowTitle)">$INFO[ListItem.TVShowTitle]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
+		<value condition="!String.IsEmpty(ListItem.OriginalTitle)">$INFO[ListItem.OriginalTitle]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 		<value condition="!String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 		<value>$INFO[ListItem.Label]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 	</variable>
@@ -286,7 +291,7 @@
 		<value>$LOCALIZE[208]</value>
 	</variable>
 	<variable name="VideoInfoSubLabelVar">
-		<value condition="String.IsEqual(ListItem.DBType,episode)">$INFO[ListItem.Season]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR],: ]$INFO[ListItem.Title]</value>
+		<value condition="String.IsEqual(ListItem.DBType,episode)">$INFO[ListItem.Season]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR],: ]$VAR[ListTitleVar]</value>
 		<value condition="String.IsEqual(ListItem.DBType,movie)">$INFO[ListItem.Tagline,[I],[/I]]</value>
 		<value>$INFO[ListItem.Genre]</value>
 	</variable>


### PR DESCRIPTION
## Description
This adds support for ListItem.OriginalTitle. If it is set, it will be used in favor of ListItem.Title.

## Motivation and Context
The Video Info pane should show the original title, not the ListItem's Title or Label (which may depend on the view). E.g. in a Most recent listing in an add-on, you get a list of all episodes for different tvshows. In this case the Label and Title may include the tvshow name because it needs to be visible to the user (an episode name is simply not enough context).

However, if you open de Video Info pane, you already have the tvshow name in the title, so the sublabel should show only the episode name. The ListItem.OriginalTitle is the best way to make this distinction.

## How Has This Been Tested?
It has been tested on LibreELEC 9.2.0 using Kodi 18.5, and has been ported to the Kodi master branch.

## Screenshots (if appropriate):
A listing showing the episodes of various TV shows, including the tvshow name.
![screenshot013](https://user-images.githubusercontent.com/388198/72037853-c08ee300-329f-11ea-9a87-71caaafb940d.png)

Before, the episode title includes the tvshow again in the ListItem.Title (**Misdaaddokters** - In het hoofd van de dader), because of the listing view:
![screenshot015](https://user-images.githubusercontent.com/388198/72037944-106daa00-32a0-11ea-8ad9-9d462d6c33c4.png)

A Video Info pane, showing the ListItem OriginalTitle (**In het hoofd van de dader**):
![screenshot014](https://user-images.githubusercontent.com/388198/72037857-c5ec2d80-329f-11ea-917a-1963084eca55.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
