### PR TITLE
[addons][pvr] fix wrong header include, reduce CAddonDll use, take ch. uid for signal ask

### DIFF
--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -42,7 +42,7 @@ namespace ADDON
   {
     public:
       virtual ~IAddonMgrCallback() = default;
-      virtual bool RequestRestart(AddonPtr addon, bool datachanged)=0;
+      virtual bool RequestRestart(const std::string& id, bool datachanged)=0;
   };
 
   /**

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -84,7 +84,7 @@ void CAddonStatusHandler::Process()
   if (m_status == ADDON_STATUS_NEED_RESTART)
   {
     HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{24074});
-    CServiceBroker::GetAddonMgr().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
+    CServiceBroker::GetAddonMgr().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon->ID(), true);
   }
   /* Some required settings are missing/invalid */
   else if (m_status == ADDON_STATUS_NEED_SETTINGS)
@@ -107,7 +107,7 @@ void CAddonStatusHandler::Process()
     {
       //! @todo Doesn't dialogaddonsettings save these automatically? It should do this.
       m_addon->SaveSettings();
-      CServiceBroker::GetAddonMgr().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
+      CServiceBroker::GetAddonMgr().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon->ID(), true);
     }
   }
 }

--- a/xbmc/addons/AddonStatusHandler.h
+++ b/xbmc/addons/AddonStatusHandler.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "IAddon.h"
-#include "addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_types.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/AddonBase.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -258,6 +258,11 @@ std::shared_ptr<CPVREpgInfoTag> CPVRPlaybackState::GetPlayingEpgTag() const
   return m_playingEpgTag;
 }
 
+int CPVRPlaybackState::GetPlayingChannelUniqueID() const
+{
+  return m_playingChannelUniqueId;
+}
+
 std::string CPVRPlaybackState::GetPlayingClientName() const
 {
   return m_strPlayingClientName;

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -137,6 +137,12 @@ public:
   std::shared_ptr<CPVREpgInfoTag> GetPlayingEpgTag() const;
 
   /*!
+   * @brief Return playing channel unique identifier
+   * @return The channel id or -1 if not present
+   */
+  int GetPlayingChannelUniqueID() const;
+
+  /*!
    * @brief Get the name of the playing client, if there is one.
    * @return The name of the client or an empty string if nothing is playing.
    */

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -73,7 +73,7 @@ void CPVRClient::StopRunningInstance()
   {
     // stop the pvr manager and stop and unload the running pvr addon. pvr manager will be restarted on demand.
     CServiceBroker::GetPVRManager().Stop();
-    CServiceBroker::GetPVRManager().Clients()->StopClient(addon, false);
+    CServiceBroker::GetPVRManager().Clients()->StopClient(addon->ID(), false);
   }
 }
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -81,19 +81,19 @@ namespace PVR
 
     /*!
      * @brief Restart a single client add-on.
-     * @param addon The add-on to restart.
+     * @param id The add-on to restart.
      * @param bDataChanged True if the client's data changed, false otherwise (unused).
      * @return True if the client was found and restarted, false otherwise.
      */
-    bool RequestRestart(ADDON::AddonPtr addon, bool bDataChanged) override;
+    bool RequestRestart(const std::string& id, bool bDataChanged) override;
 
     /*!
      * @brief Stop a client.
-     * @param addon The client to stop.
+     * @param id The client to stop.
      * @param bRestart If true, restart the client.
      * @return True if the client was found, false otherwise.
      */
-    bool StopClient(const ADDON::AddonPtr& addon, bool bRestart);
+    bool StopClient(const std::string& id, bool bRestart);
 
     /*!
      * @brief Handle addon events (enable, disable, ...).
@@ -317,17 +317,17 @@ namespace PVR
 
     /*!
      * @brief Check whether a client is known.
-     * @param client The client to check.
+     * @param id The addon id to check.
      * @return True if this client is known, false otherwise.
      */
-    bool IsKnownClient(const ADDON::AddonPtr& client) const;
+    bool IsKnownClient(const std::string& id) const;
 
     /*!
      * @brief Check whether an given addon instance is a created pvr client.
-     * @param addon The addon.
+     * @param id The addon id.
      * @return True if the the addon represents a created client, false otherwise.
      */
-    bool IsCreatedClient(const ADDON::AddonPtr& addon);
+    bool IsCreatedClient(const std::string& id);
 
     /*!
      * @brief Get all created clients and clients not (yet) ready to use.

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -195,8 +195,8 @@ void CPVRGUIInfo::UpdateQualityData()
 
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRPLAYBACK_SIGNALQUALITY))
   {
-    bool bIsPlayingRecording = CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRecording();
-    if (!bIsPlayingRecording)
+    const int channelUid = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannelUniqueID();
+    if (channelUid > 0)
     {
       std::shared_ptr<CPVRClient> client;
       CServiceBroker::GetPVRManager().Clients()->GetCreatedClient(CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingClientID(), client);
@@ -213,8 +213,8 @@ void CPVRGUIInfo::UpdateDescrambleData()
   PVR_DESCRAMBLE_INFO descrambleInfo;
   ClearDescrambleInfo(descrambleInfo);
 
-  bool bIsPlayingRecording = CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRecording();
-  if (!bIsPlayingRecording)
+  const int channelUid = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannelUniqueID();
+  if (channelUid > 0)
   {
     std::shared_ptr<CPVRClient> client;
     CServiceBroker::GetPVRManager().Clients()->GetCreatedClient(CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingClientID(), client);


### PR DESCRIPTION
## Description

Few independent code parts taken from rework request to reduce his size.

Commit 1:
----------------------------
**[addons] change `xbmc_addon_types.h` include to `AddonBase.h` on `AddonStatusHandler.h`**

The xbmc_addon_types.h is obsolete and only include the AddonBase.h.
There was the last place in Kodi where it was included in his sources.

Commit 2:
-------------------------
**[addons][pvr] Pass in addon string ID and not its class**

This change is an independent part of the rework to switch to the new API.
This removes the use of `CAddonDll` in some places and gives its string
identification instead.

This is not critical since the called up positions only need this.

The background to this change is that in the multiple instance way the
addon class is no longer usable because it can also affect other instances.

The other reason is to reduce the rework request in size.

> **Note:** The complete addon handling way need to be reworked after PVR is changed (that all systems equal) and to have all Types secure in case of changes und updates. But to heavy to include on this or PVR rework. This request not change the way, it takes only the id instead class on some places.

Commit 3:
------------------------
**[addons][pvr] add GetPlayingChannelUniqueID to playback state**

This add `int CPVRPlaybackState::GetPlayingChannelUniqueID() const` to get
on wanted places the currently running PVR channel unique identifier.

This are also now used by "CPVRGUIInfo::UpdateQualityData()" and
`CPVRGUIInfo::UpdateDescrambleData()` and this `!IsPlayingRecording()`
becomes replaced with them.

`GetPlayingChannelUniqueID()` match more the wanted target as to ask
that is not a recording.

Further is this value also needed on reworked PVR system to pass to addon.
But this change here is mostly independent and thats why separated

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
To reduce amount of changes on https://github.com/xbmc/xbmc/pull/16485

After this is in a rebase of #16485 becomes done
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Doing the next days check on addons.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
