### PR TITLE
[Estuary] Info dialog cosmetics

### DIFF
--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -349,16 +349,16 @@
 					</focusedlayout>
 				</control>
 				<control type="grouplist" id="9000">
-					<left>-30</left>
+					<left>-80</left>
 					<top>864</top>
-					<width>1760</width>
+					<width>1920</width>
 					<height>300</height>
 					<onleft>9000</onleft>
 					<onright>9000</onright>
 					<onup>130</onup>
 					<ondown>50</ondown>
 					<align>center</align>
-					<itemgap>-13</itemgap>
+					<itemgap>-15</itemgap>
 					<orientation>horizontal</orientation>
 					<control type="radiobutton" id="155">
 						<include content="VideoInfoButtonsCommon">
@@ -376,7 +376,7 @@
 						<visible>!String.IsEqual(ListItem.DBType,artist)</visible>
 					</control>
 					<control type="group" id="420">
-						<width>262</width>
+						<width>264</width>
 						<visible>String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song)</visible>
 						<control type="button" id="7">
 							<include content="VideoInfoButtonsCommon">
@@ -394,12 +394,12 @@
 							<font>font45_title</font>
 							<left>0</left>
 							<top>24</top>
-							<width>262</width>
+							<width>264</width>
 							<align>center</align>
 						</control>
 						<control type="image">
 							<texture>icons/infodialogs/rating.png</texture>
-							<left>107</left>
+							<left>108</left>
 							<top>30</top>
 							<width>48</width>
 							<height>48</height>
@@ -430,7 +430,7 @@
 					<include content="InfoDialogButton">
 						<param name="id" value="12" />
 						<param name="icon" value="icons/infodialogs/info.png" />
-						<param name="label" value="$LOCALIZE[20413]" />
+						<param name="label" value="" />
 					</include>
 				</control>
 				<include content="LeftRightArrows">
@@ -467,17 +467,10 @@
 								<control type="label">
 									<left>10</left>
 									<top>0</top>
-									<width>150</width>
+									<width>410</width>
 									<height>30</height>
 									<font>font27_narrow</font>
-									<label>$INFO[ListItem.Label,[COLOR button_focus], [/COLOR]]</label>
-								</control>
-								<control type="label">
-									<left>170</left>
-									<width>240</width>
-									<height>30</height>
-									<font>font27_narrow</font>
-									<label>$INFO[ListItem.Label2]</label>
+									<label>$INFO[ListItem.Label,[COLOR button_focus],[/COLOR]] $INFO[ListItem.Label2]</label>
 								</control>
 							</itemlayout>
 							<focusedlayout height="35">
@@ -492,38 +485,22 @@
 								<control type="label">
 									<left>10</left>
 									<top>0</top>
-									<width>150</width>
+									<width>410</width>
 									<height>30</height>
 									<font>font27_narrow</font>
-									<label>$INFO[ListItem.Label]</label>
+									<label>$INFO[ListItem.Label] $INFO[ListItem.Label2]</label>
+									<scroll>true</scroll>
 									<visible>Control.HasFocus(41)</visible>
 								</control>
 								<control type="label">
 									<left>10</left>
 									<top>0</top>
-									<width>150</width>
+									<width>410</width>
 									<height>30</height>
 									<font>font27_narrow</font>
-									<label>$INFO[ListItem.Label,[COLOR button_focus], [/COLOR]]</label>
-									<visible>!Control.HasFocus(41)</visible>
-								</control>
-								<control type="label">
-									<left>170</left>
-									<width>240</width>
-									<height>30</height>
-									<font>font27_narrow</font>
-									<label>$INFO[ListItem.Label2]</label>
+									<label>$INFO[ListItem.Label,[COLOR button_focus],[/COLOR]] $INFO[ListItem.Label2]</label>
 									<scroll>false</scroll>
 									<visible>!Control.HasFocus(41)</visible>
-								</control>
-								<control type="label">
-									<left>170</left>
-									<width>240</width>
-									<height>30</height>
-									<font>font27_narrow</font>
-									<label>$INFO[ListItem.Label2]</label>
-									<scroll>true</scroll>
-									<visible>Control.HasFocus(41)</visible>
 								</control>
 							</focusedlayout>
 							<content>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -511,7 +511,7 @@
 					<onup>140</onup>
 					<ondown condition="!Integer.IsGreater(Container(5000).Position,4)">SetFocus(50,$INFO[Container(5000).Position])</ondown>
 					<ondown condition="Integer.IsGreater(Container(5000).Position,4)">SetFocus(50,4)</ondown>
-					<itemgap>-16</itemgap>
+					<itemgap>-18</itemgap>
 					<align>center</align>
 					<orientation>horizontal</orientation>
 					<scrolltime tween="quadratic">200</scrolltime>
@@ -537,7 +537,7 @@
 						<param name="visible" value="System.HasAddon(script.cinemavision) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]" />
 					</include>
 					<control type="group" id="400">
-						<width>262</width>
+						<width>264</width>
 						<visible>Control.IsEnabled(7) | !String.IsEmpty(ListItem.UserRating)</visible>
 						<control type="button" id="7">
 							<include content="VideoInfoButtonsCommon">
@@ -559,12 +559,12 @@
 							<font>font45_title</font>
 							<left>0</left>
 							<top>24</top>
-							<width>262</width>
+							<width>264</width>
 							<align>center</align>
 						</control>
 						<control type="image">
 							<texture>icons/infodialogs/rating.png</texture>
-							<left>107</left>
+							<left>108</left>
 							<top>30</top>
 							<width>48</width>
 							<height>48</height>

--- a/addons/skin.estuary/xml/Includes_Buttons.xml
+++ b/addons/skin.estuary/xml/Includes_Buttons.xml
@@ -203,7 +203,7 @@
 		</definition>
 	</include>
 	<include name="VideoInfoButtonsCommon">
-		<param name="width">262</param>
+		<param name="width">264</param>
 		<definition>
 			<width>$PARAM[width]</width>
 			<height>142</height>
@@ -211,7 +211,7 @@
 			<aligny>top</aligny>
 			<texturefocus border="21" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
 			<texturenofocus border="21">buttons/button-nofo.png</texturenofocus>
-			<textoffsetx>35</textoffsetx>
+			<textoffsetx>22</textoffsetx>
 			<textoffsety>78</textoffsety>
 			<radioposx>108</radioposx>
 			<radioposy>13</radioposy>
@@ -226,7 +226,7 @@
 		</definition>
 	</include>
 	<include name="InfoDialogButton">
-		<param name="width">262</param>
+		<param name="width">264</param>
 		<param name="onclick_1_condition">true</param>
 		<param name="onclick_2_condition">true</param>
 		<param name="onclick_3_condition">true</param>
@@ -238,7 +238,7 @@
 				<aligny>top</aligny>
 				<texturefocus border="21" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
 				<texturenofocus border="21">buttons/button-nofo.png</texturenofocus>
-				<textoffsetx>35</textoffsetx>
+				<textoffsetx>22</textoffsetx>
 				<textoffsety>78</textoffsety>
 				<radioposx>108</radioposx>
 				<radioposy>16</radioposy>


### PR DESCRIPTION
a few minor tweaks to the music info dialog:
1. remove the unneeded space between the name and value of the metadata
2. increase the button (and label) width of bottom row buttons (applies to the video info dialog as well)
3. center align the bottom button row

before:
![old](https://user-images.githubusercontent.com/687265/75391496-79f65600-58ea-11ea-9a34-5de7361d61d3.jpg)

after:
![new](https://user-images.githubusercontent.com/687265/75391516-837fbe00-58ea-11ea-8915-8baf80fefc1a.jpg)

@KarellenX @DaVukovic 