### PR TITLE
replace strcmp and strcasecmp methods with StringUtils::CompareNoCase

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2559,7 +2559,7 @@ void CFileItemList::FilterCueItems()
               for (int j = 0; j < (int)m_items.size(); j++)
               {
                 CFileItemPtr pItem = m_items[j];
-                if (stricmp(pItem->GetPath().c_str(), strMediaFile.c_str()) == 0)
+                if (StringUtils::CompareNoCase(pItem->GetPath(), strMediaFile) == 0)
                   pItem->SetCueDocument(cuesheet);
               }
             }
@@ -2575,7 +2575,7 @@ void CFileItemList::FilterCueItems()
     for (int j = 0; j < (int)m_items.size(); j++)
     {
       CFileItemPtr pItem = m_items[j];
-      if (stricmp(pItem->GetPath().c_str(), itemstodelete[i].c_str()) == 0)
+      if (StringUtils::CompareNoCase(pItem->GetPath(), itemstodelete[i]) == 0)
       { // delete this item
         m_items.erase(m_items.begin() + j);
         break;

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -706,7 +706,7 @@ bool CDateTime::SetFromDateString(const std::string &date)
   size_t iPos2 = date.find(",");
   std::string strDay = (date.size() >= iPos) ? date.substr(iPos, iPos2-iPos) : "";
   std::string strYear = date.substr(date.find(' ', iPos2) + 1);
-  while (months[j] && stricmp(strMonth.c_str(),months[j]) != 0)
+  while (months[j] && StringUtils::CompareNoCase(strMonth, months[j]) != 0)
     j++;
   if (!months[j])
     return false;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -110,7 +110,7 @@ TYPE ScraperTypeFromContent(const CONTENT_TYPE &content)
 // if the XML root is <error>, throw CScraperError with enclosed <title>/<message> values
 static void CheckScraperError(const TiXmlElement *pxeRoot)
 {
-  if (!pxeRoot || stricmp(pxeRoot->Value(), "error"))
+  if (!pxeRoot || StringUtils::CompareNoCase(pxeRoot->Value(), "error"))
     return;
   std::string sTitle;
   std::string sMessage;

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -353,9 +353,9 @@ static void VFSDirEntriesToCFileItemList(int num_entries,
       item->m_strTitle = entries[i].title;
     for (unsigned int j=0;j<entries[i].num_props;++j)
     {
-      if (strcasecmp(entries[i].properties[j].name, "propmisusepreformatted") == 0)
+      if (StringUtils::CompareNoCase(entries[i].properties[j].name, "propmisusepreformatted") == 0)
       {
-        if (strcasecmp(entries[i].properties[j].name, "true") == 0)
+        if (StringUtils::CompareNoCase(entries[i].properties[j].name, "true") == 0)
           item->SetLabelPreformatted(true);
         else
           item->SetLabelPreformatted(false);

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
@@ -189,12 +189,12 @@ bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSetti
   {
     CLog::Log(LOGDEBUG, "CAddonCallbacksAddon - %s - add-on '%s' requests setting '%s'", __FUNCTION__, addonHelper->m_addon->Name().c_str(), strSettingName);
 
-    if (strcasecmp(strSettingName, "__addonpath__") == 0)
+    if (StringUtils::CompareNoCase(strSettingName, "__addonpath__") == 0)
     {
       strcpy((char*) settingValue, addonHelper->m_addon->Path().c_str());
       return true;
     }
-    else if (strcasecmp(strSettingName, "__addonname__") == 0)
+    else if (StringUtils::CompareNoCase(strSettingName, "__addonname__") == 0)
     {
       strcpy((char*)settingValue, addonHelper->m_addon->Name().c_str());
       return true;

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -82,31 +82,31 @@ char* Interface_General::get_addon_info(void* kodiBase, const char* id)
   }
 
   std::string str;
-  if (strcmpi(id, "author") == 0)
+  if (StringUtils::CompareNoCase(id, "author") == 0)
     str = addon->Author();
-  else if (strcmpi(id, "changelog") == 0)
+  else if (StringUtils::CompareNoCase(id, "changelog") == 0)
     str = addon->ChangeLog();
-  else if (strcmpi(id, "description") == 0)
+  else if (StringUtils::CompareNoCase(id, "description") == 0)
     str = addon->Description();
-  else if (strcmpi(id, "disclaimer") == 0)
+  else if (StringUtils::CompareNoCase(id, "disclaimer") == 0)
     str = addon->Disclaimer();
-  else if (strcmpi(id, "fanart") == 0)
+  else if (StringUtils::CompareNoCase(id, "fanart") == 0)
     str = addon->FanArt();
-  else if (strcmpi(id, "icon") == 0)
+  else if (StringUtils::CompareNoCase(id, "icon") == 0)
     str = addon->Icon();
-  else if (strcmpi(id, "id") == 0)
+  else if (StringUtils::CompareNoCase(id, "id") == 0)
     str = addon->ID();
-  else if (strcmpi(id, "name") == 0)
+  else if (StringUtils::CompareNoCase(id, "name") == 0)
     str = addon->Name();
-  else if (strcmpi(id, "path") == 0)
+  else if (StringUtils::CompareNoCase(id, "path") == 0)
     str = addon->Path();
-  else if (strcmpi(id, "profile") == 0)
+  else if (StringUtils::CompareNoCase(id, "profile") == 0)
     str = addon->Profile();
-  else if (strcmpi(id, "summary") == 0)
+  else if (StringUtils::CompareNoCase(id, "summary") == 0)
     str = addon->Summary();
-  else if (strcmpi(id, "type") == 0)
+  else if (StringUtils::CompareNoCase(id, "type") == 0)
     str = ADDON::CAddonInfo::TranslateType(addon->Type());
-  else if (strcmpi(id, "version") == 0)
+  else if (StringUtils::CompareNoCase(id, "version") == 0)
     str = addon->Version().asString();
   else
   {
@@ -338,7 +338,7 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
   }
 
   std::string result;
-  if (strcmpi(id, "datelong") == 0)
+  if (StringUtils::CompareNoCase(id, "datelong") == 0)
   {
     result = g_langInfo.GetDateFormat(true);
     StringUtils::Replace(result, "DDDD", "%A");
@@ -346,7 +346,7 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
     StringUtils::Replace(result, "D", "%d");
     StringUtils::Replace(result, "YYYY", "%Y");
   }
-  else if (strcmpi(id, "dateshort") == 0)
+  else if (StringUtils::CompareNoCase(id, "dateshort") == 0)
   {
     result = g_langInfo.GetDateFormat(false);
     StringUtils::Replace(result, "MM", "%m");
@@ -360,11 +360,11 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
 #endif
     StringUtils::Replace(result, "YYYY", "%Y");
   }
-  else if (strcmpi(id, "tempunit") == 0)
+  else if (StringUtils::CompareNoCase(id, "tempunit") == 0)
     result = g_langInfo.GetTemperatureUnitString();
-  else if (strcmpi(id, "speedunit") == 0)
+  else if (StringUtils::CompareNoCase(id, "speedunit") == 0)
     result = g_langInfo.GetSpeedUnitString();
-  else if (strcmpi(id, "time") == 0)
+  else if (StringUtils::CompareNoCase(id, "time") == 0)
   {
     result = g_langInfo.GetTimeFormat();
     StringUtils::Replace(result, "H", "%H");
@@ -373,7 +373,7 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
     StringUtils::Replace(result, "ss", "%S");
     StringUtils::Replace(result, "xx", "%p");
   }
-  else if (strcmpi(id, "meridiem") == 0)
+  else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
     result = StringUtils::Format("%s/%s",
                                   g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
                                   g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -139,7 +139,7 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
       hr = (UuidToString((*itt).lpGuid, &wszUuid));
       std::string sztmp = KODI::PLATFORM::WINDOWS::FromW(reinterpret_cast<wchar_t*>(wszUuid));
       std::string szGUID = "{" + std::string(sztmp.begin(), sztmp.end()) + "}";
-      if (strcasecmp(szGUID.c_str(), strDeviceGUID.c_str()) == 0)
+      if (StringUtils::CompareNoCase(szGUID, strDeviceGUID) == 0)
       {
         deviceGUID = (*itt).lpGuid;
         deviceFriendlyName = (*itt).name.c_str();

--- a/xbmc/cores/DllLoader/DllLoader.cpp
+++ b/xbmc/cores/DllLoader/DllLoader.cpp
@@ -620,7 +620,7 @@ bool DllLoader::Load()
       // but the export isn't really needed for normal operation
       // and dll works anyway, so let's ignore it
 
-      if(stricmp(GetName(), "vp7vfw.dll") != 0)
+      if (StringUtils::CompareNoCase(GetName(), "vp7vfw.dll") != 0)
         return false;
 
 

--- a/xbmc/cores/DllLoader/DllLoaderContainer.cpp
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.cpp
@@ -72,8 +72,11 @@ LibraryLoader* DllLoaderContainer::GetModule(const char* sName)
 {
   for (int i = 0; i < m_iNrOfDlls && m_dlls[i] != NULL; i++)
   {
-    if (stricmp(m_dlls[i]->GetName(), sName) == 0) return m_dlls[i];
-    if (!m_dlls[i]->IsSystemDll() && stricmp(m_dlls[i]->GetFileName(), sName) == 0) return m_dlls[i];
+    if (StringUtils::CompareNoCase(m_dlls[i]->GetName(), sName) == 0)
+      return m_dlls[i];
+    if (!m_dlls[i]->IsSystemDll() &&
+        StringUtils::CompareNoCase(m_dlls[i]->GetFileName(), sName) == 0)
+      return m_dlls[i];
   }
 
   return NULL;
@@ -263,7 +266,8 @@ bool DllLoaderContainer::IsSystemDll(const char* sName)
 {
   for (int i = 0; i < m_iNrOfDlls && m_dlls[i] != NULL; i++)
   {
-    if (m_dlls[i]->IsSystemDll() && stricmp(m_dlls[i]->GetName(), sName) == 0) return true;
+    if (m_dlls[i]->IsSystemDll() && StringUtils::CompareNoCase(m_dlls[i]->GetName(), sName) == 0)
+      return true;
   }
 
   return false;

--- a/xbmc/cores/DllLoader/dll.cpp
+++ b/xbmc/cores/DllLoader/dll.cpp
@@ -193,8 +193,8 @@ extern "C" intptr_t (*__stdcall dllGetProcAddress(HMODULE hModule, const char* f
       DllTrackInfo* track = tracker_get_dlltrackinfo(loc);
       /* some dll's require us to always return a function or it will fail, other's  */
       /* decide functionality depending on if the functions exist and may fail      */
-      if( dll->IsSystemDll() && track
-       && stricmp(track->pDll->GetName(), "CoreAVCDecoder.ax") == 0 )
+      if (dll->IsSystemDll() && track &&
+          StringUtils::CompareNoCase(track->pDll->GetName(), "CoreAVCDecoder.ax") == 0)
       {
         address = (void*)create_dummy_function(dll->GetName(), function);
         tracker_dll_data_track(track->pDll, (uintptr_t)address);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1601,7 +1601,7 @@ extern "C"
       return -1;
 
 #ifdef TARGET_POSIX
-    if (!_stricmp(path, "D:") || !_stricmp(path, "D:\\"))
+    if (!StringUtils::CompareNoCase(path, "D:") || !StringUtils::CompareNoCase(path, "D:\\"))
     {
       buffer->st_mode = S_IFDIR;
       return 0;
@@ -1644,7 +1644,7 @@ extern "C"
       return -1;
 
 #ifdef TARGET_POSIX
-    if (!_stricmp(path, "D:") || !_stricmp(path, "D:\\"))
+    if (!StringUtils::CompareNoCase(path, "D:") || !StringUtils::CompareNoCase(path, "D:\\"))
     {
       buffer->st_mode = _S_IFDIR;
       return 0;

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1595,9 +1595,9 @@ extern "C"
   //SLOW CODE SHOULD BE REVISED
   int dll_stat(const char *path, struct stat *buffer)
   {
-    if (!strnicmp(path, "shout://", 8)) // don't stat shoutcast
+    if (!StringUtils::CompareNoCase(path, "shout://", 8)) // don't stat shoutcast
       return -1;
-    if (!strnicmp(path, "mms://", 6)) // don't stat mms
+    if (!StringUtils::CompareNoCase(path, "mms://", 6)) // don't stat mms
       return -1;
 
 #ifdef TARGET_POSIX
@@ -1639,9 +1639,9 @@ extern "C"
 
   int dll_stat64(const char *path, struct __stat64 *buffer)
   {
-    if (!strnicmp(path, "shout://", 8)) // don't stat shoutcast
+    if (!StringUtils::CompareNoCase(path, "shout://", 8)) // don't stat shoutcast
       return -1;
-    if (!strnicmp(path, "mms://", 6)) // don't stat mms
+    if (!StringUtils::CompareNoCase(path, "mms://", 6)) // don't stat mms
       return -1;
 
 #ifdef TARGET_POSIX
@@ -1840,7 +1840,7 @@ extern "C"
             if (dll__environ[i] != NULL)
             {
               // we only support overwriting the old values
-              if (strnicmp(dll__environ[i], var, strlen(var)) == 0)
+              if (StringUtils::CompareNoCase(dll__environ[i], var, strlen(var)) == 0)
               {
                 // free it first
                 free(dll__environ[i]);
@@ -1891,7 +1891,7 @@ extern "C"
       {
         if (dll__environ[i])
         {
-          if (strnicmp(dll__environ[i], szKey, strlen(szKey)) == 0)
+          if (StringUtils::CompareNoCase(dll__environ[i], szKey, strlen(szKey)) == 0)
           {
             // found it
             value = dll__environ[i] + strlen(szKey) + 1;

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1607,7 +1607,8 @@ extern "C"
       return 0;
     }
 #endif
-    if (!stricmp(path, "\\Device\\Cdrom0") || !stricmp(path, "\\Device\\Cdrom0\\"))
+    if (!StringUtils::CompareNoCase(path, "\\Device\\Cdrom0") ||
+        !StringUtils::CompareNoCase(path, "\\Device\\Cdrom0\\"))
     {
       buffer->st_mode = _S_IFDIR;
       return 0;
@@ -1650,7 +1651,8 @@ extern "C"
       return 0;
     }
 #endif
-    if (!stricmp(path, "\\Device\\Cdrom0") || !stricmp(path, "\\Device\\Cdrom0\\"))
+    if (!StringUtils::CompareNoCase(path, "\\Device\\Cdrom0") ||
+        !StringUtils::CompareNoCase(path, "\\Device\\Cdrom0\\"))
     {
       buffer->st_mode = _S_IFDIR;
       return 0;

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -618,16 +618,16 @@ void CExternalPlayer::GetCustomRegexpReplacers(TiXmlElement *pRootElement,
   int iAction = 0; // overwrite
   // for backward compatibility
   const char* szAppend = pRootElement->Attribute("append");
-  if ((szAppend && stricmp(szAppend, "yes") == 0))
+  if ((szAppend && StringUtils::CompareNoCase(szAppend, "yes") == 0))
     iAction = 1;
   // action takes precedence if both attributes exist
   const char* szAction = pRootElement->Attribute("action");
   if (szAction)
   {
     iAction = 0; // overwrite
-    if (stricmp(szAction, "append") == 0)
+    if (StringUtils::CompareNoCase(szAction, "append") == 0)
       iAction = 1; // append
-    else if (stricmp(szAction, "prepend") == 0)
+    else if (StringUtils::CompareNoCase(szAction, "prepend") == 0)
       iAction = 2; // prepend
   }
   if (iAction == 0)
@@ -641,8 +641,8 @@ void CExternalPlayer::GetCustomRegexpReplacers(TiXmlElement *pRootElement,
     {
       const char* szGlobal = pReplacer->Attribute("global");
       const char* szStop = pReplacer->Attribute("stop");
-      bool bGlobal = szGlobal && stricmp(szGlobal, "true") == 0;
-      bool bStop = szStop && stricmp(szStop, "true") == 0;
+      bool bGlobal = szGlobal && StringUtils::CompareNoCase(szGlobal, "true") == 0;
+      bool bStop = szStop && StringUtils::CompareNoCase(szStop, "true") == 0;
 
       std::string strMatch;
       std::string strPat;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -53,7 +53,7 @@ static bool IsDownmixDecoder(const std::string &name)
   };
   for (const char **ptr = downmixDecoders; *ptr; ptr++)
   {
-    if (!strnicmp(*ptr, name.c_str(), strlen(*ptr)))
+    if (!StringUtils::CompareNoCase(*ptr, name, strlen(*ptr)))
       return true;
   }
   return false;
@@ -67,7 +67,7 @@ static bool IsDecoderWhitelisted(const std::string &name)
   };
   for (const char **ptr = whitelistDecoders; *ptr; ptr++)
   {
-    if (!strnicmp(*ptr, name.c_str(), strlen(*ptr)))
+    if (!StringUtils::CompareNoCase(*ptr, name, strlen(*ptr)))
       return true;
   }
   return false;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -91,7 +91,7 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
       if (!strncmp(ptr, "palette:", 8))
         if (sscanf(ptr, "palette: %x, %x, %x, %x, %x, %x, %x, %x,"
                                 " %x, %x, %x, %x, %x, %x, %x, %x", ...
-      if (!strncasecmp(ptr, "forced subs: on", 15))
+      if (!StringUtils::CompareNoCase(ptr, "forced subs: on", 15))
         forced_subs_only = 1;
       */
       // if tried all possibilities, then read newline char and move to next line

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -40,8 +40,8 @@ bool CDVDInputStreamFFmpeg::Open()
 
   m_aborted = false;
 
-  if(strnicmp(m_item.GetDynPath().c_str(), "udp://", 6) == 0 ||
-     strnicmp(m_item.GetDynPath().c_str(), "rtp://", 6) == 0)
+  if (StringUtils::CompareNoCase(m_item.GetDynPath(), "udp://", 6) == 0 ||
+      StringUtils::CompareNoCase(m_item.GetDynPath(), "rtp://", 6) == 0)
   {
     m_realtime = true;
   }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/config.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/config.h
@@ -62,9 +62,6 @@
 #define PATH_MAX MAX_PATH
 #endif
 
-#ifndef strcasecmp
-#define strcasecmp stricmp
-#endif
 #ifndef strncasecmp
 #define strncasecmp strnicmp
 #endif

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/config.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/dvdnav/config.h
@@ -62,10 +62,6 @@
 #define PATH_MAX MAX_PATH
 #endif
 
-#ifndef strncasecmp
-#define strncasecmp strnicmp
-#endif
-
 #ifndef S_ISDIR
 #define S_ISDIR(m) ((m) & _S_IFDIR)
 #endif

--- a/xbmc/cores/playercorefactory/PlayerCoreConfig.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreConfig.h
@@ -37,8 +37,8 @@ public:
       m_config = static_cast<TiXmlElement*>(pConfig->Clone());
       const char *sAudio = pConfig->Attribute("audio");
       const char *sVideo = pConfig->Attribute("video");
-      m_bPlaysAudio = sAudio && stricmp(sAudio, "true") == 0;
-      m_bPlaysVideo = sVideo && stricmp(sVideo, "true") == 0;
+      m_bPlaysAudio = sAudio && StringUtils::CompareNoCase(sAudio, "true") == 0;
+      m_bPlaysVideo = sVideo && StringUtils::CompareNoCase(sVideo, "true") == 0;
     }
     else
     {

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -331,7 +331,7 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
     m_vecPlayerConfigs.push_back(retroPlayer);
   }
 
-  if (!pConfig || strcmpi(pConfig->Value(), "playercorefactory") != 0)
+  if (!pConfig || StringUtils::CompareNoCase(pConfig->Value(), "playercorefactory") != 0)
   {
     CLog::Log(LOGERROR, "Error loading configuration, no <playercorefactory> node");
     return false;

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -381,11 +381,11 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
     const char* szAction = pRule->Attribute("action");
     if (szAction)
     {
-      if (stricmp(szAction, "append") == 0)
+      if (StringUtils::CompareNoCase(szAction, "append") == 0)
       {
         m_vecCoreSelectionRules.push_back(new CPlayerSelectionRule(pRule));
       }
-      else if (stricmp(szAction, "prepend") == 0)
+      else if (StringUtils::CompareNoCase(szAction, "prepend") == 0)
       {
         m_vecCoreSelectionRules.insert(m_vecCoreSelectionRules.begin(), 1, new CPlayerSelectionRule(pRule));
       }

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -93,8 +93,10 @@ int CPlayerSelectionRule::GetTristate(const char* szValue)
 {
   if (szValue)
   {
-    if (stricmp(szValue, "true") == 0) return 1;
-    if (stricmp(szValue, "false") == 0) return 0;
+    if (StringUtils::CompareNoCase(szValue, "true") == 0)
+      return 1;
+    if (StringUtils::CompareNoCase(szValue, "false") == 0)
+      return 0;
   }
   return -1;
 }

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -94,7 +94,7 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
   if (discStubXML.LoadFile(item.GetPath()))
   {
     TiXmlElement * pRootElement = discStubXML.RootElement();
-    if (!pRootElement || strcmpi(pRootElement->Value(), "discstub") != 0)
+    if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "discstub") != 0)
       CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.GetPath().c_str());
     else
     {

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -57,11 +57,11 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   AVDictionaryEntry* tag=nullptr;
   while ((tag = av_dict_get(m_fctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
   {
-    if (strcasecmp(tag->key,"title") == 0)
+    if (StringUtils::CompareNoCase(tag->key, "title") == 0)
       title = tag->value;
-    else if (strcasecmp(tag->key,"album") == 0)
+    else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
       album = tag->value;
-    else if (strcasecmp(tag->key,"artist") == 0)
+    else if (StringUtils::CompareNoCase(tag->key, "artist") == 0)
       author = tag->value;
   }
 
@@ -77,11 +77,11 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     std::string chapalbum;
     while ((tag=av_dict_get(m_fctx->chapters[i]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
     {
-      if (strcasecmp(tag->key,"title") == 0)
+      if (StringUtils::CompareNoCase(tag->key, "title") == 0)
         chaptitle = tag->value;
-      else if (strcasecmp(tag->key,"artist") == 0)
+      else if (StringUtils::CompareNoCase(tag->key, "artist") == 0)
         chapauthor = tag->value;
-      else if (strcasecmp(tag->key,"album") == 0)
+      else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
         chapalbum = tag->value;
     }
     CFileItemPtr item(new CFileItem(url.Get(),false));

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -240,7 +240,7 @@ std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
         while ((de = readdir(dir)) != NULL)
         {
           // check if there's a file with same name but different case
-          if (strcasecmp(de->d_name, tokens[i].c_str()) == 0)
+          if (StringUtils::CompareNoCase(de->d_name, tokens[i]) == 0)
           {
             result += "/";
             result += de->d_name;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -581,7 +581,7 @@ void CGUIBaseContainer::OnJumpLetter(char letter, bool skip /*=false*/)
     std::string label = item->GetLabel();
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
       label = SortUtils::RemoveArticles(label);
-    if (0 == strnicmp(label.c_str(), m_match.c_str(), m_match.size()))
+    if (0 == StringUtils::CompareNoCase(label, m_match, m_match.size()))
     {
       SelectItem(i);
       return;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -340,9 +340,11 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
     GetRectFromString(border, image.border);
   image.orientation = 0;
   const char *flipX = pNode->Attribute("flipx");
-  if (flipX && strcmpi(flipX, "true") == 0) image.orientation = 1;
+  if (flipX && StringUtils::CompareNoCase(flipX, "true") == 0)
+    image.orientation = 1;
   const char *flipY = pNode->Attribute("flipy");
-  if (flipY && strcmpi(flipY, "true") == 0) image.orientation = 3 - image.orientation;  // either 3 or 2
+  if (flipY && StringUtils::CompareNoCase(flipY, "true") == 0)
+    image.orientation = 3 - image.orientation; // either 3 or 2
   image.diffuse = XMLUtils::GetAttribute(pNode, "diffuse");
   image.diffuseColor.Parse(XMLUtils::GetAttribute(pNode, "colordiffuse"), 0);
   const char *background = pNode->Attribute("background");
@@ -453,7 +455,7 @@ bool CGUIControlFactory::GetAnimations(TiXmlNode *control, const CRect &rect, in
       CAnimation anim;
       anim.Create(node, rect, context);
       animations.push_back(anim);
-      if (strcmpi(node->FirstChild()->Value(), "VisibleChange") == 0)
+      if (StringUtils::CompareNoCase(node->FirstChild()->Value(), "VisibleChange") == 0)
       { // add the hidden one as well
         TiXmlElement hidden(*node);
         hidden.FirstChild()->SetValue("hidden");

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -192,7 +192,7 @@ bool CGUIControlFactory::GetDimension(const TiXmlNode *pRootNode, const char* st
 {
   const TiXmlElement* pNode = pRootNode->FirstChildElement(strTag);
   if (!pNode || !pNode->FirstChild()) return false;
-  if (0 == strnicmp("auto", pNode->FirstChild()->Value(), 4))
+  if (0 == StringUtils::CompareNoCase("auto", pNode->FirstChild()->Value(), 4))
   { // auto-width - at least min must be set
     value = ParsePosition(pNode->Attribute("max"), parentSize);
     min = ParsePosition(pNode->Attribute("min"), parentSize);
@@ -348,7 +348,7 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
   image.diffuse = XMLUtils::GetAttribute(pNode, "diffuse");
   image.diffuseColor.Parse(XMLUtils::GetAttribute(pNode, "colordiffuse"), 0);
   const char *background = pNode->Attribute("background");
-  if (background && strnicmp(background, "true", 4) == 0)
+  if (background && StringUtils::CompareNoCase(background, "true", 4) == 0)
     image.useLarge = true;
   image.filename = pNode->FirstChild() ? pNode->FirstChild()->Value() : "";
   return true;
@@ -818,7 +818,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   if (XMLUtils::GetInt(pControlNode, "defaultcontrol", defaultControl))
   {
     const char *always = pControlNode->FirstChildElement("defaultcontrol")->Attribute("always");
-    if (always && strnicmp(always, "true", 4) == 0)
+    if (always && StringUtils::CompareNoCase(always, "true", 4) == 0)
       defaultAlways = true;
   }
   XMLUtils::GetInt(pControlNode, "pagecontrol", pageControl);

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -70,7 +70,7 @@ void CGUIStaticItem::UpdateProperties(int contextWindow)
   {
     const GUIINFO::CGUIInfoLabel& info = i.first;
     const std::string& name = i.second;
-    bool preferTexture = strnicmp("label", name.c_str(), 5) != 0;
+    bool preferTexture = StringUtils::CompareNoCase("label", name, 5) != 0;
     std::string value(info.GetLabel(contextWindow, preferTexture));
     if (StringUtils::EqualsNoCase(name, "label"))
       SetLabel(value);

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -89,31 +89,31 @@ std::shared_ptr<Tweener> CAnimEffect::GetTweener(const TiXmlElement *pAnimationN
   const char *tween = pAnimationNode->Attribute("tween");
   if (tween)
   {
-    if (strcmpi(tween, "linear")==0)
+    if (StringUtils::CompareNoCase(tween, "linear") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new LinearTweener());
-    else if (strcmpi(tween, "quadratic")==0)
+    else if (StringUtils::CompareNoCase(tween, "quadratic") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new QuadTweener());
-    else if (strcmpi(tween, "cubic")==0)
+    else if (StringUtils::CompareNoCase(tween, "cubic") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new CubicTweener());
-    else if (strcmpi(tween, "sine")==0)
+    else if (StringUtils::CompareNoCase(tween, "sine") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new SineTweener());
-    else if (strcmpi(tween, "back")==0)
+    else if (StringUtils::CompareNoCase(tween, "back") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new BackTweener());
-    else if (strcmpi(tween, "circle")==0)
+    else if (StringUtils::CompareNoCase(tween, "circle") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new CircleTweener());
-    else if (strcmpi(tween, "bounce")==0)
+    else if (StringUtils::CompareNoCase(tween, "bounce") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new BounceTweener());
-    else if (strcmpi(tween, "elastic")==0)
+    else if (StringUtils::CompareNoCase(tween, "elastic") == 0)
       m_pTweener = std::shared_ptr<Tweener>(new ElasticTweener());
 
     const char *easing = pAnimationNode->Attribute("easing");
     if (m_pTweener && easing)
     {
-      if (strcmpi(easing, "in")==0)
+      if (StringUtils::CompareNoCase(easing, "in") == 0)
         m_pTweener->SetEasing(EASE_IN);
-      else if (strcmpi(easing, "out")==0)
+      else if (StringUtils::CompareNoCase(easing, "out") == 0)
         m_pTweener->SetEasing(EASE_OUT);
-      else if (strcmpi(easing, "inout")==0)
+      else if (StringUtils::CompareNoCase(easing, "inout") == 0)
         m_pTweener->SetEasing(EASE_INOUT);
     }
   }
@@ -210,7 +210,7 @@ CRotateEffect::CRotateEffect(const TiXmlElement *node, EFFECT_TYPE effect) : CAn
   const char *centerPos = node->Attribute("center");
   if (centerPos)
   {
-    if (strcmpi(centerPos, "auto") == 0)
+    if (StringUtils::CompareNoCase(centerPos, "auto") == 0)
       m_autoCenter = true;
     else
     {
@@ -304,7 +304,7 @@ CZoomEffect::CZoomEffect(const TiXmlElement *node, const CRect &rect) : CAnimEff
   const char *centerPos = node->Attribute("center");
   if (centerPos)
   {
-    if (strcmpi(centerPos, "auto") == 0)
+    if (StringUtils::CompareNoCase(centerPos, "auto") == 0)
       m_autoCenter = true;
     else
     {
@@ -606,7 +606,7 @@ void CAnimation::Create(const TiXmlElement *node, const CRect &rect, int context
   if (condition)
     m_condition = CServiceBroker::GetGUI()->GetInfoManager().Register(condition, context);
   const char *reverse = node->Attribute("reversible");
-  if (reverse && strcmpi(reverse, "false") == 0)
+  if (reverse && StringUtils::CompareNoCase(reverse, "false") == 0)
     m_reversible = false;
 
   const TiXmlElement *effect = node->FirstChildElement("effect");
@@ -633,10 +633,10 @@ void CAnimation::Create(const TiXmlElement *node, const CRect &rect, int context
 
     // pulsed or loop animations
     const char *pulse = node->Attribute("pulse");
-    if (pulse && strcmpi(pulse, "true") == 0)
+    if (pulse && StringUtils::CompareNoCase(pulse, "true") == 0)
       m_repeatAnim = ANIM_REPEAT_PULSE;
     const char *loop = node->Attribute("loop");
-    if (loop && strcmpi(loop, "true") == 0)
+    if (loop && StringUtils::CompareNoCase(loop, "true") == 0)
       m_repeatAnim = ANIM_REPEAT_LOOP;
   }
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -159,7 +159,7 @@ bool CButtonTranslator::LoadKeymap(const std::string &keymapPath)
       const char *szWindow = pWindow->Value();
       if (szWindow != nullptr)
       {
-        if (strcmpi(szWindow, "global") == 0)
+        if (StringUtils::CompareNoCase(szWindow, "global") == 0)
           windowID = -1;
         else
           windowID = CWindowTranslator::TranslateWindow(szWindow);

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -143,7 +143,7 @@ unsigned int CIRTranslator::TranslateButton(const std::string &szDevice, const s
     return 0;
 
   // Convert the button to code
-  if (strnicmp((*it2).second.c_str(), "obc", 3) == 0)
+  if (StringUtils::CompareNoCase((*it2).second, "obc", 3) == 0)
     return TranslateUniversalRemoteString((*it2).second);
 
   return TranslateString((*it2).second);
@@ -230,7 +230,7 @@ uint32_t CIRTranslator::TranslateString(std::string strButton)
 
 uint32_t CIRTranslator::TranslateUniversalRemoteString(const std::string &szButton)
 {
-  if (szButton.empty() || szButton.length() < 4 || strnicmp(szButton.c_str(), "obc", 3))
+  if (szButton.empty() || szButton.length() < 4 || StringUtils::CompareNoCase(szButton, "obc", 3))
     return 0;
 
   const char *szCode = szButton.c_str() + 3;

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -307,7 +307,7 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
       else if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iDbId > 0)
         object[ID] = item->GetVideoInfoTag()->m_iDbId;
 
-      if (stricmp(ID, "id") == 0)
+      if (StringUtils::CompareNoCase(ID, "id") == 0)
       {
         if (item->HasPVRChannelInfoTag())
           object["type"] = "channel";

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -199,33 +199,33 @@ namespace XBMCAddon
 
     String Addon::getAddonInfo(const char* id)
     {
-      if (strcmpi(id, "author") == 0)
+      if (StringUtils::CompareNoCase(id, "author") == 0)
         return pAddon->Author();
-      else if (strcmpi(id, "changelog") == 0)
+      else if (StringUtils::CompareNoCase(id, "changelog") == 0)
         return pAddon->ChangeLog();
-      else if (strcmpi(id, "description") == 0)
+      else if (StringUtils::CompareNoCase(id, "description") == 0)
         return pAddon->Description();
-      else if (strcmpi(id, "disclaimer") == 0)
+      else if (StringUtils::CompareNoCase(id, "disclaimer") == 0)
         return pAddon->Disclaimer();
-      else if (strcmpi(id, "fanart") == 0)
+      else if (StringUtils::CompareNoCase(id, "fanart") == 0)
         return pAddon->FanArt();
-      else if (strcmpi(id, "icon") == 0)
+      else if (StringUtils::CompareNoCase(id, "icon") == 0)
         return pAddon->Icon();
-      else if (strcmpi(id, "id") == 0)
+      else if (StringUtils::CompareNoCase(id, "id") == 0)
         return pAddon->ID();
-      else if (strcmpi(id, "name") == 0)
+      else if (StringUtils::CompareNoCase(id, "name") == 0)
         return pAddon->Name();
-      else if (strcmpi(id, "path") == 0)
+      else if (StringUtils::CompareNoCase(id, "path") == 0)
         return pAddon->Path();
-      else if (strcmpi(id, "profile") == 0)
+      else if (StringUtils::CompareNoCase(id, "profile") == 0)
         return pAddon->Profile();
-      else if (strcmpi(id, "stars") == 0)
+      else if (StringUtils::CompareNoCase(id, "stars") == 0)
         return StringUtils::Format("-1");
-      else if (strcmpi(id, "summary") == 0)
+      else if (StringUtils::CompareNoCase(id, "summary") == 0)
         return pAddon->Summary();
-      else if (strcmpi(id, "type") == 0)
+      else if (StringUtils::CompareNoCase(id, "type") == 0)
         return ADDON::CAddonInfo::TranslateType(pAddon->Type());
-      else if (strcmpi(id, "version") == 0)
+      else if (StringUtils::CompareNoCase(id, "version") == 0)
         return pAddon->Version().asString();
       else
         throw AddonException("'%s' is an invalid Id", id);

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -220,7 +220,7 @@ namespace XBMCAddon
       if (!shares)
       {
         CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
-        if (strcmpi(s_shares.c_str(), "local") != 0)
+        if (StringUtils::CompareNoCase(s_shares, "local") != 0)
           CServiceBroker::GetMediaManager().GetNetworkLocations(localShares);
       }
       else // always append local drives
@@ -255,7 +255,7 @@ namespace XBMCAddon
       if (!shares)
       {
         CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
-        if (strcmpi(s_shares.c_str(), "local") != 0)
+        if (StringUtils::CompareNoCase(s_shares, "local") != 0)
           CServiceBroker::GetMediaManager().GetNetworkLocations(localShares);
       }
       else // always append local drives

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -338,7 +338,7 @@ namespace XBMCAddon
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
 
-      if (strcmpi(type, "video") == 0)
+      if (StringUtils::CompareNoCase(type, "video") == 0)
       {
         auto& videotag = *GetVideoInfoTag();
         for (const auto& it: infoLabels)
@@ -505,7 +505,7 @@ namespace XBMCAddon
             CLog::Log(LOGERROR,"NEWADDON Unknown Video Info Key \"%s\"", key.c_str());
         }
       }
-      else if (strcmpi(type, "music") == 0)
+      else if (StringUtils::CompareNoCase(type, "music") == 0)
       {
         std::string type;
         for (auto it = infoLabels.begin(); it != infoLabels.end(); ++it)
@@ -598,7 +598,7 @@ namespace XBMCAddon
           musictag.SetLoaded(true);
         }
       }
-      else if (strcmpi(type,"pictures") == 0)
+      else if (StringUtils::CompareNoCase(type, "pictures") == 0)
       {
         for (const auto& it: infoLabels)
         {
@@ -742,7 +742,7 @@ namespace XBMCAddon
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
 
-      if (strcmpi(cType, "video") == 0)
+      if (StringUtils::CompareNoCase(cType, "video") == 0)
       {
         CStreamDetailVideo* video = new CStreamDetailVideo;
         for (const auto& it: dictionary)
@@ -767,7 +767,7 @@ namespace XBMCAddon
         }
         GetVideoInfoTag()->m_streamDetails.AddStream(video);
       }
-      else if (strcmpi(cType, "audio") == 0)
+      else if (StringUtils::CompareNoCase(cType, "audio") == 0)
       {
         CStreamDetailAudio* audio = new CStreamDetailAudio;
         for (const auto& it: dictionary)
@@ -784,7 +784,7 @@ namespace XBMCAddon
         }
         GetVideoInfoTag()->m_streamDetails.AddStream(audio);
       }
-      else if (strcmpi(cType, "subtitle") == 0)
+      else if (StringUtils::CompareNoCase(cType, "subtitle") == 0)
       {
         CStreamDetailSubtitle* subtitle = new CStreamDetailSubtitle;
         for (const auto& it: dictionary)

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -413,15 +413,15 @@ namespace XBMCAddon
       XBMC_TRACE;
       std::string result;
 
-      if (strcmpi(id, "datelong") == 0)
-        {
-          result = g_langInfo.GetDateFormat(true);
-          StringUtils::Replace(result, "DDDD", "%A");
-          StringUtils::Replace(result, "MMMM", "%B");
-          StringUtils::Replace(result, "D", "%d");
-          StringUtils::Replace(result, "YYYY", "%Y");
+      if (StringUtils::CompareNoCase(id, "datelong") == 0)
+      {
+        result = g_langInfo.GetDateFormat(true);
+        StringUtils::Replace(result, "DDDD", "%A");
+        StringUtils::Replace(result, "MMMM", "%B");
+        StringUtils::Replace(result, "D", "%d");
+        StringUtils::Replace(result, "YYYY", "%Y");
         }
-      else if (strcmpi(id, "dateshort") == 0)
+        else if (StringUtils::CompareNoCase(id, "dateshort") == 0)
         {
           result = g_langInfo.GetDateFormat(false);
           StringUtils::Replace(result, "MM", "%m");
@@ -435,11 +435,11 @@ namespace XBMCAddon
 #endif
           StringUtils::Replace(result, "YYYY", "%Y");
         }
-      else if (strcmpi(id, "tempunit") == 0)
-        result = g_langInfo.GetTemperatureUnitString();
-      else if (strcmpi(id, "speedunit") == 0)
-        result = g_langInfo.GetSpeedUnitString();
-      else if (strcmpi(id, "time") == 0)
+        else if (StringUtils::CompareNoCase(id, "tempunit") == 0)
+          result = g_langInfo.GetTemperatureUnitString();
+        else if (StringUtils::CompareNoCase(id, "speedunit") == 0)
+          result = g_langInfo.GetSpeedUnitString();
+        else if (StringUtils::CompareNoCase(id, "time") == 0)
         {
           result = g_langInfo.GetTimeFormat();
           if (StringUtils::StartsWith(result, "HH"))
@@ -451,12 +451,12 @@ namespace XBMCAddon
           StringUtils::Replace(result, "ss", "%S");
           StringUtils::Replace(result, "xx", "%p");
         }
-      else if (strcmpi(id, "meridiem") == 0)
-        result = StringUtils::Format("%s/%s",
-                                     g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
-                                     g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
+        else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
+          result =
+              StringUtils::Format("%s/%s", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM).c_str(),
+                                  g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM).c_str());
 
-      return result;
+        return result;
     }
 
     //! @todo Add a mediaType enum
@@ -464,11 +464,11 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       String result;
-      if (strcmpi(mediaType, "video") == 0)
+      if (StringUtils::CompareNoCase(mediaType, "video") == 0)
         result = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
-      else if (strcmpi(mediaType, "music") == 0)
+      else if (StringUtils::CompareNoCase(mediaType, "music") == 0)
         result = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
-      else if (strcmpi(mediaType, "picture") == 0)
+      else if (StringUtils::CompareNoCase(mediaType, "picture") == 0)
         result = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
 
       //! @todo implement

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -33,7 +33,7 @@ CStaticListProvider::CStaticListProvider(const TiXmlElement *element, int parent
   if (XMLUtils::GetInt(element, "default", m_defaultItem))
   {
     const char *always = element->FirstChildElement("default")->Attribute("always");
-    if (always && strnicmp(always, "true", 4) == 0)
+    if (always && StringUtils::CompareNoCase(always, "true", 4) == 0)
       m_defaultAlways = true;
   }
 }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -10651,10 +10651,10 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
     // Count the number of artists, albums and songs
     while (entry)
     {
-      if (strnicmp(entry->Value(), "artist", 6)==0 ||
-          strnicmp(entry->Value(), "album", 5)==0)
+      if (StringUtils::CompareNoCase(entry->Value(), "artist", 6) == 0 ||
+          StringUtils::CompareNoCase(entry->Value(), "album", 5) == 0)
         total++;
-      else if (strnicmp(entry->Value(), "song", 4) == 0)
+      else if (StringUtils::CompareNoCase(entry->Value(), "song", 4) == 0)
         songtotal++;
 
       entry = entry->NextSiblingElement();
@@ -10665,7 +10665,7 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
     while (entry)
     {
       std::string strTitle;
-      if (strnicmp(entry->Value(), "artist", 6) == 0)
+      if (StringUtils::CompareNoCase(entry->Value(), "artist", 6) == 0)
       {
         CArtist importedArtist;
         importedArtist.Load(entry);
@@ -10684,7 +10684,7 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           CLog::Log(LOGDEBUG, "%s - Not import additional artist data as %s not found", __FUNCTION__, importedArtist.strArtist.c_str());
         current++;
       }
-      else if (strnicmp(entry->Value(), "album", 5) == 0)
+      else if (StringUtils::CompareNoCase(entry->Value(), "album", 5) == 0)
       {
         CAlbum importedAlbum;
         importedAlbum.Load(entry);
@@ -10778,7 +10778,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile, const int tot
       float fRating = 0.0;
       int iVotes;
       std::string strSQLSong;
-      if (strnicmp(entry->Value(), "song", 4) == 0)
+      if (StringUtils::CompareNoCase(entry->Value(), "song", 4) == 0)
       {      
         XMLUtils::GetString(entry, "artistdesc", strArtistDisp);
         XMLUtils::GetString(entry, "title", strTitle);

--- a/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
@@ -87,62 +87,62 @@ bool CMusicInfoTagLoaderFFmpeg::Load(const std::string& strFileName, CMusicInfoT
   */
   auto&& ParseTag = [&tag](AVDictionaryEntry* avtag)
                           {
-                            if (strcasecmp(avtag->key, "album") == 0)
+                            if (StringUtils::CompareNoCase(avtag->key, "album") == 0)
                               tag.SetAlbum(avtag->value);
-                            else if (strcasecmp(avtag->key, "artist") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "artist") == 0)
                               tag.SetArtist(avtag->value);
-                            else if (strcasecmp(avtag->key, "album_artist") == 0 ||
-                                     strcasecmp(avtag->key, "album artist") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "album_artist") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "album artist") == 0)
                               tag.SetAlbumArtist(avtag->value);
-                            else if (strcasecmp(avtag->key, "title") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "title") == 0)
                               tag.SetTitle(avtag->value);
-                            else if (strcasecmp(avtag->key, "genre") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "genre") == 0)
                               tag.SetGenre(avtag->value);
-                            else if (strcasecmp(avtag->key, "part_number") == 0 ||
-                                     strcasecmp(avtag->key, "track") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "part_number") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "track") == 0)
                               tag.SetTrackNumber(strtol(avtag->value, nullptr, 10));
-                            else if (strcasecmp(avtag->key, "disc") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "disc") == 0)
                               tag.SetDiscNumber(strtol(avtag->value, nullptr, 10));
-                            else if (strcasecmp(avtag->key, "date") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "date") == 0)
                               tag.SetReleaseDate(avtag->value);
-                            else if (strcasecmp(avtag->key, "compilation") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "compilation") == 0)
                               tag.SetCompilation((strtol(avtag->value, nullptr, 10) == 0) ? false : true);
-                            else if (strcasecmp(avtag->key, "encoded_by") == 0) {}
-                            else if (strcasecmp(avtag->key, "composer") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "encoded_by") == 0) {}
+                            else if (StringUtils::CompareNoCase(avtag->key, "composer") == 0)
                               tag.AddArtistRole("Composer", avtag->value);
-                            else if (strcasecmp(avtag->key, "performer") == 0) // Conductor or TPE3 tag
+                            else if (StringUtils::CompareNoCase(avtag->key, "performer") == 0) // Conductor or TPE3 tag
                               tag.AddArtistRole("Conductor", avtag->value);
-                            else if (strcasecmp(avtag->key, "TEXT") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "TEXT") == 0)
                               tag.AddArtistRole("Lyricist", avtag->value);
-                            else if (strcasecmp(avtag->key, "TPE4") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "TPE4") == 0)
                               tag.AddArtistRole("Remixer", avtag->value);
-                            else if (strcasecmp(avtag->key, "LABEL") == 0 ||
-                                     strcasecmp(avtag->key, "TPUB") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "LABEL") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "TPUB") == 0)
                               tag.SetRecordLabel(avtag->value);
-                            else if (strcasecmp(avtag->key, "copyright") == 0 ||
-                                     strcasecmp(avtag->key, "TCOP") == 0) {} // Copyright message
-                            else if (strcasecmp(avtag->key, "TDRC") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "copyright") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "TCOP") == 0) {} // Copyright message
+                            else if (StringUtils::CompareNoCase(avtag->key, "TDRC") == 0)
                               tag.SetReleaseDate(avtag->value);
-                            else if (strcasecmp(avtag->key, "TDOR") == 0  ||
-                                     strcasecmp(avtag->key, "TORY") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "TDOR") == 0  ||
+                                     StringUtils::CompareNoCase(avtag->key, "TORY") == 0)
                               tag.SetOriginalDate(avtag->value);
-                            else if (strcasecmp(avtag->key , "TDAT") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key , "TDAT") == 0)
                               tag.AddReleaseDate(avtag->value, true); // MMDD part
-                            else if (strcasecmp(avtag->key, "TYER") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "TYER") == 0)
                               tag.AddReleaseDate(avtag->value); // YYYY part
-                            else if (strcasecmp(avtag->key, "TBPM") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "TBPM") == 0)
                               tag.SetBPM(strtol(avtag->value, nullptr, 10));
-                            else if (strcasecmp(avtag->key, "TDTG") == 0) {} // Tagging time
-                            else if (strcasecmp(avtag->key, "language") == 0 ||
-                                     strcasecmp(avtag->key, "TLAN") == 0) {} // Languages
-                            else if (strcasecmp(avtag->key, "mood") == 0 ||
-                                     strcasecmp(avtag->key, "TMOO") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "TDTG") == 0) {} // Tagging time
+                            else if (StringUtils::CompareNoCase(avtag->key, "language") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "TLAN") == 0) {} // Languages
+                            else if (StringUtils::CompareNoCase(avtag->key, "mood") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "TMOO") == 0)
                               tag.SetMood(avtag->value);
-                            else if (strcasecmp(avtag->key, "artist-sort") == 0 ||
-                                     strcasecmp(avtag->key, "TSOP") == 0) {}
-                            else if (strcasecmp(avtag->key, "TSO2") == 0) {}  // Album artist sort
-                            else if (strcasecmp(avtag->key, "TSOC") == 0) {}  // composer sort
-                            else if (strcasecmp(avtag->key, "TSST") == 0)
+                            else if (StringUtils::CompareNoCase(avtag->key, "artist-sort") == 0 ||
+                                     StringUtils::CompareNoCase(avtag->key, "TSOP") == 0) {}
+                            else if (StringUtils::CompareNoCase(avtag->key, "TSO2") == 0) {}  // Album artist sort
+                            else if (StringUtils::CompareNoCase(avtag->key, "TSOC") == 0) {}  // composer sort
+                            else if (StringUtils::CompareNoCase(avtag->key, "TSST") == 0)
                               tag.SetDiscSubtitle(avtag->value);
                           };
 

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -806,7 +806,7 @@ void CWakeOnAccess::LoadFromXML()
   }
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
-  if (strcmpi(pRootElement->Value(), "onaccesswakeup"))
+  if (StringUtils::CompareNoCase(pRootElement->Value(), "onaccesswakeup"))
   {
     CLog::Log(LOGERROR, "%s - XML file %s doesnt contain <onaccesswakeup>", __FUNCTION__, GetSettingFile().c_str());
     return;

--- a/xbmc/network/websocket/WebSocketV13.cpp
+++ b/xbmc/network/websocket/WebSocketV13.cpp
@@ -47,7 +47,8 @@ bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &resp
 
   // The request must be GET
   value = header.getMethod();
-  if (value == NULL || strnicmp(value, WS_HTTP_METHOD, strlen(WS_HTTP_METHOD)) != 0)
+  if (value == NULL ||
+      StringUtils::CompareNoCase(value, WS_HTTP_METHOD, strlen(WS_HTTP_METHOD)) != 0)
   {
     CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid HTTP method received (GET expected)");
     return false;
@@ -83,7 +84,8 @@ bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &resp
 
   // There must be a "Upgrade" header with the value "websocket"
   value = header.getValue(WS_HEADER_UPGRADE_LC);
-  if (value == NULL || strnicmp(value, WS_HEADER_UPGRADE_VALUE, strlen(WS_HEADER_UPGRADE_VALUE)) != 0)
+  if (value == NULL || StringUtils::CompareNoCase(value, WS_HEADER_UPGRADE_VALUE,
+                                                  strlen(WS_HEADER_UPGRADE_VALUE)) != 0)
   {
     CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_UPGRADE);
     return true;

--- a/xbmc/network/websocket/WebSocketV8.cpp
+++ b/xbmc/network/websocket/WebSocketV8.cpp
@@ -50,7 +50,8 @@ bool CWebSocketV8::Handshake(const char* data, size_t length, std::string &respo
 
   // The request must be GET
   value = header.getMethod();
-  if (value == NULL || strnicmp(value, WS_HTTP_METHOD, strlen(WS_HTTP_METHOD)) != 0)
+  if (value == NULL ||
+      StringUtils::CompareNoCase(value, WS_HTTP_METHOD, strlen(WS_HTTP_METHOD)) != 0)
   {
     CLog::Log(LOGINFO, "WebSocket [hybi-10]: invalid HTTP method received (GET expected)");
     return false;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -487,7 +487,7 @@ bool CPeripherals::LoadMappings()
   }
 
   TiXmlElement *pRootElement = xmlDoc.RootElement();
-  if (!pRootElement || strcmpi(pRootElement->Value(), "peripherals") != 0)
+  if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "peripherals") != 0)
   {
     CLog::Log(LOGERROR, "%s - peripherals.xml does not contain <peripherals>", __FUNCTION__);
     return false;

--- a/xbmc/platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.cpp
+++ b/xbmc/platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.cpp
@@ -49,7 +49,7 @@ CMediaCodecDecoderFilterManager::CMediaCodecDecoderFilterManager()
     uint32_t flags = CDecoderFilter::FLAG_GENERAL_ALLOWED | CDecoderFilter::FLAG_DVD_ALLOWED;
     for (const char **ptr = blacklisted_decoders; *ptr && flags; ptr++)
     {
-      if (!strnicmp(*ptr, codecname.c_str(), strlen(*ptr)))
+      if (!StringUtils::CompareNoCase(*ptr, codecname, strlen(*ptr)))
         flags = 0;
     }
     add(CDecoderFilter(codecname, flags, 0));

--- a/xbmc/platform/darwin/osx/CocoaInterface.mm
+++ b/xbmc/platform/darwin/osx/CocoaInterface.mm
@@ -179,7 +179,7 @@ char* Cocoa_MountPoint2DeviceName(char *path)
     mounts = getmntinfo(&mntbufp, MNT_WAIT);  // NOT THREAD SAFE!
     for (i = 0; i < mounts; i++)
     {
-      if( !strcasecmp(mntbufp[i].f_mntonname, strDVDDevice) )
+      if (!StringUtils::CompareNoCase(mntbufp[i].f_mntonname, strDVDDevice))
       {
         // Replace "/dev/" with "/dev/r"
         path = (char*)realloc(path, strlen(mntbufp[i].f_mntfromname) + 2 );

--- a/xbmc/platform/darwin/osx/CocoaInterface.mm
+++ b/xbmc/platform/darwin/osx/CocoaInterface.mm
@@ -170,7 +170,7 @@ char* Cocoa_MountPoint2DeviceName(char *path)
   // path will get realloc'ed and replaced IF this is a physical DVD.
   char* strDVDDevice;
   strDVDDevice = strdup(path);
-  if (strncasecmp(strDVDDevice, "/Volumes/", 9) == 0)
+  if (StringUtils::CompareNoCase(strDVDDevice, "/Volumes/", 9) == 0)
   {
     struct statfs *mntbufp;
     int i, mounts;

--- a/xbmc/platform/posix/PlatformDefs.h
+++ b/xbmc/platform/posix/PlatformDefs.h
@@ -53,7 +53,6 @@
 
 #define _fdopen fdopen
 #define _vsnprintf vsnprintf
-#define stricmp   strcasecmp
 #define strcmpi strcasecmp
 #define strnicmp  strncasecmp
 

--- a/xbmc/platform/posix/PlatformDefs.h
+++ b/xbmc/platform/posix/PlatformDefs.h
@@ -53,7 +53,6 @@
 
 #define _fdopen fdopen
 #define _vsnprintf vsnprintf
-#define strcmpi strcasecmp
 #define strnicmp  strncasecmp
 
 #define __stdcall

--- a/xbmc/platform/posix/PlatformDefs.h
+++ b/xbmc/platform/posix/PlatformDefs.h
@@ -53,7 +53,6 @@
 
 #define _fdopen fdopen
 #define _vsnprintf vsnprintf
-#define strnicmp  strncasecmp
 
 #define __stdcall
 #define __cdecl

--- a/xbmc/platform/posix/PlatformDefs.h
+++ b/xbmc/platform/posix/PlatformDefs.h
@@ -53,7 +53,6 @@
 
 #define _fdopen fdopen
 #define _vsnprintf vsnprintf
-#define _stricmp  strcasecmp
 #define stricmp   strcasecmp
 #define strcmpi strcasecmp
 #define strnicmp  strncasecmp

--- a/xbmc/platform/win32/PlatformDefs.h
+++ b/xbmc/platform/win32/PlatformDefs.h
@@ -28,9 +28,6 @@ typedef intptr_t      ssize_t;
 
 #define ftello64 _ftelli64
 #define fseeko64 _fseeki64
-#ifndef strcasecmp
-#define strcasecmp strcmpi
-#endif
 #ifndef strncasecmp
 #define strncasecmp strnicmp
 #endif

--- a/xbmc/platform/win32/PlatformDefs.h
+++ b/xbmc/platform/win32/PlatformDefs.h
@@ -28,9 +28,6 @@ typedef intptr_t      ssize_t;
 
 #define ftello64 _ftelli64
 #define fseeko64 _fseeki64
-#ifndef strncasecmp
-#define strncasecmp strnicmp
-#endif
 
 #if defined TARGET_WINDOWS_DESKTOP
 #define popen   _popen

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -958,7 +958,8 @@ extern "C" {
     for (; n1 != NULL; n1 = n2, n2 = NULL) {
       for (i = 0; i < c; i++, n1++) {
         len = strlen(*n1);
-        if (strnicmp(*n1, (const char *)bp, len) == 0) {
+        if (StringUtils::CompareNoCase(*n1, (const char*)bp, len) == 0)
+        {
           *tgt = i;
           return bp + len;
         }

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -86,7 +86,7 @@ bool CPlayListXML::Load( const std::string& strFileName )
   TiXmlElement *pRootElement = xmlDoc.RootElement();
 
   // If the stream does not contain "streams", still ok. Not an error.
-  if ( !pRootElement || stricmp( pRootElement->Value(), "streams" ) )
+  if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "streams"))
   {
     CLog::Log(LOGERROR, "Playlist %s has no <streams> root", strFileName.c_str());
     return false;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1221,16 +1221,16 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
     int iAction = 0; // overwrite
     // for backward compatibility
     const char* szAppend = pElement->Attribute("append");
-    if ((szAppend && stricmp(szAppend, "yes") == 0))
+    if ((szAppend && StringUtils::CompareNoCase(szAppend, "yes") == 0))
       iAction = 1;
     // action takes precedence if both attributes exist
     const char* szAction = pElement->Attribute("action");
     if (szAction)
     {
       iAction = 0; // overwrite
-      if (stricmp(szAction, "append") == 0)
+      if (StringUtils::CompareNoCase(szAction, "append") == 0)
         iAction = 1; // append
-      else if (stricmp(szAction, "prepend") == 0)
+      else if (StringUtils::CompareNoCase(szAction, "prepend") == 0)
         iAction = 2; // prepend
     }
     if (iAction == 0)
@@ -1277,16 +1277,16 @@ void CAdvancedSettings::GetCustomRegexps(TiXmlElement *pRootElement, std::vector
     int iAction = 0; // overwrite
     // for backward compatibility
     const char* szAppend = pElement->Attribute("append");
-    if ((szAppend && stricmp(szAppend, "yes") == 0))
+    if ((szAppend && StringUtils::CompareNoCase(szAppend, "yes") == 0))
       iAction = 1;
     // action takes precedence if both attributes exist
     const char* szAction = pElement->Attribute("action");
     if (szAction)
     {
       iAction = 0; // overwrite
-      if (stricmp(szAction, "append") == 0)
+      if (StringUtils::CompareNoCase(szAction, "append") == 0)
         iAction = 1; // append
-      else if (stricmp(szAction, "prepend") == 0)
+      else if (StringUtils::CompareNoCase(szAction, "prepend") == 0)
         iAction = 2; // prepend
     }
     if (iAction == 0)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -470,7 +470,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   }
 
   TiXmlElement *pRootElement = advancedXML.RootElement();
-  if (!pRootElement || strcmpi(pRootElement->Value(),"advancedsettings") != 0)
+  if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "advancedsettings") != 0)
   {
     CLog::Log(LOGERROR, "Error loading %s, no <advancedsettings> node", file.c_str());
     return;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -860,7 +860,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     // as altering it will do nothing - we don't write to advancedsettings.xml
     XMLUtils::GetInt(pRootElement, "loglevel", m_logLevelHint, LOG_LEVEL_NONE, LOG_LEVEL_MAX);
     const char* hide = pElement->Attribute("hide");
-    if (hide == NULL || strnicmp("false", hide, 5) != 0)
+    if (hide == NULL || StringUtils::CompareNoCase("false", hide, 5) != 0)
     {
       SettingPtr setting = CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_DEBUG_SHOWLOGINFO);
       if (setting != NULL)

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -99,7 +99,7 @@ bool CMediaManager::LoadSources()
     return false;
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
-  if ( !pRootElement || strcmpi(pRootElement->Value(), "mediasources") != 0)
+  if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "mediasources") != 0)
   {
     CLog::Log(LOGERROR, "Error loading %s, Line %d (%s)", MEDIA_SOURCES_XML, xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
     return false;

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -123,7 +123,8 @@ bool CRssManager::Load()
     if (pSet->QueryIntAttribute("id", &iId) == TIXML_SUCCESS)
     {
       RssSet set;
-      set.rtl = pSet->Attribute("rtl") != NULL && strcasecmp(pSet->Attribute("rtl"), "true") == 0;
+      set.rtl = pSet->Attribute("rtl") != NULL &&
+                StringUtils::CompareNoCase(pSet->Attribute("rtl"), "true") == 0;
       const TiXmlElement* pFeed = pSet->FirstChildElement("feed");
       while (pFeed != NULL)
       {

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -190,18 +190,18 @@ void CScraperParser::ParseExpression(const std::string& input, std::string& dest
     bool bInsensitive=true;
     const char* sensitive = pExpression->Attribute("cs");
     if (sensitive)
-      if (stricmp(sensitive,"yes") == 0)
+      if (StringUtils::CompareNoCase(sensitive, "yes") == 0)
         bInsensitive=false; // match case sensitive
 
     CRegExp::utf8Mode eUtf8 = CRegExp::autoUtf8;
     const char* const strUtf8 = pExpression->Attribute("utf8");
     if (strUtf8)
     {
-      if (stricmp(strUtf8, "yes") == 0)
+      if (StringUtils::CompareNoCase(strUtf8, "yes") == 0)
         eUtf8 = CRegExp::forceUtf8;
-      else if (stricmp(strUtf8, "no") == 0)
+      else if (StringUtils::CompareNoCase(strUtf8, "no") == 0)
         eUtf8 = CRegExp::asciiOnly;
-      else if (stricmp(strUtf8, "auto") == 0)
+      else if (StringUtils::CompareNoCase(strUtf8, "auto") == 0)
         eUtf8 = CRegExp::autoUtf8;
     }
 
@@ -222,12 +222,12 @@ void CScraperParser::ParseExpression(const std::string& input, std::string& dest
     bool bRepeat = false;
     const char* szRepeat = pExpression->Attribute("repeat");
     if (szRepeat)
-      if (stricmp(szRepeat,"yes") == 0)
+      if (StringUtils::CompareNoCase(szRepeat, "yes") == 0)
         bRepeat = true;
 
     const char* szClear = pExpression->Attribute("clear");
     if (szClear)
-      if (stricmp(szClear,"yes") == 0)
+      if (StringUtils::CompareNoCase(szClear, "yes") == 0)
         dest=""; // clear no matter if regexp fails
 
     bool bClean[MAX_SCRAPER_BUFFERS];
@@ -465,7 +465,7 @@ const std::string CScraperParser::Parse(const std::string& strTag,
   std::string tmp = m_param[iResult-1];
 
   const char* szClearBuffers = pChildElement->Attribute("clearbuffers");
-  if (!szClearBuffers || stricmp(szClearBuffers,"no") != 0)
+  if (!szClearBuffers || StringUtils::CompareNoCase(szClearBuffers, "no") != 0)
     ClearBuffers();
 
   return tmp;

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -74,12 +74,12 @@ bool CScraperUrl::ParseElement(const TiXmlElement* element)
   url.m_url = element->FirstChild()->Value();
   url.m_spoof = XMLUtils::GetAttribute(element, "spoof");
   const char* szPost=element->Attribute("post");
-  if (szPost && stricmp(szPost,"yes") == 0)
+  if (szPost && StringUtils::CompareNoCase(szPost, "yes") == 0)
     url.m_post = true;
   else
     url.m_post = false;
   const char* szIsGz=element->Attribute("gzip");
-  if (szIsGz && stricmp(szIsGz,"yes") == 0)
+  if (szIsGz && StringUtils::CompareNoCase(szIsGz, "yes") == 0)
     url.m_isgz = true;
   else
     url.m_isgz = false;
@@ -88,7 +88,7 @@ bool CScraperUrl::ParseElement(const TiXmlElement* element)
   const char* szType = element->Attribute("type");
   url.m_type = URL_TYPE_GENERAL;
   url.m_season = -1;
-  if (szType && stricmp(szType,"season") == 0)
+  if (szType && StringUtils::CompareNoCase(szType, "season") == 0)
   {
     url.m_type = URL_TYPE_SEASON;
     const char* szSeason = element->Attribute("season");

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -408,21 +408,24 @@ bool StringUtils::EqualsNoCase(const char *s1, const char *s2)
   return true;
 }
 
-int StringUtils::CompareNoCase(const std::string &str1, const std::string &str2)
+int StringUtils::CompareNoCase(const std::string& str1, const std::string& str2, size_t n /* = 0 */)
 {
-  return CompareNoCase(str1.c_str(), str2.c_str());
+  return CompareNoCase(str1.c_str(), str2.c_str(), n);
 }
 
-int StringUtils::CompareNoCase(const char *s1, const char *s2)
+int StringUtils::CompareNoCase(const char* s1, const char* s2, size_t n /* = 0 */)
 {
   char c2; // we need only one char outside the loop
+  size_t index = 0;
   do
   {
     const char c1 = *s1++; // const local variable should help compiler to optimize
     c2 = *s2++;
+    index++;
     if (c1 != c2 && ::tolower(c1) != ::tolower(c2)) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
       return ::tolower(c1) - ::tolower(c2);
-  } while (c2 != '\0'); // At this point, we know c1 == c2, so there's no need to test them both.
+  } while (c2 != '\0' &&
+           index != n); // At this point, we know c1 == c2, so there's no need to test them both.
   return 0;
 }
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -113,8 +113,8 @@ public:
   static bool EqualsNoCase(const std::string &str1, const std::string &str2);
   static bool EqualsNoCase(const std::string &str1, const char *s2);
   static bool EqualsNoCase(const char *s1, const char *s2);
-  static int  CompareNoCase(const std::string &str1, const std::string &str2);
-  static int  CompareNoCase(const char *s1, const char *s2);
+  static int CompareNoCase(const std::string& str1, const std::string& str2, size_t n = 0);
+  static int CompareNoCase(const char* s1, const char* s2, size_t n = 0);
   static int ReturnDigits(const std::string &str);
   static std::string Left(const std::string &str, size_t count);
   static std::string Mid(const std::string &str, size_t first, size_t count = std::string::npos);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -263,7 +263,8 @@ void URIUtils::GetCommonPath(std::string& strParent, const std::string& strPath)
 {
   // find the common path of parent and path
   unsigned int j = 1;
-  while (j <= std::min(strParent.size(), strPath.size()) && strnicmp(strParent.c_str(), strPath.c_str(), j) == 0)
+  while (j <= std::min(strParent.size(), strPath.size()) &&
+         StringUtils::CompareNoCase(strParent, strPath, j) == 0)
     j++;
   strParent.erase(j - 1);
   // they should at least share a / at the end, though for things such as path/cd1 and path/cd2 there won't be

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -9,9 +9,6 @@
 #include "XMLUtils.h"
 #include "URL.h"
 #include "StringUtils.h"
-#ifdef TARGET_WINDOWS
-#include "PlatformDefs.h" //for strcasecmp
-#endif
 
 bool XMLUtils::GetHex(const TiXmlNode* pRootNode, const char* strTag, uint32_t& hexValue)
 {
@@ -121,7 +118,7 @@ bool XMLUtils::GetString(const TiXmlNode* pRootNode, const char* strTag, std::st
   if (pNode != NULL)
   {
     strStringValue = pNode->ValueStr();
-    if (encoded && strcasecmp(encoded,"yes") == 0)
+    if (encoded && StringUtils::CompareNoCase(encoded, "yes") == 0)
       strStringValue = CURL::Decode(strStringValue);
     return true;
   }
@@ -160,7 +157,7 @@ bool XMLUtils::GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag,
       bResult = true;
       strTemp = node->FirstChild()->Value();
       const char* clear=node->Attribute("clear");
-      if (strStringValue.empty() || (clear && strcasecmp(clear,"true")==0))
+      if (strStringValue.empty() || (clear && StringUtils::CompareNoCase(clear, "true") == 0))
         strStringValue = strTemp;
       else
         strStringValue += strSeparator+strTemp;
@@ -190,7 +187,7 @@ bool XMLUtils::GetStringArray(const TiXmlNode* pRootNode, const char* strTag, st
       strTemp = node->FirstChild()->ValueStr();
 
       const char* clearAttr = node->Attribute("clear");
-      if (clearAttr && strcasecmp(clearAttr, "true") == 0)
+      if (clearAttr && StringUtils::CompareNoCase(clearAttr, "true") == 0)
         arrayValue.clear();
 
       if (strTemp.empty())
@@ -220,7 +217,7 @@ bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, std::stri
   if (pNode != NULL)
   {
     strStringValue = pNode->Value();
-    if (encoded && strcasecmp(encoded,"yes") == 0)
+    if (encoded && StringUtils::CompareNoCase(encoded, "yes") == 0)
       strStringValue = CURL::Decode(strStringValue);
     return true;
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10071,9 +10071,9 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
     // first count the number of items...
     while (movie)
     {
-      if (strnicmp(movie->Value(), MediaTypeMovie, 5)==0 ||
-          strnicmp(movie->Value(), MediaTypeTvShow, 6)==0 ||
-          strnicmp(movie->Value(), MediaTypeMusicVideo,10)==0 )
+      if (StringUtils::CompareNoCase(movie->Value(), MediaTypeMovie, 5) == 0 ||
+          StringUtils::CompareNoCase(movie->Value(), MediaTypeTvShow, 6) == 0 ||
+          StringUtils::CompareNoCase(movie->Value(), MediaTypeMusicVideo, 10) == 0)
         total++;
       movie = movie->NextSiblingElement();
     }
@@ -10116,7 +10116,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
     while (movie)
     {
       CVideoInfoTag info;
-      if (strnicmp(movie->Value(), MediaTypeMovie, 5) == 0)
+      if (StringUtils::CompareNoCase(movie->Value(), MediaTypeMovie, 5) == 0)
       {
         info.Load(movie);
         CFileItem item(info);
@@ -10150,7 +10150,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         scanner.AddVideo(&item, CONTENT_MOVIES, useFolders, true, NULL, true);
         current++;
       }
-      else if (strnicmp(movie->Value(), MediaTypeMusicVideo, 10) == 0)
+      else if (StringUtils::CompareNoCase(movie->Value(), MediaTypeMusicVideo, 10) == 0)
       {
         info.Load(movie);
         CFileItem item(info);
@@ -10165,7 +10165,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         scanner.AddVideo(&item, CONTENT_MUSICVIDEOS, useFolders, true, NULL, true);
         current++;
       }
-      else if (strnicmp(movie->Value(), MediaTypeTvShow, 6) == 0)
+      else if (StringUtils::CompareNoCase(movie->Value(), MediaTypeTvShow, 6) == 0)
       {
         // load the TV show in.  NOTE: This deletes all episodes under the TV Show, which may not be
         // what we desire.  It may make better sense to only delete (or even better, update) the show information

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1171,7 +1171,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   if (epguide)
   {
     // DEPRECIATE ME - support for old XML-encoded <episodeguide> blocks.
-    if (epguide->FirstChild() && strnicmp("<episodeguide", epguide->FirstChild()->Value(), 13) == 0)
+    if (epguide->FirstChild() &&
+        StringUtils::CompareNoCase("<episodeguide", epguide->FirstChild()->Value(), 13) == 0)
       m_strEpisodeGuide = epguide->FirstChild()->Value();
     else
     {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1053,7 +1053,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         thumb = thumb->NextSiblingElement("thumb");
       }
       const char* clear=node->Attribute("clear");
-      if (clear && stricmp(clear,"true"))
+      if (clear && StringUtils::CompareNoCase(clear, "true"))
         m_cast.clear();
       m_cast.push_back(info);
     }
@@ -1102,7 +1102,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     if (pValue)
     {
       const char* clear=node->Attribute("clear");
-      if (clear && stricmp(clear,"true")==0)
+      if (clear && StringUtils::CompareNoCase(clear, "true") == 0)
         artist.clear();
       std::vector<std::string> newArtists = StringUtils::Split(pValue, itemSeparator);
       artist.insert(artist.end(), newArtists.begin(), newArtists.end());

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -184,14 +184,14 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
   bool hastag = false;
   while ((avtag = av_dict_get(m_fctx->metadata, "", avtag, AV_DICT_IGNORE_SUFFIX)))
   {
-    if (strcasecmp(avtag->key, "title") == 0)
+    if (StringUtils::CompareNoCase(avtag->key, "title") == 0)
       tag.SetTitle(avtag->value);
-    else if (strcasecmp(avtag->key, "director") == 0)
+    else if (StringUtils::CompareNoCase(avtag->key, "director") == 0)
     {
       std::vector<std::string> dirs = StringUtils::Split(avtag->value, " / ");
       tag.SetDirector(dirs);
     }
-    else if (strcasecmp(avtag->key, "date_released") == 0)
+    else if (StringUtils::CompareNoCase(avtag->key, "date_released") == 0)
       tag.SetYear(atoi(avtag->value));
     hastag = true;
   }

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -98,7 +98,7 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
     XOutput xoutput;
     xoutput.name = output->Attribute("name");
     StringUtils::Trim(xoutput.name);
-    xoutput.isConnected = (strcasecmp(output->Attribute("connected"), "true") == 0);
+    xoutput.isConnected = (StringUtils::CompareNoCase(output->Attribute("connected"), "true") == 0);
     xoutput.screen = screennum;
     xoutput.w = (output->Attribute("w") != NULL ? atoi(output->Attribute("w")) : 0);
     xoutput.h = (output->Attribute("h") != NULL ? atoi(output->Attribute("h")) : 0);
@@ -107,8 +107,9 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
     xoutput.crtc = (output->Attribute("crtc") != NULL ? atoi(output->Attribute("crtc")) : 0);
     xoutput.wmm = (output->Attribute("wmm") != NULL ? atoi(output->Attribute("wmm")) : 0);
     xoutput.hmm = (output->Attribute("hmm") != NULL ? atoi(output->Attribute("hmm")) : 0);
-    if (output->Attribute("rotation") != NULL
-        && (strcasecmp(output->Attribute("rotation"), "left") == 0 || strcasecmp(output->Attribute("rotation"), "right") == 0))
+    if (output->Attribute("rotation") != NULL &&
+        (StringUtils::CompareNoCase(output->Attribute("rotation"), "left") == 0 ||
+         StringUtils::CompareNoCase(output->Attribute("rotation"), "right") == 0))
     {
       xoutput.isRotated = true;
     }
@@ -127,8 +128,8 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
       xmode.hz = atof(mode->Attribute("hz"));
       xmode.w = atoi(mode->Attribute("w"));
       xmode.h = atoi(mode->Attribute("h"));
-      xmode.isPreferred = (strcasecmp(mode->Attribute("preferred"), "true") == 0);
-      xmode.isCurrent = (strcasecmp(mode->Attribute("current"), "true") == 0);
+      xmode.isPreferred = (StringUtils::CompareNoCase(mode->Attribute("preferred"), "true") == 0);
+      xmode.isCurrent = (StringUtils::CompareNoCase(mode->Attribute("current"), "true") == 0);
       xoutput.modes.push_back(xmode);
       if (xmode.isCurrent)
         hascurrent = true;
@@ -390,7 +391,7 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
   }
 
   TiXmlElement *pRootElement = xmlDoc.RootElement();
-  if (strcasecmp(pRootElement->Value(), "modelines") != 0)
+  if (StringUtils::CompareNoCase(pRootElement->Value(), "modelines") != 0)
   {
     //! @todo ERROR
     return;


### PR DESCRIPTION
strcmp, strcasecmp and their derivatives aren't cross platform so let's just use our method and remove the defines in PlatformDefs.h