### PR TITLE
[backport][WM] Stop bypassing lockcode of mediasources

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5753,7 +5753,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogGamepad.cpp
 #: xbmc/dialogs/GUIDialogNumeric.cpp
 msgctxt "#12343"
-msgid "retries left "
+msgid "retries left"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogGamepad.cpp

--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -65,6 +65,7 @@ set(HEADERS AppParamParser.h
             IProgressCallback.h
             InfoScanner.h
             LangInfo.h
+            LockType.h
             MediaSource.h
             NfoFile.h
             PartyModeManager.h

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -25,6 +25,7 @@
 #include "games/addons/GameClient.h"
 #include "games/tags/GameInfoTag.h"
 #include "guilib/LocalizeStrings.h"
+#include "media/MediaLockState.h"
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
@@ -493,7 +494,7 @@ void CFileItem::Initialize()
   m_idepth = 1;
   m_iLockMode = LOCK_MODE_EVERYONE;
   m_iBadPwdCount = 0;
-  m_iHasLock = 0;
+  m_iHasLock = LOCK_STATE_NO_LOCK;
   m_bCanQueue = true;
   m_specialSort = SortSpecialNone;
   m_doContentLookup = true;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1,63 +1,63 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
 
-#include <cstdlib>
-
 #include "FileItem.h"
+
+#include "CueDocument.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
-#include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
-#include "utils/Archive.h"
+#include "URL.h"
 #include "Util.h"
-#include "playlists/PlayListFactory.h"
-#include "utils/Crc32.h"
+#include "events/IEvent.h"
+#include "filesystem/CurlFile.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "filesystem/StackDirectory.h"
-#include "filesystem/CurlFile.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/MusicDatabaseDirectory.h"
+#include "filesystem/StackDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
-#include "games/addons/GameClient.h"
 #include "games/GameUtils.h"
+#include "games/addons/GameClient.h"
 #include "games/tags/GameInfoTag.h"
-#include "music/tags/MusicInfoTagLoaderFactory.h"
-#include "CueDocument.h"
-#include "video/VideoDatabase.h"
+#include "guilib/LocalizeStrings.h"
+#include "music/Album.h"
+#include "music/Artist.h"
 #include "music/MusicDatabase.h"
+#include "music/tags/MusicInfoTag.h"
+#include "music/tags/MusicInfoTagLoaderFactory.h"
+#include "pictures/PictureInfoTag.h"
+#include "playlists/PlayListFactory.h"
 #include "pvr/PVRManager.h"
-#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
-#include "video/Bookmark.h"
-#include "video/VideoInfoTag.h"
-#include "threads/SingleLock.h"
-#include "music/tags/MusicInfoTag.h"
-#include "pictures/PictureInfoTag.h"
-#include "music/Artist.h"
-#include "music/Album.h"
-#include "URL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "threads/SingleLock.h"
+#include "utils/Archive.h"
+#include "utils/Crc32.h"
 #include "utils/FileExtensionProvider.h"
-#include "utils/RegExp.h"
-#include "utils/log.h"
-#include "utils/Variant.h"
 #include "utils/Mime.h"
 #include "utils/Random.h"
-#include "events/IEvent.h"
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+#include "video/Bookmark.h"
+#include "video/VideoDatabase.h"
+#include "video/VideoInfoTag.h"
 
 #include <algorithm>
+#include <cstdlib>
 
 using namespace KODI;
 using namespace XFILE;

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -29,6 +29,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 #include "view/ViewStateSettings.h"
 
 #include <utility>
@@ -42,41 +43,33 @@ CGUIPassword::CGUIPassword(void)
 }
 CGUIPassword::~CGUIPassword(void) = default;
 
-bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
+template<typename T>
+bool CGUIPassword::IsItemUnlocked(T pItem,
+                                  const std::string& strType,
+                                  const std::string& strLabel,
+                                  const std::string& strHeading)
 {
-  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
-
-  // \brief Tests if the user is allowed to access the share folder
-  // \param pItem The share folder item to access
-  // \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
-  // \return If access is granted, returns \e true
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
   if (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   while (pItem->m_iHasLock > LOCK_STATE_LOCK_BUT_UNLOCKED)
   {
-    std::string strLockCode = pItem->m_strLockCode;
-    std::string strLabel = pItem->GetLabel();
-    int iResult = 0;  // init to user succeeded state, doing this to optimize switch statement below
-    char buffer[33]; // holds 32 places plus sign character
-    if(g_passwordManager.bMasterUser)// Check if we are the MasterUser!
+    const std::string strLockCode = pItem->m_strLockCode;
+    int iResult = 0; // init to user succeeded state, doing this to optimize switch statement below
+    if (!g_passwordManager.bMasterUser) // Check if we are the MasterUser!
     {
-      iResult = 0;
-    }
-    else
-    {
-      if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES) && pItem->m_iBadPwdCount >= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES))
-      { // user previously exhausted all retries, show access denied error
+      if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                   CSettings::SETTING_MASTERLOCK_MAXRETRIES) &&
+          pItem->m_iBadPwdCount >= CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                       CSettings::SETTING_MASTERLOCK_MAXRETRIES))
+      {
+        // user previously exhausted all retries, show access denied error
         HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
         return false;
       }
       // show the appropriate lock dialog
-      std::string strHeading = "";
-      if (pItem->m_bIsFolder)
-        strHeading = g_localizeStrings.Get(12325);
-      else
-        strHeading = g_localizeStrings.Get(12348);
-
       iResult = VerifyPassword(pItem->m_iLockMode, strLockCode, strHeading);
     }
     switch (iResult)
@@ -91,19 +84,20 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
         // password entry succeeded
         pItem->m_iBadPwdCount = 0;
         pItem->m_iHasLock = LOCK_STATE_LOCK_BUT_UNLOCKED;
-        g_passwordManager.LockSource(strType,strLabel,false);
-        sprintf(buffer,"%i",pItem->m_iBadPwdCount);
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount", buffer);
+        g_passwordManager.LockSource(strType, strLabel, false);
+        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
+                                                         std::to_string(pItem->m_iBadPwdCount));
         CMediaSourceSettings::GetInstance().Save();
         break;
       }
     case 1:
       {
         // password entry failed
-        if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES))
+        if (0 != CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                     CSettings::SETTING_MASTERLOCK_MAXRETRIES))
           pItem->m_iBadPwdCount++;
-        sprintf(buffer,"%i",pItem->m_iBadPwdCount);
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount", buffer);
+        CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount",
+                                                         std::to_string(pItem->m_iBadPwdCount));
         CMediaSourceSettings::GetInstance().Save();
         break;
       }
@@ -118,12 +112,32 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
   return true;
 }
 
+bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string& strType)
+{
+  const std::string strLabel = pItem->GetLabel();
+  std::string strHeading;
+  if (pItem->m_bIsFolder)
+    strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
+  else
+    strHeading = g_localizeStrings.Get(12348); // "Item locked"
+
+  return IsItemUnlocked<CFileItem*>(pItem, strType, strLabel, strHeading);
+}
+
+bool CGUIPassword::IsItemUnlocked(CMediaSource* pItem, const std::string& strType)
+{
+  const std::string strLabel = pItem->strName;
+  std::string strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
+
+  return IsItemUnlocked<CMediaSource*>(pItem, strType, strLabel, strHeading);
+}
+
 bool CGUIPassword::CheckStartUpLock()
 {
   // prompt user for mastercode if the mastercode was set b4 or by xml
   int iVerifyPasswordResult = -1;
 
-  std::string strHeader = g_localizeStrings.Get(20075);
+  std::string strHeader = g_localizeStrings.Get(20075); // "Enter master lock code"
 
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
@@ -145,7 +159,7 @@ bool CGUIPassword::CheckStartUpLock()
       if (iVerifyPasswordResult != 0 )
       {
         std::string strLabel1;
-        strLabel1 = g_localizeStrings.Get(12343);
+        strLabel1 = g_localizeStrings.Get(12343); // "retries left"
         int iLeft = g_passwordManager.iMasterLockRetriesLeft-i;
         std::string strLabel = StringUtils::Format("%i %s", iLeft, strLabel1.c_str());
 
@@ -177,6 +191,7 @@ bool CGUIPassword::SetMasterLockMode(bool bDetails)
   if (profile)
   {
     CProfile::CLock locks = profile->GetLocks();
+    // prompt user for master lock
     if (CGUIDialogLockSettings::ShowAndGetLock(locks, 12360, true, bDetails))
     {
       profile->SetLocks(locks);
@@ -226,6 +241,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
     else
     {
       if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+        // prompt user for profile lock code
         return CheckLock(profile->getLockMode(),profile->getLockCode(),20095,bCanceled);
     }
   }
@@ -303,14 +319,15 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
         g_passwordManager.iMasterLockRetriesLeft = 0;
         // Tell the user they ran out of retry attempts
         HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
-        return ;
+        return;
       }
     }
     std::string dlgLine1 = "";
     if (0 < g_passwordManager.iMasterLockRetriesLeft)
-      dlgLine1 = StringUtils::Format("%d %s",
-                                     g_passwordManager.iMasterLockRetriesLeft,
-                                     g_localizeStrings.Get(12343).c_str());
+      dlgLine1 = StringUtils::Format("%d %s", g_passwordManager.iMasterLockRetriesLeft,
+                                     g_localizeStrings.Get(12343).c_str()); // "retries left"
+
+    // prompt user for master lock
     HELPERS::ShowOKDialogLines(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
   }
   else
@@ -501,7 +518,9 @@ void CGUIPassword::RemoveSourceLocks()
       {
         it->m_iHasLock = LOCK_STATE_NO_LOCK;
         it->m_iLockMode = LOCK_MODE_EVERYONE;
-        CMediaSourceSettings::GetInstance().UpdateSource(strType, it->strName, "lockmode", "0"); // removes locks from xml
+
+        // remove locks from xml
+        CMediaSourceSettings::GetInstance().UpdateSource(strType, it->strName, "lockmode", "0");
       }
   }
   CMediaSourceSettings::GetInstance().Save();
@@ -520,11 +539,38 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES
   bool bName = false;
   int iIndex = CUtil::GetMatchingSource(strPath, vecSources, bName);
 
-  if (iIndex > -1 && iIndex < (int)vecSources.size())
+  if (iIndex > -1 && iIndex < static_cast<int>(vecSources.size()))
     if (vecSources[iIndex].m_iHasLock < LOCK_STATE_LOCKED)
       return true;
 
   return false;
+}
+
+bool CGUIPassword::IsMediaPathUnlocked(const std::string& strPath, const std::string& strType)
+{
+  if (StringUtils::StartsWithNoCase(strPath, "root") ||
+      StringUtils::StartsWithNoCase(strPath, "library://"))
+  {
+    // no mediasource-lookup needed
+    CLog::Log(LOGDEBUG, "CGUIPassword::IsMediaPathUnlocked - entering from {}", strPath);
+    return true;
+  }
+
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  if (g_passwordManager.bMasterUser ||
+      profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+    return true;
+
+  VECSOURCES& vecSources = *CMediaSourceSettings::GetInstance().GetSources(strType);
+  bool bName = false;
+  int iIndex = CUtil::GetMatchingSource(strPath, vecSources, bName);
+  if (iIndex > -1 && iIndex < static_cast<int>(vecSources.size()))
+    return g_passwordManager.IsItemUnlocked(&vecSources[iIndex], strType);
+
+  // need to add a missing filter (root/library.. etc.)
+  CLog::Log(LOGERROR, "CGUIPassword::IsMediaPathUnlocked - missing filter: {}", strPath);
+  return true;
 }
 
 void CGUIPassword::OnSettingAction(std::shared_ptr<const CSetting> setting)

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,27 +7,28 @@
  */
 
 #include "GUIPassword.h"
+
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "messaging/ApplicationMessenger.h"
+#include "Util.h"
 #include "dialogs/GUIDialogGamepad.h"
+#include "dialogs/GUIDialogNumeric.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "dialogs/GUIDialogNumeric.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
-#include "Util.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "guilib/GUIWindowManager.h"
-#include "FileItem.h"
-#include "guilib/LocalizeStrings.h"
-#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/StringUtils.h"
-#include "view/ViewStateSettings.h"
 #include "utils/Variant.h"
+#include "view/ViewStateSettings.h"
 
 #include <utility>
 

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "media/MediaLockState.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfileManager.h"
@@ -52,7 +53,7 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
   if (profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
-  while (pItem->m_iHasLock > 1)
+  while (pItem->m_iHasLock > LOCK_STATE_LOCK_BUT_UNLOCKED)
   {
     std::string strLockCode = pItem->m_strLockCode;
     std::string strLabel = pItem->GetLabel();
@@ -89,7 +90,7 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
       {
         // password entry succeeded
         pItem->m_iBadPwdCount = 0;
-        pItem->m_iHasLock = 1;
+        pItem->m_iHasLock = LOCK_STATE_LOCK_BUT_UNLOCKED;
         g_passwordManager.LockSource(strType,strLabel,false);
         sprintf(buffer,"%i",pItem->m_iBadPwdCount);
         CMediaSourceSettings::GetInstance().UpdateSource(strType, strLabel, "badpwdcount", buffer);
@@ -459,9 +460,9 @@ bool CGUIPassword::LockSource(const std::string& strType, const std::string& str
   {
     if (it->strName == strName)
     {
-      if (it->m_iHasLock > 0)
+      if (it->m_iHasLock > LOCK_STATE_NO_LOCK)
       {
-        it->m_iHasLock = bState?2:1;
+        it->m_iHasLock = bState ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED;
         bResult = true;
       }
       break;
@@ -482,7 +483,7 @@ void CGUIPassword::LockSources(bool lock)
     VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(strType);
     for (IVECSOURCES it=shares->begin();it != shares->end();++it)
       if (it->m_iLockMode != LOCK_MODE_EVERYONE)
-        it->m_iHasLock = lock ? 2 : 1;
+        it->m_iHasLock = lock ? LOCK_STATE_LOCKED : LOCK_STATE_LOCK_BUT_UNLOCKED;
   }
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
@@ -498,7 +499,7 @@ void CGUIPassword::RemoveSourceLocks()
     for (IVECSOURCES it=shares->begin();it != shares->end();++it)
       if (it->m_iLockMode != LOCK_MODE_EVERYONE) // remove old info
       {
-        it->m_iHasLock = 0;
+        it->m_iHasLock = LOCK_STATE_NO_LOCK;
         it->m_iLockMode = LOCK_MODE_EVERYONE;
         CMediaSourceSettings::GetInstance().UpdateSource(strType, it->strName, "lockmode", "0"); // removes locks from xml
       }
@@ -520,7 +521,7 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES
   int iIndex = CUtil::GetMatchingSource(strPath, vecSources, bName);
 
   if (iIndex > -1 && iIndex < (int)vecSources.size())
-    if (vecSources[iIndex].m_iHasLock < 2)
+    if (vecSources[iIndex].m_iHasLock < LOCK_STATE_LOCKED)
       return true;
 
   return false;

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -446,9 +446,13 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       break;
     case WINDOW_MUSIC_NAV:      // Music
       bCheckPW = profileManager->GetCurrentProfile().musicLocked();
+      if (!bCheckPW && strMediasourcePath != "") // check mediasource by path
+        return g_passwordManager.IsMediaPathUnlocked(strMediasourcePath, "music");
       break;
     case WINDOW_VIDEO_NAV:      // Video
       bCheckPW = profileManager->GetCurrentProfile().videoLocked();
+      if (!bCheckPW && strMediasourcePath != "") // check mediasource by path
+        return g_passwordManager.IsMediaPathUnlocked(strMediasourcePath, "video");
       break;
     case WINDOW_PICTURES:       // Pictures
       bCheckPW = profileManager->GetCurrentProfile().picturesLocked();

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -25,7 +25,22 @@ class CGUIPassword : public ISettingCallback
 public:
   CGUIPassword(void);
   ~CGUIPassword(void) override;
+  template<typename T>
+  bool IsItemUnlocked(T pItem,
+                      const std::string& strType,
+                      const std::string& strLabel,
+                      const std::string& strHeading);
+  /* \brief Tests if the user is allowed to access the share folder
+   \param pItem The share folder item to access
+   \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
+   \return If access is granted, returns \e true
+   */
   bool IsItemUnlocked(CFileItem* pItem, const std::string &strType);
+  /* \brief Tests if the user is allowed to access the Mediasource
+   \param pItem The share folder item to access
+   \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
+   \return If access is granted, returns \e true
+   */
   bool IsItemUnlocked(CMediaSource* pItem, const std::string &strType);
   bool CheckLock(LockType btnType, const std::string& strPassword, int iHeading);
   bool CheckLock(LockType btnType, const std::string& strPassword, int iHeading, bool& bCanceled);
@@ -49,6 +64,12 @@ public:
   void LockSources(bool lock);
   void RemoveSourceLocks();
   bool IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources);
+  /* \brief Tests if the user is allowed to access the path by looking up the matching Mediasource
+   \param strPath The folder path to access
+   \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
+   \return If access is granted, returns \e true
+   */
+  bool IsMediaPathUnlocked(const std::string& strPath, const std::string& strType);
 
   void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -75,6 +75,7 @@ public:
 
   bool bMasterUser;
   int iMasterLockRetriesLeft;
+  std::string strMediasourcePath;
 
 private:
   int VerifyPassword(LockType btnType, const std::string& strPassword, const std::string& strHeading);

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -30,13 +30,13 @@ public:
                       const std::string& strType,
                       const std::string& strLabel,
                       const std::string& strHeading);
-  /* \brief Tests if the user is allowed to access the share folder
+  /*! \brief Tests if the user is allowed to access the share folder
    \param pItem The share folder item to access
    \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
    \return If access is granted, returns \e true
    */
   bool IsItemUnlocked(CFileItem* pItem, const std::string &strType);
-  /* \brief Tests if the user is allowed to access the Mediasource
+  /*! \brief Tests if the user is allowed to access the Mediasource
    \param pItem The share folder item to access
    \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
    \return If access is granted, returns \e true
@@ -64,7 +64,7 @@ public:
   void LockSources(bool lock);
   void RemoveSourceLocks();
   bool IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources);
-  /* \brief Tests if the user is allowed to access the path by looking up the matching Mediasource
+  /*! \brief Tests if the user is allowed to access the path by looking up the matching Mediasource
    \param strPath The folder path to access
    \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
    \return If access is granted, returns \e true

--- a/xbmc/LockType.h
+++ b/xbmc/LockType.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,11 +7,12 @@
  */
 
 #include "MediaSource.h"
-#include "Util.h"
+
 #include "URL.h"
+#include "Util.h"
 #include "filesystem/MultiPathDirectory.h"
-#include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 
 using namespace XFILE;
 

--- a/xbmc/MediaSource.cpp
+++ b/xbmc/MediaSource.cpp
@@ -11,6 +11,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/MultiPathDirectory.h"
+#include "media/MediaLockState.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -41,7 +42,7 @@ void CMediaSource::FromNameAndPaths(const std::string &category, const std::stri
   m_iLockMode = LOCK_MODE_EVERYONE;
   m_strLockCode = "0";
   m_iBadPwdCount = 0;
-  m_iHasLock = 0;
+  m_iHasLock = LOCK_STATE_NO_LOCK;
   m_allowSharing = true;
 
   if (URIUtils::IsMultiPath(strPath))

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,9 +8,10 @@
 
 #pragma once
 
+#include "LockType.h"
+
 #include <string>
 #include <vector>
-#include "LockType.h"
 
 /*!
 \ingroup windows

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "LockType.h"
+#include "media/MediaLockState.h"
 
 #include <string>
 #include <vector>
@@ -79,7 +80,7 @@ public:
   */
   LockType m_iLockMode = LOCK_MODE_EVERYONE;
   std::string m_strLockCode;  ///< Input code for Lock UI to verify, can be chosen freely.
-  int m_iHasLock = 0;
+  int m_iHasLock = LOCK_STATE_NO_LOCK;
   int m_iBadPwdCount = 0; ///< Number of wrong passwords user has entered since share was last unlocked
 
   std::string m_strThumbnailImage; ///< Path to a thumbnail image for the share, or blank for default

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -26,6 +26,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "media/MediaLockState.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -249,11 +250,15 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
   }
   if (share && LOCK_MODE_EVERYONE != CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetMasterProfile().getLockMode())
   {
-    if (share->m_iHasLock == 0 && (CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
+    if (share->m_iHasLock == LOCK_STATE_NO_LOCK && (CServiceBroker::GetSettingsComponent()
+                                                        ->GetProfileManager()
+                                                        ->GetCurrentProfile()
+                                                        .canWriteSources() ||
+                                                    g_passwordManager.bMasterUser))
       buttons.Add(CONTEXT_BUTTON_ADD_LOCK, 12332);
-    else if (share->m_iHasLock == 1)
+    else if (share->m_iHasLock == LOCK_STATE_LOCK_BUT_UNLOCKED)
       buttons.Add(CONTEXT_BUTTON_REMOVE_LOCK, 12335);
-    else if (share->m_iHasLock == 2)
+    else if (share->m_iHasLock == LOCK_STATE_LOCKED)
     {
       buttons.Add(CONTEXT_BUTTON_REMOVE_LOCK, 12335);
 
@@ -267,7 +272,7 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
         buttons.Add(CONTEXT_BUTTON_CHANGE_LOCK, 12356);
     }
   }
-  if (share && !g_passwordManager.bMasterUser && item->m_iHasLock == 1)
+  if (share && !g_passwordManager.bMasterUser && item->m_iHasLock == LOCK_STATE_LOCK_BUT_UNLOCKED)
     buttons.Add(CONTEXT_BUTTON_REACTIVATE_LOCK, 12353);
 }
 
@@ -437,7 +442,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       if (!CGUIDialogLockSettings::ShowAndGetLock(share->m_iLockMode,strNewPassword))
         return false;
       // password entry and re-entry succeeded, write out the lock data
-      share->m_iHasLock = 2;
+      share->m_iHasLock = LOCK_STATE_LOCKED;
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockcode", strNewPassword);
       strNewPassword = StringUtils::Format("%i", share->m_iLockMode);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockmode", strNewPassword);
@@ -465,10 +470,11 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
 
+      // prompt user if they want to really remove the lock
       if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12335}, CVariant{750}))
         return false;
 
-      share->m_iHasLock = 0;
+      share->m_iHasLock = LOCK_STATE_NO_LOCK;
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockmode", "0");
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockcode", "0");
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,33 +7,34 @@
  */
 
 #include "GUIDialogContextMenu.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIButtonControl.h"
-#include "guilib/GUIControlGroupList.h"
+
+#include "FileItem.h"
 #include "GUIDialogFileBrowser.h"
-#include "GUIUserMessages.h"
+#include "GUIDialogMediaSource.h"
+#include "GUIDialogYesNo.h"
 #include "GUIPassword.h"
+#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
+#include "TextureCache.h"
+#include "URL.h"
 #include "Util.h"
-#include "utils/URIUtils.h"
+#include "addons/Scraper.h"
+#include "filesystem/File.h"
+#include "guilib/GUIButtonControl.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIControlGroupList.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "input/Key.h"
+#include "profiles/ProfileManager.h"
+#include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "GUIDialogMediaSource.h"
-#include "profiles/ProfileManager.h"
-#include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "storage/MediaManager.h"
-#include "guilib/GUIWindowManager.h"
-#include "input/Key.h"
-#include "GUIDialogYesNo.h"
-#include "FileItem.h"
-#include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
-#include "TextureCache.h"
-#include "URL.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
-#include "addons/Scraper.h"
 
 #define BACKGROUND_IMAGE       999
 #define GROUP_LIST             996

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -1,22 +1,23 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
 
-#include "ServiceBroker.h"
 #include "SourcesDirectory.h"
-#include "utils/URIUtils.h"
+
+#include "File.h"
+#include "FileItem.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "FileItem.h"
-#include "File.h"
+#include "guilib/TextureManager.h"
 #include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
-#include "guilib/TextureManager.h"
 #include "storage/MediaManager.h"
+#include "utils/URIUtils.h"
 
 using namespace XFILE;
 

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -14,6 +14,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "guilib/TextureManager.h"
+#include "media/MediaLockState.h"
 #include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
@@ -88,7 +89,8 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       strIcon = "DefaultHardDisk.png";
 
     pItem->SetIconImage(strIcon);
-    if (share.m_iHasLock == 2 && m_profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+    if (share.m_iHasLock == LOCK_STATE_LOCKED &&
+        m_profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_LOCKED);
     else
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_NONE);

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -23,6 +23,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "media/MediaLockState.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -292,7 +293,7 @@ std::string CGUIWindowGames::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex >= 0)
   {
-    if (iIndex < (int)shares.size() && shares[iIndex].m_iHasLock == 2)
+    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].m_iHasLock == LOCK_STATE_LOCKED)
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item, "games"))

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,24 +7,25 @@
  */
 
 #include "GUIWindowGames.h"
-#include "addons/GUIDialogAddonInfo.h"
+
 #include "Application.h"
+#include "FileItem.h"
+#include "GUIPassword.h"
+#include "PlayListPlayer.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "Util.h"
+#include "addons/GUIDialogAddonInfo.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogMediaSource.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "FileItem.h"
 #include "games/addons/GameClient.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
-#include "GUIPassword.h"
-#include "PlayListPlayer.h"
-#include "ServiceBroker.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "URL.h"
-#include "Util.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -776,9 +776,18 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   // debug
   CLog::Log(LOGDEBUG, "Activating window ID: %i", iWindowID);
 
+  // make sure we check mediasources from home
+  if (GetActiveWindow() == WINDOW_HOME)
+    g_passwordManager.strMediasourcePath = !params.empty() ? params[0] : "";
+  else
+    g_passwordManager.strMediasourcePath = "";
+
   if (!g_passwordManager.CheckMenuLock(iWindowID))
   {
-    CLog::Log(LOGERROR, "MasterCode is Wrong: Window with id %d will not be loaded! Enter a correct MasterCode!", iWindowID);
+    CLog::Log(LOGERROR,
+              "MasterCode or Mediasource-code is wrong: Window with id {} will not be loaded! "
+              "Enter a correct code!",
+              iWindowID);
     if (GetActiveWindow() == WINDOW_INVALID && iWindowID != WINDOW_HOME)
       ActivateWindow(WINDOW_HOME);
     return;

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -17,6 +17,7 @@
 #include "VideoLibrary.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "media/MediaLockState.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
@@ -41,7 +42,7 @@ JSONRPC_STATUS CFileOperations::GetRootDirectory(const std::string &method, ITra
     for (unsigned int i = 0; i < (unsigned int)sources->size(); i++)
     {
       // Do not show sources which are locked
-      if (sources->at(i).m_iHasLock == 2)
+      if (sources->at(i).m_iHasLock == LOCK_STATE_LOCKED)
         continue;
 
       items.Add(CFileItemPtr(new CFileItem(sources->at(i))));

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,21 +7,22 @@
  */
 
 #include "FileOperations.h"
-#include "VideoLibrary.h"
+
 #include "AudioLibrary.h"
+#include "FileItem.h"
 #include "MediaSource.h"
 #include "ServiceBroker.h"
+#include "URL.h"
+#include "Util.h"
+#include "VideoLibrary.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "FileItem.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
-#include "Util.h"
-#include "URL.h"
 #include "utils/FileExtensionProvider.h"
-#include "utils/URIUtils.h"
 #include "utils/FileUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 

--- a/xbmc/media/CMakeLists.txt
+++ b/xbmc/media/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES MediaType.cpp)
 
-set(HEADERS MediaType.h)
+set(HEADERS MediaLockState.h
+            MediaType.h)
 
 core_add_library(media)

--- a/xbmc/media/MediaLockState.h
+++ b/xbmc/media/MediaLockState.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+typedef enum
+{
+  LOCK_STATE_NO_LOCK = 0,
+  LOCK_STATE_LOCK_BUT_UNLOCKED = 1,
+  LOCK_STATE_LOCKED = 2,
+} MediaLockState;

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2018 Team Kodi
+ *  Copyright (C) 2011-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -11,6 +11,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
+#include "media/MediaLockState.h"
 #include "network/WebServer.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
@@ -52,7 +53,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
           for (VECSOURCES::const_iterator source = sources->begin(); source != sources->end() && !accessible; ++source)
           {
             // don't allow access to locked / disabled sharing sources
-            if (source->m_iHasLock == 2 || !source->m_allowSharing)
+            if (source->m_iHasLock == LOCK_STATE_LOCKED || !source->m_allowSharing)
               continue;
 
             for (std::vector<std::string>::const_iterator path = source->vecPaths.begin(); path != source->vecPaths.end(); ++path)
@@ -74,8 +75,8 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
             g_mediaManager.GetRemovableDrives(removableSources);
             int sourceIndex = CUtil::GetMatchingSource(realPath, removableSources, isSource);
             if (sourceIndex >= 0 && sourceIndex < static_cast<int>(removableSources.size()) &&
-              removableSources.at(sourceIndex).m_iHasLock != 2 &&
-              removableSources.at(sourceIndex).m_allowSharing)
+                removableSources.at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
+                removableSources.at(sourceIndex).m_allowSharing)
               accessible = true;
           }
         }

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -24,6 +24,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "interfaces/AnnouncementManager.h"
+#include "media/MediaLockState.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
@@ -603,7 +604,7 @@ std::string CGUIWindowPictures::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex > -1)
   {
-    if (iIndex < (int)shares.size() && shares[iIndex].m_iHasLock == 2)
+    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].m_iHasLock == LOCK_STATE_LOCKED)
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item,"pictures"))

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -1,41 +1,42 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
 
-#include "threads/SystemClock.h"
 #include "GUIWindowPictures.h"
+
+#include "Application.h"
+#include "Autorun.h"
+#include "GUIDialogPictureInfo.h"
+#include "GUIPassword.h"
+#include "GUIWindowSlideShow.h"
+#include "PictureInfoLoader.h"
+#include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "Application.h"
-#include "GUIPassword.h"
-#include "GUIDialogPictureInfo.h"
 #include "addons/GUIDialogAddonInfo.h"
 #include "dialogs/GUIDialogMediaSource.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "playlists/PlayListFactory.h"
-#include "PictureInfoLoader.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "view/GUIViewState.h"
+#include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
+#include "playlists/PlayListFactory.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
-#include "utils/URIUtils.h"
-#include "utils/Variant.h"
-#include "Autorun.h"
-#include "interfaces/AnnouncementManager.h"
+#include "threads/SystemClock.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
-#include "GUIWindowSlideShow.h"
+#include "utils/URIUtils.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+#include "view/GUIViewState.h"
 
 #ifdef TARGET_POSIX
 #include "platform/linux/XTimeUtils.h"

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,13 +7,14 @@
  */
 
 #include "PlayListXML.h"
-#include "filesystem/File.h"
+
 #include "Util.h"
-#include "utils/log.h"
+#include "filesystem/File.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/XMLUtils.h"
 #include "utils/Variant.h"
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
 
 using namespace PLAYLIST;
 using namespace XFILE;

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -10,6 +10,7 @@
 
 #include "Util.h"
 #include "filesystem/File.h"
+#include "media/MediaLockState.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -136,7 +137,7 @@ bool CPlayListXML::Load( const std::string& strFileName )
        if ( !lockpass.empty() )
        {
          newItem->m_strLockCode = lockpass;
-         newItem->m_iHasLock = 2;
+         newItem->m_iHasLock = LOCK_STATE_LOCKED;
          newItem->m_iLockMode = LOCK_MODE_NUMERIC;
        }
 
@@ -181,7 +182,7 @@ void CPlayListXML::Save(const std::string& strFileName) const
     if ( !item->GetProperty("remotechannel").empty() )
       write += StringUtils::Format("    <channel>%s</channel>", item->GetProperty("remotechannel").c_str() );
 
-    if ( item->m_iHasLock > 0 )
+    if (item->m_iHasLock > LOCK_STATE_NO_LOCK)
       write += StringUtils::Format("    <lockpassword>%s<lockpassword>", item->m_strLockCode.c_str() );
 
     write += StringUtils::Format("  </stream>\n\n" );

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
+#include "media/MediaLockState.h"
 #include "settings/MediaSourceSettings.h"
 #include "utils/StringUtils.h"
 
@@ -158,7 +159,7 @@ std::string CGUIWindowPrograms::GetStartFolder(const std::string &dir)
   int iIndex = CUtil::GetMatchingSource(dir, shares, bIsSourceName);
   if (iIndex > -1)
   {
-    if (iIndex < (int)shares.size() && shares[iIndex].m_iHasLock == 2)
+    if (iIndex < static_cast<int>(shares.size()) && shares[iIndex].m_iHasLock == LOCK_STATE_LOCKED)
     {
       CFileItem item(shares[iIndex]);
       if (!g_passwordManager.IsItemUnlocked(&item,"programs"))

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,18 +7,19 @@
  */
 
 #include "GUIWindowPrograms.h"
-#include "Util.h"
-#include "GUIPassword.h"
-#include "addons/GUIDialogAddonInfo.h"
+
 #include "Autorun.h"
+#include "FileItem.h"
+#include "GUIPassword.h"
+#include "ServiceBroker.h"
+#include "Util.h"
+#include "addons/GUIDialogAddonInfo.h"
 #include "dialogs/GUIDialogMediaSource.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "FileItem.h"
-#include "settings/MediaSourceSettings.h"
 #include "input/Key.h"
+#include "settings/MediaSourceSettings.h"
 #include "utils/StringUtils.h"
-#include "ServiceBroker.h"
 
 #define CONTROL_BTNVIEWASICONS 2
 #define CONTROL_BTNSORTBY      3

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -12,6 +12,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
+#include "media/MediaLockState.h"
 #include "network/WakeOnAccess.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
@@ -399,7 +400,7 @@ bool CMediaSourceSettings::GetSource(const std::string &category, const TiXmlNod
   if (pLockMode)
   {
     share.m_iLockMode = (LockType)std::strtol(pLockMode->FirstChild()->Value(), NULL, 10);
-    share.m_iHasLock = 2;
+    share.m_iHasLock = LOCK_STATE_LOCKED;
   }
 
   if (pLockCode && pLockCode->FirstChild())

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -1,27 +1,28 @@
 /*
- *  Copyright (C) 2013-2018 Team Kodi
+ *  Copyright (C) 2013-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
 
-#include <cstdlib>
-#include <string>
-
 #include "MediaSourceSettings.h"
+
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
+#include "network/WakeOnAccess.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
-#include "network/WakeOnAccess.h"
-#include "ServiceBroker.h"
+#include "utils/log.h"
+
+#include <cstdlib>
+#include <string>
 
 #define SOURCES_FILE  "sources.xml"
 #define XML_SOURCES   "sources"

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -20,6 +20,7 @@
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/LocalizeStrings.h"
+#include "media/MediaLockState.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -145,7 +146,9 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   {
     VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources(sourceName);
     int sourceIndex = CUtil::GetMatchingSource(realPath, *sources, isSource);
-    if (sourceIndex >= 0 && sourceIndex < (int)sources->size() && sources->at(sourceIndex).m_iHasLock != 2 && sources->at(sourceIndex).m_allowSharing)
+    if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources->size()) &&
+        sources->at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
+        sources->at(sourceIndex).m_allowSharing)
       return true;
   }  
   // Check auto-mounted sources
@@ -153,8 +156,9 @@ bool CFileUtils::RemoteAccessAllowed(const std::string &strPath)
   g_mediaManager.GetRemovableDrives(sources);   // Sources returned allways have m_allowsharing = true
   //! @todo Make sharing of auto-mounted sources user configurable
   int sourceIndex = CUtil::GetMatchingSource(realPath, sources, isSource);
-  if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources.size()) && 
-      sources.at(sourceIndex).m_iHasLock != 2 && sources.at(sourceIndex).m_allowSharing)
+  if (sourceIndex >= 0 && sourceIndex < static_cast<int>(sources.size()) &&
+      sources.at(sourceIndex).m_iHasLock != LOCK_STATE_LOCKED &&
+      sources.at(sourceIndex).m_allowSharing)
     return true;
 
   return false;

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2018 Team Kodi
+ *  Copyright (C) 2010-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,24 +7,25 @@
  */
 
 #include "FileUtils.h"
-#include "ServiceBroker.h"
-#include "guilib/GUIKeyboardFactory.h"
-#include "utils/log.h"
-#include "guilib/LocalizeStrings.h"
-#include "JobManager.h"
+
 #include "FileOperationJob.h"
+#include "JobManager.h"
+#include "ServiceBroker.h"
+#include "StringUtils.h"
 #include "URIUtils.h"
+#include "URL.h"
+#include "Util.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/StackDirectory.h"
+#include "guilib/GUIKeyboardFactory.h"
+#include "guilib/LocalizeStrings.h"
 #include "settings/MediaSourceSettings.h"
-#include "Util.h"
-#include "StringUtils.h"
-#include "URL.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 
 #if defined(TARGET_WINDOWS)
 #include "platform/win32/WIN32Util.h"


### PR DESCRIPTION
## Description

backport of #17129 / #17381 to Kodi Leia (+ some additional cleanup)

## How Has This Been Tested?
running on debian in the living room. all tests passed.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
