### PR TITLE
[GBM][Wayland] share EGL base class

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -14,6 +14,7 @@
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::GBM;
+using namespace KODI::WINDOWING::LINUX;
 
 bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint apiType)
 {
@@ -127,24 +128,4 @@ bool CWinSystemGbmEGLContext::DestroyWindowSystem()
 void CWinSystemGbmEGLContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) const
 {
   VaapiProxyDelete(p);
-}
-
-EGLDisplay CWinSystemGbmEGLContext::GetEGLDisplay() const
-{
-  return m_eglContext.GetEGLDisplay();
-}
-
-EGLSurface CWinSystemGbmEGLContext::GetEGLSurface() const
-{
-  return m_eglContext.GetEGLSurface();
-}
-
-EGLContext CWinSystemGbmEGLContext::GetEGLContext() const
-{
-  return m_eglContext.GetEGLContext();
-}
-
-EGLConfig  CWinSystemGbmEGLContext::GetEGLConfig() const
-{
-  return m_eglContext.GetEGLConfig();
 }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -10,6 +10,7 @@
 
 #include "WinSystemGbm.h"
 #include "utils/EGLUtils.h"
+#include "windowing/linux/WinSystemEGL.h"
 
 #include <memory>
 
@@ -22,7 +23,7 @@ namespace GBM
 
 class CVaapiProxy;
 
-class CWinSystemGbmEGLContext : public CWinSystemGbm
+class CWinSystemGbmEGLContext : public KODI::WINDOWING::LINUX::CWinSystemEGL, public CWinSystemGbm
 {
 public:
   ~CWinSystemGbmEGLContext() override = default;
@@ -33,13 +34,9 @@ public:
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
 
-  EGLDisplay GetEGLDisplay() const;
-  EGLSurface GetEGLSurface() const;
-  EGLContext GetEGLContext() const;
-  EGLConfig  GetEGLConfig() const;
 protected:
-  CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension) :
-    m_eglContext(platform, platformExtension)
+  CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)
+    : CWinSystemEGL{platform, platformExtension}
   {}
 
   /**
@@ -48,8 +45,6 @@ protected:
    */
   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
   virtual bool CreateContext() = 0;
-
-  CEGLContextUtils m_eglContext;
 
   struct delete_CVaapiProxy
   {

--- a/xbmc/windowing/linux/CMakeLists.txt
+++ b/xbmc/windowing/linux/CMakeLists.txt
@@ -6,6 +6,11 @@ if(DBUS_FOUND)
   list(APPEND HEADERS OSScreenSaverFreedesktop.h)
 endif()
 
+if(EGL_FOUND)
+  list(APPEND SOURCES WinSystemEGL.cpp)
+  list(APPEND HEADERS WinSystemEGL.h)
+endif()
+
 if(SOURCES)
   core_add_library(windowing_linux)
 endif()

--- a/xbmc/windowing/linux/WinSystemEGL.cpp
+++ b/xbmc/windowing/linux/WinSystemEGL.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WinSystemEGL.h"
+
+using namespace KODI::WINDOWING::LINUX;
+
+CWinSystemEGL::CWinSystemEGL(EGLenum platform, std::string const& platformExtension)
+  : m_eglContext{platform, platformExtension}
+{
+}
+
+EGLDisplay CWinSystemEGL::GetEGLDisplay() const
+{
+  return m_eglContext.GetEGLDisplay();
+}
+
+EGLSurface CWinSystemEGL::GetEGLSurface() const
+{
+  return m_eglContext.GetEGLSurface();
+}
+
+EGLContext CWinSystemEGL::GetEGLContext() const
+{
+  return m_eglContext.GetEGLContext();
+}
+
+EGLConfig CWinSystemEGL::GetEGLConfig() const
+{
+  return m_eglContext.GetEGLConfig();
+}

--- a/xbmc/windowing/linux/WinSystemEGL.h
+++ b/xbmc/windowing/linux/WinSystemEGL.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/EGLUtils.h"
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace LINUX
+{
+
+class CWinSystemEGL
+{
+public:
+  CWinSystemEGL(EGLenum platform, std::string const& platformExtension);
+  ~CWinSystemEGL() = default;
+
+  EGLDisplay GetEGLDisplay() const;
+  EGLSurface GetEGLSurface() const;
+  EGLContext GetEGLContext() const;
+  EGLConfig GetEGLConfig() const;
+
+protected:
+  CEGLContextUtils m_eglContext;
+};
+
+} // namespace LINUX
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -17,9 +17,10 @@
 #include <EGL/eglext.h>
 
 using namespace KODI::WINDOWING::WAYLAND;
+using namespace KODI::WINDOWING::LINUX;
 
 CWinSystemWaylandEGLContext::CWinSystemWaylandEGLContext()
-: m_eglContext{EGL_PLATFORM_WAYLAND_EXT, "EGL_EXT_platform_wayland"}
+  : CWinSystemEGL{EGL_PLATFORM_WAYLAND_EXT, "EGL_EXT_platform_wayland"}
 {}
 
 bool CWinSystemWaylandEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint apiType)
@@ -145,9 +146,4 @@ void CWinSystemWaylandEGLContext::PresentFrame(bool rendered)
   }
 
   FinishFramePresentation();
-}
-
-EGLDisplay CWinSystemWaylandEGLContext::GetEGLDisplay() const
-{
-  return m_eglContext.GetEGLDisplay();
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -10,6 +10,7 @@
 
 #include "WinSystemWayland.h"
 #include "utils/EGLUtils.h"
+#include "windowing/linux/WinSystemEGL.h"
 
 #include <wayland-egl.hpp>
 
@@ -20,7 +21,8 @@ namespace WINDOWING
 namespace WAYLAND
 {
 
-class CWinSystemWaylandEGLContext : public CWinSystemWayland
+class CWinSystemWaylandEGLContext : public KODI::WINDOWING::LINUX::CWinSystemEGL,
+                                    public CWinSystemWayland
 {
 public:
   CWinSystemWaylandEGLContext();
@@ -31,8 +33,6 @@ public:
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
   bool DestroyWindowSystem() override;
-
-  EGLDisplay GetEGLDisplay() const;
 
 protected:
   /**
@@ -47,7 +47,6 @@ protected:
 
   virtual bool CreateContext() = 0;
 
-  CEGLContextUtils m_eglContext;
   wayland::egl_window_t m_nativeWindow;
 };
 


### PR DESCRIPTION
This PR creates a new class `CWinSystemEGL`. This class is used as a common class for `CWinSystemGbmEGLContext` and `CWinSystemWaylandEGLContext`.

The reason behind this is to allow for windowing agnostic calls to get the `EGLDisplay`. This can then be used to allow the `CRendererDRMPRIMEGLES` and `CRPRendererGBM` (soon to be renamed) classes to work with gbm or wayland windowing without ifdefs.

I'm not yet sure if this is the best solution (but's it's simple) ~~or if just using `CEGLContextUtils` as an inherited class would be better (more difficult).~~

Let me know what you think.

Example usage can be seen here: https://github.com/lrusak/xbmc/commit/77a49a150428da341cf0321822b72236b277133d
and in this branch: https://github.com/lrusak/xbmc/commits/drm-prime-sw-buffer-object

EDIT:
~~I've updated this to just inherit from `CEGLContextUtils`. I've only updated gbm and wayland for now.~~
I've changed it back again :smirk: 