### PR TITLE
Change Exists function usage in FilesystemInstaller.cpp

### DIFF
--- a/xbmc/addons/FilesystemInstaller.cpp
+++ b/xbmc/addons/FilesystemInstaller.cpp
@@ -9,6 +9,7 @@
 
 #include "FileItem.h"
 #include "filesystem/Directory.h"
+#include "filesystem/DirectoryCache.h"
 #include "filesystem/SpecialProtocol.h"
 #include "utils/FileOperationJob.h"
 #include "utils/StringUtils.h"
@@ -38,7 +39,15 @@ bool CFilesystemInstaller::InstallToFilesystem(const std::string& archive, const
     return false;
   }
 
-  bool hasOldData = CDirectory::Exists(addonFolder);
+  bool hasOldData = false;
+  bool bPathInCache = false;
+  if (g_directoryCache.FileExists(addonFolder, bPathInCache))
+    hasOldData = true;
+  else if (bPathInCache)
+    hasOldData = false;
+  else
+    hasOldData = CDirectory::Exists(addonFolder, false);
+
   if (hasOldData)
   {
     if (!CFile::Rename(addonFolder, oldAddonData))


### PR DESCRIPTION
Fixes issue in installing addon just after uninstalling it

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
CDirectory::Exists incorrectly returned that g_directoryCache contained directory of uninstalled addon. This change fixes the issue by directly querying g_directoryCache for addon directory and then calling CDirectory::Exists with argument to bypass cache

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes https://github.com/xbmc/xbmc/issues/17049

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on Linux-x64 machine by repeatedly uninstalling and installing same addon

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
