### PR TITLE
[addons][inputstream] don't give addon instance class & add blocksize ask support

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -23,14 +23,6 @@
 #include "cores/VideoPlayer/Interface/Addon/DemuxPacket.h"
 #endif
 
-namespace kodi
-{
-namespace addon
-{
-class CInstanceInputStream;
-}
-} // namespace kodi
-
 //Increment this level always if you add features which can lead to compile failures in the addon
 #define INPUTSTREAM_VERSION_LEVEL 2
 
@@ -316,7 +308,7 @@ extern "C"
   struct AddonInstance_InputStream;
   typedef struct KodiToAddonFuncTable_InputStream /* internal */
   {
-    kodi::addon::CInstanceInputStream* addonInstance;
+    KODI_HANDLE addonInstance;
 
     bool(__cdecl* open)(const AddonInstance_InputStream* instance, INPUTSTREAM* props);
     void(__cdecl* close)(const AddonInstance_InputStream* instance);
@@ -720,63 +712,66 @@ private:
 
   inline static bool ADDON_Open(const AddonInstance_InputStream* instance, INPUTSTREAM* props)
   {
-    return instance->toAddon.addonInstance->Open(*props);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->Open(*props);
   }
 
   inline static void ADDON_Close(const AddonInstance_InputStream* instance)
   {
-    instance->toAddon.addonInstance->Close();
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->Close();
   }
 
   inline static void ADDON_GetCapabilities(const AddonInstance_InputStream* instance,
                                            INPUTSTREAM_CAPABILITIES* capabilities)
   {
-    instance->toAddon.addonInstance->GetCapabilities(*capabilities);
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->GetCapabilities(*capabilities);
   }
 
 
   // IDemux
   inline static struct INPUTSTREAM_IDS ADDON_GetStreamIds(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->GetStreamIds();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetStreamIds();
   }
 
   inline static struct INPUTSTREAM_INFO ADDON_GetStream(const AddonInstance_InputStream* instance,
                                                         int streamid)
   {
-    return instance->toAddon.addonInstance->GetStream(streamid);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetStream(streamid);
   }
 
   inline static void ADDON_EnableStream(const AddonInstance_InputStream* instance,
                                         int streamid,
                                         bool enable)
   {
-    instance->toAddon.addonInstance->EnableStream(streamid, enable);
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->EnableStream(streamid, enable);
   }
 
   inline static bool ADDON_OpenStream(const AddonInstance_InputStream* instance, int streamid)
   {
-    return instance->toAddon.addonInstance->OpenStream(streamid);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->OpenStream(streamid);
   }
 
   inline static void ADDON_DemuxReset(const AddonInstance_InputStream* instance)
   {
-    instance->toAddon.addonInstance->DemuxReset();
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxReset();
   }
 
   inline static void ADDON_DemuxAbort(const AddonInstance_InputStream* instance)
   {
-    instance->toAddon.addonInstance->DemuxAbort();
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxAbort();
   }
 
   inline static void ADDON_DemuxFlush(const AddonInstance_InputStream* instance)
   {
-    instance->toAddon.addonInstance->DemuxFlush();
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxFlush();
   }
 
   inline static DemuxPacket* ADDON_DemuxRead(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->DemuxRead();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxRead();
   }
 
   inline static bool ADDON_DemuxSeekTime(const AddonInstance_InputStream* instance,
@@ -784,80 +779,82 @@ private:
                                          bool backwards,
                                          double* startpts)
   {
-    return instance->toAddon.addonInstance->DemuxSeekTime(time, backwards, *startpts);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->DemuxSeekTime(time, backwards, *startpts);
   }
 
   inline static void ADDON_DemuxSetSpeed(const AddonInstance_InputStream* instance, int speed)
   {
-    instance->toAddon.addonInstance->DemuxSetSpeed(speed);
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxSetSpeed(speed);
   }
 
   inline static void ADDON_SetVideoResolution(const AddonInstance_InputStream* instance,
                                               int width,
                                               int height)
   {
-    instance->toAddon.addonInstance->SetVideoResolution(width, height);
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->SetVideoResolution(width, height);
   }
 
 
   // IDisplayTime
   inline static int ADDON_GetTotalTime(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->GetTotalTime();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetTotalTime();
   }
 
   inline static int ADDON_GetTime(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->GetTime();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetTime();
   }
 
   // ITime
   inline static bool ADDON_GetTimes(const AddonInstance_InputStream* instance,
                                     INPUTSTREAM_TIMES* times)
   {
-    return instance->toAddon.addonInstance->GetTimes(*times);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetTimes(*times);
   }
 
   // IPosTime
   inline static bool ADDON_PosTime(const AddonInstance_InputStream* instance, int ms)
   {
-    return instance->toAddon.addonInstance->PosTime(ms);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->PosTime(ms);
   }
 
   inline static int ADDON_GetChapter(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->GetChapter();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapter();
   }
 
   inline static int ADDON_GetChapterCount(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->GetChapterCount();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapterCount();
   }
 
   inline static const char* ADDON_GetChapterName(const AddonInstance_InputStream* instance, int ch)
   {
-    return instance->toAddon.addonInstance->GetChapterName(ch);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapterName(ch);
   }
 
   inline static int64_t ADDON_GetChapterPos(const AddonInstance_InputStream* instance, int ch)
   {
-    return instance->toAddon.addonInstance->GetChapterPos(ch);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapterPos(ch);
   }
 
   inline static bool ADDON_SeekChapter(const AddonInstance_InputStream* instance, int ch)
   {
-    return instance->toAddon.addonInstance->SeekChapter(ch);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->SeekChapter(ch);
   }
 
   // Seekable (mandatory)
   inline static bool ADDON_CanPauseStream(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->CanPauseStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->CanPauseStream();
   }
 
   inline static bool ADDON_CanSeekStream(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->CanSeekStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->CanSeekStream();
   }
 
 
@@ -865,34 +862,36 @@ private:
                                      uint8_t* buffer,
                                      unsigned int bufferSize)
   {
-    return instance->toAddon.addonInstance->ReadStream(buffer, bufferSize);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->ReadStream(buffer, bufferSize);
   }
 
   inline static int64_t ADDON_SeekStream(const AddonInstance_InputStream* instance,
                                          int64_t position,
                                          int whence)
   {
-    return instance->toAddon.addonInstance->SeekStream(position, whence);
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+        ->SeekStream(position, whence);
   }
 
   inline static int64_t ADDON_PositionStream(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->PositionStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->PositionStream();
   }
 
   inline static int64_t ADDON_LengthStream(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->LengthStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->LengthStream();
   }
 
   inline static void ADDON_PauseStream(const AddonInstance_InputStream* instance, double time)
   {
-    instance->toAddon.addonInstance->PauseStream(time);
+    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->PauseStream(time);
   }
 
   inline static bool ADDON_IsRealTimeStream(const AddonInstance_InputStream* instance)
   {
-    return instance->toAddon.addonInstance->IsRealTimeStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->IsRealTimeStream();
   }
 
   AddonInstance_InputStream* m_instanceData;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -86,7 +86,7 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.11"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.12"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.7"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -200,6 +200,14 @@ int64_t CInputStreamAddon::GetLength()
   return m_struct.toAddon.length_stream(&m_struct);
 }
 
+int CInputStreamAddon::GetBlockSize()
+{
+  if (!m_struct.toAddon.block_size_stream)
+    return 0;
+
+  return m_struct.toAddon.block_size_stream(&m_struct);
+}
+
 bool CInputStreamAddon::Pause(double time)
 {
   if (!m_struct.toAddon.pause_stream)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -55,6 +55,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool Pause(double dTime) override;
   int64_t GetLength() override;
+  int GetBlockSize() override;
   bool IsEOF() override;
   bool CanSeek() override; //! @todo drop this
   bool CanPause() override;


### PR DESCRIPTION
## Description

This two commits are parts of https://github.com/xbmc/xbmc/pull/17438 and intended to make it smaller.

API inputstream version increased to **2.0.12**, the min stays the same.

Commit 1:
-----------------------------
**[addons][inputstream] don't give addon instance class to Kodi**

This old breaks "C" ABI interface and not possible to use as this only.

This is a small and not critical change, therefore introduced here, since other commit also require an API version increase.

Not everything "C" ABI is compatible with this, but it becomes more manageable with such smaller commits.

Commit 2:
-----------------------------
**[addons][inputstream] add blocksize ask support**

This required on some streams to define wanted blocksize for read on addon. Specially needed for PVR addons in future.

Tested with reworked pvr.vdr.vnsi and by use of this a big stream read improvement was come.

But I can also imagine that it is good at inputstream.rtmp, since this is the only addon that runs without its own demuxer.
@notspiff what you think about?

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
Make the addon interface better and cleaner.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?

Tested with `inputstream.adaptive`, `inputstream.ffmpegdirect` and `inputstream.rtmp`
- Kodi new <-> addon new
- Kodi old <-> addon new
- Kodi new <-> addon old

Everything has worked correct on test streams.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
