### PR TITLE
[Estuary] Add new music infolabels to Includes_MusicInfo.xml

### DIFF
--- a/addons/skin.estuary/xml/Includes_MusicInfo.xml
+++ b/addons/skin.estuary/xml/Includes_MusicInfo.xml
@@ -79,9 +79,19 @@
 			<visible>!String.IsEmpty(ListItem.Property(Album_Type))</visible>
 		</item>
 		<item>
+			<label>$LOCALIZE[172]:</label>
+			<label2>$INFO[ListItem.ReleaseDate]</label2>
+			<visible>!String.IsEmpty(ListItem.ReleaseDate)</visible>
+		</item>
+		<item>
+			<label>$LOCALIZE[38079]:</label>
+			<label2>$INFO[ListItem.OriginalDate]</label2>
+			<visible>!String.IsEmpty(ListItem.OriginalDate) + !String.IsEqual(ListItem.ReleaseDate, ListItem.OriginalDate)</visible>
+		</item>
+		<item>
 			<label>$LOCALIZE[562]:</label>
 			<label2>$INFO[ListItem.Year]</label2>
-			<visible>!String.IsEmpty(ListItem.Year)</visible>
+			<visible>!String.IsEmpty(ListItem.Year) + String.IsEmpty(ListItem.ReleaseDate) + String.IsEmpty(ListItem.OriginalDate)</visible>
 		</item>
 		<item>
 			<label>$LOCALIZE[515]:</label>
@@ -161,14 +171,29 @@
 			<visible>!String.IsEmpty(ListItem.Mood)</visible>
 		</item>
 		<item>
+			<label>$LOCALIZE[172]:</label>
+			<label2>$INFO[ListItem.ReleaseDate]</label2>
+			<visible>!String.IsEmpty(ListItem.ReleaseDate)</visible>
+		</item>
+		<item>
+			<label>$LOCALIZE[38079]:</label>
+			<label2>$INFO[ListItem.OriginalDate]</label2>
+			<visible>!String.IsEmpty(ListItem.OriginalDate) + !String.IsEqual(ListItem.ReleaseDate, ListItem.OriginalDate)</visible>
+		</item>
+		<item>
 			<label>$LOCALIZE[562]:</label>
 			<label2>$INFO[ListItem.Year]</label2>
-			<visible>!String.IsEmpty(ListItem.Year)</visible>
+			<visible>!String.IsEmpty(ListItem.Year) + String.IsEmpty(ListItem.ReleaseDate) + String.IsEmpty(ListItem.OriginalDate)</visible>
 		</item>
 		<item>
 			<label>$LOCALIZE[554]:</label>
 			<label2>$INFO[ListItem.TrackNumber]</label2>
 			<visible>!String.IsEmpty(ListItem.TrackNumber)</visible>
+		</item>
+		<item>
+			<label>$LOCALIZE[38080]:</label>
+			<label2>$INFO[ListItem.Bpm]</label2>
+			<visible>!String.IsEmpty(ListItem.Bpm)</visible>
 		</item>
 		<item>
 			<label>$LOCALIZE[563]:</label>


### PR DESCRIPTION
## Description
Update the music info dialog to display the new infolabels added by https://github.com/xbmc/xbmc/pull/17437

## How Has This Been Tested?
Tested locally on Ubuntu18.04 with a freshly built master and newly scanned music db.

## Screenshots (if appropriate):
Album info showing both dates
<a href="https://ibb.co/n7CrLhZ"><img src="https://i.ibb.co/GWT75gB/screenshot142.png" alt="screenshot142" border="0"></a>

Song info, again showing both dates
<a href="https://ibb.co/C0CrtYJ"><img src="https://i.ibb.co/x594sBm/screenshot143.png" alt="screenshot143" border="0"></a>

Song info showing BPM
<a href="https://ibb.co/8MBLkt8"><img src="https://i.ibb.co/zs5TdDf/screenshot144.png" alt="screenshot144" border="0"></a>

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
