### PR TITLE
[Doxygen] Fix builtin functions and infolabels/bools table. Whitespace cleanup.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5800,7 +5800,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.IsNew`</b>,
 ///                  \anchor ListItem_IsNew
 ///                  _boolean_,
-///     @return **True** if the item is new (for example, a Live TV show that will be first aired).
+///     @return **True** if the item is new (for example\, a Live TV show that will be first aired).
 ///     <p><hr>
 ///     @skinning_v19 **[New Infolabel]** \link ListItem_IsNew `ListItem.IsNew`\endlink
 ///     <p>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -86,14 +86,14 @@ typedef struct
 ///
 /// Skins can use infolabels with <b>$INFO[infolabel]</b> or the <b>\<info\></b> tag. Scripts
 /// can read infolabels with <b>xbmc.getInfoLabel('infolabel')</b>.
-/// 
+///
 /// @todo [docs] Improve the description and create links for functions
 /// @todo [docs] Separate boolean conditions from infolabels
 /// @todo [docs] Order items alphabetically within subsections for a better search experience
 /// @todo [docs] Order subsections alphabetically
 /// @todo [docs] Use links instead of bold values for infolabels/bools
 /// so we can use a link to point users when providing help
-/// 
+///
 
 
 /// \page modules__infolabels_boolean_conditions
@@ -139,7 +139,7 @@ typedef struct
 ///                  _boolean_,
 ///     @return **True** if the info is empty.
 ///     @param info - infolabel
-///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \, 
+///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \,
 ///     \link ListItem_Genre `ListItem.Genre` \endlink.
 ///     Please note that string can also be a `$LOCALIZE[]`.
 ///     Also note that in a panelview or similar this only works on the focused item
@@ -153,7 +153,7 @@ typedef struct
 ///     @return **True** if the info is equal to the given string.
 ///     @param info - infolabel
 ///     @param string - comparison string
-///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \, 
+///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \,
 ///     \link ListItem_Genre `ListItem.Genre` \endlink.
 ///     Please note that string can also be a `$LOCALIZE[]`.
 ///     Also note that in a panelview or similar this only works on the focused item
@@ -167,7 +167,7 @@ typedef struct
 ///     @return **True** if the info starts with the given substring.
 ///     @param info - infolabel
 ///     @param substring - substring to check
-///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \, 
+///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \,
 ///     \link ListItem_Genre `ListItem.Genre` \endlink.
 ///     Please note that string can also be a `$LOCALIZE[]`.
 ///     Also note that in a panelview or similar this only works on the focused item
@@ -181,7 +181,7 @@ typedef struct
 ///     @return **True** if the info ends with the given substring.
 ///     @param info - infolabel
 ///     @param substring - substring to check
-///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \, 
+///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \,
 ///     \link ListItem_Genre `ListItem.Genre` \endlink.
 ///     Please note that string can also be a `$LOCALIZE[]`.
 ///     Also note that in a panelview or similar this only works on the focused item
@@ -195,7 +195,7 @@ typedef struct
 ///     @return **True** if the info contains the given substring.
 ///     @param info - infolabel
 ///     @param substring - substring to check
-///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \, 
+///     @note **Example of info:** \link ListItem_Title `ListItem.Title` \endlink \,
 ///     \link ListItem_Genre `ListItem.Genre` \endlink.
 ///     Please note that string can also be a `$LOCALIZE[]`.
 ///     Also note that in a panelview or similar this only works on the focused item
@@ -550,7 +550,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   \table_row3{   <b>`Player.FilenameAndPath`</b>,
 ///                  \anchor Player_FilenameAndPath
 ///                  _string_,
-///     @return The full path with filename of the currently 
+///     @return The full path with filename of the currently
 ///     playing song or movie
 ///     <p>
 ///   }
@@ -583,14 +583,14 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   \table_row3{   <b>`Player.ChannelPreviewActive`</b>,
 ///                  \anchor Player_ChannelPreviewActive
 ///                  _boolean_,
-///     @return **True** if PVR channel preview is active (used 
+///     @return **True** if PVR channel preview is active (used
 ///     channel tag different from played tag)
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.TempoEnabled`</b>,
 ///                  \anchor Player_TempoEnabled
 ///                  _boolean_,
-///     @return **True** if player supports tempo (i.e. speed up/down normal 
+///     @return **True** if player supports tempo (i.e. speed up/down normal
 ///     playback speed)
 ///     <p><hr>
 ///     @skinning_v17 **[New Boolean Condition]** \link Player_TempoEnabled `Player.TempoEnabled`\endlink
@@ -608,9 +608,9 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   \table_row3{   <b>`Player.PlaySpeed`</b>,
 ///                  \anchor Player_PlaySpeed
 ///                  _string_,
-///     @return The player playback speed with the format `%1.2f` (1.00 means normal 
+///     @return The player playback speed with the format `%1.2f` (1.00 means normal
 ///     playback speed).
-///     @note For Tempo\, the default range is 0.80 - 1.50 (it can be changed 
+///     @note For Tempo\, the default range is 0.80 - 1.50 (it can be changed
 ///     in advanced settings). If \ref Player_PlaySpeed "Player.PlaySpeed" returns a value different from 1.00
 ///     and \ref Player_IsTempo "Player.IsTempo" is false it means the player is in ff/rw mode.
 ///     <p>
@@ -618,7 +618,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   \table_row3{   <b>`Player.HasResolutions`</b>,
 ///                  \anchor Player_HasResolutions
 ///                  _boolean_,
-///     @return **True** if the player is allowed to switch resolution and refresh rate 
+///     @return **True** if the player is allowed to switch resolution and refresh rate
 ///     (i.e. if whitelist modes are configured in Kodi's System/Display settings)
 ///     <p><hr>
 ///     @skinning_v18 **[New Boolean Condition]** \link Player_HasResolutions `Player.HasResolutions`\endlink
@@ -627,7 +627,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   \table_row3{   <b>`Player.HasPrograms`</b>,
 ///                  \anchor Player_HasPrograms
 ///                  _boolean_,
-///     @return **True** if the media file being played has programs\, i.e. groups of streams. 
+///     @return **True** if the media file being played has programs\, i.e. groups of streams.
 ///     @note Ex: if a media file has multiple streams (quality\, channels\, etc) a program represents
 ///     a particular stream combo.
 ///     <p>
@@ -648,7 +648,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     the icon will be returned\, if available.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link Player_Icon `Player.Icon`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.Cutlist`</b>,
 ///                  \anchor Player_Cutlist
@@ -1115,7 +1115,7 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///                  _boolean_,
 ///     @return **True** if PVR is supported from Kodi.
 ///     @note normally always true
-///     
+///
 ///   }
 ///   \table_row3{   <b>`System.HasPVRAddon`</b>,
 ///                  \anchor System_HasPVRAddon
@@ -1411,7 +1411,7 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///   \table_row3{   <b>`System.FriendlyName`</b>,
 ///                  \anchor System_FriendlyName
 ///                  _string_,
-///     @return The Kodi instance name. 
+///     @return The Kodi instance name.
 ///     @note It will auto append (%hostname%) in case
 ///     the device name was not changed. eg. "Kodi (htpc)"
 ///     <p>
@@ -1583,7 +1583,7 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///   \table_row3{   <b>`System.GetBool(boolean)`</b>,
 ///                  \anchor System_GetBool
 ///                  _string_,
-///     @return The value of any standard system boolean setting. 
+///     @return The value of any standard system boolean setting.
 ///     @note Will not work with settings in advancedsettings.xml
 ///     <p>
 ///   }
@@ -2038,9 +2038,9 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///                  _string_,
 ///     @return The name of the dj who remixed the selected song.
 ///     @todo So maybe rather than a row each have one entry for Role.XXXXX with composer\, arranger etc. as listed values
-///     @note MusicPlayer.Property(Role.any_custom_role) also works\, 
+///     @note MusicPlayer.Property(Role.any_custom_role) also works\,
 ///     where any_custom_role could be an instrument violin or some other production activity e.g. sound engineer.
-///     The roles listed (composer\, arranger etc.) are standard ones but there are many possible. 
+///     The roles listed (composer\, arranger etc.) are standard ones but there are many possible.
 ///     Music file tagging allows for the musicians and all other people involved in the recording to be added\, Kodi
 ///     will gathers and stores that data\, and it is availlable to GUI.
 ///     <p><hr>
@@ -2104,7 +2104,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///                  _string_,
 ///     @return Artist(s) of the song which has an offset `number` with respect
 ///     to the start of the playlist.
-///     @param number - the offset of the song with respect to 
+///     @param number - the offset of the song with respect to
 ///     the start of the playlist
 ///     <p>
 ///   }
@@ -2126,7 +2126,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     @return The sortname of the currently playing Artist.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link MusicPlayer_Property_Artist_Sortname `MusicPlayer.Property(Artist_Sortname)`\endlink
-///     <p> 
+///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.Property(Artist_Type)`</b>,
 ///                  \anchor MusicPlayer_Property_Artist_Type
@@ -2135,7 +2135,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     group\, orchestra\, choir etc.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link MusicPlayer_Property_Artist_Type `MusicPlayer.Property(Artist_Type)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.Property(Artist_Gender)`</b>,
 ///                  \anchor MusicPlayer_Property_Artist_Gender
@@ -2144,7 +2144,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     female\, other.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link MusicPlayer_Property_Artist_Gender `MusicPlayer.Property(Artist_Gender)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.Property(Artist_Disambiguation)`</b>,
 ///                  \anchor MusicPlayer_Property_Artist_Disambiguation
@@ -2153,7 +2153,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     from others with the same name.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link MusicPlayer_Property_Artist_Disambiguation `MusicPlayer.Property(Artist_Disambiguation)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.Property(Artist_Born)`</b>,
 ///                  \anchor MusicPlayer_Property_Artist_Born
@@ -2303,7 +2303,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     @return The scraped rating of the currently playing song (1-10).
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link MusicPlayer_UserRating `MusicPlayer.UserRating`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`MusicPlayer.Votes`</b>,
 ///                  \anchor MusicPlayer_Votes
@@ -2442,7 +2442,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///                  _string_,
 ///     @return The track number of the song with an offset `number`
 ///     with respect to start of the playlist.
-///     @param number - The offset number of the song with respect 
+///     @param number - The offset number of the song with respect
 ///     to start of the playlist
 ///     <p>
 ///   }
@@ -3190,7 +3190,7 @@ const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
 ///       - original (Shrink to the original resolution)
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link RetroPlayer_StretchMode `RetroPlayer.StretchMode`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`RetroPlayer.VideoRotation`</b>,
 ///                  \anchor RetroPlayer_VideoRotation
@@ -3204,7 +3204,7 @@ const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
 ///       - 270 (Shown in the GUI as 90 degrees)
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link RetroPlayer_VideoRotation `RetroPlayer.VideoRotation`\endlink
-///     <p>  
+///     <p>
 ///   }
 /// \table_end
 ///
@@ -3403,14 +3403,14 @@ const infomap mediacontainer[] = {{ "hasfiles",         CONTAINER_HASFILES },
 ///   \table_row3{   <b>`Container(id).NumItems`</b>,
 ///                  \anchor Container_NumItems
 ///                  _integer_,
-///     @return The number of items in the container or grouplist with given id excluding parent folder item. 
+///     @return The number of items in the container or grouplist with given id excluding parent folder item.
 ///     @note If no id is specified it grabs the current container.
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Container(id).NumAllItems`</b>,
 ///                  \anchor Container_NumAllItems
 ///                  _integer_,
-///     @return The number of all items in the container or grouplist with given id including parent folder item. 
+///     @return The number of all items in the container or grouplist with given id including parent folder item.
 ///     @note If no id is specified it grabs the current container.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link Container_NumAllItems `Container(id).NumAllItems`\endlink
@@ -3420,7 +3420,7 @@ const infomap mediacontainer[] = {{ "hasfiles",         CONTAINER_HASFILES },
 ///                  \anchor Container_NumNonFolderItems
 ///                  _integer_,
 ///     @return The Number of items in the container or grouplist with given id excluding all folder items.
-///     @note **Example:** pvr recordings folders\, parent ".." folder). 
+///     @note **Example:** pvr recordings folders\, parent ".." folder).
 ///     If no id is specified it grabs the current container.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link Container_NumNonFolderItems `Container(id).NumNonFolderItems`\endlink
@@ -3439,7 +3439,7 @@ const infomap mediacontainer[] = {{ "hasfiles",         CONTAINER_HASFILES },
 ///     @return **True** if the user is currently scrolling through the container
 ///     with id (or current container if id is omitted).
 ///     @note This is slightly delayed from the actual scroll start. Use
-///     \ref Container_OnScrollNext "Container(id).OnScrollNext" or 
+///     \ref Container_OnScrollNext "Container(id).OnScrollNext" or
 ///     \ref Container_OnScrollPrevious "Container(id).OnScrollPrevious" to trigger animations
 ///     immediately on scroll.
 ///     <p>
@@ -3599,8 +3599,8 @@ const infomap container_ints[] = {{ "row",              CONTAINER_ROW },
 ///     @return the same as \link Container_ListItem_property `Container(id).ListItem(offset).Property` \endlink
 ///     but it won't wrap.
 ///     @param offset - The offset for the listitem.
-///     @note That means if the last item of a list is focused\, `ListItemNoWrap(1)` 
-///     will be empty while `ListItem(1)` will return the first item of the list. 
+///     @note That means if the last item of a list is focused\, `ListItemNoWrap(1)`
+///     will be empty while `ListItem(1)` will return the first item of the list.
 ///     `Property` has to be replaced with `Label`\, `Label2`\, `Icon` etc.
 ///     @note **Example:** `Container(50).ListitemNoWrap(1).Plot`
 ///     <p>
@@ -3627,15 +3627,15 @@ const infomap container_ints[] = {{ "row",              CONTAINER_ROW },
 ///                  \anchor Container_Content_parameter
 ///                  _string_,
 ///     @return **True** if the current container you are in contains the following:
-///       - <b>files</b> 
-///       - <b>songs</b> 
+///       - <b>files</b>
+///       - <b>songs</b>
 ///       - <b>artists</b>
-///       - <b>albums</b> 
+///       - <b>albums</b>
 ///       - <b>movies</b>
 ///       - <b>tvshows</b>
 ///       - <b>seasons</b>
-///       - <b>episodes</b> 
-///       - <b>musicvideos</b> 
+///       - <b>episodes</b>
+///       - <b>musicvideos</b>
 ///       - <b>genres</b>
 ///       - <b>years</b>
 ///       - <b>actors</b>
@@ -3698,7 +3698,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.Icon`</b>,
 ///                  \anchor ListItem_Icon
 ///                  _string_,
-///     @return The thumbnail (if it exists) of the currently selected item in a list or thumb control. 
+///     @return The thumbnail (if it exists) of the currently selected item in a list or thumb control.
 ///     @note If no thumbnail image exists\, it will show the icon.
 ///     <p>
 ///   }
@@ -4392,9 +4392,9 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.PictureExpTime`</b>,
 ///                  \anchor ListItem_PictureExpTime
 ///                  _string_,
-///     @return The exposure time of the selected picture\, in seconds. 
+///     @return The exposure time of the selected picture\, in seconds.
 ///     @note This is the value of the EXIF ExposureTime tag (hex code 0x829A).
-///     If the ExposureTime tag is not found\, the ShutterSpeedValue tag (hex code 0x9201) 
+///     If the ExposureTime tag is not found\, the ShutterSpeedValue tag (hex code 0x9201)
 ///     might be used.
 ///     <p>
 ///   }
@@ -4417,7 +4417,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.PictureFocusDist`</b>,
 ///                  \anchor ListItem_PictureFocusDist
 ///                  _string_,
-///     @return The focal length of the lens\, in mm. 
+///     @return The focal length of the lens\, in mm.
 ///     @note This is the value of the EXIF FocalLength tag (hex code 0x920A).
 ///   }
 ///   \table_row3{   <b>`ListItem.PictureGPSLat`</b>,
@@ -4432,7 +4432,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PictureGPSLon
 ///                  _string_,
 ///     @return The longitude where the selected picture was taken (degrees\,
-///     minutes\, seconds East or West). 
+///     minutes\, seconds East or West).
 ///     @note This is the value of the EXIF GPSInfo.GPSLongitude and GPSInfo.GPSLongitudeRef tags.
 ///     <p>
 ///   }
@@ -4513,7 +4513,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PictureLongDate
 ///                  _string_,
 ///     @return Only the localized date of the selected picture. The long form of
-///     the date is used. 
+///     the date is used.
 ///     @note The value of the EXIF DateTimeOriginal tag (hex code
 ///     0x9003) is preferred. If the DateTimeOriginal tag is not found\, the
 ///     value of DateTimeDigitized (hex code 0x9004) or of DateTime (hex code
@@ -4526,7 +4526,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PictureLongDatetime
 ///                  _string_,
 ///     @return The date/timestamp of the selected picture. The localized long
-///     form of the date and time is used. 
+///     form of the date and time is used.
 ///     @note The value of the EXIF DateTimeOriginal
 ///     tag (hex code 0x9003) is preferred. if the DateTimeOriginal tag is not
 ///     found\, the value of DateTimeDigitized (hex code 0x9004) or of DateTime
@@ -4540,7 +4540,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     possible values are:
 ///      - <b>"Center weight"</b>
 ///      - <b>"Spot"</b>
-///      - <b>"Matrix"</b> 
+///      - <b>"Matrix"</b>
 ///     @note This is the value of the EXIF MeteringMode tag (hex code 0x9207).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link ListItem_PictureMeteringMode `ListItem.PictureMeteringMode`\endlink
@@ -4559,11 +4559,11 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PictureOrientation
 ///                  _string_,
 ///     @return The orientation of the selected picture. Possible values are:
-///       - <b>"Top Left"</b> 
+///       - <b>"Top Left"</b>
 ///       - <b>"Top Right"</b>
 ///       - <b>"Left Top"</b>
 ///       - <b>"Right Bottom"</b>
-///       - etc 
+///       - etc
 ///     @note This is the value of the EXIF Orientation tag (hex code 0x0112).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link ListItem_PictureOrientation `ListItem.PictureOrientation`\endlink
@@ -4764,8 +4764,8 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.Rating([name])`</b>,
 ///                  \anchor ListItem_Rating
 ///                  _string_,
-///     @return The scraped rating of the currently selected item in a container (1-10). 
-///     @param name - [opt] you can specify the name of the scraper to retrieve a specific rating\, 
+///     @return The scraped rating of the currently selected item in a container (1-10).
+///     @param name - [opt] you can specify the name of the scraper to retrieve a specific rating\,
 ///     for use in dialogvideoinfo.xml.
 ///     <p><hr>
 ///     @skinning_v18 **[Infolabel Updated]** \link ListItem_Rating `ListItem.Rating([name])`\endlink replaces
@@ -4781,7 +4781,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the set the movie is part of.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Set `ListItem.Set`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.SetId`</b>,
 ///                  \anchor ListItem_SetId
@@ -4789,7 +4789,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The id of the set the movie is part of.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_SetId `ListItem.SetId`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Status`</b>,
 ///                  \anchor ListItem_Status
@@ -4804,7 +4804,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @note For use with tv shows.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Status `ListItem.Status`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.EndTimeResume`</b>,
 ///                  \anchor ListItem_EndTimeResume
@@ -4812,7 +4812,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return Returns the time a video will end if you resume it\, instead of playing it from the beginning.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_EndTimeResume `ListItem.EndTimeResume`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.UserRating`</b>,
 ///                  \anchor ListItem_UserRating
@@ -4834,7 +4834,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @skinning_v17 **[Infolabel Updated]** \link ListItem_Votes `ListItem.Votes([name])`\endlink
 ///     add optional param <b>name</b> to specify the scrapper.
 ///     @skinning_v13 **[New Infolabel]** \link ListItem_Votes `ListItem.Votes`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.RatingAndVotes([name])`</b>,
 ///                  \anchor ListItem_RatingAndVotes
@@ -4847,7 +4847,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_RatingAndVotes `ListItem.RatingAndVotes([name])`\endlink
 ///     @skinning_v17 **[Infolabel Updated]** \link ListItem_RatingAndVotes `ListItem.RatingAndVotes`\endlink
 ///     now available for albums/songs.
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Mood`</b>,
 ///                  \anchor ListItem_Mood
@@ -4855,7 +4855,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The mood of the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Mood `ListItem.Mood`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Mpaa`</b>,
 ///                  \anchor ListItem_Mpaa
@@ -4895,7 +4895,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  _string_,
 ///     @return The database type of the \ref ListItem_DBID "ListItem.DBID" for videos (movie\, set\,
 ///     genre\, actor\, tvshow\, season\, episode). It does not return any value
-///     for the music library. 
+///     for the music library.
 ///     @note Beware with season\, the "*all seasons" entry does
 ///     give a DBTYPE "season" and a DBID\, but you can't get the details of that
 ///     entry since it's a virtual entry in the Video Library.
@@ -4970,7 +4970,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The summary of current Video in a container.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Tag `ListItem.Tag`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Tagline`</b>,
 ///                  \anchor ListItem_Tagline
@@ -5067,7 +5067,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_VideoResolution
 ///                  _string_,
 ///     @return The resolution of the currently selected video. Possible values:
-///       - <b>480</b> 
+///       - <b>480</b>
 ///       - <b>576</b>
 ///       - <b>540</b>
 ///       - <b>720</b>
@@ -5183,7 +5183,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.Property(SubtitleLanguage.[n])`</b>,
 ///                  \anchor ListItem_Property_SubtitleLanguage
 ///                  _string_,
-///     @return The subtitle language of the currently selected video 
+///     @return The subtitle language of the currently selected video
 ///     @param n - the number of the subtitle (values: see \ref ListItem_SubtitleLanguage "ListItem.SubtitleLanguage")
 ///     <p><hr>
 ///     @skinning_v16 **[New Infolabel]** \link ListItem_Property_SubtitleLanguage `ListItem.Property(SubtitleLanguage.[n])`\endlink
@@ -5604,7 +5604,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///       - <b>artist.fanart</b> - the artist fanart of an album or song item.
 ///       - <b>album.thumb</b> - the album thumb (cover) of a song item.
 ///       - <b>artist[n].*</b> - in case a song has multiple artists\, a digit is added to the art type for the 2nd artist onwards
-/// e.g `Listitem.Art(artist1.thumb)` gives the thumb of the 2nd artist of a song.	
+/// e.g `Listitem.Art(artist1.thumb)` gives the thumb of the 2nd artist of a song.
 ///       - <b>albumartist[n].*</b> - n case a song has multiple album artists\, a digit is added to the art type for the 2nd artist
 /// onwards e.g `Listitem.Art(artist1.thumb)` gives the thumb of the 2nd artist of a song.
 ///     <p>
@@ -5612,7 +5612,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     <p><hr>
 ///     @skinning_v18 **[Infolabel Updated]** \link ListItem_Art_Type `ListItem.Art(type)`\endlink add <b>artist[n].*</b> and
 ///     <b>albumartist[n].*</b> as possible targets for <b>type</b>
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Platform`</b>,
 ///                  \anchor ListItem_Platform
@@ -5620,7 +5620,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The game platform (e.g. "Atari 2600") (RETROPLAYER).
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Platform `ListItem.Platform`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Genres`</b>,
 ///                  \anchor ListItem_Genres
@@ -5628,7 +5628,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The game genres (e.g. "["Action"\,"Strategy"]") (RETROPLAYER).
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Genres `ListItem.Genres`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Publisher`</b>,
 ///                  \anchor ListItem_Publisher
@@ -5636,7 +5636,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The game publisher (e.g. "Nintendo") (RETROPLAYER).
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Publisher `ListItem.Publisher`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Developer`</b>,
 ///                  \anchor ListItem_Developer
@@ -5644,7 +5644,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The game developer (e.g. "Square") (RETROPLAYER).
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Developer `ListItem.Developer`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Overview`</b>,
 ///                  \anchor ListItem_Overview
@@ -5652,7 +5652,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The game overview/summary (RETROPLAYER).
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Overview `ListItem.Overview`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.GameClient`</b>,
 ///                  \anchor ListItem_GameClient
@@ -5661,7 +5661,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     (e.g. game.libretro.fceumm) (RETROPLAYER).
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_GameClient `ListItem.GameClient`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(propname)`</b>,
 ///                  \anchor ListItem_Property_Propname
@@ -5676,7 +5676,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who composed the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Composer `ListItem.Property(Role.Composer)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Conductor)`</b>,
 ///                  \anchor ListItem_Property_Role_Conductor
@@ -5684,7 +5684,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who conducted the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Conductor `ListItem.Property(Role.Conductor)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Orchestra)`</b>,
 ///                  \anchor ListItem_Property_Role_Orchestra
@@ -5692,7 +5692,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the orchestra performing the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Orchestra `ListItem.Property(Role.Orchestra)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Lyricist)`</b>,
 ///                  \anchor ListItem_Property_Role_Lyricist
@@ -5700,7 +5700,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who wrote the lyrics of the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Lyricist `ListItem.Property(Role.Lyricist)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Remixer)`</b>,
 ///                  \anchor ListItem_Property_Role_Remixer
@@ -5708,7 +5708,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who remixed the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Remixer `ListItem.Property(Role.Remixer)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Arranger)`</b>,
 ///                  \anchor ListItem_Property_Role_Arranger
@@ -5716,7 +5716,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who arranged the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Arranger `ListItem.Property(Role.Arranger)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Engineer)`</b>,
 ///                  \anchor ListItem_Property_Role_Engineer
@@ -5724,7 +5724,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who was the engineer of the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Engineer `ListItem.Property(Role.Engineer)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Producer)`</b>,
 ///                  \anchor ListItem_Property_Role_Producer
@@ -5732,7 +5732,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who produced the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_Producer `ListItem.Property(Role.Producer)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.DJMixer)`</b>,
 ///                  \anchor ListItem_Property_Role_DJMixer
@@ -5740,7 +5740,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the dj who remixed the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_DJMixer `ListItem.Property(Role.DJMixer)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Role.Mixer)`</b>,
 ///                  \anchor ListItem_Property_Role_Mixer
@@ -5748,7 +5748,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of the person who mixed the selected song.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link ListItem_Property_Role_DJMixer `ListItem.Property(Role.DJMixer)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Game.VideoFilter)`</b>,
 ///                  \anchor ListItem_Property_Game_VideoFilter
@@ -5759,7 +5759,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     for the possible values.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Property_Game_VideoFilter `ListItem.Property(Game.VideoFilter)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Game.StretchMode)`</b>,
 ///                  \anchor ListItem_Property_Game_StretchMode
@@ -5770,7 +5770,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     for the possible values.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Property_Game_StretchMode `ListItem.Property(Game.StretchMode)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.Property(Game.VideoRotation)`</b>,
 ///                  \anchor ListItem_Property_Game_VideoRotation
@@ -5781,7 +5781,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     for the possible values.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link ListItem_Property_Game_VideoRotation `ListItem.Property(Game.VideoRotation)`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.ParentalRating`</b>,
 ///                  \anchor ListItem_ParentalRating
@@ -6238,7 +6238,7 @@ const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
 ///                  \anchor Window_IsModalDialogTopmost
 ///                  _boolean_,
 ///     @return **True** if the dialog with id or title _dialog_ is on top of the
-///     modal dialog stack 
+///     modal dialog stack
 ///     @note Excludes fade out time on dialogs
 ///     <p>
 ///   }
@@ -6305,7 +6305,7 @@ const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
 ///       - 36Hour.%i.OutlookIcon
 ///       - Weekend.%i.OutlookIcon
 ///       - Hourly.%i.OutlookIcon
-///     
+///
 ///     previously the openweathermap addon would provide the full\, hardcoded path to the icon
 ///     ie. `resource://resource.images.weathericons.default/28.png`
 ///     to make it easier for skins to work with custom icon sets\, it now will return the filename only
@@ -6912,7 +6912,7 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///     @return The currently entered channel number while in numeric channel input mode\, an empty string otherwise.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_ChannelNumberInput `PVR.ChannelNumberInput`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.CanRecordPlayingChannel`</b>,
 ///                  \anchor PVR_CanRecordPlayingChannel
@@ -6946,7 +6946,7 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///     @return The percentage of the current play position within the PVR timeshift progress.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_TimeshiftProgressPlayPos `PVR.TimeshiftProgressPlayPos`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.TimeshiftProgressEpgStart`</b>,
 ///                  \anchor PVR_TimeshiftProgressEpgStart
@@ -7115,7 +7115,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     @note <b>hh:</b> will be omitted if hours value is zero.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_EpgEventRemainingTime `PVR.EpgEventRemainingTime`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventRemainingTime(format)`</b>,
 ///                  \anchor PVR_EpgEventRemainingTime_format
@@ -7133,7 +7133,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     @note <b>hh:</b> will be omitted if hours value is zero.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_EpgEventSeekTime `PVR.EpgEventSeekTime`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventSeekTime(format)`</b>,
 ///                  \anchor PVR_EpgEventSeekTime_format
@@ -7151,7 +7151,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     @note <b>hh:</b> will be omitted if hours value is zero.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_EpgEventFinishTime `PVR.EpgEventFinishTime`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventFinishTime(format)`</b>,
 ///                  \anchor PVR_EpgEventFinishTime_format
@@ -7233,7 +7233,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     @note <b>hh:</b> will be omitted if hours value is zero.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_TimeshiftProgressDuration `PVR.TimeshiftProgressDuration`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.TimeshiftProgressDuration(format)`</b>,
 ///                  \anchor PVR_TimeshiftProgressDuration_format
@@ -7251,7 +7251,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     @note <b>hh:</b> will be omitted if hours value is zero.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_TimeshiftProgressStartTime `PVR.TimeshiftProgressStartTime`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.TimeshiftProgressStartTime(format)`</b>,
 ///                  \anchor PVR_TimeshiftProgressStartTime_format
@@ -7269,7 +7269,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     @note hh: will be omitted if hours value is zero.
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link PVR_TimeshiftProgressEndTime `PVR.TimeshiftProgressEndTime`\endlink
-///     <p>  
+///     <p>
 ///   }
 ///   \table_row3{   <b>`PVR.TimeshiftProgressEndTime(format)`</b>,
 ///                  \anchor PVR_TimeshiftProgressEndTime_format
@@ -7298,7 +7298,7 @@ const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURA
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_RDS RDS
 /// @note Only supported if both the PVR backend and the Kodi client support RDS.
-/// 
+///
 /// \table_start
 ///   \table_h3{ Labels, Type, Description }
 ///   \table_row3{   <b>`RDS.HasRds`</b>,
@@ -7839,7 +7839,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_Author
 ///                  _string_,
 ///     @return The name of the person involved in writing about the current
-///     picture. 
+///     picture.
 ///     @note This is the value of the IPTC Writer tag (hex code 0x7A).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_Author `Slideshow.Author`\endlink
@@ -7848,7 +7848,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.Byline`</b>,
 ///                  \anchor Slideshow_Byline
 ///                  _string_,
-///     @return The name of the person who created the current picture. 
+///     @return The name of the person who created the current picture.
 ///     @note This is the value of the IPTC Byline tag (hex code 0x50).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_Byline `Slideshow.Byline`\endlink
@@ -7857,7 +7857,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.BylineTitle`</b>,
 ///                  \anchor Slideshow_BylineTitle
 ///                  _string_,
-///     @return The title of the person who created the current picture. 
+///     @return The title of the person who created the current picture.
 ///     @note This is the value of the IPTC BylineTitle tag (hex code 0x55).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_BylineTitle `Slideshow.BylineTitle`\endlink
@@ -7874,14 +7874,14 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_CameraModel
 ///                  _string_,
 ///     @return The manufacturer's model name or number of the camera used to take
-///     the current picture. 
+///     the current picture.
 ///     @note This is the value of the EXIF Model tag (hex code 0x0110).
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Slideshow.Caption`</b>,
 ///                  \anchor Slideshow_Caption
 ///                  _string_,
-///     @return A description of the current picture. 
+///     @return A description of the current picture.
 ///     @note This is the value of the IPTC Caption tag (hex code 0x78).
 ///     <p>
 ///   }
@@ -7898,7 +7898,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_CCDWidth
 ///                  _string_,
 ///     @return The width of the CCD in the camera used to take the current
-///     picture. 
+///     picture.
 ///     @note This is calculated from three EXIF tags (0xA002 * 0xA210 / 0xA20e).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_CCDWidth `Slideshow.CCDWidth`\endlink
@@ -7926,7 +7926,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.CopyrightNotice`</b>,
 ///                  \anchor Slideshow_CopyrightNotice
 ///                  _string_,
-///     @return The copyright notice of the current picture. 
+///     @return The copyright notice of the current picture.
 ///     @note This is the value of the IPTC Copyright tag (hex code 0x74).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_CopyrightNotice `Slideshow.CopyrightNotice`\endlink
@@ -7945,7 +7945,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_CountryCode
 ///                  _string_,
 ///     @return The country code of the country where the current picture was
-///     taken. 
+///     taken.
 ///     @note This is the value of the IPTC CountryCode tag (hex code 0x64).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_CountryCode `Slideshow.CountryCode`\endlink
@@ -7954,7 +7954,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.Credit`</b>,
 ///                  \anchor Slideshow_Credit
 ///                  _string_,
-///     @return Who provided the current picture. 
+///     @return Who provided the current picture.
 ///     @note This is the value of the IPTC Credit tag (hex code 0x6E).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_Credit `Slideshow.Credit`\endlink
@@ -7972,8 +7972,8 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.EXIFComment`</b>,
 ///                  \anchor Slideshow_EXIFComment
 ///                  _string_,
-///     @return A description of the current picture. 
-///     @note This is the value of the EXIF User Comment tag (hex code 0x9286). 
+///     @return A description of the current picture.
+///     @note This is the value of the EXIF User Comment tag (hex code 0x9286).
 ///     This is the same value as \ref Slideshow_SlideComment "Slideshow.SlideComment".
 ///     <p>
 ///   }
@@ -7994,7 +7994,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_EXIFDescription
 ///                  _string_,
 ///     @return A short description of the current picture. The SlideComment\,
-///     EXIFComment or Caption values might contain a longer description. 
+///     EXIFComment or Caption values might contain a longer description.
 ///     @note This is the value of the EXIF ImageDescription tag (hex code 0x010E).
 ///     <p>
 ///   }
@@ -8002,7 +8002,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_EXIFSoftware
 ///                  _string_,
 ///     @return The name and version of the firmware used by the camera that took
-///     the current picture. 
+///     the current picture.
 ///     @note This is the value of the EXIF Software tag (hex code 0x0131).
 ///     <p>
 ///   }
@@ -8010,10 +8010,10 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_EXIFTime
 ///                  _string_,
 ///     @return The date/timestamp of the current picture. The localized short
-///     form of the date and time is used. 
-///     @note The value of the EXIF DateTimeOriginal tag (hex code 0x9003) is 
-///     preferred. If the DateTimeOriginal tag is not found\, the value of 
-///     DateTimeDigitized (hex code 0x9004) or of DateTime (hex code 0x0132) 
+///     form of the date and time is used.
+///     @note The value of the EXIF DateTimeOriginal tag (hex code 0x9003) is
+///     preferred. If the DateTimeOriginal tag is not found\, the value of
+///     DateTimeDigitized (hex code 0x9004) or of DateTime (hex code 0x0132)
 ///     might be used.
 ///     <p>
 ///   }
@@ -8026,7 +8026,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///      - <b>"Program (Auto)"</b>
 ///      - <b>"Aperture priority (Semi-Auto)"</b>
 ///      - <b>"Shutter priority (semi-auto)"</b>
-///      - etc... 
+///      - etc...
 ///     @note This is the value of the EXIF ExposureProgram tag
 ///     (hex code 0x8822).
 ///     <p><hr>
@@ -8093,7 +8093,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.FocalLength`</b>,
 ///                  \anchor Slideshow_FocalLength
 ///                  _string_,
-///     @return The focal length of the lens\, in mm. 
+///     @return The focal length of the lens\, in mm.
 ///     @note This is the value of the EXIF FocalLength tag (hex code 0x920A).
 ///     <p>
 ///   }
@@ -8148,8 +8148,8 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_Latitude
 ///                  _string_,
 ///     @return The latitude where the current picture was taken (degrees\,
-///     minutes\, seconds North or South). 
-///     @note This is the value of the EXIF GPSInfo.GPSLatitude and 
+///     minutes\, seconds North or South).
+///     @note This is the value of the EXIF GPSInfo.GPSLatitude and
 ///     GPSInfo.GPSLatitudeRef tags.
 ///     <p>
 ///   }
@@ -8171,7 +8171,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_LongEXIFDate
 ///                  _string_,
 ///     @return Only the localized date of the current picture. The long form of
-///     the date is used. 
+///     the date is used.
 ///     @note The value of the EXIF DateTimeOriginal tag (hex code
 ///     0x9003) is preferred. If the DateTimeOriginal tag is not found\, the
 ///     value of DateTimeDigitized (hex code 0x9004) or of DateTime (hex code
@@ -8198,7 +8198,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  _string_,
 ///     @return The longitude where the current picture was taken (degrees\,
 ///     minutes\, seconds East or West).
-///     @note This is the value of the EXIF GPSInfo.GPSLongitude and 
+///     @note This is the value of the EXIF GPSInfo.GPSLongitude and
 ///     GPSInfo.GPSLongitudeRef tags.
 ///     <p>
 ///   }
@@ -8271,8 +8271,8 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///   \table_row3{   <b>`Slideshow.SlideComment`</b>,
 ///                  \anchor Slideshow_SlideComment
 ///                  _string_,
-///     @return A description of the current picture. 
-///     @note This is the value of the EXIF User Comment tag (hex code 0x9286). 
+///     @return A description of the current picture.
+///     @note This is the value of the EXIF User Comment tag (hex code 0x9286).
 ///     This is the same value as \ref Slideshow_EXIFComment "Slideshow.EXIFComment".
 ///     <p>
 ///   }
@@ -8314,7 +8314,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_Sublocation
 ///                  _string_,
 ///     @return The location within a city where the current picture was taken -
-///     might indicate the nearest landmark. 
+///     might indicate the nearest landmark.
 ///     @note This is the value of the IPTC SubLocation tag (hex code 0x5C).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_Sublocation `Slideshow.Sublocation`\endlink
@@ -8324,7 +8324,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_SupplementalCategories
 ///                  _string_,
 ///     @return The supplemental category codes to further refine the subject of the
-///     current picture. 
+///     current picture.
 ///     @note This is the value of the IPTC SuppCategory tag (hex
 ///     code 0x14).
 ///     <p><hr>
@@ -8335,7 +8335,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_TimeCreated
 ///                  _string_,
 ///     @return The time when the intellectual content of the current picture was
-///     created\, rather than when the picture was created. 
+///     created\, rather than when the picture was created.
 ///     @note This is the value of the IPTC TimeCreated tag (hex code 0x3C).
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_TimeCreated `Slideshow.TimeCreated`\endlink
@@ -8345,7 +8345,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_TransmissionReference
 ///                  _string_,
 ///     @return A code representing the location of original transmission of the
-///     current picture. 
+///     current picture.
 ///     @note This is the value of the IPTC TransmissionReference tag
 ///     (hex code 0x67).
 ///     <p><hr>
@@ -8356,7 +8356,7 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_Urgency
 ///                  _string_,
 ///     @return The urgency of the current picture. Values are 1-9. The 1 is most
-///     urgent. 
+///     urgent.
 ///     @note Some image management programs use urgency to indicate picture
 ///     rating\, where urgency 1 is 5 stars and urgency 5 is 1 star. Urgencies
 ///     6-9 are not used for rating. This is the value of the IPTC Urgency tag
@@ -8625,7 +8625,7 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 /// \subsection modules_rm_infolabels_booleans_v18 Kodi v18 (Leia)
 ///
 /// @skinning_v18 **[Removed Infolabels]** The following infolabels have been removed:
-///   - `Listitem.Property(artistthumbs)`, `Listitem.Property(artistthumb)` - use 
+///   - `Listitem.Property(artistthumbs)`, `Listitem.Property(artistthumb)` - use
 /// \link ListItem_Art_Type `ListItem.Art(type)`\endlink with <b>albumartist[n].*</b> or <b>artist[n].*</b> as <b>type</b>
 ///   - `ADSP.ActiveStreamType`
 ///   - `ADSP.DetectedStreamType`
@@ -8633,10 +8633,10 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 ///   - `ADSP.MasterInfo`
 ///   - `ADSP.MasterOwnIcon`
 ///   - `ADSP.MasterOverrideIcon`
-///   - `ListItem.ChannelNumber`, `ListItem.SubChannelNumber`, `MusicPlayer.ChannelNumber`, 
+///   - `ListItem.ChannelNumber`, `ListItem.SubChannelNumber`, `MusicPlayer.ChannelNumber`,
 /// `MusicPlayer.SubChannelNumber`, `VideoPlayer.ChannelNumber`,
 /// `VideoPlayer.SubChannelNumber`. Please use the following alternatives
-/// \link ListItem_ChannelNumberLabel `ListItem.ChannelNumberLabel` \endlink, 
+/// \link ListItem_ChannelNumberLabel `ListItem.ChannelNumberLabel` \endlink,
 /// \link MusicPlayer_ChannelNumberLabel `MusicPlayer.ChannelNumberLabel` \endlink
 /// \link VideoPlayer_ChannelNumberLabel `VideoPlayer.ChannelNumberLabel` \endlink from now on.
 ///
@@ -8677,7 +8677,7 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 ///    - `ADSP.HasOutputResample`
 ///    - `ADSP.MasterActive`
 ///    - `System.HasModalDialog`
-/// 
+///
 ///  @skinning_v16 **[New Infolabels]** The following infolabels were added:
 ///    - `ADSP.ActiveStreamType`
 ///    - `ADSP.DetectedStreamType`
@@ -8685,7 +8685,7 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 ///    - `ADSP.MasterInfo`
 ///    - `ADSP.MasterOwnIcon`
 ///    - `ADSP.MasterOverrideIcon`
-///   
+///
 ///   @skinning_v16 **[Removed Boolean Conditions]** The following infobols were removed:
 ///    - `System.Platform.ATV2`
 
@@ -8697,12 +8697,12 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 ///    - `ListItem.SubChannelNumber`
 ///    - `MusicPlayer.SubChannelNumber`
 ///    - `VideoPlayer.SubChannelNumber`
-/// 
+///
 /// <hr>
 /// \subsection modules_rm_infolabels_booleans_v13 XBMC v13 (Gotham)
 ///   @skinning_v13 **[Removed Infolabels]** The following infolabels were removed:
 ///    - `Network.SubnetAddress`
-/// 
+///
 /// <hr>
 // Crazy part, to use tableofcontents must it be on end
 /// \page modules__infolabels_boolean_conditions

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -394,7 +394,9 @@ static int UpdateLocals(const std::vector<std::string>& params)
 ///     ,
 ///     Enable the specified plugin/script
 ///     @param[in] id                    The add-on id
+///     <p><hr>
 ///     @skinning_v19 **[New builtin]**
+///     <p>
 ///   }
 ///   \table_row2_l{
 ///     <b>`InstallAddon(id)`</b>


### PR DESCRIPTION
## Description

PR #13762 and PR #16697 broke the table of infolabels. This PR fixes it.
A third commit is added to remove leftover whitespaces for the list of infobools

## How Has This Been Tested?
Compiled docs

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
