### PR TITLE
Inputstream fixes

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -133,7 +133,7 @@ extern "C"
   {
     enum STREAM_TYPE
     {
-      TYPE_NONE,
+      TYPE_NONE = 0,
       TYPE_VIDEO,
       TYPE_AUDIO,
       TYPE_SUBTITLE,
@@ -207,7 +207,7 @@ extern "C"
     // Keep in sync with AVColorRange
     enum COLORRANGE
     {
-      COLORRANGE_UNKNOWN,
+      COLORRANGE_UNKNOWN = 0,
       COLORRANGE_LIMITED,
       COLORRANGE_FULLRANGE,
       COLORRANGE_MAX

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -55,7 +55,7 @@ CInputStreamAddon::CInputStreamAddon(BinaryAddonBasePtr& addonBase, IVideoPlayer
     key = name + "." + key;
   }
   m_struct = {{ 0 }};
-  m_caps.m_mask = 0;
+  m_caps = { 0 };
 }
 
 CInputStreamAddon::~CInputStreamAddon()
@@ -120,7 +120,7 @@ bool CInputStreamAddon::Open()
   if (CreateInstance(&m_struct) != ADDON_STATUS_OK || !m_struct.toAddon.open)
     return false;
 
-  INPUTSTREAM props;
+  INPUTSTREAM props = { 0 };
   std::map<std::string, std::string> propsMap;
   for (auto &key : m_fileItemProps)
   {
@@ -153,7 +153,7 @@ bool CInputStreamAddon::Open()
   bool ret = m_struct.toAddon.open(&m_struct, &props);
   if (ret)
   {
-    memset(&m_caps, 0, sizeof(m_caps));
+    m_caps = { 0 };
     m_struct.toAddon.get_capabilities(&m_struct, &m_caps);
 
     m_subAddonProvider = std::shared_ptr<CInputStreamProvider>(new CInputStreamProvider(GetAddonBase(), m_struct.toAddon.addonInstance));


### PR DESCRIPTION
## Description
The Inputstream class should make sure that the structs it defines are initialized with reasonable default values by their default constructor. Before this change the code relied on users to do the initialization, and not all users actually did this, leading to undefined behavior.
 
## Motivation and Context
This fixes https://github.com/xbmc/inputstream.rtmp/issues/27
**Update:** It doesn't fix it any longer, but it's still a minor cleanup.

## How Has This Been Tested?
I have only compiled this change, not actually tested it.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [] All new and existing tests passed
