### PR TITLE
Don't try to generate a thumb for unresolved plugin path

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -84,6 +84,7 @@ bool CThumbExtractor::DoWork()
   ||  URIUtils::IsPVRRecording(m_item.GetDynPath())
   ||  URIUtils::IsUPnP(m_item.GetPath())
   ||  URIUtils::IsBluray(m_item.GetPath())
+  ||  URIUtils::IsPlugin(m_item.GetDynPath()) // plugin path not fully resolved
   ||  m_item.IsBDFile()
   ||  m_item.IsDVD()
   ||  m_item.IsDiscImage()


### PR DESCRIPTION
## Description
Followup to #17202, giving plugins a loader in `CFileFactory` means they make it to the thumbloader now, but it still can't process them.

## Motivation and Context
Fixes a Kodi crash when a generated thumbnail is requested for a plugin path.

## How Has This Been Tested?
Quick runtime testing.