### PR TITLE
[Backport] bump gnutls (3.6.11.1) and nettle(3.5.1)

### DIFF
--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -34,7 +34,7 @@ list(APPEND DEPLIBS "-framework DiskArbitration" "-framework IOKit"
                     "-framework ApplicationServices" "-framework AppKit"
                     "-framework CoreAudio" "-framework AudioToolbox"
                     "-framework CoreGraphics" "-framework CoreMedia"
-                    "-framework VideoToolbox")
+                    "-framework VideoToolbox" "-framework Security")
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 set(CMAKE_XCODE_ATTRIBUTE_CLANG_LINK_OBJC_RUNTIME OFF)

--- a/tools/depends/target/gnutls/02-darwin-getentropy.patch
+++ b/tools/depends/target/gnutls/02-darwin-getentropy.patch
@@ -1,14 +1,15 @@
---- a/configure.ac
-+++ b/configure.ac
-@@ -220,6 +220,7 @@
- 		   rnd_variant=getrandom],
- 		  [AC_MSG_RESULT(no)])
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2019-12-02 08:32:16.000000000 -0800
++++ b/configure.ac	2020-01-31 10:25:36.473631501 -0800
+@@ -278,6 +278,7 @@
+ 
+ AM_CONDITIONAL(HAVE_KERN_ARND, test "$rnd_variant" = "kern_arnd")
  
 +if test "x$have_macosx" != "xyes"; then
  AC_MSG_CHECKING([for getentropy])
  AC_LINK_IFELSE([AC_LANG_PROGRAM([
  	   #include <unistd.h>
-@@ -233,6 +234,7 @@
+@@ -294,6 +295,7 @@
  		   AC_DEFINE([HAVE_GETENTROPY], 1, [Enable the OpenBSD getentropy function])
  		   rnd_variant=getentropy],
  		  [AC_MSG_RESULT(no)])

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile size-max.patch 02-darwin-getentropy.patch
+DEPS= ../../Makefile.include Makefile size-max.patch 02-darwin-getentropy.patch remove-weak_import-check-for-osx.patch add-dl-as-private-lib.patch
 
 # lib name, version
 LIBNAME=gnutls
-VERSION=3.5.10
+VERSION=3.6.11.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
 
@@ -15,10 +15,9 @@ CONFIGURE_HACKS+= ac_cv_func_fork=no
 endif
 
 # configuration settings
-CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
-          ./configure --prefix=$(PREFIX) --disable-shared --without-p11-kit --disable-nls --with-included-unistring \
+CONFIGURE=./configure --prefix=$(PREFIX) --disable-shared --without-p11-kit --disable-nls --with-included-unistring \
                       --with-included-libtasn1 --enable-local-libopts --disable-doc --disable-tests --disable-guile \
-                      $(CONFIGURE_HACKS)
+                      --disable-tools $(CONFIGURE_HACKS)
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 
@@ -32,6 +31,8 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 < ../size-max.patch
 	cd $(PLATFORM); patch -p1 -i ../02-darwin-getentropy.patch
+	cd $(PLATFORM); patch -p1 -i ../remove-weak_import-check-for-osx.patch
+	cd $(PLATFORM); patch -p1 -i ../add-dl-as-private-lib.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/tools/depends/target/gnutls/add-dl-as-private-lib.patch
+++ b/tools/depends/target/gnutls/add-dl-as-private-lib.patch
@@ -1,0 +1,26 @@
+diff --git a/configure.ac b/configure.ac
+index db1ce841f..264712b56 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -512,6 +512,9 @@ LT_INIT([disable-static,win32-dll,shared])
+ 
+ 
+ AC_LIB_HAVE_LINKFLAGS(dl,, [#include <dlfcn.h>], [dladdr (0, 0);])
++if test "x$HAVE_LIBDL" = "xyes"; then
++      AC_SUBST([LIBDL], [-ldl])
++fi
+ 
+ AC_ARG_ENABLE(fips140-mode,
+   AS_HELP_STRING([--enable-fips140-mode], [enable FIPS140-2 mode]),
+diff --git a/lib/gnutls.pc.in b/lib/gnutls.pc.in
+index ffad3e168..15b990764 100644
+--- a/lib/gnutls.pc.in
++++ b/lib/gnutls.pc.in
+@@ -19,6 +19,6 @@ Description: Transport Security Layer implementation for the GNU system
+ URL: https://www.gnutls.org/
+ Version: @VERSION@
+ Libs: -L${libdir} -lgnutls
+-Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBIDN2_LIBS@ @LIBATOMIC_LIBS@
++Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBIDN2_LIBS@ @LIBATOMIC_LIBS@ @LIBDL@
+ @GNUTLS_REQUIRES_PRIVATE@
+ Cflags: -I${includedir}

--- a/tools/depends/target/gnutls/remove-weak_import-check-for-osx.patch
+++ b/tools/depends/target/gnutls/remove-weak_import-check-for-osx.patch
@@ -1,0 +1,17 @@
+--- a/configure.ac	2020-01-25 08:26:59.223068640 -0800
++++ b/configure.ac	2020-01-25 08:26:38.846233553 -0800
+@@ -122,14 +122,6 @@
+   ;;
+   *darwin*)
+     have_macosx=yes
+-    save_LDFLAGS="$LDFLAGS"
+-    dnl Try to use -no_weak_imports if available. This makes sure we
+-    dnl error out when linking to a function that doesn't exist in the
+-    dnl intended minimum runtime version.
+-    LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
+-    AC_MSG_CHECKING([whether the linker supports -Wl,-no_weak_imports])
+-    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+-      [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no); LDFLAGS="$save_LDFLAGS"])
+   ;;
+   *solaris*)
+     have_elf=yes

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile 01-disable_testsuite.patch
 
 # lib name, version
 LIBNAME=nettle
-VERSION=3.2
+VERSION=3.5.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
## Description
Partitial backport of: https://github.com/xbmc/xbmc/pull/17259
Bump gnutls (3.6.11.1) and nettle(3.5.1)

## Motivation and Context
Kodi 18.x segfaults on Android 10 when opening an internetstream using libCURL.
Segfault happens in gnutls library when performing vsnprintf.

## How Has This Been Tested?
Play any stream of ComedyCentral on Huawei Mate 30 / Android 10

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
