### PR TITLE
Fix UHD BD Dolby Vision dual layer streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1727,6 +1727,14 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
 #ifdef HAVE_LIBBLURAY
     if (m_pInput->IsStreamType(DVDSTREAM_TYPE_BLURAY))
     {
+      // UHD BD have a secondary video stream called by Dolby as enhancement layer.
+      // This is not used by streaming services and devices (ATV, Nvidia Shield, XONE).
+      if (pStream->id == 0x1015)
+      {
+        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::AddStream - discarding Dolby Vision stream");
+        pStream->discard = AVDISCARD_ALL;
+        return nullptr;
+      }
       stream->dvdNavId = pStream->id;
 
       auto it = std::find_if(m_streams.begin(), m_streams.end(),


### PR DESCRIPTION
## Description
When playing any container (mkv, mp4...) that has a Dolby Vision idependent layer stream will show up as 1080p HEVC/AVC stream resulting in a solid green screen. 
This is not a big problem when playing idependent files like mkv/mp4 because you are able to select the video stream. This is a big problem when playing UHD BD in Disc Navigation mode that changing the video streams during the menus cause the menu to end and the movie to start. 
This also results in menus that are not readable or watchable because of the solid green screen on top. 

Exclusive to UHD BD, Dolby made a second layer called the enhancement layer. 
This layer is merged by the player during playback and uses proprietary Dolby software to do so. 
Discarding this layer has no effect on Apple TV, or Nvidia Shield of Xbox One S/X because
those can only play Dolby Vision single layer tracks that is embended into the first video stream.

Dolby Vision documentation:
https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-white-paper.pdf

## Motivation and Context
The if statement might seem unspecific and could cause wrong streams to be removed by mistake. 
This is **NOT** the case here. 

The streamID 0x1015 is exclusive to the Dolby Vision enhancement layer that Kodi cannot play in any way or form. 
The only possible scenario as it would by mistaken by another track is if the video container had 5 video tracks, since those are made in sequence 0x1011 being the first. 
Audio starts at 0x1100 and subtitles at 0x12A0.

FFMpeg uses the following method to check for DV streams:
https://github.com/FFmpeg/FFmpeg/commit/6ebe88f3a4c427511eba7495896f4a57a2b4b529

Identification using the codec_tag as identified by ffmpeg is not possible for two reasons:

1. If detected it would remove the first track (unless we made a code similar to the one that checks for Dolby True HD audio track and removes duplicated audio tracks).
2. On UHD BD those streams have the exact same codec_tag as you can see on this sample from a debug log which was added a CLog output to check codec_tag of both streams:
https://pastebin.com/spCfL2FQ

Those tracks are also mistaken by MediaInfo as can be seen here:
https://pastebin.com/Zv2fndLF

## How Has This Been Tested?
This has been tested in a Windows x64 enviroment with DVDs, Blurays and UHD BDs. 
This has been tested with 3 titles that have Dolby Vision enhancement layer: 2001 Space Odyssey, The Shining and The Hereditary.

This causes no harm to dolby vision playback on Nvidia Shield or Apple TV because the first layer, which is the only layer that those players can identify and play is embended into the first video stream, so removing the second one causes no harm. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
