### PR TITLE
Fix SiriRemote keymap

### DIFF
--- a/system/keymaps/customcontroller.SiriRemote.xml
+++ b/system/keymaps/customcontroller.SiriRemote.xml
@@ -8,18 +8,18 @@
 
 <!-- The format is:                                                                              -->
 <!--    <device>                                                                                 -->
-<!--      <button id=""#>xbmc action</button>
+<!--      <button id=""#>xbmc action</button>                                                    -->
 <!--    </device>                                                                                -->
 
 <!-- To map keys from other remotes using the RCA protocol, you may add <customcontroller name="SiriRemote"> blocks -->
 <!-- In this case, the tags used are <button id=""#> where # is the original button code (OBC) of the key -->
 <!-- You set it up by adding a <customcontroller name="SiriRemote"> block to the window or <global> section:        -->
 <!--    <customcontroller name="SiriRemote">                                                                        -->
-<!--       <button id="45">Stop</button>
+<!--       <button id="45">Stop</button>                                                         -->
 <!--    </customcontroller>                                                                       -->
 
 <!-- Note that the action can be a built-in function.                                            -->
-<!--            eg <button id="6">ActivateWindow(Favourites)</button>
+<!--            eg <button id="6">ActivateWindow(Favourites)</button>                            -->
 <!-- would bring up Favourites when the button with the id of 6 is press. In this case, "Menu"   -->
 
 <!--                                                                                             -->
@@ -126,16 +126,11 @@
       <button id="7">OSD</button>
     </customcontroller>
   </VideoMenu>
-  <MyVideoLibrary>
+  <Videos>
     <customcontroller name="SiriRemote">
       <button id="7">Info</button>
     </customcontroller>
-  </MyVideoLibrary>
-  <MyVideoFiles>
-    <customcontroller name="SiriRemote">
-      <button id="7">Info</button>
-    </customcontroller>
-  </MyVideoFiles>
+  </Videos>
   <PictureInfo>
     <customcontroller name="SiriRemote">
       <button id="3">Left</button>


### PR DESCRIPTION
getting rid of these errors on startup:
```
INFO: Loading special://xbmc/system/keymaps/customcontroller.SiriRemote.xml
ERROR: Window Translator: Can't find window MyVideoLibrary
ERROR: Window Translator: Can't find window MyVideoFiles
```

those two windows were merged and renamed to `Videos` long ago.
also fixes a few style errors in the xml comments