### PR TITLE
Support displaying recording sizes for PVR and being able to sort by them

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -49,7 +49,7 @@
 					<width>1050</width>
 					<height>425</height>
 					<align>justify</align>
-					<label>$INFO[ListItem.ChannelName,[B],[/B][CR]]$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]$VAR[PremieredLabel]$INFO[ListItem.Rating,[COLOR grey]$LOCALIZE[563]:[/COLOR] ,[CR]]$VAR[ExpirationDateTimeLabel]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]$INFO[ListItem.Writer,[COLOR grey]$LOCALIZE[20417]:[/COLOR] ,[CR]]$INFO[ListItem.Director,[COLOR grey]$LOCALIZE[20339]:[/COLOR] ,[CR]]$INFO[ListItem.Cast,[COLOR grey]$LOCALIZE[206]:[/COLOR] ,[CR]][CR]$INFO[ListItem.Plot]</label>
+					<label>$INFO[ListItem.ChannelName,[B],[/B][CR]]$INFO[ListItem.Date,[COLOR grey]$LOCALIZE[552]:[/COLOR] ,[CR]]$INFO[ListItem.Duration,[COLOR grey]$LOCALIZE[180]:[/COLOR] ,[CR]]$VAR[RecordingSizeLabel]$VAR[PremieredLabel]$INFO[ListItem.Rating,[COLOR grey]$LOCALIZE[563]:[/COLOR] ,[CR]]$VAR[ExpirationDateTimeLabel]$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ,[CR]]$INFO[ListItem.Writer,[COLOR grey]$LOCALIZE[20417]:[/COLOR] ,[CR]]$INFO[ListItem.Director,[COLOR grey]$LOCALIZE[20339]:[/COLOR] ,[CR]]$INFO[ListItem.Cast,[COLOR grey]$LOCALIZE[206]:[/COLOR] ,[CR]][CR]$INFO[ListItem.Plot]</label>
 					<autoscroll time="3000" delay="4000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
 				</control>
 				<control type="grouplist" id="9000">

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -288,7 +288,7 @@
 				<top>10</top>
 				<width>830</width>
 				<height>262</height>
-				<label>$LOCALIZE[19076] ($INFO[Container(5000).NumItems,[B],[/B] $LOCALIZE[31036]])</label>
+				<label>$LOCALIZE[19076] ($INFO[Container(5000).NumItems,[B],[/B] $LOCALIZE[31036]]) $INFO[ListItem.Property(recordingsize),- $LOCALIZE[20161]: [B],[/B]]</label>
 				<font>font37</font>
 				<visible>!ListItem.IsParentFolder</visible>
 			</control>
@@ -307,7 +307,7 @@
 							<height>90</height>
 							<width>830</width>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+							<label>$VAR[RecordingDateSizeLabel]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</focusedlayout>
@@ -317,7 +317,7 @@
 							<height>90</height>
 							<width>830</width>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+							<label>$VAR[RecordingDateSizeLabel]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</itemlayout>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -488,6 +488,13 @@
 		<value condition="ListItem.IsNew + String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode) + String.IsEmpty(ListItem.EpisodeName)">[B][COLOR button_focus]$LOCALIZE[842][/COLOR][/B]</value>
 		<value condition="ListItem.IsNew">[B][COLOR button_focus]$LOCALIZE[842][/COLOR][/B] - </value>
 	</variable>
+	<variable name="RecordingSizeLabel">
+		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0 B)">$INFO[ListItem.Size,[COLOR grey]$LOCALIZE[22031]:[/COLOR] ,[CR]]</value>
+	</variable>
+	<variable name="RecordingDateSizeLabel">
+		<value condition="!String.IsEmpty(ListItem.Size) + !String.IsEqual(ListItem.Size,0 B)">$INFO[ListItem.Date,[COLOR grey],[/COLOR]]$INFO[ListItem.Size, (,)[CR]]</value>
+		<value>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]</value>
+	</variable>
 	<variable name="ExpirationDateTimeLabel">
 		<value condition="!String.IsEmpty(ListItem.ExpirationDate)">[COLOR grey]$LOCALIZE[19299]:[/COLOR] $INFO[ListItem.ExpirationDate] $INFO[ListItem.ExpirationTime][CR]</value>
 	</variable>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -216,6 +216,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
   m_strPath = record->m_strFileNameAndPath;
   SetLabel(record->m_strTitle);
   m_dateTime = record->RecordingTimeAsLocalTime();
+  m_dwSize = record->GetSizeInBytes();
 
   // Set art
   if (!record->m_strIconPath.empty())

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "6.2.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "6.2.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "6.3.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "6.3.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \
                                                       "xbmc_pvr_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -344,6 +344,16 @@ extern "C"
   PVR_ERROR GetRecordingEdl(const PVR_RECORDING& recording, PVR_EDL_ENTRY edl[], int *size);
 
   /*!
+   * Retrieve the size of a recording on the backend.
+   * @param[in] recording in: The recording to get the size in bytes for.
+   * @param[out] sizeInBytes out: The size in bytes of the recording
+   * @return PVR_ERROR_NO_ERROR if the recording's size has been set successfully.
+   * @remarks Required if bSupportsRecordingSize is set to true.
+   *          Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
+   */
+  PVR_ERROR GetRecordingSize(const PVR_RECORDING* recording, int64_t* sizeInBytes);
+
+  /*!
    * Retrieve the timer types supported by the backend.
    * @param types out: The function has to write the definition of the supported timer types into this array.
    * @param typesCount in: The maximum size of the list, out: the actual size of the list. default: PVR_ADDON_TIMERTYPE_ARRAY_SIZE
@@ -732,6 +742,7 @@ extern "C"
     pClient->toAddon.SetRecordingLastPlayedPosition = SetRecordingLastPlayedPosition;
     pClient->toAddon.GetRecordingLastPlayedPosition = GetRecordingLastPlayedPosition;
     pClient->toAddon.GetRecordingEdl                = GetRecordingEdl;
+    pClient->toAddon.GetRecordingSize               = GetRecordingSize;
 
     pClient->toAddon.GetTimerTypes                  = GetTimerTypes;
     pClient->toAddon.GetTimersAmount                = GetTimersAmount;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -316,6 +316,7 @@ extern "C" {
     bool bSupportsRecordingsLifetimeChange; /*!< @brief true if the backend supports changing lifetime for recordings. */
     bool bSupportsDescrambleInfo;       /*!< @brief true if the backend supports descramble information for playing channels. */
     bool bSupportsAsyncEPGTransfer;     /*!< @brief true if this addon-on supports asynchronous transfer of epg events to Kodi using the callback function EpgEventStateChange. */
+    bool bSupportsRecordingSize;        /*!< @brief true if this addon-on supports retrieving size of recordings. */
 
     unsigned int iRecordingsLifetimesSize; /*!< @brief (required) Count of possible values for PVR_RECORDING.iLifetime. 0 means lifetime is not supported for recordings or no own value definition wanted, but to use Kodi defaults of 1..365. */
     PVR_ATTRIBUTE_INT_VALUE recordingsLifetimeValues[PVR_ADDON_ATTRIBUTE_VALUES_ARRAY_SIZE]; /*!< @brief (optional) Array containing the possible values for PVR_RECORDING.iLifetime. Must be filled if iLifetimesSize > 0 */
@@ -575,6 +576,7 @@ extern "C" {
     PVR_RECORDING_CHANNEL_TYPE channelType;               /*!< @brief (optional) channel type. Set to PVR_RECORDING_CHANNEL_TYPE_UNKNOWN if the type cannot be determined. */
     char   strFirstAired[PVR_ADDON_DATE_STRING_LENGTH];   /*!< @brief (optional) first aired date of this recording. Used only for display purposes. Specify in W3C date format "YYYY-MM-DD". */
     unsigned int iFlags;                                  /*!< @brief (optional) bit field of independent flags associated with the recording */
+    int64_t sizeInBytes;                                  /*!< @brief (optional) size of the recording in bytes */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!
@@ -689,6 +691,7 @@ extern "C" {
     PVR_ERROR (__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING&, int);
     int (__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING&);
     PVR_ERROR (__cdecl* GetRecordingEdl)(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
+    PVR_ERROR (__cdecl* GetRecordingSize)(const PVR_RECORDING*, int64_t*);
     PVR_ERROR (__cdecl* GetTimerTypes)(PVR_TIMER_TYPE[], int*);
     int (__cdecl* GetTimersAmount)(void);
     PVR_ERROR (__cdecl* GetTimers)(ADDON_HANDLE);

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -410,6 +410,13 @@ void CGUIListItem::IncrementProperty(const std::string &strKey, int nVal)
   SetProperty(strKey, i);
 }
 
+void CGUIListItem::IncrementProperty(const std::string& strKey, int64_t nVal)
+{
+  int64_t i = GetProperty(strKey).asInteger();
+  i += nVal;
+  SetProperty(strKey, i);
+}
+
 void CGUIListItem::IncrementProperty(const std::string &strKey, double dVal)
 {
   double d = GetProperty(strKey).asDouble();

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -140,6 +140,7 @@ public:
   void SetProperty(const std::string &strKey, const CVariant &value);
 
   void IncrementProperty(const std::string &strKey, int nVal);
+  void IncrementProperty(const std::string& strKey, int64_t nVal);
   void IncrementProperty(const std::string &strKey, double dVal);
 
   void ClearProperties();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -531,6 +531,10 @@ void CPVRManager::Process()
       /* try to play channel on startup */
       TriggerPlayChannelOnStartup();
     }
+
+    if (m_addons->AnyClientSupportingRecordingsSize())
+      TriggerRecordingsSizeInProgressUpdate();
+
     /* execute the next pending jobs if there are any */
     try
     {
@@ -755,6 +759,13 @@ void CPVRManager::TriggerRecordingsUpdate()
 {
   m_pendingUpdates->Append("pvr-update-recordings", [this]() {
     return Recordings()->Update();
+  });
+}
+
+void CPVRManager::TriggerRecordingsSizeInProgressUpdate()
+{
+  m_pendingUpdates->Append("pvr-update-recordings-size", [this]() {
+    return Recordings()->UpdateInProgressSize();
   });
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -266,6 +266,11 @@ namespace PVR
     void TriggerRecordingsUpdate();
 
     /*!
+     * @brief Let the background thread update the size for any in progress recordings.
+     */
+    void TriggerRecordingsSizeInProgressUpdate();
+
+    /*!
      * @brief Let the background thread update the timer list.
      */
     void TriggerTimersUpdate();

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -923,6 +923,15 @@ PVR_ERROR CPVRClient::GetRecordingEdl(const CPVRRecording& recording, std::vecto
   }, m_clientCapabilities.SupportsRecordingsEdl());
 }
 
+PVR_ERROR CPVRClient::GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes)
+{
+  return DoAddonCall(__FUNCTION__, [&recording, &sizeInBytes](const AddonInstance* addon) {
+    PVR_RECORDING tag;
+    WriteClientRecordingInfo(recording, tag);
+    return addon->GetRecordingSize(&tag, &sizeInBytes);
+  }, m_clientCapabilities.SupportsRecordingsSize());
+}
+
 PVR_ERROR CPVRClient::GetTimersAmount(int& iTimers)
 {
   iTimers = -1;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -181,6 +181,16 @@ namespace PVR
      */
     void GetRecordingsLifetimeValues(std::vector<std::pair<std::string, int>>& list) const;
 
+    /*!
+     * @brief Check whether this add-on supports retrieving the size recordings..
+     * @return True if supported, false otherwise.
+     */
+    bool SupportsRecordingsSize() const
+    {
+      return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings &&
+             m_addonCapabilities->bSupportsRecordingSize;
+    }
+
     /////////////////////////////////////////////////////////////////////////////////
     //
     // Streams
@@ -549,6 +559,14 @@ namespace PVR
     * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
     */
     PVR_ERROR GetRecordingEdl(const CPVRRecording& recording, std::vector<PVR_EDL_ENTRY>& edls);
+
+    /*!
+    * @brief Retrieve the size of a recording on the backend.
+    * @param recording The recording.
+    * @param sizeInBytes The size in bytes
+    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+    */
+    PVR_ERROR GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes);
 
     /*!
     * @brief Retrieve the edit decision list (EDL) from the backend.

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -552,6 +552,17 @@ std::vector<std::shared_ptr<CPVRClient>> CPVRClients::GetClientsSupportingChanne
   return possibleSettingsClients;
 }
 
+bool CPVRClients::AnyClientSupportingRecordingsSize() const
+{
+  std::vector<std::shared_ptr<CPVRClient>> recordingSizeClients;
+  ForCreatedClients(__FUNCTION__, [&recordingSizeClients](const std::shared_ptr<CPVRClient>& client) {
+    if (client->GetClientCapabilities().SupportsRecordingsSize())
+      recordingSizeClients.emplace_back(client);
+    return PVR_ERROR_NO_ERROR;
+  });
+  return recordingSizeClients.size() != 0;
+}
+
 void CPVRClients::OnSystemSleep()
 {
   ForCreatedClients(__FUNCTION__, [](const std::shared_ptr<CPVRClient>& client) {

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -267,6 +267,12 @@ namespace PVR
      */
     std::vector<std::shared_ptr<CPVRClient>> GetClientsSupportingChannelSettings(bool bRadio) const;
 
+    /*!
+     * @brief Get whether or not any client supports recording size.
+     * @return True if any client supports recording size.
+     */
+    bool AnyClientSupportingRecordingsSize() const;
+
     //@}
 
     /*! @name Power management methods */

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -205,6 +205,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
       item->SetProperty("totalepisodes", 0);
       item->SetProperty("watchedepisodes", 0);
       item->SetProperty("unwatchedepisodes", 0);
+      item->SetProperty("sizeinbytes", UINT64_C(0));
 
       // Assume all folders are watched, we'll change the overlay later
       item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED, false);
@@ -230,6 +231,18 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     item->SetLabel2(StringUtils::Format("%s / %s",
         item->GetProperty("watchedepisodes").asString().c_str(),
         item->GetProperty("totalepisodes").asString().c_str()));
+
+    item->IncrementProperty("sizeinbytes", recording->GetSizeInBytes());
+  }
+
+  // Replace the incremental size of the recordings with a string equivalent
+  for (auto& item : results.GetList())
+  {
+    int64_t size = item->GetProperty("sizeinbytes").asInteger();
+    item->ClearProperty("sizeinbytes");
+    item->m_dwSize = size; // We'll also sort recording folders by size
+    if (size > 0)
+      item->SetProperty("recordingsize", StringUtils::SizeToString(size));
   }
 
   // Change the watched overlay to unwatched for folders containing unwatched entries

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -441,6 +441,13 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
           return true;
         }
         return false;
+      case LISTITEM_SIZE:
+        if (recording->GetSizeInBytes() > 0)
+        {
+          strValue = StringUtils::SizeToString(recording->GetSizeInBytes());
+          return true;
+        }
+        return false;
     }
     return false;
   }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -76,6 +76,30 @@ void CPVRRecordings::Update()
   CServiceBroker::GetPVRManager().PublishEvent(PVREvent::RecordingsInvalidated);
 }
 
+void CPVRRecordings::UpdateInProgressSize()
+{
+  CSingleLock lock(m_critSection);
+  if (m_bIsUpdating)
+    return;
+  m_bIsUpdating = true;
+
+  CLog::LogFC(LOGDEBUG, LOGPVR, "Updating recordings size");
+  bool bHaveUpdatedInProgessRecording = false;
+  for (auto& recording : m_recordings)
+  {
+    if (recording.second->IsInProgress())
+    {
+      if (recording.second->UpdateRecordingSize())
+        bHaveUpdatedInProgessRecording = true;
+    }
+  }
+
+  m_bIsUpdating = false;
+
+  if (bHaveUpdatedInProgessRecording)
+    CServiceBroker::GetPVRManager().PublishEvent(PVREvent::RecordingsInvalidated);
+}
+
 int CPVRRecordings::GetNumTVRecordings() const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -48,6 +48,11 @@ namespace PVR
      */
     void Update();
 
+    /*!
+     * @brief refresh the size of any in progress recordings from the clients.
+     */
+    void UpdateInProgressSize();
+
     int GetNumTVRecordings() const;
     bool HasDeletedTVRecordings() const;
     int GetNumRadioRecordings() const;

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -10,6 +10,8 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClients.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimersPath.h"
 #include "settings/Settings.h"
@@ -45,6 +47,8 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
   AddSortMethod(SortByDate,  552, LABEL_MASKS("%L", "%d", "%L", "%d")); // "Date"     : Filename, DateTime | Foldername, DateTime
   AddSortMethod(SortByTime,  180, LABEL_MASKS("%L", "%D", "%L", ""));   // "Duration" : Filename, Duration | Foldername, empty
   AddSortMethod(SortByFile,  561, LABEL_MASKS("%L", "%d", "%L", ""));   // "File"     : Filename, DateTime | Foldername, empty
+  if (CServiceBroker::GetPVRManager().Clients()->AnyClientSupportingRecordingsSize())
+    AddSortMethod(SortBySize,  553, LABEL_MASKS("%L", "%I", "%L", "%I")); // "Size"   : Filename, DateTime | Foldername, empty
 
   // Default sorting
   SetSortMethod(SortByDate);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Supporting sizes for recordings and displaying them on the folder view side pane and info screen. In addition ability to sort by size.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Makes it easy when needing to make space for recordings for backend that don't support expiration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

MacOSX with pvr.vuplus

## Screenshots (if appropriate):

<img width="2158" alt="Screenshot 2020-03-21 at 22 15 12" src="https://user-images.githubusercontent.com/4601187/77239044-f9b3cf80-6bcd-11ea-9856-8e2668b051fe.png">

<img width="2165" alt="Screenshot 2020-03-21 at 22 14 54" src="https://user-images.githubusercontent.com/4601187/77239046-020c0a80-6bce-11ea-978d-f7954b71f95f.png">

Sort by size:
<img width="2158" alt="Screenshot 2020-03-21 at 23 39 49" src="https://user-images.githubusercontent.com/4601187/77239049-06382800-6bce-11ea-9be5-da6bc339aa42.png">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
