### PR TITLE
[python] add custom button to yesno dialog

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -45,6 +45,7 @@ namespace XBMCAddon
     bool Dialog::yesno(const String& heading, const String& message,
                        const String& nolabel,
                        const String& yeslabel,
+                       const String& customlabel,
                        int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
@@ -62,6 +63,8 @@ namespace XBMCAddon
         pDialog->SetChoice(0, CVariant{nolabel});
       if (!yeslabel.empty())
         pDialog->SetChoice(1, CVariant{yeslabel});
+      if (!customlabel.empty())
+        pDialog->SetChoice(2, CVariant{customlabel});
 
       if (autoclose > 0)
         pDialog->SetAutoClose(autoclose);

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -52,7 +52,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
-      /// \python_func{ xbmcgui.Dialog().yesno(heading, message, nolabel, yeslabel, autoclose]) }
+      /// \python_func{ xbmcgui.Dialog().yesno(heading, message, nolabel, yeslabel, customlabel, autoclose]) }
       ///------------------------------------------------------------------------
       ///
       /// **Yes / no dialog**
@@ -64,6 +64,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @param message        string or unicode - message text.
       /// @param nolabel        [opt] label to put on the no button.
       /// @param yeslabel       [opt] label to put on the yes button.
+      /// @param customlabel    [opt] label to put on the custom button.
       /// @param autoclose      [opt] integer - milliseconds to autoclose dialog. (default=do not autoclose)
       /// @return Returns True if 'Yes' was pressed, else False.
       ///
@@ -74,6 +75,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       /// @python_v19 Renamed option **line1** to **message**.
       /// @python_v19 Removed option **line2**.
       /// @python_v19 Removed option **line3**.
+      /// @python_v19 Added new option **customlabel**.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -88,6 +90,7 @@ constexpr int ALPHANUM_HIDE_INPUT{2};
       bool yesno(const String& heading, const String& message,
                  const String& nolabel = emptyString,
                  const String& yeslabel = emptyString,
+                 const String& customlabel = emptyString,
                  int autoclose = 0);
 #endif
 


### PR DESCRIPTION
a few years ago, a third button was added to the YesNo dialog.
(see: https://github.com/xbmc/xbmc/pull/8865)

this button was not exposed through the python api though.
this PR corrects that omission.