### PR TITLE
[tvOS] Fix cropped Now Playing image

### DIFF
--- a/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.mm
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedNowPlayingInfoManager.mm
@@ -14,6 +14,7 @@
 #include "platform/darwin/tvos/XBMCController.h"
 #endif
 
+#import <AVFoundation/AVFoundation.h>
 #import <MediaPlayer/MediaPlayer.h>
 
 @implementation DarwinEmbedNowPlayingInfoManager
@@ -49,10 +50,19 @@
   {
     if (auto image = [UIImage imageWithContentsOfFile:thumb])
     {
+      auto square_size = image.size.height;
+      if (image.size.width > square_size)
+        square_size = image.size.width;
+      auto rect = CGRectMake(0, 0, square_size, square_size);
+      UIGraphicsBeginImageContextWithOptions(rect.size, YES, 0.0);
+      [image drawInRect:AVMakeRectWithAspectRatioInsideRect(image.size, rect)];
+      image = UIGraphicsGetImageFromCurrentImageContext();
+      UIGraphicsEndImageContext();
       if (auto mArt =
-          [[MPMediaItemArtwork alloc] initWithBoundsSize:image.size
-                                          requestHandler:^UIImage* _Nonnull(CGSize aSize) {
-                                            return image;}])
+              [[MPMediaItemArtwork alloc] initWithBoundsSize:rect.size
+                                              requestHandler:^UIImage* _Nonnull(CGSize aSize) {
+                                                return image;
+                                              }])
       {
         dict[MPMediaItemPropertyArtwork] = mArt;
       }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
If the image used for the NowPlaying artwork is not a perfect square, then this image is cropped on the NowPlaying view of the Apple TV (see screenshot).
To fix this issue we can put this image in a square.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Just a little fix for a beautiful NowPlaying image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On Apple TV 4K NowPlaying view and iPhone 7 NowPlaying view.

## Screenshots (if appropriate):

**Before:**

<img width="1402" alt="Capture d’écran 2020-01-13 à 08 55 44" src="https://user-images.githubusercontent.com/11562279/72239967-fbb44d80-35e2-11ea-8958-5889b1762d2f.png">

**After:**

<img width="1564" alt="Capture d’écran 2020-01-13 à 08 56 32" src="https://user-images.githubusercontent.com/11562279/72239985-04a51f00-35e3-11ea-8c54-d4e0c67de63a.png">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
