### PR TITLE
[music][gui] Ensure disc subtitle is in ListItem.Title for skins to display

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4816,8 +4816,8 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
           itemUrl.AddOption("discid", discnum);
         CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), album));
         pItem->SetLabel2(record->at(0).get_asString()); // GUI show label2 for disc sort order??
-        pItem->GetMusicInfoTag()->SetDiscNumber(
-            discnum); // Skins show discnumber for "albums"?? Confluence does.
+        pItem->GetMusicInfoTag()->SetDiscNumber(discnum);
+        pItem->GetMusicInfoTag()->SetTitle(strDiscSubtitle);
         pItem->SetLabel(strDiscSubtitle);
         pItem->SetArt("icon", "DefaultAlbumCover.png");
         items.Add(pItem);


### PR DESCRIPTION
## Description

As per the title and after comments by @ronie  & @DaveTBlake make sure that when displaying discs, ListItem.Title contains the disc subtitle.

## Motivation and Context

Currently core sets `ListItem.Label` to contain the disc subtitle and leaves `ListItem.Title` as the album title.  This was because I thought that `ListItem.Label` was used as a sub label for the title and that as a disc title is really a subtitle of an album, that this would be acceptable.  @ronie has pointed out that this is incorrect and that `ListItem.Title` should contain the title of whatever listitem Kodi is currently displaying.  This change ensures that `ListItem.Title` is correctly set when displaying discs whilst also setting `ListItem.Label` to the same value to retain compatibility with skins using that (eg Confluence).

## How Has This Been Tested?

Tested with a fresh build of current master on Ubuntu 18.04 with a fresh music library.  Estuary displays disc titles in all music views where appropriate without any changes to the skin.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
