### PR TITLE
[PVR] Fix CPVREpgTagsCache missing channel data.

### DIFF
--- a/xbmc/pvr/epg/EpgTagsCache.cpp
+++ b/xbmc/pvr/epg/EpgTagsCache.cpp
@@ -22,6 +22,18 @@ namespace
 const CDateTimeSpan ONE_SECOND(0, 0, 0, 1);
 }
 
+void CPVREpgTagsCache::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
+{
+  m_channelData = data;
+
+  if (m_lastEndedTag)
+    m_lastEndedTag->SetChannelData(data);
+  if (m_nowActiveTag)
+    m_nowActiveTag->SetChannelData(data);
+  if (m_nextStartingTag)
+    m_nextStartingTag->SetChannelData(data);
+}
+
 std::shared_ptr<CPVREpgInfoTag> CPVREpgTagsCache::GetLastEndedTag()
 {
   Refresh(true);

--- a/xbmc/pvr/epg/EpgTagsCache.h
+++ b/xbmc/pvr/epg/EpgTagsCache.h
@@ -31,6 +31,8 @@ public:
   {
   }
 
+  void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
+
   void Reset();
 
   std::shared_ptr<CPVREpgInfoTag> GetLastEndedTag();

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -43,6 +43,7 @@ void CPVREpgTagsContainer::SetEpgID(int iEpgID)
 void CPVREpgTagsContainer::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data)
 {
   m_channelData = data;
+  m_tagsCache->SetChannelData(data);
   for (const auto& tag : m_changedTags)
     tag.second->SetChannelData(data);
 }


### PR DESCRIPTION
Fallout from #17195 

Fixes for example missing channel icon and buttons in PVR programme info dialog

@phunkyfish for review. channel data might be set asynchronously and I forgot about that when writing the code for the tags cache. :-/

