### PR TITLE
Fix Android DPI detection / eventloop is not called

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -139,10 +139,11 @@ float CXBMCApp::m_refreshRate = 0.0f;
 
 uint32_t CXBMCApp::m_playback_state = PLAYBACK_STATE_STOPPED;
 
-CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
-  : CJNIMainActivity(nativeActivity)
-  , CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver")
-  , m_videosurfaceInUse(false)
+CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputHandler)
+  : CJNIMainActivity(nativeActivity),
+    CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver"),
+    m_inputHandler(inputHandler),
+    m_videosurfaceInUse(false)
 {
   m_xbmcappinstance = this;
   m_activity = nativeActivity;
@@ -371,6 +372,7 @@ void CXBMCApp::Initialize()
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(CXBMCApp::get());
   runNativeOnUiThread(RegisterDisplayListener, nullptr);
   m_activityManager.reset(new CJNIActivityManager(getSystemService(CJNIContext::ACTIVITY_SERVICE)));
+  m_inputHandler.setDPI(GetDPI());
 }
 
 void CXBMCApp::Deinitialize()
@@ -1440,6 +1442,7 @@ void CXBMCApp::onDisplayChanged(int displayId)
     winSystemAndroid->UpdateDisplayModes();
 
   m_displayChangeEvent.Set();
+  m_inputHandler.setDPI(GetDPI());
   android_printf("%s: ", __PRETTY_FUNCTION__);
 }
 

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -85,7 +85,7 @@ class CXBMCApp
     , public CJNISurfaceHolderCallback
 {
 public:
-  explicit CXBMCApp(ANativeActivity *nativeActivity);
+  explicit CXBMCApp(ANativeActivity* nativeActivity, IInputHandler& inputhandler);
   ~CXBMCApp() override;
   static CXBMCApp* get() { return m_xbmcappinstance; }
 
@@ -224,6 +224,7 @@ private:
   static void RegisterDisplayListener(CVariant*);
 
   static ANativeActivity *m_activity;
+  IInputHandler& m_inputHandler;
   static CJNIWakeLock *m_wakeLock;
   static int m_batteryLevel;
   static bool m_hasFocus;

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -100,12 +100,11 @@ extern void android_main(struct android_app* state)
     state->inputPollSource.process = process_input;
 
     CEventLoop eventLoop(state);
-    CXBMCApp xbmcApp(state->activity);
+    IInputHandler inputHandler;
+    CXBMCApp xbmcApp(state->activity, inputHandler);
     if (xbmcApp.isValid())
     {
       start_logger("Kodi");
-
-      IInputHandler inputHandler;
       eventLoop.run(xbmcApp, inputHandler);
     }
     else


### PR DESCRIPTION
## Description
Kodi does not work with the correct display DPI value, because https://github.com/xbmc/xbmc/blob/master/xbmc/platform/android/activity/EventLoop.cpp#L68 is not called anymore. This PR implements additional DPI detection on app initialization and on displayChange events.

## Motivation and Context
Gestures on touch screens are dependent on the DPI, see #17548.

## How Has This Been Tested?
Using kodi with gestures on Android phone / log debug interpretation.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
