### PR TITLE
[EPG] change season/episode infolabels for specials

### DIFF
--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -643,7 +643,7 @@ bool CPVREpgInfoTag::IsPlayable() const
 
 bool CPVREpgInfoTag::IsSeries() const
 {
-  if ((m_iFlags & EPG_TAG_FLAG_IS_SERIES) > 0 || SeriesNumber() > 0 || EpisodeNumber() > 0 || EpisodePart() > 0)
+  if ((m_iFlags & EPG_TAG_FLAG_IS_SERIES) > 0 || SeriesNumber() >= 0 || EpisodeNumber() >= 0 || EpisodePart() >= 0)
     return true;
   else
     return false;

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -442,9 +442,9 @@ namespace PVR
     int m_iGenreSubType = 0; /*!< genre subtype */
     int m_iParentalRating = 0; /*!< parental rating */
     int m_iStarRating = 0; /*!< star rating */
-    int m_iSeriesNumber = 0; /*!< series number */
-    int m_iEpisodeNumber = 0; /*!< episode number */
-    int m_iEpisodePart = 0; /*!< episode part number */
+    int m_iSeriesNumber = -1; /*!< series number */
+    int m_iEpisodeNumber = -1; /*!< episode number */
+    int m_iEpisodePart = -1; /*!< episode part number */
     unsigned int m_iUniqueBroadcastID = 0; /*!< unique broadcast ID */
     std::string m_strTitle; /*!< title */
     std::string m_strPlotOutline; /*!< plot outline */

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -564,7 +564,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         return false;
       case VIDEOPLAYER_SEASON:
       case LISTITEM_SEASON:
-        if (epgTag->SeriesNumber() > 0)
+        if (epgTag->SeriesNumber() >= 0)
         {
           strValue = StringUtils::Format("%i", epgTag->SeriesNumber());
           return true;
@@ -572,12 +572,9 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         return false;
       case VIDEOPLAYER_EPISODE:
       case LISTITEM_EPISODE:
-        if (epgTag->EpisodeNumber() > 0)
+        if (epgTag->EpisodeNumber() >= 0)
         {
-          if (epgTag->SeriesNumber() == 0) // prefix episode with 'S'
-            strValue = StringUtils::Format("S%i", epgTag->EpisodeNumber());
-          else
-            strValue = StringUtils::Format("%i", epgTag->EpisodeNumber());
+          strValue = StringUtils::Format("%i", epgTag->EpisodeNumber());
           return true;
         }
         return false;


### PR DESCRIPTION
this is follow-up to https://github.com/xbmc/xbmc/pull/17408

i missed the fact that PVR uses their own code for the season and episode infolabels,
this PR now corrects that code as well.


before:
```
ListItem.Season:
ListItem.Episode: S1
```

after:
```
ListItem.Season: 0
ListItem.Episode: 1
```

(the same change applies to VideoPlayer.Season / VideoPlayer.Episode)

fixes https://github.com/xbmc/xbmc/issues/17402

for skinners / addon devs it's much easier to work with those infolabels this way.