### PR TITLE
[Music]Fix music library migration to MyMusic74

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -7932,12 +7932,13 @@ void CMusicDatabase::UpdateTables(int version)
   if (version < 73)
   {
     // add bBoxedSet to album table
-    m_pDS->exec("ALTER TABLE album ADD bBoxedSet INTEGER \n");
+    m_pDS->exec("ALTER TABLE album ADD bBoxedSet INTEGER NOT NULL DEFAULT 0 \n");
     //  add iDiscTotal to album table
-    m_pDS->exec("ALTER TABLE album ADD iDiscTotal INTEGER \n");
+    m_pDS->exec("ALTER TABLE album ADD iDiscTotal INTEGER NOT NULL DEFAULT 0 \n");
     // populate iDiscTotal from the data already in the song table
     m_pDS->exec("UPDATE album SET iDisctotal = (SELECT COUNT(DISTINCT (iTrack >> 16)) "
-                "FROM song WHERE song.idAlbum = album.idAlbum GROUP BY idAlbum ) ");
+                "FROM song WHERE song.idAlbum = album.idAlbum GROUP BY idAlbum ) "
+                "WHERE EXISTS (SELECT 1 FROM song WHERE song.idAlbum = album.idAlbum)");
     // add strDiscSubtitles to song table
     m_pDS->exec("ALTER TABLE song ADD strDiscSubtitle TEXT \n");
   }


### PR DESCRIPTION
Make migration from earlier music library versions more robust. 

A v72 db that had an album without any songs failed to migrate. The library should not be in this state, but I guess could be if scanning or cleanup was interrupted. Anyway such a thing exists in the wild, so make the migration process more robust.

No bump to music library version needed for this.