### PR TITLE
Favourites Dialog - fix crash

### DIFF
--- a/xbmc/favourites/GUIDialogFavourites.cpp
+++ b/xbmc/favourites/GUIDialogFavourites.cpp
@@ -94,10 +94,11 @@ void CGUIDialogFavourites::OnClick(int item)
   if (item < 0 || item >= m_favourites->Size())
     return;
 
-  Close();
-
   CGUIMessage message(GUI_MSG_EXECUTE, 0, GetID());
   message.SetStringParam(m_favouritesService.GetExecutePath(*(*m_favourites)[item], GetID()));
+
+  Close();
+
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
 }
 


### PR DESCRIPTION
this fixes a crash when selecting an item from favourites.
(ref: https://forum.kodi.tv/showthread.php?tid=352715)

crashlog: https://paste.kodi.tv/calajupaja.kodi

as far as i understand the crash happens because the dialog is closed (and the favourites list is cleared) before the path of the selected item is resolved.

i've tested this change and did not notice any side effects.