### PR TITLE
PeripheralBusUSBLibUdev: Filter on USB only

### DIFF
--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
@@ -81,6 +81,13 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
 
   /* set up a devices monitor that listen for any device change */
   m_udevMon = udev_monitor_new_from_netlink(m_udev, "udev");
+
+  /* filter to only receive usb events */
+  if (udev_monitor_filter_add_match_subsystem_devtype(m_udevMon, "usb", NULL) < 0)
+  {
+    CLog::Log(LOGERROR, "Could not limit filter on USB only");
+  }
+
   udev_monitor_enable_receiving(m_udevMon);
 
   CLog::Log(LOGDEBUG, "%s - initialised udev monitor", __FUNCTION__);

--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
@@ -72,36 +72,18 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
 
   m_udev          = NULL;
   m_udevMon       = NULL;
-
-  if (!(m_udev = udev_new()))
-  {
-    CLog::Log(LOGERROR, "%s - failed to allocate udev context", __FUNCTION__);
-    return;
-  }
-
-  /* set up a devices monitor that listen for any device change */
-  m_udevMon = udev_monitor_new_from_netlink(m_udev, "udev");
-
-  /* filter to only receive usb events */
-  if (udev_monitor_filter_add_match_subsystem_devtype(m_udevMon, "usb", NULL) < 0)
-  {
-    CLog::Log(LOGERROR, "Could not limit filter on USB only");
-  }
-
-  udev_monitor_enable_receiving(m_udevMon);
-
-  CLog::Log(LOGDEBUG, "%s - initialised udev monitor", __FUNCTION__);
 }
 
 CPeripheralBusUSB::~CPeripheralBusUSB(void)
 {
   StopThread(true);
-  udev_monitor_unref(m_udevMon);
-  udev_unref(m_udev);
 }
 
 bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)
 {
+  // We don't want this one to be called from outside world
+  assert(IsCurrentThread());
+
   struct udev_enumerate *enumerate;
   struct udev_list_entry *devices, *dev_list_entry;
   struct udev_device *dev(NULL), *parent(NULL);
@@ -195,6 +177,24 @@ PeripheralType CPeripheralBusUSB::GetType(int iDeviceClass)
 
 void CPeripheralBusUSB::Process(void)
 {
+  if (!(m_udev = udev_new()))
+  {
+    CLog::Log(LOGERROR, "%s - failed to allocate udev context", __FUNCTION__);
+    return;
+  }
+
+  /* set up a devices monitor that listen for any device change */
+  m_udevMon = udev_monitor_new_from_netlink(m_udev, "udev");
+
+  /* filter to only receive usb events */
+  if (udev_monitor_filter_add_match_subsystem_devtype(m_udevMon, "usb", nullptr) < 0)
+  {
+    CLog::Log(LOGERROR, "Could not limit filter on USB only");
+  }
+
+  CLog::Log(LOGDEBUG, "%s - initialised udev monitor", __FUNCTION__);
+
+  udev_monitor_enable_receiving(m_udevMon);
   bool bUpdated(false);
   ScanForDevices();
   while (!m_bStop)
@@ -203,6 +203,8 @@ void CPeripheralBusUSB::Process(void)
     if (bUpdated && !m_bStop)
       ScanForDevices();
   }
+  udev_monitor_unref(m_udevMon);
+  udev_unref(m_udev);
 }
 
 void CPeripheralBusUSB::Clear(void)


### PR DESCRIPTION
While debugging a high load issue on the forum: [1]. I stumbled upon udevadm monitor events that constantly wakeup our kodi m_udevMon poll with new devices, therefore causing high cpu load.

The user had some virtual thermal entries that constantly appeared and disappeared. While I am not sure this fixes the root cause of the highload, one thing is clear: if we only want USB notifications we should filter them appropriately.

While looking into this issue, discussion with @fernetmenta came up and we see that current implementation creates udev instances in one thread and uses them in another, this is wrong by udev documation [2].

[1]: https://forum.kodi.tv/showthread.php?tid=350652
[2]: https://www.freedesktop.org/software/systemd/man/libudev.html

This PR does not intend to fix [2] - but resolve / mitigate [1]

Edit: [2] should be fixed now as well.