### PR TITLE
[PVR] Context menus: Implement 'Record', 'Stop recording', 'Switch to channel' for EPG gap tags.

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -414,8 +414,13 @@ namespace PVR
     if (CheckParentalLock(channel) != ParentalCheckResult::SUCCESS)
       return false;
 
-    const std::shared_ptr<CPVREpgInfoTag> epgTag(CPVRItem(item).GetEpgInfoTag());
-    if (!epgTag && bCreateRule)
+    std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
+    if (epgTag)
+    {
+      if (epgTag->IsGapTag())
+        epgTag.reset(); // for gap tags, we can only create instant timers
+    }
+    else if (bCreateRule)
     {
       CLog::LogF(LOGERROR, "No epg tag!");
       return false;
@@ -667,6 +672,16 @@ namespace PVR
                 if (epgTag->ProgressPercentage() > 90.0f)
                   ePreselect = RECORD_NEXT_SHOW;
               }
+            }
+
+            if (ePreselect == RECORD_INSTANTRECORDTIME)
+            {
+              if (iDurationDefault == 30)
+                ePreselect = RECORD_30_MINUTES;
+              else if (iDurationDefault == 60)
+                ePreselect = RECORD_60_MINUTES;
+              else if (iDurationDefault == 120)
+                ePreselect = RECORD_120_MINUTES;
             }
 
             selector.PreSelectAction(ePreselect);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -393,7 +393,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
         }
 
         const std::shared_ptr<CFileItem> pItem = GetCurrentListItem();
-        if (pItem && !pItem->GetEPGInfoTag()->IsGapTag())
+        if (pItem)
         {
           switch (message.GetParam1())
           {
@@ -491,43 +491,6 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
               OnPopupMenu(GetCurrentListItemIndex(pItem));
               bReturn = true;
               break;
-          }
-        }
-        else
-        {
-          switch (message.GetParam1())
-          {
-            case ACTION_SELECT_ITEM:
-            case ACTION_MOUSE_LEFT_CLICK:
-            case ACTION_PLAYER_PLAY:
-            {
-              // EPG "gap" selected => switch to associated channel.
-              CGUIEPGGridContainer* epgGridContainer = GetGridControl();
-              if (epgGridContainer)
-              {
-                const CFileItemPtr item(epgGridContainer->GetSelectedGridItem());
-                if (item)
-                {
-                  CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, true);
-                  bReturn = true;
-                }
-              }
-              break;
-            }
-            case ACTION_CONTEXT_MENU:
-            {
-              // EPG "gap" selected => create and process special context menu with item independent entries.
-              CContextButtons buttons;
-              GetContextButtons(-1, buttons);
-
-              int iButton = CGUIDialogContextMenu::ShowAndGetChoice(buttons);
-              if (iButton >= 0)
-              {
-                OnContextButton(-1, static_cast<CONTEXT_BUTTON>(iButton));
-              }
-              bReturn = true;
-              break;
-            }
           }
         }
       }


### PR DESCRIPTION
Improvements for context menus in the Guide window:
* Implement 'Record', 'Stop recording', 'Switch to channel' for EPG gap tags. (Formerly, only 'Navigate' was available in the context menu of 'gap tags'.)
* Implementing 'Add timer', 'Edit timer', 'Delete timer' for management of time-based timer rules is NOT in scope of this PR. This is a bit more work as Timer settings dialog and other pieces of code need non-trivial changes for that.
* Code cleanup: No more special handling for EPG gap tags in `CGUIWindowPVRGuideBase`

![screenshot001](https://user-images.githubusercontent.com/3226626/73003366-d35bf880-3e05-11ea-9dda-59d79a8f9c9d.png)

![screenshot005](https://user-images.githubusercontent.com/3226626/73003415-ec64a980-3e05-11ea-9169-f9c6394fc0fd.png)

Setting 'Instant recording action' is taken into account:

![screenshot003](https://user-images.githubusercontent.com/3226626/73003480-056d5a80-3e06-11ea-8732-a5e5e7922972.png)

![screenshot002](https://user-images.githubusercontent.com/3226626/73003557-259d1980-3e06-11ea-8823-970771ad0da3.png)

![screenshot000](https://user-images.githubusercontent.com/3226626/73003517-1918c100-3e06-11ea-8244-bf03c1e92d3a.png)


Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish for review?