### PR TITLE
[PVR] Convert EPG First Aired from time_t to date string

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "6.1.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "6.1.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "6.2.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "6.2.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \
                                                       "xbmc_pvr_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
@@ -58,6 +58,7 @@ extern "C" {
   /* EPG_TAG.iFlags values */
   const unsigned int EPG_TAG_FLAG_UNDEFINED = 0x00000000; /*!< @brief nothing special to say about this entry */
   const unsigned int EPG_TAG_FLAG_IS_SERIES = 0x00000001; /*!< @brief this EPG entry is part of a series */
+  const unsigned int EPG_TAG_FLAG_IS_NEW    = 0x00000002; /*!< @brief this EPG entry will be flagged as new */
 
   /* Special EPG_TAG.iUniqueBroadcastId value */
 
@@ -97,7 +98,7 @@ extern "C" {
     int           iGenreType;          /*!< @brief (optional) genre type */
     int           iGenreSubType;       /*!< @brief (optional) genre sub type */
     const char *  strGenreDescription; /*!< @brief (optional) genre. Will be used only when iGenreType == EPG_GENRE_USE_STRING or iGenreSubType == EPG_GENRE_USE_STRING. Use EPG_STRING_TOKEN_SEPARATOR to separate different genres. */
-    time_t        firstAired;          /*!< @brief (optional) first aired in UTC */
+    const char *  strFirstAired;       /*!< @brief (optional) first aired date of the event. Used only for display purposes. Specify in W3C date format "YYYY-MM-DD". */
     int           iParentalRating;     /*!< @brief (optional) parental rating */
     int           iStarRating;         /*!< @brief (optional) star rating */
     int           iSeriesNumber;       /*!< @brief (optional) series number */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -649,8 +649,11 @@ public:
     startTime = t;
     kodiTag->EndAsUTC().GetAsTime(t);
     endTime = t;
-    kodiTag->FirstAiredAsUTC().GetAsTime(t);
-    firstAired = t;
+
+    const CDateTime firstAired = kodiTag->FirstAired();
+    if (firstAired.IsValid())
+      m_strFirstAired = firstAired.GetAsW3CDate();
+
     iUniqueBroadcastId = kodiTag->UniqueBroadcastID();
     iUniqueChannelId = kodiTag->UniqueChannelID();
     iParentalRating = kodiTag->ParentalRating();
@@ -674,6 +677,7 @@ public:
     strIconPath = m_strIconPath.c_str();
     strSeriesLink = m_strSeriesLink.c_str();
     strGenreDescription = m_strGenreDescription.c_str();
+    strFirstAired = m_strFirstAired.c_str();
   }
 
   virtual ~CAddonEpgTag() = default;
@@ -691,6 +695,7 @@ private:
   std::string m_strIconPath;
   std::string m_strSeriesLink;
   std::string m_strGenreDescription;
+  std::string m_strFirstAired;
 };
 
 PVR_ERROR CPVRClient::IsRecordable(const std::shared_ptr<const CPVREpgInfoTag>& tag, bool& bIsRecordable) const

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -63,7 +63,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 12; }
+    int GetSchemaVersion() const override { return 13; }
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -72,9 +72,9 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG& data, int iClientId, const std::sh
   m_iFlags(data.iFlags),
   m_iEpgID(iEpgID)
 {
-  // firstAired is optional, so check if supported before assigning it
-  if (data.firstAired > 0)
-    m_firstAired = time_t(data.firstAired + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection);
+  // strFirstAired is optional, so check if supported before assigning it
+  if (data.strFirstAired && strlen(data.strFirstAired) > 0)
+    m_firstAired.SetFromW3CDate(data.strFirstAired);
 
   if (channelData)
   {
@@ -419,16 +419,9 @@ const std::vector<std::string> CPVREpgInfoTag::Genre() const
   return m_genre;
 }
 
-CDateTime CPVREpgInfoTag::FirstAiredAsUTC() const
+CDateTime CPVREpgInfoTag::FirstAired() const
 {
   return m_firstAired;
-}
-
-CDateTime CPVREpgInfoTag::FirstAiredAsLocalTime() const
-{
-  CDateTime retVal;
-  retVal.SetFromUTCDateTime(m_firstAired);
-  return retVal;
 }
 
 int CPVREpgInfoTag::ParentalRating() const
@@ -665,6 +658,11 @@ bool CPVREpgInfoTag::IsGapTag() const
 {
   CSingleLock lock(m_critSection);
   return m_bIsGapTag;
+}
+
+bool CPVREpgInfoTag::IsNew() const
+{
+  return (m_iFlags & EPG_TAG_FLAG_IS_NEW) > 0;
 }
 
 const std::vector<std::string> CPVREpgInfoTag::Tokenize(const std::string& str)

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -271,15 +271,9 @@ namespace PVR
 
     /*!
      * @brief Get the first air date of this event.
-     * @return The first air date in UTC.
+     * @return The first air date.
      */
-    CDateTime FirstAiredAsUTC() const;
-
-    /*!
-     * @brief Get the first air date of this event.
-     * @return The first air date as local time.
-     */
-    CDateTime FirstAiredAsLocalTime() const;
+    CDateTime FirstAired() const;
 
     /*!
      * @brief Get the parental rating of this event.
@@ -392,6 +386,12 @@ namespace PVR
      * @return True if this event is a gap, false otherwise.
      */
     bool IsGapTag() const;
+
+    /*!
+     * @brief Check whether this tag will be flagged as new.
+     * @return True if this tag will be flagged as new, false otherwise
+     */
+    bool IsNew() const;
 
     /*!
      * @brief Return the flags (EPG_TAG_FLAG_*) of this event as a bitfield.

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -609,9 +609,14 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         return false;
       case VIDEOPLAYER_PREMIERED:
       case LISTITEM_PREMIERED:
-        if (epgTag->FirstAiredAsLocalTime().IsValid())
+        if (epgTag->FirstAired().IsValid())
         {
-          strValue = epgTag->FirstAiredAsLocalTime().GetAsLocalizedDate(true);
+          strValue = epgTag->FirstAired().GetAsLocalizedDate(true);
+          return true;
+        }
+        else if (epgTag->Year() > 0)
+        {
+          strValue = StringUtils::Format("%i", epgTag->Year());
           return true;
         }
         return false;
@@ -1249,16 +1254,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
     case LISTITEM_IS_NEW:
       if (item->IsEPG())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
-        const CDateTime firstAired = epgTag->FirstAiredAsUTC();
-        const CDateTime start = epgTag->StartAsUTC();
-        if (firstAired.IsValid() && start.IsValid())
-        {
-          bValue = firstAired.GetYear() == start.GetYear() &&
-                   firstAired.GetMonth() == start.GetMonth() &&
-                   firstAired.GetDay() == start.GetDay();
-          return true;
-        }
+        bValue = item->GetEPGInfoTag()->IsNew();
+        return true;
       }
       break;
     case MUSICPLAYER_CONTENT:


### PR DESCRIPTION
## Description
This PR changes the time_t-based "first aired" EPG_TAG into a W3C date string (YYYY-MM-DD) instead.  This allows for dates prior to 1/1/1970 to be displayed in the Kodi UI "Programme Information" screen.

Given the difficulties for backends that cannot provide first aired as a specific date/time that can be localized and compared within the user's time zone, this PR also adds a new EPG_TAG_FLAG to represent "new".  Previously the firstAired time was being compared to the program start time to determine this.

NOTE: **This is a breaking change that will affect all PVR addons;** I understand that they must all be updated prior to acceptance of this PR.  I will need help contacting the maintainers for PVRs I cannot run here

PVR addons will need to be modified to produce a date string rather than a time_t value to supply First Aired.  Additionally, addons will need to have new logic added to determine if an event should be flagged as "new" on their own.  

The addons will now be in full control over both data elements, whatever date they provide for first aired will be displayed as-is, and the "new" indicator will only appear if the addon specifies that it should.

During database migration, existing time_t values will be converted to string dates as possible, although this information is likely to be overwritten by the PVR after the upgrade has taken place.

I also removed the unused "bNotify" flag from the epgtags table since it needs to be upgraded anyway.

edit: After some additional "live" testing with my PVR addon I found that giving the addon the ability to specify just a year instead of a specific date has merit for events like Movies.  PR was updated to include this logic, and screenshots have been added below.

## Motivation and Context
Many EPG backends are incapable of providing a granular enough time_t value that can be localized for the user's time zone and/or compared with the program start time to determine if it's "new" or not.  It's seemingly impossible to provide a "one size fits all" solution.

Being able to specify dates prior to January 1, 1970 is also nice. 

## How Has This Been Tested?
Tested against master branch, Windows x64 Desktop debug build.  Database upgrade path has been tested as has new database path.  Database persistence has been verified as accurate for the data I have available.

I can generate before/after CSV files of an upgraded Epg12 database for review if desired.

## Screenshots (if appropriate):
Sample image with date prior to 1/1/1970 being supported.
![pr](https://user-images.githubusercontent.com/706055/72388831-f0e9dd80-36f4-11ea-8d11-7412d4b607ca.png)

Sample image of an EPG event that specifies a Year but not a First Aired date (I believe this is useful for Movie events, perhaps more):
![pr-2](https://user-images.githubusercontent.com/706055/72403760-2f958d00-3721-11ea-8c08-15e2c1c3fa47.png)

Sample image of a pre-1970 event that specifies a First Aired date but not a year:
![pr-3](https://user-images.githubusercontent.com/706055/72403794-450ab700-3721-11ea-8c88-28606d35eb15.png)


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project *
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

* There are numerous instances where I left non-clang-format formatting in place to follow conventions within the file; am happy to change any of them.