### PR TITLE
[Fix]Wake from screensaver on PlayFile()

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -860,6 +860,9 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
 
   case TMSG_MEDIA_PLAY:
   {
+    g_application.ResetScreenSaver();
+    g_application.WakeUpScreenSaverAndDPMS();
+
     // first check if we were called from the PlayFile() function
     if (pMsg->lpVoid && pMsg->param2 == 0)
     {
@@ -872,9 +875,6 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
       delete item;
       return;
     }
-
-    g_application.ResetScreenSaver();
-    g_application.WakeUpScreenSaverAndDPMS();
 
     //g_application.StopPlaying();
     // play file


### PR DESCRIPTION
Fix so that all PlayFile() requests stop the screensaver and wake up GUI before starting playback.

This solves the problem that the screen saver would continue after playback of music or video had started if  play was requested without using the GUI e.g. from remotes using JSON, python scripts or keyboard shortcuts etc.  

To test set screensaver 1 minute and wait for it to start e.g. fading the UI, then start playing a video file via a remote app