### PR TITLE
[PVR] Fix CPVREpgTagsContainer::UpdateEntries to reset the tags cache…

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -155,7 +155,7 @@ bool CPVREpgTagsContainer::UpdateEntries(const CPVREpgTagsContainer& tags)
     }
 
     if (bResetCache)
-      m_tagsCache.reset();
+      m_tagsCache->Reset();
   }
   else
   {

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -197,9 +197,8 @@ private:
 
   int m_iEpgID = 0;
   std::shared_ptr<CPVREpgChannelData> m_channelData;
-  std::shared_ptr<CPVREpgDatabase> m_database;
-
-  std::unique_ptr<CPVREpgTagsCache> m_tagsCache;
+  const std::shared_ptr<CPVREpgDatabase> m_database;
+  const std::unique_ptr<CPVREpgTagsCache> m_tagsCache;
 
   std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>> m_changedTags;
   std::map<CDateTime, std::shared_ptr<CPVREpgInfoTag>> m_deletedTags;


### PR DESCRIPTION
… data, not the tags cache instance. Make two members const to prevent those kind of bugs in the future.

Fixes #17267 

@djp952 fyi
@phunkyfish for review

