### PR TITLE
[python] set abi to 3.0.0

### DIFF
--- a/addons/xbmc.python/addon.xml
+++ b/addons/xbmc.python/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.python" version="3.0.0" provider-name="Team Kodi">
-  <backwards-compatibility abi="2.1.0"/>
+  <backwards-compatibility abi="3.0.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
since the switch to python 3 we are no longer backward compatible to the kodi python 2.1.0 api.

- this change will make sure all installed py2 addons will get disabled when a user upgrades to kodi v19.
- this change will prevent a user from installing (repo and/or zip) py2 addons in kodi.

**TODO:**
we have been accepting py2/py3 compatible addons in the leia and lower repos, but we do not have a way to handle that. all those addons will be disabled by this change as well!
two years ago, several solutions were suggested and consensus was reached on this: https://forum.kodi.tv/showthread.php?tid=323369&pid=2688320#pid2688320 (internal link)

so far no-one has stepped-up to actually implement it... and this is becoming a blocking issue when it comes to the release of v19.

i would appreciate any/all comments, thoughts & ideas on how we can get us out of this situation.
 
