### PR TITLE
[RetroPlayer] CRenderBufferDMA: add sync support

### DIFF
--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -103,6 +103,13 @@ else()
   message(WARNING, "dma-heap: include/linux/dma-heap.h not found")
 endif()
 
+check_include_files("linux/dma-buf.h" HAVE_LINUX_DMA_BUF)
+if(HAVE_LINUX_DMA_BUF)
+  list(APPEND ARCH_DEFINES "-DHAVE_LINUX_DMA_BUF=1")
+else()
+  message(STATUS "include/linux/dma-buf.h not found")
+endif()
+
 include(CheckSymbolExists)
 set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
 check_symbol_exists("mkostemp" "stdlib.h" HAVE_MKOSTEMP)

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -60,12 +60,14 @@ size_t CRenderBufferDMA::GetFrameSize() const
 
 uint8_t* CRenderBufferDMA::GetMemory()
 {
+  m_bo->SyncStart();
   return m_bo->GetMemory();
 }
 
 void CRenderBufferDMA::ReleaseMemory()
 {
   m_bo->ReleaseMemory();
+  m_bo->SyncEnd();
 }
 
 void CRenderBufferDMA::CreateTexture()

--- a/xbmc/utils/BufferObject.cpp
+++ b/xbmc/utils/BufferObject.cpp
@@ -9,6 +9,12 @@
 #include "BufferObject.h"
 
 #include "BufferObjectFactory.h"
+#include "utils/log.h"
+
+#if defined(HAVE_LINUX_DMA_BUF)
+#include <linux/dma-buf.h>
+#include <sys/ioctl.h>
+#endif
 
 std::unique_ptr<CBufferObject> CBufferObject::GetBufferObject()
 {
@@ -28,4 +34,28 @@ uint32_t CBufferObject::GetStride()
 uint64_t CBufferObject::GetModifier()
 {
   return 0; // linear
+}
+
+void CBufferObject::SyncStart()
+{
+#if defined(HAVE_LINUX_DMA_BUF)
+  struct dma_buf_sync sync;
+  sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_RW;
+
+  int ret = ioctl(m_fd, DMA_BUF_IOCTL_SYNC, &sync);
+  if (ret < 0)
+    CLog::LogF(LOGERROR, "ioctl DMA_BUF_IOCTL_SYNC failed, ret={} errno={}", ret, strerror(errno));
+#endif
+}
+
+void CBufferObject::SyncEnd()
+{
+#if defined(HAVE_LINUX_DMA_BUF)
+  struct dma_buf_sync sync;
+  sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_RW;
+
+  int ret = ioctl(m_fd, DMA_BUF_IOCTL_SYNC, &sync);
+  if (ret < 0)
+    CLog::LogF(LOGERROR, "ioctl DMA_BUF_IOCTL_SYNC failed, ret={} errno={}", ret, strerror(errno));
+#endif
 }

--- a/xbmc/utils/BufferObject.h
+++ b/xbmc/utils/BufferObject.h
@@ -32,6 +32,9 @@ public:
   virtual uint32_t GetStride() override;
   virtual uint64_t GetModifier() override;
 
+  void SyncStart() override;
+  void SyncEnd() override;
+
 protected:
   int m_fd{-1};
   uint32_t m_stride{0};

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -100,6 +100,18 @@ public:
   virtual uint64_t GetModifier() = 0;
 
   /**
+   * @brief Must be called before reading/writing data to the BufferObject.
+   *
+   */
+  virtual void SyncStart() = 0;
+
+  /**
+   * @brief Must be called after reading/writing data to the BufferObject.
+   *
+   */
+  virtual void SyncEnd() = 0;
+
+  /**
    * @brief Get the Name of the BufferObject type in use
    *
    * @return std::string name of the BufferObject type in use


### PR DESCRIPTION
This allows us to make sure we are done reading or writing to the buffers before displaying them. I haven't seen any issues without this but I've been using it for sw buffer in videoplayer so I figure I should add them to the interface.

See here for more information: https://01.org/linuxgraphics/gfx-docs/drm/driver-api/dma-buf.html