### PR TITLE
Dialog.Close(all) should only close modal dialogs

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -851,7 +851,8 @@ void CGUIWindowManager::CloseDialogs(bool forceClose) const
   auto activeDialogs = m_activeDialogs;
   for (const auto& window : activeDialogs)
   {
-    window->Close(forceClose);
+    if (window->IsModalDialog())
+      window->Close(forceClose);
   }
 }
 


### PR DESCRIPTION
Skins need to make sure all dialogs are closed before they can activate another window.
For this, they use the `Dialog.Close(all)` builtin.

This function currently closes all dialogs, including non-modal ones.
For instance, the extended progress dialog (which is shown when you are scanning items to the library) is being closed by the `Dialog.Close(all)` builtin.
There is however no need to close modeless dialogs as well, only the modal ones need to be closed.

@sualfred 