### PR TITLE
Fix Linux GL Renderer color primaries detection

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
@@ -14,6 +14,11 @@
 
 #include <string>
 
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
+
 enum CMS_DATA_FORMAT
 {
   CMS_DATA_FMT_RGB,
@@ -76,22 +81,23 @@ public:
 
   /*!
    \brief Get a 3D LUT for video color correction
-   \param primaries video primaries (see CONF_FLAGS_COLPRI)
+   \param srcPrimaries video primaries (see AVColorPrimaries)
    \param cmsToken pointer to a color manager configuration token
    \param format of CLUT data
    \param clutSize CLUT resolution
    \param clutData pointer to CLUT data
    \return true on success, false otherwise
    */
-  bool GetVideo3dLut(int primaries, int *cmsToken, CMS_DATA_FORMAT format, int clutSize, uint16_t *clutData);
+  bool GetVideo3dLut(AVColorPrimaries srcPrimaries, int* cmsToken, CMS_DATA_FORMAT format,
+                     int clutSize, uint16_t* clutData);
 
   /*!
    \brief Check if a 3D LUT is still valid
    \param cmsToken pointer to a color manager configuration token
-   \param flags video renderer flags (see CONF_FLAGS_COLPRI)
+   \param srcPrimaries video primaries (see AVColorPrimaries)
    \return true on valid, false if 3D LUT should be reloaded
    */
-  bool CheckConfiguration(int cmsToken, int flags);
+  bool CheckConfiguration(int cmsToken, AVColorPrimaries srcPrimaries);
 
   /*!
   \brief Get a 3D LUT dimention and data size for video color correction

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -244,7 +244,7 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   // load 3DLUT
   if (m_ColorManager->IsEnabled())
   {
-    if (!m_ColorManager->CheckConfiguration(m_cmsToken, m_iFlags))
+    if (!m_ColorManager->CheckConfiguration(m_cmsToken, m_srcPrimaries))
     {
       CLog::Log(LOGDEBUG, "CMS configuration changed, reload LUT");
       if (!LoadCLUT())
@@ -674,7 +674,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
                             (m_pixelRatio > 1.001f || m_pixelRatio < 0.999f);
   bool nonLinStretchChanged = false;
   bool cmsChanged = (m_cmsOn != m_ColorManager->IsEnabled()) ||
-                    (m_cmsOn && !m_ColorManager->CheckConfiguration(m_cmsToken, m_iFlags));
+                    (m_cmsOn && !m_ColorManager->CheckConfiguration(m_cmsToken, m_srcPrimaries));
   if (m_nonLinStretchGui != CDisplaySettings::GetInstance().IsNonLinearStretched() || pixelRatioChanged)
   {
     m_nonLinStretchGui = CDisplaySettings::GetInstance().IsNonLinearStretched();
@@ -714,7 +714,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
   {
     if (m_ColorManager->IsEnabled())
     {
-      if (!m_ColorManager->CheckConfiguration(m_cmsToken, m_iFlags))
+      if (!m_ColorManager->CheckConfiguration(m_cmsToken, m_srcPrimaries))
       {
         CLog::Log(LOGDEBUG, "CMS configuration changed, reload LUT");
         LoadCLUT();
@@ -2670,7 +2670,8 @@ bool CLinuxRendererGL::LoadCLUT()
   m_CLUT = static_cast<uint16_t*>(malloc(dataSize));
 
   // load 3DLUT
-  if ( !m_ColorManager->GetVideo3dLut(m_iFlags, &m_cmsToken, CMS_DATA_FMT_RGB, m_CLUTsize, m_CLUT) )
+  if (!m_ColorManager->GetVideo3dLut(m_srcPrimaries, &m_cmsToken, CMS_DATA_FMT_RGB, m_CLUTsize,
+                                     m_CLUT))
   {
     free(m_CLUT);
     CLog::Log(LOGERROR, "Error loading the LUT");
@@ -2681,7 +2682,7 @@ bool CLinuxRendererGL::LoadCLUT()
   CLog::Log(LOGDEBUG, "LinuxRendererGL: creating 3DLUT");
   glGenTextures(1, &m_tCLUTTex);
   glActiveTexture(GL_TEXTURE4);
-  if ( m_tCLUTTex <= 0 )
+  if (m_tCLUTTex <= 0)
   {
     CLog::Log(LOGERROR, "Error creating 3DLUT texture");
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -137,7 +137,7 @@ protected:
   explicit CRendererBase(CVideoSettings& videoSettings);
 
   bool CreateIntermediateTarget(unsigned int width, unsigned int height, bool dynamic = false);
-  void OnCMSConfigChanged(unsigned flags);
+  void OnCMSConfigChanged(AVColorPrimaries srcPrimaries);
   void ReorderDrawPoints(const CRect& destRect, CPoint(&rotatedPoints)[4]) const;
   bool CreateRenderBuffer(int index);
   void DeleteRenderBuffer(int index);


### PR DESCRIPTION
## Description
The m_iFlags are passed to ColorManager for detecting the color primaries of the video, so it needs to contain the color primary flags for the Colour Management -> Primaries -> Automatic to work as expected.

This is a follow-up to #17109 and fixes desaturated colours for BT.2020 videos that were previously handled at BT.709 because that is the fallback value, when no color primaries flag is set.

## Motivation and Context
After #17109 color management can finally be used with the Linux GL Renderer without crashing. When testing this with 4K HDR videos with BT.2020 primaries I noticed that the colours were completely desaturated. After manually setting Colour Management -> Primaries -> UHDTV (BT.2020), the colors were accurate.

This fix is essential for playing back BT.2020 videos on non-BT.2020 capable displays (eg. sRGB or BT.709).

Since the bug also affects Leia it should be backported, similar to the changes from #17109.

## How Has This Been Tested?
The fix was tested against master@f4f9d88a35 with both software decoding and VAAPI.

The bug was observed without the fix on both Leia stable and nightly builds on Ubuntu 19.10 with Gemini Lake (Intel UHD 605) graphics and both i965 and iHD VAAPI drivers as well as software decoding.

The following settings were used:

* Color management: Enabled
* Colour management mode: ICC Profile
* ICC display profile: (path to monitors ICM profile extracted from windows driver, a standard sRGB.icc should work as well for testing)
* Whitepont: D65
* Gamma mode: BT.1886
* Lookup table size: 4 or 5 (doesn't matter)

The following videos were tested:

* 2160p HDR BT.2020 HEVC MKV
* 1080p SDR BT.709 AVC MKV

For some movies both 4K and Full-HD versions were tested to compare the color timing and the BT.2020 color levels after tone mapping and color management on an Asus PA328Q (100% sRGB IPS) were compared to a Sony Z9D HDR TV as a reference.

Without the fix all BT.2020 content looked completely desaturated with either colour management disabled or set to Primaries -> Automatic, but looked fine with Primaries -> BT.2020. Conversely BT.709 videos looked ok with Automatic, but oversaturated with BT.2020 hinting at the broken auto-detection.

## Screenshots (if appropriate):

Example 1080p SDR BT.709 w/o CM:
![lk_sdr_bt709_no_cm](https://user-images.githubusercontent.com/909587/72572037-9baef700-38c1-11ea-8917-3e9cd73b8dc0.jpg)

Same with CM enabled and automatic primaries:
![lk_sdr_bt709_cm_auto_primaries](https://user-images.githubusercontent.com/909587/72572036-9baef700-38c1-11ea-9280-61f5fb1205e6.jpg)

Example 2160p HDR BT.2020 Reinhard Tone Mapping to SDR w/o CM:
![lk_hdr_bt2020_no_cm](https://user-images.githubusercontent.com/909587/72572035-9baef700-38c1-11ea-92df-a859474dfa13.jpg)

Same with CM enabled and automatic primaries (after fix):
![lk_hdr_bt2020_cm_auto_primaries](https://user-images.githubusercontent.com/909587/72572033-9b166080-38c1-11ea-9656-f394ab5b68f0.jpg)

Same with CM enabled and BT.709 primaries (simulates "automatic" w/o fix):
![lk_hdr_bt2020_cm_bt709_primaries](https://user-images.githubusercontent.com/909587/72572034-9baef700-38c1-11ea-8e90-29a7b160951f.jpg)

Please view screenshots in fullscreen for best results.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed (not tested)
