### PR TITLE
Games: Fix launching disk images and zip files

### DIFF
--- a/system/playercorefactory.xml
+++ b/system/playercorefactory.xml
@@ -26,7 +26,7 @@
 
     <!-- DVDs -->
     <rule name="dvd" dvd="true" player="VideoPlayer" />
-    <rule name="dvdimage" dvdimage="true" player="VideoPlayer" />
+    <rule name="dvdimage" dvdimage="true" game="false" player="VideoPlayer" />
 
     <!-- Only VideoPlayer can handle these normally -->
     <rule name="sdp/asf" filetypes="sdp|asf" player="VideoPlayer" />

--- a/system/playercorefactory.xml
+++ b/system/playercorefactory.xml
@@ -26,7 +26,7 @@
 
     <!-- DVDs -->
     <rule name="dvd" dvd="true" player="VideoPlayer" />
-    <rule name="dvdimage" dvdimage="true" game="false" player="VideoPlayer" />
+    <rule name="discimage" discimage="true" game="false" player="VideoPlayer" />
 
     <!-- Only VideoPlayer can handle these normally -->
     <rule name="sdp/asf" filetypes="sdp|asf" player="VideoPlayer" />

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -758,12 +758,12 @@ public:
 
   void ClearSortState();
 
-  VECFILEITEMS::const_iterator begin() { return m_items.cbegin(); }
-  VECFILEITEMS::const_iterator end() { return m_items.cend(); }
+  VECFILEITEMS::iterator begin() { return m_items.begin(); }
+  VECFILEITEMS::iterator end() { return m_items.end(); }
   VECFILEITEMS::const_iterator begin() const { return m_items.begin(); }
   VECFILEITEMS::const_iterator end() const { return m_items.end(); }
-  VECFILEITEMS::const_iterator cbegin() const { return m_items.begin(); }
-  VECFILEITEMS::const_iterator cend() const { return m_items.end(); }
+  VECFILEITEMS::const_iterator cbegin() const { return m_items.cbegin(); }
+  VECFILEITEMS::const_iterator cend() const { return m_items.cend(); }
 private:
   void Sort(FILEITEMLISTCOMPARISONFUNC func);
   void FillSortFields(FILEITEMFILLFUNC func);

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -47,6 +47,7 @@ void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
   m_tRemote = GetTristate(pRule->Attribute("remote"));
   m_tAudio = GetTristate(pRule->Attribute("audio"));
   m_tVideo = GetTristate(pRule->Attribute("video"));
+  m_tGame = GetTristate(pRule->Attribute("game"));
 
   m_tBD = GetTristate(pRule->Attribute("bd"));
   m_tDVD = GetTristate(pRule->Attribute("dvd"));
@@ -111,6 +112,8 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, std::vector<std::st
   if (m_tAudio >= 0 && (m_tAudio > 0) != item.IsAudio())
     return;
   if (m_tVideo >= 0 && (m_tVideo > 0) != item.IsVideo())
+    return;
+  if (m_tGame >= 0 && (m_tGame > 0) != item.IsGame())
     return;
   if (m_tInternetStream >= 0 && (m_tInternetStream > 0) != item.IsInternetStream())
     return;

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -52,7 +52,13 @@ void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
   m_tBD = GetTristate(pRule->Attribute("bd"));
   m_tDVD = GetTristate(pRule->Attribute("dvd"));
   m_tDVDFile = GetTristate(pRule->Attribute("dvdfile"));
-  m_tDVDImage = GetTristate(pRule->Attribute("dvdimage"));
+  m_tDiscImage = GetTristate(pRule->Attribute("discimage"));
+  if (m_tDiscImage < 0)
+  {
+    m_tDiscImage = GetTristate(pRule->Attribute("dvdimage"));
+    if (m_tDiscImage >= 0)
+      CLog::Log(LOGWARNING, "\"dvdimage\" tag is deprecated. use \"discimage\"");
+  }
 
   m_protocols = XMLUtils::GetAttribute(pRule, "protocols");
   m_fileTypes = XMLUtils::GetAttribute(pRule, "filetypes");
@@ -126,7 +132,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, std::vector<std::st
     return;
   if (m_tDVDFile >= 0 && (m_tDVDFile > 0) != item.IsDVDFile())
     return;
-  if (m_tDVDImage >= 0 && (m_tDVDImage > 0) != item.IsDiscImage())
+  if (m_tDiscImage >= 0 && (m_tDiscImage > 0) != item.IsDiscImage())
     return;
 
   CRegExp regExp(false, CRegExp::autoUtf8);

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -35,6 +35,7 @@ private:
 
   int m_tAudio;
   int m_tVideo;
+  int m_tGame;
   int m_tInternetStream;
   int m_tRemote;
 

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -42,7 +42,7 @@ private:
   int m_tBD;
   int m_tDVD;
   int m_tDVDFile;
-  int m_tDVDImage;
+  int m_tDiscImage;
 
   std::string m_protocols;
   std::string m_fileTypes;

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -265,6 +265,13 @@ bool CGUIWindowGames::GetDirectory(const std::string &strDirectory, CFileItemLis
   if (!content.empty())
     items.SetContent(content);
 
+  // Ensure a game info tag is created so that files are recognized as games
+  for (const CFileItemPtr& item : items)
+  {
+    if (!item->m_bIsFolder)
+      item->GetGameInfoTag();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Description
This PR fixes two errors when launching games. Closes #15841.

### First fix

The first fix is for disk images. In `system/playercorefactory.xml` is the line:

```xml
<rule name="dvdimage" dvdimage="true" player="VideoPlayer" />
```

Setting `dvdimage="true"` calls into FileItem [here](https://github.com/xbmc/xbmc/blob/f4d6b4022/xbmc/FileItem.cpp#L1087) to see if the extension is a disk image: 

```c++
bool CFileItem::IsDiscImage() const
{
  return URIUtils::HasExtension(m_strPath, ".img|.iso|.nrg|.udf");
}
```

We want to avoid using VideoPlayer for fileitems with a game info tag, so I've modified the xml line to be:

```xml
<rule name="dvdimage" dvdimage="true" game="false" player="VideoPlayer" />
```

This skips the `IsDiscImage()` comparison for FileItems with a game info tag.

### Second fix

The second fix is for zip and 7z games not launching. They aren't matched to a player and default to VideoPlayer. When launched, VideoPlayer shows a buffering window then immediately exits to the previous window.

I fixed this by giving ListItems a game info tag in MyGames. Now, when no rules match, RetroPlayer is used to open the file.

## Motivation and Context

See #15841

## How Has This Been Tested?

Test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-18.5-20200127

### Launching a .zip file

Before:

```
DEBUG: CPlayerCoreFactory::GetPlayers(/Users/xxx/Library/Application Support/Kodi/userdata/addon_data/plugin.program.iagl/temp_iagl/88games.7z)
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: system rules
DEBUG: CPlayerSelectionRule::GetPlayers: matches rule: system rules
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: mms/udp
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: lastfm/shout
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: rtmp
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: rtsp
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: streams
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: dvd
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: sdp/asf
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: nsv
DEBUG: CPlayerSelectionRule::GetPlayers: considering rule: radio
DEBUG: CPlayerCoreFactory::GetPlayers: matched 0 rules with players
DEBUG: CPlayerCoreFactory::GetPlayers: adding videodefaultplayer (VideoPlayer)
DEBUG: CPlayerCoreFactory::GetPlayers: for video=1, audio=0
DEBUG: CPlayerCoreFactory::GetPlayers: for video=1, audio=1
DEBUG: CPlayerCoreFactory::GetPlayers: added 1 players
```

After:

```
Debug Print: CPlayerCoreFactory::GetPlayers(C:\Users\xxx\Desktop\temp_iagl\88games.zip)
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: system rules
Debug Print: CPlayerSelectionRule::GetPlayers: matches rule: system rules
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: mms/udp
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: lastfm/shout
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: rtmp
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: rtsp
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: streams
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: dvd
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: dvdimage
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: sdp/asf
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: nsv
Debug Print: CPlayerSelectionRule::GetPlayers: considering rule: radio
Debug Print: CPlayerCoreFactory::GetPlayers: matched 0 rules with players
Debug Print: CPlayerCoreFactory::GetPlayers: adding retroplayer
Debug Print: CPlayerCoreFactory::GetPlayers: added 1 players
...
Debug Print: Select game client dialog: Found 9 candidates
Debug Print: Adding game.libretro.cap32 as a candidate
Debug Print: Adding game.libretro.fbalpha2012 as a candidate
Debug Print: Adding game.libretro.mame2000 as a candidate
Debug Print: Adding game.libretro.mame2010 as a candidate
Debug Print: Adding game.libretro.hatari as a candidate
Debug Print: Adding game.libretro.uae as a candidate
Debug Print: Adding game.libretro.vice as a candidate
Debug Print: Adding game.libretro.reicast as a candidate
Debug Print: Adding game.libretro.yabause as a candidate
Debug Print: Select game client dialog: Found 1 installable clients
Debug Print: Adding game.libretro.fbalpha as an installable client
Debug Print: Select game client dialog: Loading savestate metadata
Debug Print: Loading savestate from C:\Users\xxx\Desktop\temp_iagl\88games.sav
Debug Print: Failed to open savestate file C:\Users\xxx\Desktop\temp_iagl\88games.sa
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
