### PR TITLE
FFmpeg: Bump to 4.2.2-Matrix-Alpha1

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -33,14 +33,14 @@
 #
 
 # required ffmpeg library versions
-set(REQUIRED_FFMPEG_VERSION 4.0)
-set(_avcodec_ver ">=58.18.100")
-set(_avfilter_ver ">=7.16.100")
-set(_avformat_ver ">=58.12.100")
-set(_avutil_ver ">=56.14.100")
-set(_swscale_ver ">=5.1.100")
-set(_swresample_ver ">=3.1.100")
-set(_postproc_ver ">=55.1.100")
+set(REQUIRED_FFMPEG_VERSION 4.2)
+set(_avcodec_ver ">=58.54.100")
+set(_avfilter_ver ">=7.57.100")
+set(_avformat_ver ">=58.29.100")
+set(_avutil_ver ">=56.31.100")
+set(_swscale_ver ">=5.5.100")
+set(_swresample_ver ">=3.5.100")
+set(_postproc_ver ">=55.5.100")
 
 
 # Allows building with external ffmpeg not found in system paths,

--- a/tools/buildsteps/windows/patches/0001-ffmpeg-detect-openssl.patch
+++ b/tools/buildsteps/windows/patches/0001-ffmpeg-detect-openssl.patch
@@ -1,26 +1,13 @@
-From 18de5c60ae0a987680681d5a0602009b428504fa Mon Sep 17 00:00:00 2001
-From: Gilles Khouzam <gillesk@microsoft.com>
-Date: Mon, 19 Jun 2017 16:33:38 -0700
-Subject: [PATCH] Add better detection for Openssl on Windows.
-
-Look for libeay32 and ssleay32 as another detection mechanism
----
- configure | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/configure b/configure
-index a1818dc..1cf2a7c 100755
+index 34c2adb4a4..160884d8f9 100755
 --- a/configure
 +++ b/configure
-@@ -6147,6 +6147,8 @@
+@@ -6358,6 +6358,8 @@ enabled openssl           && { check_pkg_config openssl openssl openssl/ssl.h OP
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
 +                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -llibssl -llibcrypto -lws2_32 -lgdi32 -ladvapi32 -luser32 ||
 +                               check_lib openssl openssl/ssl.h SSL_library_init -llibeay32 -lssleay32 ||
                                 die "ERROR: openssl not found"; }
+ enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
  enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/rk_mpi.h mpp_create &&
-                                require_pkg_config rockchip_mpp "rockchip_mpp >= 1.3.7" rockchip/rk_mpi.h mpp_create &&
--- 
-2.10.1.windows.1
-

--- a/tools/buildsteps/windows/patches/0002-ffmpeg-zlib-config-conflict.patch
+++ b/tools/buildsteps/windows/patches/0002-ffmpeg-zlib-config-conflict.patch
@@ -1,6 +1,17 @@
+diff --git a/configure b/configure
+index 34c2adb4a4..a2a2515525 100755
 --- a/configure
 +++ b/configure
-@@ -7197,6 +7197,9 @@
+@@ -6358,6 +6358,8 @@ enabled openssl           && { check_pkg_config openssl openssl openssl/ssl.h OP
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
++                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -llibssl -llibcrypto -lws2_32 -lgdi32 -ladvapi32 -luser32 ||
++                               check_lib openssl openssl/ssl.h SSL_library_init -llibeay32 -lssleay32 ||
+                                die "ERROR: openssl not found"; }
+ enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
+ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/rk_mpi.h mpp_create &&
+@@ -7437,6 +7439,9 @@ print_config CONFIG_ "$config_files" $CONFIG_LIST       \
                                       $CONFIG_EXTRA      \
                                       $ALL_COMPONENTS    \
  

--- a/tools/buildsteps/windows/patches/0003-ffmpeg-static.patch
+++ b/tools/buildsteps/windows/patches/0003-ffmpeg-static.patch
@@ -1,6 +1,8 @@
+diff --git a/configure b/configure
+index 34c2adb4a4..9c0ff0cd88 100755
 --- a/configure
 +++ b/configure
-@@ -5131,6 +5131,8 @@
+@@ -5312,6 +5312,8 @@ case $target_os in
          enabled shared && ! enabled small && test_cmd $windres --version && enable gnu_windres
          enabled x86_32 && check_ldflags -Wl,--large-address-aware
          shlibdir_default="$bindir_default"
@@ -9,7 +11,7 @@
          SLIBPREF=""
          SLIBSUF=".dll"
          SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
-@@ -5180,6 +5182,8 @@
+@@ -5361,6 +5363,8 @@ case $target_os in
          fi
          enabled x86_32 && check_ldflags -LARGEADDRESSAWARE
          shlibdir_default="$bindir_default"
@@ -18,3 +20,22 @@
          SLIBPREF=""
          SLIBSUF=".dll"
          SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
+@@ -6358,6 +6362,8 @@ enabled openssl           && { check_pkg_config openssl openssl openssl/ssl.h OP
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
++                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -llibssl -llibcrypto -lws2_32 -lgdi32 -ladvapi32 -luser32 ||
++                               check_lib openssl openssl/ssl.h SSL_library_init -llibeay32 -lssleay32 ||
+                                die "ERROR: openssl not found"; }
+ enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
+ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/rk_mpi.h mpp_create &&
+@@ -7437,6 +7443,9 @@ print_config CONFIG_ "$config_files" $CONFIG_LIST       \
+                                      $CONFIG_EXTRA      \
+                                      $ALL_COMPONENTS    \
+ 
++echo "#if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H == 0" >> $TMPH
++echo "#undef HAVE_UNISTD_H" >> $TMPH
++echo "#endif" >> $TMPH
+ echo "#endif /* FFMPEG_CONFIG_H */" >> $TMPH
+ echo "endif # FFMPEG_CONFIG_MAK" >> ffbuild/config.mak
+ 

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -184,3 +184,4 @@ linux-system-libs: linux-system-libs-egl
 	[ -f $(PREFIX)/lib/pkgconfig/xmu.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/xmu.pc $(PREFIX)/lib/pkgconfig/xmu.pc
 	[ -f $(PREFIX)/lib/pkgconfig/libdrm.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/libdrm.pc $(PREFIX)/lib/pkgconfig/libdrm.pc
 	[ -f $(PREFIX)/lib/pkgconfig/xkbcommon.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/xkbcommon.pc $(PREFIX)/lib/pkgconfig/xkbcommon.pc
+	[ -f $(PREFIX)/lib/pkgconfig/libva.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/libva.pc $(PREFIX)/lib/pkgconfig/libva.pc

--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.0.4-Leia-18.4
+VERSION=4.2.2-Matrix-Alpha1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -157,6 +157,7 @@ bool CActiveAEFilter::CreateAtempoFilter()
   m_needData = true;
   m_filterEof = false;
   m_started = false;
+  m_ptsInitialized = false;
 
   return true;
 }
@@ -182,6 +183,8 @@ void CActiveAEFilter::CloseFilter()
 
   m_SamplesIn = 0;
   m_SamplesOut = 0;
+
+  m_ptsInitialized = false;
 }
 
 int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, int src_bufsize)
@@ -211,6 +214,11 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
     frame->sample_rate = m_sampleRate;
     frame->nb_samples = src_samples;
     frame->format = m_sampleFormat;
+    if (!m_ptsInitialized)
+    {
+      frame->pts = 0;
+      m_ptsInitialized = true;
+    }
 
     m_SamplesIn += src_samples;
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.h
@@ -52,6 +52,7 @@ protected:
   bool m_started;
   bool m_hasData;
   bool m_needData;
+  bool m_ptsInitialized;
   int m_sampleOffset;
   int64_t m_SamplesIn;
   int64_t m_SamplesOut;


### PR DESCRIPTION
It's time to get this going. We are behind on ffmpeg and should try to stay as up to date as possible.

The version here is the latest commit in the `release/4.2` branch https://github.com/xbmc/FFmpeg/commits/release/4.2-kodi

I bumped the av libs versions to that provided by the pkgconfig version

```
libavcodec.pc: Version: 58.54.100
libavdevice.pc: Version: 58.8.100
libavfilter.pc: Version: 7.57.100
libavformat.pc: Version: 58.29.100
libavutil.pc: Version: 56.31.100
libpostproc.pc: Version: 55.5.100
libswresample.pc: Version: 3.5.100
libswscale.pc :Version: 5.5.100
```

This will need testing on every platform
 - [x] Android [arm apk](https://mirrors.kodi.tv/test-builds/android/arm/kodi-20200131-925623c0-PR17300-merge-armeabi-v7a.apk) | [arm64 apk](https://mirrors.kodi.tv/test-builds/android/arm64-v8a/kodi-20200131-925623c0-PR17300-merge-arm64-v8a.apk)
 - [ ] iOS [arm64 deb](https://mirrors.kodi.tv/test-builds/darwin/ios-arm64/kodi-20200131-925623c0-PR17300-merge-ios64.deb)
 - [x] TVOS
 - [x] Linux X11
 - [x] Linux GBM
 - [ ] OSX [x86_64 build](https://mirrors.kodi.tv/test-builds/osx/x86_64/kodi-20200131-925623c0-PR17300-merge-x86_64.dmg)
 - [x] Raspberry-Pi
 - [x] Windows [x86_64 exe](https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20200131-925623c0-PR17300-merge-x64.exe) | [x86_64 pdb](https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20200131-925623c0-PR17300-merge-x64.pdb)
 - [ ] Windows UWP


EDIT:
Seems to work fine on linux-gbm with vaapi - http://ix.io/28LC

----

# WARNING

## DON'T MERGE BEFORE TAGGING THE NEW FFMPEG VERSION