### PR TITLE
[Estuary] Rating position fix + position adjustments for ListThumbInfoPanel & RightListPanel

### DIFF
--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -50,12 +50,12 @@
 						<height>850</height>
 						<bottom>124</bottom>
 						<fadetime>200</fadetime>
-						<aspectratio align="center" aligny="center">keep</aspectratio>
+						<aspectratio aligny="bottom">keep</aspectratio>
 						<texture fallback="DefaultVideo.png" background="true">$VAR[InfoWallThumbVar]</texture>
 					</control>
 					<control type="group">
-						<left>318</left>
-						<top>936</top>
+						<left>291</left>
+						<top>950</top>
 						<include content="RatingCircle">
 							<param name="animation" value="True" />
 						</include>
@@ -65,18 +65,32 @@
 					<visible>Control.IsVisible(503) + Window.IsActive(musicplaylist)</visible>
 					<control type="image">
 						<left>58</left>
-						<top>120</top>
+						<top>110</top>
 						<width>540</width>
 						<height>470</height>
 						<aspectratio aligny="bottom">keep</aspectratio>
 						<fadetime>300</fadetime>
 						<texture fallback="DefaultAudio.png" background="true">$INFO[Player.Icon]</texture>
 					</control>
+					<control type="group">
+						<left>301</left>
+						<top>560</top>
+						<control type="group">
+							<animation effect="fade" time="0" condition="$PARAM[animation]">VisibleChange</animation>
+							<include content="UserRatingContent" condition="Skin.HasSetting(circle_userrating)">
+								<param name="infolabel" value="MusicPlayer.UserRating" />
+							</include>
+							<include content="UserRatingContent" condition="Skin.HasSetting(circle_rating)">
+								<param name="infolabel" value="MusicPlayer.Rating" />
+							</include>
+						</control>
+					</control>
 					<control type="textbox" id="15599">
 						<visible>Player.HasAudio + Window.IsActive(musicplaylist)</visible>
 						<left>58</left>
 						<top>600</top>
 						<width>540</width>
+						<bottom>70</bottom>
 						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>[COLOR button_focus][B]$LOCALIZE[31000]: [/COLOR]$INFO[musicplayer.Playlistposition,]$INFO[musicplayer.Playlistlength,/][/B][CR]$VAR[NowPlayingInfoVar]</label>
 					</control>
@@ -85,6 +99,7 @@
 						<left>58</left>
 						<top>640</top>
 						<width>540</width>
+						<bottom>70</bottom>
 						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>[COLOR button_focus][B]$LOCALIZE[31000]: [/COLOR]$LOCALIZE[36623][/B]</label>
 					</control>
@@ -219,7 +234,7 @@
 				</include>
 				<control type="image">
 					<left>30</left>
-					<top>140</top>
+					<top>110</top>
 					<width>540</width>
 					<height>470</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -229,7 +244,7 @@
 				</control>
 				<control type="image">
 					<left>30</left>
-					<top>140</top>
+					<top>110</top>
 					<width>540</width>
 					<height>330</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -239,7 +254,7 @@
 				</control>
 				<control type="image">
 					<left>30</left>
-					<top>120</top>
+					<top>110</top>
 					<width>540</width>
 					<height>470</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -249,7 +264,7 @@
 				</control>
 				<control type="group">
 					<left>273</left>
-					<top>590</top>
+					<top>560</top>
 					<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
 					<animation effect="slide" end="0,-140" time="0" condition="String.IsEqual(ListItem.DbType,episode)">conditional</animation>
 				</control>
@@ -257,17 +272,17 @@
 					<visible>!Container.Content() | !String.isempty(ListItem.Plot)</visible>
 					<left>30</left>
 					<control type="textbox" id="15500">
-						<top>640</top>
+						<top>600</top>
 						<width>540</width>
-						<bottom>117</bottom>
+						<bottom>70</bottom>
 						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>$VAR[ListBoxInfoVar]</label>
 						<visible>!String.IsEqual(ListItem.DbType,episode) + !String.IsEqual(ListItem.DBType,song)</visible>
 					</control>
 					<control type="textbox" id="15501">
-						<top>485</top>
+						<top>465</top>
 						<width>540</width>
-						<bottom>96</bottom>
+						<bottom>70</bottom>
 						<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>$INFO[ListItem.Plot]</label>
 						<visible>String.IsEqual(ListItem.DbType,episode)</visible>
@@ -275,7 +290,7 @@
 					<control type="textbox" id="15502">
 						<top>600</top>
 						<width>540</width>
-						<height>410</height>
+						<bottom>70</bottom>
 						<autoscroll time="3000" delay="3000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
 						<label>[COLOR button_focus][B]$LOCALIZE[31037]: [/COLOR]$INFO[Container.CurrentItem,,/]$INFO[Container.NumItems][/B][CR]$VAR[ListBoxInfoVar]</label>
 						<visible>String.IsEqual(ListItem.DBType,song)</visible>


### PR DESCRIPTION
## Description

Merged code in https://github.com/xbmc/xbmc/pull/17010 had wrong position for rating circle (star) for Music List and Now Playing views. This has been adjusted and took the opportunity to revisit rating star and plot positioning for TV Shows, again minor adjustments.

Additionally added rating circle for the current playing song in Now Playing.

**Before**
![image](https://user-images.githubusercontent.com/5781142/72219714-e25ac500-3540-11ea-97de-7551a17a0bd3.png)

**After**
![image](https://user-images.githubusercontent.com/5781142/72219720-ec7cc380-3540-11ea-8df4-58ef2ac815e2.png)

**Before**
https://i.imgur.com/JSpdtqQ.png
![image](https://user-images.githubusercontent.com/5781142/72219884-da9c2000-3542-11ea-9791-38496840fde4.png)

**After**
![image](https://user-images.githubusercontent.com/5781142/72219728-00c0c080-3541-11ea-8198-5bc0c67ee310.png)

## Motivation and Context
Bug fix and some minor adjust to improve layout.

## How Has This Been Tested?
Tested on Windows x64 with variety of Music and TV Shows with and without User Ratings.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
