### PR TITLE
[pvr] always add new members to group at end in group manager

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -714,6 +714,20 @@ bool CPVRChannelGroup::AddToGroup(const std::shared_ptr<CPVRChannel>& channel, c
   return bReturn;
 }
 
+bool CPVRChannelGroup::AppendToGroup(const std::shared_ptr<CPVRChannel>& channel)
+{
+  CSingleLock lock(m_critSection);
+
+  unsigned int channelNumberMax = 0;
+  for (const auto& member : m_sortedMembers)
+  {
+    if (member->channelNumber.GetChannelNumber() > channelNumberMax)
+      channelNumberMax = member->channelNumber.GetChannelNumber();
+  }
+
+  return AddToGroup(channel, CPVRChannelNumber(channelNumberMax + 1, 0), 0, false);
+}
+
 bool CPVRChannelGroup::IsGroupMember(const std::shared_ptr<CPVRChannel>& channel) const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -150,13 +150,20 @@ namespace PVR
     /*!
      * @brief Add a channel to this container.
      * @param channel The channel to add.
-     * @param channelNumber The channel number of the channel to add. Use empty channel number to add it at the end.
+     * @param channelNumber The channel number of the channel to add. Use empty channel number if it's to be generated.
      * @param iOrder The value denoting the order of this member in the group, 0 if unknown and needs to be generated
      * @param bUseBackendChannelNumbers True, if channelNumber contains a backend channel number.
      * @param clientChannelNumber The client channel number of the channel to add. (optional)
      * @return True if the channel was added, false otherwise.
      */
     virtual bool AddToGroup(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber, int iOrder, bool bUseBackendChannelNumbers, const CPVRChannelNumber& clientChannelNumber = {});
+
+    /*!
+     * @brief Append a channel to this container.
+     * @param channel The channel to append.
+     * @return True if the channel was appended, false otherwise.
+     */
+    virtual bool AppendToGroup(const std::shared_ptr<CPVRChannel>& channel);
 
     /*!
      * @brief Change the name of this group.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -157,6 +157,13 @@ bool CPVRChannelGroupInternal::AddToGroup(const std::shared_ptr<CPVRChannel>& ch
   return bReturn;
 }
 
+bool CPVRChannelGroupInternal::AppendToGroup(const std::shared_ptr<CPVRChannel>& channel)
+{
+  CSingleLock lock(m_critSection);
+
+  return AddToGroup(channel, CPVRChannelNumber(), 0, false);
+}
+
 bool CPVRChannelGroupInternal::RemoveFromGroup(const std::shared_ptr<CPVRChannel>& channel)
 {
   if (!IsGroupMember(channel))

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -58,6 +58,11 @@ namespace PVR
     bool AddToGroup(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber, int iOrder, bool bUseBackendChannelNumbers, const CPVRChannelNumber& clientChannelNumber = {}) override;
 
     /*!
+     * @see CPVRChannelGroup::AppendToGroup
+     */
+    bool AppendToGroup(const std::shared_ptr<CPVRChannel>& channel) override;
+
+    /*!
      * @see CPVRChannelGroup::RemoveFromGroup
      */
     bool RemoveFromGroup(const std::shared_ptr<CPVRChannel>& channel) override;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -201,7 +201,8 @@ bool CGUIDialogPVRGroupManager::ActionButtonUngroupedChannels(CGUIMessage& messa
       else if (m_ungroupedChannels->GetFileCount() > 0)
       {
         CFileItemPtr pItemChannel = m_ungroupedChannels->Get(m_iSelectedUngroupedChannel);
-        if (m_selectedGroup->AddToGroup(pItemChannel->GetPVRChannelInfoTag(), CPVRChannelNumber(), 0, false))
+
+        if (m_selectedGroup->AppendToGroup(pItemChannel->GetPVRChannelInfoTag()))
         {
           ClearSelectedGroupsThumbnail();
           Update();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Always add new channels to groups at the end in group manager.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Then adding support for group specific channel numbering and numbering from 1  (https://github.com/xbmc/xbmc/pull/16593) logic was missed in the group manager GUI. 

Fixes: https://github.com/xbmc/xbmc/issues/17324

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
