### PR TITLE
[videos] allow 0.0 rating in RatingAndVotes

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -154,14 +154,16 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       case LISTITEM_RATING_AND_VOTES:
       {
         CRating rating = tag->GetRating(info.GetData3());
-        if (rating.rating > 0.f)
+        if (rating.rating >= 0.f)
         {
-          if (rating.votes == 0)
+          if (rating.rating > 0.f && rating.votes == 0)
             value = StringUtils::FormatNumber(rating.rating);
-          else
+          else if (rating.votes > 0)
             value = StringUtils::Format(g_localizeStrings.Get(20350).c_str(),
                                         StringUtils::FormatNumber(rating.rating).c_str(),
                                         StringUtils::FormatNumber(rating.votes).c_str());
+          else
+            break;
           return true;
         }
         break;


### PR DESCRIPTION
as mentioned on the forum (https://forum.kodi.tv/showthread.php?tid=351129&pid=2918231) videos can have a rating of 0.0

currently ListItem.RatingAndVotes won't display a value when a video has a 0.0 rating.

this PR fixes that by accepting rating 0.0 as a valid value for videos where votes > 0.

