### PR TITLE
[Addons] Remove noicon/nofanart and old fallback paths to the root of…

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -330,21 +330,6 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon, const TiXmlElement* 
       if (element && element->GetText() != nullptr)
         addon->AddExtraInfo("reuselanguageinvoker", element->GetText());
 
-      /* Parse addon.xml "<noicon">...</noicon>" */
-      if (addon->m_icon.empty())
-      {
-        element = child->FirstChildElement("noicon");
-        addon->m_icon = (element && strcmp(element->GetText() , "true") == 0) ? "" : URIUtils::AddFileToFolder(assetBasePath, "icon.png");
-      }
-
-      /* Parse addon.xml "<nofanart">...</nofanart>" */
-      if (addon->m_art.empty())
-      {
-        element = child->FirstChildElement("nofanart");
-        if (!element || strcmp(element->GetText(), "true") != 0)
-          addon->m_art["fanart"] = URIUtils::AddFileToFolder(assetBasePath, "fanart.jpg");
-      }
-
       /* Parse addon.xml "<size">...</size>" */
       element = child->FirstChildElement("size");
       if (element && element->GetText() != nullptr)


### PR DESCRIPTION
## Description
This PR removes the fallback behaviour for icon.png and fanart.jpg (as well as the `noicon` and `nofanart` elements in addon.xml to avoid the checks).

## Motivation and Context
Same functionality can be achieved via the `assets` element since krypton. Majority of the addons are python and we have enforced the requirement for the assets element in all repository submissions since the krypton branch.

## How Has This Been Tested?
Compile and runtime tested

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
