### PR TITLE
StringUtils: define FMT_DEPRECATED to fix windows coverity build

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -26,6 +26,11 @@
 #include <sstream>
 #include <locale>
 
+// workaround for broken [[depreciated]] in coverity
+#if defined(__COVERITY__)
+#undef FMT_DEPRECATED
+#define FMT_DEPRECATED
+#endif
 #include <fmt/format.h>
 
 #if FMT_VERSION >= 40000


### PR DESCRIPTION
This fixes the following issue when running coverity on windows. If someone has a better idea I'm all ears.

```
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|> "F:\builds\workspace\WIN-64-CoverityScan\project\BuildDependencies\x64\include\
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|> 
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|>           fmt/core.h", line 544: error #1882: attribute does not apply to any
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|> 
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|>           entity
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|> 
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|>   using parse_context FMT_DEPRECATED_ALIAS = basic_format_parse_context<char>;
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|> 
2020-01-25T04:28:58.643972Z|cov-translate|9652|output|>                       ^
```