### PR TITLE
CDMAHeapBufferObject: add new class to abstract new dma-heap buffers

### DIFF
--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -96,6 +96,13 @@ else()
   message(WARNING, "udmabuf: include/linux/udmabuf.h not found")
 endif()
 
+check_include_files("linux/dma-heap.h" HAVE_LINUX_DMA_HEAP)
+if(HAVE_LINUX_DMA_HEAP)
+  list(APPEND ARCH_DEFINES "-DHAVE_LINUX_DMA_HEAP=1")
+else()
+  message(WARNING, "dma-heap: include/linux/dma-heap.h not found")
+endif()
+
 include(CheckSymbolExists)
 set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
 check_symbol_exists("mkostemp" "stdlib.h" HAVE_MKOSTEMP)

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -201,6 +201,11 @@ if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
     list(APPEND HEADERS UDMABufferObject.h)
   endif()
 
+  if(HAVE_LINUX_DMA_HEAP)
+    list(APPEND SOURCES DMAHeapBufferObject.cpp)
+    list(APPEND HEADERS DMAHeapBufferObject.h)
+  endif()
+
   if(GBM_HAS_BO_MAP)
     list(APPEND SOURCES GBMBufferObject.cpp)
     list(APPEND HEADERS GBMBufferObject.h)

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -1,0 +1,173 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DMAHeapBufferObject.h"
+
+#include "ServiceBroker.h"
+#include "utils/BufferObjectFactory.h"
+#include "utils/log.h"
+
+#include <array>
+
+#include <drm/drm_fourcc.h>
+#include <linux/dma-heap.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+
+namespace
+{
+
+std::array<const char*, 2> DMA_HEAP_PATHS = {
+    "/dev/dma_heap/reserved",
+    "/dev/dma_heap/system",
+};
+
+static const char* DMA_HEAP_PATH;
+
+} // namespace
+
+std::unique_ptr<CBufferObject> CDMAHeapBufferObject::Create()
+{
+  return std::make_unique<CDMAHeapBufferObject>();
+}
+
+void CDMAHeapBufferObject::Register()
+{
+  for (auto path : DMA_HEAP_PATHS)
+  {
+    int fd = open(path, O_RDWR);
+    if (fd < 0)
+    {
+      CLog::LogF(LOGERROR, "unable to open {}: {}", path, strerror(errno));
+      continue;
+    }
+
+    close(fd);
+    DMA_HEAP_PATH = path;
+    break;
+  }
+
+  if (!DMA_HEAP_PATH)
+    return;
+
+  CLog::LogF(LOGDEBUG, "using {}: for dma-heap", DMA_HEAP_PATH);
+
+  CBufferObjectFactory::RegisterBufferObject(CDMAHeapBufferObject::Create);
+}
+
+CDMAHeapBufferObject::~CDMAHeapBufferObject()
+{
+  ReleaseMemory();
+  DestroyBufferObject();
+
+  close(m_dmaheapfd);
+  m_dmaheapfd = -1;
+}
+
+bool CDMAHeapBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint32_t height)
+{
+  if (m_fd >= 0)
+    return true;
+
+  uint32_t bpp{1};
+
+  switch (format)
+  {
+    case DRM_FORMAT_ARGB8888:
+      bpp = 4;
+      break;
+    case DRM_FORMAT_ARGB1555:
+    case DRM_FORMAT_RGB565:
+      bpp = 2;
+      break;
+    default:
+      throw std::system_error(errno, std::generic_category(), "pixel format not implemented");
+  }
+
+  m_size = width * height * bpp;
+  m_stride = width * bpp;
+
+  if (m_dmaheapfd < 0)
+  {
+    m_dmaheapfd = open(DMA_HEAP_PATH, O_RDWR);
+    if (m_dmaheapfd < 0)
+    {
+      CLog::LogF(LOGERROR, "failed to open {}:", DMA_HEAP_PATH, strerror(errno));
+      return false;
+    }
+  }
+
+  struct dma_heap_allocation_data allocData = {
+      .len = m_size, .fd_flags = (O_CLOEXEC | O_RDWR), .heap_flags = 0};
+
+  int ret = ioctl(m_dmaheapfd, DMA_HEAP_IOCTL_ALLOC, &allocData);
+  if (ret < 0)
+  {
+    CLog::LogF(LOGERROR, "ioctl DMA_HEAP_IOCTL_ALLOC failed, ret={} errno={}", ret,
+               strerror(errno));
+    return false;
+  }
+
+  m_fd = allocData.fd;
+  m_size = allocData.len;
+
+  if (m_fd < 0 || m_size <= 0)
+  {
+    CLog::LogF(LOGERROR, "invalid allocation data: fd={} len={}", m_fd, m_size);
+    return false;
+  }
+
+  return true;
+}
+
+void CDMAHeapBufferObject::DestroyBufferObject()
+{
+  if (m_fd < 0)
+    return;
+
+  int ret = close(m_fd);
+  if (ret < 0)
+    CLog::LogF(LOGERROR, "close failed, errno={}", __FUNCTION__, strerror(errno));
+
+  m_fd = -1;
+  m_stride = 0;
+  m_size = 0;
+}
+
+uint8_t* CDMAHeapBufferObject::GetMemory()
+{
+  if (m_fd < 0)
+    return nullptr;
+
+  if (m_map)
+  {
+    CLog::LogF(LOGDEBUG, "already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
+    return m_map;
+  }
+
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
+  if (m_map == MAP_FAILED)
+  {
+    CLog::LogF(LOGERROR, "mmap failed, errno={}", strerror(errno));
+    return nullptr;
+  }
+
+  return m_map;
+}
+
+void CDMAHeapBufferObject::ReleaseMemory()
+{
+  if (!m_map)
+    return;
+
+  int ret = munmap(m_map, m_size);
+  if (ret < 0)
+    CLog::LogF(LOGERROR, "munmap failed, errno={}", strerror(errno));
+
+  m_map = nullptr;
+}

--- a/xbmc/utils/DMAHeapBufferObject.h
+++ b/xbmc/utils/DMAHeapBufferObject.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/BufferObject.h"
+
+#include <memory>
+#include <stdint.h>
+
+class CDMAHeapBufferObject : public CBufferObject
+{
+public:
+  CDMAHeapBufferObject() = default;
+  virtual ~CDMAHeapBufferObject() override;
+
+  // Registration
+  static std::unique_ptr<CBufferObject> Create();
+  static void Register();
+
+  // IBufferObject overrides via CBufferObject
+  bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
+  void DestroyBufferObject() override;
+  uint8_t* GetMemory() override;
+  void ReleaseMemory() override;
+
+private:
+  int m_dmaheapfd{-1};
+  uint64_t m_size{0};
+  uint8_t* m_map{nullptr};
+};

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -21,6 +21,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "utils/BufferObjectFactory.h"
+#include "utils/DMAHeapBufferObject.h"
 #include "utils/DumbBufferObject.h"
 #include "utils/GBMBufferObject.h"
 #include "utils/UDMABufferObject.h"
@@ -81,6 +82,9 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
 #endif
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
+#endif
+#if defined(HAVE_LINUX_DMA_HEAP)
+  CDMAHeapBufferObject::Register();
 #endif
 
   return true;


### PR DESCRIPTION
This new buffer type was added in [linux 5.6](https://lore.kernel.org/patchwork/patch/1103667/)

This buffer type can be taken from CMA which is guaranteed to be contiguous. This will most likely be the buffer type of choice for when we implement the SW buffers code for VideoPlayer.

This will only be built and registered if your kernel is new enough to support linux/dma-heap.h which is version 5.6 and later.

To use this you need to be able to read/write to `/dev/dma_heap/reserved` or `/dev/dma_heap/system`. You need to use the following udev rule:
```
SUBSYSTEM=="dma_heap", MODE="0666"
```

You may also need to set your CMA allocation:

via kernel config
```
CONFIG_CMA_SIZE_MBYTES=128
CONFIG_CMA_SIZE_SEL_MBYTES=y
```
or kernel cmdline
```
cma=128M
```

The `CDMAHeapBufferObject` class will check if it can open the device and only register if the permissions are correct.

This also will allow using wayland with dmabufs in the future. That will be coming later when we figure out some other stuff.

and to add to the table in https://github.com/xbmc/xbmc/pull/17523#issuecomment-602068828
|   | CPU Cached | Supports DMA | Requires GBM | Contiguous |
|---|------------|--------------|--------------|--------------|
| DMA-HEAP | :grey_question: |  :white_check_mark:       |      :x: |  :white_check_mark:  |
| UDMA |      :grey_question:     |       :white_check_mark:       |      :x:         | :grey_question: |
| GBM |       :x:      |       :white_check_mark:       |       :white_check_mark:       | :white_check_mark: |
| Dumb |      :x:       |       :white_check_mark:       |       :x:        | :white_check_mark: |

