### PR TITLE
[Estuary] fix brackets in DialogVideoInfo.xml

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -229,7 +229,7 @@
 						<param name="control_id" value="161" />
 						<param name="label" value="[COLOR button_focus]$LOCALIZE[570]: [/COLOR]$INFO[ListItem.DateAdded]" />
 						<param name="altlabel" value="$LOCALIZE[570]: $INFO[ListItem.DateAdded]" />
-						<param name="visible" value="!String.IsEmpty(ListItem.DateAdded) + (String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,video))" />
+						<param name="visible" value="!String.IsEmpty(ListItem.DateAdded) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,video)]" />
 					</include>
 					<include content="InfoDialogMetadata">
 						<param name="control_id" value="163" />


### PR DESCRIPTION
fixes these errors:
```
INFO: Loading skin file: DialogVideoInfo.xml, load type: KEEP_IN_MEMORY
ERROR: unmatched parentheses in (string.isequal(listitem.dbtype,episode)
ERROR: unmatched parentheses in string.isequal(listitem.dbtype,video))
```