### PR TITLE
[ios] apply safe area insets to Kodi GUI

### DIFF
--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -60,7 +60,7 @@ using namespace KODI::MESSAGING;
 //--------------------------------------------------------------
 - (void) resizeFrameBuffer
 {
-  auto frame = currentScreen == UIScreen.mainScreen ? self.bounds : currentScreen.bounds;
+  auto frame = currentScreen.bounds;
   CAEAGLLayer *eaglLayer = (CAEAGLLayer *)[self layer];
   //allow a maximum framebuffer size of 1080p
   //needed for tvout on iPad3/4 and iphone4/5 and maybe AppleTV3

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -105,6 +105,7 @@ static CEvent screenChangeEvent;
     {
       [[IOSScreenManager sharedInstance] fadeFromBlack:timeSwitchingToInternalSecs];
     }
+    [g_xbmcController setGUIInsetsFromMainThread:YES];
 
     int w = [[newScreen currentMode] size].width;
     int h = [[newScreen currentMode] size].height;

--- a/xbmc/platform/darwin/ios/XBMCController.h
+++ b/xbmc/platform/darwin/ios/XBMCController.h
@@ -60,6 +60,7 @@
 - (void) observeDefaultCenterStuff: (NSNotification *) notification;
 - (CGRect)fullscreenSubviewFrame;
 - (void)onXbmcAlive;
+- (void)setGUIInsetsFromMainThread:(BOOL)isMainThread;
 - (void) setFramebuffer;
 - (bool) presentFramebuffer;
 - (CGSize) getScreenSize;

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -22,6 +22,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayList.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/ISettingCallback.h"
@@ -604,8 +605,7 @@ public:
   self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.view.autoresizesSubviews = YES;
 
-  m_glView = [[IOSEAGLView alloc] initWithFrame:[self fullscreenSubviewFrame]
-                                     withScreen:UIScreen.mainScreen];
+  m_glView = [[IOSEAGLView alloc] initWithFrame:self.view.bounds withScreen:UIScreen.mainScreen];
   [[IOSScreenManager sharedInstance] setView:m_glView];
   [m_glView setMultipleTouchEnabled:YES];
 
@@ -712,6 +712,18 @@ public:
 - (void)onXbmcAlive
 {
   m_debugLogSharingPresenter = std::make_unique<DebugLogSharingPresenter>();
+
+  // apply safe area to Kodi GUI
+  UIEdgeInsets __block insets;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    insets = m_window.safeAreaInsets;
+  });
+  if (!UIEdgeInsetsEqualToEdgeInsets(insets, UIEdgeInsetsZero))
+  {
+    auto scale = [m_glView getScreenScale:UIScreen.mainScreen];
+    CDisplaySettings::GetInstance().GetCurrentResolutionInfo().guiInsets = EdgeInsets(
+        insets.left * scale, insets.top * scale, insets.right * scale, insets.bottom * scale);
+  }
 }
 //--------------------------------------------------------------
 - (void) setFramebuffer

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -675,10 +675,10 @@ void CGraphicContext::GetGUIScaling(const RESOLUTION_INFO &res, float &scaleX, f
     RESOLUTION_INFO info = GetResInfo();
     float fFromWidth  = (float)res.iWidth;
     float fFromHeight = (float)res.iHeight;
-    float fToPosX     = (float)info.Overscan.left;
-    float fToPosY     = (float)info.Overscan.top;
-    float fToWidth    = (float)info.Overscan.right  - fToPosX;
-    float fToHeight   = (float)info.Overscan.bottom - fToPosY;
+    auto fToPosX = info.Overscan.left + info.guiInsets.left;
+    auto fToPosY = info.Overscan.top + info.guiInsets.top;
+    auto fToWidth = info.Overscan.right - info.guiInsets.right - fToPosX;
+    auto fToHeight = info.Overscan.bottom - info.guiInsets.bottom - fToPosY;
 
     float fZoom = (100 + CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_LOOKANDFEEL_SKINZOOM)) * 0.01f;
 

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -20,6 +20,10 @@
 
 #include <cstdlib>
 
+EdgeInsets::EdgeInsets(float l, float t, float r, float b) : left(l), top(t), right(r), bottom(b)
+{
+}
+
 RESOLUTION_INFO::RESOLUTION_INFO(int width, int height, float aspect, const std::string &mode) :
   strMode(mode)
 {
@@ -34,11 +38,12 @@ RESOLUTION_INFO::RESOLUTION_INFO(int width, int height, float aspect, const std:
   dwFlags = iSubtitles = 0;
 }
 
-RESOLUTION_INFO::RESOLUTION_INFO(const RESOLUTION_INFO& res) :
-  Overscan(res.Overscan),
-  strMode(res.strMode),
-  strOutput(res.strOutput),
-  strId(res.strId)
+RESOLUTION_INFO::RESOLUTION_INFO(const RESOLUTION_INFO& res)
+  : Overscan(res.Overscan),
+    guiInsets(res.guiInsets),
+    strMode(res.strMode),
+    strOutput(res.strOutput),
+    strId(res.strId)
 {
   bFullScreen = res.bFullScreen;
   iWidth = res.iWidth; iHeight = res.iHeight;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -41,9 +41,21 @@ public:
   }
 };
 
+struct EdgeInsets
+{
+  float left = 0.0f;
+  float top = 0.0f;
+  float right = 0.0f;
+  float bottom = 0.0f;
+
+  EdgeInsets() = default;
+  EdgeInsets(float l, float t, float r, float b);
+};
+
 struct RESOLUTION_INFO
 {
   OVERSCAN Overscan;
+  EdgeInsets guiInsets;
   bool bFullScreen;
   int iWidth;
   int iHeight;


### PR DESCRIPTION
## Description
Extends `RESOLUTION_INFO` with `guiInsets` field that adds edge insets when computing GUI scaling in `CGraphicContext::GetGUIScaling()`.

## Motivation and Context
This is a better approach to making GUI not being obscured by device's notch originally introduced in #16719, because it still allows rendering video in full screen. Originally requested at https://forum.kodi.tv/showthread.php?tid=348671.

## How Has This Been Tested?
Tested on iPhone XR (with notch) and iPhone 6+ / iPad Air 2 (without) and with external screen connected via HDMI adapter.

## Screenshots:
![1_framed](https://user-images.githubusercontent.com/1557784/72747620-395a3d00-3bc6-11ea-906d-c9c5d7b21fc4.png)
![1force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/72747621-395a3d00-3bc6-11ea-88aa-d088129e3230.png)
![2_framed](https://user-images.githubusercontent.com/1557784/72747622-39f2d380-3bc6-11ea-8d31-c8b956e8913d.png)
![2force_landscapeleft_framed](https://user-images.githubusercontent.com/1557784/72747623-39f2d380-3bc6-11ea-8720-39b484e24f52.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
