### PR TITLE
[PVR][guiinfo] Fixup multiline episode name strings (which do not fit…

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -404,6 +404,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case VIDEOPLAYER_EPISODENAME:
       case LISTITEM_EPISODENAME:
         strValue = recording->EpisodeName();
+        // fixup multiline episode name strings (which do not fit in any way in our GUI)
+        StringUtils::Replace(strValue, "\n", ", ");
         return true;
       case VIDEOPLAYER_CHANNEL_NAME:
       case LISTITEM_CHANNEL_NAME:
@@ -582,7 +584,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case VIDEOPLAYER_EPISODENAME:
       case LISTITEM_EPISODENAME:
         if (!CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
+        {
           strValue = epgTag->EpisodeName();
+          // fixup multiline episode name strings (which do not fit in any way in our GUI)
+          StringUtils::Replace(strValue, "\n", ", ");
+        }
         return true;
       case VIDEOPLAYER_CAST:
       case LISTITEM_CAST:


### PR DESCRIPTION
… in any way in our GUI).

Fixes the issue described in #17132 

Before:
![screenshot000](https://user-images.githubusercontent.com/3226626/73480130-a1184100-4399-11ea-8d0f-a85c1ff5e90b.png)
![screenshot003](https://user-images.githubusercontent.com/3226626/73480159-aaa1a900-4399-11ea-8af4-fd832256a85c.png)

After:
![screenshot001](https://user-images.githubusercontent.com/3226626/73480175-b2614d80-4399-11ea-8b8e-f1af713b38e6.png)
![screenshot002](https://user-images.githubusercontent.com/3226626/73480183-b55c3e00-4399-11ea-8711-d48f725ec072.png)

@phunkyfish for review.
@ronie fyi.
