### PR TITLE
[Estuary] Add additional media flags to Music Visualization window info

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -22,7 +22,7 @@
 				<visible>!Window.IsVisible(videoosd) + !Window.IsVisible(musicosd)</visible>
 				<animation effect="fade" time="200">VisibleChange</animation>
 				<control type="image">
-					<left>200</left>
+					<left>20</left>
 					<top>120</top>
 					<width>264</width>
 					<height>40</height>
@@ -79,12 +79,57 @@
 					<visible>Player.ShowInfo + !Player.ChannelPreviewActive + Window.IsActive(visualisation)</visible>
 					<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
 					<include content="MediaFlag">
-						<param name="texture" value="$INFO[MusicPlayer.Codec,flags/audiocodec/,.png]" />
-					</include>
-					<include content="MediaFlag">
 						<param name="texture" value="flags/rds/rds.png" />
 						<param name="visible" value="RDS.HasRDS" />
 					</include>
+					<include content="MediaFlag">
+						<param name="texture" value="$INFO[MusicPlayer.Codec,flags/audiocodec/,.png]" />
+					</include>
+					<include content="MediaFlag">
+						<param name="texture" value="$INFO[MusicPlayer.Channels,flags/audiochannel/,.png]" />
+					</include>
+					<control type="group">
+						<width>115</width>
+						<control type="label">
+							<width>115</width>
+							<height>60</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<label>$INFO[MusicPlayer.SampleRate, ,kHz]</label>
+							<font>font_flag</font>
+						</control>
+						<include content="MediaFlag">
+							<param name="texture" value="flags/flag.png" />
+						</include>
+					</control>
+					<control type="group">
+						<width>115</width>
+						<control type="label">
+							<width>115</width>
+							<height>60</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<label>$INFO[MusicPlayer.BitRate, ,kbps ]</label>
+							<font>font_flag</font>
+						</control>
+						<include content="MediaFlag">
+							<param name="texture" value="flags/flag.png" />
+						</include>
+					</control>
+					<control type="group">
+						<width>115</width>
+						<control type="label">
+							<width>115</width>
+							<height>60</height>
+							<align>center</align>
+							<aligny>center</aligny>
+							<label>$INFO[MusicPlayer.BitsPerSample, ,bit]</label>
+							<font>font_flag</font>
+						</control>
+						<include content="MediaFlag">
+							<param name="texture" value="flags/flag.png" />
+						</include>
+					</control>
 				</control>
 				<control type="group">
 					<visible>[PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive] | PVR.IsPlayingActiveRecording</visible>


### PR DESCRIPTION
## Description
Something often requested by uses is for Estuary to the audio file properties on the Music Visualisation window info which is supplied via DialogSeekBar.xml

It'd been the No.1 thing asked for in https://forum.kodi.tv/showthread.php?tid=335000

## Motivation and Context
User requests and we have the info labels available and the space available so why not show it.
## How Has This Been Tested?
Playing music in fullscreen visualisation window.

## Screenshots (if appropriate):

**Before**
![image](https://user-images.githubusercontent.com/5781142/72220534-79c41600-3549-11ea-8087-3be7862d6935.png)

**After**
![image](https://user-images.githubusercontent.com/5781142/72220537-7fb9f700-3549-11ea-9085-084293db247a.png)

**After**
![image](https://user-images.githubusercontent.com/5781142/72220540-85174180-3549-11ea-9ceb-a854ede6d023.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x ] My change requires a change to the documentation, either Doxygen or wiki
- [x ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x ] I have added tests to cover my change
- [x ] All new and existing tests passed
