### PR TITLE
[linux] CSysfsPath: fix reading from strings with spaces

### DIFF
--- a/xbmc/platform/linux/SysfsPath.cpp
+++ b/xbmc/platform/linux/SysfsPath.cpp
@@ -17,3 +17,21 @@ bool CSysfsPath::Exists()
 
   return true;
 }
+
+template<>
+std::string CSysfsPath::Get()
+{
+  std::ifstream file(m_path);
+
+  std::string value;
+
+  std::getline(file, value);
+
+  if (file.bad())
+  {
+    CLog::LogF(LOGERROR, "error reading from '{}'", m_path);
+    throw std::runtime_error("error reading from " + m_path);
+  }
+
+  return value;
+}

--- a/xbmc/platform/linux/test/TestSysfsPath.cpp
+++ b/xbmc/platform/linux/test/TestSysfsPath.cpp
@@ -15,14 +15,15 @@
 struct TestSysfsPath : public ::testing::Test
 {
   ~TestSysfsPath() { std::remove("/tmp/kodi-test"); }
+
+  std::ofstream m_output{"/tmp/kodi-test"};
 };
 
-TEST_F(TestSysfsPath, SysfsPathTest)
+TEST_F(TestSysfsPath, SysfsPathTestInt)
 {
   int temp{1234};
-  std::ofstream output{"/tmp/kodi-test"};
-  output << temp;
-  output.close();
+  m_output << temp;
+  m_output.close();
 
   CSysfsPath path("/tmp/kodi-test");
   ASSERT_TRUE(path.Exists());
@@ -33,8 +34,32 @@ TEST_F(TestSysfsPath, SysfsPathTest)
   ASSERT_TRUE(path.Get<uint16_t>() == 1234);
   ASSERT_TRUE(path.Get<unsigned int>() == 1234);
   ASSERT_TRUE(path.Get<unsigned long int>() == 1234);
-  ASSERT_TRUE(path.Get<std::string>() == "1234");
+}
 
+TEST_F(TestSysfsPath, SysfsPathTestString)
+{
+  std::string temp{"test"};
+  m_output << temp;
+  m_output.close();
+
+  CSysfsPath path("/tmp/kodi-test");
+  ASSERT_TRUE(path.Exists());
+  ASSERT_TRUE(path.Get<std::string>() == "test");
+}
+
+TEST_F(TestSysfsPath, SysfsPathTestLongString)
+{
+  std::string temp{"test with spaces"};
+  m_output << temp;
+  m_output.close();
+
+  CSysfsPath path("/tmp/kodi-test");
+  ASSERT_TRUE(path.Exists());
+  ASSERT_TRUE(path.Get<std::string>() == "test with spaces");
+}
+
+TEST_F(TestSysfsPath, SysfsPathTestPathDoesNotExist)
+{
   CSysfsPath otherPath{"/thispathdoesnotexist"};
   ASSERT_FALSE(otherPath.Exists());
 }


### PR DESCRIPTION
There was an error introduced by #16097 which resulted in long strings with spaces only having the first word read. Let's read the whole line. If we need more then one line in the future this can be expanded then.

@chewitt this should fix your issue.