### PR TITLE
[settings/lib] support static <enable> tag for <setting> definitions

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -105,6 +105,11 @@ bool CSetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (parentSetting != nullptr)
     m_parentSetting = parentSetting;
 
+  // get <enable>
+  bool value;
+  if (XMLUtils::GetBoolean(node, SETTING_XML_ELM_ENABLED, value))
+    m_enabled = value;
+
   // get the <level>
   int level = -1;
   if (XMLUtils::GetInt(node, SETTING_XML_ELM_LEVEL, level))

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -25,6 +25,7 @@
 #define SETTING_XML_ELM_VISIBLE "visible"
 #define SETTING_XML_ELM_REQUIREMENT "requirement"
 #define SETTING_XML_ELM_CONDITION "condition"
+#define SETTING_XML_ELM_ENABLED "enable"
 #define SETTING_XML_ELM_LEVEL "level"
 #define SETTING_XML_ELM_DEFAULT "default"
 #define SETTING_XML_ELM_VALUE "value"


### PR DESCRIPTION
## Description
Right now only old style add-on settings can statically disable a setting. New style add-ons would have to use some dependency condition magic which doesn't make any sense. Therefore I've added support for the `<enable>` tag as part of a `<setting>` definition. Using `<enable>true</enable>` doesn't make much sense in general (similar to `<visible>true</visible>`) but might come in handy if some setting is disabled by default but should be enabled for a specific platform.

@ronie once this has been merged can you update your documentation on the wiki?

## Motivation and Context
@sarbes and @ronie discussed this missing feature on Slack.

## How Has This Been Tested?
Manually

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
