### PR TITLE
PlatformDefs.h: remove _atoi64 define

### DIFF
--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -534,7 +534,7 @@ double field_value::get_asDouble() const {
 int64_t field_value::get_asInt64() const {
     switch (field_type) {
     case ft_String: {
-      return _atoi64(str_value.c_str());
+      return std::stoll(str_value);
     }
     case ft_Boolean:{
       return (int64_t)bool_value;

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -115,7 +115,7 @@ static void ParseItemMRSS(CFileItem* item, SResources& resources, TiXmlElement* 
     item_child->Attribute("bitrate", &res.bitrate);
     item_child->Attribute("duration", &res.duration);
     if(item_child->Attribute("fileSize"))
-      res.size     = _atoi64(item_child->Attribute("fileSize"));
+      res.size = std::atoll(item_child->Attribute("fileSize"));
 
     resources.push_back(res);
     ParseItem(item, resources, item_child, path);
@@ -267,7 +267,7 @@ static void ParseItemRSS(CFileItem* item, SResources& resources, TiXmlElement* i
     res.path = XMLUtils::GetAttribute(item_child, "url");
     res.mime = XMLUtils::GetAttribute(item_child, "type");
     if(len)
-      res.size = _atoi64(len);
+      res.size = std::atoll(len);
 
     resources.push_back(res);
   }

--- a/xbmc/platform/posix/PlatformDefs.h
+++ b/xbmc/platform/posix/PlatformDefs.h
@@ -86,7 +86,6 @@
 #define stricmp   strcasecmp
 #define strcmpi strcasecmp
 #define strnicmp  strncasecmp
-#define _atoi64(x) atoll(x)
 
 #define __stdcall
 #define __cdecl


### PR DESCRIPTION
more cleanup of PlatformDefs.h

remove this trivial define with the `std` equivalents.