### PR TITLE
Revert "DVDVideoCodecAndroidMediaCodec: Properly set MAX WIDTH and MAX_HEIGHT

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1172,8 +1172,6 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
   AMediaFormat_setString(mediaformat, AMEDIAFORMAT_KEY_MIME, m_mime.c_str());
   AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_WIDTH, m_hints.width);
   AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_HEIGHT, m_hints.height);
-  AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_MAX_WIDTH, m_hints.width);
-  AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_MAX_HEIGHT, m_hints.height);
   AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_MAX_INPUT_SIZE, 0);
 
   if (CJNIBase::GetSDKVersion() >= 23 && m_render_surface)


### PR DESCRIPTION
This caused sever regressions on:

- Some Philips TVs
- Sony TVs

While it fixed a broken firmware of another Philips TV series. The key is entirely optional, therefore let's not set it at all as the standard wants it.

Documentation: https://developer.android.com/reference/android/media/MediaFormat#KEY_MAX_HEIGHT

Bugreport: https://github.com/xbmc/xbmc/issues/17520
Forum-Thread: https://forum.kodi.tv/showthread.php?tid=352515