### PR TITLE
Allow internetstream video sources in a LAN to look for exernal subtitle files.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1974,7 +1974,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   unsigned int startTimer = XbmcThreads::SystemClockMillis();
 
   CFileItem item(strMovie, false);
-  if (item.IsInternetStream()
+  if ((item.IsInternetStream() && !URIUtils::IsOnLAN(item.GetDynPath()))
     || item.IsPlayList()
     || item.IsLiveTV()
     || !item.IsVideo())


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
internetstream video sources (http, ftp etc) do not automatically look for subtitle files. This fix allows for internetstream video sources which are on a local LAN to look for subtitle files automatically. This is particularly important for forced external subtitle files.

<!--- Describe your change in detail here -->
internetstream video sources (http, ftp etc) do not automatically look for subtitle files. This fix allows for internetstream video sources which are on a local LAN to look for subtitle files automatically. This is particularly important for forced external subtitle files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows for internetstream video sources which are on a local LAN to look for subtitle files automatically

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Recompiled with changed code. Version with changed code finds subtitle files for videos as per wiki - https://kodi.wiki/view/Subtitles#Manually_downloaded_external_subtitle_files.
Standard version without changed code does not.

<!--- Include details of your testing environment, and the tests you ran to -->
Arch linux.
Version with changed code finds subtitle files for videos as per wiki - https://kodi.wiki/view/Subtitles#Manually_downloaded_external_subtitle_files.
Standard version without changed code does not.

<!--- see how your change affects other areas of the code, etc -->
It does not appear to.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
