### PR TITLE
[osx] drop i386 support

### DIFF
--- a/addons/xbmc.addon/metadata.xsd
+++ b/addons/xbmc.addon/metadata.xsd
@@ -41,7 +41,6 @@
       <xs:enumeration value="linux"/>
       <xs:enumeration value="osx"/>
       <xs:enumeration value="osx64"/>
-      <xs:enumeration value="osx32"/>
       <xs:enumeration value="ios"/>
       <xs:enumeration value="windx"/>
       <xs:enumeration value="windows"/>

--- a/docs/README.macOS.md
+++ b/docs/README.macOS.md
@@ -82,18 +82,11 @@ Kodi can be built as either a 32bit or 64bit program. The dependencies are built
 
 **TIP:** Look for comments starting with `Or ...` and only execute the command(s) you need.
 
-Configure build for 64bit (**recommended**):
+Configure build:
 ```
 cd $HOME/kodi/tools/depends
 ./bootstrap
 ./configure --host=x86_64-apple-darwin
-```
-
-Or configure build for 32bit:
-```
-cd $HOME/kodi/tools/depends
-./bootstrap
-./configure --host=i386-apple-darwin
 ```
 
 Build tools and dependencies:
@@ -166,17 +159,12 @@ Change to build directory:
 cd $HOME/kodi-build
 ```
 
-Generate Xcode project for 64bit (**recommended**):
+Generate Xcode project:
 ```
 /Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=/Users/Shared/xbmc-depends/macosx10.13_x86_64-target-debug/share/Toolchain.cmake ../kodi
 ```
 
-Or generate Xcode project for 32bit:
-```
-/Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=/Users/Shared/xbmc-depends/macosx10.13_i386-target-debug/share/Toolchain.cmake ../kodi
-```
-
-**WARNING:** The toolchain file location differs depending on SDK version. You have to replace `x86_64-darwin17.5.0-native` and `macosx10.13_x86_64-target-debug` or `macosx10.13_i386-target-debug` in the paths above with the correct ones on your system.
+**WARNING:** The toolchain file location differs depending on SDK version. You have to replace `x86_64-darwin17.5.0-native` and `macosx10.13_x86_64-target-debug` in the paths above with the correct ones on your system.
 
 You can check `Users/Shared/xbmc-depends` directory content with:
 ```

--- a/tools/depends/.gitignore
+++ b/tools/depends/.gitignore
@@ -21,12 +21,8 @@
 /target/*/aarch64-linux-*/*
 /target/*/macosx*.*_x86_64-target-*/
 /target/*/macosx*.*_x86_64-target-*/*
-/target/*/macosx*.*_i386-target-*/
-/target/*/macosx*.*_i386-target-*/*
 /target/*/iphoneos*.*_arm*-target-*/
 /target/*/iphoneos*.*_arm*-target-*/*
-/target/*/iphonesimulator*.*_i386*-target-*/
-/target/*/iphonesimulator*.*_i386*-target-*/*
 /target/*/iphonesimulator*.*_x86_64*-target-*/
 /target/*/iphonesimulator*.*_x86_64*-target-*/*
 /target/*/appletvos*.*_arm64*-target-*/

--- a/tools/depends/README.md
+++ b/tools/depends/README.md
@@ -20,9 +20,6 @@ Paths below are examples. If you want to build Kodi, follow our **[build guides]
 ### All platforms
 `./bootstrap`
 ### Darwin
-**macOS (i386)**  
-`./configure --host=i386-apple-darwin`
-
 **macOS (x86_64)**  
 `./configure --host=x86_64-apple-darwin`
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -313,25 +313,13 @@ case $host in
     platform_cxxflags="-no-cpp-precomp"
 
     case $host in
-      *86*-apple-darwin)
+      x86_64-apple-darwin)
         MC_CHECK_NOT_CPU([$use_cpu], "arm")
 
         # setup which cpu to use
-        case $host in
-          x86_64-apple-darwin*)
-            if test "x$use_cpu" = "xauto"; then
-              use_cpu=x86_64
-            fi
-          ;;
-          i*86-apple-darwin*)
-            if test "x$use_cpu" = "xauto"; then
-              use_cpu=i386
-            fi
-            platform_ldflags+=" -read_only_relocs suppress"
-         ;;
-          *)
-            AC_MSG_ERROR(error in configure of --with-arch=$use_cpu)
-        esac
+        if test "x$use_cpu" = "xauto"; then
+          use_cpu=x86_64
+        fi
 
         # setup which sdk to use
         target_platform=macosx

--- a/tools/depends/m4/xbmc_arch.m4
+++ b/tools/depends/m4/xbmc_arch.m4
@@ -51,9 +51,6 @@ case $host in
   *86*-apple-darwin*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX")
      ;;
-  powerpc-apple-darwin*)
-     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX")
-     ;;
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_POWERPC")
      ;;

--- a/tools/depends/m4/xbmc_arch.m4
+++ b/tools/depends/m4/xbmc_arch.m4
@@ -14,7 +14,7 @@ case $build in
   amd64-*-freebsd*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_FREEBSD")
      ;;
-  *86*-apple-darwin*)
+  x86_64-apple-darwin*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX")
      ;;
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)
@@ -48,7 +48,7 @@ case $host in
   arm-apple-darwin*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_EMBEDDED")
      ;;
-  *86*-apple-darwin*)
+  x86_64-apple-darwin*)
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX")
      ;;
   powerpc-*-linux-gnu*|powerpc-*-linux-uclibc*)

--- a/tools/depends/target/libcdio-gplv3/osx.patch
+++ b/tools/depends/target/libcdio-gplv3/osx.patch
@@ -13,7 +13,7 @@
         ##     [Define 1 if you have AIX CD-ROM support])
         ;;
 -     darwin[[6-9]].*|darwin1[[0-6]].*)
-+     *86*-apple-darwin*)
++     x86_64-apple-darwin*)
         AC_CHECK_HEADERS(IOKit/IOKitLib.h CoreFoundation/CFBase.h,
                          [have_iokit_h="yes"])
         if test "x$have_iokit_h" = "xyes" ; then

--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -21,11 +21,7 @@ ifeq ($(OS), darwin_embedded)
   endif
 endif
 ifeq ($(OS), osx)
-  ifeq ($(CPU),x86_64)
-    CONFIGURE=./Configure darwin64-$(CPU)-cc zlib no-asm no-shared --prefix=$(PREFIX)
-  else
-    CONFIGURE=./Configure darwin-$(CPU)-cc zlib no-asm no-shared --prefix=$(PREFIX)
-  endif
+  CONFIGURE=./Configure darwin64-$(CPU)-cc zlib no-asm no-shared --prefix=$(PREFIX)
 endif
 LIBDYLIB=$(PLATFORM)/libssl.a
 

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -620,9 +620,6 @@ bool CAddonInfoBuilder::PlatformSupportsAddon(const AddonInfoPtr& addon)
 #if defined(__x86_64__)
     "osx64",
     "osx-x86_64",
-#elif defined(__i686__)
-    "osx-i686",
-    "osx32",
 #else
 #warning no architecture dependant platform tag
 #endif

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -914,8 +914,6 @@ const std::string& CSysInfo::GetKernelCpuFamily(void)
         kernelCpuFamily = "x86";
       else if (cpuType == CPU_TYPE_ARM)
         kernelCpuFamily = "ARM";
-      else if (cpuType == CPU_TYPE_POWERPC)
-        kernelCpuFamily = "PowerPC";
 #ifdef CPU_TYPE_MIPS
       else if (cpuType == CPU_TYPE_MIPS)
         kernelCpuFamily = "MIPS";
@@ -1072,8 +1070,6 @@ std::string CSysInfo::GetUserAgent()
   std::string cpuFam(GetBuildTargetCpuFamily());
   if (cpuFam == "x86")
     result += "Intel ";
-  else if (cpuFam == "PowerPC")
-    result += "PPC ";
   result += "Mac OS X ";
   std::string OSXVersion(GetOsVersion());
   StringUtils::Replace(OSXVersion, '.', '_');


### PR DESCRIPTION
## Motivation and Context
Since OSX 10.8 (Mountain Lion) the operating system is x86_64 so there is no need for an i386 Kodi application.


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
