### PR TITLE
DRMPRIMEGLES: set the drm prime renderer setting as visible

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -10,12 +10,20 @@
 
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "utils/EGLFence.h"
 #include "utils/log.h"
 #include "windowing/gbm/WinSystemGbmGLESContext.h"
 
 using namespace KODI::WINDOWING::GBM;
 using namespace KODI::UTILS::EGL;
+
+namespace
+{
+constexpr auto SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
+}
 
 CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 {
@@ -33,6 +41,11 @@ CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
 
 void CRendererDRMPRIMEGLES::Register()
 {
+  CServiceBroker::GetSettingsComponent()
+      ->GetSettings()
+      ->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)
+      ->SetVisible(true);
+
   VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime_gles", CRendererDRMPRIMEGLES::Create);
 }
 


### PR DESCRIPTION
it's currently not possible to change the drm prime render method if no valid planes are available for the drm prime renderer. This sets the setting to visible if this EGL method is available. Ideally we should check to see if the EGL implementation supports the formats we want to import but not all EGL implementation support this. I have this coded already and will add it at a later time.

