### PR TITLE
Add IPlayer::AddSubtitle() with name and language

### DIFF
--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -737,6 +737,16 @@ void CApplicationPlayer::AddSubtitle(const std::string& strSubPath)
     player->AddSubtitle(strSubPath);
 }
 
+void CApplicationPlayer::AddSubtitle(const std::string& strSubPath,
+                                     const std::string& name,
+                                     const std::string& language,
+                                     bool activate /* = true */)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->AddSubtitle(strSubPath, name, language, activate);
+}
+
 void CApplicationPlayer::SetSubTitleDelay(float fValue)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -72,6 +72,10 @@ public:
 
   // proxy calls
   void AddSubtitle(const std::string& strSubPath);
+  void AddSubtitle(const std::string& strSubPath,
+                   const std::string& name,
+                   const std::string& language,
+                   bool activate = true);
   bool CanPause() const;
   bool CanSeek() const;
   void DoAudioWork();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -137,6 +137,12 @@ public:
   *   \param[in] strSubPath The full path of the subtitle file.
   */
   virtual void AddSubtitle(const std::string& strSubPath) {}
+  virtual void AddSubtitle(const std::string& strSubPath,
+                           const std::string& name,
+                           const std::string& language,
+                           bool activate = true)
+  {
+  }
 
   virtual int GetAudioStreamCount() const { return 0; }
   virtual int  GetAudioStream()       { return -1; }

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -70,6 +70,14 @@ struct SStateMsg
   int player;
 };
 
+struct SSubtitleMsg
+{
+  std::string path;
+  std::string name;
+  std::string language;
+  bool activate = false;
+};
+
 class CDVDVideoCodec;
 
 class IDVDStreamPlayerVideo : public IDVDStreamPlayer

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -291,6 +291,10 @@ public:
   void SetSubtitleVerticalPosition(const int value, bool save) override;
 
   void AddSubtitle(const std::string& strSubPath) override;
+  void AddSubtitle(const std::string& strSubPath,
+                   const std::string& name,
+                   const std::string& language,
+                   bool activate = true) override;
 
   int GetAudioStreamCount() const override;
   int GetAudioStream() override;
@@ -401,7 +405,10 @@ protected:
   void ProcessRadioRDSData(CDemuxStream* pStream, DemuxPacket* pPacket);
   void ProcessAudioID3Data(CDemuxStream* pStream, DemuxPacket* pPacket);
 
-  int  AddSubtitleFile(const std::string& filename, const std::string& subfilename = "");
+  int AddSubtitleFile(const std::string& filename,
+                      const std::string& subfilename = "",
+                      const std::string& name = "",
+                      const std::string& language = "");
   void SetSubtitleVisibleInternal(bool bVisible);
 
   /**

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -457,6 +457,21 @@ namespace XBMCAddon
       g_application.SeekTime( pTime );
     }
 
+    void Player::addSubtitle(const char* subtitleFile,
+                             const char* name,
+                             const char* language,
+                             bool activate /* = true */)
+    {
+      XBMC_TRACE;
+      if (subtitleFile == nullptr || name == nullptr || language == nullptr)
+        return;
+
+      if (getAppPlayer()->HasPlayer())
+      {
+        getAppPlayerMut()->AddSubtitle(subtitleFile, name, language, activate);
+      }
+    }
+
     void Player::setSubtitles(const char* cLine)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -513,6 +513,28 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Player
+      /// @brief \python_func{ addSubtitle(subtitleFile, name, language, activate) }
+      ///-----------------------------------------------------------------------
+      /// Add subtitle file with name and language and optionally activate it.
+      ///
+      /// @param subtitleFile        File to use as the source of subtitles
+      /// @param name                Name of the subtitle to display
+      /// @param language            Language of the subtitle to use
+      /// @param activate            Whether or not to activate the subtitle
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      addSubtitle(...);
+#else
+      void addSubtitle(const char* subtitleFile,
+                       const char* name,
+                       const char* language,
+                       bool activate = true);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Player
       /// @brief \python_func{ setSubtitles(subtitleFile) }
       /// Set subtitle file and enable subtitles.
       ///


### PR DESCRIPTION
## Description
This adds an overload of `IPlayer::AddSubtitle()` which in addition to taken the path to the subtitle also takes the name of the subtitle and its language. Only `CVideoPlayer` implements this interface method (same as the existing `AddSubtitle()` method).

Furthermore the `Player` class in the python add-on API has also been extended with an `addSubtitle()` method which makes use of the new `IPlayer::AddSubtitle()` method.

## Motivation and Context
While working on my media import stuff people requested support for external subtitles. Media backends like Emby and Plex already look for external subtitles and determine metdata like name, language, codec etc. Right now `VideoPlayer` only supports getting a file and then determining all of this metadata itself. @angelblue05 has come up with a workaround for this misfit in "Emby for Kodi" by manually downloading external subtitles from Emby to the local disk and then manually naming them based on the metadata from Emby and finally providing them to Kodi.

I'm mainly interested in whether this would be accepted at all. It doesn't have to merged now and I can keep it as part of my media import work but I don't want to further persue this if it has no chance to hit Kodi mainline.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
