### PR TITLE
[GBM/Wayland] register all the CBufferObjects and CRPRendererDMA for GL

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -18,6 +18,7 @@
 #include "utils/BufferObjectFactory.h"
 #include "utils/DumbBufferObject.h"
 #include "utils/GBMBufferObject.h"
+#include "utils/UDMABufferObject.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
@@ -65,6 +66,9 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   CDumbBufferObject::Register();
 #if defined(HAS_GBM_BO_MAP)
   CGBMBufferObject::Register();
+#endif
+#if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
+  CUDMABufferObject::Register();
 #endif
 
   return true;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -17,6 +17,7 @@
 #include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "utils/BufferObjectFactory.h"
 #include "utils/DumbBufferObject.h"
+#include "utils/GBMBufferObject.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
@@ -62,6 +63,9 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
 
   CBufferObjectFactory::ClearBufferObjects();
   CDumbBufferObject::Register();
+#if defined(HAS_GBM_BO_MAP)
+  CGBMBufferObject::Register();
+#endif
 
   return true;
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -10,6 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
@@ -44,6 +45,7 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   CDVDFactoryCodec::ClearHWAccels();
   CLinuxRendererGL::Register();
   RETRO::CRPProcessInfoGbm::Register();
+  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMA);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
   if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_BIT, EGL_OPENGL_API))

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -16,6 +16,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "utils/BufferObjectFactory.h"
+#include "utils/DMAHeapBufferObject.h"
 #include "utils/DumbBufferObject.h"
 #include "utils/GBMBufferObject.h"
 #include "utils/UDMABufferObject.h"
@@ -69,6 +70,9 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
 #endif
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
+#endif
+#if defined(HAVE_LINUX_DMA_HEAP)
+  CDMAHeapBufferObject::Register();
 #endif
 
   return true;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -15,6 +15,8 @@
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
+#include "utils/BufferObjectFactory.h"
+#include "utils/DumbBufferObject.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
@@ -57,6 +59,9 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   }
 
   CScreenshotSurfaceGL::Register();
+
+  CBufferObjectFactory::ClearBufferObjects();
+  CDumbBufferObject::Register();
 
   return true;
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -14,6 +14,7 @@
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "utils/BufferObjectFactory.h"
+#include "utils/DMAHeapBufferObject.h"
 #include "utils/UDMABufferObject.h"
 #include "utils/log.h"
 
@@ -51,6 +52,9 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   CBufferObjectFactory::ClearBufferObjects();
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
+#endif
+#if defined(HAVE_LINUX_DMA_HEAP)
+  CDMAHeapBufferObject::Register();
 #endif
 
   CScreenshotSurfaceGL::Register();

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -10,6 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
@@ -37,6 +38,7 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   }
 
   CLinuxRendererGL::Register();
+  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryDMA);
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
   bool general, deepColor;

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -13,6 +13,8 @@
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
+#include "utils/BufferObjectFactory.h"
+#include "utils/UDMABufferObject.h"
 #include "utils/log.h"
 
 #include <EGL/egl.h>
@@ -45,6 +47,11 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   {
     ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
+
+  CBufferObjectFactory::ClearBufferObjects();
+#if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
+  CUDMABufferObject::Register();
+#endif
 
   CScreenshotSurfaceGL::Register();
 


### PR DESCRIPTION
This keeps things in line with the GLES gbm windowing. This will only build after #17544 due to some cmake changes that allow OpenGL to be used

@a1rwulf please test :smile_cat: 