### PR TITLE
[Estuary] [music] Show disc title instead of album title in wall views

### DIFF
--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -100,6 +100,18 @@
 					<shadowcolor>text_shadow</shadowcolor>
 					<scroll>$PARAM[focused]</scroll>
 					<align>center</align>
+					<visible>!String.IsEqual(Container.SortMethod,$LOCALIZE[427])</visible>
+				</control>
+				<control type="label">
+					<left>29</left>
+					<top>300</top>
+					<width>260</width>
+					<label>$INFO[ListItem.Label]</label>
+					<font>font10</font>
+					<shadowcolor>text_shadow</shadowcolor>
+					<scroll>$PARAM[focused]</scroll>
+					<align>center</align>
+					<visible>String.IsEqual(Container.SortMethod,$LOCALIZE[427])</visible>
 				</control>
 				<control type="label">
 					<left>29</left>


### PR DESCRIPTION
## Description
Show the disc title instead of the Album title when viewing in wall or info_wall views if 'split by disc' is enabled or the album is a box set.  See screenshots.

## Motivation and Context
Currently, Estuary only shows the disc titles in Shift and Wide List views.  This PR shows the disc titles in the wall views as well, if either navigation by discs is enabled or the album is a boxset.  The title of the album/boxset is already displayed at the top left of the screen.

## How Has This Been Tested?
Tested locally on a clean build of current master.

## Screenshots (if appropriate):
Before change
<a href="https://ibb.co/Nx9hztg"><img src="https://i.ibb.co/9nbXjcm/screenshot053.png" alt="screenshot053" border="0"></a>

After change
<a href="https://ibb.co/QbLDgSq"><img src="https://i.ibb.co/X21YQ0d/screenshot052.png" alt="screenshot052" border="0"></a>
## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
