### PR TITLE
[Backport] Add missing cstddef includes

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -17,6 +17,8 @@
 using namespace DirectX;
 #endif
 
+#include <cstddef>
+
 using namespace KODI;
 using namespace RETRO;
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -32,6 +32,8 @@ using namespace DirectX;
 using namespace Microsoft::WRL;
 #endif
 
+#include <cstddef>
+
 #define IMMEDIATE_TRANSITION_TIME          20
 
 #define PICTURE_MOVE_AMOUNT              0.02f


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/17214
