### PR TITLE
[Estuary] Media Flags fix

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -89,6 +89,7 @@
 						<param name="texture" value="$INFO[MusicPlayer.Channels,flags/audiochannel/,.png]" />
 					</include>
 					<control type="group">
+						<visible>!String.IsEmpty(MusicPlayer.SampleRate)</visible>
 						<width>115</width>
 						<control type="label">
 							<width>115</width>
@@ -103,6 +104,7 @@
 						</include>
 					</control>
 					<control type="group">
+						<visible>!String.IsEmpty(MusicPlayer.BitRate)</visible>
 						<width>115</width>
 						<control type="label">
 							<width>115</width>
@@ -117,6 +119,7 @@
 						</include>
 					</control>
 					<control type="group">
+						<visible>!String.IsEmpty(MusicPlayer.BitsPerSample)</visible>
 						<width>115</width>
 						<control type="label">
 							<width>115</width>


### PR DESCRIPTION
Follow up PR to https://github.com/xbmc/xbmc/pull/17183 to fix a problem introduced whereby empty media flags on seekbar can show for PVR Radio using musicplayer as reported by @ksooo at https://github.com/xbmc/xbmc/pull/17183#issuecomment-576383483 

Screenshot shared by ksooo showing the issue

![image](https://user-images.githubusercontent.com/5781142/72806154-79640300-3c4c-11ea-8c75-c82ea40f07a1.png)

Needs testing as I don't have PVR Radio so this has been coded blind.