### PR TITLE
[gbm] define EGL_NO_X11 to follow upstream changes

### DIFF
--- a/cmake/platform/linux/gbm.cmake
+++ b/cmake/platform/linux/gbm.cmake
@@ -14,4 +14,4 @@ else()
 endif()
 
 # __GBM__ is needed by eglplatform.h in case it is included before gbm.h
-list(APPEND PLATFORM_DEFINES -DMESA_EGL_NO_X11_HEADERS -D__GBM__=1 -DPLATFORM_SETTINGS_FILE=gbm.xml)
+list(APPEND PLATFORM_DEFINES -DMESA_EGL_NO_X11_HEADERS -DEGL_NO_X11 -D__GBM__=1 -DPLATFORM_SETTINGS_FILE=gbm.xml)


### PR DESCRIPTION
This avoids the following warning

```
/usr/include/EGL/eglplatform.h:59:2: warning: #warning "`MESA_EGL_NO_X11_HEADERS` is deprecated, and doesn't work with the unmodified Khronos header" [-Wcpp]
   59 | #warning "`MESA_EGL_NO_X11_HEADERS` is deprecated, and doesn't work with the unmodified Khronos header"
      |  ^~~~~~~
/usr/include/EGL/eglplatform.h:60:2: warning: #warning "Please use `EGL_NO_X11` instead, as `MESA_EGL_NO_X11_HEADERS` will be removed soon" [-Wcpp]
   60 | #warning "Please use `EGL_NO_X11` instead, as `MESA_EGL_NO_X11_HEADERS` will be removed soon"
      |  ^~~~~~~

```

upstream change is here https://gitlab.freedesktop.org/mesa/mesa/commit/6202a13b71e18dc31ba7e2f4ea915b67eacc1ddb
