### PR TITLE
CLog: add IsLogLevelLogged method for component logging

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1161,7 +1161,7 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const std::string& filters, bool scale)
     return result;
   }
 
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGVIDEO))
+  if (CLog::IsLogLevelLogged(LOGDEBUG, LOGVIDEO))
   {
     char* graphDump = avfilter_graph_dump(m_pFilterGraph, nullptr);
     if (graphDump)

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -181,6 +181,14 @@ bool CLog::IsLogLevelLogged(int loglevel)
   return (loglevel & LOGMASK) >= LOGNOTICE;
 }
 
+bool CLog::IsLogLevelLogged(int logLevel, int component)
+{
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(component) &&
+      IsLogLevelLogged(logLevel))
+    return true;
+
+  return false;
+}
 
 void CLog::PrintDebugString(const std::string& line)
 {

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -97,6 +97,7 @@ public:
   static int  GetLogLevel();
   static void SetExtraLogLevels(int level);
   static bool IsLogLevelLogged(int loglevel);
+  static bool IsLogLevelLogged(int logLevel, int component);
 
 protected:
   static void LogString(int logLevel, std::string&& logString);


### PR DESCRIPTION
This allows guarding the construction parameters of the log call without having to include advancedsettings/settingscomponents/etc in the code.

The example I included that uses this new method doesn't really benefit from this method but I wanted to show where it may be used.

I would like to use it in some upcoming code I'm writing.