### PR TITLE
[addons][videocodec][inputstream][demux] minor addon related changes

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/StreamCrypto.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/StreamCrypto.h
@@ -11,19 +11,29 @@
 #include <inttypes.h>
 #include <string.h>
 
-typedef struct CRYPTO_INFO
+#ifdef __cplusplus
+extern "C"
 {
-  enum CRYPTO_KEY_SYSTEM : uint8_t
+#endif /* __cplusplus */
+
+  typedef struct CRYPTO_INFO
   {
-    CRYPTO_KEY_SYSTEM_NONE = 0,
-    CRYPTO_KEY_SYSTEM_WIDEVINE,
-    CRYPTO_KEY_SYSTEM_PLAYREADY,
-    CRYPTO_KEY_SYSTEM_COUNT
-  } m_CryptoKeySystem;                 /*!< @brief keysystem for encrypted media, KEY_SYSTEM_NONE for unencrypted media */
+    enum CRYPTO_KEY_SYSTEM : uint8_t
+    {
+      CRYPTO_KEY_SYSTEM_NONE = 0,
+      CRYPTO_KEY_SYSTEM_WIDEVINE,
+      CRYPTO_KEY_SYSTEM_PLAYREADY,
+      CRYPTO_KEY_SYSTEM_COUNT
+    } m_CryptoKeySystem; /*!< @brief keysystem for encrypted media, KEY_SYSTEM_NONE for unencrypted media */
 
-  static const uint8_t FLAG_SECURE_DECODER = 1; /*!< @brief is set in flags if decoding has to be done in TEE environment */
+    static const uint8_t FLAG_SECURE_DECODER =
+        1; /*!< @brief is set in flags if decoding has to be done in TEE environment */
 
-  uint8_t flags;
-  uint16_t m_CryptoSessionIdSize;      /*!< @brief The size of the crypto session key id */
-  const char *m_CryptoSessionId;       /*!< @brief The crypto session key id */
-} CRYPTO_INFO;
+    uint8_t flags;
+    uint16_t m_CryptoSessionIdSize; /*!< @brief The size of the crypto session key id */
+    const char* m_CryptoSessionId; /*!< @brief The crypto session key id */
+  } CRYPTO_INFO;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -26,8 +26,10 @@
 //Increment this level always if you add features which can lead to compile failures in the addon
 #define INPUTSTREAM_VERSION_LEVEL 2
 
+#ifdef __cplusplus
 extern "C"
 {
+#endif /* __cplusplus */
 
   /*!
    * @brief InputStream add-on capabilities. All capabilities are set to "false" as default.
@@ -285,7 +287,7 @@ extern "C"
   };
 
   /*!
-   * @brief Structure to transfer the methods from xbmc_inputstream_dll.h to XBMC
+   * @brief "C" ABI Structures to transfer the methods from this to Kodi
    */
 
   // this are properties given to the addon on create
@@ -379,6 +381,7 @@ extern "C"
     KodiToAddonFuncTable_InputStream toAddon;
   } AddonInstance_InputStream;
 
+#ifdef __cplusplus
 } /* extern "C" */
 
 namespace kodi
@@ -917,3 +920,5 @@ private:
 
 } /* namespace addon */
 } /* namespace kodi */
+
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -80,7 +80,7 @@ extern "C"
 
     int64_t pts;
 
-    void *buffer; //< will be passed in release_frame_buffer
+    KODI_HANDLE buffer; //< will be passed in release_frame_buffer
   };
 
   enum VIDEOCODEC_RETVAL

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -321,10 +321,10 @@ bool CAddonVideoCodec::GetFrameBuffer(VIDEOCODEC_PICTURE &picture)
   return true;
 }
 
-void CAddonVideoCodec::ReleaseFrameBuffer(void *buffer)
+void CAddonVideoCodec::ReleaseFrameBuffer(KODI_HANDLE videoBufferHandle)
 {
-  if (buffer)
-    static_cast<CVideoBuffer*>(buffer)->Release();
+  if (videoBufferHandle)
+    static_cast<CVideoBuffer*>(videoBufferHandle)->Release();
 }
 
 /*********************     ADDON-TO-KODI    **********************/
@@ -337,10 +337,10 @@ bool CAddonVideoCodec::get_frame_buffer(void* kodiInstance, VIDEOCODEC_PICTURE *
   return static_cast<CAddonVideoCodec*>(kodiInstance)->GetFrameBuffer(*picture);
 }
 
-void CAddonVideoCodec::release_frame_buffer(void* kodiInstance, void *buffer)
+void CAddonVideoCodec::release_frame_buffer(void* kodiInstance, KODI_HANDLE videoBufferHandle)
 {
   if (!kodiInstance)
     return;
 
-  static_cast<CAddonVideoCodec*>(kodiInstance)->ReleaseFrameBuffer(buffer);
+  static_cast<CAddonVideoCodec*>(kodiInstance)->ReleaseFrameBuffer(videoBufferHandle);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
@@ -42,10 +42,10 @@ private:
    * In case buffer allocation fails, return false.
    */
   bool GetFrameBuffer(VIDEOCODEC_PICTURE &picture);
-  void ReleaseFrameBuffer(void *buffer);
+  void ReleaseFrameBuffer(KODI_HANDLE videoBufferHandle);
 
   static bool get_frame_buffer(void* kodiInstance, VIDEOCODEC_PICTURE *picture);
-  static void release_frame_buffer(void* kodiInstance, void *buffer);
+  static void release_frame_buffer(void* kodiInstance, KODI_HANDLE videoBufferHandle);
 
   AddonInstance_VideoCodec m_struct;
   int m_codecFlags;

--- a/xbmc/cores/VideoPlayer/Interface/Addon/DemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/DemuxPacket.h
@@ -16,26 +16,36 @@
 #define DMX_SPECIALID_STREAMINFO    -10
 #define DMX_SPECIALID_STREAMCHANGE  -11
 
-struct DemuxCryptoInfo;
-
-typedef struct DemuxPacket
+#ifdef __cplusplus
+extern "C"
 {
-  DemuxPacket() = default;
+#endif /* __cplusplus */
 
-  uint8_t *pData = nullptr;
-  int iSize = 0;
-  int iStreamId = -1;
-  int64_t demuxerId = -1; // id of the demuxer that created the packet
-  int iGroupId = -1; // the group this data belongs to, used to group data from different streams together
+  struct DemuxCryptoInfo;
 
-  void *pSideData = nullptr;
-  int iSideDataElems = 0;
+  typedef struct DemuxPacket
+  {
+    DemuxPacket() = default;
 
-  double pts = DVD_NOPTS_VALUE;
-  double dts = DVD_NOPTS_VALUE;
-  double duration = 0; // duration in DVD_TIME_BASE if available
-  int dispTime = 0;
-  bool recoveryPoint = false;
+    uint8_t* pData = nullptr;
+    int iSize = 0;
+    int iStreamId = -1;
+    int64_t demuxerId = -1; // id of the demuxer that created the packet
+    int iGroupId =
+        -1; // the group this data belongs to, used to group data from different streams together
 
-  std::shared_ptr<DemuxCryptoInfo> cryptoInfo;
-} DemuxPacket;
+    void* pSideData = nullptr;
+    int iSideDataElems = 0;
+
+    double pts = DVD_NOPTS_VALUE;
+    double dts = DVD_NOPTS_VALUE;
+    double duration = 0; // duration in DVD_TIME_BASE if available
+    int dispTime = 0;
+    bool recoveryPoint = false;
+
+    std::shared_ptr<DemuxCryptoInfo> cryptoInfo;
+  } DemuxPacket;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */


### PR DESCRIPTION
## Description

Commit 1:
----------------------------
**[addons][videocodec] change buffer handle to use "KODI_HANDLE"**

Before was this used as "`void *buffer`" and thought first that is
something used from addon itself and then seen it is "`CVideoBuffer*`"
class from Kodi and given to addon for interact back to Kodi.

This change it to "`KODI_HANDLE videoBufferHandle`" on Kodi's calls, but
leaved on `VIDEOCODEC_PICTURE` by buffer only to prevent compatibility
problems. This then done on major changes.

Commit 2:
----------------------------
**[addons][videocodec][demux] add '`extern "C"`' to DemuxPacket**

This is a minor change taken from another request to reduce his size.
On DemuxPacket structure is nothing changed only is the extern "C" added
and related to clang 2 characters moved forward.

The DemuxPacket.h need to change on other request to have only "C" in
structure.

As Future Info: For that becomes then a Kodi side class added where has this
as parent and his constructor parts removed there.

Commit 3:
----------------------------
**[addons][inputstream] add '`extern "C"`' to StreamCrypto.h**

Also a small minor change without change on API where '`extern "C"`' is
added and the other parts moved 2 character forward to match clang.

Commit 4:
---------------------------
**[addons][inputstream] add `extern "C"` to Inputstream.h**

Also here to allow "C" ABI only after the rest is cleaned on other
request. Only added here to reduce other and to have only work
related changes in view there.

In API/ABI is there no change and backward compatible.

## Motivation and Context
Cleanup and reduce https://github.com/xbmc/xbmc/pull/17438 amount.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
With `inputstream.adaptive` before and after this change, API stays compatible.
Thats also why API version stays the same, to prevent a problem on newer compiled by older Kodi.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
