### PR TITLE
[darwin_embedded] enable xcode project binary addon build for ios

### DIFF
--- a/cmake/scripts/darwin_embedded/Install.cmake
+++ b/cmake/scripts/darwin_embedded/Install.cmake
@@ -81,19 +81,17 @@ set_target_properties(${APP_NAME_LC} PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTI
                                                 XCODE_ATTRIBUTE_PROVISIONING_PROFILE_SPECIFIER "${PROVISIONING_PROFILE_APP}")
 
 # Create xcode target that allows to build binary-addons.
-if(CORE_PLATFORM_NAME_LC STREQUAL tvos)
-  if(ADDONS_TO_BUILD)
-    set(_addons "ADDONS=${ADDONS_TO_BUILD}")
-  endif()
-  add_custom_target(binary-addons
-    COMMAND $(MAKE) -C ${CMAKE_SOURCE_DIR}/tools/depends/target/binary-addons clean
-    COMMAND $(MAKE) -C ${CMAKE_SOURCE_DIR}/tools/depends/target/binary-addons VERBOSE=1 V=99
-          INSTALL_PREFIX="${CMAKE_BINARY_DIR}/addons" CROSS_COMPILING=yes ${_addons})
-  if(ENABLE_XCODE_ADDONBUILD)
-    add_dependencies(${APP_NAME_LC} binary-addons)
-  endif()
-  unset(_addons)
+if(ADDONS_TO_BUILD)
+  set(_addons "ADDONS=${ADDONS_TO_BUILD}")
 endif()
+add_custom_target(binary-addons
+  COMMAND $(MAKE) -C ${CMAKE_SOURCE_DIR}/tools/depends/target/binary-addons clean
+  COMMAND $(MAKE) -C ${CMAKE_SOURCE_DIR}/tools/depends/target/binary-addons VERBOSE=1 V=99
+        INSTALL_PREFIX="${CMAKE_BINARY_DIR}/addons" CROSS_COMPILING=yes ${_addons})
+if(ENABLE_XCODE_ADDONBUILD)
+  add_dependencies(${APP_NAME_LC} binary-addons)
+endif()
+unset(_addons)
 
 add_custom_command(TARGET ${APP_NAME_LC} POST_BUILD
     # TODO: Remove in sync with CopyRootFiles-darwin_embedded expecting the ".bin" file

--- a/docs/README.iOS.md
+++ b/docs/README.iOS.md
@@ -8,7 +8,9 @@ This guide has been tested with macOS 10.13.4(17E199) High Sierra and 10.14.4(18
 2. **[Prerequisites](#2-prerequisites)**
 3. **[Get the source code](#3-get-the-source-code)**
 4. **[Configure and build tools and dependencies](#4-configure-and-build-tools-and-dependencies)**
-5. **[Build binary add-ons](#5-build-binary-add-ons)**
+5. **[Build binary add-ons](#5-build-binary-add-ons)**  
+  5.1. **[Independent Add-on building](#51-Independent-Add-on-building)**  
+  5.2. **[Xcode project building](#52-Xcode-project-building)**  
 6. **[Build Kodi](#6-build-kodi)**  
   6.1. **[Generate Project Files](#61-Generate-Project-Files)**  
   6.2. **[Build with Xcode](#62-build)**  
@@ -104,7 +106,10 @@ make -j$(getconf _NPROCESSORS_ONLN)
 **[back to top](#table-of-contents)** | **[back to section top](#4-configure-and-build-tools-and-dependencies)**
 
 ## 5. Build binary add-ons
+
 You can find a complete list of available binary add-ons **[here](https://github.com/xbmc/repo-binary-addons)**.
+
+## 5.1. Independent Add-on building
 
 Change to Kodi's source code directory:
 ```
@@ -124,6 +129,41 @@ make -C tools/depends/target/binary-addons ADDONS="audioencoder.flac pvr.vdr.vns
 Build a specific group of add-ons:
 ```
 make -j$(getconf _NPROCESSORS_ONLN) -C tools/depends/target/binary-addons ADDONS="pvr.*"
+```
+
+## 5.2. Xcode project building
+
+Binary addons will be built as a dependency in the Xcode project. You can choose the addons 
+you wish to build during the Xcode project generation step
+
+Generate Xcode project to build specific add-ons:
+```sh
+make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-DENABLE_XCODE_ADDONBUILD=ON -DADDONS_TO_BUILD='audioencoder.flac pvr.vdr.vnsi audiodecoder.snesapu'"
+```
+
+Generate Xcode project to build a specific group of add-ons:
+```sh
+make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-DENABLE_XCODE_ADDONBUILD=ON -DADDONS_TO_BUILD='pvr.*'"
+```
+
+**TIP:** When using addontype.* for -DADDONS_TO_BUILD argument, you cannot have multiple 
+addon types. ie -DADDONS_TO_BUILD='game.libretro.* peripheral.*' is not valid. You will 
+need to individually list the addons as per the first example for specific addon building.
+
+Generate Xcode project to build all add-ons automatically:
+```sh
+make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-DENABLE_XCODE_ADDONBUILD=ON"
+```
+
+**TIP:** If you wish to not automatically build addons added to your xcode project, omit
+`-DENABLE_XCODE_ADDONBUILD=ON`. The target will be added to the project, but the dependency
+ will not be set to automatically build  
+**TIP:** Binary add-ons added to the generated Xcode project can be built independently of 
+the Kodi app by selecting the scheme/target `binary-addons` in the Xcode project.
+You can also build the binary-addons target via xcodebuild. This will not build the Kodi
+App, but will build any/all binary addons added for the project Generation.
+```sh
+xcodebuild -config "Debug" -target binary-addons
 ```
 
 **[back to top](#table-of-contents)**


### PR DESCRIPTION
Just enables xcode binary-addon creation as part of the xcode project.

## Description
I've been able to test this thoroughly whilst troubleshooting game.libretro.* addons on ios. Works as expected, so should be ok to open the implementation up from tvos only to both darwin_embedded platforms.

## Motivation and Context
Equality between ios/tvos xcode project builds

## How Has This Been Tested?
Extensively using multiple addon types (game.*, pvr.*, peripheral.*) via xcode project.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
