### PR TITLE
[PVR] EPG Memory optimizations/Performance improvements

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9538,11 +9538,7 @@ msgctxt "#19071"
 msgid "Update interval"
 msgstr ""
 
-#. pvr settings "store epg data in database" setting label
-#: system/settings/settings.xml
-msgctxt "#19072"
-msgid "Store data in database"
-msgstr ""
+#empty string with id 19072
 
 #. pvr settings "delay channel switch" setting label
 #: system/settings/settings.xml
@@ -10598,11 +10594,7 @@ msgctxt "#19249"
 msgid "Filter channels"
 msgstr ""
 
-#. label 'loading epg data from database' for progress dialog text
-#: xbmc/pvr/epg/EpgContainer.cpp
-msgctxt "#19250"
-msgid "Loading guide from database"
-msgstr ""
+#empty string with id 19250
 
 #. label for 'update epg' context menu item and 'update epg' confirmation dialog header
 #: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -18803,10 +18795,7 @@ msgctxt "#36222"
 msgid "Don't import the guide data while playing TV to minimise CPU usage."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36223"
-msgid "Activate to store epg data in a database. This may speedup importing epg data on startup."
-msgstr ""
+#empty string with id 36223
 
 #: system/settings/settings.xml
 msgctxt "#36224"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1353,11 +1353,6 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="epg.storeepgindatabase" type="boolean" label="19072" help="36223">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="epg.resetepg" type="action" label="19185" help="36225">
           <level>1</level>
           <control type="button" format="action" />

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -17,7 +17,6 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
@@ -305,9 +304,7 @@ bool CPVRDatabase::Delete(const CPVRChannel& channel)
 
 int CPVRDatabase::Get(CPVRChannelGroup& results, bool bCompressDB)
 {
-  int iReturn(0);
-  bool bUseEpgDB = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_EPG_STOREEPGINDATABASE);
-
+  int iReturn = 0;
   std::string strQuery = PrepareSQL("SELECT channels.idChannel, channels.iUniqueId, channels.bIsRadio, channels.bIsHidden, channels.bIsUserSetIcon, channels.bIsUserSetName, "
       "channels.sIconPath, channels.sChannelName, channels.bIsVirtual, channels.bEPGEnabled, channels.sEPGScraper, channels.iLastWatched, channels.iClientId, channels.bIsLocked, "
       "map_channelgroups_channels.iChannelNumber, map_channelgroups_channels.iSubChannelNumber, map_channelgroups_channels.iOrder, map_channelgroups_channels.iClientChannelNumber, "
@@ -338,7 +335,7 @@ int CPVRDatabase::Get(CPVRChannelGroup& results, bool bCompressDB)
         channel->m_strEPGScraper = m_pDS->fv("sEPGScraper").get_asString();
         channel->m_iLastWatched = static_cast<time_t>(m_pDS->fv("iLastWatched").get_asInt());
         channel->m_iClientId = m_pDS->fv("iClientId").get_asInt();
-        channel->m_iEpgId = bUseEpgDB ? m_pDS->fv("idEpg").get_asInt() : -1;
+        channel->m_iEpgId = m_pDS->fv("idEpg").get_asInt();
         channel->m_bHasArchive = m_pDS->fv("bHasArchive").get_asBool();
         channel->UpdateEncryptionName();
 

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -153,7 +153,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem> item)
     m_iplayingChannelUniqueID = -1;
     m_strPlayingClientName.clear();
   }
-  else if (item->HasEPGInfoTag() && item->GetEPGInfoTag() == m_playingEpgTag)
+  else if (item->HasEPGInfoTag() && m_playingEpgTag && *item->GetEPGInfoTag() == *m_playingEpgTag)
   {
     bChanged = true;
     m_playingEpgTag.reset();

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "XBDateTime.h"
+#include "cores/DataCacheCore.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/channels/PVRChannel.h"
@@ -313,6 +314,16 @@ void CPVRPlaybackState::SetPlayingGroup(const std::shared_ptr<CPVRChannel>& chan
 std::shared_ptr<CPVRChannelGroup> CPVRPlaybackState::GetPlayingGroup(bool bRadio) const
 {
   return CServiceBroker::GetPVRManager().ChannelGroups()->GetSelectedGroup(bRadio);
+}
+
+CDateTime CPVRPlaybackState::GetPlaybackTime() const
+{
+  // start time valid?
+  time_t startTime = CServiceBroker::GetDataCacheCore().GetStartTime();
+  if (startTime > 0)
+    return CDateTime(startTime + CServiceBroker::GetDataCacheCore().GetPlayTime() / 1000);
+  else
+    return CDateTime::GetUTCDateTime();
 }
 
 void CPVRPlaybackState::UpdateLastWatched(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& time)

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -185,6 +185,12 @@ public:
    */
   std::shared_ptr<CPVRChannelGroup> GetPlayingGroup(bool bRadio) const;
 
+  /*!
+   * @brief Get current playback time, taking timeshifting into account.
+   * @return The playback time.
+   */
+  CDateTime GetPlaybackTime() const;
+
 private:
   /*!
    * @brief Set the playing group to the first group the channel is in if the given channel is not part of the current playing group

--- a/xbmc/pvr/epg/CMakeLists.txt
+++ b/xbmc/pvr/epg/CMakeLists.txt
@@ -3,13 +3,15 @@ set(SOURCES EpgContainer.cpp
             EpgDatabase.cpp
             EpgInfoTag.cpp
             EpgSearchFilter.cpp
-            EpgChannelData.cpp)
+            EpgChannelData.cpp
+            EpgTagsContainer.cpp)
 
 set(HEADERS Epg.h
             EpgContainer.h
             EpgDatabase.h
             EpgInfoTag.h
             EpgSearchFilter.h
-            EpgChannelData.h)
+            EpgChannelData.h
+            EpgTagsContainer.h)
 
 core_add_library(pvr_epg)

--- a/xbmc/pvr/epg/CMakeLists.txt
+++ b/xbmc/pvr/epg/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES EpgContainer.cpp
             EpgInfoTag.cpp
             EpgSearchFilter.cpp
             EpgChannelData.cpp
+            EpgTagsCache.cpp
             EpgTagsContainer.cpp)
 
 set(HEADERS Epg.h
@@ -12,6 +13,7 @@ set(HEADERS Epg.h
             EpgInfoTag.h
             EpgSearchFilter.h
             EpgChannelData.h
+            EpgTagsCache.h
             EpgTagsContainer.h)
 
 core_add_library(pvr_epg)

--- a/xbmc/pvr/epg/CMakeLists.txt
+++ b/xbmc/pvr/epg/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES EpgContainer.cpp
             Epg.cpp
             EpgDatabase.cpp
             EpgInfoTag.cpp
+            EpgSearchData.cpp
             EpgSearchFilter.cpp
             EpgChannelData.cpp
             EpgTagsCache.cpp
@@ -11,6 +12,7 @@ set(HEADERS Epg.h
             EpgContainer.h
             EpgDatabase.h
             EpgInfoTag.h
+            EpgSearchData.h
             EpgSearchFilter.h
             EpgChannelData.h
             EpgTagsCache.h

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -37,8 +37,12 @@ namespace PVR
      * @param iEpgID The ID of this table or <= 0 to create a new ID.
      * @param strName The name of this table.
      * @param strScraperName The name of the scraper to use.
+     * @param database The EPG database
      */
-    CPVREpg(int iEpgID, const std::string& strName, const std::string& strScraperName);
+    CPVREpg(int iEpgID,
+            const std::string& strName,
+            const std::string& strScraperName,
+            const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
      * @brief Create a new EPG instance.
@@ -46,8 +50,13 @@ namespace PVR
      * @param strName The name of this table.
      * @param strScraperName The name of the scraper to use.
      * @param channelData The channel data.
+     * @param database The EPG database
      */
-    CPVREpg(int iEpgID, const std::string& strName, const std::string& strScraperName, const std::shared_ptr<CPVREpgChannelData>& channelData);
+    CPVREpg(int iEpgID,
+            const std::string& strName,
+            const std::string& strScraperName,
+            const std::shared_ptr<CPVREpgChannelData>& channelData,
+            const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
      * @brief Destroy this EPG instance.
@@ -280,7 +289,6 @@ namespace PVR
      */
     void Cleanup(int iPastDays);
 
-    bool m_bChanged = false; /*!< true if anything changed that needs to be persisted, false otherwise */
     bool m_bUpdatePending = false; /*!< true if manual update is pending */
     int m_iEpgID = 0; /*!< the database ID of this table */
     std::string m_strName; /*!< the name of this table */

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -55,13 +55,6 @@ namespace PVR
     virtual ~CPVREpg();
 
     /*!
-     * @brief Load all entries for this table from the given database.
-     * @param database The database.
-     * @return True if any entries were loaded, false otherwise.
-     */
-    bool Load(const std::shared_ptr<CPVREpgDatabase>& database);
-
-    /*!
      * @brief Get data for the channel associated with this EPG.
      * @return The data.
      */
@@ -107,12 +100,6 @@ namespace PVR
      * @return The database ID of this table.
      */
     int EpgID() const;
-
-    /*!
-     * @brief Check whether this EPG contains valid entries.
-     * @return True if it has valid entries, false if not.
-     */
-    bool HasValidEntries() const;
 
     /*!
      * @brief Remove all entries from this EPG that finished before the given time.
@@ -171,10 +158,9 @@ namespace PVR
      * @brief Update an entry in this EPG.
      * @param tag The tag to update.
      * @param newState the new state of the event.
-     * @param bUpdateDatabase If set to true, this event will be persisted in the database.
      * @return True if it was updated successfully, false otherwise.
      */
-    bool UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_STATE newState, bool bUpdateDatabase);
+    bool UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_STATE newState);
 
     /*!
      * @brief Update the EPG from 'start' till 'end'.
@@ -273,12 +259,6 @@ namespace PVR
     bool UpdateFromScraper(time_t start, time_t end, bool bForceUpdate);
 
     /*!
-     * @brief Add an infotag to this container.
-     * @param tag The tag to add.
-     */
-    void AddEntry(const CPVREpgInfoTag& tag);
-
-    /*!
      * @brief Load all EPG entries from clients into a temporary table and update this table with the contents of that temporary table.
      * @param start Only get entries after this start time. Use 0 to get all entries before "end".
      * @param end Only get entries before this end time. Use 0 to get all entries after "begin". If both "begin" and "end" are 0, all entries will be updated.
@@ -290,10 +270,9 @@ namespace PVR
     /*!
      * @brief Update the contents of this table with the contents provided in "epg"
      * @param epg The updated contents.
-     * @param bStoreInDb True to store the updated contents in the db, false otherwise.
      * @return True if the update was successful, false otherwise.
      */
-    bool UpdateEntries(const CPVREpg& epg, bool bStoreInDb = true);
+    bool UpdateEntries(const CPVREpg& epg);
 
     /*!
      * @brief Remove all entries from this EPG that finished before the given amount of days.
@@ -302,7 +281,6 @@ namespace PVR
     void Cleanup(int iPastDays);
 
     bool m_bChanged = false; /*!< true if anything changed that needs to be persisted, false otherwise */
-    bool m_bLoaded = false; /*!< true when the initial entries have been loaded */
     bool m_bUpdatePending = false; /*!< true if manual update is pending */
     int m_iEpgID = 0; /*!< the database ID of this table */
     std::string m_strName; /*!< the name of this table */

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "pvr/epg/EpgTagsContainer.h"
 #include "threads/CriticalSection.h"
 #include "utils/EventStream.h"
 
@@ -169,14 +170,6 @@ namespace PVR
     /*!
      * @brief Update an entry in this EPG.
      * @param tag The tag to update.
-     * @param bUpdateDatabase If set to true, this event will be persisted in the database.
-     * @return True if it was updated successfully, false otherwise.
-     */
-    bool UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bUpdateDatabase);
-
-    /*!
-     * @brief Update an entry in this EPG.
-     * @param tag The tag to update.
      * @param newState the new state of the event.
      * @param bUpdateDatabase If set to true, this event will be persisted in the database.
      * @return True if it was updated successfully, false otherwise.
@@ -280,13 +273,6 @@ namespace PVR
     bool UpdateFromScraper(time_t start, time_t end, bool bForceUpdate);
 
     /*!
-     * @brief Fix overlapping events from the tables.
-     * @param bUpdateDb If set to yes, any changes to tags during fixing will be persisted to database
-     * @return True if anything changed, false otherwise.
-     */
-    bool FixOverlappingEvents(bool bUpdateDb = false);
-
-    /*!
      * @brief Add an infotag to this container.
      * @param tag The tag to add.
      */
@@ -315,31 +301,17 @@ namespace PVR
      */
     void Cleanup(int iPastDays);
 
-    /*!
-     * @brief Create a "gap" tag
-     * @param start The start time of the gap.
-     * @param end The end time of the gap.
-     * @return The tag.
-     */
-    std::shared_ptr<CPVREpgInfoTag> CreateGapTag(const CDateTime& start,
-                                                 const CDateTime& end) const;
-
-    std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>> m_tags;
-    std::map<int, std::shared_ptr<CPVREpgInfoTag>> m_changedTags;
-    std::map<int, std::shared_ptr<CPVREpgInfoTag>> m_deletedTags;
     bool m_bChanged = false; /*!< true if anything changed that needs to be persisted, false otherwise */
-    bool m_bTagsChanged = false; /*!< true when any tags are changed and not persisted, false otherwise */
     bool m_bLoaded = false; /*!< true when the initial entries have been loaded */
     bool m_bUpdatePending = false; /*!< true if manual update is pending */
     int m_iEpgID = 0; /*!< the database ID of this table */
     std::string m_strName; /*!< the name of this table */
     std::string m_strScraperName; /*!< the name of the scraper to use */
-    mutable CDateTime m_nowActiveStart; /*!< the start time of the tag that is currently active */
     CDateTime m_lastScanTime; /*!< the last time the EPG has been updated */
     mutable CCriticalSection m_critSection; /*!< critical section for changes in this table */
     bool m_bUpdateLastScanTime = false;
-
     std::shared_ptr<CPVREpgChannelData> m_channelData;
+    CPVREpgTagsContainer m_tags;
 
     CEventSource<PVREvent> m_events;
   };

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -508,7 +508,8 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::CreateChannelEpg(int iEpgId, const st
     if (iEpgId <= 0)
       iEpgId = NextEpgId();
 
-    epg.reset(new CPVREpg(iEpgId, channelData->ChannelName(), strScraperName, channelData));
+    epg.reset(new CPVREpg(iEpgId, channelData->ChannelName(), strScraperName, channelData,
+                          GetEpgDatabase()));
 
     CSingleLock lock(m_critSection);
     m_epgIdToEpgMap.insert({iEpgId, epg});

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -153,12 +153,6 @@ namespace PVR
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllTags() const;
 
     /*!
-     * @brief Check whether data should be persisted to the EPG database.
-     * @return True if data should be persisted to the EPG database, false otherwise.
-     */
-    bool UseDatabase() const;
-
-    /*!
      * @brief Notify EPG container that there are pending manual EPG updates
      * @param bHasPendingUpdates The new value
      */

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -214,9 +214,11 @@ namespace PVR
 
     /*!
      * @brief Call Persist() on each table
+     * @param iMaxTimeslice time in milliseconds for max processing. Return after this time
+     *        even if not all data was persisted, unless value is -1
      * @return True when they all were persisted, false otherwise.
      */
-    bool PersistAll();
+    bool PersistAll(unsigned int iMaxTimeslice);
 
     /*!
      * @brief Remove old EPG entries.

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -34,6 +34,8 @@ namespace PVR
 
   enum class PVREvent;
 
+  struct PVREpgSearchData;
+
   class CPVREpgContainer : private CThread
   {
     friend class CPVREpgDatabase;
@@ -147,10 +149,11 @@ namespace PVR
     std::shared_ptr<CPVREpgInfoTag> GetTagById(const std::shared_ptr<CPVREpg>& epg, unsigned int iBroadcastId) const;
 
     /*!
-     * @brief Get all EPG tags.
-     * @return The tags.
+     * @brief Get all EPG tags matching the given search criteria.
+     * @param searchData The search criteria.
+     * @return The matching tags.
      */
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllTags() const;
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTags(const PVREpgSearchData& searchData) const;
 
     /*!
      * @brief Notify EPG container that there are pending manual EPG updates
@@ -218,7 +221,7 @@ namespace PVR
      *        even if not all data was persisted, unless value is -1
      * @return True when they all were persisted, false otherwise.
      */
-    bool PersistAll(unsigned int iMaxTimeslice);
+    bool PersistAll(unsigned int iMaxTimeslice) const;
 
     /*!
      * @brief Remove old EPG entries.

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -174,18 +174,6 @@ bool CPVREpgDatabase::Delete(const CPVREpg& table)
   return DeleteValues("epg", filter);
 }
 
-bool CPVREpgDatabase::DeleteEpgEntries(const CDateTime& maxEndTime)
-{
-  time_t iMaxEndTime;
-  maxEndTime.GetAsTime(iMaxEndTime);
-
-  Filter filter;
-
-  CSingleLock lock(m_critSection);
-  filter.AppendWhere(PrepareSQL("iEndTime < %u", iMaxEndTime));
-  return DeleteValues("epgtags", filter);
-}
-
 bool CPVREpgDatabase::Delete(const CPVREpgInfoTag& tag)
 {
   /* tag without a database ID was not persisted */

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -86,13 +86,6 @@ namespace PVR
     bool Delete(const CPVREpg& table);
 
     /*!
-     * @brief Erase all EPG entries with an end time less than the given time.
-     * @param maxEndTime The maximum allowed end time.
-     * @return True if the entries were removed successfully, false otherwise.
-     */
-    bool DeleteEpgEntries(const CDateTime& maxEndTime);
-
-    /*!
      * @brief Remove a single EPG entry.
      * @param tag The entry to remove.
      * @return True if it was removed successfully, false otherwise.

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -21,6 +21,8 @@ namespace PVR
   class CPVREpg;
   class CPVREpgInfoTag;
 
+  struct PVREpgSearchData;
+
   /** The EPG database */
 
   class CPVREpgDatabase : public CDatabase, public std::enable_shared_from_this<CPVREpgDatabase>
@@ -134,6 +136,13 @@ namespace PVR
      * @return The time.
      */
     CDateTime GetMaxEndTime(int iEpgID, const CDateTime& maxEnd);
+
+    /*!
+     * @brief Get all EPG tags matching the given search criteria.
+     * @param searchData The search criteria.
+     * @return The matching tags.
+     */
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTags(const PVREpgSearchData& searchData);
 
     /*!
      * @brief Get an EPG tag given its EPG id and unique broadcast ID.

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -399,11 +399,14 @@ void CPVREpgInfoTag::SetGenre(int iGenreType, int iGenreSubType, const char* str
        * EPG_GENRE_USE_STRING leaving type available for genre category, use the provided genre description for the text. */
       m_genre = Tokenize(strGenre);
     }
-    else
-    {
-      /* Determine the genre description from the type and subtype IDs */
-      m_genre = StringUtils::Split(CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
-    }
+  }
+
+  if (m_genre.empty())
+  {
+    // Determine the genre description from the type and subtype IDs.
+    m_genre = StringUtils::Split(
+        CPVREpg::ConvertGenreIdToString(iGenreType, iGenreSubType),
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
   }
 }
 

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -138,35 +138,10 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
     return true;
 
   CSingleLock lock(m_critSection);
-  return (m_iDatabaseID == right.m_iDatabaseID &&
-          m_iGenreType == right.m_iGenreType &&
-          m_iGenreSubType == right.m_iGenreSubType &&
-          m_iParentalRating == right.m_iParentalRating &&
-          m_firstAired == right.m_firstAired &&
-          m_iStarRating == right.m_iStarRating &&
-          m_iSeriesNumber == right.m_iSeriesNumber &&
-          m_iEpisodeNumber == right.m_iEpisodeNumber &&
-          m_iEpisodePart == right.m_iEpisodePart &&
-          m_iUniqueBroadcastID == right.m_iUniqueBroadcastID &&
-          m_strTitle == right.m_strTitle &&
-          m_strPlotOutline == right.m_strPlotOutline &&
-          m_strPlot == right.m_strPlot &&
-          m_strOriginalTitle == right.m_strOriginalTitle &&
-          m_cast == right.m_cast &&
-          m_directors == right.m_directors &&
-          m_writers == right.m_writers &&
-          m_iYear == right.m_iYear &&
-          m_strIMDBNumber == right.m_strIMDBNumber &&
-          m_genre == right.m_genre &&
-          m_strEpisodeName == right.m_strEpisodeName &&
-          m_iEpgID == right.m_iEpgID &&
-          m_strIconPath == right.m_strIconPath &&
-          m_strFileNameAndPath == right.m_strFileNameAndPath &&
-          m_startTime == right.m_startTime &&
-          m_endTime == right.m_endTime &&
-          m_iFlags == right.m_iFlags &&
-          m_strSeriesLink == right.m_strSeriesLink &&
-          m_channelData == right.m_channelData);
+  return (m_iUniqueBroadcastID == right.m_iUniqueBroadcastID && m_channelData &&
+          right.m_channelData &&
+          m_channelData->UniqueClientChannelId() == right.m_channelData->UniqueClientChannelId() &&
+          m_channelData->ClientId() == right.m_channelData->ClientId());
 }
 
 bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
-#include "cores/DataCacheCore.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClient.h"
@@ -197,17 +196,12 @@ int CPVREpgInfoTag::ClientID() const
 
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
 {
-  if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingChannel(ClientID(), UniqueChannelID()))
-  {
-    // start time valid?
-    time_t startTime = CServiceBroker::GetDataCacheCore().GetStartTime();
-    if (startTime > 0)
-    {
-      return CDateTime(startTime + CServiceBroker::GetDataCacheCore().GetPlayTime() / 1000);
-    }
-  }
-
-  return CDateTime::GetUTCDateTime();
+  const std::shared_ptr<CPVRPlaybackState> playbackState =
+      CServiceBroker::GetPVRManager().PlaybackState();
+  if (playbackState && playbackState->IsPlayingChannel(ClientID(), UniqueChannelID()))
+    return playbackState->GetPlaybackTime();
+  else
+    return CDateTime::GetUTCDateTime();
 }
 
 bool CPVREpgInfoTag::IsActive() const

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -27,7 +27,7 @@ namespace PVR
   class CPVREpgInfoTag final : public ISerializable,
                                public std::enable_shared_from_this<CPVREpgInfoTag>
   {
-    friend class CPVREpg;
+    friend class CPVREpgTagsContainer;
     friend class CPVREpgDatabase;
 
   public:

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -27,7 +27,6 @@ namespace PVR
   class CPVREpgInfoTag final : public ISerializable,
                                public std::enable_shared_from_this<CPVREpgInfoTag>
   {
-    friend class CPVREpgTagsContainer;
     friend class CPVREpgDatabase;
 
   public:

--- a/xbmc/pvr/epg/EpgSearchData.cpp
+++ b/xbmc/pvr/epg/EpgSearchData.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpgSearchData.h"
+
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "utils/log.h"
+
+using namespace PVR;
+
+void PVREpgSearchData::Reset()
+{
+  m_strSearchTerm.clear();
+  m_bSearchInDescription = false;
+  m_iGenreType = EPG_SEARCH_UNSET;
+
+  m_startDateTime.SetFromUTCDateTime(
+      CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate());
+  if (!m_startDateTime.IsValid())
+  {
+    CLog::Log(LOGWARNING, "No valid epg start time. Defaulting search start time to 'now'");
+    m_startDateTime.SetFromUTCDateTime(CDateTime::GetUTCDateTime()); // default to 'now'
+  }
+
+  m_endDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate());
+  if (!m_endDateTime.IsValid())
+  {
+    CLog::Log(
+        LOGWARNING,
+        "No valid epg end time. Defaulting search end time to search start time plus 10 days");
+    m_endDateTime.SetFromUTCDateTime(m_startDateTime +
+                                     CDateTimeSpan(10, 0, 0, 0)); // default to start + 10 days
+  }
+
+  m_iUniqueBroadcastId = EPG_TAG_INVALID_UID;
+}

--- a/xbmc/pvr/epg/EpgSearchData.h
+++ b/xbmc/pvr/epg/EpgSearchData.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "XBDateTime.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+
+#include <string>
+
+namespace PVR
+{
+
+static constexpr int EPG_SEARCH_UNSET = -1;
+
+struct PVREpgSearchData
+{
+  std::string m_strSearchTerm; /*!< The term to search for */
+  bool m_bSearchInDescription = false; /*!< Search for strSearchTerm in the description too */
+  int m_iGenreType = EPG_SEARCH_UNSET; /*!< The genre type for an entry */
+  CDateTime m_startDateTime; /*!< The minimum start time for an entry */
+  CDateTime m_endDateTime; /*!< The maximum end time for an entry */
+  unsigned int m_iUniqueBroadcastId = EPG_TAG_INVALID_UID; /*!< The broadcastid to search for */
+
+  void Reset();
+};
+
+} // namespace PVR

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "pvr/channels/PVRChannelNumber.h"
+#include "pvr/epg/EpgSearchData.h"
 
 #include <memory>
 #include <string>
@@ -17,8 +18,6 @@
 
 namespace PVR
 {
-  #define EPG_SEARCH_UNSET (-1)
-
   class CPVREpgInfoTag;
 
   /** Filter to apply with on a CPVREpgInfoTag */
@@ -58,21 +57,24 @@ namespace PVR
      */
     bool IsRadio() const { return m_bIsRadio; }
 
-    const std::string& GetSearchTerm() const { return m_strSearchTerm; }
-    void SetSearchTerm(const std::string& strSearchTerm) { m_strSearchTerm = strSearchTerm; }
+    const std::string& GetSearchTerm() const { return m_searchData.m_strSearchTerm; }
+    void SetSearchTerm(const std::string& strSearchTerm)
+    {
+      m_searchData.m_strSearchTerm = strSearchTerm;
+    }
     void SetSearchPhrase(const std::string& strSearchPhrase);
 
     bool IsCaseSensitive() const { return m_bIsCaseSensitive; }
     void SetCaseSensitive(bool bIsCaseSensitive) { m_bIsCaseSensitive = bIsCaseSensitive; }
 
-    bool ShouldSearchInDescription() const { return m_bSearchInDescription; }
-    void SetSearchInDescription(bool bSearchInDescription) {m_bSearchInDescription = bSearchInDescription; }
+    bool ShouldSearchInDescription() const { return m_searchData.m_bSearchInDescription; }
+    void SetSearchInDescription(bool bSearchInDescription)
+    {
+      m_searchData.m_bSearchInDescription = bSearchInDescription;
+    }
 
-    int GetGenreType() const { return m_iGenreType; }
-    void SetGenreType(int iGenreType) { m_iGenreType = iGenreType; }
-
-    int GetGenreSubType() const { return m_iGenreSubType; }
-    void SetGenreSubType(int iGenreSubType) { m_iGenreSubType = iGenreSubType; }
+    int GetGenreType() const { return m_searchData.m_iGenreType; }
+    void SetGenreType(int iGenreType) { m_searchData.m_iGenreType = iGenreType; }
 
     int GetMinimumDuration() const { return m_iMinimumDuration; }
     void SetMinimumDuration(int iMinimumDuration) { m_iMinimumDuration = iMinimumDuration; }
@@ -80,11 +82,14 @@ namespace PVR
     int GetMaximumDuration() const { return m_iMaximumDuration; }
     void SetMaximumDuration(int iMaximumDuration) { m_iMaximumDuration = iMaximumDuration; }
 
-    const CDateTime& GetStartDateTime() const { return m_startDateTime; }
-    void SetStartDateTime(const CDateTime& startDateTime) { m_startDateTime = startDateTime; }
+    const CDateTime& GetStartDateTime() const { return m_searchData.m_startDateTime; }
+    void SetStartDateTime(const CDateTime& startDateTime)
+    {
+      m_searchData.m_startDateTime = startDateTime;
+    }
 
-    const CDateTime& GetEndDateTime() const  { return m_endDateTime; }
-    void SetEndDateTime(const CDateTime& endDateTime) { m_endDateTime = endDateTime; }
+    const CDateTime& GetEndDateTime() const { return m_searchData.m_endDateTime; }
+    void SetEndDateTime(const CDateTime& endDateTime) { m_searchData.m_endDateTime = endDateTime; }
 
     bool ShouldIncludeUnknownGenres() const { return m_bIncludeUnknownGenres; }
     void SetIncludeUnknownGenres(bool bIncludeUnknownGenres) { m_bIncludeUnknownGenres = bIncludeUnknownGenres; }
@@ -107,8 +112,14 @@ namespace PVR
     bool ShouldIgnorePresentRecordings() const { return m_bIgnorePresentRecordings; }
     void SetIgnorePresentRecordings(bool bIgnorePresentRecordings) { m_bIgnorePresentRecordings = bIgnorePresentRecordings; }
 
-    unsigned int GetUniqueBroadcastId() const { return m_iUniqueBroadcastId; }
-    void SetUniqueBroadcastId(unsigned int iUniqueBroadcastId) { m_iUniqueBroadcastId = iUniqueBroadcastId; }
+    unsigned int GetUniqueBroadcastId() const { return m_searchData.m_iUniqueBroadcastId; }
+    void SetUniqueBroadcastId(unsigned int iUniqueBroadcastId)
+    {
+      m_searchData.m_iUniqueBroadcastId = iUniqueBroadcastId;
+    }
+
+    const PVREpgSearchData& GetEpgSearchData() const { return m_searchData; }
+    void SetEpgSearchDataFiltered() { m_bEpgSearchDataFiltered = true; }
 
   private:
     bool MatchGenre(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
@@ -123,25 +134,21 @@ namespace PVR
     bool MatchTimers(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
     bool MatchRecordings(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
 
-    std::string m_strSearchTerm; /*!< The term to search for */
+    PVREpgSearchData m_searchData;
+    bool m_bEpgSearchDataFiltered = false;
+
     bool m_bIsCaseSensitive; /*!< Do a case sensitive search */
-    bool m_bSearchInDescription; /*!< Search for strSearchTerm in the description too */
-    int m_iGenreType; /*!< The genre type for an entry */
-    int m_iGenreSubType; /*!< The genre subtype for an entry */
     int m_iMinimumDuration; /*!< The minimum duration for an entry */
     int m_iMaximumDuration; /*!< The maximum duration for an entry */
-    CDateTime m_startDateTime; /*!< The minimum start time for an entry */
-    CDateTime m_endDateTime; /*!< The maximum end time for an entry */
     bool m_bIncludeUnknownGenres; /*!< Include unknown genres or not */
     bool m_bRemoveDuplicates; /*!< True to remove duplicate events, false if not */
-    const bool m_bIsRadio; /*!< True to filter radio channels only, false to tv only */
 
-    /* PVR specific filters */
+    // PVR specific filters
+    const bool m_bIsRadio; /*!< True to filter radio channels only, false to tv only */
     CPVRChannelNumber m_channelNumber; /*!< The channel number in the selected channel group */
     bool m_bFreeToAirOnly; /*!< Include free to air channels only */
     int m_iChannelGroup; /*!< The group this channel belongs to */
     bool m_bIgnorePresentTimers; /*!< True to ignore currently present timers (future recordings), false if not */
     bool m_bIgnorePresentRecordings; /*!< True to ignore currently active recordings, false if not */
-    unsigned int m_iUniqueBroadcastId; /*!< The broadcastid to search for */
   };
 }

--- a/xbmc/pvr/epg/EpgTagsCache.cpp
+++ b/xbmc/pvr/epg/EpgTagsCache.cpp
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpgTagsCache.h"
+
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/PVRPlaybackState.h"
+#include "pvr/epg/EpgDatabase.h"
+#include "pvr/epg/EpgInfoTag.h"
+#include "utils/log.h"
+
+using namespace PVR;
+
+namespace
+{
+const CDateTimeSpan ONE_SECOND(0, 0, 0, 1);
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsCache::GetLastEndedTag()
+{
+  Refresh(true);
+  return m_lastEndedTag;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsCache::GetNowActiveTag(bool bUpdateIfNeeded)
+{
+  Refresh(bUpdateIfNeeded);
+  return m_nowActiveTag;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsCache::GetNextStartingTag()
+{
+  Refresh(true);
+  return m_nextStartingTag;
+}
+
+void CPVREpgTagsCache::Reset()
+{
+  m_lastEndedTag.reset();
+
+  m_nowActiveTag.reset();
+  m_nowActiveStart.Reset();
+  m_nowActiveEnd.Reset();
+
+  m_nextStartingTag.reset();
+}
+
+void CPVREpgTagsCache::Refresh(bool bUpdateIfNeeded)
+{
+  const CDateTime activeTime = CServiceBroker::GetPVRManager().PlaybackState()->GetPlaybackTime();
+
+  if (m_nowActiveStart.IsValid() && m_nowActiveEnd.IsValid() && m_nowActiveStart <= activeTime &&
+      m_nowActiveEnd > activeTime)
+    return;
+
+  if (bUpdateIfNeeded)
+  {
+    m_lastEndedTag.reset();
+    m_nowActiveTag.reset();
+    m_nextStartingTag.reset();
+
+    for (const auto& tag : m_changedTags)
+    {
+      if (tag.second->StartAsUTC() <= activeTime && tag.second->EndAsUTC() > activeTime)
+      {
+        m_nowActiveTag = tag.second;
+        m_nowActiveStart = m_nowActiveTag->StartAsUTC();
+        m_nowActiveEnd = m_nowActiveTag->EndAsUTC();
+        break;
+      }
+    }
+
+    if (!m_nowActiveTag && m_database)
+    {
+      const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags =
+          m_database->GetEpgTagsByMinEndMaxStartTime(m_iEpgID, activeTime, activeTime);
+      if (!tags.empty())
+      {
+        if (tags.size() > 1)
+          CLog::LogF(LOGWARNING, "Got multiple results. Picking up the first.");
+
+        m_nowActiveTag = tags.front();
+        m_nowActiveTag->SetChannelData(m_channelData);
+        m_nowActiveStart = m_nowActiveTag->StartAsUTC();
+        m_nowActiveEnd = m_nowActiveTag->EndAsUTC();
+      }
+    }
+
+    RefreshLastEndedTag(activeTime);
+    RefreshNextStartingTag(activeTime);
+
+    if (!m_nowActiveTag)
+    {
+      // we're in a gap. remember start and end time of that gap to avoid unneeded db load.
+      if (m_lastEndedTag)
+        m_nowActiveStart = m_lastEndedTag->EndAsUTC() + ONE_SECOND;
+      else
+        m_nowActiveStart = activeTime - CDateTimeSpan(1000, 0, 0, 0); // fake start far in the past
+
+      if (m_nextStartingTag)
+        m_nowActiveEnd = m_nextStartingTag->StartAsUTC() - ONE_SECOND;
+      else
+        m_nowActiveEnd = activeTime + CDateTimeSpan(1000, 0, 0, 0); // fake end far in the future
+    }
+  }
+}
+
+void CPVREpgTagsCache::RefreshLastEndedTag(const CDateTime& activeTime)
+{
+  if (m_database)
+  {
+    m_lastEndedTag = m_database->GetEpgTagByMaxEndTime(m_iEpgID, activeTime - ONE_SECOND);
+    if (m_lastEndedTag)
+      m_lastEndedTag->SetChannelData(m_channelData);
+  }
+
+  for (auto it = m_changedTags.rbegin(); it != m_changedTags.rend(); ++it)
+  {
+    if (it->second->WasActive())
+    {
+      if (!m_lastEndedTag || m_lastEndedTag->EndAsUTC() < it->second->EndAsUTC())
+      {
+        m_lastEndedTag = it->second;
+        break;
+      }
+    }
+  }
+}
+
+void CPVREpgTagsCache::RefreshNextStartingTag(const CDateTime& activeTime)
+{
+  if (m_database)
+  {
+    m_nextStartingTag = m_database->GetEpgTagByMinStartTime(m_iEpgID, activeTime + ONE_SECOND);
+    if (m_nextStartingTag)
+      m_nextStartingTag->SetChannelData(m_channelData);
+  }
+
+  for (const auto& tag : m_changedTags)
+  {
+    if (tag.second->IsUpcoming())
+    {
+      if (!m_nextStartingTag || m_nextStartingTag->StartAsUTC() > tag.second->StartAsUTC())
+      {
+        m_nextStartingTag = tag.second;
+        break;
+      }
+    }
+  }
+}

--- a/xbmc/pvr/epg/EpgTagsCache.h
+++ b/xbmc/pvr/epg/EpgTagsCache.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "XBDateTime.h"
+
+#include <map>
+#include <memory>
+
+namespace PVR
+{
+class CPVREpgChannelData;
+class CPVREpgDatabase;
+class CPVREpgInfoTag;
+
+class CPVREpgTagsCache
+{
+public:
+  CPVREpgTagsCache() = delete;
+  CPVREpgTagsCache(int iEpgID,
+                   const std::shared_ptr<CPVREpgChannelData>& channelData,
+                   const std::shared_ptr<CPVREpgDatabase>& database,
+                   const std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>>& changedTags)
+    : m_iEpgID(iEpgID), m_channelData(channelData), m_database(database), m_changedTags(changedTags)
+  {
+  }
+
+  void Reset();
+
+  std::shared_ptr<CPVREpgInfoTag> GetLastEndedTag();
+  std::shared_ptr<CPVREpgInfoTag> GetNowActiveTag(bool bUpdateIfNeeded);
+  std::shared_ptr<CPVREpgInfoTag> GetNextStartingTag();
+
+private:
+  void Refresh(bool bUpdateIfNeeded);
+  void RefreshLastEndedTag(const CDateTime& activeTime);
+  void RefreshNextStartingTag(const CDateTime& activeTime);
+
+  int m_iEpgID;
+  std::shared_ptr<CPVREpgChannelData> m_channelData;
+  std::shared_ptr<CPVREpgDatabase> m_database;
+  const std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>>& m_changedTags;
+
+  std::shared_ptr<CPVREpgInfoTag> m_lastEndedTag;
+  std::shared_ptr<CPVREpgInfoTag> m_nowActiveTag;
+  std::shared_ptr<CPVREpgInfoTag> m_nextStartingTag;
+
+  CDateTime m_nowActiveStart;
+  CDateTime m_nowActiveEnd;
+};
+
+} // namespace PVR

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -1,0 +1,430 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpgTagsContainer.h"
+
+#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "pvr/epg/EpgDatabase.h"
+#include "pvr/epg/EpgInfoTag.h"
+#include "utils/log.h"
+
+using namespace PVR;
+
+void CPVREpgTagsContainer::SetEpgID(int iEpgID)
+{
+  m_iEpgID = iEpgID;
+  for (const auto& tag : m_tags)
+    tag.second->SetEpgID(iEpgID);
+}
+
+void CPVREpgTagsContainer::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
+{
+  m_channelData = data;
+  for (const auto& tag : m_tags)
+    tag.second->SetChannelData(data);
+}
+
+bool CPVREpgTagsContainer::UpdateEntries(const CPVREpgTagsContainer& tags, bool bUpdateDatabase)
+{
+  for (const auto& tag : tags.m_tags)
+    UpdateEntry(tag.second, bUpdateDatabase);
+
+  FixOverlappingEvents(bUpdateDatabase);
+
+  return true;
+}
+
+bool CPVREpgTagsContainer::FixOverlappingEvents(bool bUpdateDatabase)
+{
+  bool bReturn = false;
+  std::shared_ptr<CPVREpgInfoTag> previousTag, currentTag;
+
+  for (auto it = m_tags.begin(); it != m_tags.end(); it != m_tags.end() ? it++ : it)
+  {
+    if (!previousTag)
+    {
+      previousTag = it->second;
+      continue;
+    }
+    currentTag = it->second;
+
+    if (previousTag->EndAsUTC() >= currentTag->EndAsUTC())
+    {
+      // delete the current tag. it's completely overlapped
+      if (bUpdateDatabase)
+        m_deletedTags.insert(std::make_pair(currentTag->UniqueBroadcastID(), currentTag));
+
+      if (m_nowActiveStart == it->first)
+        m_nowActiveStart.SetValid(false);
+
+      m_tags.erase(it++);
+    }
+    else if (previousTag->EndAsUTC() > currentTag->StartAsUTC())
+    {
+      previousTag->SetEndFromUTC(currentTag->StartAsUTC());
+      if (bUpdateDatabase)
+        m_changedTags.insert(std::make_pair(previousTag->UniqueBroadcastID(), previousTag));
+
+      previousTag = it->second;
+    }
+    else
+    {
+      previousTag = it->second;
+    }
+  }
+
+  return bReturn;
+}
+
+void CPVREpgTagsContainer::AddEntry(const CPVREpgInfoTag& tag)
+{
+  std::shared_ptr<CPVREpgInfoTag> newTag = GetTag(tag.StartAsUTC());
+  if (!newTag)
+  {
+    newTag.reset(new CPVREpgInfoTag());
+    m_tags.insert({tag.StartAsUTC(), newTag});
+  }
+
+  newTag->Update(tag);
+  newTag->SetChannelData(m_channelData);
+  newTag->SetEpgID(m_iEpgID);
+}
+
+bool CPVREpgTagsContainer::UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag,
+                                       bool bUpdateDatabase)
+{
+  bool bNewTag = false;
+
+  std::shared_ptr<CPVREpgInfoTag> infoTag = GetTag(tag->StartAsUTC());
+  if (!infoTag)
+  {
+    infoTag.reset(new CPVREpgInfoTag());
+    infoTag->SetUniqueBroadcastID(tag->UniqueBroadcastID());
+    m_tags.insert({tag->StartAsUTC(), infoTag});
+    bNewTag = true;
+  }
+
+  infoTag->Update(*tag, bNewTag);
+  infoTag->SetChannelData(m_channelData);
+  infoTag->SetEpgID(m_iEpgID);
+
+  if (bUpdateDatabase)
+    m_changedTags.insert({infoTag->UniqueBroadcastID(), infoTag});
+
+  return true;
+}
+
+bool CPVREpgTagsContainer::DeleteEntry(const std::shared_ptr<CPVREpgInfoTag>& tag,
+                                       bool bUpdateDatabase)
+{
+  if (m_tags.erase(tag->StartAsUTC()) > 0)
+  {
+    if (bUpdateDatabase)
+      m_deletedTags.insert(std::make_pair(tag->UniqueBroadcastID(), tag));
+
+    if (m_nowActiveStart == tag->StartAsUTC())
+      m_nowActiveStart.SetValid(false);
+
+    return true;
+  }
+  return false;
+}
+
+void CPVREpgTagsContainer::Cleanup(const CDateTime& time)
+{
+  for (auto it = m_tags.begin(); it != m_tags.end();)
+  {
+    if (it->second->EndAsUTC() < time)
+    {
+      if (m_nowActiveStart == it->first)
+        m_nowActiveStart.SetValid(false);
+
+      it = m_tags.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+void CPVREpgTagsContainer::Clear()
+{
+  m_tags.clear();
+}
+
+bool CPVREpgTagsContainer::IsEmpty() const
+{
+  return m_tags.empty();
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTag(const CDateTime& time) const
+{
+  const auto it = m_tags.find(time);
+  if (it == m_tags.cend())
+    return {};
+
+  return (*it).second;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTag(unsigned int iUniqueBroadcastId) const
+{
+  if (iUniqueBroadcastId != EPG_TAG_INVALID_UID)
+  {
+    for (const auto& tag : m_tags)
+    {
+      if (tag.second->UniqueBroadcastID() == iUniqueBroadcastId)
+        return tag.second;
+    }
+  }
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTagBetween(const CDateTime& start,
+                                                                    const CDateTime& end) const
+{
+  for (const auto& tag : m_tags)
+  {
+    if (tag.second->StartAsUTC() >= start)
+    {
+      if (tag.second->EndAsUTC() <= end)
+        return tag.second;
+      else
+        break;
+    }
+  }
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetActiveTag(bool bUpdateIfNeeded) const
+{
+  if (m_nowActiveStart.IsValid())
+  {
+    const auto it = m_tags.find(m_nowActiveStart);
+    if (it != m_tags.end() && it->second->IsActive())
+      return it->second;
+  }
+
+  if (bUpdateIfNeeded)
+  {
+    std::shared_ptr<CPVREpgInfoTag> lastActiveTag;
+
+    // one of the first items will always match if the list is sorted
+    for (const auto& tag : m_tags)
+    {
+      if (tag.second->IsActive())
+      {
+        m_nowActiveStart = tag.first;
+        return tag.second;
+      }
+      else if (tag.second->WasActive())
+        lastActiveTag = tag.second;
+    }
+
+    // there might be a gap between the last and next event. return the last if found and it
+    // ended not more than 5 minutes ago
+    if (lastActiveTag &&
+        lastActiveTag->EndAsUTC() + CDateTimeSpan(0, 0, 5, 0) >= CDateTime::GetUTCDateTime())
+      return lastActiveTag;
+  }
+
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetLastEndedTag() const
+{
+  for (auto it = m_tags.rbegin(); it != m_tags.rend(); ++it)
+  {
+    if (it->second->WasActive())
+      return it->second;
+  }
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetFirstUpcomingTag() const
+{
+  for (const auto& tag : m_tags)
+  {
+    if (tag.second->IsUpcoming())
+      return tag.second;
+  }
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetPredecessor(
+    const std::shared_ptr<CPVREpgInfoTag>& tag) const
+{
+  auto it = m_tags.find(tag->StartAsUTC());
+  if (it != m_tags.end() && it != m_tags.begin())
+  {
+    --it;
+    return it->second;
+  }
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetSuccessor(
+    const std::shared_ptr<CPVREpgInfoTag>& tag) const
+{
+  auto it = m_tags.find(tag->StartAsUTC());
+  if (it != m_tags.end() && ++it != m_tags.end())
+    return it->second;
+
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetFirstTag() const
+{
+  if (m_tags.empty())
+    return {};
+
+  return m_tags.cbegin()->second;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetLastTag() const
+{
+  if (m_tags.empty())
+    return {};
+
+  return m_tags.crbegin()->second;
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::CreateGapTag(const CDateTime& start,
+                                                                   const CDateTime& end) const
+{
+  return std::make_shared<CPVREpgInfoTag>(m_channelData, m_iEpgID, start, end, true);
+}
+
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetTimeline(
+    const CDateTime& timelineStart,
+    const CDateTime& timelineEnd,
+    const CDateTime& minEventEnd,
+    const CDateTime& maxEventStart) const
+{
+  static const CDateTimeSpan ONE_SECOND(0, 0, 0, 1);
+
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
+
+  CDateTime lastEnd = minEventEnd;
+  for (const auto& epgTag : m_tags)
+  {
+    if (epgTag.second->EndAsUTC() > minEventEnd)
+    {
+      const CDateTime start = epgTag.second->StartAsUTC();
+
+      if (start <= maxEventStart)
+      {
+        if (start > minEventEnd && (start - lastEnd) > ONE_SECOND &&
+            epgTag.second != (*m_tags.cbegin()).second)
+        {
+          // insert gap tag between two events
+          tags.emplace_back(CreateGapTag(lastEnd, start - ONE_SECOND));
+        }
+
+        tags.emplace_back(epgTag.second);
+      }
+      else
+      {
+        if (tags.empty())
+        {
+          if (epgTag.second != (*m_tags.cbegin()).second)
+          {
+            // insert gap tag spanning pred of last checked event end to next event start
+            tags.emplace_back(CreateGapTag(lastEnd, start - ONE_SECOND));
+          }
+        }
+        else
+        {
+          if (maxEventStart >= tags.back()->EndAsUTC() && (start - ONE_SECOND) <= timelineEnd)
+          {
+            // append gap tag spanning last found event end to next event start
+            tags.emplace_back(CreateGapTag(tags.back()->EndAsUTC(), start - ONE_SECOND));
+          }
+
+          if (minEventEnd <= tags.front()->StartAsUTC() - ONE_SECOND &&
+              tags.front() != (*m_tags.cbegin()).second)
+          {
+            // prepend gap tag spanning pred of first found event end to first found event start
+            tags.insert(tags.begin(),
+                        CreateGapTag(lastEnd, tags.front()->StartAsUTC() - ONE_SECOND));
+          }
+        }
+        break; // done. m_tags is sorted by date, ascending
+      }
+    }
+    lastEnd = epgTag.second->EndAsUTC();
+  }
+
+  if (tags.empty())
+  {
+    if (m_tags.empty())
+    {
+      // insert gap tag spanning whole timeline
+      tags.emplace_back(CreateGapTag(timelineStart, timelineEnd));
+    }
+    else if (maxEventStart <= (*m_tags.cbegin()).second->StartAsUTC())
+    {
+      // insert gap tag spanning timeline start to very first event start
+      tags.emplace_back(
+          CreateGapTag(timelineStart, (*m_tags.cbegin()).second->StartAsUTC() - ONE_SECOND));
+    }
+    else if (minEventEnd >= (*m_tags.crbegin()).second->EndAsUTC())
+    {
+      // insert gap tag spanning very last event end to timeline end
+      tags.emplace_back(CreateGapTag((*m_tags.crbegin()).second->EndAsUTC(), timelineEnd));
+    }
+    else
+    {
+      CLog::LogF(LOGERROR, "Could not find any epgtag for requested timeline");
+    }
+  }
+  else
+  {
+    if (tags.front() == (*m_tags.cbegin()).second && tags.front()->StartAsUTC() >= minEventEnd)
+    {
+      // prepend gap tag spanning timeline start to very first event start
+      tags.insert(tags.begin(), CreateGapTag(timelineStart,
+                                             (*m_tags.cbegin()).second->StartAsUTC() - ONE_SECOND));
+    }
+
+    if (tags.back() == (*m_tags.crbegin()).second && tags.back()->EndAsUTC() <= maxEventStart)
+    {
+      // append gap tag spanning very last event end to timeline end
+      tags.emplace_back(CreateGapTag((*m_tags.crbegin()).second->EndAsUTC(), timelineEnd));
+    }
+  }
+
+  return tags;
+}
+
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetAllTags() const
+{
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
+
+  for (const auto& tag : m_tags)
+    tags.emplace_back(tag.second);
+
+  return tags;
+}
+
+bool CPVREpgTagsContainer::NeedsSave() const
+{
+  return !m_changedTags.empty() || !m_deletedTags.empty();
+}
+
+void CPVREpgTagsContainer::Persist(const std::shared_ptr<CPVREpgDatabase>& database)
+{
+  for (const auto& tag : m_deletedTags)
+    database->Delete(*tag.second);
+
+  for (const auto& tag : m_changedTags)
+    tag.second->Persist(database, false);
+
+  m_deletedTags.clear();
+  m_changedTags.clear();
+}

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -227,7 +227,6 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::CreateEntry(
   if (tag)
   {
     tag->SetChannelData(m_channelData);
-    tag->SetEpgID(m_iEpgID);
   }
   return tag;
 }
@@ -238,7 +237,6 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::CreateEntries
   for (auto& tag : tags)
   {
     tag->SetChannelData(m_channelData);
-    tag->SetEpgID(m_iEpgID);
   }
   return tags;
 }

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -11,165 +11,344 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
 #include "pvr/epg/EpgDatabase.h"
 #include "pvr/epg/EpgInfoTag.h"
+#include "pvr/epg/EpgTagsCache.h"
 #include "utils/log.h"
 
 using namespace PVR;
 
+namespace
+{
+const CDateTimeSpan ONE_SECOND(0, 0, 0, 1);
+}
+
+CPVREpgTagsContainer::CPVREpgTagsContainer(int iEpgID,
+                                           const std::shared_ptr<CPVREpgChannelData>& channelData,
+                                           const std::shared_ptr<CPVREpgDatabase>& database)
+  : m_iEpgID(iEpgID),
+    m_channelData(channelData),
+    m_database(database),
+    m_tagsCache(new CPVREpgTagsCache(iEpgID, channelData, database, m_changedTags))
+{
+}
+
+CPVREpgTagsContainer::~CPVREpgTagsContainer() = default;
+
 void CPVREpgTagsContainer::SetEpgID(int iEpgID)
 {
   m_iEpgID = iEpgID;
-  for (const auto& tag : m_tags)
+  for (const auto& tag : m_changedTags)
     tag.second->SetEpgID(iEpgID);
 }
 
 void CPVREpgTagsContainer::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
 {
   m_channelData = data;
-  for (const auto& tag : m_tags)
+  for (const auto& tag : m_changedTags)
     tag.second->SetChannelData(data);
 }
 
+namespace
+{
+
+void ResolveConflictingTags(const std::shared_ptr<CPVREpgInfoTag>& changedTag,
+                            std::vector<std::shared_ptr<CPVREpgInfoTag>>& tags)
+{
+  const CDateTime changedTagStart = changedTag->StartAsUTC();
+  const CDateTime changedTagEnd = changedTag->EndAsUTC();
+
+  for (auto it = tags.begin(); it != tags.end();)
+  {
+    bool bInsert = false;
+
+    if (changedTagEnd > (*it)->StartAsUTC() && changedTagStart < (*it)->EndAsUTC())
+    {
+      it = tags.erase(it);
+
+      if (it == tags.end())
+      {
+        bInsert = true;
+      }
+    }
+    else if ((*it)->StartAsUTC() >= changedTagEnd)
+    {
+      bInsert = true;
+    }
+    else
+    {
+      ++it;
+    }
+
+    if (bInsert)
+    {
+      tags.emplace(it, changedTag);
+      break;
+    }
+  }
+}
+
+} // unnamed namespace
+
 bool CPVREpgTagsContainer::UpdateEntries(const CPVREpgTagsContainer& tags)
 {
-  for (const auto& tag : tags.m_tags)
-    UpdateEntry(tag.second);
+  if (tags.m_changedTags.empty())
+    return false;
 
-  FixOverlappingEvents();
+  if (m_database)
+  {
+    const CDateTime minEventEnd = (*tags.m_changedTags.cbegin()).second->StartAsUTC();
+    const CDateTime maxEventStart = (*tags.m_changedTags.crbegin()).second->EndAsUTC();
+
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> existingTags =
+        m_database->GetEpgTagsByMinEndMaxStartTime(m_iEpgID, minEventEnd, maxEventStart);
+
+    if (!m_changedTags.empty())
+    {
+      // Fix data inconsistencies
+      for (const auto& changedTagsEntry : m_changedTags)
+      {
+        const auto& changedTag = changedTagsEntry.second;
+
+        if (changedTag->EndAsUTC() > minEventEnd && changedTag->StartAsUTC() <= maxEventStart)
+        {
+          // tag is in queried range, thus it could cause inconsistencies...
+          ResolveConflictingTags(changedTag, existingTags);
+        }
+      }
+    }
+
+    bool bResetCache = false;
+    for (const auto& tagsEntry : tags.m_changedTags)
+    {
+      const auto& tag = tagsEntry.second;
+
+      tag->SetChannelData(m_channelData);
+      tag->SetEpgID(m_iEpgID);
+
+      std::shared_ptr<CPVREpgInfoTag> existingTag;
+      for (const auto& t : existingTags)
+      {
+        if (t->StartAsUTC() == tag->StartAsUTC())
+        {
+          existingTag = t;
+          break;
+        }
+      }
+
+      if (existingTag)
+      {
+        existingTag->SetChannelData(m_channelData);
+        existingTag->SetEpgID(m_iEpgID);
+
+        if (existingTag->Update(*tag, false))
+        {
+          // tag differs from existing tag and must be persisted
+          m_changedTags.insert({existingTag->StartAsUTC(), existingTag});
+          bResetCache = true;
+        }
+      }
+      else
+      {
+        // new tags must always be persisted
+        m_changedTags.insert({tag->StartAsUTC(), tag});
+        bResetCache = true;
+      }
+    }
+
+    if (bResetCache)
+      m_tagsCache.reset();
+  }
+  else
+  {
+    for (const auto& tag : tags.m_changedTags)
+      UpdateEntry(tag.second);
+  }
 
   return true;
 }
 
-bool CPVREpgTagsContainer::FixOverlappingEvents()
+void CPVREpgTagsContainer::FixOverlappingEvents(
+    std::vector<std::shared_ptr<CPVREpgInfoTag>>& tags) const
 {
-  bool bReturn = false;
-  std::shared_ptr<CPVREpgInfoTag> previousTag, currentTag;
-
-  for (auto it = m_tags.begin(); it != m_tags.end(); it != m_tags.end() ? it++ : it)
+  std::shared_ptr<CPVREpgInfoTag> previousTag;
+  for (auto it = tags.begin(); it != tags.end();)
   {
+    const std::shared_ptr<CPVREpgInfoTag> currentTag = *it;
     if (!previousTag)
     {
-      previousTag = it->second;
+      previousTag = currentTag;
+      ++it;
       continue;
     }
-    currentTag = it->second;
 
     if (previousTag->EndAsUTC() >= currentTag->EndAsUTC())
     {
       // delete the current tag. it's completely overlapped
-      m_deletedTags.insert(std::make_pair(currentTag->UniqueBroadcastID(), currentTag));
+      CLog::LogF(LOGWARNING,
+                 "Erasing completely overlapped event from EPG timeline "
+                 "(%u - %s - %s - %s) "
+                 "(%u - %s - %s - %s).",
+                 previousTag->UniqueBroadcastID(), previousTag->Title().c_str(),
+                 previousTag->StartAsUTC().GetAsDBDateTime(),
+                 previousTag->EndAsUTC().GetAsDBDateTime(), currentTag->UniqueBroadcastID(),
+                 currentTag->Title().c_str(), currentTag->StartAsUTC().GetAsDBDateTime(),
+                 currentTag->EndAsUTC().GetAsDBDateTime());
 
-      if (m_nowActiveStart == it->first)
-        m_nowActiveStart.SetValid(false);
-
-      m_tags.erase(it++);
+      it = tags.erase(it);
+      m_tagsCache->Reset();
     }
     else if (previousTag->EndAsUTC() > currentTag->StartAsUTC())
     {
-      previousTag->SetEndFromUTC(currentTag->StartAsUTC());
-      m_changedTags.insert(std::make_pair(previousTag->UniqueBroadcastID(), previousTag));
+      // fix the end time of the predecessor of the event
+      CLog::LogF(LOGWARNING,
+                 "Fixing partly overlapped event in EPG timeline "
+                 "(%u - %s - %s - %s) "
+                 "(%u - %s - %s - %s).",
+                 previousTag->UniqueBroadcastID(), previousTag->Title().c_str(),
+                 previousTag->StartAsUTC().GetAsDBDateTime(),
+                 previousTag->EndAsUTC().GetAsDBDateTime(), currentTag->UniqueBroadcastID(),
+                 currentTag->Title().c_str(), currentTag->StartAsUTC().GetAsDBDateTime(),
+                 currentTag->EndAsUTC().GetAsDBDateTime());
 
-      previousTag = it->second;
+      previousTag->SetEndFromUTC(currentTag->StartAsUTC() - ONE_SECOND);
+      previousTag = currentTag;
+      ++it;
     }
     else
     {
-      previousTag = it->second;
+      previousTag = currentTag;
+      ++it;
     }
   }
+}
 
-  return bReturn;
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::CreateEntry(
+    const std::shared_ptr<CPVREpgInfoTag>& tag) const
+{
+  if (tag)
+  {
+    tag->SetChannelData(m_channelData);
+    tag->SetEpgID(m_iEpgID);
+  }
+  return tag;
+}
+
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::CreateEntries(
+    const std::vector<std::shared_ptr<CPVREpgInfoTag>>& tags) const
+{
+  for (auto& tag : tags)
+  {
+    tag->SetChannelData(m_channelData);
+    tag->SetEpgID(m_iEpgID);
+  }
+  return tags;
 }
 
 bool CPVREpgTagsContainer::UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag)
 {
-  bool bNewTag = false;
+  tag->SetChannelData(m_channelData);
+  tag->SetEpgID(m_iEpgID);
 
-  std::shared_ptr<CPVREpgInfoTag> infoTag = GetTag(tag->StartAsUTC());
-  if (!infoTag)
+  std::shared_ptr<CPVREpgInfoTag> existingTag = GetTag(tag->StartAsUTC());
+  if (existingTag)
   {
-    infoTag.reset(new CPVREpgInfoTag());
-    infoTag->SetUniqueBroadcastID(tag->UniqueBroadcastID());
-    m_tags.insert({tag->StartAsUTC(), infoTag});
-    bNewTag = true;
+    if (existingTag->Update(*tag, false))
+    {
+      // tag differs from existing tag and must be persisted
+      m_changedTags.insert({existingTag->StartAsUTC(), existingTag});
+      m_tagsCache->Reset();
+    }
+  }
+  else
+  {
+    // new tags must always be persisted
+    m_changedTags.insert({tag->StartAsUTC(), tag});
+    m_tagsCache->Reset();
   }
 
-  infoTag->Update(*tag, bNewTag);
-  infoTag->SetChannelData(m_channelData);
-  infoTag->SetEpgID(m_iEpgID);
-
-  m_changedTags.insert({infoTag->UniqueBroadcastID(), infoTag});
   return true;
 }
 
 bool CPVREpgTagsContainer::DeleteEntry(const std::shared_ptr<CPVREpgInfoTag>& tag)
 {
-  if (m_tags.erase(tag->StartAsUTC()) > 0)
-  {
-    m_deletedTags.insert({tag->UniqueBroadcastID(), tag});
-
-    if (m_nowActiveStart == tag->StartAsUTC())
-      m_nowActiveStart.SetValid(false);
-
-    return true;
-  }
-  return false;
+  m_changedTags.erase(tag->StartAsUTC());
+  m_deletedTags.insert({tag->StartAsUTC(), tag});
+  m_tagsCache->Reset();
+  return true;
 }
 
 void CPVREpgTagsContainer::Cleanup(const CDateTime& time)
 {
-  for (auto it = m_tags.begin(); it != m_tags.end();)
+  for (auto it = m_changedTags.begin(); it != m_changedTags.end();)
   {
     if (it->second->EndAsUTC() < time)
     {
-      m_deletedTags.insert({it->second->UniqueBroadcastID(), it->second});
+      m_tagsCache->Reset();
 
-      if (m_nowActiveStart == it->first)
-        m_nowActiveStart.SetValid(false);
+      const auto it1 = m_deletedTags.find(it->first);
+      if (it1 != m_deletedTags.end())
+        m_deletedTags.erase(it1);
 
-      it = m_tags.erase(it);
+      it = m_changedTags.erase(it);
     }
     else
     {
       ++it;
     }
   }
+
+  if (m_database)
+    m_database->DeleteEpgTags(m_iEpgID, time);
 }
 
 void CPVREpgTagsContainer::Clear()
 {
-  m_tags.clear();
+  m_changedTags.clear();
 }
 
 bool CPVREpgTagsContainer::IsEmpty() const
 {
-  return m_tags.empty();
+  if (!m_changedTags.empty())
+    return false;
+
+  if (m_database)
+    return !m_database->GetFirstStartTime(m_iEpgID).IsValid();
+
+  return true;
 }
 
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTag(const CDateTime& time) const
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTag(const CDateTime& startTime) const
 {
-  const auto it = m_tags.find(time);
-  if (it == m_tags.cend())
+  const auto it = m_changedTags.find(startTime);
+  if (it != m_changedTags.cend())
+    return (*it).second;
+
+  if (m_database)
+    return CreateEntry(m_database->GetEpgTagByStartTime(m_iEpgID, startTime));
+
+  return {};
+}
+
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTag(unsigned int iUniqueBroadcastID) const
+{
+  if (iUniqueBroadcastID == EPG_TAG_INVALID_UID)
     return {};
 
-  return (*it).second;
-}
-
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTag(unsigned int iUniqueBroadcastId) const
-{
-  if (iUniqueBroadcastId != EPG_TAG_INVALID_UID)
+  for (const auto& tag : m_changedTags)
   {
-    for (const auto& tag : m_tags)
-    {
-      if (tag.second->UniqueBroadcastID() == iUniqueBroadcastId)
-        return tag.second;
-    }
+    if (tag.second->UniqueBroadcastID() == iUniqueBroadcastID)
+      return tag.second;
   }
+
+  if (m_database)
+    return CreateEntry(m_database->GetEpgTagByUniqueBroadcastID(m_iEpgID, iUniqueBroadcastID));
+
   return {};
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTagBetween(const CDateTime& start,
                                                                     const CDateTime& end) const
 {
-  for (const auto& tag : m_tags)
+  for (const auto& tag : m_changedTags)
   {
     if (tag.second->StartAsUTC() >= start)
     {
@@ -179,100 +358,36 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetTagBetween(const CDateT
         break;
     }
   }
+
+  if (m_database)
+  {
+    const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags =
+        CreateEntries(m_database->GetEpgTagsByMinStartMaxEndTime(m_iEpgID, start, end));
+    if (!tags.empty())
+    {
+      if (tags.size() > 1)
+        CLog::LogF(LOGWARNING, "Got multiple tags. Picking up the first.");
+
+      return tags.front();
+    }
+  }
+
   return {};
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetActiveTag(bool bUpdateIfNeeded) const
 {
-  if (m_nowActiveStart.IsValid())
-  {
-    const auto it = m_tags.find(m_nowActiveStart);
-    if (it != m_tags.end() && it->second->IsActive())
-      return it->second;
-  }
-
-  if (bUpdateIfNeeded)
-  {
-    std::shared_ptr<CPVREpgInfoTag> lastActiveTag;
-
-    // one of the first items will always match if the list is sorted
-    for (const auto& tag : m_tags)
-    {
-      if (tag.second->IsActive())
-      {
-        m_nowActiveStart = tag.first;
-        return tag.second;
-      }
-      else if (tag.second->WasActive())
-        lastActiveTag = tag.second;
-    }
-
-    // there might be a gap between the last and next event. return the last if found and it
-    // ended not more than 5 minutes ago
-    if (lastActiveTag &&
-        lastActiveTag->EndAsUTC() + CDateTimeSpan(0, 0, 5, 0) >= CDateTime::GetUTCDateTime())
-      return lastActiveTag;
-  }
-
-  return {};
+  return m_tagsCache->GetNowActiveTag(bUpdateIfNeeded);
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetLastEndedTag() const
 {
-  for (auto it = m_tags.rbegin(); it != m_tags.rend(); ++it)
-  {
-    if (it->second->WasActive())
-      return it->second;
-  }
-  return {};
+  return m_tagsCache->GetLastEndedTag();
 }
 
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetFirstUpcomingTag() const
+std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetNextStartingTag() const
 {
-  for (const auto& tag : m_tags)
-  {
-    if (tag.second->IsUpcoming())
-      return tag.second;
-  }
-  return {};
-}
-
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetPredecessor(
-    const std::shared_ptr<CPVREpgInfoTag>& tag) const
-{
-  auto it = m_tags.find(tag->StartAsUTC());
-  if (it != m_tags.end() && it != m_tags.begin())
-  {
-    --it;
-    return it->second;
-  }
-  return {};
-}
-
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetSuccessor(
-    const std::shared_ptr<CPVREpgInfoTag>& tag) const
-{
-  auto it = m_tags.find(tag->StartAsUTC());
-  if (it != m_tags.end() && ++it != m_tags.end())
-    return it->second;
-
-  return {};
-}
-
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetFirstTag() const
-{
-  if (m_tags.empty())
-    return {};
-
-  return m_tags.cbegin()->second;
-}
-
-std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::GetLastTag() const
-{
-  if (m_tags.empty())
-    return {};
-
-  return m_tags.crbegin()->second;
+  return m_tagsCache->GetNextStartingTag();
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsContainer::CreateGapTag(const CDateTime& start,
@@ -287,110 +402,175 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetTimeline(
     const CDateTime& minEventEnd,
     const CDateTime& maxEventStart) const
 {
-  static const CDateTimeSpan ONE_SECOND(0, 0, 0, 1);
-
-  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
-
-  CDateTime lastEnd = minEventEnd;
-  for (const auto& epgTag : m_tags)
+  if (m_database)
   {
-    if (epgTag.second->EndAsUTC() > minEventEnd)
-    {
-      const CDateTime start = epgTag.second->StartAsUTC();
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
 
-      if (start <= maxEventStart)
+    if (!m_changedTags.empty() && !m_database->GetFirstStartTime(m_iEpgID).IsValid())
+    {
+      // nothing in the db yet. take what we have in memory.
+      for (const auto& tag : m_changedTags)
       {
-        if (start > minEventEnd && (start - lastEnd) > ONE_SECOND &&
-            epgTag.second != (*m_tags.cbegin()).second)
-        {
-          // insert gap tag between two events
-          tags.emplace_back(CreateGapTag(lastEnd, start - ONE_SECOND));
-        }
-
-        tags.emplace_back(epgTag.second);
+        if (tag.second->EndAsUTC() > minEventEnd && tag.second->StartAsUTC() <= maxEventStart)
+          tags.emplace_back(tag.second);
       }
-      else
-      {
-        if (tags.empty())
-        {
-          if (epgTag.second != (*m_tags.cbegin()).second)
-          {
-            // insert gap tag spanning pred of last checked event end to next event start
-            tags.emplace_back(CreateGapTag(lastEnd, start - ONE_SECOND));
-          }
-        }
-        else
-        {
-          if (maxEventStart >= tags.back()->EndAsUTC() && (start - ONE_SECOND) <= timelineEnd)
-          {
-            // append gap tag spanning last found event end to next event start
-            tags.emplace_back(CreateGapTag(tags.back()->EndAsUTC(), start - ONE_SECOND));
-          }
 
-          if (minEventEnd <= tags.front()->StartAsUTC() - ONE_SECOND &&
-              tags.front() != (*m_tags.cbegin()).second)
-          {
-            // prepend gap tag spanning pred of first found event end to first found event start
-            tags.insert(tags.begin(),
-                        CreateGapTag(lastEnd, tags.front()->StartAsUTC() - ONE_SECOND));
-          }
-        }
-        break; // done. m_tags is sorted by date, ascending
-      }
-    }
-    lastEnd = epgTag.second->EndAsUTC();
-  }
-
-  if (tags.empty())
-  {
-    if (m_tags.empty())
-    {
-      // insert gap tag spanning whole timeline
-      tags.emplace_back(CreateGapTag(timelineStart, timelineEnd));
-    }
-    else if (maxEventStart <= (*m_tags.cbegin()).second->StartAsUTC())
-    {
-      // insert gap tag spanning timeline start to very first event start
-      tags.emplace_back(
-          CreateGapTag(timelineStart, (*m_tags.cbegin()).second->StartAsUTC() - ONE_SECOND));
-    }
-    else if (minEventEnd >= (*m_tags.crbegin()).second->EndAsUTC())
-    {
-      // insert gap tag spanning very last event end to timeline end
-      tags.emplace_back(CreateGapTag((*m_tags.crbegin()).second->EndAsUTC(), timelineEnd));
+      if (!tags.empty())
+        FixOverlappingEvents(tags);
     }
     else
     {
-      CLog::LogF(LOGERROR, "Could not find any epgtag for requested timeline");
-    }
-  }
-  else
-  {
-    if (tags.front() == (*m_tags.cbegin()).second && tags.front()->StartAsUTC() >= minEventEnd)
-    {
-      // prepend gap tag spanning timeline start to very first event start
-      tags.insert(tags.begin(), CreateGapTag(timelineStart,
-                                             (*m_tags.cbegin()).second->StartAsUTC() - ONE_SECOND));
+      tags = m_database->GetEpgTagsByMinEndMaxStartTime(m_iEpgID, minEventEnd, maxEventStart);
+
+      if (!m_changedTags.empty())
+      {
+        // Fix data inconsistencies
+        for (const auto& changedTagsEntry : m_changedTags)
+        {
+          const auto& changedTag = changedTagsEntry.second;
+
+          if (changedTag->EndAsUTC() > minEventEnd && changedTag->StartAsUTC() <= maxEventStart)
+          {
+            // tag is in queried range, thus it could cause inconsistencies...
+            ResolveConflictingTags(changedTag, tags);
+          }
+        }
+      }
     }
 
-    if (tags.back() == (*m_tags.crbegin()).second && tags.back()->EndAsUTC() <= maxEventStart)
+    tags = CreateEntries(tags);
+
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> result;
+
+    for (const auto& epgTag : tags)
     {
-      // append gap tag spanning very last event end to timeline end
-      tags.emplace_back(CreateGapTag((*m_tags.crbegin()).second->EndAsUTC(), timelineEnd));
+      if (!result.empty())
+      {
+        const CDateTime currStart = epgTag->StartAsUTC();
+        const CDateTime prevEnd = result.back()->EndAsUTC();
+        if ((currStart - prevEnd) > ONE_SECOND)
+        {
+          // insert gap tag before current tag
+          result.emplace_back(CreateGapTag(prevEnd, currStart - ONE_SECOND));
+        }
+      }
+
+      result.emplace_back(epgTag);
     }
+
+    if (result.empty())
+    {
+      // create single gap tag
+      CDateTime maxEnd = m_database->GetMaxEndTime(m_iEpgID, minEventEnd);
+      if (!maxEnd.IsValid() || maxEnd < timelineStart)
+        maxEnd = timelineStart;
+
+      CDateTime minStart = m_database->GetMinStartTime(m_iEpgID, maxEventStart);
+      if (!minStart.IsValid() || minStart > timelineEnd)
+        minStart = timelineEnd;
+      else
+        minStart -= ONE_SECOND;
+
+      result.emplace_back(CreateGapTag(maxEnd, minStart));
+    }
+    else
+    {
+      if (result.front()->StartAsUTC() > minEventEnd)
+      {
+        // prepend gap tag
+        CDateTime maxEnd = m_database->GetMaxEndTime(m_iEpgID, minEventEnd);
+        if (!maxEnd.IsValid() || maxEnd < timelineStart)
+          maxEnd = timelineStart;
+
+        result.insert(result.begin(),
+                      CreateGapTag(maxEnd, result.front()->StartAsUTC() - ONE_SECOND));
+      }
+
+      if (result.back()->EndAsUTC() < maxEventStart)
+      {
+        // append gap tag
+        CDateTime minStart = m_database->GetMinStartTime(m_iEpgID, maxEventStart);
+        if (!minStart.IsValid() || minStart > timelineEnd)
+          minStart = timelineEnd;
+        else
+          minStart -= ONE_SECOND;
+
+        result.emplace_back(CreateGapTag(result.back()->EndAsUTC(), minStart));
+      }
+    }
+
+    return result;
   }
 
-  return tags;
+  return {};
 }
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetAllTags() const
 {
-  std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
+  if (m_database)
+  {
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> tags;
+    if (!m_changedTags.empty() && !m_database->GetFirstStartTime(m_iEpgID).IsValid())
+    {
+      // nothing in the db yet. take what we have in memory.
+      for (const auto& tag : m_changedTags)
+        tags.emplace_back(tag.second);
 
-  for (const auto& tag : m_tags)
-    tags.emplace_back(tag.second);
+      if (!tags.empty())
+        FixOverlappingEvents(tags);
+    }
+    else
+    {
+      tags = m_database->GetAllEpgTags(m_iEpgID);
 
-  return tags;
+      if (!m_changedTags.empty())
+      {
+        // Fix data inconsistencies
+        for (const auto& changedTagsEntry : m_changedTags)
+        {
+          ResolveConflictingTags(changedTagsEntry.second, tags);
+        }
+      }
+    }
+
+    return CreateEntries(tags);
+  }
+
+  return {};
+}
+
+CDateTime CPVREpgTagsContainer::GetFirstStartTime() const
+{
+  CDateTime result;
+
+  if (!m_changedTags.empty())
+    result = (*m_changedTags.cbegin()).second->StartAsUTC();
+
+  if (m_database)
+  {
+    const CDateTime dbResult = m_database->GetFirstStartTime(m_iEpgID);
+    if (!result.IsValid() || (dbResult.IsValid() && dbResult < result))
+      result = dbResult;
+  }
+
+  return result;
+}
+
+CDateTime CPVREpgTagsContainer::GetLastEndTime() const
+{
+  CDateTime result;
+
+  if (!m_changedTags.empty())
+    result = (*m_changedTags.crbegin()).second->EndAsUTC();
+
+  if (m_database)
+  {
+    const CDateTime dbResult = m_database->GetLastEndTime(m_iEpgID);
+    if (result.IsValid() || (dbResult.IsValid() && dbResult > result))
+      result = dbResult;
+  }
+
+  return result;
 }
 
 bool CPVREpgTagsContainer::NeedsSave() const
@@ -398,14 +578,34 @@ bool CPVREpgTagsContainer::NeedsSave() const
   return !m_changedTags.empty() || !m_deletedTags.empty();
 }
 
-void CPVREpgTagsContainer::Persist(const std::shared_ptr<CPVREpgDatabase>& database)
+void CPVREpgTagsContainer::Persist(bool bCommit)
 {
-  for (const auto& tag : m_deletedTags)
-    database->Delete(*tag.second);
+  if (m_database)
+  {
+    m_database->Lock();
 
-  for (const auto& tag : m_changedTags)
-    tag.second->Persist(database, false);
+    CLog::Log(LOGNOTICE, "EPG Tags Container: Updating %d, deleting %d events...",
+              m_changedTags.size(), m_deletedTags.size());
 
-  m_deletedTags.clear();
-  m_changedTags.clear();
+    for (const auto& tag : m_deletedTags)
+      m_database->Delete(*tag.second);
+
+    m_deletedTags.clear();
+
+    for (const auto& tag : m_changedTags)
+    {
+      // remove any conflicting events from database before persisting the new event
+      m_database->DeleteEpgTagsByMinEndMaxStartTime(m_iEpgID, tag.second->StartAsUTC(),
+                                                    tag.second->EndAsUTC() - ONE_SECOND);
+
+      tag.second->Persist(m_database, false);
+    }
+
+    m_changedTags.clear();
+
+    if (bCommit)
+      m_database->CommitInsertQueries();
+
+    m_database->Unlock();
+  }
 }

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -33,21 +33,16 @@ public:
 
   void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
 
-  void AddEntry(const CPVREpgInfoTag& tag);
-
   /*!
    * @brief Update an entry in this EPG.
    * @param tag The tag to update.
-   * @param bUpdateDatabase If set to true, this event will be persisted in the database.
-   * @param channelData ...
-   * @param iEpgID
    * @return True if it was updated successfully, false otherwise.
    */
-  bool UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bUpdateDatabase);
+  bool UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag);
 
-  bool DeleteEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bUpdateDatabase);
+  bool DeleteEntry(const std::shared_ptr<CPVREpgInfoTag>& tag);
 
-  bool UpdateEntries(const CPVREpgTagsContainer& tags, bool bUpdateDatabase);
+  bool UpdateEntries(const CPVREpgTagsContainer& tags);
 
   void Clear();
 
@@ -96,10 +91,9 @@ private:
 
   /*!
    * @brief Fix overlapping events from the tables.
-   * @param bUpdateDatabase True, to persist any changes to tags during fixup
    * @return True if anything changed, false otherwise.
    */
-  bool FixOverlappingEvents(bool bUpdateDatabase);
+  bool FixOverlappingEvents();
 
   int m_iEpgID = 0;
   std::shared_ptr<CPVREpgChannelData> m_channelData;

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "XBDateTime.h"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace PVR
+{
+class CPVREpgChannelData;
+class CPVREpgDatabase;
+class CPVREpgInfoTag;
+
+class CPVREpgTagsContainer
+{
+public:
+  CPVREpgTagsContainer() = delete;
+  CPVREpgTagsContainer(int iEpgID, const std::shared_ptr<CPVREpgChannelData>& channelData)
+    : m_iEpgID(iEpgID), m_channelData(channelData)
+  {
+  }
+
+  void SetEpgID(int iEpgID);
+
+  void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
+
+  void AddEntry(const CPVREpgInfoTag& tag);
+
+  /*!
+   * @brief Update an entry in this EPG.
+   * @param tag The tag to update.
+   * @param bUpdateDatabase If set to true, this event will be persisted in the database.
+   * @param channelData ...
+   * @param iEpgID
+   * @return True if it was updated successfully, false otherwise.
+   */
+  bool UpdateEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bUpdateDatabase);
+
+  bool DeleteEntry(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bUpdateDatabase);
+
+  bool UpdateEntries(const CPVREpgTagsContainer& tags, bool bUpdateDatabase);
+
+  void Clear();
+
+  void Cleanup(const CDateTime& time);
+
+  bool IsEmpty() const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetTag(const CDateTime& time) const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetTag(unsigned int iUniqueBroadcastId) const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetTagBetween(const CDateTime& start, const CDateTime& end) const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetActiveTag(bool bUpdateIfNeeded) const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetFirstUpcomingTag() const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetLastEndedTag() const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetPredecessor(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetSuccessor(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
+
+  std::shared_ptr<CPVREpgInfoTag> GetFirstTag() const;
+  std::shared_ptr<CPVREpgInfoTag> GetLastTag() const;
+
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> GetTimeline(const CDateTime& timelineStart,
+                                                           const CDateTime& timelineEnd,
+                                                           const CDateTime& minEventEnd,
+                                                           const CDateTime& maxEventStart) const;
+
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllTags() const;
+
+  bool NeedsSave() const;
+
+  void Persist(const std::shared_ptr<CPVREpgDatabase>& database);
+
+private:
+  /*!
+   * @brief Create a "gap" tag
+   * @param start The start time of the gap.
+   * @param end The end time of the gap.
+   * @return The tag.
+   */
+  std::shared_ptr<CPVREpgInfoTag> CreateGapTag(const CDateTime& start, const CDateTime& end) const;
+
+  /*!
+   * @brief Fix overlapping events from the tables.
+   * @param bUpdateDatabase True, to persist any changes to tags during fixup
+   * @return True if anything changed, false otherwise.
+   */
+  bool FixOverlappingEvents(bool bUpdateDatabase);
+
+  int m_iEpgID = 0;
+  std::shared_ptr<CPVREpgChannelData> m_channelData;
+  mutable CDateTime m_nowActiveStart;
+
+  std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>> m_tags;
+
+  std::map<int, std::shared_ptr<CPVREpgInfoTag>> m_changedTags;
+  std::map<int, std::shared_ptr<CPVREpgInfoTag>> m_deletedTags;
+};
+
+} // namespace PVR

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -291,7 +291,7 @@ std::string CPVRGUITimesInfo::GetEpgEventElapsedTime(const std::shared_ptr<CPVRE
 {
   int iElapsed = 0;
   CSingleLock lock(m_critSection);
-  if (epgTag && epgTag != m_playingEpgTag)
+  if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     iElapsed = epgTag->Progress();
   else
     iElapsed = GetElapsedTime();
@@ -336,7 +336,7 @@ int CPVRGUITimesInfo::GetElapsedTime() const
 int CPVRGUITimesInfo::GetRemainingTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
   CSingleLock lock(m_critSection);
-  if (epgTag && epgTag != m_playingEpgTag)
+  if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     return epgTag->GetDuration() - epgTag->Progress();
   else
     return m_iDuration - GetElapsedTime();
@@ -399,7 +399,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressBufferEnd() const
 int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
   CSingleLock lock(m_critSection);
-  if (epgTag && epgTag != m_playingEpgTag)
+  if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     return epgTag->GetDuration();
   else
     return m_iDuration;
@@ -408,7 +408,7 @@ int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>&
 int CPVRGUITimesInfo::GetEpgEventProgress(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
   CSingleLock lock(m_critSection);
-  if (epgTag && epgTag != m_playingEpgTag)
+  if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
     return std::lrintf(epgTag->ProgressPercentage());
   else
     return std::lrintf(static_cast<float>(GetElapsedTime()) / m_iDuration * 100);

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -11,7 +11,6 @@
 #include "XBDateTime.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "threads/CriticalSection.h"
-#include "threads/SystemClock.h"
 #include "utils/ISerializable.h"
 
 #include <memory>
@@ -382,6 +381,6 @@ namespace PVR
     mutable std::shared_ptr<CPVREpgInfoTag> m_epgTag; /*!< epg info tag matching m_iEpgUid. */
     mutable std::shared_ptr<CPVRChannel> m_channel;
 
-    mutable XbmcThreads::EndTime m_epTagRefetchTimeout;
+    mutable bool m_bProbedEpgTag = false;
   };
 }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -204,7 +204,6 @@ const std::string CSettings::SETTING_EPG_SELECTACTION = "epg.selectaction";
 const std::string CSettings::SETTING_EPG_HIDENOINFOAVAILABLE = "epg.hidenoinfoavailable";
 const std::string CSettings::SETTING_EPG_EPGUPDATE = "epg.epgupdate";
 const std::string CSettings::SETTING_EPG_PREVENTUPDATESWHILEPLAYINGTV = "epg.preventupdateswhileplayingtv";
-const std::string CSettings::SETTING_EPG_STOREEPGINDATABASE = "epg.storeepgindatabase";
 const std::string CSettings::SETTING_EPG_RESETEPG = "epg.resetepg";
 const std::string CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN = "pvrplayback.switchtofullscreen";
 const std::string CSettings::SETTING_PVRPLAYBACK_SIGNALQUALITY = "pvrplayback.signalquality";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -169,7 +169,6 @@ public:
   static const std::string SETTING_EPG_HIDENOINFOAVAILABLE;
   static const std::string SETTING_EPG_EPGUPDATE;
   static const std::string SETTING_EPG_PREVENTUPDATESWHILEPLAYINGTV;
-  static const std::string SETTING_EPG_STOREEPGINDATABASE;
   static const std::string SETTING_EPG_RESETEPG;
   static const std::string SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN;
   static const std::string SETTING_PVRPLAYBACK_SIGNALQUALITY;


### PR DESCRIPTION
## Description
This is followup to #16953, where I announced:

"There is only one last puzzle piece left for making the "4K channels with 30 days of EPG" story actually true. Currently, all EPG data (all channels, all days) are permanently kept in RAM. This must be changed.

I plan to change the current EPG implementation to always use Kodi's EPG database for storing tags delivered by the clients and to load EPG tags on demand into RAM (- with some intelligent caching, ofc).

I believe that fetching the tags on demand from the clients will not work - performance wise. Clients do not expect to fetch and return single tags."

This PR implements the abovementioned last missing puzzle piece.

@phunkyfish @Jalle19 your code review would be appreciated
## Motivation and Context

I want to make the "4K channels with 30 days of EPG each" story actually true. Currently, keeping all EPG data (all channels, all days) are permanently in RAM, kills this story - memory and performance wise, even on machines with beefy CPUs and lots of RAM.

I tesed whether fetching EPG tags directly from the pvr clients on demand and dropping EPG database completely does work. It doesn't - perfomance-wise.

## How Has This Been Tested?

Several weeks by my whole family, on Android, in our living room.
Additionally extensive tests on macOS, including profiling and the like.

## Screenshots (if appropriate):

Nothing changed, except setting "PVR -> EPG -> Store data in local database" got removed, because now the database will always be used.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x ] All new and existing tests passed
