### PR TITLE
webserver: Fix file access on auto-mounted sources

### DIFF
--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -9,10 +9,13 @@
 #include "HTTPVfsHandler.h"
 
 #include "MediaSource.h"
+#include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
 #include "filesystem/File.h"
 #include "network/WebServer.h"
 #include "settings/MediaSourceSettings.h"
+#include "storage/MediaManager.h"
 #include "utils/URIUtils.h"
 
 CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
@@ -40,6 +43,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
         while (URIUtils::IsInArchive(realPath))
           realPath = CURL(realPath).GetHostName();
 
+        // Check manually configured sources
         VECSOURCES *sources = NULL;
         for (unsigned int index = 0; index < size && !accessible; index++)
         {
@@ -66,6 +70,19 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
               }
             }
           }
+        }
+
+        // Check auto-mounted sources
+        if (!accessible)
+        {
+          bool isSource;
+          VECSOURCES removableSources;
+          CServiceBroker::GetMediaManager().GetRemovableDrives(removableSources);
+          int sourceIndex = CUtil::GetMatchingSource(realPath, removableSources, isSource);
+          if (sourceIndex >= 0 && sourceIndex < static_cast<int>(removableSources.size()) &&
+              removableSources.at(sourceIndex).m_iHasLock != 2 &&
+              removableSources.at(sourceIndex).m_allowSharing)
+            accessible = true;
         }
       }
 


### PR DESCRIPTION
Fix to allow access to media files on auto-mounted sources via webserver that is consistent with that on manually added sources.

The problem was that having added music files located on a USB stick to the music library, unlike other library items, I was unable to play them locally using Chorus 2. 

This was caused because `CHTTPVfsHandler` was only checking assesibility on sources that had been manually added (and stored in sources.xml) and not allowing access to removeable sources such as CDROM and USB sticks and portable drives that are auto-mounted (not in sources.xml).

@Montellese can you review as it seems you are the webserver expert historically.