### PR TITLE
[settings] allow TranslatableIntegerSettingOption to get string from addon

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -959,7 +959,8 @@ SettingPtr CAddonSettings::InitializeFromOldSettingSelect(const std::string& set
 
       TranslatableIntegerSettingOptions options;
       for (uint32_t i = 0; i < values.size(); ++i)
-        options.push_back(std::make_pair(static_cast<int>(strtol(values[i].c_str(), nullptr, 0)), i));
+        options.push_back(TranslatableIntegerSettingOption(
+            static_cast<int>(strtol(values[i].c_str(), nullptr, 0)), i));
       settingInt->SetTranslatableOptions(options);
 
       setting = settingInt;
@@ -1104,7 +1105,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(const std::string& sett
         if (settingEntries.size() > i)
           value = static_cast<int>(strtol(settingEntries[i].c_str(), nullptr, 0));
 
-        options.push_back(std::make_pair(label, value));
+        options.push_back(TranslatableIntegerSettingOption(label, value));
       }
 
       settingInt->SetTranslatableOptions(options);

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -436,9 +436,9 @@ void CGUIDialogMediaFilter::InitializeSettings()
         value = filter.rule->m_operator == CDatabaseQueryRule::OPERATOR_TRUE ? CHECK_YES : CHECK_NO;
 
       TranslatableIntegerSettingOptions entries;
-      entries.push_back(std::pair<int, int>(CHECK_LABEL_ALL, CHECK_ALL));
-      entries.push_back(std::pair<int, int>(CHECK_LABEL_NO,  CHECK_NO));
-      entries.push_back(std::pair<int, int>(CHECK_LABEL_YES, CHECK_YES));
+      entries.push_back(TranslatableIntegerSettingOption(CHECK_LABEL_ALL, CHECK_ALL));
+      entries.push_back(TranslatableIntegerSettingOption(CHECK_LABEL_NO, CHECK_NO));
+      entries.push_back(TranslatableIntegerSettingOption(CHECK_LABEL_YES, CHECK_YES));
 
       filter.setting = AddSpinner(group, settingId, filter.label, SettingLevel::Basic, value, entries, true);
     }

--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -491,8 +491,8 @@ bool CSettingsOperations::SerializeSettingInt(std::shared_ptr<const CSettingInt>
       for (const auto& itOption : options)
       {
         CVariant varOption(CVariant::VariantTypeObject);
-        varOption["label"] = g_localizeStrings.Get(itOption.first);
-        varOption["value"] = itOption.second;
+        varOption["label"] = g_localizeStrings.Get(itOption.label);
+        varOption["value"] = itOption.value;
         obj["options"].push_back(varOption);
       }
       break;

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -384,15 +384,15 @@ void CGUIDialogInfoProviderSettings::InitializeSettings()
     entries.clear();
     if (m_singleScraperType == CONTENT_ALBUMS)
     {
-      entries.push_back(std::make_pair(38066, INFOPROVIDER_THISITEM));
-      entries.push_back(std::make_pair(38067, INFOPROVIDER_ALLVIEW));
+      entries.push_back(TranslatableIntegerSettingOption(38066, INFOPROVIDER_THISITEM));
+      entries.push_back(TranslatableIntegerSettingOption(38067, INFOPROVIDER_ALLVIEW));
     }
     else
     {
-      entries.push_back(std::make_pair(38064, INFOPROVIDER_THISITEM));
-      entries.push_back(std::make_pair(38065, INFOPROVIDER_ALLVIEW));
+      entries.push_back(TranslatableIntegerSettingOption(38064, INFOPROVIDER_THISITEM));
+      entries.push_back(TranslatableIntegerSettingOption(38065, INFOPROVIDER_ALLVIEW));
     }
-    entries.push_back(std::make_pair(38063, INFOPROVIDER_DEFAULT));
+    entries.push_back(TranslatableIntegerSettingOption(38063, INFOPROVIDER_DEFAULT));
     AddList(group1, SETTING_APPLYTOITEMS, 38338, SettingLevel::Basic, m_applyToItems, entries, 38339); // "Apply settings to"
   }
 

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -196,7 +196,8 @@ void CGUIDialogNetworkSetup::InitializeSettings()
   // Add our protocols
   TranslatableIntegerSettingOptions labels;
   for (size_t idx = 0; idx < m_protocols.size(); ++idx)
-    labels.push_back(std::make_pair(m_protocols[idx].label, idx));
+    labels.push_back(
+        TranslatableIntegerSettingOption(m_protocols[idx].label, idx, m_protocols[idx].addonId));
 
   AddSpinner(group, SETTING_PROTOCOL, 1008, SettingLevel::Basic, m_protocol, labels);
   AddEdit(group, SETTING_SERVER_ADDRESS, 1010, SettingLevel::Basic, m_server, true);
@@ -448,10 +449,9 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
       {
         // only use first protocol
         auto prots = StringUtils::Split(info.type, "|");
-        m_protocols.emplace_back(Protocol{ info.supportPath, info.supportUsername,
-          info.supportPassword, info.supportPort,
-          info.supportBrowsing, info.defaultPort,
-          prots.front(), info.label });
+        m_protocols.emplace_back(Protocol{
+            info.supportPath, info.supportUsername, info.supportPassword, info.supportPort,
+            info.supportBrowsing, info.defaultPort, prots.front(), info.label, addon->ID()});
       }
     }
   }

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -24,6 +24,7 @@ public:
     int defaultPort;       //!< Default port to use for protocol
     std::string type;      //!< URL type for protocol
     int label;             //!< String ID to use as label in dialog
+    std::string addonId; //!< Addon identifier, leaved empty if inside Kodi
   };
 
   CGUIDialogNetworkSetup(void);

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -575,7 +575,7 @@ void CPeripherals::GetSettingsFromMappingsFile(TiXmlElement *xmlNode, std::map<s
       std::string strEnums = XMLUtils::GetAttribute(currentNode, "lvalues");
       if (!strEnums.empty())
       {
-        std::vector< std::pair<int,int> > enums;
+        TranslatableIntegerSettingOptions enums;
         std::vector<std::string> valuesVec;
         StringUtils::Tokenize(strEnums, valuesVec, "|");
         for (unsigned int i = 0; i < valuesVec.size(); i++)

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -270,11 +270,11 @@ void CGUIDialogLockSettings::InitializeSettings()
     AddToggle(groupDetails, SETTING_LOCK_FILEMANAGER, 20042, SettingLevel::Basic, m_locks.files);
 
     TranslatableIntegerSettingOptions settingsLevelOptions;
-    settingsLevelOptions.push_back(std::make_pair(106, LOCK_LEVEL::NONE));
-    settingsLevelOptions.push_back(std::make_pair(593, LOCK_LEVEL::ALL));
-    settingsLevelOptions.push_back(std::make_pair(10037, LOCK_LEVEL::STANDARD));
-    settingsLevelOptions.push_back(std::make_pair(10038, LOCK_LEVEL::ADVANCED));
-    settingsLevelOptions.push_back(std::make_pair(10039, LOCK_LEVEL::EXPERT));
+    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(106, LOCK_LEVEL::NONE));
+    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(593, LOCK_LEVEL::ALL));
+    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(10037, LOCK_LEVEL::STANDARD));
+    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(10038, LOCK_LEVEL::ADVANCED));
+    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(10039, LOCK_LEVEL::EXPERT));
     AddList(groupDetails, SETTING_LOCK_SETTINGS, 20043, SettingLevel::Basic, static_cast<int>(m_locks.settings), settingsLevelOptions, 20043);
 
     AddToggle(groupDetails, SETTING_LOCK_ADDONMANAGER, 24090, SettingLevel::Basic, m_locks.addonManager);

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -347,11 +347,11 @@ void CGUIDialogProfileSettings::InitializeSettings()
     }
 
     TranslatableIntegerSettingOptions entries;
-    entries.push_back(std::make_pair(20062, 0));
-    entries.push_back(std::make_pair(20063, 1));
-    entries.push_back(std::make_pair(20061, 2));
+    entries.push_back(TranslatableIntegerSettingOption(20062, 0));
+    entries.push_back(TranslatableIntegerSettingOption(20063, 1));
+    entries.push_back(TranslatableIntegerSettingOption(20061, 2));
     if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
-      entries.push_back(std::make_pair(20107, 3));
+      entries.push_back(TranslatableIntegerSettingOption(20107, 3));
 
     AddSpinner(groupMedia, SETTING_PROFILE_MEDIA, 20060, SettingLevel::Basic, m_dbMode, entries);
     AddSpinner(groupMedia, SETTING_PROFILE_MEDIA_SOURCES, 20094, SettingLevel::Basic, m_sourcesMode, entries);

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -346,21 +346,23 @@ void CGUIDialogLibExportSettings::InitializeSettings()
 
   TranslatableIntegerSettingOptions entries;
 
-  entries.push_back(std::make_pair(38301, ELIBEXPORT_SINGLEFILE));
-  entries.push_back(std::make_pair(38303, ELIBEXPORT_TOLIBRARYFOLDER));
-  entries.push_back(std::make_pair(38302, ELIBEXPORT_SEPARATEFILES));
-  entries.push_back(std::make_pair(38321, ELIBEXPORT_ARTISTFOLDERS));
+  entries.push_back(TranslatableIntegerSettingOption(38301, ELIBEXPORT_SINGLEFILE));
+  entries.push_back(TranslatableIntegerSettingOption(38303, ELIBEXPORT_TOLIBRARYFOLDER));
+  entries.push_back(TranslatableIntegerSettingOption(38302, ELIBEXPORT_SEPARATEFILES));
+  entries.push_back(TranslatableIntegerSettingOption(38321, ELIBEXPORT_ARTISTFOLDERS));
   AddList(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_FILETYPE, 38304, SettingLevel::Basic, m_settings.GetExportType(), entries, 38304); // "Choose kind of export output"
   AddButton(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, 38305, SettingLevel::Basic);
 
   entries.clear();
   if (!m_settings.IsArtistFoldersOnly())
-    entries.push_back(std::make_pair(132, ELIBEXPORT_ALBUMS));  //ablums
+    entries.push_back(TranslatableIntegerSettingOption(132, ELIBEXPORT_ALBUMS)); //ablums
   if (m_settings.IsSingleFile())
-    entries.push_back(std::make_pair(134, ELIBEXPORT_SONGS));  //songs
-  entries.push_back(std::make_pair(38043, ELIBEXPORT_ALBUMARTISTS)); //album artists
-  entries.push_back(std::make_pair(38312, ELIBEXPORT_SONGARTISTS)); //song artists
-  entries.push_back(std::make_pair(38313, ELIBEXPORT_OTHERARTISTS)); //other artists
+    entries.push_back(TranslatableIntegerSettingOption(134, ELIBEXPORT_SONGS)); //songs
+  entries.push_back(
+      TranslatableIntegerSettingOption(38043, ELIBEXPORT_ALBUMARTISTS)); //album artists
+  entries.push_back(TranslatableIntegerSettingOption(38312, ELIBEXPORT_SONGARTISTS)); //song artists
+  entries.push_back(
+      TranslatableIntegerSettingOption(38313, ELIBEXPORT_OTHERARTISTS)); //other artists
 
   std::vector<int> items;
   if (m_settings.IsArtistFoldersOnly())

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -850,10 +850,12 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
         auto optionElement = options->FirstChildElement(SETTING_XML_ELM_OPTION);
         while (optionElement != nullptr)
         {
-          std::pair<int, int> entry;
-          if (optionElement->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &entry.first) == TIXML_SUCCESS && entry.first > 0)
+          TranslatableIntegerSettingOption entry;
+          if (optionElement->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &entry.label) ==
+                  TIXML_SUCCESS &&
+              entry.label > 0)
           {
-            entry.second = strtol(optionElement->FirstChild()->Value(), nullptr, 10);
+            entry.value = strtol(optionElement->FirstChild()->Value(), nullptr, 10);
             m_translatableOptions.push_back(entry);
           }
           else

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -89,7 +89,19 @@ struct StringSettingOption
   std::vector<std::pair<std::string, CVariant>> properties;
 };
 
-using TranslatableIntegerSettingOption = std::pair<int, int>;
+struct TranslatableIntegerSettingOption
+{
+  TranslatableIntegerSettingOption() = default;
+  TranslatableIntegerSettingOption(int _label, int _value, const std::string& _addonId = "")
+    : label(_label), value(_value), addonId(_addonId)
+  {
+  }
+
+  int label = 0;
+  int value = 0;
+  std::string addonId; // Leaved empty for Kodi labels
+};
+
 using TranslatableIntegerSettingOptions = std::vector<TranslatableIntegerSettingOption>;
 using IntegerSettingOptions = std::vector<IntegerSettingOption>;
 using TranslatableStringSettingOption = std::pair<int, std::string>;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -46,10 +46,19 @@
 
 using namespace ADDON;
 
-static std::string Localize(std::uint32_t code, ILocalizer* localizer)
+static std::string Localize(std::uint32_t code,
+                            ILocalizer* localizer,
+                            const std::string& addonId = "")
 {
   if (localizer == nullptr)
     return "";
+
+  if (!addonId.empty())
+  {
+    std::string label = g_localizeStrings.GetAddonString(addonId, code);
+    if (!label.empty())
+      return label;
+  }
 
   return localizer->Localize(code);
 }
@@ -113,7 +122,8 @@ static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& op
     {
       const TranslatableIntegerSettingOptions& settingOptions = pSettingInt->GetTranslatableOptions();
       for (const auto& option : settingOptions)
-        options.push_back(IntegerSettingOption(Localize(option.first, localizer), option.second));
+        options.push_back(
+            IntegerSettingOption(Localize(option.label, localizer, option.addonId), option.value));
       break;
     }
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -213,7 +213,9 @@ void CMediaManager::GetNetworkLocations(VECSOURCES &locations, bool autolocation
         if (!info.type.empty() && info.supportBrowsing)
         {
           share.strPath = info.type + "://";
-          share.strName = g_localizeStrings.Get(info.label);
+          share.strName = g_localizeStrings.GetAddonString(addon->ID(), info.label);
+          if (share.strName.empty())
+            share.strName = g_localizeStrings.Get(info.label);
           locations.push_back(share);
         }
       }

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -116,10 +116,10 @@ void CGUIDialogCMSSettings::InitializeSettings()
 
   int currentMode = settings->GetInt(SETTING_VIDEO_CMSMODE);
   entries.clear();
-  // entries.push_back(std::make_pair(16039, CMS_MODE_OFF)); // FIXME: get from CMS class
-  entries.push_back(std::make_pair(36580, CMS_MODE_3DLUT));
+  // entries.push_back(TranslatableIntegerSettingOption(16039, CMS_MODE_OFF)); // FIXME: get from CMS class
+  entries.push_back(TranslatableIntegerSettingOption(36580, CMS_MODE_3DLUT));
 #ifdef HAVE_LCMS2
-  entries.push_back(std::make_pair(36581, CMS_MODE_PROFILE));
+  entries.push_back(TranslatableIntegerSettingOption(36581, CMS_MODE_PROFILE));
 #endif
   std::shared_ptr<CSettingInt> settingCmsMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSMODE, 36562, SettingLevel::Basic, currentMode, entries);
   settingCmsMode->SetDependencies(depsCmsEnabled);
@@ -131,29 +131,29 @@ void CGUIDialogCMSSettings::InitializeSettings()
   // display settings
   int currentWhitepoint = settings->GetInt(SETTING_VIDEO_CMSWHITEPOINT);
   entries.clear();
-  entries.push_back(std::make_pair(36586, CMS_WHITEPOINT_D65));
-  entries.push_back(std::make_pair(36587, CMS_WHITEPOINT_D93));
+  entries.push_back(TranslatableIntegerSettingOption(36586, CMS_WHITEPOINT_D65));
+  entries.push_back(TranslatableIntegerSettingOption(36587, CMS_WHITEPOINT_D93));
   std::shared_ptr<CSettingInt> settingCmsWhitepoint = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSWHITEPOINT, 36568, SettingLevel::Basic, currentWhitepoint, entries);
   settingCmsWhitepoint->SetDependencies(depsCmsIcc);
 
   int currentPrimaries = settings->GetInt(SETTING_VIDEO_CMSPRIMARIES);
   entries.clear();
-  entries.push_back(std::make_pair(36588, CMS_PRIMARIES_AUTO));
-  entries.push_back(std::make_pair(36589, CMS_PRIMARIES_BT709));
-  entries.push_back(std::make_pair(36579, CMS_PRIMARIES_BT2020));
-  entries.push_back(std::make_pair(36590, CMS_PRIMARIES_170M));
-  entries.push_back(std::make_pair(36591, CMS_PRIMARIES_BT470M));
-  entries.push_back(std::make_pair(36592, CMS_PRIMARIES_BT470BG));
-  entries.push_back(std::make_pair(36593, CMS_PRIMARIES_240M));
+  entries.push_back(TranslatableIntegerSettingOption(36588, CMS_PRIMARIES_AUTO));
+  entries.push_back(TranslatableIntegerSettingOption(36589, CMS_PRIMARIES_BT709));
+  entries.push_back(TranslatableIntegerSettingOption(36579, CMS_PRIMARIES_BT2020));
+  entries.push_back(TranslatableIntegerSettingOption(36590, CMS_PRIMARIES_170M));
+  entries.push_back(TranslatableIntegerSettingOption(36591, CMS_PRIMARIES_BT470M));
+  entries.push_back(TranslatableIntegerSettingOption(36592, CMS_PRIMARIES_BT470BG));
+  entries.push_back(TranslatableIntegerSettingOption(36593, CMS_PRIMARIES_240M));
   std::shared_ptr<CSettingInt> settingCmsPrimaries = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSPRIMARIES, 36570, SettingLevel::Basic, currentPrimaries, entries);
   settingCmsPrimaries->SetDependencies(depsCmsIcc);
 
   int currentGammaMode = settings->GetInt(SETTING_VIDEO_CMSGAMMAMODE);
   entries.clear();
-  entries.push_back(std::make_pair(36582, CMS_TRC_BT1886));
-  entries.push_back(std::make_pair(36583, CMS_TRC_INPUT_OFFSET));
-  entries.push_back(std::make_pair(36584, CMS_TRC_OUTPUT_OFFSET));
-  entries.push_back(std::make_pair(36585, CMS_TRC_ABSOLUTE));
+  entries.push_back(TranslatableIntegerSettingOption(36582, CMS_TRC_BT1886));
+  entries.push_back(TranslatableIntegerSettingOption(36583, CMS_TRC_INPUT_OFFSET));
+  entries.push_back(TranslatableIntegerSettingOption(36584, CMS_TRC_OUTPUT_OFFSET));
+  entries.push_back(TranslatableIntegerSettingOption(36585, CMS_TRC_ABSOLUTE));
   std::shared_ptr<CSettingInt> settingCmsGammaMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSGAMMAMODE, 36572, SettingLevel::Basic, currentGammaMode, entries);
   settingCmsGammaMode->SetDependencies(depsCmsIcc);
 
@@ -164,9 +164,9 @@ void CGUIDialogCMSSettings::InitializeSettings()
 
   int currentLutSize = settings->GetInt(SETTING_VIDEO_CMSLUTSIZE);
   entries.clear();
-  entries.push_back(std::make_pair(36594, 4));
-  entries.push_back(std::make_pair(36595, 6));
-  entries.push_back(std::make_pair(36596, 8));
+  entries.push_back(TranslatableIntegerSettingOption(36594, 4));
+  entries.push_back(TranslatableIntegerSettingOption(36595, 6));
+  entries.push_back(TranslatableIntegerSettingOption(36596, 8));
   std::shared_ptr<CSettingInt> settingCmsLutSize = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSLUTSIZE, 36576, SettingLevel::Basic, currentLutSize, entries);
   settingCmsLutSize->SetDependencies(depsCmsIcc);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -302,31 +302,34 @@ void CGUIDialogVideoSettings::InitializeSettings()
   TranslatableIntegerSettingOptions entries;
 
   entries.clear();
-  entries.push_back(std::make_pair(16039, VS_INTERLACEMETHOD_NONE));
-  entries.push_back(std::make_pair(16019, VS_INTERLACEMETHOD_AUTO));
-  entries.push_back(std::make_pair(20131, VS_INTERLACEMETHOD_RENDER_BLEND));
-  entries.push_back(std::make_pair(20129, VS_INTERLACEMETHOD_RENDER_WEAVE));
-  entries.push_back(std::make_pair(16021, VS_INTERLACEMETHOD_RENDER_BOB));
-  entries.push_back(std::make_pair(16020, VS_INTERLACEMETHOD_DEINTERLACE));
-  entries.push_back(std::make_pair(16036, VS_INTERLACEMETHOD_DEINTERLACE_HALF));
-  entries.push_back(std::make_pair(16311, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL));
-  entries.push_back(std::make_pair(16310, VS_INTERLACEMETHOD_VDPAU_TEMPORAL));
-  entries.push_back(std::make_pair(16325, VS_INTERLACEMETHOD_VDPAU_BOB));
-  entries.push_back(std::make_pair(16318, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF));
-  entries.push_back(std::make_pair(16317, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF));
-  entries.push_back(std::make_pair(16327, VS_INTERLACEMETHOD_VAAPI_BOB));
-  entries.push_back(std::make_pair(16328, VS_INTERLACEMETHOD_VAAPI_MADI));
-  entries.push_back(std::make_pair(16329, VS_INTERLACEMETHOD_VAAPI_MACI));
-  entries.push_back(std::make_pair(16330, VS_INTERLACEMETHOD_MMAL_ADVANCED));
-  entries.push_back(std::make_pair(16331, VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF));
-  entries.push_back(std::make_pair(16332, VS_INTERLACEMETHOD_MMAL_BOB));
-  entries.push_back(std::make_pair(16333, VS_INTERLACEMETHOD_MMAL_BOB_HALF));
-  entries.push_back(std::make_pair(16320, VS_INTERLACEMETHOD_DXVA_AUTO));
+  entries.push_back(TranslatableIntegerSettingOption(16039, VS_INTERLACEMETHOD_NONE));
+  entries.push_back(TranslatableIntegerSettingOption(16019, VS_INTERLACEMETHOD_AUTO));
+  entries.push_back(TranslatableIntegerSettingOption(20131, VS_INTERLACEMETHOD_RENDER_BLEND));
+  entries.push_back(TranslatableIntegerSettingOption(20129, VS_INTERLACEMETHOD_RENDER_WEAVE));
+  entries.push_back(TranslatableIntegerSettingOption(16021, VS_INTERLACEMETHOD_RENDER_BOB));
+  entries.push_back(TranslatableIntegerSettingOption(16020, VS_INTERLACEMETHOD_DEINTERLACE));
+  entries.push_back(TranslatableIntegerSettingOption(16036, VS_INTERLACEMETHOD_DEINTERLACE_HALF));
+  entries.push_back(
+      TranslatableIntegerSettingOption(16311, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL));
+  entries.push_back(TranslatableIntegerSettingOption(16310, VS_INTERLACEMETHOD_VDPAU_TEMPORAL));
+  entries.push_back(TranslatableIntegerSettingOption(16325, VS_INTERLACEMETHOD_VDPAU_BOB));
+  entries.push_back(
+      TranslatableIntegerSettingOption(16318, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF));
+  entries.push_back(
+      TranslatableIntegerSettingOption(16317, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF));
+  entries.push_back(TranslatableIntegerSettingOption(16327, VS_INTERLACEMETHOD_VAAPI_BOB));
+  entries.push_back(TranslatableIntegerSettingOption(16328, VS_INTERLACEMETHOD_VAAPI_MADI));
+  entries.push_back(TranslatableIntegerSettingOption(16329, VS_INTERLACEMETHOD_VAAPI_MACI));
+  entries.push_back(TranslatableIntegerSettingOption(16330, VS_INTERLACEMETHOD_MMAL_ADVANCED));
+  entries.push_back(TranslatableIntegerSettingOption(16331, VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF));
+  entries.push_back(TranslatableIntegerSettingOption(16332, VS_INTERLACEMETHOD_MMAL_BOB));
+  entries.push_back(TranslatableIntegerSettingOption(16333, VS_INTERLACEMETHOD_MMAL_BOB_HALF));
+  entries.push_back(TranslatableIntegerSettingOption(16320, VS_INTERLACEMETHOD_DXVA_AUTO));
 
   /* remove unsupported methods */
   for (TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end(); )
   {
-    if (g_application.GetAppPlayer().Supports((EINTERLACEMETHOD)it->second))
+    if (g_application.GetAppPlayer().Supports(static_cast<EINTERLACEMETHOD>(it->value)))
       ++it;
     else
       it = entries.erase(it);
@@ -343,26 +346,26 @@ void CGUIDialogVideoSettings::InitializeSettings()
   }
 
   entries.clear();
-  entries.push_back(std::make_pair(16301, VS_SCALINGMETHOD_NEAREST));
-  entries.push_back(std::make_pair(16302, VS_SCALINGMETHOD_LINEAR));
-  entries.push_back(std::make_pair(16303, VS_SCALINGMETHOD_CUBIC ));
-  entries.push_back(std::make_pair(16304, VS_SCALINGMETHOD_LANCZOS2));
-  entries.push_back(std::make_pair(16323, VS_SCALINGMETHOD_SPLINE36_FAST));
-  entries.push_back(std::make_pair(16315, VS_SCALINGMETHOD_LANCZOS3_FAST));
-  entries.push_back(std::make_pair(16322, VS_SCALINGMETHOD_SPLINE36));
-  entries.push_back(std::make_pair(16305, VS_SCALINGMETHOD_LANCZOS3));
-  entries.push_back(std::make_pair(16306, VS_SCALINGMETHOD_SINC8));
-  entries.push_back(std::make_pair(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE));
-  entries.push_back(std::make_pair(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE));
-  entries.push_back(std::make_pair(16309, VS_SCALINGMETHOD_SINC_SOFTWARE));
-  entries.push_back(std::make_pair(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE));
-  entries.push_back(std::make_pair(16319, VS_SCALINGMETHOD_DXVA_HARDWARE));
-  entries.push_back(std::make_pair(16316, VS_SCALINGMETHOD_AUTO));
+  entries.push_back(TranslatableIntegerSettingOption(16301, VS_SCALINGMETHOD_NEAREST));
+  entries.push_back(TranslatableIntegerSettingOption(16302, VS_SCALINGMETHOD_LINEAR));
+  entries.push_back(TranslatableIntegerSettingOption(16303, VS_SCALINGMETHOD_CUBIC));
+  entries.push_back(TranslatableIntegerSettingOption(16304, VS_SCALINGMETHOD_LANCZOS2));
+  entries.push_back(TranslatableIntegerSettingOption(16323, VS_SCALINGMETHOD_SPLINE36_FAST));
+  entries.push_back(TranslatableIntegerSettingOption(16315, VS_SCALINGMETHOD_LANCZOS3_FAST));
+  entries.push_back(TranslatableIntegerSettingOption(16322, VS_SCALINGMETHOD_SPLINE36));
+  entries.push_back(TranslatableIntegerSettingOption(16305, VS_SCALINGMETHOD_LANCZOS3));
+  entries.push_back(TranslatableIntegerSettingOption(16306, VS_SCALINGMETHOD_SINC8));
+  entries.push_back(TranslatableIntegerSettingOption(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE));
+  entries.push_back(TranslatableIntegerSettingOption(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE));
+  entries.push_back(TranslatableIntegerSettingOption(16309, VS_SCALINGMETHOD_SINC_SOFTWARE));
+  entries.push_back(TranslatableIntegerSettingOption(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE));
+  entries.push_back(TranslatableIntegerSettingOption(16319, VS_SCALINGMETHOD_DXVA_HARDWARE));
+  entries.push_back(TranslatableIntegerSettingOption(16316, VS_SCALINGMETHOD_AUTO));
 
   /* remove unsupported methods */
   for(TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end(); )
   {
-    if (g_application.GetAppPlayer().Supports((ESCALINGMETHOD)it->second))
+    if (g_application.GetAppPlayer().Supports(static_cast<ESCALINGMETHOD>(it->value)))
       ++it;
     else
       it = entries.erase(it);
@@ -404,17 +407,17 @@ void CGUIDialogVideoSettings::InitializeSettings()
   if (g_application.GetAppPlayer().Supports(RENDERFEATURE_TONEMAP))
   {
     entries.clear();
-    entries.push_back(std::make_pair(36554, VS_TONEMAPMETHOD_OFF));
-    entries.push_back(std::make_pair(36555, VS_TONEMAPMETHOD_REINHARD));
+    entries.push_back(TranslatableIntegerSettingOption(36554, VS_TONEMAPMETHOD_OFF));
+    entries.push_back(TranslatableIntegerSettingOption(36555, VS_TONEMAPMETHOD_REINHARD));
     AddSpinner(groupVideo, SETTING_VIDEO_TONEMAP_METHOD, 36553, SettingLevel::Basic, videoSettings.m_ToneMapMethod, entries);
     AddSlider(groupVideo, SETTING_VIDEO_TONEMAP_PARAM, 36556, SettingLevel::Basic, videoSettings.m_ToneMapParam, "%2.2f", 0.1f, 0.1f, 5.0f, 36556, usePopup);
   }
 
   // stereoscopic settings
   entries.clear();
-  entries.push_back(std::make_pair(16316, RENDER_STEREO_MODE_OFF));
-  entries.push_back(std::make_pair(36503, RENDER_STEREO_MODE_SPLIT_HORIZONTAL));
-  entries.push_back(std::make_pair(36504, RENDER_STEREO_MODE_SPLIT_VERTICAL));
+  entries.push_back(TranslatableIntegerSettingOption(16316, RENDER_STEREO_MODE_OFF));
+  entries.push_back(TranslatableIntegerSettingOption(36503, RENDER_STEREO_MODE_SPLIT_HORIZONTAL));
+  entries.push_back(TranslatableIntegerSettingOption(36504, RENDER_STEREO_MODE_SPLIT_VERTICAL));
   AddSpinner(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICMODE, 36535, SettingLevel::Basic, videoSettings.m_StereoMode, entries);
   AddToggle(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICINVERT, 36536, SettingLevel::Basic, videoSettings.m_StereoInvert);
 


### PR DESCRIPTION
## Description

Before was this pair with "integer, integer" value, where first string
identifier and second setting value identifier. But with this was it
not possible to handle them on addons where can give own strings.

This change it from `std::pair` to a structure like the others already have
and with add of third value to get in case of addon string his related
addon identifier.

For this it looks a bit bigger as some places are touched to change from
pair to class constructor.

This change is related to https://github.com/xbmc/xbmc/pull/17527

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

Here on selection field is it used to get string from addon:
![](http://alwinesch.github.io/cpp_kodi_addon_vfs_protocol_2.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
