### PR TITLE
[PVR] CPVRTimerInfoTag::ConvertUTCToLocalTime: Fix leap year detection.

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -963,7 +963,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
 
 namespace
 {
-  #define IsLeapYear(y) ((!(y % 4)) ? (((!(y % 400)) && (y % 100)) ? 1 : 0) : 0)
+  #define IsLeapYear(y) ((y % 4 == 0) && (y % 100 != 0 || y % 400 == 0))
 
   int days_from_0(int year)
   {


### PR DESCRIPTION
Fixes a stupid bug in a leap year detection macro (which I had copied from somewhere).

Runtime-tested on macOS, latest Kodi master.

@phunkyfish when you get time for a review.