### PR TITLE
[application] Fix black screen when switching from PVR Live TV channel to PVR Radio channel.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4558,8 +4558,10 @@ void CApplication::SeekPercentage(float percent)
 // SwitchToFullScreen() returns true if a switch is made, else returns false
 bool CApplication::SwitchToFullScreen(bool force /* = false */)
 {
+  const int activeWindowID = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
+
   // don't switch if the slideshow is active
-  if (CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_SLIDESHOW))
+  if (activeWindowID == WINDOW_SLIDESHOW)
     return false;
 
   // if playing from the video info window, close it first!
@@ -4589,25 +4591,25 @@ bool CApplication::SwitchToFullScreen(bool force /* = false */)
 
   int windowID = WINDOW_INVALID;
 
-  // See if we're playing a game, and are in GUI mode
-  if (m_appPlayer.IsPlayingGame() && CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_FULLSCREEN_GAME)
+  // See if we're playing a game
+  if (activeWindowID != WINDOW_FULLSCREEN_GAME && m_appPlayer.IsPlayingGame())
     windowID = WINDOW_FULLSCREEN_GAME;
 
-  // See if we're playing a video, and are in GUI mode
-  else if (m_appPlayer.IsPlayingVideo() && CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO)
+  // See if we're playing a video
+  else if (activeWindowID != WINDOW_FULLSCREEN_VIDEO && m_appPlayer.IsPlayingVideo())
     windowID = WINDOW_FULLSCREEN_VIDEO;
 
-  // special case for switching between GUI & visualisation mode. (only if we're playing an audio song)
-  if (m_appPlayer.IsPlayingAudio() && CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_VISUALISATION)
+  // See if we're playing an audio song
+  if (activeWindowID != WINDOW_VISUALISATION && m_appPlayer.IsPlayingAudio())
     windowID = WINDOW_VISUALISATION;
 
-
-  if (windowID != WINDOW_INVALID)
+  if (windowID != WINDOW_INVALID && (force || windowID != activeWindowID))
   {
     if (force)
       CServiceBroker::GetGUI()->GetWindowManager().ForceActivateWindow(windowID);
     else
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(windowID);
+
     return true;
   }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2101,10 +2101,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
 
 
   case TMSG_SWITCHTOFULLSCREEN:
-    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_FULLSCREEN_VIDEO &&
-        CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_FULLSCREEN_GAME &&
-        CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_VISUALISATION)
-      SwitchToFullScreen(true);
+    SwitchToFullScreen(true);
     break;
 
   case TMSG_VIDEORESIZE:


### PR DESCRIPTION
This fixes #17556

When switching from a PVR Live TV to a PVR Radio channel, active window must be changed from `WINDOW_FULLSCREEN_VIDEO` to `WINDOW_VISUALISATION`. On stream change VideoPlayer fires a `TMSG_SWITCHTOFULLSCREEN` event which is handled by `CApplication::OnApplicationMessage`. The check for the active window there prevents switching the window, because when the event arrives the active window is still `WINDOW_FULLSCREEN_VIDEO`.

Same problem occurs when switching from Radio to Live TV since #17225, btw.

Removing the checks for the active window in `CApplication::OnApplicationMessage` fixes the issue and has no other negative side effects.

This issue is spacial to PVR, because VideoPalyer has special handling for PVR stream changes (fast channel switch).

Runtime tested on macOS and Android, latest Kodi master.

Hard to find a reviewer for this I guess (who is maintainer of CApplication?) , but maybe @phunkyfish can look at the change.