### PR TITLE
[macos][packaging] fix parsing device handle of a mounted dmg

### DIFF
--- a/tools/darwin/packaging/osx/dmgmaker.pl
+++ b/tools/darwin/packaging/osx/dmgmaker.pl
@@ -35,7 +35,7 @@ sub make_dmg {
     `hdiutil create -fs HFS+ -volname "$pkgname" -format UDRW -srcfolder "$mpkg" "$volname.dmg"`;
     $dev_handle = `hdiutil attach -readwrite -noverify -noautoopen "$volname.dmg" | grep Apple_HFS`;
     chomp $dev_handle;
-    $dev_handle = $1 if $dev_handle =~ /^\/dev\/(disk.)/;
+    $dev_handle = $1 if $dev_handle =~ /^\/dev\/(disk\d+)/;
     die("Could not obtain device handle\n") if !$dev_handle;
     print "Got device handle \"$dev_handle\"\n";
     #clear the volume - we will copy stuff on it with ditto later


### PR DESCRIPTION
Backport of #17245.