### PR TITLE
skip comments in .edl files

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -134,6 +134,12 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       strFields[1] = strFields[0];
     }
 
+    if (StringUtils::StartsWith(strFields[0], "##"))
+    {
+      CLog::Log(LOGDEBUG, "Skipping comment line %i in EDL file: %s", iLine,
+                CURL::GetRedacted(edlFilename).c_str());
+      continue;
+    }
     /*
      * For each of the first two fields read, parse based on whether it is a time string
      * (HH:MM:SS.sss), frame marker (#12345), or normal seconds string (123.45).


### PR DESCRIPTION
## Description
As per the title, skip comments in .edl files.
Currently, if there is a comment in an .edl file, it is flagged as an error and the .edl file doesn't correctly skip or mute.  Instead it is ignored and no edit decisions are made.

## Motivation and Context
This issue was reported in a forum thread https://forum.kodi.tv/showthread.php?tid=349685
It appears that the OP is using an addon to create the .edl files and that this addon inserts comments of the form `###### This section is automatically maintained by the Mute Profanity plugin ######`.  These comments stop Kodi from properly interpreting the edl file and instead cause it to create an error `ERROR: Edl::ReadEdl - Frame number not supported in EDL files when frame rate is unavailable (ts) - supplied frame number: #####`

Although this could be fixed in the addon itself, Kodi should be able to differentiate between comments and actual EDL decisions in an EDL file.  Other addons could also write comments into the edl file so core should be able to handle that.

This PR fixes this issue by skipping over lines that start with `##`

## How Has This Been Tested?
Runtime tested with the same .edl file against this PR and the current Matrix master on Linux x86_64
Current Matrix master logs an error (see above).  With this PR, the comment lines are skipped and the debug log shows this. `DEBUG: Skipping comment line in EDL file`
This doesn't affect any other code.

Example .edl file
`###### This section is automatically maintained by the Mute Profanity plugin ######`
`5.00	238.16	1`
`1101.16	1238.40	3`
`1789.84	1927.40	3`
`3302.12	3399.28	3`
 `##### END Mute Profanity plugin section ######`
`4067.96	4165.28	3`
`4827.24	4866.04	3`

## Screenshots (if appropriate):

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
