### PR TITLE
[PVR] add watched count to grouped recordings list

### DIFF
--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -202,6 +202,8 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
       item->SetLabel(strCurrent);
       item->SetLabelPreformatted(true);
       item->m_dateTime = recording->RecordingTimeAsLocalTime();
+      item->SetProperty("totalepisodes", 0);
+      item->SetProperty("watchedepisodes", 0);
       item->SetProperty("unwatchedepisodes", 0);
 
       // Assume all folders are watched, we'll change the overlay later
@@ -215,11 +217,19 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
         item->m_dateTime = recording->RecordingTimeAsLocalTime();
     }
 
+    item->IncrementProperty("totalepisodes", 1);
     if (recording->GetPlayCount() == 0)
     {
       unwatchedFolders.insert(item);
       item->IncrementProperty("unwatchedepisodes", 1);
     }
+    else
+    {
+      item->IncrementProperty("watchedepisodes", 1);
+    }
+    item->SetLabel2(StringUtils::Format("%s / %s",
+        item->GetProperty("watchedepisodes").asString().c_str(),
+        item->GetProperty("totalepisodes").asString().c_str()));
   }
 
   // Change the watched overlay to unwatched for folders containing unwatched entries


### PR DESCRIPTION
## Description
This adds a watched/total episodes count to the grouped PVR Recordings list view

## Motivation and Context
Showing the watched/total episodes count in the grouped PVR recordings list helps the user to quickly see how many unwatched episodes are in each folder. This also makes the experience more consistent with other areas of the application where the watched/total count is shown (e.g. the TV Shows library view)

## How Has This Been Tested?
With this commit in place I have been into the Grouped recordings view to verify that the counts are now shown. I also double-checked that in the non-grouped view, the Date label (ListItem.Label2) still shows correctly (as this shares the same label)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/14977362/76950305-c6d5b700-6901-11ea-8a53-e37501946d9f.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
