### PR TITLE
Update DVDInputStreamBluray for UHD BD

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -549,6 +549,8 @@ void CDVDInputStreamBluray::ProcessEvent() {
   case BD_EVENT_SECONDARY_VIDEO_SIZE:
   case BD_EVENT_SECONDARY_VIDEO_STREAM:
   case BD_EVENT_PLAYMARK:
+  case BD_EVENT_KEY_INTEREST_TABLE:
+  case BD_EVENT_UO_MASK_CHANGED:
     break;
 
   case BD_EVENT_PLAYLIST_STOP:
@@ -1133,8 +1135,15 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
   }
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_REGION_CODE, static_cast<uint32_t>(region));
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_PARENTAL, 99);
-  bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_PLAYER_PROFILE, BLURAY_PLAYER_PROFILE_5_v2_4);
   bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_3D_CAP, 0xffffffff);
+#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(1, 0, 2))  
+  bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_PLAYER_PROFILE, BLURAY_PLAYER_PROFILE_6_v3_1);
+  bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_UHD_CAP, 0xffffffff);
+  bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_UHD_DISPLAY_CAP, 0xffffffff);
+  bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_HDR_PREFERENCE, 0xffffffff);
+#else
+  bd_set_player_setting(m_bd, BLURAY_PLAYER_SETTING_PLAYER_PROFILE, BLURAY_PLAYER_PROFILE_5_v2_4);
+#endif
 
   std::string langCode;
   g_LangCodeExpander.ConvertToISO6392T(g_langInfo.GetDVDAudioLanguage(), langCode);


### PR DESCRIPTION
## Description
Fix: WARNING: CDVDInputStreamBluray - unhandled libbluray event 32
Fix: WARNING: CDVDInputStreamBluray - unhandled libbluray event 33

Set Bluray Player profile to accomodate UHD BDs.
Set Bluray Player UHD capabilities
Set HDR Preference. If HDR metadata is present it should be used and if the display doesn't support it, it will tonemap to SDR.

## Motivation and Context
Now that libbluray was updated to 1.1.2 two new events are added
BD_EVENT_KEY_INTEREST_TABLE and BD_EVENT_UO_MASK_CHANGED, those would appear as unhandled in Kodi's logs.

Updated the player profile that is requested when playing a disc to the newest one: profile 6v3.1.
If disc requests if the player supports 4K, libbluray will report as yes, even if the screen is 1080p Kodi will downscale normaly.
If disc requests if the player support HDR, libbluray will report as yes and even if the screen does not, Kodi will tonemap normaly. 

## How Has This Been Tested?
This has been tested on a Windows x64 build.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
