### PR TITLE
[PVR][GUI] Add sort by 'Episode' for PVR Recordings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12964,6 +12964,7 @@ msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/pvr/windows/GUIViewStatePVR.cpp
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20359"

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -38,13 +38,14 @@ void CGUIViewStateWindowPVRChannels::SaveViewState()
 
 CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int windowId, const CFileItemList& items) : CGUIViewStatePVR(windowId, items)
 {
-  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%d", "%L", ""),    // "Name"     : Filename, DateTime | Foldername, empty
+  AddSortMethod(SortByLabel,           551, LABEL_MASKS("%L", "%d", "%L", ""),    // "Name"        : Filename, DateTime | Foldername, empty
                 CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
                   ? SortAttributeIgnoreArticle
                   : SortAttributeNone);
-  AddSortMethod(SortByDate,  552, LABEL_MASKS("%L", "%d", "%L", "%d")); // "Date"     : Filename, DateTime | Foldername, DateTime
-  AddSortMethod(SortByTime,  180, LABEL_MASKS("%L", "%D", "%L", ""));   // "Duration" : Filename, Duration | Foldername, empty
-  AddSortMethod(SortByFile,  561, LABEL_MASKS("%L", "%d", "%L", ""));   // "File"     : Filename, DateTime | Foldername, empty
+  AddSortMethod(SortByDate,            552, LABEL_MASKS("%L", "%d", "%L", "%d")); // "Date"        : Filename, DateTime | Foldername, DateTime
+  AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%L", "%e", "%L", ""));   // "Episode"     : Filename, SeasonEpisode | Foldername, empty
+  AddSortMethod(SortByTime,            180, LABEL_MASKS("%L", "%D", "%L", ""));   // "Duration"    : Filename, Duration | Foldername, empty
+  AddSortMethod(SortByFile,            561, LABEL_MASKS("%L", "%d", "%L", ""));   // "File"        : Filename, DateTime | Foldername, empty
 
   // Default sorting
   SetSortMethod(SortByDate);

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -94,12 +94,13 @@ using namespace MUSIC_INFO;
  *  %b - Total number of discs
  *  %c - Relevance - Used for actors' appearances
  *  %d - Date and Time
+ *  %e - Season and Episode
  *  %p - Last Played
  *  %r - User Rating
  *  *t - Date Taken (suitable for Pictures)
  */
 
-#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWabcdiprstuv"
+#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWabcdeiprstuv"
 
 CLabelFormatter::CLabelFormatter(const std::string &mask, const std::string &mask2)
 {
@@ -324,6 +325,15 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 'd': // date and time
     if (item->m_dateTime.IsValid())
       value = item->m_dateTime.GetAsLocalizedDateTime();
+    break;
+  case 'e': // season and episode
+    if (movie && movie->m_iEpisode > 0)
+    {
+      if (movie->m_iSeason == 0)
+        value = StringUtils::Format("S%i", movie->m_iEpisode);
+      else
+        value = StringUtils::Format("S%iE%i", movie->m_iSeason, movie->m_iEpisode);
+    }
     break;
   case 'p': // Last played
     if (movie && movie->m_lastPlayed.IsValid())


### PR DESCRIPTION
## Description
This PR adds a new "Episode" sort method for PVR Recordings.  This uses existing features and functions with the exception of needing to add a new format specifier to LabelFormatter.  The proposed format "%e" will use the format used by the PVR GUI - S%iE%i.  

There is already a similar format specifier, %H, but the format it produces does not match the PVR GUI and looks odd, "3x4" as opposed to "S3E4", for example.  My personal format preference would have been S%2.2iE%2.2i (S03E04), but again that does not match the existing PVR GUI elements.

## Motivation and Context
Users that have recordings that were recorded out of order currently have no means to sort the Recordings list(s) to view them in the order in which they were produced.  By adding an "Episode" sort, the user will now be able to view their recordings in that order if they choose.

## How Has This Been Tested?
Tested against master branch, ref [8454ab3](https://github.com/xbmc/xbmc/commit/8454ab3b67655435d2367031622f95341c0dd908) on Windows x64 Desktop.  Tested against data elements with both Season and Episode ("SxEx"), just Episode ("Sx"), and just Season (empty), which matches the display logic for format %H.

## Screenshots (if appropriate):

View of the new sort menu option, uses existing stock string #20359 ("Episode" in english):
![pr-3](https://user-images.githubusercontent.com/706055/73127631-3e860600-3f91-11ea-9455-0ca5739ceeed.png)

View of a set of recordings that are sorted by date, but give no indication what order they should be viewed in.  User must highlight each one and check the info pane to the right:
![pr-2](https://user-images.githubusercontent.com/706055/73127650-8d33a000-3f91-11ea-896a-198e321b7e06.png)

View of the same set of recordings sorted by 'Episode', which makes it clear what the production order was.
![pr-1](https://user-images.githubusercontent.com/706055/73127655-aa686e80-3f91-11ea-85f5-185a212b23b6.png)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project *
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

* As usual there are places where applying the current clang-format to the code would mess up existing layout.  I opted to maintain existing formatting to be consistent when it seemed appropriate to do so.