### PR TITLE
Fix TextureCache::CacheImage does not fill texture outparam

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -7,18 +7,19 @@
  */
 
 #include "TextureCache.h"
+#include "ServiceBroker.h"
 #include "TextureCacheJob.h"
+#include "URL.h"
 #include "filesystem/File.h"
+#include "guilib/Texture.h"
 #include "profiles/ProfileManager.h"
-#include "threads/SingleLock.h"
-#include "utils/Crc32.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
-#include "utils/URIUtils.h"
+#include "threads/SingleLock.h"
+#include "utils/Crc32.h"
 #include "utils/StringUtils.h"
-#include "URL.h"
-#include "ServiceBroker.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
 
 using namespace XFILE;
 
@@ -161,7 +162,20 @@ std::string CTextureCache::CacheImage(const std::string &image, CBaseTexture **t
   CTextureDetails tempDetails;
   if (!details)
     details = &tempDetails;
-  return GetCachedImage(url, *details, true);
+
+  std::string cachedpath = GetCachedImage(url, *details, true);
+  if (!cachedpath.empty())
+  {
+    if (texture)
+      *texture = CBaseTexture::LoadFromFile(cachedpath, 0, 0);
+  }
+  else
+  {
+    CLog::Log(LOGDEBUG, "CTextureCache::%s - Return NULL texture because cache is not ready",
+              __FUNCTION__);
+  }
+
+  return cachedpath;
 }
 
 bool CTextureCache::CacheImage(const std::string &image, CTextureDetails &details)


### PR DESCRIPTION
Backport of: https://github.com/xbmc/xbmc/pull/17277

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
