### PR TITLE
[PVR] EPG Guide window: Prevent scrolling of the grid if causing action was not user-initiated

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -84,6 +84,8 @@ namespace PVR
      */
     void SetRenderOffset(const CPoint& offset);
 
+    void JumpToNow();
+
     void GoToBegin();
     void GoToEnd();
     void GoToNow();
@@ -208,6 +210,11 @@ namespace PVR
 
     void UpdateItems();
 
+    float GetChannelScrollOffsetPos() const;
+    float GetProgrammeScrollOffsetPos() const;
+    int GetChannelScrollOffset(CGUIListItemLayout* layout) const;
+    int GetProgrammeScrollOffset() const;
+
     int m_rulerUnit; //! number of blocks that makes up one element of the ruler
     int m_channelsPerPage;
     int m_programmesPerPage;
@@ -242,6 +249,9 @@ namespace PVR
 
     std::shared_ptr<CFileItem> m_lastItem;
     std::shared_ptr<CFileItem> m_lastChannel;
+
+    bool m_bEnableProgrammeScrolling = true;
+    bool m_bEnableChannelScrolling = true;
 
     int m_scrollTime;
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -75,7 +75,7 @@ void CGUIWindowPVRGuideBase::InitEpgGridControl()
   if (epgGridContainer)
   {
     m_bChannelSelectionRestored = epgGridContainer->SetChannel(CServiceBroker::GetPVRManager().GUIActions()->GetSelectedItemPath(m_bRadio));
-    epgGridContainer->GoToNow();
+    epgGridContainer->JumpToNow();
   }
 
   if (epgGridContainer && !epgGridContainer->HasData())


### PR DESCRIPTION
EPG grid data should scroll for example when traveling through the data using the cursor keys, but not when just (re-)opening the Guide window or on automatic grid data update that leads to a view port /selection change.. 

Currently, when opening the Guide window, you see the grid view port scrolling to "now". Especially on Estuary with slide animations on window open enabled (which is the default) the two concurrent scrolling effects look somehow odd (at least to me) and they can easily lead to stuttering of the GUI while opening the window. This actually happens on my Android Shield TV box and looks ugly. 

 This PR changes EPG grid control behavior like described above.

 Runtime tested on macOS and Android, latest Kodi master.

 @phunkyfish might want to take a look at the code changes.