### PR TITLE
[addons] move GetTempAddonBasePath() from binary to normal AddonManager

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -131,6 +131,10 @@ bool CAddonMgr::Init()
 void CAddonMgr::DeInit()
 {
   m_database.Close();
+
+  /* If temporary directory was used from add-on, delete it */
+  if (XFILE::CDirectory::Exists(m_tempAddonBasePath))
+    XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(m_tempAddonBasePath));
 }
 
 bool CAddonMgr::HasAddons(const TYPE &type)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -238,6 +238,15 @@ namespace ADDON
     bool GetAddonInfos(AddonInfos& addonInfos, TYPE type);
     const AddonInfoPtr GetAddonInfo(const std::string& id, TYPE type = ADDON_UNKNOWN);
 
+    /*!
+     * @brief Get the path where temporary add-on files are stored
+     *
+     * @return the base path used for temporary addon paths
+     *
+     * @warning the folder and its contents are deleted when Kodi is closed
+     */
+    const std::string& GetTempAddonBasePath() { return m_tempAddonBasePath; }
+
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;
 
@@ -258,6 +267,9 @@ namespace ADDON
     std::set<std::string> m_systemAddons;
     std::set<std::string> m_optionalAddons;
     ADDON_INFO_LIST m_installedAddons;
+
+    // Temporary path given to add-ons, whose content is deleted when Kodi is stopped
+    const std::string m_tempAddonBasePath = "special://temp/addons";
   };
 
 }; /* namespace ADDON */

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -18,11 +18,6 @@
 
 using namespace ADDON;
 
-CBinaryAddonManager::CBinaryAddonManager()
-  : m_tempAddonBasePath("special://temp/binary-addons")
-{
-}
-
 CBinaryAddonManager::~CBinaryAddonManager()
 {
   DeInit();
@@ -49,10 +44,6 @@ bool CBinaryAddonManager::Init()
 
 void CBinaryAddonManager::DeInit()
 {
-  /* If temporary directory was used from addon delete them */
-  if (XFILE::CDirectory::Exists(m_tempAddonBasePath))
-    XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(m_tempAddonBasePath));
-
   CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 }
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -28,7 +28,7 @@ namespace ADDON
   class CBinaryAddonManager
   {
   public:
-    CBinaryAddonManager();
+    CBinaryAddonManager() = default;
     CBinaryAddonManager(const CBinaryAddonManager&) = delete;
     ~CBinaryAddonManager();
 
@@ -119,16 +119,6 @@ namespace ADDON
      */
     AddonPtr GetRunningAddon(const std::string& addonId) const;
 
-    /*!
-     * @brief To get the path where temporary addon parts can be becomes stored
-     *
-     * @return the base path used for temporary addon paths
-     *
-     * @warning the folder and his contents becomes deleted during stop and
-     * close of Kodi
-     */
-    const std::string& GetTempAddonBasePath() { return m_tempAddonBasePath; }
-
   private:
     bool AddAddonBaseEntry(BINARY_ADDON_LIST_ENTRY& entry);
 
@@ -142,8 +132,6 @@ namespace ADDON
     typedef std::map<std::string, BinaryAddonBasePtr> BinaryAddonMgrBaseList;
     BinaryAddonMgrBaseList m_installedAddons;
     BinaryAddonMgrBaseList m_enabledAddons;
-
-    const std::string m_tempAddonBasePath;
   };
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -308,7 +308,8 @@ char* Interface_General::get_temp_path(void* kodiBase)
     return nullptr;
   }
 
-  std::string tempPath = URIUtils::AddFileToFolder(CServiceBroker::GetBinaryAddonManager().GetTempAddonBasePath(), addon->ID());
+  std::string tempPath =
+      URIUtils::AddFileToFolder(CServiceBroker::GetAddonMgr().GetTempAddonBasePath(), addon->ID());
   tempPath += "-temp";
   XFILE::CDirectory::Create(tempPath);
 


### PR DESCRIPTION
## Description
This is the first step to remove the CBinaryAddonManager. Since removal
of cpluff this no more direct needed.

Therefore this request, alone, since this is currently used for the binaries, I also want to ask whether there is something similar in the ***Python*** addons, which gives them a temporary path?
If so, we could combine the two so that there is more order in the mess.

My goal is to make the addon interface cleaner and then try to make it more stable. 
Because there is so much mix between things at the moment, it becomes difficult to create a centrally controlled path that takes care of what (e.g. ongoing addon changes while Kodi is running...)

I may also change the name "GetTempAddonBasePath" to something else. Can you think of something or do you think it's OK?

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
