### PR TITLE
[python] revert onAbortRequested removal

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -159,11 +159,6 @@ web applications or frameworks for the Python programming language.
       <b>xbmc.monitor().onDatabaseScanStarted()</b> function was removed completely.
 }
 \python_removed_function{
-      onAbortRequested,
-      "",
-      <b>xbmc.monitor().onAbortRequested()</b> function was removed completely.
-}
-\python_removed_function{
       create,
       "",
       <b>xbmcgui.DialogBusy().create()</b> function was removed completely.

--- a/xbmc/interfaces/generic/ILanguageInvocationHandler.h
+++ b/xbmc/interfaces/generic/ILanguageInvocationHandler.h
@@ -23,6 +23,7 @@ public:
 
   virtual bool OnScriptInitialized(ILanguageInvoker *invoker) { return true; }
   virtual void OnScriptStarted(ILanguageInvoker *invoker) { }
+  virtual void OnScriptAbortRequested(ILanguageInvoker *invoker) { }
   virtual void OnExecutionEnded(ILanguageInvoker* invoker) {}
   virtual void OnScriptFinalized(ILanguageInvoker *invoker) { }
 

--- a/xbmc/interfaces/generic/ILanguageInvoker.cpp
+++ b/xbmc/interfaces/generic/ILanguageInvoker.cpp
@@ -63,6 +63,12 @@ bool ILanguageInvoker::onExecutionInitialized()
   return m_invocationHandler->OnScriptInitialized(this);
 }
 
+void ILanguageInvoker::onAbortRequested()
+{
+  if (m_invocationHandler)
+    m_invocationHandler->OnScriptAbortRequested(this);
+}
+
 void ILanguageInvoker::onExecutionFailed()
 {
   if (m_invocationHandler)

--- a/xbmc/interfaces/generic/ILanguageInvoker.h
+++ b/xbmc/interfaces/generic/ILanguageInvoker.h
@@ -55,6 +55,7 @@ protected:
 
   virtual void pulseGlobalEvent();
   virtual bool onExecutionInitialized();
+  virtual void onAbortRequested();
   virtual void onExecutionFailed();
   virtual void onExecutionDone();
   virtual void onExecutionFinalized();

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -26,6 +26,13 @@ namespace XBMCAddon
       }
     }
 
+    void Monitor::OnAbortRequested()
+    {
+      XBMC_TRACE;
+      abortEvent.Set();
+      invokeCallback(new CallbackFunction<Monitor>(this,&Monitor::onAbortRequested));
+    }
+
     bool Monitor::waitForAbort(double timeout)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -56,6 +56,8 @@ namespace XBMCAddon
 
       inline const String& GetId() { return Id; }
       inline long GetInvokerId() { return invokerId; }
+
+      void OnAbortRequested();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -214,6 +216,18 @@ namespace XBMCAddon
       onCleanFinished(...);
 #else
       virtual void onCleanFinished(const String library) { XBMC_TRACE; }
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_monitor
+      /// @brief \python_func{ onAbortRequested() }
+      ///-----------------------------------------------------------------------
+      /// @python_v14 Deprecated. Use **waitForAbort()** to be notified about this event.
+      ///
+      onAbortRequested();
+#else
+      virtual void    onAbortRequested() { XBMC_TRACE; }
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -491,6 +491,14 @@ bool CPythonInvoker::stop(bool abort)
 
       PyEval_RestoreThread((PyThreadState*)m_threadState);
 
+      //tell xbmc.Monitor to call onAbortRequested()
+      if (m_addon)
+      {
+        CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): trigger Monitor abort request", GetId(),
+                  m_sourceFile.c_str());
+        onAbortRequested();
+      }
+
       PyObject* m;
       m = PyImport_AddModule("xbmc");
       if (m == NULL || PyObject_SetAttrString(m, "abortRequested", PyBool_FromLong(1)))

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -628,6 +628,25 @@ void XBPython::OnScriptStarted(ILanguageInvoker *invoker)
   m_vecPyList.push_back(inf);
 }
 
+void XBPython::OnScriptAbortRequested(ILanguageInvoker *invoker)
+{
+  XBMC_TRACE;
+
+  long invokerId(-1);
+  if (invoker != NULL)
+    invokerId = invoker->GetId();
+
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
+  for (auto& it : tmp)
+  {
+    if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
+    {
+      if (invokerId < 0 || it->GetInvokerId() == invokerId)
+        it->OnAbortRequested();
+    }
+  }
+}
+
 void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
 {
   CSingleLock lock(m_vecPyList);

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -90,6 +90,7 @@ public:
   void Uninitialize() override;
   bool OnScriptInitialized(ILanguageInvoker *invoker) override;
   void OnScriptStarted(ILanguageInvoker *invoker) override;
+  void OnScriptAbortRequested(ILanguageInvoker *invoker) override;
   void OnExecutionEnded(ILanguageInvoker* invoker) override;
   void OnScriptFinalized(ILanguageInvoker *invoker) override;
   ILanguageInvoker* CreateInvoker() override;


### PR DESCRIPTION
revert commit https://github.com/xbmc/xbmc/pull/17456/commits/2bb85067d8ebde85295cc495ce941087b241ccfd of  https://github.com/xbmc/xbmc/pull/17456

the removal of the onAbortRequested() method is causing issues.
addons no longer exit cleanly on Kodi shutdown.

@MilhouseVH 