### PR TITLE
[build][android] modernize android sdk detection

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -502,7 +502,7 @@ if test "$platform_os" == "android"; then
     AC_MSG_ERROR("SDK path is required for android")
   fi
 
-  if [ ! test -f $use_sdk_path/tools/android ]; then
+  if [ ! test -f $use_sdk_path/tools/bin/sdkmanager ]; then
     AC_MSG_ERROR(verify sdk path)
   fi
 


### PR DESCRIPTION
## Description
This PR changes the path for the android sdk detection from `$use_sdk_path/tools/android` to `$use_sdk_path/tools/bin/sdkmanager`.

## Motivation and Context
`tools/android` have been removed since revision 25.3.0 (March 2017) of the android sdk tools.

## How Has This Been Tested?
With custom kodi builds and latest commandlinetools of the android sdk.
See: https://developer.android.com/studio/releases/sdk-tools

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
