### PR TITLE
contextmenu - hide favourites option if we have no path

### DIFF
--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -84,7 +84,8 @@ bool CAddRemoveFavourite::IsVisible(const CFileItem& item) const
          !URIUtils::IsProtocol(item.GetPath(), "newtag") &&
          !URIUtils::IsProtocol(item.GetPath(), "musicsearch") &&
          !StringUtils::StartsWith(item.GetPath(), "pvr://guide/") &&
-         !StringUtils::StartsWith(item.GetPath(), "pvr://timers/");
+         !StringUtils::StartsWith(item.GetPath(), "pvr://timers/") &&
+         !item.GetPath().empty();
 }
 
 bool CAddRemoveFavourite::Execute(const CFileItemPtr& item) const


### PR DESCRIPTION
the context menu in the eventlog section currently offers the option to add an event to favourites.
i don't think that makes any sense?

![fav](https://user-images.githubusercontent.com/687265/77196512-cd238900-6ae3-11ea-9cce-fbcd80e0ea5d.jpg)

looking at: https://github.com/xbmc/xbmc/blob/4226dc17e91405345d6642b4a6fdb5094dee702c/xbmc/ContextMenus.cpp#L77-L88
the visibility of the 'favourites' option is based on the path of an item.
since events don't have a path, i decided to add a check for empty paths as well.


i've tested this change by checking if the favourites option was still present in the usual places.