### PR TITLE
[depends] bump libjpeg-turbo to 2.0.4

### DIFF
--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -44,6 +44,7 @@ dpkg: automake gettext libtool pkg-config tar
 flatbuffers: cmake
 heimdal: libtool
 libtool: automake
+libjpeg-turbo: cmake yasm
 libpng: zlib
 meson: python3 setuptools
 ninja: python3

--- a/tools/depends/native/libjpeg-turbo/01-disable-executables.patch
+++ b/tools/depends/native/libjpeg-turbo/01-disable-executables.patch
@@ -1,0 +1,130 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -592,18 +592,6 @@
+       set_target_properties(turbojpeg PROPERTIES
+         LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
+     endif()
+-
+-    add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
+-    target_link_libraries(tjunittest turbojpeg)
+-
+-    add_executable(tjbench tjbench.c tjutil.c)
+-    target_link_libraries(tjbench turbojpeg)
+-    if(UNIX)
+-      target_link_libraries(tjbench m)
+-    endif()
+-
+-    add_executable(tjexample tjexample.c)
+-    target_link_libraries(tjexample turbojpeg)
+   endif()
+ 
+   if(ENABLE_STATIC)
+@@ -615,16 +603,6 @@
+     if(NOT MSVC)
+       set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
+     endif()
+-
+-    add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
+-      md5/md5hl.c)
+-    target_link_libraries(tjunittest-static turbojpeg-static)
+-
+-    add_executable(tjbench-static tjbench.c tjutil.c)
+-    target_link_libraries(tjbench-static turbojpeg-static)
+-    if(UNIX)
+-      target_link_libraries(tjbench-static m)
+-    endif()
+   endif()
+ endif()
+ 
+@@ -639,33 +617,11 @@
+   set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
+ endif()
+ 
+-if(ENABLE_STATIC)
+-  add_executable(cjpeg-static cjpeg.c cdjpeg.c rdgif.c rdppm.c rdswitch.c
+-    ${CJPEG_BMP_SOURCES})
+-  set_property(TARGET cjpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
+-  target_link_libraries(cjpeg-static jpeg-static)
+-
+-  add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrgif.c
+-    wrppm.c ${DJPEG_BMP_SOURCES})
+-  set_property(TARGET djpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
+-  target_link_libraries(djpeg-static jpeg-static)
+-
+-  add_executable(jpegtran-static jpegtran.c cdjpeg.c rdswitch.c transupp.c)
+-  target_link_libraries(jpegtran-static jpeg-static)
+-  set_property(TARGET jpegtran-static PROPERTY COMPILE_FLAGS "${USE_SETMODE}")
+-endif()
+-
+-add_executable(rdjpgcom rdjpgcom.c)
+-
+-add_executable(wrjpgcom wrjpgcom.c)
+-
+ 
+ ###############################################################################
+ # TESTS
+ ###############################################################################
+ 
+-add_subdirectory(md5)
+-
+ if(MSVC_IDE OR XCODE)
+   set(OBJDIR "\${CTEST_CONFIGURATION_TYPE}/")
+ else()
+@@ -1337,7 +1293,7 @@
+ 
+ if(WITH_TURBOJPEG)
+   if(ENABLE_SHARED)
+-    install(TARGETS turbojpeg tjbench
++    install(TARGETS turbojpeg
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+@@ -1350,15 +1306,6 @@
+   if(ENABLE_STATIC)
+     install(TARGETS turbojpeg-static ARCHIVE
+       DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-    if(NOT ENABLE_SHARED)
+-      if(MSVC_IDE OR XCODE)
+-        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
+-      else()
+-        set(DIR ${CMAKE_CURRENT_BINARY_DIR})
+-      endif()
+-      install(PROGRAMS ${DIR}/tjbench-static${EXE}
+-        DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
+-    endif()
+   endif()
+   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+@@ -1366,23 +1313,8 @@
+ 
+ if(ENABLE_STATIC)
+   install(TARGETS jpeg-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  if(NOT ENABLE_SHARED)
+-    if(MSVC_IDE OR XCODE)
+-      set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
+-    else()
+-      set(DIR ${CMAKE_CURRENT_BINARY_DIR})
+-    endif()
+-    install(PROGRAMS ${DIR}/cjpeg-static${EXE}
+-      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME cjpeg${EXE})
+-    install(PROGRAMS ${DIR}/djpeg-static${EXE}
+-      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME djpeg${EXE})
+-    install(PROGRAMS ${DIR}/jpegtran-static${EXE}
+-      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
+-  endif()
+ endif()
+ 
+-install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
+   ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.txt
+   ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
+@@ -1398,8 +1330,6 @@
+ if(UNIX OR MINGW)
+   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
+     ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
+-    ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
+-    ${CMAKE_CURRENT_SOURCE_DIR}/wrjpgcom.1
+     DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+ endif()
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgscripts/libjpeg.pc

--- a/tools/depends/native/libjpeg-turbo/Makefile
+++ b/tools/depends/native/libjpeg-turbo/Makefile
@@ -1,20 +1,15 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-disable-executables.patch
 
 # lib name, version
 LIBNAME=libjpeg-turbo
-VERSION=1.5.1
+VERSION=2.0.4
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
-# configuration settings
-CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
-          ./configure --prefix=$(PREFIX) --with-jpeg8 --without-simd
 
-CFLAGS+=-O3
-
-LIBDYLIB=$(PLATFORM)/.libs/libjpeg.a
+LIBDYLIB=$(PLATFORM)/build/libjpeg.a
 
 all: .installed-$(PLATFORM)
 
@@ -24,14 +19,14 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM); $(CONFIGURE)
+	cd $(PLATFORM); patch -p1 -i ../01-disable-executables.patch
+	cd $(PLATFORM); $(CMAKE) -B build -DCMAKE_TOOLCHAIN_FILE= -DCMAKE_ASM_NASM_COMPILER:FILEPATH=$(NATIVEPREFIX)/bin/yasm -DENABLE_SHARED:BOOL=OFF -DWITH_JPEG8:BOOL=ON
 
 $(LIBDYLIB): $(PLATFORM)
-	$(MAKE) -j 1 -C $(PLATFORM)
-	touch $@
+	$(MAKE) -C $(PLATFORM)/build
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	$(MAKE) -C $(PLATFORM) install
+	$(MAKE) -C $(PLATFORM)/build install
 	touch $@
 
 clean:

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -2,6 +2,11 @@ set(DEPENDS_PATH "@prefix@/@deps_dir@")
 set(NATIVEPREFIX "@prefix@/@tool_dir@")
 
 set(OS "@platform_os@")
+set(CMAKE_SYSTEM_PROCESSOR @host_cpu@)
+# TODO: remove this after the host triplet for arm64 darwin builds is corrected to aarch64-apple-darwin
+if(@platform_os@ STREQUAL darwin_embedded AND @use_cpu@ STREQUAL arm64)
+  set(CMAKE_SYSTEM_PROCESSOR aarch64)
+endif()
 set(CPU "@use_cpu@")
 set(PLATFORM "@target_platform@")
 

--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -1,4 +1,9 @@
 set(OS "@platform_os@")
+set(CMAKE_SYSTEM_PROCESSOR @host_cpu@)
+# TODO: remove this after the host triplet for arm64 darwin builds is corrected to aarch64-apple-darwin
+if(@platform_os@ STREQUAL darwin_embedded AND @use_cpu@ STREQUAL arm64)
+  set(CMAKE_SYSTEM_PROCESSOR aarch64)
+endif()
 set(CPU "@use_cpu@")
 set(PLATFORM "@target_platform@")
 set(APP_RENDER_SYSTEM @app_rendersystem@)

--- a/tools/depends/target/libjpeg-turbo/01-disable-executables.patch
+++ b/tools/depends/target/libjpeg-turbo/01-disable-executables.patch
@@ -1,0 +1,130 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -592,18 +592,6 @@
+       set_target_properties(turbojpeg PROPERTIES
+         LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
+     endif()
+-
+-    add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
+-    target_link_libraries(tjunittest turbojpeg)
+-
+-    add_executable(tjbench tjbench.c tjutil.c)
+-    target_link_libraries(tjbench turbojpeg)
+-    if(UNIX)
+-      target_link_libraries(tjbench m)
+-    endif()
+-
+-    add_executable(tjexample tjexample.c)
+-    target_link_libraries(tjexample turbojpeg)
+   endif()
+ 
+   if(ENABLE_STATIC)
+@@ -615,16 +603,6 @@
+     if(NOT MSVC)
+       set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
+     endif()
+-
+-    add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
+-      md5/md5hl.c)
+-    target_link_libraries(tjunittest-static turbojpeg-static)
+-
+-    add_executable(tjbench-static tjbench.c tjutil.c)
+-    target_link_libraries(tjbench-static turbojpeg-static)
+-    if(UNIX)
+-      target_link_libraries(tjbench-static m)
+-    endif()
+   endif()
+ endif()
+ 
+@@ -639,33 +617,11 @@
+   set(DJPEG_BMP_SOURCES wrbmp.c wrtarga.c)
+ endif()
+ 
+-if(ENABLE_STATIC)
+-  add_executable(cjpeg-static cjpeg.c cdjpeg.c rdgif.c rdppm.c rdswitch.c
+-    ${CJPEG_BMP_SOURCES})
+-  set_property(TARGET cjpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
+-  target_link_libraries(cjpeg-static jpeg-static)
+-
+-  add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrgif.c
+-    wrppm.c ${DJPEG_BMP_SOURCES})
+-  set_property(TARGET djpeg-static PROPERTY COMPILE_FLAGS ${COMPILE_FLAGS})
+-  target_link_libraries(djpeg-static jpeg-static)
+-
+-  add_executable(jpegtran-static jpegtran.c cdjpeg.c rdswitch.c transupp.c)
+-  target_link_libraries(jpegtran-static jpeg-static)
+-  set_property(TARGET jpegtran-static PROPERTY COMPILE_FLAGS "${USE_SETMODE}")
+-endif()
+-
+-add_executable(rdjpgcom rdjpgcom.c)
+-
+-add_executable(wrjpgcom wrjpgcom.c)
+-
+ 
+ ###############################################################################
+ # TESTS
+ ###############################################################################
+ 
+-add_subdirectory(md5)
+-
+ if(MSVC_IDE OR XCODE)
+   set(OBJDIR "\${CTEST_CONFIGURATION_TYPE}/")
+ else()
+@@ -1337,7 +1293,7 @@
+ 
+ if(WITH_TURBOJPEG)
+   if(ENABLE_SHARED)
+-    install(TARGETS turbojpeg tjbench
++    install(TARGETS turbojpeg
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+@@ -1350,15 +1306,6 @@
+   if(ENABLE_STATIC)
+     install(TARGETS turbojpeg-static ARCHIVE
+       DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-    if(NOT ENABLE_SHARED)
+-      if(MSVC_IDE OR XCODE)
+-        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
+-      else()
+-        set(DIR ${CMAKE_CURRENT_BINARY_DIR})
+-      endif()
+-      install(PROGRAMS ${DIR}/tjbench-static${EXE}
+-        DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
+-    endif()
+   endif()
+   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+@@ -1366,23 +1313,8 @@
+ 
+ if(ENABLE_STATIC)
+   install(TARGETS jpeg-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  if(NOT ENABLE_SHARED)
+-    if(MSVC_IDE OR XCODE)
+-      set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
+-    else()
+-      set(DIR ${CMAKE_CURRENT_BINARY_DIR})
+-    endif()
+-    install(PROGRAMS ${DIR}/cjpeg-static${EXE}
+-      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME cjpeg${EXE})
+-    install(PROGRAMS ${DIR}/djpeg-static${EXE}
+-      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME djpeg${EXE})
+-    install(PROGRAMS ${DIR}/jpegtran-static${EXE}
+-      DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME jpegtran${EXE})
+-  endif()
+ endif()
+ 
+-install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
+   ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.txt
+   ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
+@@ -1398,8 +1330,6 @@
+ if(UNIX OR MINGW)
+   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
+     ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
+-    ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
+-    ${CMAKE_CURRENT_SOURCE_DIR}/wrjpgcom.1
+     DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+ endif()
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgscripts/libjpeg.pc

--- a/tools/depends/target/libjpeg-turbo/02-fix-gas-preprocessor-with-ccache.patch
+++ b/tools/depends/target/libjpeg-turbo/02-fix-gas-preprocessor-with-ccache.patch
@@ -1,0 +1,5 @@
+--- a/simd/gas-preprocessor.in
++++ b/simd/gas-preprocessor.in
+@@ -1 +1,2 @@
++#!/bin/sh
+ gas-preprocessor.pl @CMAKE_ASM_COMPILER@ ${1+"$@"}

--- a/tools/depends/target/libjpeg-turbo/Makefile
+++ b/tools/depends/target/libjpeg-turbo/Makefile
@@ -1,18 +1,13 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-disable-executables.patch 02-fix-gas-preprocessor-with-ccache.patch
 
 # lib name, version
 LIBNAME=libjpeg-turbo
-VERSION=1.5.1
+VERSION=2.0.4
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
-# configuration settings
-CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
-          ./configure --prefix=$(PREFIX) --with-jpeg8 --disable-shared
 
-export CFLAGS=-O3
-
-LIBDYLIB=$(PLATFORM)/.libs/libjpeg.a
+LIBDYLIB=$(PLATFORM)/build/libjpeg.a
 
 all: .installed-$(PLATFORM)
 
@@ -22,13 +17,15 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM); $(CONFIGURE)
+	cd $(PLATFORM); patch -p1 -i ../01-disable-executables.patch
+	cd $(PLATFORM); patch -p1 -i ../02-fix-gas-preprocessor-with-ccache.patch
+	cd $(PLATFORM); $(CMAKE) -B build -DCMAKE_ASM_NASM_COMPILER:FILEPATH=$(NATIVEPREFIX)/bin/yasm -DENABLE_SHARED:BOOL=OFF -DWITH_JPEG8:BOOL=ON
 
 $(LIBDYLIB): $(PLATFORM)
-	$(MAKE) -j 1 -C $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/build
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	$(MAKE) -C $(PLATFORM) install
+	$(MAKE) -C $(PLATFORM)/build install
 	touch $@
 
 clean:


### PR DESCRIPTION
## How Has This Been Tested?
compiled libjpeg-turbo and it's dependencies for Android (aarch64, arm, i686), iOS (aarch64, arm), macOS and tvOS

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
