### PR TITLE
Fixed checking if proxy and username pass are empty

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -604,7 +604,7 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
 
     const std::string userpass =
       m_proxyuser + std::string(":") + m_proxypassword;
-    if (!userpass.empty())
+    if (userpass != ":")
       g_curlInterface.easy_setopt(h, CURLOPT_PROXYUSERPWD, userpass.c_str());
   }
   if (m_customrequest.length() > 0)


### PR DESCRIPTION
Regular developers, this is a "drive by" fix and a trivial once you find it. Feel free to pick up the change and insert it into your merge, I dont have time to adhere to whatever policies you have for merging.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
You are having a trivial to fix bug in filesystem/CurlFile.cpp[605] which probably brakes proxy functionality when no password is set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes checking if username and password are set
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/xbmc/xbmc/issues/17336

## How Has This Been Tested?
Nothing tested, the change is apparent.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
