### PR TITLE
[python] fixed incorrectly formatted region time

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -442,7 +442,10 @@ namespace XBMCAddon
       else if (strcmpi(id, "time") == 0)
         {
           result = g_langInfo.GetTimeFormat();
-          StringUtils::Replace(result, "H", "%H");
+          if (StringUtils::StartsWith(result, "HH"))
+            StringUtils::Replace(result, "HH", "%H");
+          else
+            StringUtils::Replace(result, "H", "%H");
           StringUtils::Replace(result, "h", "%I");
           StringUtils::Replace(result, "mm", "%M");
           StringUtils::Replace(result, "ss", "%S");


### PR DESCRIPTION
## Description
This PR corrects an incorrectly formatted string for the region time if you select a time format in the regional settings that consists of more than one letter for the hours (e.g. <code>HH:mm:ss</code>) and call <code>xbmc.getRegion("time")</code>.

Before:
Time format (settings): <code>HH:mm:ss</code>
Returned formatted string: <code>%H%H:%M:%S</code>

After:
Time format (settings): <code>HH:mm:ss</code>
Returned formatted string: <code>%H:%M:%S</code>

## Motivation and Context
Bug fixes for:
#15862 
https://github.com/im85288/service.upnext/issues/169

## How Has This Been Tested?
On my Shield TV with custom kodi builds and various time format settings.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
