### PR TITLE
[addons] cleanup, prevent C++ from addon in Kodi, fix addon CStructHdl

### DIFF
--- a/xbmc/addons/AddonProvider.h
+++ b/xbmc/addons/AddonProvider.h
@@ -8,13 +8,15 @@
 
 #pragma once
 
+#include "addons/kodi-addon-dev-kit/include/kodi/AddonBase.h"
+
+#include <memory>
+
 /*
 * CAddonProvider
 * IUnknown implementation to retrieve sub-addons from already active addons
 * See Inputstream.cpp/h for an explaric use case
 */
-
-namespace kodi { namespace addon { class IAddonInstance; } }
 
 namespace ADDON
 {
@@ -27,9 +29,12 @@ namespace ADDON
     virtual ~IAddonProvider() = default;
     enum INSTANCE_TYPE
     {
+      INSTANCE_INPUTSTREAM,
       INSTANCE_VIDEOCODEC
     };
-    virtual void getAddonInstance(INSTANCE_TYPE instance_type, ADDON::BinaryAddonBasePtr& addonBase, kodi::addon::IAddonInstance*& parentInstance) = 0;
+    virtual void getAddonInstance(INSTANCE_TYPE instance_type,
+                                  ADDON::BinaryAddonBasePtr& addonBase,
+                                  KODI_HANDLE& parentInstance) = 0;
   };
 
   } //Namespace

--- a/xbmc/addons/kodi-addon-dev-kit/include/NOTE
+++ b/xbmc/addons/kodi-addon-dev-kit/include/NOTE
@@ -7,6 +7,3 @@ Kodi related classes or functions.
 
 Also this headers are never changed without a API Version
 change.
-
-The current PVR API version can be found in xbmc_pvr_types.h:
-XBMC_PVR_API_VERSION

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -364,9 +364,9 @@ public:
     assert(cStructure);
   }
 
-  const CPP_CLASS& operator=(const CPP_CLASS& right)
+  const CStructHdl& operator=(const CStructHdl& right)
   {
-    assert(*right.m_cStructure);
+    assert(&right.m_cStructure);
     if (m_owner)
       delete m_cStructure;
     m_owner = true;
@@ -374,9 +374,9 @@ public:
     return *this;
   }
 
-  const CPP_CLASS& operator=(const C_STRUCT& right)
+  const CStructHdl& operator=(const C_STRUCT& right)
   {
-    assert(*right);
+    assert(&right);
     if (m_owner)
       delete m_cStructure;
     m_owner = true;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -50,7 +50,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
   if (hint.externalInterfaces)
   {
     ADDON::BinaryAddonBasePtr addonInfo;
-    kodi::addon::IAddonInstance* parentInstance;
+    KODI_HANDLE parentInstance;
     hint.externalInterfaces->getAddonInstance(ADDON::IAddonProvider::INSTANCE_VIDEOCODEC, addonInfo, parentInstance);
     if (addonInfo && parentInstance)
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -18,11 +18,13 @@
 
 using namespace kodi::addon;
 
-CAddonVideoCodec::CAddonVideoCodec(CProcessInfo &processInfo, ADDON::BinaryAddonBasePtr& addonInfo, kodi::addon::IAddonInstance* parentInstance)
+CAddonVideoCodec::CAddonVideoCodec(CProcessInfo& processInfo,
+                                   ADDON::BinaryAddonBasePtr& addonInfo,
+                                   KODI_HANDLE parentInstance)
   : CDVDVideoCodec(processInfo),
-    IAddonInstanceHandler(ADDON_INSTANCE_VIDEOCODEC, addonInfo, parentInstance)
-  , m_codecFlags(0)
-  , m_displayAspect(0.0f)
+    IAddonInstanceHandler(ADDON_INSTANCE_VIDEOCODEC, addonInfo, parentInstance),
+    m_codecFlags(0),
+    m_displayAspect(0.0f)
 {
   m_struct = { { 0 } };
   m_struct.toKodi.kodiInstance = this;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
@@ -20,7 +20,9 @@ class CAddonVideoCodec
   , public ADDON::IAddonInstanceHandler
 {
 public:
-  CAddonVideoCodec(CProcessInfo &processInfo, ADDON::BinaryAddonBasePtr& addonInfo, kodi::addon::IAddonInstance* parentInstance);
+  CAddonVideoCodec(CProcessInfo& processInfo,
+                   ADDON::BinaryAddonBasePtr& addonInfo,
+                   KODI_HANDLE parentInstance);
   ~CAddonVideoCodec() override;
 
   bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -20,13 +20,15 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
-CInputStreamProvider::CInputStreamProvider(ADDON::BinaryAddonBasePtr addonBase, kodi::addon::IAddonInstance* parentInstance)
-  : m_addonBase(addonBase)
-  , m_parentInstance(parentInstance)
+CInputStreamProvider::CInputStreamProvider(ADDON::BinaryAddonBasePtr addonBase,
+                                           KODI_HANDLE parentInstance)
+  : m_addonBase(addonBase), m_parentInstance(parentInstance)
 {
 }
 
-void CInputStreamProvider::getAddonInstance(INSTANCE_TYPE instance_type, ADDON::BinaryAddonBasePtr& addonBase, kodi::addon::IAddonInstance*& parentInstance)
+void CInputStreamProvider::getAddonInstance(INSTANCE_TYPE instance_type,
+                                            ADDON::BinaryAddonBasePtr& addonBase,
+                                            KODI_HANDLE& parentInstance)
 {
   if (instance_type == ADDON::IAddonProvider::INSTANCE_VIDEOCODEC)
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -21,13 +21,15 @@ class CInputStreamProvider
   : public ADDON::IAddonProvider
 {
 public:
-  CInputStreamProvider(ADDON::BinaryAddonBasePtr addonBase, kodi::addon::IAddonInstance* parentInstance);
+  CInputStreamProvider(ADDON::BinaryAddonBasePtr addonBase, KODI_HANDLE parentInstance);
 
-  void getAddonInstance(INSTANCE_TYPE instance_type, ADDON::BinaryAddonBasePtr& addonBase, kodi::addon::IAddonInstance*& parentInstance) override;
+  void getAddonInstance(INSTANCE_TYPE instance_type,
+                        ADDON::BinaryAddonBasePtr& addonBase,
+                        KODI_HANDLE& parentInstance) override;
 
 private:
   ADDON::BinaryAddonBasePtr m_addonBase;
-  kodi::addon::IAddonInstance* m_parentInstance;
+  KODI_HANDLE m_parentInstance;
 };
 
 //! \brief Input stream class

--- a/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
@@ -8,6 +8,23 @@
 
 #pragma once
 
-#define STREAM_PROPERTY_INPUTSTREAMCLASS  "inputstreamclass" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities or to allow ffmpeg to handle directly set to STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG. */
-#define STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream" /*!< @brief "true" to denote that the stream that should be played is a realtime stream. Any other value indicates that this is not a realtime stream.*/
-#define STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG  "inputstream.ffmpeg" /*!< @brief special value for STREAM_PROPERTY_INPUTSTREAMCLASS to use ffmpeg to directly play a stream URL. */
+/*!
+ * @brief the name of the inputstream add-on that should be used by Kodi to
+ * play the stream denoted by STREAM_PROPERTY_STREAMURL. Leave blank to use
+ * Kodi's built-in playing capabilities or to allow ffmpeg to handle directly
+ * set to STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG.
+ */
+#define STREAM_PROPERTY_INPUTSTREAMCLASS "inputstreamclass"
+
+/*!
+ * @brief "true" to denote that the stream that should be played is a
+ * realtime stream. Any other value indicates that this is not a realtime
+ * stream.
+ */
+#define STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream"
+
+/*!
+ * @brief special value for STREAM_PROPERTY_INPUTSTREAMCLASS to use
+ * ffmpeg to directly play a stream URL.
+ */
+#define STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG "inputstream.ffmpeg"


### PR DESCRIPTION
## Description

Some independent changes taken from PVR system rework, they are not critical and in work is nothing changed, only bit bigger by "clang" cleanup.

  - Commit 1:
    - ***[addons] remove wrong PVR API version note***
       A old and since long time no more matching note

  - Commit 2:
    - ***[addons] Don't use kodi::addon::IAddonInstance on Kodi side***
       To use a C++ part from addon side inside Kodi breaks "C" interface
usage.

        Further is wanted to allow pure "C" way for addons where need to change
also this in future on all "KodiToAddonFuncTable_..." structures to use
only KODI_HANDLE (void*) instead of class name.

        For PVR this becomes already prepared to allow "C" only.
But to allow this must be this come first.

  - Commit 3:
    - ***[addons] fix CStructHdl operator= with before has not worked***
      During tests seen `operator=` does not work and need to be fixed
      > Note: Currently not used and API change not needed

  - Commit 4:
    - ***[videoplayer] cleanup Inputstream constants documentation***
      To have in one line by so big text, makes it hard to read and looks a bit ugly.

_____________

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
