### PR TITLE
[pvr] CPVRPlaybackState class cleanup

### DIFF
--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -65,7 +65,7 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem> item)
   m_playingRecording.reset();
   m_playingEpgTag.reset();
   m_playingClientId = -1;
-  m_iplayingChannelUniqueID = -1;
+  m_playingChannelUniqueId = -1;
   m_strPlayingClientName.clear();
 
   if (item->HasPVRChannelInfoTag())
@@ -74,7 +74,7 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem> item)
 
     m_playingChannel = channel;
     m_playingClientId = m_playingChannel->ClientID();
-    m_iplayingChannelUniqueID = m_playingChannel->UniqueID();
+    m_playingChannelUniqueId = m_playingChannel->UniqueID();
 
     SetPlayingGroup(channel);
 
@@ -143,7 +143,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem> item)
     bChanged = true;
     m_playingChannel.reset();
     m_playingClientId = -1;
-    m_iplayingChannelUniqueID = -1;
+    m_playingChannelUniqueId = -1;
     m_strPlayingClientName.clear();
   }
   else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag() == m_playingRecording)
@@ -151,7 +151,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem> item)
     bChanged = true;
     m_playingRecording.reset();
     m_playingClientId = -1;
-    m_iplayingChannelUniqueID = -1;
+    m_playingChannelUniqueId = -1;
     m_strPlayingClientName.clear();
   }
   else if (item->HasEPGInfoTag() && m_playingEpgTag && *item->GetEPGInfoTag() == *m_playingEpgTag)
@@ -159,7 +159,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem> item)
     bChanged = true;
     m_playingEpgTag.reset();
     m_playingClientId = -1;
-    m_iplayingChannelUniqueID = -1;
+    m_playingChannelUniqueId = -1;
     m_strPlayingClientName.clear();
   }
 
@@ -204,7 +204,7 @@ bool CPVRPlaybackState::IsPlayingEpgTag() const
 
 bool CPVRPlaybackState::IsPlayingChannel(int iClientID, int iUniqueChannelID) const
 {
-  return m_playingChannel && m_playingClientId == iClientID && m_iplayingChannelUniqueID == iUniqueChannelID;
+  return m_playingChannel && m_playingClientId == iClientID && m_playingChannelUniqueId == iUniqueChannelID;
 }
 
 bool CPVRPlaybackState::IsPlayingChannel(const std::shared_ptr<CPVRChannel>& channel) const

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -210,7 +210,7 @@ private:
   std::shared_ptr<CPVREpgInfoTag> m_playingEpgTag;
   std::string m_strPlayingClientName;
   int m_playingClientId = -1;
-  int m_iplayingChannelUniqueID = -1;
+  int m_playingChannelUniqueId = -1;
 
   class CLastWatchedUpdateTimer;
   std::unique_ptr<CLastWatchedUpdateTimer> m_lastWatchedUpdateTimer;


### PR DESCRIPTION
## Description

Is only a rename of `m_iplayingChannelUniqueID` to mor matching `m_playingChannelUniqueId`, is without `i` to match more the others.

 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
