### PR TITLE
[backport][addons][vfs] fix Kodi start crash if incompatible VFS addon present

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -487,8 +487,11 @@ bool CAddonDll::CheckAPIVersion(int type)
       addonMinVersion.asString(),
       addonVersion.asString());
 
-    CEventLog &eventLog = CServiceBroker::GetEventLog();
-    eventLog.AddWithNotification(EventPtr(new CNotificationEvent(Name(), 24152, EventLevel::Error)));
+    if (CServiceBroker::GetGUI())
+    {
+      CEventLog &eventLog = CServiceBroker::GetEventLog();
+      eventLog.AddWithNotification(EventPtr(new CNotificationEvent(Name(), 24152, EventLevel::Error)));
+    }
 
     return false;
   }


### PR DESCRIPTION
## Description

Backport of: https://github.com/xbmc/xbmc/pull/17539

Before does Kodi always crash if a incompatible VFS addon was present, that was comming during his version checks on start and try to send a GUI message without a available GUI!

This add a check about GUIManager is present and prevent his call if not.
The wanted message is still be shown as Dialog from addon system after GUI start.

**Backtrace:**
```
Thread 1 "kodi-x11" received signal SIGSEGV, Segmentation fault.
0x00005555565a00c4 in CGUIComponent::GetWindowManager() ()
(gdb) bt
#0  0x00005555565a00c4 in CGUIComponent::GetWindowManager() ()
#1  0x0000555556efe685 in CEventLog::SendMessage(std::shared_ptr<IEvent const> const&, int) ()
#2  0x0000555556efec1b in CEventLog::Add(std::shared_ptr<IEvent const> const&) ()
#3  0x0000555556efeea0 in CEventLog::AddWithNotification(std::shared_ptr<IEvent const> const&, unsigned int, unsigned int, bool) ()
#4  0x000055555677afe1 in ADDON::CAddonDll::CheckAPIVersion(int) ()
#5  0x000055555677e8ac in ADDON::CAddonDll::CreateInstance(ADDON_TYPE, void const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void*, void*) ()
#6  0x0000555556781d86 in ADDON::IAddonInstanceHandler::CreateInstance(void*) ()
#7  0x0000555556832ad3 in ADDON::CVFSEntry::CVFSEntry(std::shared_ptr<ADDON::CBinaryAddonBase>) ()
#8  0x000055555683315d in ADDON::CVFSAddonCache::Update() ()
#9  0x00005555568ea198 in CServiceManager::InitStageTwo(CAppParamParser const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#10 0x0000555556843c20 in CApplication::Create(CAppParamParser const&) ()
#11 0x00005555564d882c in XBMC_Run ()
#12 0x0000555555e04b8a in main ()
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Background is that Kodi's VFS need to start before GUI is available, thats then for this case a stupid hen and egg problem and the `if (CServiceBroker::GetGUI())` needed there :unamused:.

Not sure if Issue https://github.com/xbmc/xbmc/issues/15488 related to them or another present about.

Also not sure if it could make sense about a backtrace to Leia with them.

## How Has This Been Tested?

To produce the failure build incompatible VFS addon where his API is different and incompatible to Kodi's API version.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

Now a wanted dialog is shown and not the crash
![Bildschirmfoto von 2020-03-22 11-58-02](https://user-images.githubusercontent.com/6879739/77247849-45e62a80-6c35-11ea-9fcc-680068bbaeb8.png)

Here the place where this message thought for:
![Bildschirmfoto von 2020-03-22 12-40-42](https://user-images.githubusercontent.com/6879739/77248548-8eecad80-6c3a-11ea-8504-d8fdf6df77e8.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
