### PR TITLE
[Music] Smart playlists - allow song lists to be grouped into albums

### DIFF
--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -649,6 +649,8 @@ std::vector<Field> CSmartPlaylistRule::GetGroups(const std::string &type)
         CSettings::SETTING_MUSICLIBRARY_USEORIGINALDATE))
       groups.push_back(FieldOrigYear);
   }
+  else if (type == "songs")
+    groups.push_back(FieldAlbum);
   if (type == "movies")
   {
     groups.push_back(FieldNone);


### PR DESCRIPTION
## Description
As per the title, this small addition allows smart playlists to group the songs from a song type playlist into their respective albums.

## Motivation and Context
Currently, the only way to achieve this functionality is by converting a smart playlist into a node and adding `<group>albums</group>` to it.  However, many users won't know that this is even possible and/or how to do it.  This addition will, for instance, allow you to list all your flac albums by using a rule of `file endswith flac` and grouping by album.  Without the grouping applied it's just a long list of songs which although correct, makes it difficult to find a specific album and play it.

## How Has This Been Tested?
Tested locally on a fresh build with various playlist rules for selecting songs.

## Screenshots (if appropriate):
file endswith flac (no grouping) - 1471 tracks
<a href="https://ibb.co/SKvY9My"><img src="https://i.ibb.co/VvBnPz9/screenshot161.png" alt="screenshot161" border="0"></a>

with grouping by album applied - 64 albums
<a href="https://ibb.co/jhfhXY6"><img src="https://i.ibb.co/rk0krh7/screenshot162.png" alt="screenshot162" border="0"></a>
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
