### PR TITLE
[FIX] Chapter selection in UHD BD and BD

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -500,6 +500,7 @@ void CDVDInputStreamBluray::ProcessEvent() {
       m_title = disc_info->titles[m_event.param];
     else
       m_title = nullptr;
+    m_menu = false;
 
     break;
   }
@@ -758,7 +759,6 @@ void CDVDInputStreamBluray::OverlayFlush(int64_t pts)
 
   m_player->OnDiscNavResult(static_cast<void*>(group), BD_EVENT_MENU_OVERLAY);
   group->Release();
-  m_menu = true;
 #endif
 }
 
@@ -1108,7 +1108,10 @@ void CDVDInputStreamBluray::OnMenu()
   }
 
   if(bd_user_input(m_bd, -1, BD_VK_POPUP) >= 0)
+  {
+    m_menu = !m_menu;
     return;
+  }
   CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::OnMenu - popup failed, trying root");
 
   if(bd_user_input(m_bd, -1, BD_VK_ROOT_MENU) >= 0)


### PR DESCRIPTION
## Description
Fix current chapter and chapter selection on UHD BD and Blurays with POPUP menus.

## Motivation and Context
When playing UHD Blurays or Blurays that have popup menus m_menu is set to true all the time in disc navigation mode. 
This causes the player to stop using `CDVDDemuxFFmpeg::GetChapter()` and `CDVDInputStreamBluray::GetChapter()` for the current chapter and uses `CApplicationPlayer::GetChapter()` resulting in the current chapter always 0 and skiping chapters failing. 

For POPUP menus, those are present all the time even if not visible. 
During various sessions of debuging `ov->cmd` is receives a value of 0x3 or 0x6 this means `BD_OVERLAY_CLOSE`, `BD_OVERLAY_CLEAR` or `BD_OVERLAY_HIDE` are never called so we have no means to identify when the POPUP menu leaves the screen. 

The value of `m_planes[BD_OVERLAY_IG].o.empty()` is always != 0 during playback so this can't be used either. 

The proposed solution here is that m_menu should be set to on only during `BD_EVENT_TITLE` that matches TOP Menu and set to false to all others. 
This also proposes that m_menu should be set to true when the user tries to access the POPUP menu and should be set to off when pressing again to hide it. 

## How Has This Been Tested?
This has been tested with a Windows x64 build with several Blurays and UHD Blurays. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
