### PR TITLE
[macos] implement code signining

### DIFF
--- a/cmake/scripts/osx/Install.cmake
+++ b/cmake/scripts/osx/Install.cmake
@@ -30,12 +30,26 @@ add_dependencies(bundle ${APP_NAME_LC})
 configure_file(${CMAKE_SOURCE_DIR}/tools/darwin/packaging/osx/mkdmg-osx.sh.in
                ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx/mkdmg-osx.sh @ONLY)
 
+string(TOLOWER ${CORE_BUILD_CONFIG} CORE_BUILD_CONFIG_LOWERCASED)
+if(${CORE_BUILD_CONFIG_LOWERCASED} STREQUAL "release")
+  set(ALLOW_DEBUGGER "false")
+else()
+  set(ALLOW_DEBUGGER "true")
+endif()
+configure_file(${CMAKE_SOURCE_DIR}/tools/darwin/packaging/osx/Kodi.entitlements.in
+               ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx/Kodi.entitlements @ONLY)
+
 add_custom_target(dmg
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tools/darwin/packaging/osx/
                                                ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx/
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tools/darwin/packaging/media/osx/
                                                ${CMAKE_BINARY_DIR}/tools/darwin/packaging/media/osx/
-    COMMAND ./mkdmg-osx.sh ${CORE_BUILD_CONFIG}
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tools/darwin/Support/Codesign.command
+                                     ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx/Codesign.command
+    COMMAND "CODESIGNING_FOLDER_PATH=${PACKAGE_OUTPUT_DIR}/${APP_NAME}.app"
+            "EXPANDED_CODE_SIGN_IDENTITY_NAME=${CODE_SIGN_IDENTITY}"
+            "PLATFORM_NAME=${PLATFORM}"
+            ./mkdmg-osx.sh ${CORE_BUILD_CONFIG_LOWERCASED}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx)
 set_target_properties(dmg PROPERTIES FOLDER "Build Utilities")
 add_dependencies(dmg bundle)

--- a/cmake/scripts/osx/Install.cmake
+++ b/cmake/scripts/osx/Install.cmake
@@ -47,6 +47,9 @@ add_custom_target(dmg
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tools/darwin/Support/Codesign.command
                                      ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx/Codesign.command
     COMMAND "CODESIGNING_FOLDER_PATH=${PACKAGE_OUTPUT_DIR}/${APP_NAME}.app"
+            "DEV_ACCOUNT=${DEV_ACCOUNT}"
+            "DEV_ACCOUNT_PASSWORD=${DEV_ACCOUNT_PASSWORD}"
+            "DEV_TEAM=${DEV_TEAM}"
             "EXPANDED_CODE_SIGN_IDENTITY_NAME=${CODE_SIGN_IDENTITY}"
             "PLATFORM_NAME=${PLATFORM}"
             ./mkdmg-osx.sh ${CORE_BUILD_CONFIG_LOWERCASED}

--- a/tools/buildsteps/jenkins_docs/README.mac
+++ b/tools/buildsteps/jenkins_docs/README.mac
@@ -86,7 +86,7 @@ java -Djava.awt.headless=true -jar slave.jar -jar-cache /Users/Shared/jenkins/ca
 
 16. install java JDK
 
-17. Install xcode 6.1.1 to /Applications/Xcode6.1.1.app (get it from developer.apple.com -> Downloads) and start it once (accept license)
+17. Install xcode 10.2 to /Applications/Xcode10.2.app (get it from developer.apple.com -> Downloads) and start it once (accept license)
 
 18. Install xcode 9.0 to /Applications/Xcode9.0.app (get it from developer.apple.com -> Downloads) and start it once (accept license)
 

--- a/tools/buildsteps/jenkins_docs/README.mac
+++ b/tools/buildsteps/jenkins_docs/README.mac
@@ -65,6 +65,8 @@ java -Djava.awt.headless=true -jar slave.jar -jar-cache /Users/Shared/jenkins/ca
     <true/>
     <key>RunAtLoad</key>
     <true/>
+    <key>SessionCreate</key>
+    <true/>
     <key>UserName</key>
     <string>jenkins</string>
     <key>WorkingDirectory</key>

--- a/tools/buildsteps/osx64/configure-xbmc
+++ b/tools/buildsteps/osx64/configure-xbmc
@@ -2,4 +2,4 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=osx64
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-make -C $WORKSPACE/tools/depends/target/cmakebuildsys
+make -C $WORKSPACE/tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-D CODE_SIGN_IDENTITY='$CODE_SIGN_IDENTITY' -D DEV_ACCOUNT='$DEV_ACCOUNT' -D DEV_ACCOUNT_PASSWORD='$DEV_ACCOUNT_PASSWORD' -D DEV_TEAM='$DEV_TEAM'"

--- a/tools/buildsteps/osx64/load-env
+++ b/tools/buildsteps/osx64/load-env
@@ -1,0 +1,3 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=osx64
+. $WORKSPACE/tools/buildsteps/defaultenv

--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -69,7 +69,7 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
 
   #if user has set a code_sign_identity different from iPhone Developer we do a real codesign (for deployment on non-jailbroken devices)
   if ! [ -z "${CODE_SIGN_IDENTITY}" ]; then
-    if egrep -q --max-count=1 -e '^iPhone (Developer|Distribution): ' -e '^Apple (Development|Distribution): ' <<<"${CODE_SIGN_IDENTITY}"; then
+    if egrep -q --max-count=1 -e '^iPhone (Developer|Distribution): ' -e '^Apple (Development|Distribution): ' -e '^[[:xdigit:]]+$' <<<"${CODE_SIGN_IDENTITY}"; then
       echo "Doing a full bundle sign using genuine identity ${CODE_SIGN_IDENTITY}"
       for binext in $LIST_BINARY_EXTENSIONS
       do

--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -69,7 +69,7 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
 
   #if user has set a code_sign_identity different from iPhone Developer we do a real codesign (for deployment on non-jailbroken devices)
   if ! [ -z "${CODE_SIGN_IDENTITY}" ]; then
-    if echo ${CODE_SIGN_IDENTITY} | grep -cim1 "iPhone Developer" &>/dev/null || echo ${CODE_SIGN_IDENTITY} | grep -cim1 "Apple Development" &>/dev/null; then
+    if egrep -q --max-count=1 -e '^iPhone (Developer|Distribution): ' -e '^Apple (Development|Distribution): ' <<<"${CODE_SIGN_IDENTITY}"; then
       echo "Doing a full bundle sign using genuine identity ${CODE_SIGN_IDENTITY}"
       for binext in $LIST_BINARY_EXTENSIONS
       do

--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -9,14 +9,20 @@ GEN_ENTITLEMENTS="$NATIVEPREFIX/bin/gen_entitlements.py"
 IOS11_ENTITLEMENTS="$XBMC_DEPENDS/share/ios11_entitlements.xml"
 LDID="$NATIVEPREFIX/bin/ldid"
 
-if [ ! -f ${GEN_ENTITLEMENTS} ]; then
+if [ "${PLATFORM_NAME}" == "macosx" ]; then
+  MACOS=1
+fi
+
+if [[ ! "$MACOS" && ! -f ${GEN_ENTITLEMENTS} ]]; then
   echo "error: $GEN_ENTITLEMENTS not found. Codesign won't work."
   exit -1
 fi
 
-if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]; then
-  if [ -f "/Users/Shared/buildslave/keychain_unlock.sh" ]; then
-    /Users/Shared/buildslave/keychain_unlock.sh
+if [[ "$MACOS" || "${PLATFORM_NAME}" == "iphoneos" || "${PLATFORM_NAME}" == "appletvos" ]]; then
+  if [ "$MACOS" ]; then
+    CONTENTS_PATH="${CODESIGNING_FOLDER_PATH}/Contents"
+  else
+    CONTENTS_PATH="${CODESIGNING_FOLDER_PATH}"
   fi
 
   # todo: is this required anymore?
@@ -28,7 +34,7 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
       ${LDID} -S${IOS11_ENTITLEMENTS} ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/${EXECUTABLE_NAME}
     
       #repackage python eggs
-      EGGS=`find ${CODESIGNING_FOLDER_PATH} -name "*.egg" -type f`
+      EGGS=$(find "${CONTENTS_PATH}" -name "*.egg" -type f)
         for i in $EGGS; do
           echo $i
           mkdir del
@@ -42,11 +48,7 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
   fi
 
   # pull the CFBundleIdentifier out of the built xxx.app
-  BUNDLEID=`mdls -raw -name kMDItemCFBundleIdentifier ${CODESIGNING_FOLDER_PATH}`
-  if [ "${BUNDLEID}" == "(null)" ] ; then
-    BUNDLEID=`/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' ${CODESIGNING_FOLDER_PATH}/Info.plist`
-  fi
-
+  BUNDLEID=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${CONTENTS_PATH}/Info.plist")
   echo "CFBundleIdentifier is ${BUNDLEID}"
 
   # Prefer the expanded name, if available.
@@ -57,25 +59,27 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
   fi
   echo "${CODE_SIGN_IDENTITY_FOR_ITEMS}"
 
-  ${GEN_ENTITLEMENTS} "${BUNDLEID}" "${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/${EXECUTABLE_NAME}.xcent";
+  if [ ! "$MACOS" ]; then
+    ${GEN_ENTITLEMENTS} "${BUNDLEID}" "${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/${EXECUTABLE_NAME}.xcent"
+  fi
 
   # delete existing codesigning
-  if [ -d "${CODESIGNING_FOLDER_PATH}/_CodeSignature" ]; then
-    rm -r ${CODESIGNING_FOLDER_PATH}/_CodeSignature
+  if [ -d "${CONTENTS_PATH}/_CodeSignature" ]; then
+    rm -r "${CONTENTS_PATH}/_CodeSignature"
   fi
-  if [ -f "${CODESIGNING_FOLDER_PATH}/embedded.mobileprovision" ]; then
-    rm -f ${CODESIGNING_FOLDER_PATH}/embedded.mobileprovision
+  if [[ ! "$MACOS" && -f "${CONTENTS_PATH}/embedded.mobileprovision" ]]; then
+    rm -f "${CONTENTS_PATH}/embedded.mobileprovision"
   fi
 
   #if user has set a code_sign_identity different from iPhone Developer we do a real codesign (for deployment on non-jailbroken devices)
-  if ! [ -z "${CODE_SIGN_IDENTITY}" ]; then
-    if egrep -q --max-count=1 -e '^iPhone (Developer|Distribution): ' -e '^Apple (Development|Distribution): ' -e '^[[:xdigit:]]+$' <<<"${CODE_SIGN_IDENTITY}"; then
-      echo "Doing a full bundle sign using genuine identity ${CODE_SIGN_IDENTITY}"
+  if ! [ -z "${CODE_SIGN_IDENTITY_FOR_ITEMS}" ]; then
+    if egrep -q --max-count=1 -e '^iPhone (Developer|Distribution): ' -e '^Apple (Development|Distribution): ' -e '^[[:xdigit:]]+$' -e '^Developer ID Application: ' <<<"${CODE_SIGN_IDENTITY_FOR_ITEMS}"; then
+      echo "Doing a full bundle sign using genuine identity ${CODE_SIGN_IDENTITY_FOR_ITEMS}"
       for binext in $LIST_BINARY_EXTENSIONS
       do
         echo "Signing binary: $binext"
         # check if at least 1 file with the extension exists to sign, otherwise do nothing
-        FINDOUTPUT=`find ${CODESIGNING_FOLDER_PATH} -name "*.$binext" -type f`
+        FINDOUTPUT=$(find "${CONTENTS_PATH}" -name "*.$binext" -type f)
         if [ `echo $FINDOUTPUT | wc -l` != 0 ]; then
           for singlefile in $FINDOUTPUT; do
             codesign -s "${CODE_SIGN_IDENTITY_FOR_ITEMS}" -fvvv -i "${BUNDLEID}" "${singlefile}"
@@ -84,17 +88,17 @@ if [ "${PLATFORM_NAME}" == "iphoneos" ] || [ "${PLATFORM_NAME}" == "appletvos" ]
       done
       echo "In case your app crashes with SIG_SIGN check the variable LIST_BINARY_EXTENSIONS in tools/darwin/Support/Codesign.command"
 
-      for FRAMEWORK_PATH in `find ${CODESIGNING_FOLDER_PATH} -name "*.framework" -type d`
+      for FRAMEWORK_PATH in $(find "${CONTENTS_PATH}" -name "*.framework" -type d)
       do
         DYLIB_BASENAME=$(basename "${FRAMEWORK_PATH%.framework}")
         echo "Signing Framework: ${DYLIB_BASENAME}.framework"
         FRAMEWORKBUNDLEID="${BUNDLEID}.framework.${DYLIB_BASENAME}"
-        codesign -s "${CODE_SIGN_IDENTITY_FOR_ITEMS}" -fvvv -i "${FRAMEWORKBUNDLEID}" ${FRAMEWORK_PATH}/${DYLIB_BASENAME}
-        codesign -s "${CODE_SIGN_IDENTITY_FOR_ITEMS}" -fvvv -i "${FRAMEWORKBUNDLEID}" ${FRAMEWORK_PATH}
+        codesign -s "${CODE_SIGN_IDENTITY_FOR_ITEMS}" -fvvv -i "${FRAMEWORKBUNDLEID}" "${FRAMEWORK_PATH}/${DYLIB_BASENAME}"
+        codesign -s "${CODE_SIGN_IDENTITY_FOR_ITEMS}" -fvvv -i "${FRAMEWORKBUNDLEID}" "${FRAMEWORK_PATH}"
       done
 
       #repackage python eggs
-      EGGS=`find ${CODESIGNING_FOLDER_PATH} -name "*.egg" -type f`
+      EGGS=$(find "${CONTENTS_PATH}" -name "*.egg" -type f)
       echo "Signing Eggs"
       for i in $EGGS; do
         echo $i

--- a/tools/darwin/packaging/osx/Kodi.entitlements.in
+++ b/tools/darwin/packaging/osx/Kodi.entitlements.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<@ALLOW_DEBUGGER@/>
+</dict>
+</plist>

--- a/tools/darwin/packaging/osx/mkdmg-osx.sh.in
+++ b/tools/darwin/packaging/osx/mkdmg-osx.sh.in
@@ -2,7 +2,7 @@
 
 # usage: ./mkdmg-osx.sh release/debug (case insensitive)
 # Allows us to run mkdmg-osx.sh from anywhere in the three, rather than the tools/darwin/packaging/osx folder only
-SWITCH=`echo $1 | tr [A-Z] [a-z]`
+SWITCH="$1"
 DIRNAME=`dirname $0`
 
 if [ ${SWITCH:-""} = "debug" ]; then
@@ -22,6 +22,16 @@ if [ ! -d $APP ]; then
 fi
 ARCHITECTURE=`file $APP/Contents/MacOS/@APP_NAME@ | awk '{print $NF}'`
 
+# codesign .app
+if [ "$EXPANDED_CODE_SIGN_IDENTITY_NAME" ]; then
+  # execute codesign script
+  "$DIRNAME/Codesign.command"
+  # sign helper tool
+  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --options runtime --timestamp --entitlements Kodi.entitlements "$APP/Contents/Resources/Kodi/tools/darwin/runtime/XBMCHelper"
+  # perform top-level signing (Xcode does it automatically when signing settings are configured)
+  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --options runtime --timestamp --entitlements Kodi.entitlements "$APP"
+fi
+
 PACKAGE=org.xbmc.@APP_NAME_LC@-osx
 
 VERSION=@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@
@@ -34,7 +44,8 @@ fi
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_macosx-intel-${ARCHITECTURE}
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION
-rm -rf $DIRNAME/$ARCHIVE.dmg
+dmgPath="$DIRNAME/$ARCHIVE.dmg"
+rm -rf "$dmgPath"
 
 if [ -e "/Volumes/@APP_NAME_LC@" ]; then
   umount /Volumes/@APP_NAME_LC@
@@ -50,3 +61,8 @@ fi
 $DIRNAME/dmgmaker.pl $APP $ARCHIVE
 
 echo "done"
+
+# codesign dmg
+if [ "$EXPANDED_CODE_SIGN_IDENTITY_NAME" ]; then
+  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$dmgPath"
+fi

--- a/tools/darwin/packaging/osx/mkdmg-osx.sh.in
+++ b/tools/darwin/packaging/osx/mkdmg-osx.sh.in
@@ -62,7 +62,8 @@ $DIRNAME/dmgmaker.pl $APP $ARCHIVE
 
 echo "done"
 
-# codesign dmg
+# codesign and notarize dmg
 if [ "$EXPANDED_CODE_SIGN_IDENTITY_NAME" ]; then
   codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$dmgPath"
+  ./notarize.sh "$dmgPath" "$APP/Contents/Info.plist"
 fi

--- a/tools/darwin/packaging/osx/notarize.sh
+++ b/tools/darwin/packaging/osx/notarize.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# credits: https://scriptingosx.com/2019/09/notarize-a-command-line-tool/
+
+if [[ -z "$DEV_ACCOUNT" || -z "$DEV_ACCOUNT_PASSWORD" ]]; then
+  echo "skipping notarization"
+  exit 0
+fi
+
+notarizefile() { # $1: path to file to notarize, $2: identifier
+  filepath=${1:?"need a filepath"}
+  identifier=${2:?"need an identifier"}
+
+  # upload file
+  echo "uploading $filepath for notarization"
+  altoolOutput=$(xcrun altool \
+    --notarize-app \
+    --type osx \
+    --file "$filepath" \
+    --primary-bundle-id "$identifier" \
+    --username "$DEV_ACCOUNT" \
+    --password "$DEV_ACCOUNT_PASSWORD" \
+    ${DEV_TEAM:+--asc-provider "$DEV_TEAM"} 2>&1)
+
+  requestUUID=$(echo "$altoolOutput" | awk '/RequestUUID/ { print $NF; }')
+
+  if [[ $requestUUID == "" ]]; then
+    echo "Failed to upload:"
+    echo "$altoolOutput"
+    return 1
+  fi
+  echo "requestUUID: $requestUUID, waiting..."
+
+  # wait for status to be not "in progress" any more
+  request_status="in progress"
+  while [[ "$request_status" == "in progress" ]]; do
+    sleep 60
+    altoolOutput=$(xcrun altool \
+      --notarization-info "$requestUUID" \
+      --username "$DEV_ACCOUNT" \
+      --password "$DEV_ACCOUNT_PASSWORD" 2>&1)
+    request_status=$(echo "$altoolOutput" | awk -F ': ' '/Status:/ { print $2; }' )
+  done
+
+  # print status information
+  echo "$altoolOutput"
+
+  if [[ $request_status != "success" ]]; then
+    echo "warning: could not notarize $filepath"
+    notarizationFailed=1
+  fi
+
+  LogFileURL=$(echo "$altoolOutput" | awk -F ': ' '/LogFileURL:/ { print $2; }')
+  if [[ "$LogFileURL" ]]; then
+    echo -e "\nnotarization details:"
+    curl "$LogFileURL"
+    echo
+  fi
+  if [[ $notarizationFailed == 1 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+dmg="$1"
+notarizefile "$dmg" $(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$2") \
+  && xcrun stapler staple "$dmg"


### PR DESCRIPTION
## Description
Adds ability to sign the built .app/.dmg and notarize the .dmg. New cmake variables:

- CODE_SIGN_IDENTITY
- DEV_ACCOUNT
- DEV_ACCOUNT_PASSWORD
- DEV_TEAM (optional)

`CODE_SIGN_IDENTITY` is used to sign binaries and .dmg (passed to `codesign` in `--sign` parameter), others are used to perform notarization (passed to `altool` in `--username`, `--password` and `--asc-provider` parameters respectively).

Example: `make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS='-D CODE_SIGN_IDENTITY="Developer ID Application: Kodi Foundation" -D DEV_ACCOUNT=appleid@kodi.tv -D DEV_ACCOUNT_PASSWORD=mypassword'`

## Motivation and Context
Starting with macOS 10.15 Catalina (even with 10.14.5 for new developer certificates, which applies to Kodi) all software distributed not through Mac App Store must (should?) be notarized by Apple. Otherwise it would be impossible to use such software without workarounds/hacks because of Gatekeeper. And notarization implies code signing. Further reading: https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution?language=objc

## How Has This Been Tested?
Built `dmg` target on local machine and on jenkins and checked that the resulting .app/.dmg are code signed properly and notarization process finishes successfully.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
