### PR TITLE
Provide OS and system properties to python addons

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -540,6 +540,16 @@ namespace XBMCAddon
       return CSysInfo::GetUserAgent();
     }
 
+    String getOsName()
+    {
+      return CSysInfo::GetOsName();
+    }
+
+    String getSystemPropertyString(const String& propertyName)
+    {
+      return CSysInfo::GetSystemPropertyString(propertyName);
+    }
+
     int getSERVER_WEBSERVER() { return CApplication::ES_WEBSERVER; }
     int getSERVER_AIRPLAYSERVER() { return CApplication::ES_AIRPLAYSERVER; }
     int getSERVER_UPNPSERVER() { return CApplication::ES_UPNPSERVER; }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -971,6 +971,38 @@ namespace XBMCAddon
 #else
     String convertLanguage(const char* language, int format);
 #endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmc
+    /// @brief \python_func{ xbmc.getOsName() }
+    ///-----------------------------------------------------------------------
+    /// @brief Returns Kodi's operating system name
+    ///
+    /// @return operation system name
+    ///
+    /// ------------------------------------------------------------------------
+    ///
+    /// example output: OS X
+    ///
+    getOsName();
+#else
+    String getOsName();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmc
+    /// @brief \python_func{ xbmc.getSystemPropertyString(propertyName) }
+    ///-----------------------------------------------------------------------
+    /// @brief Returns an Os dependend system property
+    ///
+    /// @return value assigned to propertyName
+    ///
+    getSystemPropertyString(...);
+#else
+    String getSystemPropertyString(const String& propertyName);
+#endif
     //@}
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     SWIG_CONSTANT_FROM_GETTER(int, SERVER_WEBSERVER);

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -773,6 +773,17 @@ std::string CSysInfo::GetModelName(void)
   return modelName;
 }
 
+std::string CSysInfo::GetSystemPropertyString(const std::string& propertyName)
+{
+  std::string value;
+#if defined(TARGET_ANDROID)
+  char deviceCStr[PROP_VALUE_MAX];
+  int propLen = __system_property_get(propertyName.c_str(), deviceCStr);
+  value.assign(deviceCStr, (propLen > 0 && propLen <= PROP_VALUE_MAX) ? propLen : 0);
+#endif
+  return value;
+}
+
 bool CSysInfo::IsAeroDisabled()
 {
 #ifdef TARGET_WINDOWS_STORE

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -120,6 +120,7 @@ public:
   static const std::string& GetKernelCpuFamily(void);
   static std::string GetManufacturerName(void);
   static std::string GetModelName(void);
+  static std::string GetSystemPropertyString(const std::string& propertyName);
   bool GetDiskSpace(std::string drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed);
   std::string GetHddSpaceInfo(int& percent, int drive, bool shortText=false);
   std::string GetHddSpaceInfo(int drive, bool shortText=false);


### PR DESCRIPTION
## Description
using the xbmc module 2 new functions are available:
- getOsName() -> returns the name of the os kodi is running
- getSystemPropertyString -> returns device dependent system properties

## Motivation and Context
I'm working on an addon which requires some system properties to build a token.

## How Has This Been Tested?
Sample script which includes print(xbmc.getOsName())

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
