### PR TITLE
[PVR] CPVREpgTagsContainer::GetTimeline : Fix edge case

### DIFF
--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -485,7 +485,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgTagsContainer::GetTimeline(
                       CreateGapTag(maxEnd, result.front()->StartAsUTC() - ONE_SECOND));
       }
 
-      if (result.back()->EndAsUTC() < maxEventStart)
+      if (result.back()->EndAsUTC() <= maxEventStart)
       {
         // append gap tag
         CDateTime minStart = m_database->GetMinStartTime(m_iEpgID, maxEventStart);


### PR DESCRIPTION
Fix edge case where a gap tag needs to be appended to time line. Otherwise this can lead to crashes while navigating the EPG grid in the Guide window.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you have some time