### PR TITLE
[addons][inputstream] add RDS stream support

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -138,6 +138,7 @@ extern "C"
       TYPE_AUDIO,
       TYPE_SUBTITLE,
       TYPE_TELETEXT,
+      TYPE_RDS,
     } m_streamType;
 
     enum Codec_FEATURES : uint32_t

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -86,7 +86,7 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.10"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.11"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.7"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -335,7 +335,8 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   std::string codecName(stream.m_codecName);
   AVCodec* codec = nullptr;
 
-  if (stream.m_streamType != INPUTSTREAM_INFO::TYPE_TELETEXT)
+  if (stream.m_streamType != INPUTSTREAM_INFO::TYPE_TELETEXT &&
+      stream.m_streamType != INPUTSTREAM_INFO::TYPE_RDS)
   {
     StringUtils::ToLower(codecName);
     codec = avcodec_find_decoder_by_name(codecName.c_str());
@@ -412,6 +413,11 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   {
     CDemuxStreamTeletext* teletextStream = new CDemuxStreamTeletext();
     demuxStream = teletextStream;
+  }
+  else if (stream.m_streamType == INPUTSTREAM_INFO::TYPE_RDS)
+  {
+    CDemuxStreamRadioRDS* rdsStream = new CDemuxStreamRadioRDS();
+    demuxStream = rdsStream;
   }
   else
     return nullptr;


### PR DESCRIPTION
## Description
Seen by test of PVR addon together with inputstream (related to https://github.com/xbmc/xbmc/pull/16485) that RDS was not possible to give to kodi.

This change add the RDS support.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context

To C++ changed PVR system.

The addon.xml looks like this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<addon
  id="pvr.demo"
  version="4.1.1"
  name="PVR Demo Client"
  provider-name="Pulse-Eight Ltd., Team Kodi">
  <requires>@ADDON_DEPENDS@</requires>
  <extension
    point="xbmc.pvrclient"
    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
  <extension
    point="kodi.inputstream"
    name="pvrdemo"
    protocols="pvrdemo" />
  <extension point="xbmc.addon.metadata">
...
```

Then it bring e.g. this `pvrdemo://test-stream_radio_swr3.ts/` where then becomes processed via inputstream inside pvr.demo.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?

On reworked pvr.demo on https://github.com/kodi-pvr/pvr.demo/pull/65 **+** a hacky C&P way about fast add of inputstream support (thats why not uploaded and only present here for older version https://github.com/AlwinEsch/pvr.demo/tree/add-test-stream, where was over PVR stream itself).
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

![Screenshot_20200110_145917](https://user-images.githubusercontent.com/6879739/72158529-bdd4e080-33ba-11ea-92b7-637a0da4e57c.png)
![Screenshot_20200110_150005](https://user-images.githubusercontent.com/6879739/72158541-c3cac180-33ba-11ea-9c13-4b7aeae7d6da.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
