### PR TITLE
Add missing cassert include

### DIFF
--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
@@ -11,6 +11,7 @@
 extern "C" {
 #include <libudev.h>
 }
+#include <cassert>
 #include <poll.h>
 #include "utils/log.h"
 


### PR DESCRIPTION
Without this include, ‘assert’ was not declared in this scope errors occur.

This issue was introduced by https://github.com/xbmc/xbmc/pull/17182

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
```
FAILED: build/platform/linux/peripherals/CMakeFiles/platform_linux_peripherals.dir/PeripheralBusUSBLibUdev.cpp.o 
/usr/lib/ccache/bin/x86_64-pc-linux-gnu-g++  -I/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999 -I/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/lib -I/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/lib/gtest/include -I/var/tmp/p
ortage/media-tv/kodi-9999/work/kodi-9999/xbmc -I/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/platform/linux -I/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer -Ibuild -I/var/tmp/portage/media-tv/kodi-99
99/work/kodi-9999/xbmc/platform/posix -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/include/python3.7m -I/usr/include/libxml2 -Ibuild/cores/RetroPlayer/messages -I/usr/include/freetype2 -I/usr/include/fribidi -Ibuild/libdvd
/include -I/usr/include/lzo -I/usr/include/libdrm  -DNDEBUG -O2 -march=native -pipe -fuse-linker-plugin -flto -Wl,-flto -ftree-vectorize -ftree-slp-vectorize -falign-functions=32 -fgraphite-identity -floop-nest-optimize -fno-lto -fno-use-
linker-plugin -ggdb -DPLATFORM_SETTINGS_FILE=x11.xml -Wall   -DTARGET_POSIX -DTARGET_LINUX -D_GNU_SOURCE -DHAVE_LINUX_MEMFD=1 -DHAVE_MKOSTEMP=1 -DHAVE_SSE=1 -DHAVE_SSE2=1 -DHAVE_SSE3=1 -DHAVE_SSSE3=1 -DHAVE_SSE4_1=1 -D__STDC_CONSTANT_MACR
OS -D_FILE_OFFSET_BITS=64 -DHAS_LINUX_NETWORK -DHAS_BUILTIN_SYNC_ADD_AND_FETCH=1 -DHAS_BUILTIN_SYNC_SUB_AND_FETCH=1 -DHAS_BUILTIN_SYNC_VAL_COMPARE_AND_SWAP=1 -DHAVE_INOTIFY=1 -DHAVE_POSIX_FADVISE=1 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -
DHAVE_INTTYPES_H=1 -DHAS_ALSA=1 -DHAS_AVAHI=1 -DHAS_ZEROCONF=1 -DHAVE_LIBBLURAY=1 -DHAVE_LIBBLURAY_BDJ=1 -DHAVE_LIBCEC=1 -DHAS_DBUS=1 -DHAVE_LCMS2=1 -DHAS_WEB_SERVER=1 -DHAS_WEB_INTERFACE=1 -DHAS_PULSEAUDIO=1 -DHAS_PYTHON=1 -DHAVE_LIBUDEV
=1 -DHAVE_LIBXSLT=1 -DHAVE_LIBVA=1 -DHAS_GLX=1 -DFFMPEG_VER_SHA=\"undef\" -I/usr/include/fribidi -DHAS_EGL=1 -DHAVE_X11=1 -DHAVE_LIBXRANDR=1 -DHAS_GL=1 -DHAS_UPNP=1 -DHAS_DVD_DRIVE -DHAS_CDDA_RIPPER -DBIN_INSTALL_PATH=\"/usr/lib64/kodi\" 
-DINSTALL_PATH=\"/usr/share/kodi\" -std=c++14 -MD -MT build/platform/linux/peripherals/CMakeFiles/platform_linux_peripherals.dir/PeripheralBusUSBLibUdev.cpp.o -MF build/platform/linux/peripherals/CMakeFiles/platform_linux_peripherals.dir/
PeripheralBusUSBLibUdev.cpp.o.d -o build/platform/linux/peripherals/CMakeFiles/platform_linux_peripherals.dir/PeripheralBusUSBLibUdev.cpp.o -c /var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/platform/linux/peripherals/PeripheralBu
sUSBLibUdev.cpp
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp: In member function ‘virtual bool PERIPHERALS::CPeripheralBusUSB::PerformDeviceScan(PERIPHERALS::PeripheralScanResults&)’:
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp:85:3: error: ‘assert’ was not declared in this scope
   85 |   assert(IsCurrentThread());
      |   ^~~~~~
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp:16:1: note: ‘assert’ is defined in header ‘<cassert>’; did you forget to ‘#include <cassert>’?
   15 | #include "utils/log.h"
  +++ |+#include <cassert>
   16 | 
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix compilation error :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on my system.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
