### PR TITLE
[addons] Add targetversion attribute to import element for dependencies in addon.xml

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -220,9 +220,10 @@ public:
    \param version the version to meet.
    \return true if  min_version <= version <= current_version, false otherwise.
    */
-  bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const override
+  bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version,
+                    const AddonVersion& versionTarget) const override
   {
-    return m_addonInfo->MeetsVersion(versionMin, version);
+    return m_addonInfo->MeetsVersion(versionMin, version, versionTarget);
   }
   bool ReloadSettings() override;
 

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -55,6 +55,7 @@ static std::string SerializeMetadata(const IAddon& addon)
     info["addonId"] = dep.id;
     info["version"] = dep.version.asString();
     info["minversion"] = dep.versionMin.asString();
+    info["targetversion"] = dep.versionTarget.asString();
     info["optional"] = dep.optional;
     variant["dependencies"].push_back(std::move(info));
   }
@@ -104,7 +105,8 @@ static void DeserializeMetadata(const std::string& document, CAddonInfoBuilder::
     for (auto it = variant["dependencies"].begin_array(); it != variant["dependencies"].end_array(); ++it)
     {
       deps.emplace_back((*it)["addonId"].asString(), AddonVersion((*it)["minversion"].asString()),
-                        AddonVersion((*it)["version"].asString()), (*it)["optional"].asBoolean());
+                        AddonVersion((*it)["version"].asString()), AddonVersion((*it)["targetversion"].asString()),
+                        (*it)["optional"].asBoolean());
     }
     builder.SetDependencies(std::move(deps));
   }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -311,13 +311,14 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     const std::string &addonID = it.id;
     const AddonVersion& versionMin = it.versionMin;
     const AddonVersion& version = it.version;
+    const AddonVersion& versionTarget = it.versionTarget;
     bool optional = it.optional;
     AddonPtr dep;
     bool haveAddon = CServiceBroker::GetAddonMgr().GetAddon(addonID, dep, ADDON_UNKNOWN, false);
-    if ((haveAddon && !dep->MeetsVersion(versionMin, version)) || (!haveAddon && !optional))
+    if ((haveAddon && !dep->MeetsVersion(versionMin, version, versionTarget)) || (!haveAddon && !optional))
     {
       // we have it but our version isn't good enough, or we don't have it and we need it
-      if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(versionMin, version))
+      if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(versionMin, version, versionTarget))
       {
         // we don't have it in a repo, or we have it but the version isn't good enough, so dep isn't satisfied.
         CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.asString().c_str());
@@ -735,10 +736,11 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
       const std::string &addonID = it->id;
       const AddonVersion& versionMin = it->versionMin;
       const AddonVersion& version = it->version;
+      const AddonVersion& versionTarget = it->versionTarget;
       bool optional = it->optional;
       AddonPtr dependency;
       bool haveAddon = CServiceBroker::GetAddonMgr().GetAddon(addonID, dependency, ADDON_UNKNOWN, false);
-      if ((haveAddon && !dependency->MeetsVersion(versionMin, version)) ||
+      if ((haveAddon && !dependency->MeetsVersion(versionMin, version, versionTarget)) ||
           (!haveAddon && !optional))
       {
         // we have it but our version isn't good enough, or we don't have it and we need it

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -727,7 +727,7 @@ bool CAddonMgr::IsCompatible(const IAddon& addon)
       {
         AddonPtr addon;
         bool haveAddon = GetAddon(dependency.id, addon);
-        if (!haveAddon || !addon->MeetsVersion(dependency.versionMin, dependency.version))
+        if (!haveAddon || !addon->MeetsVersion(dependency.versionMin, dependency.version, dependency.versionTarget))
           return false;
       }
     }

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -76,7 +76,7 @@ namespace ADDON
     virtual const std::vector<DependencyInfo> &GetDependencies() const =0;
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
     virtual bool MeetsVersion(const AddonVersion& versionMin,
-                              const AddonVersion& version) const = 0;
+                              const AddonVersion& version, const AddonVersion& versionTarget) const = 0;
     virtual bool ReloadSettings() =0;
     virtual AddonPtr GetRunningInstance() const=0;
     virtual void OnPreInstall() =0;

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -177,9 +177,10 @@ bool CAddonInfo::ProvidesSeveralSubContents() const
   return contents > 0 ? true : false;
 }
 
-bool CAddonInfo::MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const
+bool CAddonInfo::MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version,
+                              const AddonVersion& versionTarget) const
 {
-  return !(versionMin > m_version || version < m_minversion);
+  return versionMin <= m_version && (version >= m_minversion || versionTarget >= m_minversion);
 }
 
 const AddonVersion& CAddonInfo::DependencyMinVersion(const std::string& dependencyID) const

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -29,12 +29,14 @@ typedef std::vector<AddonInfoPtr> AddonInfos;
 struct DependencyInfo
 {
   std::string id;
-  AddonVersion versionMin, version;
+  AddonVersion versionMin, version, versionTarget;
   bool optional;
-  DependencyInfo(std::string id, AddonVersion versionMin, AddonVersion version, bool optional)
+  DependencyInfo(std::string id, AddonVersion versionMin, AddonVersion version,
+                 AddonVersion versionTarget, bool optional)
     : id(id)
     , versionMin(versionMin.empty() ? version : versionMin)
     , version(version)
+    , versionTarget(versionTarget.empty() ? version : versionTarget)
     , optional(optional)
   {
   }
@@ -42,7 +44,7 @@ struct DependencyInfo
   bool operator==(const DependencyInfo& rhs) const
   {
     return id == rhs.id && versionMin == rhs.versionMin && version == rhs.version &&
-           optional == rhs.optional;
+           versionTarget == rhs.versionTarget && optional == rhs.optional;
   }
 
   bool operator!=(const DependencyInfo& rhs) const
@@ -145,7 +147,8 @@ public:
   const std::string& Origin() const { return m_origin; }
   const InfoMap& ExtraInfo() const { return m_extrainfo; }
 
-  bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const;
+  bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version,
+                    const AddonVersion& versionTarget) const;
   uint64_t PackageSize() const { return m_packageSize; }
   CDateTime InstallDate() const { return m_installDate; }
   CDateTime LastUpdated() const { return m_lastUpdated; }

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -166,7 +166,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
   /*
    * Parse addon.xml:
    * <requires>
-   *   <import addon="???" minversion="???" version="???" optional="???"/>
+   *   <import addon="???" minversion="???" version="???" targetversion="???" optional="???"/>
    * </requires>
    */
   const TiXmlElement* requires = element->FirstChildElement("requires");
@@ -179,11 +179,12 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
       {
         const char* versionMin = child->Attribute("minversion");
         const char* version = child->Attribute("version");
+        const char* versionTarget = child->Attribute("targetversion");
         bool optional = false;
         child->QueryBoolAttribute("optional", &optional);
 
         addon->m_dependencies.emplace_back(cstring, AddonVersion(versionMin), AddonVersion(version),
-                                           optional);
+                                           AddonVersion(versionTarget), optional);
       }
     }
   }

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -108,9 +108,9 @@ const std::string& CBinaryAddonBase::Disclaimer() const
 }
 
 bool CBinaryAddonBase::MeetsVersion(const AddonVersion& versionMin,
-                                    const AddonVersion& version) const
+                                    const AddonVersion& version, const AddonVersion& versionTarget) const
 {
-  return m_addonInfo->MeetsVersion(versionMin, version);
+  return m_addonInfo->MeetsVersion(versionMin, version, versionTarget);
 }
 
 AddonDllPtr CBinaryAddonBase::GetAddon(const IAddonInstanceHandler* handler)

--- a/xbmc/addons/binary-addons/BinaryAddonBase.h
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.h
@@ -51,7 +51,8 @@ namespace ADDON
     const ArtMap& Art() const;
     const std::string& Disclaimer() const;
 
-    bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const;
+    bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version,
+                      const AddonVersion& versionTarget) const;
 
     AddonDllPtr GetAddon(const IAddonInstanceHandler* handler);
     void ReleaseAddon(const IAddonInstanceHandler* handler);

--- a/xbmc/addons/test/TestAddonBuilder.cpp
+++ b/xbmc/addons/test/TestAddonBuilder.cpp
@@ -29,7 +29,7 @@ TEST_F(TestAddonBuilder, ShouldFailWhenEmpty)
 TEST_F(TestAddonBuilder, ShouldBuildDependencyAddons)
 {
   std::vector<DependencyInfo> deps;
-  deps.emplace_back("a", AddonVersion("1.0.0"), AddonVersion("1.0.10"), false);
+  deps.emplace_back("a", AddonVersion("1.0.0"), AddonVersion("1.0.10"), AddonVersion("3.0.0"), false);
 
   CAddonInfoBuilder::CFromDB builder;
   builder.SetId("aa");

--- a/xbmc/addons/test/TestAddonInfoBuilder.cpp
+++ b/xbmc/addons/test/TestAddonInfoBuilder.cpp
@@ -24,6 +24,7 @@ const std::string addonXML = R"xml(
     <import addon="metadata.common.imdb.com" minversion="2.9.2" version="2.9.2"/>
     <import addon="metadata.common.themoviedb.org" minversion="3.1.0" version="3.1.0"/>
     <import addon="plugin.video.youtube" minversion="4.4.0" version="4.4.10" optional="true"/>
+    <import addon="xbmc.python" version="2.25.0" targetversion="3.0.0"/>
   </requires>
   <extension point="xbmc.metadata.scraper.movies"
              language="en"
@@ -101,7 +102,7 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
   EXPECT_EQ(addon->Source(), "https://github.com/xbmc/xbmc");
 
   const std::vector<DependencyInfo>& dependencies = addon->GetDependencies();
-  ASSERT_EQ(dependencies.size(), (long unsigned int)4);
+  ASSERT_EQ(dependencies.size(), (long unsigned int)5);
   EXPECT_EQ(dependencies[0].id, "xbmc.metadata");
   EXPECT_EQ(dependencies[0].optional, false);
   EXPECT_EQ(dependencies[0].versionMin.asString(), "2.1.0");
@@ -118,6 +119,10 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
   EXPECT_EQ(dependencies[3].optional, true);
   EXPECT_EQ(dependencies[3].versionMin.asString(), "4.4.0");
   EXPECT_EQ(dependencies[3].version.asString(), "4.4.10");
+  EXPECT_EQ(dependencies[4].id, "xbmc.python");
+  EXPECT_EQ(dependencies[4].optional, false);
+  EXPECT_EQ(dependencies[4].version.asString(), "2.25.0");
+  EXPECT_EQ(dependencies[4].versionTarget.asString(), "3.0.0");
 
   auto info = addon->ExtraInfo().find("language");
   ASSERT_NE(info, addon->ExtraInfo().end());

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -232,6 +232,7 @@ static CVariant Serialize(const AddonPtr& addon)
     info["addonid"] = dep.id;
     info["minversion"] = dep.versionMin.asString();
     info["version"] = dep.version.asString();
+    info["targetversion"] = dep.versionTarget.asString();
     info["optional"] = dep.optional;
     variant["dependencies"].push_back(std::move(info));
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This pull request adds support for Py2/3 compatibility in **addon.xml** by adding  a new optional `targetversion` xml attribute to the import element.
You can call this `targetversion` attribute a "**forward compatibility version**".

For instance, define Py2/Py3 compatibility from Kodi 17 to Kodi 19:
```
 <import addon="xbmc.python" version="2.25.0" targetversion="3.0.0"/>
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
After https://github.com/xbmc/xbmc/pull/17188 has been merged, add-on developers maintaining a single Py2/Py3 compatible codebase are forced to submit their add-on **twice** to the official Kodi repository. One time to support older Kodi versions and one time to support the new Kodi 19 Matrix. This is needed because  currently **addon.xml**  doesn't support an xml tag to identify Py2/Py3 compatible add-ons.

With this change all existing functionality is preserved and add-on developers just have to submit **once** to the official Kodi repo to get their add-on published for all compatible Kodi versions.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
This has been tested with InputStream Helper add-on on Kodi 19 master and Kodi 18.6 on Linux x64.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
