### PR TITLE
[Estuary] hide remaining time when fullscreen-info is displayed

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -164,7 +164,7 @@
 					<wrapmultiline>true</wrapmultiline>
 					<animation effect="fade" time="200">VisibleChange</animation>
 					<label>$INFO[Player.TimeRemaining,[COLOR button_focus]$LOCALIZE[31134]:[CR][/COLOR]]</label>
-					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo) | VideoPlayer.HasEpg]</visible>
+					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo) | VideoPlayer.HasEpg] + !Window.IsActive(fullscreeninfo)</visible>
 				</control>
 				<control type="label">
 					<top>110</top>
@@ -177,7 +177,7 @@
 					<wrapmultiline>true</wrapmultiline>
 					<animation effect="fade" time="200">VisibleChange</animation>
 					<label>$INFO[PVR.EpgEventRemainingTime,[COLOR button_focus]$LOCALIZE[31134]:[CR][/COLOR]]</label>
-					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo)] + VideoPlayer.HasEpg</visible>
+					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo)] + VideoPlayer.HasEpg + !Window.IsActive(fullscreeninfo)</visible>
 				</control>
 			</control>
 			<control type="label">


### PR DESCRIPTION
## Description
cosmetic surgery on the estuary-seekbar.
tags are overlapping remaining time.

## Screenshots:
![remaining](https://user-images.githubusercontent.com/58829855/76345268-4d3b3900-6303-11ea-8e88-0ab68c74eea1.png)

## Types of change
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

@ronie please review the only reasonable solution that came to my mind