### PR TITLE
SWIG: find also v4

### DIFF
--- a/cmake/modules/FindSWIG.cmake
+++ b/cmake/modules/FindSWIG.cmake
@@ -8,7 +8,7 @@
 # SWIG_FOUND - system has SWIG
 # SWIG_EXECUTABLE - the SWIG executable
 
-find_program(SWIG_EXECUTABLE NAMES swig3.0 swig2.0 swig
+find_program(SWIG_EXECUTABLE NAMES swig4.0 swig3.0 swig2.0 swig
                              PATH_SUFFIXES swig)
 if(SWIG_EXECUTABLE)
   execute_process(COMMAND ${SWIG_EXECUTABLE} -swiglib


### PR DESCRIPTION
## Description

`swig-4.0.1` is now available, but `kodi` doesn't automatically find/use it when an older version is available (eg. swig-3.0.12), because `kodi` is not looking for `swig4.0`.

## Motivation and Context

Kodi should find the latest available swig binary on systems that have both `swig3.0` and `swig4.0` available - the former in system, the latter in toolchain (with toolchain taking preference).

## How Has This Been Tested?

With `/usr/bin/swig3.0` and `${TOOLCHAIN}/bin/swig4.0` installed.

Before:
```
-- Found SWIG: /usr/bin/swig3.0 (found version "3.0.12")
```
After:
```
-- Found SWIG: /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi4.arm-9.80-devel/toolchain/bin/swig4.0 (found version "4.0.1")
```

## Screenshots (if appropriate):

N/A

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
