### PR TITLE
[Android] Implement PowerManager::OnSleep/OnWake

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -64,32 +64,34 @@
 #include "windowing/GraphicContext.h"
 #include "guilib/GUIWindowManager.h"
 // Audio Engine includes for Factory and interfaces
-#include "cores/AudioEngine/Interfaces/AE.h"
-#include "cores/AudioEngine/AESinkFactory.h"
-#include "cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h"
-
-#include "ServiceBroker.h"
 #include "GUIInfoManager.h"
-#include "guilib/guiinfo/GUIInfoLabels.h"
-#include "guilib/GUIComponent.h"
-#include "platform/android/activity/IInputDeviceCallbacks.h"
-#include "platform/android/activity/IInputDeviceEventHandler.h"
-#include "input/mouse/MouseStat.h"
-#include "input/Key.h"
-#include "utils/log.h"
-#include "utils/TimeUtils.h"
-#include "platform/android/network/NetworkAndroid.h"
+#include "ServiceBroker.h"
+#include "TextureCache.h"
+#include "cores/AudioEngine/AESinkFactory.h"
+#include "cores/AudioEngine/Interfaces/AE.h"
+#include "cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "filesystem/SpecialProtocol.h"
-#include "TextureCache.h"
-#include "utils/StringUtils.h"
 #include "filesystem/VideoDatabaseFile.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/guiinfo/GUIInfoLabels.h"
+#include "input/Key.h"
+#include "input/mouse/MouseStat.h"
+#include "platform/xbmc.h"
+#include "powermanagement/PowerManager.h"
+#include "utils/StringUtils.h"
+#include "utils/TimeUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
+#include "windowing/WinEvents.h"
 #include "windowing/android/VideoSyncAndroid.h"
 #include "windowing/android/WinSystemAndroid.h"
-#include "windowing/WinEvents.h"
-#include "platform/xbmc.h"
+
+#include "platform/android/activity/IInputDeviceCallbacks.h"
+#include "platform/android/activity/IInputDeviceEventHandler.h"
+#include "platform/android/network/NetworkAndroid.h"
+#include "platform/android/powermanagement/AndroidPowerSyscall.h"
 
 #define GIGABYTES       1073741824
 
@@ -245,6 +247,10 @@ void CXBMCApp::onResume()
   // Re-request Visible Behind
   if ((m_playback_state & PLAYBACK_STATE_PLAYING) && (m_playback_state & PLAYBACK_STATE_VIDEO))
     RequestVisibleBehind(true);
+
+  if (g_application.IsInitialized())
+    dynamic_cast<CAndroidPowerSyscall*>(CServiceBroker::GetPowerManager().GetPowerSyscall())
+        ->SetOnResume();
 }
 
 void CXBMCApp::onPause()
@@ -265,6 +271,9 @@ void CXBMCApp::onPause()
 
   EnableWakeLock(false);
   m_hasReqVisible = false;
+
+  dynamic_cast<CAndroidPowerSyscall*>(CServiceBroker::GetPowerManager().GetPowerSyscall())
+      ->SetOnPause();
 }
 
 void CXBMCApp::onStop()

--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
@@ -8,6 +8,8 @@
 
 #include "AndroidPowerSyscall.h"
 
+#include "utils/log.h"
+
 #include "platform/android/activity/XBMCApp.h"
 
 IPowerSyscall* CAndroidPowerSyscall::CreateInstance()
@@ -27,5 +29,19 @@ int CAndroidPowerSyscall::BatteryLevel(void)
 
 bool CAndroidPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
 {
+  switch (m_state)
+  {
+    case SUSPENDED:
+      callback->OnSleep();
+      CLog::Log(LOGINFO, "%s: OnSleep called", __FUNCTION__);
+      break;
+    case RESUMED:
+      callback->OnWake();
+      CLog::Log(LOGINFO, "%s: OnWake called", __FUNCTION__);
+      break;
+    default:
+      return false;
+  }
+  m_state = REPORTED;
   return true;
 }

--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.h
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.h
@@ -31,4 +31,16 @@ public:
   int BatteryLevel() override;
 
   bool PumpPowerEvents(IPowerEventsCallback* callback) override;
+
+  void SetOnPause() { m_state = SUSPENDED; }
+  void SetOnResume() { m_state = RESUMED; }
+
+private:
+  enum STATE : unsigned int
+  {
+    REPORTED = 0,
+    SUSPENDED = 1,
+    RESUMED = 2,
+  };
+  STATE m_state = REPORTED;
 };

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -48,6 +48,8 @@ public:
 
   static void SettingOptionsShutdownStatesFiller(std::shared_ptr<const CSetting> setting, std::vector<IntegerSettingOption> &list, int &current, void *data);
 
+  IPowerSyscall* GetPowerSyscall() const { return m_instance.get(); };
+
 private:
   void OnSleep() override;
   void OnWake() override;


### PR DESCRIPTION
## Description
Call CPoweManager OnWake / OnSleep (through IPowerSyscall) when Android activity lifecycle calls onResume / onPause.

## Motivation and Context
There are services inside kodi (e.g. PVR EPG poll) which should be deactivated when kodi is suspended.

## How Has This Been Tested?
- Launch kodi
- Hide kodi (using Android TV home button) -> OnSleep
- Bring back kodi into foreground ->OnWake

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
