### PR TITLE
[Profiles] Verify lock on video-playback from any screen but VIDEO_NAV

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2790,13 +2790,29 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (!bRestart)
   {
     // bRestart will be true when called from PlayStack(), skipping this block
-    m_appPlayer.SetPlaySpeed(1);
+    if (item.IsVideo())
+    {
+      // check lock from any screen but WINDOW_VIDEO_NAV
+      if (WINDOW_VIDEO_NAV != CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow())
+      {
+        if (CServiceBroker::GetSettingsComponent()
+                ->GetProfileManager()
+                ->GetCurrentProfile()
+                .videoLocked())
+        {
+          if (!g_passwordManager.IsMasterLockUnlocked(true))
+          {
+            return true; // exit func without starting playback
+          }
+        }
+      }
 
+      CUtil::ClearSubtitles();
+    }
+
+    m_appPlayer.SetPlaySpeed(1);
     m_nextPlaylistItem = -1;
     m_stackHelper.Clear();
-
-    if (item.IsVideo())
-      CUtil::ClearSubtitles();
   }
 
   if (item.IsDiscStub())


### PR DESCRIPTION
## Description
Even if lock preferences are set up, for example, like this:

![screenshot004](https://user-images.githubusercontent.com/58829855/77233407-767f8300-6ba7-11ea-92a7-5f1d815b35e5.png)

it's still possible to play "in progress", "recently added" and others by using the home-screen-widgets, remote-app or webinterface.
This PR closes this issue. A little drawback when playing files that have a resume-point:
The context-menu will then appear before the password-dialog, but I cannot locate
a better codepath to catch this than `CApplication.PlayFile()`.
Suggestions to something that makes more sense welcome.
This solution works even if starting playback via JSON-RPC or Webinterface.

## How Has This Been Tested?
Local installation on Linux - works with stacked movies too

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
