### PR TITLE
Fix TextureCache::CacheImage does not fill texture outparam

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -12,6 +12,7 @@
 #include "TextureCacheJob.h"
 #include "URL.h"
 #include "filesystem/File.h"
+#include "guilib/Texture.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -159,7 +160,20 @@ std::string CTextureCache::CacheImage(const std::string &image, CBaseTexture **t
   CTextureDetails tempDetails;
   if (!details)
     details = &tempDetails;
-  return GetCachedImage(url, *details, true);
+
+  std::string cachedpath = GetCachedImage(url, *details, true);
+  if (!cachedpath.empty())
+  {
+    if (texture)
+      *texture = CBaseTexture::LoadFromFile(cachedpath, 0, 0);
+  }
+  else
+  {
+    CLog::Log(LOGDEBUG, "CTextureCache::%s - Return NULL texture because cache is not ready",
+              __FUNCTION__);
+  }
+
+  return cachedpath;
 }
 
 bool CTextureCache::CacheImage(const std::string &image, CTextureDetails &details)


### PR DESCRIPTION
## Description
If the texture out parameter is given, it's expected to be
filled.
However when requesting a texture which is already in the
processlist, the method fails to fill the requested texture.

This resulted in a hard to trigger bug, where the default
texture is rendered instead of the real thumbnail, although
the thumbnail is available.

## Motivation and Context
Fix annyoing cover flicker, where sometime the normal layout shows the default icon
but on focus the correct thumbnail is shown.

## How Has This Been Tested?
It's quite hard to trigger, tested on linux with a big movie library.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
