### PR TITLE
fixed: Seeking with FileCache could lockup due to terminated thread

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -363,6 +363,8 @@ void CFileCache::Process()
     {
       CLog::Log(LOGDEBUG, "CFileCache::Process - Source read returned a fatal error! Will wait for buffer to empty.");
 
+      m_pCache->EndOfInput();
+
       while (m_pCache->WaitForData(0, 0) > 0)
       {
         if (m_seekEvent.WaitMSec(100))
@@ -531,10 +533,11 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     m_seekPos = std::min(iTarget, std::max((int64_t)0, m_fileSize - m_chunkSize));
 
     m_seekEvent.Set();
-    if (!m_seekEnded.Wait())
+    while (!m_seekEnded.WaitMSec(100))
     {
-      CLog::Log(LOGWARNING,"%s - seek to %" PRId64" failed.", __FUNCTION__, m_seekPos);
-      return -1;
+      // SeekEnded will never be set if FileCache thread is not running
+      if (!CThread::IsRunning())
+        return -1;
     }
 
     /* wait for any remaining data */


### PR DESCRIPTION
This fixes a problem that surfaced when creating the fix in #17208. In CFileCache::Seek() we set a seek event which triggers the FileCache thread to perform a seek. When done the thread should set the SeekEnded event for which we wait in ::Seek(). The problem is that the thread *may* terminate itself, causing the SeekEnded-event to never be set.

I'm not sure whether the approach with "CThread::IsRunning()" is the proper way. I'm open to suggestions for alternatives.