### PR TITLE
[macos] change Toggle Fullscreen shortcut to system default Cmd+Ctrl+F

### DIFF
--- a/xbmc/platform/darwin/osx/SDLMain.mm
+++ b/xbmc/platform/darwin/osx/SDLMain.mm
@@ -115,6 +115,8 @@ static void setupWindowMenu(void)
 
   // "Full/Windowed Toggle" item
   menuItem = [[NSMenuItem alloc] initWithTitle:@"Full/Windowed Toggle" action:@selector(fullScreenToggle:) keyEquivalent:@"f"];
+  // this is just for display purposes, key handling is in CWinEventsSDL::ProcessOSXShortcuts()
+  menuItem.keyEquivalentModifierMask = NSCommandKeyMask | NSControlKeyMask;
   [windowMenu addItem:menuItem];
 
   // "Full/Windowed Toggle" item

--- a/xbmc/windowing/osx/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/WinEventsSDL.cpp
@@ -206,7 +206,8 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
     // use this instead for getting the real
     // character based on the used keyboard layout
     // see http://lists.libsdl.org/pipermail/sdl-libsdl.org/2004-May/043716.html
-    if (!(event.key.keysym.unicode & 0xff80))
+    bool isControl = (event.key.keysym.mod & KMOD_CTRL) != 0;
+    if (!isControl && !(event.key.keysym.unicode & 0xff80))
       keysymbol = event.key.keysym.unicode;
 
     switch(keysymbol)
@@ -216,7 +217,9 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
         CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
       return true;
 
-    case SDLK_f: // CMD-f to toggle fullscreen
+    case SDLK_f: // CMD-Ctrl-f to toggle fullscreen
+      if (!isControl)
+        return false;
       g_application.OnAction(CAction(ACTION_TOGGLE_FULLSCREEN));
       return true;
 


### PR DESCRIPTION
## Description
Changes Toggle Fullscreen shortcut to system default Cmd+Ctrl+F.

## Motivation and Context
Common macOS shortcut to enter fullscreen mode is Cmd+Ctrl+F, but Kodi uses Cmd+F. Also requested in https://forum.kodi.tv/showthread.php?tid=349123.

## How Has This Been Tested?
Tested new shortcut by pressing respective keys.

## Screenshots (if appropriate):
![Screenshot 2020-01-09 at 18 43 00](https://user-images.githubusercontent.com/1557784/72081689-f9ff3700-330f-11ea-866f-aaae164644b0.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
