### PR TITLE
CPUInfo: remove default "N/A" value from strings

### DIFF
--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -100,13 +100,13 @@ protected:
 
   int m_lastUsedPercentage;
   XbmcThreads::EndTime m_nextUsedReadTime;
-  std::string m_cpuVendor{"N/A"};
-  std::string m_cpuModel{"N/A"};
-  std::string m_cpuBogoMips{"N/A"};
-  std::string m_cpuSoC{"N/A"};
-  std::string m_cpuHardware{"N/A"};
-  std::string m_cpuRevision{"N/A"};
-  std::string m_cpuSerial{"N/A"};
+  std::string m_cpuVendor;
+  std::string m_cpuModel;
+  std::string m_cpuBogoMips;
+  std::string m_cpuSoC;
+  std::string m_cpuHardware;
+  std::string m_cpuRevision;
+  std::string m_cpuSerial;
 
   double m_usagePercent{0.0};
   std::size_t m_activeTime{0};

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -62,30 +62,6 @@ TEST_F(TestCPUInfo, GetCPUModel)
   EXPECT_STRNE("", s.c_str());
 }
 
-TEST_F(TestCPUInfo, GetCPUBogoMips)
-{
-  std::string s = CServiceBroker::GetCPUInfo()->GetCPUBogoMips();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST_F(TestCPUInfo, GetCPUHardware)
-{
-  std::string s = CServiceBroker::GetCPUInfo()->GetCPUHardware();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST_F(TestCPUInfo, GetCPURevision)
-{
-  std::string s = CServiceBroker::GetCPUInfo()->GetCPURevision();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST_F(TestCPUInfo, GetCPUSerial)
-{
-  std::string s = CServiceBroker::GetCPUInfo()->GetCPUSerial();
-  EXPECT_STRNE("", s.c_str());
-}
-
 TEST_F(TestCPUInfo, CoreInfo)
 {
   ASSERT_TRUE(CServiceBroker::GetCPUInfo()->HasCoreId(0));


### PR DESCRIPTION
This should fix #17258 

I believe I originally added the default `N/A` so that the tests would pass. We cannot guarantee that these exist so these tests are useless, let's remove them.

@MilhouseVH please test