### PR TITLE
CCPUInfoLinux: check paths in constructor

### DIFF
--- a/xbmc/platform/linux/CPUInfoLinux.h
+++ b/xbmc/platform/linux/CPUInfoLinux.h
@@ -12,6 +12,8 @@
 
 #include "platform/posix/CPUInfoPosix.h"
 
+#include <string>
+
 class CCPUInfoLinux : public CCPUInfoPosix
 {
 public:
@@ -21,4 +23,8 @@ public:
   int GetUsedPercentage() override;
   float GetCPUFrequency() override;
   bool GetTemperature(CTemperature& temperature) override;
+
+private:
+  std::string m_freqPath;
+  std::string m_tempPath;
 };


### PR DESCRIPTION
This checks the cpu frequency sysfs path in the constructor and also checks if the cputemp path is available.

"coretemp" is intel
"k10temp" is amd
"scpi_sensors" is arm/other

There is the possibility that this will pick up an amd gpu temperature, but there is no way of knowing without more advanced methods (udev, etc)