### PR TITLE
Introduce LockState enum

### DIFF
--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -65,6 +65,8 @@ set(HEADERS AppParamParser.h
             IProgressCallback.h
             InfoScanner.h
             LangInfo.h
+            LockState.h
+            LockType.h
             MediaSource.h
             NfoFile.h
             PartyModeManager.h

--- a/xbmc/LockState.h
+++ b/xbmc/LockState.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+typedef enum
+{
+  LOCK_STATE_NO_LOCK           =  0,
+  LOCK_STATE_LOCK_BUT_UNLOCKED =  1,
+  LOCK_STATE_LOCKED            =  2
+} LockState;


### PR DESCRIPTION
## Description
This PR is introducing an ENUM to get rid of those constants in the source-tree.
used in #17129 

LOCK_STATE_NO_LOCK                        =  0
LOCK_STATE_LOCK_BUT_UNLOCKED =  1
LOCK_STATE_LOCKED                          =  2

if everyone is happy with the naming i'll rework the tree

