### PR TITLE
[backport][addons] fix stupid circumstance with addon settings on folder with file extension

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -161,9 +161,7 @@ void CAddon::SaveSettings(void)
 
   // break down the path into directories
   std::string strAddon = URIUtils::GetDirectory(m_userSettingsPath);
-  URIUtils::RemoveSlashAtEnd(strAddon);
   std::string strRoot = URIUtils::GetDirectory(strAddon);
-  URIUtils::RemoveSlashAtEnd(strRoot);
 
   // create the individual folders
   if (!CDirectory::Exists(strRoot))


### PR DESCRIPTION
## Description

Found this when adding settings to vfs.rar.

There called this place with "special://profile/addon_data/vfs.rar", this was seen
by "CFileDirectoryFactory::Create" as a file and tried to open with vfs.rar addon.

This logically leads to an error because it is only a folder.

The slash is left now on the folder so that it is recognized as a folder.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
Got a big question mark when I added the settings and they weren't saved but worked when addon was disabled.

That these slashes have been omitted has been in history since Kodi's "github". Do not see the need to leave them out and the test went well.

Backport of https://github.com/xbmc/xbmc/pull/17449.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
