### PR TITLE
[addons] use on CAddonDll instance class pointer as identifier

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -317,7 +317,11 @@ void CAddonDll::Destroy()
   m_initialized = false;
 }
 
-ADDON_STATUS CAddonDll::CreateInstance(ADDON_TYPE instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE parentInstance)
+ADDON_STATUS CAddonDll::CreateInstance(ADDON_TYPE instanceType,
+                                       ADDON_INSTANCE_HANDLER instanceClass,
+                                       const std::string& instanceID,
+                                       KODI_HANDLE instance,
+                                       KODI_HANDLE parentInstance)
 {
   ADDON_STATUS status = ADDON_STATUS_OK;
 
@@ -338,18 +342,18 @@ ADDON_STATUS CAddonDll::CreateInstance(ADDON_TYPE instanceType, const std::strin
 
   if (status == ADDON_STATUS_OK)
   {
-    m_usedInstances[instanceID] = std::make_pair(instanceType, addonInstance);
+    m_usedInstances[instanceClass] = std::make_pair(instanceType, addonInstance);
   }
 
   return status;
 }
 
-void CAddonDll::DestroyInstance(const std::string& instanceID)
+void CAddonDll::DestroyInstance(ADDON_INSTANCE_HANDLER instanceClass)
 {
   if (m_usedInstances.empty())
     return;
 
-  auto it = m_usedInstances.find(instanceID);
+  auto it = m_usedInstances.find(instanceClass);
   if (it != m_usedInstances.end())
   {
     m_interface.toAddon->destroy_instance(it->second.first, it->second.second);

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -17,6 +17,17 @@
 namespace ADDON
 {
 
+/*!
+ * Addon instance handler, used as identify for std::map to find related
+ * addon instance. This class itself not accessed here.
+ *
+ * @todo As long game addon system use CAddonDll itself and not
+ * IAddonInstanceHandler as parent, is the set of this as "void*" needed.
+ * After game system is changed should by this also changed to
+ * "const IAddonInstanceHandler*" or direct in map below.
+ */
+using ADDON_INSTANCE_HANDLER = const void*;
+
   typedef void* (*ADDON_GET_INTERFACE_FN)(const std::string &name, const std::string &version);
 
   class CAddonDll : public CAddon
@@ -67,7 +78,8 @@ namespace ADDON
      * @brief Function to create a addon instance class
      *
      * @param[in] instanceType The wanted instance type class to open on addon
-     * @param[in] instanceID The from Kodi used ID string of active instance
+     * @param[in] instanceClass The from Kodi used class for active instance
+     * @param[in] instanceID The from addon used ID string of active instance
      * @param[in] instance Pointer where the interface functions from addon
      *                     becomes stored during his instance creation.
      * @param[in] parentInstance In case the instance class is related to another
@@ -76,14 +88,18 @@ namespace ADDON
      *                           not use it.
      * @return The status of addon after the creation.
      */
-    ADDON_STATUS CreateInstance(ADDON_TYPE instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE parentInstance = nullptr);
+    ADDON_STATUS CreateInstance(ADDON_TYPE instanceType,
+                                ADDON_INSTANCE_HANDLER instanceClass,
+                                const std::string& instanceID,
+                                KODI_HANDLE instance,
+                                KODI_HANDLE parentInstance = nullptr);
 
     /*!
      * @brief Function to destroy a on addon created instance class
      *
-     * @param[in] instanceID The from Kodi used ID string of active instance
+     * @param[in] instanceClass The from Kodi used class for active instance
      */
-    void DestroyInstance(const std::string& instanceID);
+    void DestroyInstance(ADDON_INSTANCE_HANDLER instanceClass);
 
     AddonPtr GetRunningInstance() const override;
 
@@ -118,7 +134,7 @@ namespace ADDON
     DllAddon* m_pDll;
     bool m_initialized;
     bool LoadDll();
-    std::map<std::string, std::pair<ADDON_TYPE, KODI_HANDLE>> m_usedInstances;
+    std::map<ADDON_INSTANCE_HANDLER, std::pair<ADDON_TYPE, KODI_HANDLE>> m_usedInstances;
 
     virtual ADDON_STATUS TransferSettings();
 

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -28,150 +28,149 @@ namespace ADDON
  */
 using ADDON_INSTANCE_HANDLER = const void*;
 
-  typedef void* (*ADDON_GET_INTERFACE_FN)(const std::string &name, const std::string &version);
+typedef void* (*ADDON_GET_INTERFACE_FN)(const std::string& name, const std::string& version);
 
-  class CAddonDll : public CAddon
-  {
-  public:
-    CAddonDll(const AddonInfoPtr& addonInfo, BinaryAddonBasePtr addonBase);
-    explicit CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType);
-    ~CAddonDll() override;
+class CAddonDll : public CAddon
+{
+public:
+  CAddonDll(const AddonInfoPtr& addonInfo, BinaryAddonBasePtr addonBase);
+  explicit CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType);
+  ~CAddonDll() override;
 
-    virtual ADDON_STATUS GetStatus();
+  virtual ADDON_STATUS GetStatus();
 
-    static void RegisterInterface(ADDON_GET_INTERFACE_FN fn);
+  static void RegisterInterface(ADDON_GET_INTERFACE_FN fn);
 
-    // Implementation of IAddon via CAddon
-    std::string LibPath() const override;
+  // Implementation of IAddon via CAddon
+  std::string LibPath() const override;
 
-    // addon settings
-    void SaveSettings() override;
+  // addon settings
+  void SaveSettings() override;
 
-    ADDON_STATUS Create(ADDON_TYPE type, void* funcTable, void* info);
-    void Destroy();
+  ADDON_STATUS Create(ADDON_TYPE type, void* funcTable, void* info);
+  void Destroy();
 
-    bool DllLoaded(void) const;
+  bool DllLoaded(void) const;
 
-    /*!
-    * @brief Get api version of moduleType type
-    *
-    * @return The version of requested type, if dll is loaded and supported by addon.
-    *         If one of both do not match, an empty version is returned.
-    *
-    * @note This should only be called if the associated dll is loaded.
-    * Otherwise use @ref CAddonInfo::DependencyVersion(...)
-    */
-    AddonVersion GetTypeVersionDll(int type) const;
+  /*!
+   * @brief Get api version of moduleType type
+   *
+   * @return The version of requested type, if dll is loaded and supported by addon.
+   *         If one of both do not match, an empty version is returned.
+   *
+   * @note This should only be called if the associated dll is loaded.
+   * Otherwise use @ref CAddonInfo::DependencyVersion(...)
+   */
+  AddonVersion GetTypeVersionDll(int type) const;
 
-    /*!
-    * @brief Get api min version of moduleType type
-    *
-    * @return The version of requested type, if dll is loaded and supported by addon.
-    *         If one of both do not match, an empty version is returned.
-    *
-    * @note This should only be called if the associated dll is loaded.
-    * Otherwise use @ref CAddonInfo::DependencyMinVersion(...)
-    */
-    AddonVersion GetTypeMinVersionDll(int type) const;
+  /*!
+   * @brief Get api min version of moduleType type
+   *
+   * @return The version of requested type, if dll is loaded and supported by addon.
+   *         If one of both do not match, an empty version is returned.
+   *
+   * @note This should only be called if the associated dll is loaded.
+   * Otherwise use @ref CAddonInfo::DependencyMinVersion(...)
+   */
+  AddonVersion GetTypeMinVersionDll(int type) const;
 
-    /*!
-     * @brief Function to create a addon instance class
-     *
-     * @param[in] instanceType The wanted instance type class to open on addon
-     * @param[in] instanceClass The from Kodi used class for active instance
-     * @param[in] instanceID The from addon used ID string of active instance
-     * @param[in] instance Pointer where the interface functions from addon
-     *                     becomes stored during his instance creation.
-     * @param[in] parentInstance In case the instance class is related to another
-     *                           addon instance class becomes with the pointer
-     *                           given to addon. Is optional and most addon types
-     *                           not use it.
-     * @return The status of addon after the creation.
-     */
-    ADDON_STATUS CreateInstance(ADDON_TYPE instanceType,
-                                ADDON_INSTANCE_HANDLER instanceClass,
-                                const std::string& instanceID,
-                                KODI_HANDLE instance,
-                                KODI_HANDLE parentInstance = nullptr);
+  /*!
+   * @brief Function to create a addon instance class
+   *
+   * @param[in] instanceType The wanted instance type class to open on addon
+   * @param[in] instanceClass The from Kodi used class for active instance
+   * @param[in] instanceID The from addon used ID string of active instance
+   * @param[in] instance Pointer where the interface functions from addon
+   *                     becomes stored during his instance creation.
+   * @param[in] parentInstance In case the instance class is related to another
+   *                           addon instance class becomes with the pointer
+   *                           given to addon. Is optional and most addon types
+   *                           not use it.
+   * @return The status of addon after the creation.
+   */
+  ADDON_STATUS CreateInstance(ADDON_TYPE instanceType,
+                              ADDON_INSTANCE_HANDLER instanceClass,
+                              const std::string& instanceID,
+                              KODI_HANDLE instance,
+                              KODI_HANDLE parentInstance = nullptr);
 
-    /*!
-     * @brief Function to destroy a on addon created instance class
-     *
-     * @param[in] instanceClass The from Kodi used class for active instance
-     */
-    void DestroyInstance(ADDON_INSTANCE_HANDLER instanceClass);
+  /*!
+   * @brief Function to destroy a on addon created instance class
+   *
+   * @param[in] instanceClass The from Kodi used class for active instance
+   */
+  void DestroyInstance(ADDON_INSTANCE_HANDLER instanceClass);
 
-    AddonPtr GetRunningInstance() const override;
+  AddonPtr GetRunningInstance() const override;
 
-    bool Initialized() const { return m_initialized; }
+  bool Initialized() const { return m_initialized; }
 
-  protected:
-    static std::string GetDllPath(const std::string &strFileName);
+protected:
+  static std::string GetDllPath(const std::string& strFileName);
 
-    CAddonInterfaces* m_pHelpers;
-    std::string m_parentLib;
+  CAddonInterfaces* m_pHelpers;
+  std::string m_parentLib;
 
-  private:
-    /*!
-     * @brief Main addon creation call function
-     *
-     * This becomes called only one time before a addon instance becomes created.
-     * If another instance becomes requested is this Create no more used. To see
-     * like a "int main()" on exe.
-     *
-     * @param[in] firstKodiInstance The first instance who becomes used.
-     *                              In case addon supports only one instance
-     *                              and not multiple together can addon use
-     *                              only one complete class for everything.
-     *                              This is used then to interact on interface.
-     * @return The status of addon after the creation.
-     */
-    ADDON_STATUS Create(KODI_HANDLE firstKodiInstance);
+private:
+  /*!
+   * @brief Main addon creation call function
+   *
+   * This becomes called only one time before a addon instance becomes created.
+   * If another instance becomes requested is this Create no more used. To see
+   * like a "int main()" on exe.
+   *
+   * @param[in] firstKodiInstance The first instance who becomes used.
+   *                              In case addon supports only one instance
+   *                              and not multiple together can addon use
+   *                              only one complete class for everything.
+   *                              This is used then to interact on interface.
+   * @return The status of addon after the creation.
+   */
+  ADDON_STATUS Create(KODI_HANDLE firstKodiInstance);
 
-    bool CheckAPIVersion(int type);
+  bool CheckAPIVersion(int type);
 
-    BinaryAddonBasePtr m_binaryAddonBase;
-    DllAddon* m_pDll;
-    bool m_initialized;
-    bool LoadDll();
-    std::map<ADDON_INSTANCE_HANDLER, std::pair<ADDON_TYPE, KODI_HANDLE>> m_usedInstances;
+  BinaryAddonBasePtr m_binaryAddonBase;
+  DllAddon* m_pDll;
+  bool m_initialized;
+  bool LoadDll();
+  std::map<ADDON_INSTANCE_HANDLER, std::pair<ADDON_TYPE, KODI_HANDLE>> m_usedInstances;
 
-    virtual ADDON_STATUS TransferSettings();
+  virtual ADDON_STATUS TransferSettings();
 
-    bool UpdateSettingInActiveDialog(const char* id, const std::string& value);
+  bool UpdateSettingInActiveDialog(const char* id, const std::string& value);
 
-    static std::vector<ADDON_GET_INTERFACE_FN> s_registeredInterfaces;
+  static std::vector<ADDON_GET_INTERFACE_FN> s_registeredInterfaces;
 
-    /// addon to kodi basic callbacks below
-    //@{
+  /// addon to kodi basic callbacks below
+  //@{
 
-    /*!
-     * This structure, which is fixed to the addon headers, makes use of the at
-     * least supposed parts for the interface.
-     * This structure is defined in:
-     * /xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
-     */
-    AddonGlobalInterface m_interface;
+  /*!
+   * This structure, which is fixed to the addon headers, makes use of the at
+   * least supposed parts for the interface.
+   * This structure is defined in:
+   * /xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+   */
+  AddonGlobalInterface m_interface;
 
-    inline bool InitInterface(KODI_HANDLE firstKodiInstance);
-    inline void DeInitInterface();
+  inline bool InitInterface(KODI_HANDLE firstKodiInstance);
+  inline void DeInitInterface();
 
-    static char* get_addon_path(void* kodiBase);
-    static char* get_base_user_path(void* kodiBase);
-    static void addon_log_msg(void* kodiBase, const int addonLogLevel, const char* strMessage);
-    static bool get_setting_bool(void* kodiBase, const char* id, bool* value);
-    static bool get_setting_int(void* kodiBase, const char* id, int* value);
-    static bool get_setting_float(void* kodiBase, const char* id, float* value);
-    static bool get_setting_string(void* kodiBase, const char* id, char** value);
-    static bool set_setting_bool(void* kodiBase, const char* id, bool value);
-    static bool set_setting_int(void* kodiBase, const char* id, int value);
-    static bool set_setting_float(void* kodiBase, const char* id, float value);
-    static bool set_setting_string(void* kodiBase, const char* id, const char* value);
-    static void free_string(void* kodiBase, char* str);
-    static void free_string_array(void* kodiBase, char** arr, int numElements);
-    static void* get_interface(void* kodiBase, const char* name, const char *version);
-    //@}
-  };
+  static char* get_addon_path(void* kodiBase);
+  static char* get_base_user_path(void* kodiBase);
+  static void addon_log_msg(void* kodiBase, const int addonLogLevel, const char* strMessage);
+  static bool get_setting_bool(void* kodiBase, const char* id, bool* value);
+  static bool get_setting_int(void* kodiBase, const char* id, int* value);
+  static bool get_setting_float(void* kodiBase, const char* id, float* value);
+  static bool get_setting_string(void* kodiBase, const char* id, char** value);
+  static bool set_setting_bool(void* kodiBase, const char* id, bool value);
+  static bool set_setting_int(void* kodiBase, const char* id, int value);
+  static bool set_setting_float(void* kodiBase, const char* id, float value);
+  static bool set_setting_string(void* kodiBase, const char* id, const char* value);
+  static void free_string(void* kodiBase, char* str);
+  static void free_string_array(void* kodiBase, char** arr, int numElements);
+  static void* get_interface(void* kodiBase, const char* name, const char* version);
+  //@}
+};
 
-}; /* namespace ADDON */
-
+} /* namespace ADDON */

--- a/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
+++ b/xbmc/addons/binary-addons/AddonInstanceHandler.cpp
@@ -80,7 +80,8 @@ ADDON_STATUS IAddonInstanceHandler::CreateInstance(KODI_HANDLE instance)
 
   CSingleLock lock(m_cdSec);
 
-  ADDON_STATUS status = m_addon->CreateInstance(m_type, m_instanceId, instance, m_parentInstance);
+  ADDON_STATUS status =
+      m_addon->CreateInstance(m_type, this, m_instanceId, instance, m_parentInstance);
   if (status != ADDON_STATUS_OK)
   {
     CLog::Log(LOGERROR, "IAddonInstanceHandler::%s: %s returned bad status \"%s\" during instance creation",
@@ -95,7 +96,7 @@ void IAddonInstanceHandler::DestroyInstance()
 {
   CSingleLock lock(m_cdSec);
   if (m_addon)
-    m_addon->DestroyInstance(m_instanceId);
+    m_addon->DestroyInstance(this);
 }
 
 } /* namespace ADDON */

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -168,8 +168,7 @@ bool CGameClient::Initialize(void)
   m_struct.toKodi.HwGetProcAddress = cb_hw_get_proc_address;
   m_struct.toKodi.InputEvent = cb_input_event;
 
-  if (CreateInstance(ADDON_INSTANCE_GAME, StringUtils::Format("%p", static_cast<void*>(this)),
-                     &m_struct, nullptr) == ADDON_STATUS_OK)
+  if (CreateInstance(ADDON_INSTANCE_GAME, this, "", &m_struct, nullptr) == ADDON_STATUS_OK)
   {
     Input().Initialize();
     LogAddonProperties();
@@ -183,7 +182,7 @@ void CGameClient::Unload()
 {
   Input().Deinitialize();
 
-  DestroyInstance(StringUtils::Format("%p", static_cast<void*>(this)));
+  DestroyInstance(this);
 }
 
 bool CGameClient::OpenFile(const CFileItem& file, RETRO::IStreamManager& streamManager, IGameInputCallback *input)


### PR DESCRIPTION
## Description

Before was a string used (where was in most cases only a pointer as string).
Seen during PVR rework, where it becomes needed to use a own identifier, to pass
same name several times to identify e.g. "channel" or "recording".

With same string then comes in conflict with the std::map where store used
Instances on CAddonDll, by use of the related class pointer this is more safe.

Only was related to game addon system, where currently not use
`IAddonInstanceHandler` (games to complex for me to find direct a way with them),
a add of `PSEUDO_INSTANCE_CLASS` (const void*) needed.

On addon interface change this nothing, only store the map in Kodi it by
different value.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
