### PR TITLE
[PVR] Channel Manager: If started via channel's context menu, presele…

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -164,7 +164,24 @@ void CGUIDialogPVRChannelManager::OnInitWindow()
   m_bContainsChanges = false;
   m_bAllowNewChannel = false;
   SetProperty("IsRadio", "");
+
   Update();
+
+  if (m_initialSelection)
+  {
+    // set initial selection
+    const std::shared_ptr<CPVRChannel> channel = m_initialSelection->GetPVRChannelInfoTag();
+    for (int i = 0; i < m_channelItems->Size(); ++i)
+    {
+      if (m_channelItems->Get(i)->GetPVRChannelInfoTag() == channel)
+      {
+        m_iSelected = i;
+        m_viewControl.SetSelectedItem(m_iSelected);
+        break;
+      }
+    }
+    m_initialSelection.reset();
+  }
   SetData(m_iSelected);
 }
 
@@ -173,6 +190,12 @@ void CGUIDialogPVRChannelManager::OnDeinitWindow(int nextWindowID)
   Clear();
 
   CGUIDialog::OnDeinitWindow(nextWindowID);
+}
+
+void CGUIDialogPVRChannelManager::Open(const std::shared_ptr<CFileItem>& initialSelection)
+{
+  m_initialSelection = initialSelection;
+  CGUIDialog::Open();
 }
 
 bool CGUIDialogPVRChannelManager::OnClickListChannels(CGUIMessage& message)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.h
@@ -36,6 +36,8 @@ namespace PVR
     bool HasListItems() const override{ return true; }
     CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
+    void Open(const std::shared_ptr<CFileItem>& initialSelection);
+
   protected:
     void OnInitWindow() override;
     void OnDeinitWindow(int nextWindowID) override;
@@ -74,6 +76,7 @@ namespace PVR
     bool m_bContainsChanges = false;
     bool m_bAllowNewChannel = false;
 
+    std::shared_ptr<CFileItem> m_initialSelection;
     int m_iSelected = 0;
     CFileItemList* m_channelItems;
     CGUIViewControl m_viewControl;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -304,8 +304,11 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
 void CGUIWindowPVRChannelsBase::ShowChannelManager()
 {
   CGUIDialogPVRChannelManager* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRChannelManager>(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
-  if (dialog)
-    dialog->Open();
+  if (!dialog)
+    return;
+
+  const int iItem = m_viewControl.GetSelectedItem();
+  dialog->Open(iItem >= 0 && iItem < m_vecItems->Size() ? m_vecItems->Get(iItem) : nullptr);
 }
 
 void CGUIWindowPVRChannelsBase::ShowGroupManager()


### PR DESCRIPTION
…ct that channel on dialog open.

Closes #17167.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish for review?