### PR TITLE
[RetroPlayer] CRPRendererDMA: use GL_TEXTURE_2D 

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
@@ -52,7 +52,7 @@ namespace RETRO
     CRenderContext &m_context;
     const int m_fourcc = 0;
 
-    const GLenum m_textureTarget = GL_TEXTURE_EXTERNAL_OES;
+    const GLenum m_textureTarget = GL_TEXTURE_2D;
     GLuint m_textureId = 0;
 
   private:

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
@@ -42,7 +42,6 @@ CRPRendererDMA::CRPRendererDMA(const CRenderSettings& renderSettings,
                                std::shared_ptr<IRenderBufferPool> bufferPool)
   : CRPRendererOpenGLES(renderSettings, context, std::move(bufferPool))
 {
-  m_textureTarget = GL_TEXTURE_EXTERNAL_OES;
 }
 
 void CRPRendererDMA::Render(uint8_t alpha)
@@ -69,7 +68,7 @@ void CRPRendererDMA::Render(uint8_t alpha)
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE_RGBA_OES);
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE_NOALPHA);
 
   GLubyte colour[4];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip


### PR DESCRIPTION
`GL_TEXTURE_EXTERNAL_OES` seems to only be needed when using YUV formats (atleast according to mesa). The spec doesn't say anything about what formats are accepted.

The render still worked ok however there was a constant `unhandled #` being printed out on the console. That printf originates in this switch/case https://gitlab.freedesktop.org/mesa/mesa/-/blob/19.3/src/mesa/state_tracker/st_program.h#L80-104

This change just lets us use GL_TEXTURE_2D which works fine and stops the error from printing. I don't think we will ever have to support YUV formats with RetroPlayer but if we do then we can always revisit this.
