### PR TITLE
Adjust mouse and gesture handling

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -225,8 +225,11 @@ private:
   CStopWatch m_matchTimer;
   std::string m_match;
   float m_scrollItemsPerFrame;
-
   static const int letter_match_timeout = 1000;
+
+  // early inertial scroll cancellation
+  bool m_waitForScrollEnd = false;
+  float m_lastScrollValue;
 };
 
 

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -105,16 +105,17 @@ void CGUIFixedListContainer::Scroll(int amount)
   // increase or decrease the offset within [-minCursor, m_items.size() - maxCursor]
   int minCursor, maxCursor;
   GetCursorRange(minCursor, maxCursor);
+  const int nextCursor = GetCursor() + amount;
   int offset = GetOffset() + amount;
   if (offset < -minCursor)
   {
     offset = -minCursor;
-    SetCursor(minCursor);
+    SetCursor(nextCursor < minCursor ? minCursor : nextCursor);
   }
   if (offset > (int)m_items.size() - 1 - maxCursor)
   {
     offset = m_items.size() - 1 - maxCursor;
-    SetCursor(maxCursor);
+    SetCursor(nextCursor > maxCursor ? maxCursor : nextCursor);
   }
   ScrollToOffset(offset);
 }

--- a/xbmc/input/InertialScrollingHandler.h
+++ b/xbmc/input/InertialScrollingHandler.h
@@ -45,4 +45,5 @@ class CInertialScrollingHandler
     CPoint        m_iLastGesturePoint;
     CVector       m_inertialDeacceleration;
     unsigned int  m_inertialStartTime = 0;
+    float m_timeToZero = 0.0f;
 };

--- a/xbmc/input/touch/ITouchInputHandler.h
+++ b/xbmc/input/touch/ITouchInputHandler.h
@@ -86,6 +86,7 @@ public:
   virtual bool UpdateTouchPointer(int32_t pointer, float x, float y, int64_t time, float size = 0.0f) { return false; }
 
   void SetScreenDPI(float dpi) { if (dpi > 0.0f) m_dpi = dpi; }
+  float GetScreenDPI() { return m_dpi; }
 
 protected:
   /*!

--- a/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchInputHandler.cpp
@@ -19,7 +19,7 @@
 
 namespace
 {
-constexpr int TOUCH_HOLD_TIMEOUT = 1000;
+constexpr int TOUCH_HOLD_TIMEOUT = 500;
 }
 
 CGenericTouchInputHandler::CGenericTouchInputHandler()


### PR DESCRIPTION
## Description
**Commit 1:**
This PR affects mouse and touch behaviour:
- Don't change selected item in ListView during MouseMove and GesturePan
- Select element on GestureEnd (could be after inertial scroll), cancel inertial scroll when start / end of list is reached
- Fix selection on beginning / end if using Middle mouse wheel

**Commit 2:**
- Adjust gesture Longpress time from 1sec > 0.5 sec
- Reduce inertial scroll time (scroll after swipe) for low velocities
- Take DPI into account when calculating  inertial scroll values

## Motivation and Context
In the last period I tested lot on android phones / and for validation on my windows laptop with touch and mouse support. Navigating with mouse felt something nervous / stressing, this PR reduces select actions to have a more relexed navigation. Beside this it will save battery live due to much less image / content change actions.   

## How Has This Been Tested?
Navigate inside main menu and video library with android phone / windows laptop (touch and mouse)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
