### PR TITLE
[ios] fix visibility of input field with iPad's floating/split keyboard

### DIFF
--- a/xbmc/platform/darwin/ios/IOSKeyboardView.mm
+++ b/xbmc/platform/darwin/ios/IOSKeyboardView.mm
@@ -174,8 +174,10 @@ static CEvent keyboardFinishedEvent;
   return YES;
 }
 
-- (void)keyboardDidChangeFrame:(id)sender
+- (void)keyboardDidChangeFrame:(NSNotification*)notification
 {
+  _kbRect = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  [self setNeedsLayout];
 }
 
 - (void)keyboardDidHide:(id)sender


### PR DESCRIPTION
## Description
Makes sure that native input field is always on top of the iOS keyboard and not obscured by it.

## Motivation and Context
When iPad's keyboard is set to a floating or split mode, moving it over the screen partially or fully hides the input field. Also, after closing keyboard in split mode, next time keyboard appears the input field is completely invisible (although input still works). Reported by @Memphiz .

## How Has This Been Tested?
Tested on iPad Air 2 with various keyboard states and iPhone 6+.

## Screenshots:
![Screen Shot 2020-01-21 at 17 34 27](https://user-images.githubusercontent.com/1557784/72814633-682fec00-3c76-11ea-868f-0b82d227ae4d.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
