### PR TITLE
[PVR] CGUIEPGGridContainer: Fix GUI_MSG_REFRESH_LIST message parameters.

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -2351,7 +2351,8 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
     if (m_gridModel->FreeProgrammeMemory(firstChannel, lastChannel, firstBlock, lastBlock))
     {
       // announce changed viewport
-      const CGUIMessage msg(GUI_MSG_REFRESH_LIST, GetID(), 0, static_cast<int>(PVREvent::Epg));
+      const CGUIMessage msg(
+          GUI_MSG_REFRESH_LIST, GetParentID(), GetID(), static_cast<int>(PVREvent::Epg));
       KODI::MESSAGING::CApplicationMessenger::GetInstance().SendGUIMessage(msg);
     }
   }


### PR DESCRIPTION
When Guide control dialog is active and controls are used (changes view port of the Guide window), the Guide window did not receive GUI_MSG_REFRESH_LIST, which led to unsynchronized data between grid model and window (wrong item selected etc.).

Runtime-tested on macOS, latest Kodi master.

@phunkyfish when you have time for a review.