### PR TITLE
[gbm] add CBufferObjectFactory and CDumbBufferObject

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/buffers/CMakeLists.txt
@@ -24,7 +24,7 @@ if(OPENGL_FOUND)
                       RenderBufferPoolOpenGL.cpp)
 endif()
 
-if(GBM_HAS_BO_MAP AND OPENGLES_FOUND)
+if(GBM_FOUND AND OPENGLES_FOUND)
   list(APPEND SOURCES RenderBufferGBM.cpp
                       RenderBufferPoolGBM.cpp)
   list(APPEND HEADERS RenderBufferGBM.h

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.cpp
@@ -9,20 +9,20 @@
 #include "RenderBufferGBM.h"
 
 #include "ServiceBroker.h"
+#include "utils/BufferObject.h"
 #include "utils/EGLImage.h"
-#include "utils/GBMBufferObject.h"
 #include "windowing/gbm/WinSystemGbmEGLContext.h"
 
 using namespace KODI::WINDOWING::GBM;
 using namespace KODI;
 using namespace RETRO;
 
-CRenderBufferGBM::CRenderBufferGBM(CRenderContext &context,
-                                   int fourcc) :
-  m_context(context),
-  m_fourcc(fourcc),
-  m_egl(new CEGLImage(static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetEGLDisplay())),
-  m_bo(new CGBMBufferObject())
+CRenderBufferGBM::CRenderBufferGBM(CRenderContext& context, int fourcc)
+  : m_context(context),
+    m_fourcc(fourcc),
+    m_egl(new CEGLImage(
+        static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetEGLDisplay())),
+    m_bo(CBufferObject::GetBufferObject())
 {
 }
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.cpp
@@ -22,7 +22,7 @@ CRenderBufferGBM::CRenderBufferGBM(CRenderContext &context,
   m_context(context),
   m_fourcc(fourcc),
   m_egl(new CEGLImage(static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetEGLDisplay())),
-  m_bo(new CGBMBufferObject(fourcc))
+  m_bo(new CGBMBufferObject())
 {
 }
 
@@ -38,7 +38,7 @@ bool CRenderBufferGBM::Allocate(AVPixelFormat format, unsigned int width, unsign
   m_width = width;
   m_height = height;
 
-  m_bo->CreateBufferObject(m_width, m_height);
+  m_bo->CreateBufferObject(m_fourcc, m_width, m_height);
 
   return true;
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferGBM.h
@@ -15,7 +15,7 @@
 #include "system_gl.h"
 
 class CEGLImage;
-class CGBMBufferObject;
+class CBufferObject;
 
 namespace KODI
 {
@@ -54,7 +54,7 @@ namespace RETRO
     void DeleteTexture();
 
     std::unique_ptr<CEGLImage> m_egl;
-    std::unique_ptr<CGBMBufferObject> m_bo;
+    std::unique_ptr<CBufferObject> m_bo;
   };
 }
 }

--- a/xbmc/utils/BufferObject.cpp
+++ b/xbmc/utils/BufferObject.cpp
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "BufferObject.h"
+
+#include "BufferObjectFactory.h"
+
+std::unique_ptr<CBufferObject> CBufferObject::GetBufferObject()
+{
+  return CBufferObjectFactory::CreateBufferObject();
+}
+
+int CBufferObject::GetFd()
+{
+  return m_fd;
+}
+
+uint32_t CBufferObject::GetStride()
+{
+  return m_stride;
+}
+
+uint64_t CBufferObject::GetModifier()
+{
+  return 0; // linear
+}

--- a/xbmc/utils/BufferObject.h
+++ b/xbmc/utils/BufferObject.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IBufferObject.h"
+
+#include <memory>
+#include <stdint.h>
+
+class CBufferObject : public IBufferObject
+{
+public:
+  static std::unique_ptr<CBufferObject> GetBufferObject();
+
+  virtual int GetFd() override;
+  virtual uint32_t GetStride() override;
+  virtual uint64_t GetModifier() override;
+
+protected:
+  int m_fd{-1};
+  uint32_t m_stride{0};
+};

--- a/xbmc/utils/BufferObject.h
+++ b/xbmc/utils/BufferObject.h
@@ -13,9 +13,19 @@
 #include <memory>
 #include <stdint.h>
 
+/**
+ * @brief base class for using the IBufferObject interface. Derived classes
+ *        should be based on this class.
+ *
+ */
 class CBufferObject : public IBufferObject
 {
 public:
+  /**
+   * @brief Get a BufferObject from CBufferObjectFactory
+   *
+   * @return std::unique_ptr<CBufferObject>
+   */
   static std::unique_ptr<CBufferObject> GetBufferObject();
 
   virtual int GetFd() override;

--- a/xbmc/utils/BufferObjectFactory.cpp
+++ b/xbmc/utils/BufferObjectFactory.cpp
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "BufferObjectFactory.h"
+
+std::vector<std::function<std::unique_ptr<CBufferObject>()>> CBufferObjectFactory::m_bufferObjects;
+
+std::unique_ptr<CBufferObject> CBufferObjectFactory::CreateBufferObject()
+{
+  return m_bufferObjects.back()();
+}
+
+void CBufferObjectFactory::RegisterBufferObject(
+    std::function<std::unique_ptr<CBufferObject>()> createFunc)
+{
+  m_bufferObjects.emplace_back(createFunc);
+}
+
+void CBufferObjectFactory::ClearBufferObjects()
+{
+  m_bufferObjects.clear();
+}

--- a/xbmc/utils/BufferObjectFactory.h
+++ b/xbmc/utils/BufferObjectFactory.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "BufferObject.h"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+class CBufferObjectFactory
+{
+public:
+  static std::unique_ptr<CBufferObject> CreateBufferObject();
+
+  static void RegisterBufferObject(std::function<std::unique_ptr<CBufferObject>()>);
+  static void ClearBufferObjects();
+
+protected:
+  static std::vector<std::function<std::unique_ptr<CBufferObject>()>> m_bufferObjects;
+};

--- a/xbmc/utils/BufferObjectFactory.h
+++ b/xbmc/utils/BufferObjectFactory.h
@@ -14,12 +14,33 @@
 #include <memory>
 #include <vector>
 
+/**
+ * @brief Factory that provides CBufferObject registration and creation
+ *
+ */
 class CBufferObjectFactory
 {
 public:
+  /**
+   * @brief Create a CBufferObject from the registered BufferObject types.
+   *        In the future this may include some criteria for selecting a specific
+   *        CBufferObject derived type. Currently it returns the CBufferObject
+   *        implementation that was registered last.
+   *
+   * @return std::unique_ptr<CBufferObject>
+   */
   static std::unique_ptr<CBufferObject> CreateBufferObject();
 
+  /**
+   * @brief Registers a CBufferObject class to class to the factory.
+   *
+   */
   static void RegisterBufferObject(std::function<std::unique_ptr<CBufferObject>()>);
+
+  /**
+   * @brief Clears the list of registered CBufferObject types
+   *
+   */
   static void ClearBufferObjects();
 
 protected:

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -190,9 +190,11 @@ if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
   list(APPEND HEADERS EGLImage.h)
 
   list(APPEND SOURCES BufferObject.cpp
-                      BufferObjectFactory.cpp)
+                      BufferObjectFactory.cpp
+                      DumbBufferObject.cpp)
   list(APPEND HEADERS BufferObject.h
-                      BufferObjectFactory.h)
+                      BufferObjectFactory.h
+                      DumbBufferObject.h)
 
   if(GBM_HAS_BO_MAP)
     list(APPEND SOURCES GBMBufferObject.cpp)

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -189,6 +189,11 @@ if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
   list(APPEND SOURCES EGLImage.cpp)
   list(APPEND HEADERS EGLImage.h)
 
+  list(APPEND SOURCES BufferObject.cpp
+                      BufferObjectFactory.cpp)
+  list(APPEND HEADERS BufferObject.h
+                      BufferObjectFactory.h)
+
   if(GBM_HAS_BO_MAP)
     list(APPEND SOURCES GBMBufferObject.cpp)
     list(APPEND HEADERS GBMBufferObject.h)

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DumbBufferObject.h"
+
+#include "ServiceBroker.h"
+#include "utils/BufferObjectFactory.h"
+#include "utils/log.h"
+#include "windowing/gbm/WinSystemGbm.h"
+#include "windowing/gbm/WinSystemGbmEGLContext.h"
+
+#include <drm/drm_fourcc.h>
+#include <sys/mman.h>
+
+using namespace KODI::WINDOWING::GBM;
+
+std::unique_ptr<CBufferObject> CDumbBufferObject::Create()
+{
+  return std::make_unique<CDumbBufferObject>();
+}
+
+void CDumbBufferObject::Register()
+{
+  CBufferObjectFactory::RegisterBufferObject(CDumbBufferObject::Create);
+}
+
+CDumbBufferObject::CDumbBufferObject()
+{
+  auto winSystem = static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem());
+
+  m_device = winSystem->GetDrm()->GetFileDescriptor();
+}
+
+CDumbBufferObject::~CDumbBufferObject()
+{
+  ReleaseMemory();
+  DestroyBufferObject();
+}
+
+bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint32_t height)
+{
+  if (m_fd >= 0)
+    return true;
+
+  uint32_t bpp;
+
+  switch (format)
+  {
+    case DRM_FORMAT_ARGB1555:
+    case DRM_FORMAT_RGB565:
+      bpp = 16;
+      break;
+    case DRM_FORMAT_ARGB8888:
+    default:
+      bpp = 32;
+      break;
+  }
+
+  struct drm_mode_create_dumb create_dumb = {.height = height, .width = width, .bpp = bpp};
+
+  int ret = drmIoctl(m_device, DRM_IOCTL_MODE_CREATE_DUMB, &create_dumb);
+  if (ret < 0)
+  {
+    CLog::LogF(LOGERROR, "ioctl DRM_IOCTL_MODE_CREATE_DUMB failed, ret={} errno={}", ret,
+               strerror(errno));
+    return false;
+  }
+
+  m_size = create_dumb.size;
+  m_stride = create_dumb.pitch;
+
+  ret = drmPrimeHandleToFD(m_device, create_dumb.handle, 0, &m_fd);
+  if (ret < 0)
+  {
+    CLog::LogF(LOGERROR, "failed to get fd from prime handle, ret={} errno={}", ret,
+               strerror(errno));
+    return false;
+  }
+
+  return true;
+}
+
+void CDumbBufferObject::DestroyBufferObject()
+{
+  if (m_fd < 0)
+    return;
+
+  int ret = close(m_fd);
+  if (ret < 0)
+    CLog::LogF(LOGERROR, "close failed, errno={}", __FUNCTION__, strerror(errno));
+
+  m_fd = -1;
+  m_stride = 0;
+  m_size = 0;
+}
+
+uint8_t* CDumbBufferObject::GetMemory()
+{
+  if (m_fd < 0)
+    return nullptr;
+
+  if (m_map)
+  {
+    CLog::LogF(LOGDEBUG, "already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
+    return m_map;
+  }
+
+  uint32_t handle;
+  int ret = drmPrimeFDToHandle(m_device, m_fd, &handle);
+  if (ret < 0)
+  {
+    CLog::LogF(LOGERROR, "failed to get handle from prime fd, ret={} errno={}", ret,
+               strerror(errno));
+    return nullptr;
+  }
+
+  struct drm_mode_map_dumb map_dumb = {.handle = handle};
+
+  ret = drmIoctl(m_device, DRM_IOCTL_MODE_MAP_DUMB, &map_dumb);
+  if (ret < 0)
+  {
+    CLog::LogF(LOGERROR, "ioctl DRM_IOCTL_MODE_MAP_DUMB failed, ret={} errno={}", ret,
+               strerror(errno));
+    return nullptr;
+  }
+
+  m_offset = map_dumb.offset;
+
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_device, m_offset));
+  if (m_map == MAP_FAILED)
+  {
+    CLog::LogF(LOGERROR, "mmap failed, errno={}", strerror(errno));
+    return nullptr;
+  }
+
+  return m_map;
+}
+
+void CDumbBufferObject::ReleaseMemory()
+{
+  if (!m_map)
+    return;
+
+  int ret = munmap(m_map, m_size);
+  if (ret < 0)
+    CLog::LogF(LOGERROR, "munmap failed, errno={}", strerror(errno));
+
+  m_map = nullptr;
+  m_offset = 0;
+}

--- a/xbmc/utils/DumbBufferObject.h
+++ b/xbmc/utils/DumbBufferObject.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/BufferObject.h"
+
+#include <memory>
+#include <stdint.h>
+
+class CDumbBufferObject : public CBufferObject
+{
+public:
+  CDumbBufferObject();
+  virtual ~CDumbBufferObject() override;
+
+  // Registration
+  static std::unique_ptr<CBufferObject> Create();
+  static void Register();
+
+  // IBufferObject overrides via CBufferObject
+  bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
+  void DestroyBufferObject() override;
+  uint8_t* GetMemory() override;
+  void ReleaseMemory() override;
+
+private:
+  int m_device{-1};
+  uint64_t m_size{0};
+  uint64_t m_offset{0};
+  uint8_t* m_map{nullptr};
+};

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -15,8 +15,7 @@
 
 using namespace KODI::WINDOWING::GBM;
 
-CGBMBufferObject::CGBMBufferObject(int format) :
-  m_format(format)
+CGBMBufferObject::CGBMBufferObject()
 {
   m_device = static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetGBMDevice();
 }
@@ -27,12 +26,12 @@ CGBMBufferObject::~CGBMBufferObject()
   DestroyBufferObject();
 }
 
-bool CGBMBufferObject::CreateBufferObject(int width, int height)
+bool CGBMBufferObject::CreateBufferObject(int format, int width, int height)
 {
   m_width = width;
   m_height = height;
 
-  m_bo = gbm_bo_create(m_device, m_width, m_height, m_format, GBM_BO_USE_LINEAR);
+  m_bo = gbm_bo_create(m_device, m_width, m_height, format, GBM_BO_USE_LINEAR);
 
   if (!m_bo)
     return false;

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -47,6 +47,8 @@ void CGBMBufferObject::DestroyBufferObject()
 
   if (m_bo)
     gbm_bo_destroy(m_bo);
+
+  m_bo = nullptr;
 }
 
 uint8_t* CGBMBufferObject::GetMemory()

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -28,6 +28,9 @@ CGBMBufferObject::~CGBMBufferObject()
 
 bool CGBMBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint32_t height)
 {
+  if (m_fd >= 0)
+    return true;
+
   m_width = width;
   m_height = height;
 
@@ -49,6 +52,7 @@ void CGBMBufferObject::DestroyBufferObject()
     gbm_bo_destroy(m_bo);
 
   m_bo = nullptr;
+  m_fd = -1;
 }
 
 uint8_t* CGBMBufferObject::GetMemory()

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -8,12 +8,23 @@
 
 #include "GBMBufferObject.h"
 
+#include "BufferObjectFactory.h"
 #include "ServiceBroker.h"
 #include "windowing/gbm/WinSystemGbmEGLContext.h"
 
 #include <gbm.h>
 
 using namespace KODI::WINDOWING::GBM;
+
+std::unique_ptr<CBufferObject> CGBMBufferObject::Create()
+{
+  return std::make_unique<CGBMBufferObject>();
+}
+
+void CGBMBufferObject::Register()
+{
+  CBufferObjectFactory::RegisterBufferObject(CGBMBufferObject::Create);
+}
 
 CGBMBufferObject::CGBMBufferObject()
 {
@@ -75,16 +86,6 @@ void CGBMBufferObject::ReleaseMemory()
     m_map_data = nullptr;
     m_map = nullptr;
   }
-}
-
-int CGBMBufferObject::GetFd()
-{
-  return m_fd;
-}
-
-uint32_t CGBMBufferObject::GetStride()
-{
-  return m_stride;
 }
 
 uint64_t CGBMBufferObject::GetModifier()

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -43,6 +43,8 @@ bool CGBMBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint3
 
 void CGBMBufferObject::DestroyBufferObject()
 {
+  close(m_fd);
+
   if (m_bo)
     gbm_bo_destroy(m_bo);
 }

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -26,7 +26,7 @@ CGBMBufferObject::~CGBMBufferObject()
   DestroyBufferObject();
 }
 
-bool CGBMBufferObject::CreateBufferObject(int format, int width, int height)
+bool CGBMBufferObject::CreateBufferObject(uint32_t format, int width, int height)
 {
   m_width = width;
   m_height = height;

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -26,7 +26,7 @@ CGBMBufferObject::~CGBMBufferObject()
   DestroyBufferObject();
 }
 
-bool CGBMBufferObject::CreateBufferObject(uint32_t format, int width, int height)
+bool CGBMBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint32_t height)
 {
   m_width = width;
   m_height = height;

--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -74,7 +74,7 @@ int CGBMBufferObject::GetFd()
   return m_fd;
 }
 
-int CGBMBufferObject::GetStride()
+uint32_t CGBMBufferObject::GetStride()
 {
   return m_stride;
 }

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -18,10 +18,10 @@ struct gbm_device;
 class CGBMBufferObject : public IBufferObject
 {
 public:
-  CGBMBufferObject(int format);
+  CGBMBufferObject();
   ~CGBMBufferObject() override;
 
-  bool CreateBufferObject(int width, int height) override;
+  bool CreateBufferObject(int format, int width, int height) override;
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
@@ -32,7 +32,6 @@ public:
 private:
   gbm_device *m_device = nullptr;
 
-  int m_format = 0;
   int m_fd = -1;
   uint32_t m_stride = 0;
   uint8_t *m_map = nullptr;

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -21,7 +21,7 @@ public:
   CGBMBufferObject();
   ~CGBMBufferObject() override;
 
-  bool CreateBufferObject(int format, int width, int height) override;
+  bool CreateBufferObject(uint32_t format, int width, int height) override;
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -21,7 +21,7 @@ public:
   CGBMBufferObject();
   ~CGBMBufferObject() override;
 
-  bool CreateBufferObject(uint32_t format, int width, int height) override;
+  bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
@@ -33,6 +33,8 @@ private:
   gbm_device *m_device = nullptr;
 
   int m_fd = -1;
+  uint32_t m_width{0};
+  uint32_t m_height{0};
   uint32_t m_stride = 0;
   uint8_t *m_map = nullptr;
   void *m_map_data = nullptr;

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -8,35 +8,40 @@
 
 #pragma once
 
-#include "utils/IBufferObject.h"
+#include "utils/BufferObject.h"
 
+#include <memory>
 #include <stdint.h>
 
 struct gbm_bo;
 struct gbm_device;
 
-class CGBMBufferObject : public IBufferObject
+class CGBMBufferObject : public CBufferObject
 {
 public:
   CGBMBufferObject();
   ~CGBMBufferObject() override;
 
+  // Registration
+  static std::unique_ptr<CBufferObject> Create();
+  static void Register();
+
+  // IBufferObject overrides via CBufferObject
   bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
-  int GetFd() override;
-  uint32_t GetStride() override;
-  uint64_t GetModifier();
+
+  // CBufferObject overrides
+  uint64_t GetModifier() override;
 
 private:
-  gbm_device *m_device = nullptr;
+  gbm_device* m_device{nullptr};
+  gbm_bo* m_bo{nullptr};
 
-  int m_fd = -1;
   uint32_t m_width{0};
   uint32_t m_height{0};
-  uint32_t m_stride = 0;
-  uint8_t *m_map = nullptr;
-  void *m_map_data = nullptr;
-  gbm_bo *m_bo = nullptr;
+
+  uint8_t* m_map{nullptr};
+  void* m_map_data{nullptr};
 };

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -26,7 +26,7 @@ public:
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
   int GetFd() override;
-  int GetStride() override;
+  uint32_t GetStride() override;
   uint64_t GetModifier();
 
 private:

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -15,7 +15,7 @@ class IBufferObject
 public:
   virtual ~IBufferObject() = default;
 
-  virtual bool CreateBufferObject(int width, int height) = 0;
+  virtual bool CreateBufferObject(int format, int width, int height) = 0;
   virtual void DestroyBufferObject() { }
   virtual uint8_t *GetMemory() = 0;
   virtual void ReleaseMemory() { }

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -15,14 +15,10 @@ class IBufferObject
 public:
   virtual ~IBufferObject() = default;
 
-  virtual bool CreateBufferObject(uint32_t format, int width, int height) = 0;
+  virtual bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) = 0;
   virtual void DestroyBufferObject() { }
   virtual uint8_t *GetMemory() = 0;
   virtual void ReleaseMemory() { }
   virtual int GetFd() { return -1; }
   virtual int GetStride() = 0;
-
-protected:
-  int m_width = 0;
-  int m_height = 0;
 };

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -20,5 +20,5 @@ public:
   virtual uint8_t *GetMemory() = 0;
   virtual void ReleaseMemory() { }
   virtual int GetFd() { return -1; }
-  virtual int GetStride() = 0;
+  virtual uint32_t GetStride() = 0;
 };

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -16,9 +16,10 @@ public:
   virtual ~IBufferObject() = default;
 
   virtual bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) = 0;
-  virtual void DestroyBufferObject() { }
+  virtual void DestroyBufferObject() = 0;
   virtual uint8_t *GetMemory() = 0;
-  virtual void ReleaseMemory() { }
-  virtual int GetFd() { return -1; }
+  virtual void ReleaseMemory() = 0;
+  virtual int GetFd() = 0;
   virtual uint32_t GetStride() = 0;
+  virtual uint64_t GetModifier() = 0;
 };

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -10,16 +10,91 @@
 
 #include <stdint.h>
 
+/**
+ * @brief Interface to describe CBufferObjects.
+ *
+ *        BufferObjects are used to abstract various memory types and present them
+ *        with a generic interface. Typically on a posix system exists the concept
+ *        of Direct Memory Access (DMA) which allows various systems to interact
+ *        with a memory location directly without having to copy the data into
+ *        userspace (ie. from kernel space). These DMA buffers are presented as
+ *        file descriptors (fds) which can be passed around to gain access to
+ *        the buffers memory location.
+ *
+ *        In order to write to these buffer types typically the memory location has
+ *        to be mapped into userspace via a call to mmap (or similar). This presents
+ *        userspace with a memory location that can be initially written to (ie. by
+ *        using memcpy or similar). Depending on the underlying implementation a
+ *        stride might be specified if the memory type requires padding to a certain
+ *        size (such as page size). The stride must be used when copying into the buffer.
+ *
+ *        Some memory implementation may provide special memory layouts in which case
+ *        modifiers are provided that describe tiling or compression. This should be
+ *        transparent to the caller as the data copied into a BufferObject will likely
+ *        be linear. The modifier will be needed when presenting the buffer via DRM or
+ *        EGL even if it is linear.
+ *
+ */
 class IBufferObject
 {
 public:
   virtual ~IBufferObject() = default;
 
+  /**
+   * @brief Create a BufferObject.
+   *
+   * @param format framebuffer pixel formats are described using the fourcc codes defined in
+   *               https://github.com/torvalds/linux/blob/master/include/uapi/drm/drm_fourcc.h
+   * @param width width of the requested buffer object.
+   * @param height height of the requested buffer object.
+   * @return true BufferObject creation was successful.
+   * @return false BufferObject creation was unsuccessful.
+   */
   virtual bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) = 0;
+
+  /**
+   * @brief Destroy a BufferObject.
+   *
+   */
   virtual void DestroyBufferObject() = 0;
+
+  /**
+   * @brief Get the Memory location of the BufferObject. This method needs to be
+   *        called to be able to copy data into the BufferObject.
+   *
+   * @return uint8_t* pointer to the memory location of the BufferObject.
+   */
   virtual uint8_t *GetMemory() = 0;
+
+  /**
+   * @brief Release the mapped memory of the BufferObject. After calling this the memory
+   *        location pointed to by GetMemory() will be invalid.
+   *
+   */
   virtual void ReleaseMemory() = 0;
+
+  /**
+   * @brief Get the File Descriptor of the BufferObject. The fd is guaranteed to be
+   *        available after calling CreateBufferObject().
+   *
+   * @return int fd for the BufferObject. Invalid if -1.
+   */
   virtual int GetFd() = 0;
+
+  /**
+   * @brief Get the Stride of the BufferObject. The stride is guaranteed to be
+   *        available after calling GetMemory().
+   *
+   * @return uint32_t stride of the BufferObject.
+   */
   virtual uint32_t GetStride() = 0;
+
+  /**
+   * @brief Get the Modifier of the BufferObject. Format Modifiers further describe
+   *        the buffer's format such as for tiling or compression.
+   *        see https://github.com/torvalds/linux/blob/master/include/uapi/drm/drm_fourcc.h
+   *
+   * @return uint64_t modifier of the BufferObject. 0 means the layout is linear (default).
+   */
   virtual uint64_t GetModifier() = 0;
 };

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -15,7 +15,7 @@ class IBufferObject
 public:
   virtual ~IBufferObject() = default;
 
-  virtual bool CreateBufferObject(int format, int width, int height) = 0;
+  virtual bool CreateBufferObject(uint32_t format, int width, int height) = 0;
   virtual void DestroyBufferObject() { }
   virtual uint8_t *GetMemory() = 0;
   virtual void ReleaseMemory() { }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -20,6 +20,8 @@
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gles/ScreenshotSurfaceGLES.h"
+#include "utils/BufferObjectFactory.h"
+#include "utils/GBMBufferObject.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
@@ -69,6 +71,11 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   VIDEOPLAYER::CProcessInfoGBM::Register();
 
   CScreenshotSurfaceGLES::Register();
+
+  CBufferObjectFactory::ClearBufferObjects();
+#if defined(HAS_GBM_BO_MAP)
+  CGBMBufferObject::Register();
+#endif
 
   return true;
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -21,6 +21,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "utils/BufferObjectFactory.h"
+#include "utils/DumbBufferObject.h"
 #include "utils/GBMBufferObject.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
@@ -73,6 +74,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   CScreenshotSurfaceGLES::Register();
 
   CBufferObjectFactory::ClearBufferObjects();
+  CDumbBufferObject::Register();
 #if defined(HAS_GBM_BO_MAP)
   CGBMBufferObject::Register();
 #endif


### PR DESCRIPTION
This PR adds a new buffer object type that uses [drm dumb buffers](https://www.systutorials.com/docs/linux/man/7-drm-memory/).

The class `CDumbBufferObject` is abstracted along side `CGBMBufferObject` by using a factory and registration through `CBufferObjectFactory`.

Currently only platforms that don't provide the method `gbm_bo_map` (non-mesa platforms) will use the dumb buffers method but there may be more factors in the future that dictate which buffer type is used for what scenario.

Currently this PR only affects RetroPlayer but I also have changes lined up to allow using this in VideoPlayer through DRM Prime.