### PR TITLE
[test] TestCPUInfo: remove useless test

### DIFF
--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -56,12 +56,6 @@ TEST_F(TestCPUInfo, GetTemperature)
   EXPECT_TRUE(t.IsValid());
 }
 
-TEST_F(TestCPUInfo, GetCPUModel)
-{
-  std::string s = CServiceBroker::GetCPUInfo()->GetCPUModel();
-  EXPECT_STRNE("", s.c_str());
-}
-
 TEST_F(TestCPUInfo, CoreInfo)
 {
   ASSERT_TRUE(CServiceBroker::GetCPUInfo()->HasCoreId(0));


### PR DESCRIPTION
missed in #17290 

This test may not be available on some hosts. It doesn't mean anything anyways.