### PR TITLE
[AddonBase] Segfault/AV in CreateInstanceEx if addonInstance is not initialized

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -330,7 +330,7 @@ ADDON_STATUS CAddonDll::CreateInstance(ADDON_TYPE instanceType, const std::strin
   if (!CheckAPIVersion(instanceType))
     return ADDON_STATUS_PERMANENT_FAILURE;
 
-  KODI_HANDLE addonInstance;
+  KODI_HANDLE addonInstance = nullptr;
   if (!m_interface.toAddon->create_instance_ex)
     status = m_interface.toAddon->create_instance(instanceType, instanceID.c_str(), instance, &addonInstance, parentInstance);
   else


### PR DESCRIPTION
## Description
While working on an InputStream Addon I noted an unexpected exception if the addon did not successfully initialize.  In AddonBase.h, the "addonInstance" argument is not initialized to NULL, and if the addon fails to also do so a segfault may occur attempting to access the m_type member variable.

## Motivation and Context
Failure to provide an initialization for "addonInstance" followed by a failed call to ADDONBASE_CreateInstanceEx() can lead to an exception or unexpected results.  This variable is tested for NULL explicitly as part of the logic, therefore it should be initialized to that value to avoid the segfault/AV.

## How Has This Been Tested?
Tested on Windows Desktop x64 as part of preliminary unit testing for an InputStream addon that may be proposed for Kodi mainline. 

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
