### PR TITLE
remove support for 'XBMC.' prefixed built-in commands

### DIFF
--- a/addons/service.xbmc.versioncheck/lib/common.py
+++ b/addons/service.xbmc.versioncheck/lib/common.py
@@ -76,7 +76,7 @@ def get_password_from_user():
     return pwd
 
 def message_upgrade_success():
-    xbmc.executebuiltin("XBMC.Notification(%s, %s, %d, %s)" %(ADDONNAME,
+    xbmc.executebuiltin("Notification(%s, %s, %d, %s)" %(ADDONNAME,
                                                               localise(32013),
                                                               15000,
                                                               ICON))

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1040,8 +1040,6 @@ void CUtil::SplitExecFunction(const std::string &execString, std::string &functi
 
   // remove any whitespace, and the standard prefix (if it exists)
   StringUtils::Trim(function);
-  if( StringUtils::StartsWithNoCase(function, "xbmc.") )
-    function.erase(0, 5);
 
   SplitParams(paramString, parameters);
 }

--- a/xbmc/guilib/GUIButtonControl.dox
+++ b/xbmc/guilib/GUIButtonControl.dox
@@ -35,7 +35,7 @@ action(s) should be performed when pushed.
       <textoffsetx></textoffsetx>
       <textoffsety></textoffsety>
       <pulseonselect></pulseonselect>
-      <onclick>XBMC.ActivateWindow(MyVideos)</onclick>
+      <onclick>ActivateWindow(MyVideos)</onclick>
       <onfocus>-</onfocus>
       <onunfocus>-</onunfocus>
       <onup>2</onup>

--- a/xbmc/interfaces/builtins/Builtins.cpp
+++ b/xbmc/interfaces/builtins/Builtins.cpp
@@ -142,7 +142,6 @@ void CBuiltins::GetHelp(std::string &help)
 
 int CBuiltins::Execute(const std::string& execString)
 {
-  // Deprecated. Get the text after the "XBMC."
   std::string execute;
   std::vector<std::string> params;
   CUtil::SplitExecFunction(execString, execute, params);


### PR DESCRIPTION
using a `XBMC.` prefix on built-in commands was deprecated many moons ago.
the initial cleanup was done in https://github.com/xbmc/xbmc/pull/5579
now it's finally time to kill it.

@enen92 