### PR TITLE
[macos][packaging] fix parsing device handle of a mounted dmg

### DIFF
--- a/tools/darwin/packaging/osx/dmgmaker.pl
+++ b/tools/darwin/packaging/osx/dmgmaker.pl
@@ -35,7 +35,7 @@ sub make_dmg {
     `hdiutil create -fs HFS+ -volname "$pkgname" -format UDRW -srcfolder "$mpkg" "$volname.dmg"`;
     $dev_handle = `hdiutil attach -readwrite -noverify -noautoopen "$volname.dmg" | grep Apple_HFS`;
     chomp $dev_handle;
-    $dev_handle = $1 if $dev_handle =~ /^\/dev\/(disk.)/;
+    $dev_handle = $1 if $dev_handle =~ /^\/dev\/(disk\d+)/;
     die("Could not obtain device handle\n") if !$dev_handle;
     print "Got device handle \"$dev_handle\"\n";
     #clear the volume - we will copy stuff on it with ditto later


### PR DESCRIPTION
## Motivation and Context
`/dev/disk` can have arbitrary amount of digits, e.g. `disk10`, but script tries to detect only a single character.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
