### PR TITLE
Re-introduce "input.enablejoystick" setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17389,14 +17389,14 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#35100"
-msgid "Enable joystick and gamepad support"
+msgid "Enable controller support"
 msgstr ""
 
 #empty string with id 35101
 
 #: system/peripherals.xml
 msgctxt "#35102"
-msgid "Disable joystick when this device is present"
+msgid "Disable controllers when this device is present"
 msgstr ""
 
 #. Label for mouse buttons. Used in the controller mapping dialog.
@@ -19728,10 +19728,10 @@ msgctxt "#36377"
 msgid "Use a mouse or touch screen device to control the interface. Note: Disabling will cause you to lose control over this application when no keyboard or remote is present."
 msgstr ""
 
-#. Description of setting with label #35100 "Enable joystick and gamepad support"
+#. Description of setting with label #35100 "Enable controller support"
 #: system/settings/settings.xml
 msgctxt "#36378"
-msgid "Use a joystick to control the interface."
+msgid "Use a game controller to control the interface."
 msgstr ""
 
 #. Description of settings category with label #798 Internet access

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6088,14 +6088,6 @@ msgctxt "#13023"
 msgid "Successfully removed storage device"
 msgstr ""
 
-msgctxt "#13024"
-msgid "Joystick plugged"
-msgstr ""
-
-msgctxt "#13025"
-msgid "Joystick unplugged"
-msgstr ""
-
 #: system/settings/settings.xml
 msgctxt "#13026"
 msgid "Try to wakeup remote servers on access"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2709,12 +2709,12 @@
       </group>
       <group id="2" label="14094">
         <setting id="input.enablemouse" type="boolean" label="21369" help="36377">
-          <level>0</level>
+          <level>2</level>
           <control type="toggle" />
           <default>true</default>
         </setting>
         <setting id="input.enablejoystick" type="boolean" label="35100" help="36378">
-          <level>0</level>
+          <level>2</level>
           <control type="toggle" />
           <default>true</default>
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2713,6 +2713,11 @@
           <control type="toggle" />
           <default>true</default>
         </setting>
+        <setting id="input.enablejoystick" type="boolean" label="35100" help="36378">
+          <level>0</level>
+          <control type="toggle" />
+          <default>true</default>
+        </setting>
         <setting id="input.asknewcontrollers" type="boolean">
           <level>0</level>
           <control type="toggle" />

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -49,6 +49,8 @@ using EVENTSERVER::CEventServer;
 using namespace KODI;
 using namespace MESSAGING;
 
+const std::string CInputManager::SETTING_INPUT_ENABLE_CONTROLLER = "input.enablejoystick";
+
 CInputManager::CInputManager(const CAppParamParser &params) :
   m_keymapEnvironment(new CKeymapEnvironment),
   m_buttonTranslator(new CButtonTranslator),
@@ -66,6 +68,7 @@ CInputManager::CInputManager(const CAppParamParser &params) :
   // Register settings
   std::set<std::string> settingSet;
   settingSet.insert(CSettings::SETTING_INPUT_ENABLEMOUSE);
+  settingSet.insert(SETTING_INPUT_ENABLE_CONTROLLER);
   CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(this, settingSet);
 }
 
@@ -89,6 +92,9 @@ void CInputManager::InitializeInputs()
 
   m_Mouse.Initialize();
   m_Mouse.SetEnabled(CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_INPUT_ENABLEMOUSE));
+
+  m_enableController = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      SETTING_INPUT_ENABLE_CONTROLLER);
 }
 
 void CInputManager::Deinitialize()
@@ -744,6 +750,11 @@ void CInputManager::SetMouseState(MOUSE_STATE mouseState)
   m_Mouse.SetState(mouseState);
 }
 
+bool CInputManager::IsControllerEnabled() const
+{
+  return m_enableController;
+}
+
 void CInputManager::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 {
   if (setting == nullptr)
@@ -752,6 +763,9 @@ void CInputManager::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   const std::string &settingId = setting->GetId();
   if (settingId == CSettings::SETTING_INPUT_ENABLEMOUSE)
     m_Mouse.SetEnabled(std::dynamic_pointer_cast<const CSettingBool>(setting)->GetValue());
+
+  else if (settingId == SETTING_INPUT_ENABLE_CONTROLLER)
+    m_enableController = std::dynamic_pointer_cast<const CSettingBool>(setting)->GetValue();
 }
 
 bool CInputManager::OnAction(const CAction& action)

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -167,6 +167,11 @@ public:
    */
   void SetMouseResolution(int maxX, int maxY, float speedX, float speedY);
 
+  /*! \brief Get the status of the controller-enable setting
+   * \return True if controller input is enabled for the UI, false otherwise
+   */
+  bool IsControllerEnabled() const;
+
   /*! \brief Returns whether or not we can handle a given built-in command.
    *
    */
@@ -289,6 +294,12 @@ private:
   std::vector<KODI::MOUSE::IMouseDriverHandler*> m_mouseHandlers;
 
   std::unique_ptr<KODI::KEYBOARD::IKeyboardDriverHandler> m_keyboardEasterEgg;
+
+  // Input state
+  bool m_enableController = true;
+
+  // Settings
+  static const std::string SETTING_INPUT_ENABLE_CONTROLLER;
 };
 
 /// \}

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -82,19 +82,19 @@ namespace PERIPHERALS
      * \brief Get the number of elements reported by the driver
      */
     unsigned int ButtonCount(void) const { return m_buttonCount; }
-    unsigned int HatCount(void) const    { return m_hatCount; }
-    unsigned int AxisCount(void) const   { return m_axisCount; }
-    unsigned int MotorCount(void) const  { return m_motorCount; }
-    bool SupportsPowerOff(void) const    { return m_supportsPowerOff; }
+    unsigned int HatCount(void) const { return m_hatCount; }
+    unsigned int AxisCount(void) const { return m_axisCount; }
+    unsigned int MotorCount(void) const { return m_motorCount; }
+    bool SupportsPowerOff(void) const { return m_supportsPowerOff; }
 
     /*!
      * \brief Set joystick properties
      */
-    void SetProvider(const std::string& provider) { m_strProvider   = provider; }
-    void SetRequestedPort(int port)               { m_requestedPort = port; }
-    void SetButtonCount(unsigned int buttonCount) { m_buttonCount   = buttonCount; }
-    void SetHatCount(unsigned int hatCount)       { m_hatCount      = hatCount; }
-    void SetAxisCount(unsigned int axisCount)     { m_axisCount     = axisCount; }
+    void SetProvider(const std::string& provider) { m_strProvider = provider; }
+    void SetRequestedPort(int port) { m_requestedPort = port; }
+    void SetButtonCount(unsigned int buttonCount) { m_buttonCount = buttonCount; }
+    void SetHatCount(unsigned int hatCount) { m_hatCount = hatCount; }
+    void SetAxisCount(unsigned int axisCount) { m_axisCount = axisCount; }
     void SetMotorCount(unsigned int motorCount); // specialized to update m_features
     void SetSupportsPowerOff(bool bSupportsPowerOff); // specialized to update m_features
 
@@ -109,20 +109,25 @@ namespace PERIPHERALS
       bool bPromiscuous;
     };
 
-    std::string                         m_strProvider;
-    int                                 m_requestedPort;
-    unsigned int                        m_buttonCount;
-    unsigned int                        m_hatCount;
-    unsigned int                        m_axisCount;
-    unsigned int                        m_motorCount;
-    bool                                m_supportsPowerOff;
+    // State parameters
+    std::string m_strProvider;
+    int m_requestedPort;
+    unsigned int m_buttonCount;
+    unsigned int m_hatCount;
+    unsigned int m_axisCount;
+    unsigned int m_motorCount;
+    bool m_supportsPowerOff;
+    CDateTime m_lastActive;
+
+    // Input clients
     std::unique_ptr<KODI::JOYSTICK::CKeymapHandling> m_appInput;
     std::unique_ptr<KODI::JOYSTICK::CRumbleGenerator> m_rumbleGenerator;
     std::unique_ptr<KODI::JOYSTICK::IInputHandler> m_joystickMonitor;
-    std::unique_ptr<KODI::JOYSTICK::IButtonMap>      m_buttonMap;
+    std::unique_ptr<KODI::JOYSTICK::IButtonMap> m_buttonMap;
     std::unique_ptr<KODI::JOYSTICK::CDeadzoneFilter> m_deadzoneFilter;
-    std::vector<DriverHandler>          m_driverHandlers;
-    CCriticalSection                    m_handlerMutex;
-    CDateTime m_lastActive;
+    std::vector<DriverHandler> m_driverHandlers;
+
+    // Synchronization parameters
+    CCriticalSection m_handlerMutex;
   };
 }


### PR DESCRIPTION
## Description

The `input.enablejoystick` setting was removed in the joystick subsystem introduced in https://github.com/xbmc/xbmc/pull/8807. Instead of this setting, controller input could be disabled from the GUI by disabling the peripheral.joystick add-on.

## Motivation and Context

The reason for re-adding this setting is due to Kodi's interaction with the window manager. On systems without a window manager, Kodi won't receive an event when the main app loses focus. By introducing this setting, an API is provided to clients so they can appropriately enable controller input based on external knowledge.

Discussion: https://forum.kodi.tv/showthread.php?tid=352475

Fixes https://github.com/garbear/xbmc/issues/105

Fixes https://trac.kodi.tv/ticket/16464

## How Has This Been Tested?

Test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-18.6-20200320

(tested on Leia for convenience)

#### Disabling controllers

Ran the command:

```
curl -v --data-binary '{"jsonrpc": "2.0", "method": "Settings.SetSettingValue", "params": {"setting": "input.enablejoystick", "value": false}, "id": 1}' -H 'content-type: application/json;' http://localhost:8080/jsonrpc
```

Result in GUI:

![Controller disabled](https://user-images.githubusercontent.com/531482/77220804-e686fe00-6b00-11ea-980f-6a829f3de152.png)

Effect: Controller disabled

#### Enabling controllers

Ran the command:

```
curl -v --data-binary '{"jsonrpc": "2.0", "method": "Settings.SetSettingValue", "params": {"setting": "input.enablejoystick", "value": true}, "id": 1}' -H 'content-type: application/json;' http://localhost:8080/jsonrpc
```

Result in GUI:
![Controller enabled 2](https://user-images.githubusercontent.com/531482/77220829-3bc30f80-6b01-11ea-9de8-f07e104edaec.png)

Effect: Controller enabled

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
