### PR TITLE
Fix enum formatting again

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -56,6 +56,17 @@ DEF_TO_STR_VALUE(foo) // outputs "4"
 #define DEF_TO_STR_NAME(x) #x
 #define DEF_TO_STR_VALUE(x) DEF_TO_STR_NAME(x)
 
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, int> = 0>
+constexpr auto&& EnumToInt(T&& arg) noexcept
+{
+  return arg;
+}
+template<typename T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+constexpr auto EnumToInt(T&& arg) noexcept
+{
+  return static_cast<int>(arg);
+}
+
 class StringUtils
 {
 public:
@@ -74,9 +85,9 @@ public:
   static std::string Format(const std::string& fmt, Args&&... args)
   {
     // coverity[fun_call_w_exception : FALSE]
-    auto result = ::fmt::format(fmt, std::forward<Args>(args)...);
+    auto result = ::fmt::format(fmt, EnumToInt(std::forward<Args>(args))...);
     if (result == fmt)
-      result = ::fmt::sprintf(fmt, std::forward<Args>(args)...);
+      result = ::fmt::sprintf(fmt, EnumToInt(std::forward<Args>(args))...);
 
     return result;
   }
@@ -84,9 +95,9 @@ public:
   static std::wstring Format(const std::wstring& fmt, Args&&... args)
   {
     // coverity[fun_call_w_exception : FALSE]
-    auto result = ::fmt::format(fmt, std::forward<Args>(args)...);
+    auto result = ::fmt::format(fmt, EnumToInt(std::forward<Args>(args))...);
     if (result == fmt)
-      result = ::fmt::sprintf(fmt, std::forward<Args>(args)...);
+      result = ::fmt::sprintf(fmt, EnumToInt(std::forward<Args>(args))...);
 
     return result;
   }

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -19,17 +19,26 @@
 //
 //------------------------------------------------------------------------
 
-#include "XBDateTime.h"
-#include "utils/params_check_macros.h"
-
-#include <locale>
-#include <ostream>
-#include <sstream>
 #include <stdarg.h>
 #include <stdint.h>
 #include <string>
-#include <type_traits>
 #include <vector>
+#include <sstream>
+#include <locale>
+
+// workaround for broken [[depreciated]] in coverity
+#if defined(__COVERITY__)
+#undef FMT_DEPRECATED
+#define FMT_DEPRECATED
+#endif
+#include <fmt/format.h>
+
+#if FMT_VERSION >= 40000
+#include <fmt/printf.h>
+#endif
+
+#include "XBDateTime.h"
+#include "utils/params_check_macros.h"
 
 /*! \brief  C-processor Token stringification
 
@@ -47,38 +56,15 @@ DEF_TO_STR_VALUE(foo) // outputs "4"
 #define DEF_TO_STR_NAME(x) #x
 #define DEF_TO_STR_VALUE(x) DEF_TO_STR_NAME(x)
 
-// clang-format off
-// This is required to format enum classes with fmt as they're not implicitly
-// convertible to int.
-// This operator has to be declared before including format.h and ostream.h.
-// We keep clang format disabled to avoid reordering and breaking things
-// https://github.com/fmtlib/fmt/issues/391
-template<typename T, typename std::enable_if_t<std::is_enum<T>::value, int> = 0>
-std::ostream& operator<<(std::ostream& os, const T& value)
-{
-  return os << static_cast<int>(value);
-}
-
-// workaround for broken [[deprecated]] in coverity
-#if defined(__COVERITY__)
-#undef FMT_DEPRECATED
-#define FMT_DEPRECATED
-#endif
-#include <fmt/format.h>
-
-#if FMT_VERSION >= 30000
-#include <fmt/ostream.h>
-#endif
-
-#if FMT_VERSION >= 40000
-#include <fmt/printf.h>
-#endif
-// clang-format on
-
 class StringUtils
 {
 public:
   /*! \brief Get a formatted string similar to sprintf
+
+  Beware that this does not support directly passing in
+  std::string objects. You need to call c_str() to pass
+  the const char* buffer representing the value of the
+  std::string object.
 
   \param fmt Format of the resulting string
   \param ... variable number of value type arguments

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -66,6 +66,17 @@ TEST(TestStringUtils, FormatEnum)
   EXPECT_STREQ(one, varstr.c_str());
 }
 
+TEST(TestStringUtils, FormatEnumWidth)
+{
+  const char* one = "01";
+
+  std::string varstr = StringUtils::Format("{:02d}", ECG::B);
+  EXPECT_STREQ(one, varstr.c_str());
+
+  varstr = StringUtils::Format("%02d", EG::D);
+  EXPECT_STREQ(one, varstr.c_str());
+}
+
 TEST(TestStringUtils, ToUpper)
 {
   std::string refstr = "TEST";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This attempt removes the enums from fmt altogether
as the wrapper functions will convert to int before fmt
sees them.

This makes the changes independent from fmt so we don't
have to worry about different behaviour for different versions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
tests pass
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
