### PR TITLE
[backport][vfs][addons] fix title show of compressed package dir

### DIFF
--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -88,7 +88,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
             else
             {
               // compressed or more than one file -> create a dir
-              *pItem = wrap->m_items;
+              pItem->SetPath(wrap->m_items.GetPath());
             }
 
             // Check for folder, if yes return also wrap.


### PR DESCRIPTION
## Description

On requests #17066 (Matrix) and #17407 (Leia) was this changed to use the
whole item from addon, but seen now that it remove then before defined
list item title.

This Partially revert the previous change and set now only path like before.
The rest stay onchanged and work confirmed.

This much nowhere else since many places took the path when title was empty.
However, there are also places that absolutely need the title.

Backport of https://github.com/xbmc/xbmc/pull/17484
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

![Bildschirmfoto von 2020-03-12 00-15-11](https://user-images.githubusercontent.com/6879739/76472797-dda67600-63f6-11ea-9eb5-1297ad3749f7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
