### PR TITLE
[macos] fix warnings introduced in #17161

### DIFF
--- a/xbmc/platform/darwin/osx/SDLMain.mm
+++ b/xbmc/platform/darwin/osx/SDLMain.mm
@@ -116,7 +116,7 @@ static void setupWindowMenu(void)
   // "Full/Windowed Toggle" item
   menuItem = [[NSMenuItem alloc] initWithTitle:@"Full/Windowed Toggle" action:@selector(fullScreenToggle:) keyEquivalent:@"f"];
   // this is just for display purposes, key handling is in CWinEventsSDL::ProcessOSXShortcuts()
-  menuItem.keyEquivalentModifierMask = NSCommandKeyMask | NSControlKeyMask;
+  menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand | NSEventModifierFlagControl;
   [windowMenu addItem:menuItem];
 
   // "Full/Windowed Toggle" item


### PR DESCRIPTION
## Description
Warnings appeared after raising deployment target in #17284.

## Motivation and Context
Jenkins macOS jobs are now marked as failed because amount of warnings is too high.

## How Has This Been Tested?
Compiled for macOS.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
