### PR TITLE
PlatformDefs.h: move FILETIME to XTimeUtils.h

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -32,14 +32,14 @@ static const char *MONTH_NAMES[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "
 
 CDateTimeSpan::CDateTimeSpan()
 {
-  m_timeSpan.dwHighDateTime=0;
-  m_timeSpan.dwLowDateTime=0;
+  m_timeSpan.highDateTime = 0;
+  m_timeSpan.lowDateTime = 0;
 }
 
 CDateTimeSpan::CDateTimeSpan(const CDateTimeSpan& span)
 {
-  m_timeSpan.dwHighDateTime=span.m_timeSpan.dwHighDateTime;
-  m_timeSpan.dwLowDateTime=span.m_timeSpan.dwLowDateTime;
+  m_timeSpan.highDateTime = span.m_timeSpan.highDateTime;
+  m_timeSpan.lowDateTime = span.m_timeSpan.lowDateTime;
 }
 
 CDateTimeSpan::CDateTimeSpan(int day, int hour, int minute, int second)
@@ -143,14 +143,14 @@ const CDateTimeSpan& CDateTimeSpan::operator -=(const CDateTimeSpan& right)
 
 void CDateTimeSpan::ToULargeInt(ULARGE_INTEGER& time) const
 {
-  time.u.HighPart=m_timeSpan.dwHighDateTime;
-  time.u.LowPart=m_timeSpan.dwLowDateTime;
+  time.u.HighPart = m_timeSpan.highDateTime;
+  time.u.LowPart = m_timeSpan.lowDateTime;
 }
 
 void CDateTimeSpan::FromULargeInt(const ULARGE_INTEGER& time)
 {
-  m_timeSpan.dwHighDateTime=time.u.HighPart;
-  m_timeSpan.dwLowDateTime=time.u.LowPart;
+  m_timeSpan.highDateTime = time.u.HighPart;
+  m_timeSpan.lowDateTime = time.u.LowPart;
 }
 
 void CDateTimeSpan::SetDateTimeSpan(int day, int hour, int minute, int second)
@@ -245,11 +245,11 @@ CDateTime::CDateTime()
 
 CDateTime::CDateTime(const KODI::TIME::SystemTime& time)
 {
-  // we store internally as a FILETIME
+  // we store internally as a FileTime
   m_state = ToFileTime(time, m_time) ? valid : invalid;
 }
 
-CDateTime::CDateTime(const FILETIME &time)
+CDateTime::CDateTime(const KODI::TIME::FileTime& time)
 {
   m_time=time;
   SetValid(true);
@@ -299,7 +299,7 @@ const CDateTime& CDateTime::operator=(const KODI::TIME::SystemTime& right)
   return *this;
 }
 
-const CDateTime& CDateTime::operator =(const FILETIME& right)
+const CDateTime& CDateTime::operator=(const KODI::TIME::FileTime& right)
 {
   m_time=right;
   SetValid(true);
@@ -351,39 +351,39 @@ bool CDateTime::operator !=(const CDateTime& right) const
   return !operator ==(right);
 }
 
-bool CDateTime::operator >(const FILETIME& right) const
+bool CDateTime::operator>(const KODI::TIME::FileTime& right) const
 {
   return KODI::TIME::CompareFileTime(&m_time, &right) > 0;
 }
 
-bool CDateTime::operator >=(const FILETIME& right) const
+bool CDateTime::operator>=(const KODI::TIME::FileTime& right) const
 {
   return operator >(right) || operator ==(right);
 }
 
-bool CDateTime::operator <(const FILETIME& right) const
+bool CDateTime::operator<(const KODI::TIME::FileTime& right) const
 {
   return KODI::TIME::CompareFileTime(&m_time, &right) < 0;
 }
 
-bool CDateTime::operator <=(const FILETIME& right) const
+bool CDateTime::operator<=(const KODI::TIME::FileTime& right) const
 {
   return operator <(right) || operator ==(right);
 }
 
-bool CDateTime::operator ==(const FILETIME& right) const
+bool CDateTime::operator==(const KODI::TIME::FileTime& right) const
 {
   return KODI::TIME::CompareFileTime(&m_time, &right) == 0;
 }
 
-bool CDateTime::operator !=(const FILETIME& right) const
+bool CDateTime::operator!=(const KODI::TIME::FileTime& right) const
 {
   return !operator ==(right);
 }
 
 bool CDateTime::operator>(const KODI::TIME::SystemTime& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator >(time);
@@ -396,7 +396,7 @@ bool CDateTime::operator>=(const KODI::TIME::SystemTime& right) const
 
 bool CDateTime::operator<(const KODI::TIME::SystemTime& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator <(time);
@@ -409,7 +409,7 @@ bool CDateTime::operator<=(const KODI::TIME::SystemTime& right) const
 
 bool CDateTime::operator==(const KODI::TIME::SystemTime& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator ==(time);
@@ -422,7 +422,7 @@ bool CDateTime::operator!=(const KODI::TIME::SystemTime& right) const
 
 bool CDateTime::operator >(const time_t& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator >(time);
@@ -435,7 +435,7 @@ bool CDateTime::operator >=(const time_t& right) const
 
 bool CDateTime::operator <(const time_t& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator <(time);
@@ -448,7 +448,7 @@ bool CDateTime::operator <=(const time_t& right) const
 
 bool CDateTime::operator ==(const time_t& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator ==(time);
@@ -461,7 +461,7 @@ bool CDateTime::operator !=(const time_t& right) const
 
 bool CDateTime::operator >(const tm& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator >(time);
@@ -474,7 +474,7 @@ bool CDateTime::operator >=(const tm& right) const
 
 bool CDateTime::operator <(const tm& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator <(time);
@@ -487,7 +487,7 @@ bool CDateTime::operator <=(const tm& right) const
 
 bool CDateTime::operator ==(const tm& right) const
 {
-  FILETIME time;
+  KODI::TIME::FileTime time;
   ToFileTime(right, time);
 
   return operator ==(time);
@@ -582,7 +582,7 @@ CDateTimeSpan CDateTime::operator -(const CDateTime& right) const
   return left;
 }
 
-CDateTime::operator FILETIME() const
+CDateTime::operator KODI::TIME::FileTime() const
 {
   return m_time;
 }
@@ -630,25 +630,25 @@ bool CDateTime::IsValid() const
   return m_state==valid;
 }
 
-bool CDateTime::ToFileTime(const KODI::TIME::SystemTime& time, FILETIME& fileTime) const
+bool CDateTime::ToFileTime(const KODI::TIME::SystemTime& time, KODI::TIME::FileTime& fileTime) const
 {
-  return SystemTimeToFileTime(&time, &fileTime) == 1 &&
-         (fileTime.dwLowDateTime > 0 || fileTime.dwHighDateTime > 0);
+  return KODI::TIME::SystemTimeToFileTime(&time, &fileTime) == 1 &&
+         (fileTime.lowDateTime > 0 || fileTime.highDateTime > 0);
 }
 
-bool CDateTime::ToFileTime(const time_t& time, FILETIME& fileTime) const
+bool CDateTime::ToFileTime(const time_t& time, KODI::TIME::FileTime& fileTime) const
 {
   long long ll = time;
   ll *= 10000000ll;
   ll += 0x19DB1DED53E8000LL;
 
-  fileTime.dwLowDateTime  = (DWORD)(ll & 0xFFFFFFFF);
-  fileTime.dwHighDateTime = (DWORD)(ll >> 32);
+  fileTime.lowDateTime = (DWORD)(ll & 0xFFFFFFFF);
+  fileTime.highDateTime = (DWORD)(ll >> 32);
 
   return true;
 }
 
-bool CDateTime::ToFileTime(const tm& time, FILETIME& fileTime) const
+bool CDateTime::ToFileTime(const tm& time, KODI::TIME::FileTime& fileTime) const
 {
   KODI::TIME::SystemTime st = {0};
 
@@ -665,14 +665,14 @@ bool CDateTime::ToFileTime(const tm& time, FILETIME& fileTime) const
 
 void CDateTime::ToULargeInt(ULARGE_INTEGER& time) const
 {
-  time.u.HighPart=m_time.dwHighDateTime;
-  time.u.LowPart=m_time.dwLowDateTime;
+  time.u.HighPart = m_time.highDateTime;
+  time.u.LowPart = m_time.lowDateTime;
 }
 
 void CDateTime::FromULargeInt(const ULARGE_INTEGER& time)
 {
-  m_time.dwHighDateTime=time.u.HighPart;
-  m_time.dwLowDateTime=time.u.LowPart;
+  m_time.highDateTime = time.u.HighPart;
+  m_time.lowDateTime = time.u.LowPart;
 }
 
 bool CDateTime::SetFromDateString(const std::string &date)
@@ -811,7 +811,7 @@ void CDateTime::GetAsSystemTime(KODI::TIME::SystemTime& time) const
 #define UNIX_BASE_TIME 116444736000000000LL /* nanoseconds since epoch */
 void CDateTime::GetAsTime(time_t& time) const
 {
-  long long ll = (static_cast<long long>(m_time.dwHighDateTime) << 32) + m_time.dwLowDateTime;
+  long long ll = (static_cast<long long>(m_time.highDateTime) << 32) + m_time.lowDateTime;
   time=(time_t)((ll - UNIX_BASE_TIME) / 10000000);
 }
 
@@ -831,7 +831,7 @@ void CDateTime::GetAsTm(tm& time) const
   mktime(&time);
 }
 
-void CDateTime::GetAsTimeStamp(FILETIME& time) const
+void CDateTime::GetAsTimeStamp(KODI::TIME::FileTime& time) const
 {
   KODI::TIME::LocalFileTimeToFileTime(&m_time, &time);
 }

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -110,19 +110,19 @@ private:
   void FromULargeInt(const ULARGE_INTEGER& time);
 
 private:
-  FILETIME m_timeSpan;
+  KODI::TIME::FileTime m_timeSpan;
 
   friend class CDateTime;
 };
 
-/// \brief DateTime class, which uses FILETIME as it's base.
+/// \brief DateTime class, which uses FileTime as it's base.
 class CDateTime final : public IArchivable
 {
 public:
   CDateTime();
   CDateTime(const CDateTime& time);
   explicit CDateTime(const KODI::TIME::SystemTime& time);
-  explicit CDateTime(const FILETIME& time);
+  explicit CDateTime(const KODI::TIME::FileTime& time);
   explicit CDateTime(const time_t& time);
   explicit CDateTime(const tm& time);
   CDateTime(int year, int month, int day, int hour, int minute, int second);
@@ -142,7 +142,7 @@ public:
   static CDateTime FromRFC1123DateTime(const std::string &dateTime);
 
   const CDateTime& operator=(const KODI::TIME::SystemTime& right);
-  const CDateTime& operator =(const FILETIME& right);
+  const CDateTime& operator=(const KODI::TIME::FileTime& right);
   const CDateTime& operator =(const time_t& right);
   const CDateTime& operator =(const tm& right);
 
@@ -153,12 +153,12 @@ public:
   bool operator ==(const CDateTime& right) const;
   bool operator !=(const CDateTime& right) const;
 
-  bool operator >(const FILETIME& right) const;
-  bool operator >=(const FILETIME& right) const;
-  bool operator <(const FILETIME& right) const;
-  bool operator <=(const FILETIME& right) const;
-  bool operator ==(const FILETIME& right) const;
-  bool operator !=(const FILETIME& right) const;
+  bool operator>(const KODI::TIME::FileTime& right) const;
+  bool operator>=(const KODI::TIME::FileTime& right) const;
+  bool operator<(const KODI::TIME::FileTime& right) const;
+  bool operator<=(const KODI::TIME::FileTime& right) const;
+  bool operator==(const KODI::TIME::FileTime& right) const;
+  bool operator!=(const KODI::TIME::FileTime& right) const;
 
   bool operator>(const KODI::TIME::SystemTime& right) const;
   bool operator>=(const KODI::TIME::SystemTime& right) const;
@@ -189,7 +189,7 @@ public:
 
   CDateTimeSpan operator -(const CDateTime& right) const;
 
-  operator FILETIME() const;
+  operator KODI::TIME::FileTime() const;
 
   void Archive(CArchive& ar) override;
 
@@ -225,7 +225,7 @@ public:
   void GetAsSystemTime(KODI::TIME::SystemTime& time) const;
   void GetAsTime(time_t& time) const;
   void GetAsTm(tm& time) const;
-  void GetAsTimeStamp(FILETIME& time) const;
+  void GetAsTimeStamp(KODI::TIME::FileTime& time) const;
 
   CDateTime GetAsUTCDateTime() const;
   std::string GetAsSaveString() const;
@@ -248,15 +248,15 @@ public:
   static CDateTimeSpan GetTimezoneBias(void);
 
 private:
-  bool ToFileTime(const KODI::TIME::SystemTime& time, FILETIME& fileTime) const;
-  bool ToFileTime(const time_t& time, FILETIME& fileTime) const;
-  bool ToFileTime(const tm& time, FILETIME& fileTime) const;
+  bool ToFileTime(const KODI::TIME::SystemTime& time, KODI::TIME::FileTime& fileTime) const;
+  bool ToFileTime(const time_t& time, KODI::TIME::FileTime& fileTime) const;
+  bool ToFileTime(const tm& time, KODI::TIME::FileTime& fileTime) const;
 
   void ToULargeInt(ULARGE_INTEGER& time) const;
   void FromULargeInt(const ULARGE_INTEGER& time);
 
 private:
-  FILETIME m_time;
+  KODI::TIME::FileTime m_time;
 
   typedef enum _STATE
   {

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -63,7 +63,7 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList &items)
   {
     if (wfd.fileName[0] != 0)
     {
-      if ((wfd.fileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+      if ((wfd.fileAttributes & KODI_FILE_ATTRIBUTE_DIRECTORY))
       {
         std::string strDir = wfd.fileName;
         if (strDir != "." && strDir != "..")
@@ -73,7 +73,7 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList &items)
           URIUtils::AddSlashAtEnd(path);
           pItem->SetPath(path);
           pItem->m_bIsFolder = true;
-          FILETIME localTime;
+          KODI::TIME::FileTime localTime;
           KODI::TIME::FileTimeToLocalFileTime(&wfd.lastWriteTime, &localTime);
           pItem->m_dateTime=localTime;
           items.Add(pItem);
@@ -86,7 +86,7 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList &items)
         pItem->SetPath(strRoot + strDir);
         pItem->m_bIsFolder = false;
         pItem->m_dwSize = CUtil::ToInt64(wfd.fileSizeHigh, wfd.fileSizeLow);
-        FILETIME localTime;
+        KODI::TIME::FileTime localTime;
         KODI::TIME::FileTimeToLocalFileTime(&wfd.lastWriteTime, &localTime);
         pItem->m_dateTime=localTime;
         items.Add(pItem);

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -178,7 +178,7 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   // We accept nfs://server/path[/file]]]]
   int ret = 0;
-  FILETIME fileTime, localTime;
+  KODI::TIME::FileTime fileTime, localTime;
   CSingleLock lock(gNfsConnection);
   std::string strDirName="";
   std::string myStrPath(url.Get());
@@ -253,8 +253,8 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       long long ll = lTimeDate & 0xffffffff;
       ll *= 10000000ll;
       ll += 116444736000000000ll;
-      fileTime.dwLowDateTime = (DWORD) (ll & 0xffffffff);
-      fileTime.dwHighDateTime = (DWORD)(ll >> 32);
+      fileTime.lowDateTime = (DWORD)(ll & 0xffffffff);
+      fileTime.highDateTime = (DWORD)(ll >> 32);
       KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
 
       CFileItemPtr pItem(new CFileItem(tmpDirent.name));

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -642,7 +642,7 @@ HANDLE iso9660::FindFirstFile9660(const char* szLocalFolder, Win32FindData* wfdF
       wfdFile->fileName[sizeof(wfdFile->fileName) - 1] = '\0';
 
       if ( m_searchpointer->type == 2 )
-        wfdFile->fileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
+        wfdFile->fileAttributes |= KODI_FILE_ATTRIBUTE_DIRECTORY;
 
       wfdFile->lastWriteTime = m_searchpointer->filetime;
       wfdFile->lastAccessTime = m_searchpointer->filetime;
@@ -669,7 +669,7 @@ int iso9660::FindNextFile(HANDLE szLocalFolder, Win32FindData* wfdFile)
     wfdFile->fileName[sizeof(wfdFile->fileName) - 1] = '\0';
 
     if ( m_searchpointer->type == 2 )
-      wfdFile->fileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
+      wfdFile->fileAttributes |= KODI_FILE_ATTRIBUTE_DIRECTORY;
 
     wfdFile->lastWriteTime = m_searchpointer->filetime;
     wfdFile->lastAccessTime = m_searchpointer->filetime;
@@ -1036,7 +1036,7 @@ bool iso9660::IsScanned()
 }
 
 //************************************************************************************
-void iso9660::IsoDateTimeToFileTime(iso9660_Datetime* isoDateTime, FILETIME* filetime)
+void iso9660::IsoDateTimeToFileTime(iso9660_Datetime* isoDateTime, KODI::TIME::FileTime* filetime)
 {
   tm t = { 0 };
   t.tm_year=isoDateTime->year;

--- a/xbmc/filesystem/iso9660.h
+++ b/xbmc/filesystem/iso9660.h
@@ -9,9 +9,10 @@
 
 #pragma once
 
-#include <vector>
+#include "XBDateTime.h"
+
 #include <string>
-#include "PlatformDefs.h" // for win32 types
+#include <vector>
 
 #ifdef TARGET_WINDOWS
 // Ideally we should just be including iso9660.h, but it's not win32-ified at this point,
@@ -131,7 +132,7 @@ struct iso_dirtree
   char type;  // bit 0 = no entry, bit 1 = file, bit 2 = dir
   DWORD Location; // number of the first sector of file data or directory
   DWORD Length;      // number of bytes of file data or length of directory
-  FILETIME filetime; // date time of the directory/file
+  KODI::TIME::FileTime filetime; // date time of the directory/file
 
   struct iso_dirtree *dirpointer; // if type is a dir, this will point to the list in that dir
   struct iso_dirtree *next;  // pointer to next file/dir in this directory
@@ -148,9 +149,9 @@ struct iso_directories
 struct Win32FindData
 {
   unsigned int fileAttributes;
-  FILETIME creationTime;
-  FILETIME lastAccessTime;
-  FILETIME lastWriteTime;
+  KODI::TIME::FileTime creationTime;
+  KODI::TIME::FileTime lastAccessTime;
+  KODI::TIME::FileTime lastWriteTime;
   unsigned int fileSizeHigh;
   unsigned int fileSizeLow;
   unsigned int reserved0;
@@ -158,6 +159,8 @@ struct Win32FindData
   char fileName[260];
   char alternateFileName[14];
 };
+
+constexpr unsigned int KODI_FILE_ATTRIBUTE_DIRECTORY{0x10};
 
 class iso9660
 {
@@ -194,7 +197,7 @@ public:
   bool IsScanned();
 
 protected:
-  void IsoDateTimeToFileTime(iso9660_Datetime* isoDateTime, FILETIME* filetime);
+  void IsoDateTimeToFileTime(iso9660_Datetime* isoDateTime, KODI::TIME::FileTime* filetime);
   struct iso_dirtree* ReadRecursiveDirFromSector( DWORD sector, const char * );
   struct iso_dirtree* FindFolder(const char *Folder );
   std::string GetThinText(unsigned char* strTxt, int iLen );

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -300,7 +300,7 @@ void CMusicInfoScanner::Start(const std::string& strDirectory, int flags)
   }
   else
   {
-    m_pathsToScan.insert(strDirectory);    
+    m_pathsToScan.insert(strDirectory);
     m_idSourcePath = m_musicDatabase.GetSourceFromPath(strDirectory);
   }
   m_musicDatabase.Close();
@@ -816,7 +816,7 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
       {
         if (common[i] == VARIOUSARTISTS_MBID)
           /* Treat "various", "various artists" and the localized equivalent name as the same
-          album artist as the artist with Musicbrainz ID 89ad4ac3-39f7-470e-963a-56509c546377. 
+          album artist as the artist with Musicbrainz ID 89ad4ac3-39f7-470e-963a-56509c546377.
           If adding this artist for the first time then the name will be set to either the primary
           artist read from tags when 3a, or the localized value for "various artists" when not 3a.
           This means that tag values are no longer translated into the current langauge.
@@ -1260,8 +1260,8 @@ int CMusicInfoScanner::GetPathHash(const CFileItemList &items, std::string &hash
     const CFileItemPtr pItem = items[i];
     digest.Update(pItem->GetPath());
     digest.Update((unsigned char *)&pItem->m_dwSize, sizeof(pItem->m_dwSize));
-    FILETIME time = pItem->m_dateTime;
-    digest.Update((unsigned char *)&time, sizeof(FILETIME));
+    KODI::TIME::FileTime time = pItem->m_dateTime;
+    digest.Update((unsigned char*)&time, sizeof(KODI::TIME::FileTime));
     if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsNFO())
       count++;
   }
@@ -1476,7 +1476,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
   CInfoScanner::INFO_TYPE result = CInfoScanner::NO_NFO;
   CNfoFile nfoReader;
   existsNFO = XFILE::CFile::Exists(strNfo);
-  // When on GUI ask user if they want to ignore nfo and refresh from Internet  
+  // When on GUI ask user if they want to ignore nfo and refresh from Internet
   if (existsNFO && pDialog && CGUIDialogYesNo::ShowAndGetInput(10523, 20446))
   {
     existsNFO = false;
@@ -1763,7 +1763,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
       CLog::Log(LOGDEBUG, "%s not have path, nfo file not possible", artist.strArtist.c_str());
   }
 
-  // When on GUI ask user if they want to ignore nfo and refresh from Internet  
+  // When on GUI ask user if they want to ignore nfo and refresh from Internet
   if (existsNFO && pDialog && CGUIDialogYesNo::ShowAndGetInput(21891, 20446))
   {
     existsNFO = false;

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
@@ -91,7 +91,7 @@ bool CTVOSDirectory::GetDirectory(const CURL& url, CFileItemList& items)
       if (tvOSFile.Stat(url2, &buffer) == 0)
       {
         // fake the datetime
-        FILETIME fileTime, localTime;
+        KODI::TIME::FileTime fileTime, localTime;
         KODI::TIME::TimeTToFileTime(buffer.st_mtime, &fileTime);
         KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
         pItem->m_dateTime = localTime;

--- a/xbmc/platform/posix/PlatformDefs.h
+++ b/xbmc/platform/posix/PlatformDefs.h
@@ -165,14 +165,6 @@ struct _stati64 {
   time_t _st_ctime;
 };
 
-typedef struct _FILETIME
-{
-  DWORD dwLowDateTime;
-  DWORD dwHighDateTime;
-} FILETIME, *PFILETIME, *LPFILETIME;
-
-#define FILE_ATTRIBUTE_DIRECTORY           0x00000010
-
 #define FILE_BEGIN              0
 #define FILE_CURRENT            1
 #define FILE_END                2

--- a/xbmc/platform/posix/XTimeUtils.cpp
+++ b/xbmc/platform/posix/XTimeUtils.cpp
@@ -85,26 +85,25 @@ void GetLocalTime(SystemTime* systemTime)
   g_timezone.m_IsDST = now.tm_isdst;
 }
 
-int FileTimeToLocalFileTime(const FILETIME* lpFileTime, LPFILETIME lpLocalFileTime)
+int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime)
 {
   ULARGE_INTEGER l;
-  l.u.LowPart = lpFileTime->dwLowDateTime;
-  l.u.HighPart = lpFileTime->dwHighDateTime;
+  l.u.LowPart = fileTime->lowDateTime;
+  l.u.HighPart = fileTime->highDateTime;
 
   time_t ft;
   struct tm tm_ft;
-  FileTimeToTimeT(lpFileTime, &ft);
+  FileTimeToTimeT(fileTime, &ft);
   localtime_r(&ft, &tm_ft);
 
   l.QuadPart += static_cast<unsigned long long>(tm_ft.tm_gmtoff) * 10000000;
 
-  lpLocalFileTime->dwLowDateTime = l.u.LowPart;
-  lpLocalFileTime->dwHighDateTime = l.u.HighPart;
+  localFileTime->lowDateTime = l.u.LowPart;
+  localFileTime->highDateTime = l.u.HighPart;
   return 1;
 }
 
-
-int SystemTimeToFileTime(const SystemTime* systemTime, LPFILETIME lpFileTime)
+int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime)
 {
   static const int dayoffset[12] = {0, 31, 59, 90, 120, 151, 182, 212, 243, 273, 304, 334};
 #if defined(TARGET_DARWIN)
@@ -140,21 +139,21 @@ int SystemTimeToFileTime(const SystemTime* systemTime, LPFILETIME lpFileTime)
   result.QuadPart = (long long)t * 10000000 + (long long)systemTime->milliseconds * 10000;
   result.QuadPart += WIN32_TIME_OFFSET;
 
-  lpFileTime->dwLowDateTime = result.u.LowPart;
-  lpFileTime->dwHighDateTime = result.u.HighPart;
+  fileTime->lowDateTime = result.u.LowPart;
+  fileTime->highDateTime = result.u.HighPart;
 
   return 1;
 }
 
-long CompareFileTime(const FILETIME* lpFileTime1, const FILETIME* lpFileTime2)
+long CompareFileTime(const FileTime* fileTime1, const FileTime* fileTime2)
 {
   ULARGE_INTEGER t1;
-  t1.u.LowPart = lpFileTime1->dwLowDateTime;
-  t1.u.HighPart = lpFileTime1->dwHighDateTime;
+  t1.u.LowPart = fileTime1->lowDateTime;
+  t1.u.HighPart = fileTime1->highDateTime;
 
   ULARGE_INTEGER t2;
-  t2.u.LowPart = lpFileTime2->dwLowDateTime;
-  t2.u.HighPart = lpFileTime2->dwHighDateTime;
+  t2.u.LowPart = fileTime2->lowDateTime;
+  t2.u.HighPart = fileTime2->highDateTime;
 
   if (t1.QuadPart == t2.QuadPart)
      return 0;
@@ -164,18 +163,18 @@ long CompareFileTime(const FILETIME* lpFileTime1, const FILETIME* lpFileTime2)
      return 1;
 }
 
-int FileTimeToSystemTime(const FILETIME* lpFileTime, SystemTime* systemTime)
+int FileTimeToSystemTime(const FileTime* fileTime, SystemTime* systemTime)
 {
-  LARGE_INTEGER fileTime;
-  fileTime.u.LowPart = lpFileTime->dwLowDateTime;
-  fileTime.u.HighPart = lpFileTime->dwHighDateTime;
+  LARGE_INTEGER file;
+  file.u.LowPart = fileTime->lowDateTime;
+  file.u.HighPart = fileTime->highDateTime;
 
-  fileTime.QuadPart -= WIN32_TIME_OFFSET;
-  fileTime.QuadPart /= 10000; /* to milliseconds */
-  systemTime->milliseconds = fileTime.QuadPart % 1000;
-  fileTime.QuadPart /= 1000; /* to seconds */
+  file.QuadPart -= WIN32_TIME_OFFSET;
+  file.QuadPart /= 10000; /* to milliseconds */
+  systemTime->milliseconds = file.QuadPart % 1000;
+  file.QuadPart /= 1000; /* to seconds */
 
-  time_t ft = fileTime.QuadPart;
+  time_t ft = file.QuadPart;
 
   struct tm tm_ft;
   gmtime_r(&ft,&tm_ft);
@@ -191,28 +190,29 @@ int FileTimeToSystemTime(const FILETIME* lpFileTime, SystemTime* systemTime)
   return 1;
 }
 
-int LocalFileTimeToFileTime( const FILETIME* lpLocalFileTime, LPFILETIME lpFileTime)
+int LocalFileTimeToFileTime(const FileTime* localFileTime, FileTime* fileTime)
 {
   ULARGE_INTEGER l;
-  l.u.LowPart = lpLocalFileTime->dwLowDateTime;
-  l.u.HighPart = lpLocalFileTime->dwHighDateTime;
+  l.u.LowPart = localFileTime->lowDateTime;
+  l.u.HighPart = localFileTime->highDateTime;
 
   l.QuadPart += (unsigned long long) timezone * 10000000;
 
-  lpFileTime->dwLowDateTime = l.u.LowPart;
-  lpFileTime->dwHighDateTime = l.u.HighPart;
+  fileTime->lowDateTime = l.u.LowPart;
+  fileTime->highDateTime = l.u.HighPart;
 
   return 1;
 }
 
-int FileTimeToTimeT(const FILETIME* lpLocalFileTime, time_t *pTimeT) {
 
-  if (lpLocalFileTime == NULL || pTimeT == NULL)
-  return false;
+int FileTimeToTimeT(const FileTime* localFileTime, time_t* pTimeT)
+{
+  if (!localFileTime || !pTimeT)
+    return false;
 
   ULARGE_INTEGER fileTime;
-  fileTime.u.LowPart  = lpLocalFileTime->dwLowDateTime;
-  fileTime.u.HighPart = lpLocalFileTime->dwHighDateTime;
+  fileTime.u.LowPart = localFileTime->lowDateTime;
+  fileTime.u.HighPart = localFileTime->highDateTime;
 
   fileTime.QuadPart -= WIN32_TIME_OFFSET;
   fileTime.QuadPart /= 10000; /* to milliseconds */
@@ -227,17 +227,17 @@ int FileTimeToTimeT(const FILETIME* lpLocalFileTime, time_t *pTimeT) {
   return 1;
 }
 
-int TimeTToFileTime(time_t timeT, FILETIME* lpLocalFileTime) {
-
-  if (lpLocalFileTime == NULL)
-  return false;
+int TimeTToFileTime(time_t timeT, FileTime* localFileTime)
+{
+  if (!localFileTime)
+    return false;
 
   ULARGE_INTEGER result;
   result.QuadPart = (unsigned long long) timeT * 10000000;
   result.QuadPart += WIN32_TIME_OFFSET;
 
-  lpLocalFileTime->dwLowDateTime  = result.u.LowPart;
-  lpLocalFileTime->dwHighDateTime = result.u.HighPart;
+  localFileTime->lowDateTime = result.u.LowPart;
+  localFileTime->highDateTime = result.u.HighPart;
 
   return 1;
 }

--- a/xbmc/platform/posix/filesystem/PosixDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/PosixDirectory.cpp
@@ -79,7 +79,7 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     {
       if (bStat || stat(pItem->GetPath().c_str(), &buffer) == 0)
       {
-        FILETIME fileTime, localTime;
+        KODI::TIME::FileTime fileTime, localTime;
         KODI::TIME::TimeTToFileTime(buffer.st_mtime, &fileTime);
         KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
         pItem->m_dateTime = localTime;

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -157,7 +157,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
         }
       }
 
-      FILETIME fileTime, localTime;
+      KODI::TIME::FileTime fileTime, localTime;
       KODI::TIME::TimeTToFileTime(lTimeDate, &fileTime);
       KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime);
 

--- a/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryDirectory.cpp
@@ -129,7 +129,11 @@ bool CWinLibraryDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
     auto props = Wait(item.GetBasicPropertiesAsync());
 
-    pItem->m_dateTime = winrt::clock::to_FILETIME(props.DateModified());
+    FILETIME fileTime1 = winrt::clock::to_FILETIME(props.DateModified());
+    KODI::TIME::FileTime fileTime2;
+    fileTime2.highDateTime = fileTime1.dwHighDateTime;
+    fileTime2.lowDateTime = fileTime1.dwLowDateTime;
+    pItem->m_dateTime = fileTime2;
     if (!pItem->m_bIsFolder)
       pItem->m_dwSize = static_cast<int64_t>(props.Size());
 

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -12,6 +12,7 @@
 #include "URL.h"
 #include "utils/CharsetConverter.h"
 #include "utils/SystemInfo.h"
+#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
 #include "platform/win32/WIN32Util.h"
@@ -93,8 +94,11 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
 
     // calculation of size and date costs a little on win32
     // so DIR_FLAG_NO_FILE_INFO flag is ignored
-    FILETIME localTime;
-    if (KODI::TIME::FileTimeToLocalFileTime(&findData.ftLastWriteTime, &localTime) == TRUE)
+    KODI::TIME::FileTime fileTime;
+    fileTime.lowDateTime = findData.ftLastWriteTime.dwLowDateTime;
+    fileTime.lowDateTime = findData.ftLastWriteTime.dwHighDateTime;
+    KODI::TIME::FileTime localTime;
+    if (KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime) == TRUE)
       pItem->m_dateTime = localTime;
     else
       pItem->m_dateTime = 0;

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -7,17 +7,19 @@
  */
 
 #include "Win32SMBDirectory.h"
+
 #include "FileItem.h"
-#include "platform/win32/WIN32Util.h"
-#include "platform/win32/CharsetConverter.h"
-#include "utils/CharsetConverter.h"
-#include "URL.h"
-#include "utils/log.h"
 #include "PasswordManager.h"
+#include "URL.h"
+#include "utils/CharsetConverter.h"
+#include "utils/XTimeUtils.h"
 #include "utils/auto_buffer.h"
+#include "utils/log.h"
+
+#include "platform/win32/CharsetConverter.h"
+#include "platform/win32/WIN32Util.h"
 
 #include <Windows.h>
-
 #include <Winnetwk.h>
 #pragma comment(lib, "mpr.lib")
 
@@ -166,8 +168,11 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
     // calculation of size and date costs a little on win32
     // so DIR_FLAG_NO_FILE_INFO flag is ignored
-    FILETIME localTime;
-    if (KODI::TIME::FileTimeToLocalFileTime(&findData.ftLastWriteTime, &localTime) == TRUE)
+    KODI::TIME::FileTime fileTime;
+    fileTime.lowDateTime = findData.ftLastWriteTime.dwLowDateTime;
+    fileTime.lowDateTime = findData.ftLastWriteTime.dwHighDateTime;
+    KODI::TIME::FileTime localTime;
+    if (KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime) == TRUE)
       pItem->m_dateTime = localTime;
     else
       pItem->m_dateTime.SetValid(false);

--- a/xbmc/utils/XTimeUtils.h
+++ b/xbmc/utils/XTimeUtils.h
@@ -53,18 +53,24 @@ constexpr int KODI_TIME_ZONE_ID_UNKNOWN{0};
 constexpr int KODI_TIME_ZONE_ID_STANDARD{1};
 constexpr int KODI_TIME_ZONE_ID_DAYLIGHT{2};
 
+struct FileTime
+{
+  unsigned int lowDateTime;
+  unsigned int highDateTime;
+};
+
 void GetLocalTime(SystemTime* systemTime);
 uint32_t GetTimeZoneInformation(TimeZoneInformation* timeZoneInformation);
 
 void Sleep(uint32_t milliSeconds);
 
-int FileTimeToLocalFileTime(const FILETIME* lpFileTime, LPFILETIME lpLocalFileTime);
-int SystemTimeToFileTime(const SystemTime* systemTime, LPFILETIME lpFileTime);
-long CompareFileTime(const FILETIME* lpFileTime1, const FILETIME* lpFileTime2);
-int FileTimeToSystemTime(const FILETIME* lpFileTime, SystemTime* systemTime);
-int LocalFileTimeToFileTime(const FILETIME* lpLocalFileTime, LPFILETIME lpFileTime);
+int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime);
+int SystemTimeToFileTime(const SystemTime* systemTime, FileTime* fileTime);
+long CompareFileTime(const FileTime* fileTime1, const FileTime* fileTime2);
+int FileTimeToSystemTime(const FileTime* fileTime, SystemTime* systemTime);
+int LocalFileTimeToFileTime(const FileTime* LocalFileTime, FileTime* fileTime);
 
-int FileTimeToTimeT(const FILETIME* lpLocalFileTime, time_t* pTimeT);
-int TimeTToFileTime(time_t timeT, FILETIME* lpLocalFileTime);
+int FileTimeToTimeT(const FileTime* localFileTime, time_t* pTimeT);
+int TimeTToFileTime(time_t timeT, FileTime* localFileTime);
 } // namespace TIME
 } // namespace KODI

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1872,8 +1872,8 @@ namespace VIDEO
       else
       {
         digest.Update(&pItem->m_dwSize, sizeof(pItem->m_dwSize));
-        FILETIME time = pItem->m_dateTime;
-        digest.Update(&time, sizeof(FILETIME));
+        KODI::TIME::FileTime time = pItem->m_dateTime;
+        digest.Update(&time, sizeof(KODI::TIME::FileTime));
       }
       if (pItem->IsVideo() && !pItem->IsPlayList() && !pItem->IsNFO())
         count++;


### PR DESCRIPTION
More namespacing and PlatformDefs cleanup.

Not sure about the win32 changes yet but we will find out :smile: 