### PR TITLE
AudioTrack: Properly use TimeStamp results in delay not in latency

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -576,6 +576,8 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
     return;
   }
 
+  bool usesAdvancedLogging =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO);
   // In their infinite wisdom, Google decided to make getPlaybackHeadPosition
   // return a 32bit "int" that you should "interpret as unsigned."  As such,
   // for wrap safety, we need to do all ops on it in 32bit integer math.
@@ -620,7 +622,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   if (m_timestamp.get_framePosition() > 0 &&
       (CurrentHostCounter() - m_timestamp.get_nanoTime()) < 2 * 1000 * 1000 * 1000)
   {
-    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+    if (usesAdvancedLogging)
     {
       CLog::Log(LOGNOTICE, "Framecounter: {} Time: {} Current-Time: {}",
                 (m_timestamp.get_framePosition() & UINT64_LOWER_BYTES), m_timestamp.get_nanoTime(),
@@ -645,7 +647,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 
     double playtime = m_timestampPos / static_cast<double>(m_sink_sampleRate);
 
-    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+    if (usesAdvancedLogging)
     {
       CLog::Log(LOGNOTICE,
                 "Delay - Timestamp: {} (ms) delta: {} (ms) playtime: {} (ms) Duration: {} ms",
@@ -663,14 +665,14 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
       m_hw_delay = hw_delay;
     else
       m_hw_delay = 0.0;
-    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+    if (usesAdvancedLogging)
     {
       CLog::Log(LOGNOTICE, "HW-Delay (1): {} ms", hw_delay * 1000);
     }
   }
 
   delay += m_hw_delay;
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+  if (usesAdvancedLogging)
   {
     CLog::Log(LOGNOTICE, "Combined Delay: {} ms", delay * 1000);
   }
@@ -685,7 +687,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 
   // track delay in local member
   m_delay = d;
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+  if (usesAdvancedLogging)
   {
     CLog::Log(LOGNOTICE, "Delay Current: %lf ms", d * 1000);
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -622,7 +622,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   {
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
     {
-      CLog::Log(LOGDEBUG, "Framecounter: {} Time: {} Current-Time: {}",
+      CLog::Log(LOGNOTICE, "Framecounter: {} Time: {} Current-Time: {}",
                 (m_timestamp.get_framePosition() & UINT64_LOWER_BYTES), m_timestamp.get_nanoTime(),
                 CurrentHostCounter());
     }
@@ -647,11 +647,11 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
     {
-      CLog::Log(LOGDEBUG,
+      CLog::Log(LOGNOTICE,
                 "Delay - Timestamp: {} (ms) delta: {} (ms) playtime: {} (ms) Duration: {} ms",
                 1000.0 * (m_duration_written - playtime), delta / 1000000.0, playtime * 1000,
                 m_duration_written * 1000);
-      CLog::Log(LOGDEBUG, "Head-Position {} Timestamp Position {} Delay-Offset: {} ms", m_headPos,
+      CLog::Log(LOGNOTICE, "Head-Position {} Timestamp Position {} Delay-Offset: {} ms", m_headPos,
                 m_timestampPos, 1000.0 * (m_headPos - m_timestampPos) / m_sink_sampleRate);
     }
     double hw_delay = m_duration_written - playtime;
@@ -665,14 +665,14 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
       m_hw_delay = 0.0;
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
     {
-      CLog::Log(LOGDEBUG, "HW-Delay (1): {}", hw_delay);
+      CLog::Log(LOGNOTICE, "HW-Delay (1): {} ms", hw_delay * 1000);
     }
   }
 
   delay += m_hw_delay;
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
   {
-    CLog::Log(LOGDEBUG, "Combined Delay: {}", delay);
+    CLog::Log(LOGNOTICE, "Combined Delay: {} ms", delay * 1000);
   }
   if (delay < 0.0)
     delay = 0.0;
@@ -687,7 +687,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   m_delay = d;
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
   {
-    CLog::Log(LOGDEBUG, "Delay Current: %lf", d * 1000);
+    CLog::Log(LOGNOTICE, "Delay Current: %lf ms", d * 1000);
   }
   status.SetDelay(d);
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -599,15 +599,6 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   if (m_pause_ms > 0.0)
     delay = m_audiotrackbuffer_sec;
 
-  const double d = GetMovingAverageDelay(delay);
-
-  // Audiotrack is caching more than we though it would
-  if (d > m_audiotrackbuffer_sec)
-    m_audiotrackbuffer_sec = d;
-
-  // track delay in local member
-  m_delay = d;
-
   if (m_stampTimer.IsTimePast())
   {
     if (!m_at_jni->getTimestamp(m_timestamp))
@@ -625,72 +616,85 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
         m_stampTimer.Set(100);
     }
   }
-  else
+  // check if last value was received less than 2 seconds ago
+  if (m_timestamp.get_framePosition() > 0 &&
+      (CurrentHostCounter() - m_timestamp.get_nanoTime()) < 2 * 1000 * 1000 * 1000)
   {
-    // check if last value was received less than 2 seconds ago
-    if (m_timestamp.get_framePosition() > 0 &&
-        (CurrentHostCounter() - m_timestamp.get_nanoTime()) < 2 * 1000 * 1000 * 1000)
+    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
     {
-      if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
-      {
-        CLog::Log(LOGDEBUG, "Framecounter: {} Time: {} Current-Time: {}",
-                  (m_timestamp.get_framePosition() & UINT64_LOWER_BYTES),
-                  m_timestamp.get_nanoTime(), CurrentHostCounter());
-      }
-      uint64_t delta = static_cast<uint64_t>(CurrentHostCounter() - m_timestamp.get_nanoTime());
-      uint64_t stamphead =
-          static_cast<uint64_t>(m_timestamp.get_framePosition() & UINT64_LOWER_BYTES) +
-          delta * m_sink_sampleRate / 1000000000.0;
+      CLog::Log(LOGDEBUG, "Framecounter: {} Time: {} Current-Time: {}",
+                (m_timestamp.get_framePosition() & UINT64_LOWER_BYTES), m_timestamp.get_nanoTime(),
+                CurrentHostCounter());
+    }
+    uint64_t delta = static_cast<uint64_t>(CurrentHostCounter() - m_timestamp.get_nanoTime());
+    uint64_t stamphead =
+        static_cast<uint64_t>(m_timestamp.get_framePosition() & UINT64_LOWER_BYTES) +
+        delta * m_sink_sampleRate / 1000000000.0;
+    // wrap around
+    // e.g. 0xFFFFFFFFFFFF0123 -> 0x0000000000002478
+    // because we only query each second the simple smaller comparison won't suffice
+    // as delay can fluctuate minimally
+    if (stamphead < m_timestampPos && (m_timestampPos - stamphead) > 0x7FFFFFFFFFFFFFFFULL)
+    {
+      uint64_t stamp = m_timestampPos;
+      stamp += (1ULL << 32);
+      stamphead = (stamp & UINT64_UPPER_BYTES) | stamphead;
+      CLog::Log(LOGDEBUG, "Wraparound happend old: {} new: {}", m_timestampPos, stamphead);
+    }
+    m_timestampPos = stamphead;
 
-      // wrap around
-      // e.g. 0xFFFFFFFFFFFF0123 -> 0x0000000000002478
-      // because we only query each second the simple smaller comparison won't suffice
-      // as delay can fluctuate minimally
-      if (stamphead < m_timestampPos && (m_timestampPos - stamphead) > 0x7FFFFFFFFFFFFFFFULL)
-      {
-        uint64_t stamp = m_timestampPos;
-        stamp += (1ULL << 32);
-        stamphead = (stamp & UINT64_UPPER_BYTES) | stamphead;
-        CLog::Log(LOGDEBUG, "Wraparound happend old: {} new: {}", m_timestampPos, stamphead);
-      }
-      m_timestampPos = stamphead;
+    double playtime = m_timestampPos / static_cast<double>(m_sink_sampleRate);
 
-      double playtime = m_timestampPos / static_cast<double>(m_sink_sampleRate);
-
-      if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
-      {
-        CLog::Log(LOGDEBUG,
-                  "Delay - Timestamp: {} (ms) delta: {} (ms) playtime: {} (ms) Duration: {} ms",
-                  1000.0 * (m_duration_written - playtime), delta / 1000000.0, playtime * 1000,
-                  m_duration_written * 1000);
-        CLog::Log(LOGDEBUG, "Head-Position {} Timestamp Position {} Delay-Offset: {} ms", m_headPos,
-                  m_timestampPos, 1000.0 * (m_headPos - m_timestampPos) / m_sink_sampleRate);
-      }
-      double hw_delay =
-          m_duration_written - m_timestampPos / static_cast<double>(m_sink_sampleRate);
-      // sadly we smooth the delay, so only compensate here what we did not yet smooth away
-      hw_delay -= d;
-      // sometimes at the beginning of the stream m_timestampPos is more accurate and ahead of
-      // m_headPos - don't use the computed value then and wait
-      if (hw_delay >= 0.0 && hw_delay < 1.0)
-        m_hw_delay = hw_delay;
-      if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
-      {
-        CLog::Log(LOGDEBUG, "HW-Delay (1): {}", hw_delay);
-      }
+    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+    {
+      CLog::Log(LOGDEBUG,
+                "Delay - Timestamp: {} (ms) delta: {} (ms) playtime: {} (ms) Duration: {} ms",
+                1000.0 * (m_duration_written - playtime), delta / 1000000.0, playtime * 1000,
+                m_duration_written * 1000);
+      CLog::Log(LOGDEBUG, "Head-Position {} Timestamp Position {} Delay-Offset: {} ms", m_headPos,
+                m_timestampPos, 1000.0 * (m_headPos - m_timestampPos) / m_sink_sampleRate);
+    }
+    double hw_delay = m_duration_written - playtime;
+    // correct by subtracting above measured delay, if lower delay gets automatically reduced
+    hw_delay -= delay;
+    // sometimes at the beginning of the stream m_timestampPos is more accurate and ahead of
+    // m_headPos - don't use the computed value then and wait
+    if (hw_delay > -1.0 && hw_delay < 1.0)
+      m_hw_delay = hw_delay;
+    else
+      m_hw_delay = 0.0;
+    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+    {
+      CLog::Log(LOGDEBUG, "HW-Delay (1): {}", hw_delay);
     }
   }
+
+  delay += m_hw_delay;
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
+  {
+    CLog::Log(LOGDEBUG, "Combined Delay: {}", delay);
+  }
+  if (delay < 0.0)
+    delay = 0.0;
+
+  const double d = GetMovingAverageDelay(delay);
+
+  // Audiotrack is caching more than we though it would
+  if (d > m_audiotrackbuffer_sec)
+    m_audiotrackbuffer_sec = d;
+
+  // track delay in local member
+  m_delay = d;
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGAUDIO))
   {
     CLog::Log(LOGDEBUG, "Delay Current: %lf", d * 1000);
   }
-
   status.SetDelay(d);
 }
 
 double CAESinkAUDIOTRACK::GetLatency()
 {
-  return m_hw_delay;
+  return 0.0;
 }
 
 double CAESinkAUDIOTRACK::GetCacheTotal()


### PR DESCRIPTION
This change properly pushes the Timestamp API results into the Delay. AE's GetLatency is something different with a different intention. It's not meant as a dynamic delay.

In old code I tried to use GetLatency to hold the delta between old API and new GetTimeStamp API, this did not compensate well.

I changed the log level if user has component logging enabled (which they never should), cause sometimes I need to debug and don't like the Debug Display.

No backport needed, cause TimeStamp API is sadly not in Leia.