### PR TITLE
[estuary] display playcount/lastplayed in musicinfo dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2633,6 +2633,7 @@ msgstr ""
 
 #. generic "play count" label used in different places
 #: xbmc/playlists/SmartPlaylist.cpp
+#: addons/skin.estuary/xml/Includes_MusicInfo.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
 msgctxt "#567"
@@ -2640,6 +2641,7 @@ msgid "Play count"
 msgstr ""
 
 #. generic "last played" label used in different places
+#: addons/skin.estuary/xml/Includes_MusicInfo.xml
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp

--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -455,7 +455,7 @@
 						<control type="list" id="41">
 							<left>42</left>
 							<top>0</top>
-							<width>430</width>
+							<width>446</width>
 							<height>385</height>
 							<onleft>130</onleft>
 							<onright>130</onright>
@@ -484,7 +484,7 @@
 								<control type="image">
 									<left>0</left>
 									<top>1</top>
-									<width>430</width>
+									<width>446</width>
 									<height>33</height>
 									<texture colordiffuse="button_focus">lists/focus.png</texture>
 									<visible>Control.HasFocus(41)</visible>

--- a/addons/skin.estuary/xml/Includes_MusicInfo.xml
+++ b/addons/skin.estuary/xml/Includes_MusicInfo.xml
@@ -123,12 +123,22 @@
 			<label2>$INFO[ListItem.FilenameAndPath]</label2>
 			<visible>!String.IsEmpty(ListItem.FilenameAndPath)</visible>
 		</item>
+		<item>
+			<label>$LOCALIZE[567]</label>
+			<label2>$INFO[ListItem.PlayCount]</label2>
+			<visible>!String.IsEmpty(ListItem.PlayCount)</visible>
+		</item>
+		<item>
+			<label>$LOCALIZE[568]</label>
+			<label2>$INFO[ListItem.LastPlayed]</label2>
+			<visible>!String.IsEmpty(ListItem.LastPlayed)</visible>
+		</item>
 	</include>
 	<include name="MusicInfoSongInfo">
 		<item>
 			<label>$LOCALIZE[568]</label>
 			<label2>$INFO[ListItem.LastPlayed]</label2>
-			<visible>!String.IsEmpty(ListItem.Playcount)</visible>
+			<visible>!String.IsEmpty(ListItem.LastPlayed)</visible>
 		</item>
 		<item>
 			<label>$LOCALIZE[557]:</label>
@@ -224,6 +234,11 @@
 			<label>$LOCALIZE[15311]</label>
 			<label2>$INFO[ListItem.FilenameAndPath]</label2>
 			<visible>!String.IsEmpty(ListItem.FilenameAndPath)</visible>
+		</item>
+		<item>
+			<label>$LOCALIZE[567]</label>
+			<label2>$INFO[ListItem.PlayCount]</label2>
+			<visible>!String.IsEmpty(ListItem.PlayCount)</visible>
 		</item>
 	</include>
 </includes>


### PR DESCRIPTION
Display the Play Count and Last Played date in the music info dialog for albums and songs.

![ps](https://user-images.githubusercontent.com/687265/75211898-9cbb2a00-5785-11ea-82b2-e5223cbcae92.jpg)


@KarellenX 