### PR TITLE
CRendererDRMPRIMEGLES: inherit from CBaseRenderer not CLinuxRendererGLES

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -9,18 +9,22 @@
 #include "RendererDRMPRIMEGLES.h"
 
 #include "ServiceBroker.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
+#include "rendering/gles/RenderSystemGLES.h"
 #include "utils/EGLFence.h"
+#include "utils/GLUtils.h"
 #include "utils/log.h"
-#include "windowing/gbm/WinSystemGbmGLESContext.h"
+#include "windowing/gbm/WinSystemGbmEGLContext.h"
 
 using namespace KODI::WINDOWING::GBM;
 using namespace KODI::UTILS::EGL;
 
 CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 {
-  for (int i = 0; i < NUM_BUFFERS; ++i)
-    DeleteTexture(i);
+  Flush(false);
 }
 
 CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
@@ -40,113 +44,167 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
                                       float fps,
                                       unsigned int orientation)
 {
-  CWinSystemGbmGLESContext* winSystem =
-      dynamic_cast<CWinSystemGbmGLESContext*>(CServiceBroker::GetWinSystem());
+  CWinSystemGbmEGLContext* winSystem =
+      dynamic_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return false;
 
-  for (auto& texture : m_DRMPRIMETextures)
-    texture.Init(winSystem->GetEGLDisplay());
+  m_format = picture.videoBuffer->GetFormat();
+  m_sourceWidth = picture.iWidth;
+  m_sourceHeight = picture.iHeight;
+  m_renderOrientation = orientation;
 
-  for (auto& fence : m_fences)
+  m_iFlags = GetFlagsChromaPosition(picture.chroma_position) |
+             GetFlagsColorMatrix(picture.color_space, picture.iWidth, picture.iHeight) |
+             GetFlagsColorPrimaries(picture.color_primaries) |
+             GetFlagsStereoMode(picture.stereoMode);
+
+  // Calculate the input frame aspect ratio.
+  CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);
+  SetViewMode(m_videoSettings.m_ViewMode);
+  ManageRenderArea();
+
+  Flush(false);
+
+  EGLDisplay eglDisplay = winSystem->GetEGLDisplay();
+  for (auto&& buf : m_buffers)
   {
-    fence.reset(new CEGLFence(winSystem->GetEGLDisplay()));
+    if (!buf.fence)
+    {
+      buf.texture.Init(eglDisplay);
+      buf.fence.reset(new CEGLFence(eglDisplay));
+    }
   }
 
-  return CLinuxRendererGLES::Configure(picture, fps, orientation);
+  m_clearColour = winSystem->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+
+  m_configured = true;
+  return true;
+}
+
+void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int index)
+{
+  BUFFER& buf = m_buffers[index];
+  if (buf.videoBuffer)
+  {
+    CLog::LogF(LOGERROR, "unreleased video buffer");
+    if (buf.fence)
+      buf.fence->DestroyFence();
+    buf.texture.Unmap();
+    buf.videoBuffer->Release();
+  }
+  buf.videoBuffer = picture.videoBuffer;
+  buf.videoBuffer->Acquire();
+}
+
+bool CRendererDRMPRIMEGLES::Flush(bool saveBuffers)
+{
+  if (!saveBuffers)
+    for (int i = 0; i < NUM_BUFFERS; i++)
+      ReleaseBuffer(i);
+
+  return saveBuffers;
 }
 
 void CRendererDRMPRIMEGLES::ReleaseBuffer(int index)
 {
-  m_fences[index]->DestroyFence();
+  BUFFER& buf = m_buffers[index];
 
-  m_DRMPRIMETextures[index].Unmap();
-  CLinuxRendererGLES::ReleaseBuffer(index);
+  if (buf.fence)
+    buf.fence->DestroyFence();
+
+  buf.texture.Unmap();
+
+  if (buf.videoBuffer)
+  {
+    buf.videoBuffer->Release();
+    buf.videoBuffer = nullptr;
+  }
 }
 
 bool CRendererDRMPRIMEGLES::NeedBuffer(int index)
 {
-  return !m_fences[index]->IsSignaled();
+  return !m_buffers[index].fence->IsSignaled();
 }
 
-bool CRendererDRMPRIMEGLES::CreateTexture(int index)
+CRenderInfo CRendererDRMPRIMEGLES::GetRenderInfo()
 {
-  CPictureBuffer& buf = m_buffers[index];
-  YuvImage& im = buf.image;
-  CYuvPlane& plane = buf.fields[0][0];
-
-  DeleteTexture(index);
-
-  im = {};
-  plane = {};
-
-  im.height = m_sourceHeight;
-  im.width = m_sourceWidth;
-  im.cshift_x = 1;
-  im.cshift_y = 1;
-
-  plane.id = 1;
-
-  return true;
+  CRenderInfo info;
+  info.max_buffer_size = NUM_BUFFERS;
+  return info;
 }
 
-void CRendererDRMPRIMEGLES::DeleteTexture(int index)
+void CRendererDRMPRIMEGLES::Update()
 {
-  ReleaseBuffer(index);
+  if (!m_configured)
+    return;
 
-  CPictureBuffer& buf = m_buffers[index];
-  buf.fields[0][0].id = 0;
+  ManageRenderArea();
 }
 
-bool CRendererDRMPRIMEGLES::UploadTexture(int index)
+void CRendererDRMPRIMEGLES::RenderUpdate(
+    int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
-  CPictureBuffer& buf = m_buffers[index];
+  if (!m_configured)
+    return;
 
-  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
+  ManageRenderArea();
 
-  if (!buffer || !buffer->IsValid())
+  if (clear)
   {
-    CLog::Log(LOGNOTICE, "CRendererDRMPRIMEGLES::{} - no buffer", __FUNCTION__);
-    return false;
+    glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glClearColor(0, 0, 0, 0);
   }
 
-  m_DRMPRIMETextures[index].Map(buffer);
+  if (alpha < 255)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
 
-  CYuvPlane& plane = buf.fields[0][0];
+  Render(flags, index);
 
-  auto size = m_DRMPRIMETextures[index].GetTextureSize();
-  plane.texwidth = size.Width();
-  plane.texheight = size.Height();
-  plane.pixpertex_x = 1;
-  plane.pixpertex_y = 1;
+  VerifyGLState();
+  glEnable(GL_BLEND);
+}
 
-  plane.id = m_DRMPRIMETextures[index].GetTexture();
-
-  CalculateTextureSourceRects(index, 1);
-
+bool CRendererDRMPRIMEGLES::RenderCapture(CRenderCapture* capture)
+{
+  capture->BeginRender();
+  capture->EndRender();
   return true;
 }
 
-bool CRendererDRMPRIMEGLES::LoadShadersHook()
+bool CRendererDRMPRIMEGLES::ConfigChanged(const VideoPicture& picture)
 {
-  CLog::Log(LOGNOTICE, "Using DRMPRIMEGLES render method");
-  m_textureTarget = GL_TEXTURE_2D;
-  m_renderMethod = RENDER_CUSTOM;
-  return true;
+  if (picture.videoBuffer->GetFormat() != m_format)
+    return true;
+
+  return false;
 }
 
-bool CRendererDRMPRIMEGLES::RenderHook(int index)
+void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
 {
+  BUFFER& buf = m_buffers[index];
+
+  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
+  if (!buffer || !buffer->IsValid())
+    return;
+
   CRenderSystemGLES* renderSystem =
       dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
-  assert(renderSystem);
+  if (!renderSystem)
+    return;
 
-  CYuvPlane& plane = m_buffers[index].fields[0][0];
+  if (!buf.texture.Map(buffer))
+    return;
 
-  glDisable(GL_DEPTH_TEST);
-
-  glActiveTexture(GL_TEXTURE0);
-  glBindTexture(GL_TEXTURE_EXTERNAL_OES, plane.id);
+  glBindTexture(GL_TEXTURE_EXTERNAL_OES, buf.texture.GetTexture());
 
   renderSystem->EnableGUIShader(SM_TEXTURE_RGBA_OES);
 
@@ -168,29 +226,29 @@ bool CRendererDRMPRIMEGLES::RenderHook(int index)
   vertex[0].x = m_rotatedDestCoords[0].x;
   vertex[0].y = m_rotatedDestCoords[0].y;
   vertex[0].z = 0.0f;
-  vertex[0].u1 = plane.rect.x1;
-  vertex[0].v1 = plane.rect.y1;
+  vertex[0].u1 = 0.0f;
+  vertex[0].v1 = 0.0f;
 
   // top right
   vertex[1].x = m_rotatedDestCoords[1].x;
   vertex[1].y = m_rotatedDestCoords[1].y;
   vertex[1].z = 0.0f;
-  vertex[1].u1 = plane.rect.x2;
-  vertex[1].v1 = plane.rect.y1;
+  vertex[1].u1 = 1.0f;
+  vertex[1].v1 = 0.0f;
 
   // bottom right
   vertex[2].x = m_rotatedDestCoords[2].x;
   vertex[2].y = m_rotatedDestCoords[2].y;
   vertex[2].z = 0.0f;
-  vertex[2].u1 = plane.rect.x2;
-  vertex[2].v1 = plane.rect.y2;
+  vertex[2].u1 = 1.0f;
+  vertex[2].v1 = 1.0f;
 
   // bottom left
   vertex[3].x = m_rotatedDestCoords[3].x;
   vertex[3].y = m_rotatedDestCoords[3].y;
   vertex[3].z = 0.0f;
-  vertex[3].u1 = plane.rect.x1;
-  vertex[3].v1 = plane.rect.y2;
+  vertex[3].u1 = 0.0f;
+  vertex[3].v1 = 1.0f;
 
   glGenBuffers(1, &vertexVBO);
   glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
@@ -223,12 +281,7 @@ bool CRendererDRMPRIMEGLES::RenderHook(int index)
 
   glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
 
-  return true;
-}
-
-void CRendererDRMPRIMEGLES::AfterRenderHook(int index)
-{
-  m_fences[index]->CreateFence();
+  buf.fence->CreateFence();
 }
 
 bool CRendererDRMPRIMEGLES::Supports(ERENDERFEATURE feature)


### PR DESCRIPTION
`CLinuxRendererGLES` is a mess and makes it too difficult to make changes to this renderer. Let's decouple them for now and add features back to this one.

Much of this was taken from `CRendererDRMPRIME` as they share a lot in common.