### PR TITLE
[PVR] CPVREpg: Fix EPG not saved for newly added channels.

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -779,17 +779,6 @@ int CPVRChannel::EpgID() const
   return m_iEpgId;
 }
 
-void CPVRChannel::SetEpgID(int iEpgId)
-{
-  CSingleLock lock(m_critSection);
-  if (m_iEpgId != iEpgId)
-  {
-    m_iEpgId = iEpgId;
-    m_epg.reset();
-    m_bChanged = true;
-  }
-}
-
 bool CPVRChannel::EPGEnabled() const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -319,12 +319,6 @@ namespace PVR
     int EpgID() const;
 
     /*!
-     * @brief Change the id of the epg that is linked to this channel
-     * @param iEpgId The new epg id
-     */
-    void SetEpgID(int iEpgId);
-
-    /*!
      * @brief Create the EPG for this channel, if it does not yet exist
      * @return true if a new epg was created, false otherwise.
      */

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -289,6 +289,7 @@ namespace PVR
      */
     void Cleanup(int iPastDays);
 
+    bool m_bChanged = false; /*!< true if anything changed that needs to be persisted, false otherwise */
     bool m_bUpdatePending = false; /*!< true if manual update is pending */
     int m_iEpgID = 0; /*!< the database ID of this table */
     std::string m_strName; /*!< the name of this table */


### PR DESCRIPTION
Fixes fallout from #17195 : EPG for channels added from backend was never persisted to database. This PR actually re-introduces the old change detection logic which was accidentally removed.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish for review?