### PR TITLE
[tvOS] Implement PowerManager::OnSleep/OnWake

### DIFF
--- a/cmake/treedata/darwin_embedded/tvos/tvos.txt
+++ b/cmake/treedata/darwin_embedded/tvos/tvos.txt
@@ -1,4 +1,5 @@
 xbmc/platform/darwin/tvos             platform/tvos
 xbmc/platform/darwin/tvos/filesystem  platform/darwin/tvos/filesystem
 xbmc/platform/darwin/tvos/input       platform/darwin/tvos/input
+xbmc/platform/darwin/tvos/powermanagement   platform/darwin/tvos/powermanagement
 xbmc/windowing/tvos                   windowing/tvos

--- a/xbmc/platform/darwin/tvos/XBMCApplication.mm
+++ b/xbmc/platform/darwin/tvos/XBMCApplication.mm
@@ -26,15 +26,19 @@
 
 - (void)applicationWillResignActive:(UIApplication*)application
 {
-  [self.xbmcController pauseAnimation];
-  [self.xbmcController becomeInactive];
+  // Occurs when Kodi is interrupted by something
+  // (e.g. Siri triggered by user, Control center opened by user, Mutlitask opened by user ...)
 }
 
 - (void)applicationDidEnterBackground:(UIApplication*)application
 {
+  // Occurs when Kodi has been backgrounded
+  // (e.g. when user uses remote to go to tvOS homescreen)
+  // applicationWillResignActive() will always be called before this method
   if (application.applicationState == UIApplicationStateBackground)
   {
     // the app is turn into background, not in by screen lock which has app state inactive.
+    [self.xbmcController pauseAnimation];
     [self.xbmcController enterBackground];
   }
 }
@@ -48,6 +52,15 @@
 
 - (void)applicationDidBecomeActive:(UIApplication*)application
 {
+  // This function occurs:
+  //  * on the first start of Kodi
+  //  * when Kodi has been activated after a beeing suspending by applicationWillResignActive()
+  //  * when Kodi has been foregrounded after applicationDidEnterBackground()
+}
+
+- (void)applicationWillEnterForeground:(UIApplication*)application
+{
+  // Occurs only after an applicationDidEnterBackground()
   [self.xbmcController resumeAnimation];
   [self.xbmcController enterForeground];
 }

--- a/xbmc/platform/darwin/tvos/XBMCController.h
+++ b/xbmc/platform/darwin/tvos/XBMCController.h
@@ -48,7 +48,6 @@ class CFileItem;
 
 - (void)enterBackground;
 - (void)enterForeground;
-- (void)becomeInactive;
 - (void)setFramebuffer;
 - (bool)presentFramebuffer;
 - (void)activateKeyboard:(UIView*)view;

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -21,6 +21,7 @@
 #include "network/Network.h"
 #include "network/NetworkServices.h"
 #include "platform/xbmc.h"
+#include "powermanagement/PowerManager.h"
 #include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -37,6 +38,7 @@
 #import "platform/darwin/tvos/input/LibInputHandler.h"
 #import "platform/darwin/tvos/input/LibInputRemote.h"
 #import "platform/darwin/tvos/input/LibInputTouch.h"
+#include "platform/darwin/tvos/powermanagement/TVOSPowerSyscall.h"
 
 #import <AVKit/AVDisplayManager.h>
 #import <AVKit/UIWindow.h>
@@ -193,45 +195,29 @@ XBMCController* g_xbmcController;
 
 - (void)enterBackground
 {
+  CLog::Log(LOGDEBUG, "%s", __PRETTY_FUNCTION__);
+
   m_bgTask = [self enableBackGroundTask];
   m_bgTaskActive = YES;
 
-  CLog::Log(LOGNOTICE, "%s: Running sleep jobs", __FUNCTION__);
+  // We need this hack, without it we stay stuck forever in
+  //    CPowerManager::OnSleep()
+  //    CApplication::StopPlaying()
+  //    CGUIWindowManager::ProcessRenderLoop
+  if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW ||
+      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
+      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
+      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION)
+    CServiceBroker::GetGUI()->GetWindowManager().PreviousWindow();
 
-  // if we were interrupted, already paused here
-  // else if user background us or lock screen, only pause video here, audio keep playing.
-  if (g_application.GetAppPlayer().IsPlayingVideo() && !g_application.GetAppPlayer().IsPaused())
-  {
-    m_isPlayingBeforeInactive = YES;
-    m_lastUsedPlayer = g_application.GetAppPlayer().GetCurrentPlayer();
-    m_playingFileItemBeforeBackground =
-        std::make_unique<CFileItem>(g_application.CurrentFileItem());
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
-    g_application.CurrentFileItem().m_lStartOffset = g_application.GetAppPlayer().GetTime() - 2.50;
-  }
+  CServiceBroker::GetNetwork().GetServices().Stop(true);
+
+  dynamic_cast<CTVOSPowerSyscall*>(CServiceBroker::GetPowerManager().GetPowerSyscall())
+      ->SetOnPause();
+  CServiceBroker::GetPowerManager().ProcessEvents();
 
   CWinSystemTVOS* winSystem = dynamic_cast<CWinSystemTVOS*>(CServiceBroker::GetWinSystem());
   winSystem->OnAppFocusChange(false);
-
-  // Media was paused, Full background shutdown, so stop now.
-  // Only do for PVR? leave regular media paused?
-  if (g_application.GetAppPlayer().IsPaused())
-  {
-    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_SLIDESHOW ||
-        CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
-        CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
-        CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION)
-      CServiceBroker::GetGUI()->GetWindowManager().PreviousWindow();
-
-    g_application.StopPlaying();
-  }
-
-  CServiceBroker::GetPVRManager().OnSleep();
-  CServiceBroker::GetActiveAE()->Suspend();
-  CServiceBroker::GetNetwork().GetServices().Stop(true);
-
-  //  if (!m_isPlayingBeforeInactive)
-  g_application.CloseNetworkShares();
 
   m_bgTaskActive = NO;
   [self disableBackGroundTask:m_bgTask];
@@ -239,6 +225,7 @@ XBMCController* g_xbmcController;
 
 - (void)enterForeground
 {
+  CLog::Log(LOGDEBUG, "%s", __PRETTY_FUNCTION__);
   // stop background task (if running)
   if (m_bgTaskActive)
   {
@@ -268,50 +255,13 @@ XBMCController* g_xbmcController;
   while (!g_application.IsInitialized())
     usleep(50 * 1000);
 
-  CServiceBroker::GetNetwork().WaitForNet();
-  CServiceBroker::GetNetwork().GetServices().Start();
-
-  if (CServiceBroker::GetActiveAE())
-    if (CServiceBroker::GetActiveAE()->IsSuspended())
-      CServiceBroker::GetActiveAE()->Resume();
-
-  CServiceBroker::GetPVRManager().OnWake();
-
   CWinSystemTVOS* winSystem = dynamic_cast<CWinSystemTVOS*>(CServiceBroker::GetWinSystem());
   winSystem->OnAppFocusChange(true);
 
-  // when we come back, restore playing if we were.
-  if (m_isPlayingBeforeInactive)
-  {
-    if (m_playingFileItemBeforeBackground->IsLiveTV())
-    {
-      CLog::Log(LOGDEBUG, "%s: Live TV was playing before suspend. Restart channel",
-                __PRETTY_FUNCTION__);
-      // Restart player with lastused FileItem
-      g_application.PlayFile(*m_playingFileItemBeforeBackground, m_lastUsedPlayer, true);
-    }
-    else
-    {
-      if (g_application.GetAppPlayer().IsPaused() && g_application.GetAppPlayer().HasPlayer())
-      {
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_UNPAUSE);
-      }
-      else
-      {
-        g_application.PlayFile(*m_playingFileItemBeforeBackground, m_lastUsedPlayer, true);
-      }
-    }
-    m_playingFileItemBeforeBackground = std::make_unique<CFileItem>();
-    m_lastUsedPlayer = "";
-    m_isPlayingBeforeInactive = NO;
-  }
-
-  // do not update if we are already updating
-  if (!(g_application.IsVideoScanning() || g_application.IsMusicScanning()))
-    g_application.UpdateLibraries();
-
-  // this will fire only if we are already alive and have 'menu'ed out and back
-  CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "xbmc", "OnWake");
+  dynamic_cast<CTVOSPowerSyscall*>(CServiceBroker::GetPowerManager().GetPowerSyscall())
+      ->SetOnResume();
+  CServiceBroker::GetPowerManager().ProcessEvents();
+  CServiceBroker::GetNetwork().GetServices().Start();
 
   // this handles what to do if we got pushed
   // into foreground by a topshelf item select/play

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -191,8 +191,13 @@ XBMCController* g_xbmcController;
 
 #pragma mark - AppFocus
 
-- (void)becomeInactive
+- (void)enterBackground
 {
+  m_bgTask = [self enableBackGroundTask];
+  m_bgTaskActive = YES;
+
+  CLog::Log(LOGNOTICE, "%s: Running sleep jobs", __FUNCTION__);
+
   // if we were interrupted, already paused here
   // else if user background us or lock screen, only pause video here, audio keep playing.
   if (g_application.GetAppPlayer().IsPlayingVideo() && !g_application.GetAppPlayer().IsPaused())
@@ -204,14 +209,6 @@ XBMCController* g_xbmcController;
     CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
     g_application.CurrentFileItem().m_lStartOffset = g_application.GetAppPlayer().GetTime() - 2.50;
   }
-}
-
-- (void)enterBackground
-{
-  m_bgTask = [self enableBackGroundTask];
-  m_bgTaskActive = YES;
-
-  CLog::Log(LOGNOTICE, "%s: Running sleep jobs", __FUNCTION__);
 
   CWinSystemTVOS* winSystem = dynamic_cast<CWinSystemTVOS*>(CServiceBroker::GetWinSystem());
   winSystem->OnAppFocusChange(false);

--- a/xbmc/platform/darwin/tvos/powermanagement/CMakeLists.txt
+++ b/xbmc/platform/darwin/tvos/powermanagement/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES TVOSPowerSyscall.cpp)
+
+set(HEADERS TVOSPowerSyscall.h)
+
+core_add_library(platform_tvos_powermanagement)

--- a/xbmc/platform/darwin/tvos/powermanagement/TVOSPowerSyscall.cpp
+++ b/xbmc/platform/darwin/tvos/powermanagement/TVOSPowerSyscall.cpp
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (C) 2012-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TVOSPowerSyscall.h"
+
+#include "utils/log.h"
+
+IPowerSyscall* CTVOSPowerSyscall::CreateInstance()
+{
+  return new CTVOSPowerSyscall;
+}
+
+void CTVOSPowerSyscall::Register()
+{
+  IPowerSyscall::RegisterPowerSyscall(CTVOSPowerSyscall::CreateInstance);
+}
+
+bool CTVOSPowerSyscall::Powerdown()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::Suspend()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::Hibernate()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::Reboot()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::CanPowerdown()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::CanSuspend()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::CanHibernate()
+{
+  return false;
+}
+
+bool CTVOSPowerSyscall::CanReboot()
+{
+  return false;
+}
+
+int CTVOSPowerSyscall::BatteryLevel()
+{
+  return 0;
+}
+
+bool CTVOSPowerSyscall::PumpPowerEvents(IPowerEventsCallback* callback)
+{
+  switch (m_state)
+  {
+    case SUSPENDED:
+      callback->OnSleep();
+      CLog::Log(LOGDEBUG, "%s: OnSleep called", __FUNCTION__);
+      break;
+    case RESUMED:
+      callback->OnWake();
+      CLog::Log(LOGDEBUG, "%s: OnWake called", __FUNCTION__);
+      break;
+    default:
+      return false;
+  }
+  m_state = REPORTED;
+  return true;
+}
+
+void CTVOSPowerSyscall::SetOnPause()
+{
+  m_state = SUSPENDED;
+}
+
+void CTVOSPowerSyscall::SetOnResume()
+{
+  m_state = RESUMED;
+}

--- a/xbmc/platform/darwin/tvos/powermanagement/TVOSPowerSyscall.h
+++ b/xbmc/platform/darwin/tvos/powermanagement/TVOSPowerSyscall.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2012-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "powermanagement/IPowerSyscall.h"
+
+class CTVOSPowerSyscall : public CPowerSyscallWithoutEvents
+{
+public:
+  CTVOSPowerSyscall() = default;
+  ~CTVOSPowerSyscall() override = default;
+
+  static IPowerSyscall* CreateInstance();
+  static void Register();
+
+  bool Powerdown() override;
+  bool Suspend() override;
+  bool Hibernate() override;
+  bool Reboot() override;
+
+  bool CanPowerdown() override;
+  bool CanSuspend() override;
+  bool CanHibernate() override;
+  bool CanReboot() override;
+  int BatteryLevel() override;
+
+  bool PumpPowerEvents(IPowerEventsCallback* callback) override;
+
+  void SetOnPause();
+  void SetOnResume();
+
+private:
+  enum STATE : unsigned int
+  {
+    REPORTED = 0,
+    SUSPENDED = 1,
+    RESUMED = 2,
+  };
+  STATE m_state = REPORTED;
+};

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -36,6 +36,7 @@
 #import "platform/darwin/DarwinUtils.h"
 #import "platform/darwin/tvos/TVOSDisplayManager.h"
 #import "platform/darwin/tvos/XBMCController.h"
+#include "platform/darwin/tvos/powermanagement/TVOSPowerSyscall.h"
 
 #include <memory>
 #include <vector>
@@ -135,6 +136,7 @@ CWinSystemTVOS::CWinSystemTVOS() : CWinSystemBase(), m_lostDeviceTimer(this)
   m_winEvents.reset(new CWinEventsTVOS());
 
   CAESinkDARWINTVOS::Register();
+  CTVOSPowerSyscall::Register();
 }
 
 CWinSystemTVOS::~CWinSystemTVOS()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR tries to adapt https://github.com/xbmc/xbmc/pull/17187 PR on tvOS.

Call CPoweManager OnWake / OnSleep (through IPowerSyscall) when tvOS activity lifecycle calls applicationWillEnterForeground / applicationDidEnterBackground.

Maybe in the future we will be able to move this code in `ios-common` to use it in both iOS and tvOS?

**Important note:**

I don't know if this problem comes from this commit, but sometimes after move to foreground my last TV channel opens well but I have no sound. I have to switch to another channel to fix the issue and re open last channel...

Also, I am not sure about the `OnAppFocusChange` line. Should we call this line before or after the power manager line? I don't really understand this line :-/
@fuzzard and @kambala-decapitator, if you can have a look please ;-)
Thank you!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
There are services inside kodi (e.g. PVR EPG poll) which should be deactivated when kodi is suspended.

Also, this PR is just another step to improve the user experience on tvOS with Kodi (see https://github.com/SylvainCecchetto/xbmc/issues/79).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested on tvOS with the following actions:

* Open/close control center while a media is playing
* Move to background then move to foreground while a media is playing


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
