### PR TITLE
[windows] Fix downloading dependencies from mirrors

### DIFF
--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -64,7 +64,7 @@ IF EXIST %1 (
 ) ELSE (
   CALL :setSubStageName Downloading %1...
   SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
-  %WGET% -S --quiet --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1 | findstr /L /I "Location:"
+  %WGET% --quiet --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (
     ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST%


### PR DESCRIPTION
## Description
This reverts commit de42ae8635eead2a678bc6c94738a03d55fb3e7b see https://github.com/xbmc/xbmc/pull/13293
As mentioned in the comments in the commit it breaks downloading dependencies from any mirror which does not return the `Location` HTTP header. Furthermore it invalidates the value of `ERRORLEVEL` which now contains the return code of `findstr` instead of from `wget`.

## Motivation and Context
When setting up my Windows 10 dev machine I noticed that lots of windows dependency downloads failed randomly and I had to restart `download-dependencies.bat` alot until I got all dependencies. Now when I setup the new windows build slave I ran into the same problem again. I then realized that from the 11 mirrors I tried
* 8 did not return the `Location` HTTP header
* 1 (https://ftp.halifax.rwth-aachen.de/xbmc/) uses a self-signed HTTPS certificate. Maybe @kib can comment on this?

which leads to the download being considered as failed (for the second reason that's correct).

This should also be backported to Leia since it was introduced there and will also lead to build failures there.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
