### PR TITLE
Re-enable OnMouseOver select

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -229,7 +229,7 @@ private:
 
   // early inertial scroll cancellation
   bool m_waitForScrollEnd = false;
-  float m_lastScrollValue;
+  float m_lastScrollValue = 0.0f;
 };
 
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -563,7 +563,7 @@ EVENT_RESULT CGUIControl::SendMouseEvent(const CPoint &point, const CMouseEvent 
   if (!CanFocusFromPoint(childPoint))
     return EVENT_RESULT_UNHANDLED;
 
-  bool handled = OnMouseOver(childPoint);
+  bool handled = event.m_id != ACTION_MOUSE_MOVE || OnMouseOver(childPoint);
   EVENT_RESULT ret = OnMouseEvent(childPoint, event);
   if (ret)
     return ret;

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -34,7 +34,8 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
   if (m_bInvalidated)
     UpdateLayout();
 
-  if (!m_layout || !m_focusedLayout) return;
+  if (!m_layout || !m_focusedLayout)
+    return;
 
   UpdateScrollOffset(currentTime);
 
@@ -91,7 +92,8 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
 
 void CGUIPanelContainer::Render()
 {
-  if (!m_layout || !m_focusedLayout) return;
+  if (!m_layout || !m_focusedLayout)
+    return;
 
   int offset = (int)(m_scroller.GetValue() / m_layout->Size(m_orientation));
 
@@ -397,8 +399,8 @@ void CGUIPanelContainer::ValidateOffset()
 
 void CGUIPanelContainer::SetCursor(int cursor)
 {
-  // +1 to ensure we're OK if we have a half item
-  if (cursor > (m_itemsPerPage + 1)*m_itemsPerRow - 1) cursor = (m_itemsPerPage + 1)*m_itemsPerRow - 1;
+  if (cursor > m_itemsPerPage * m_itemsPerRow - 1)
+    cursor = m_itemsPerPage * m_itemsPerRow - 1;
   if (cursor < 0) cursor = 0;
   if (!m_wasReset)
     SetContainerMoving(cursor - GetCursor());

--- a/xbmc/platform/android/activity/AndroidTouch.cpp
+++ b/xbmc/platform/android/activity/AndroidTouch.cpp
@@ -74,6 +74,10 @@ bool CAndroidTouch::onTouchEvent(AInputEvent* event)
     CGenericTouchInputHandler::GetInstance().UpdateTouchPointer(pointer, AMotionEvent_getX(event, pointer), AMotionEvent_getY(event, pointer),
     AMotionEvent_getEventTime(event));
 
+  // let system know that we are starting a guesture
+  if (touchEvent == TouchInputDown)
+    CGenericTouchActionHandler::GetInstance().QuerySupportedGestures(x, y);
+
   // now send the event
   return CGenericTouchInputHandler::GetInstance().HandleTouchInput(touchEvent, x, y, time, touchPointer);
 }


### PR DESCRIPTION
## Description
this is a partial revert of #17548 and re-enables GUIContainer elements when mouse moves over items.  Because touch simulates mouse events in some cases, additional changes were introduced to get touch / gesture smooth.

## Motivation and Context
See comments in #17548, beside this mouse move without any vsual feedback feels somehow wrong.

## How Has This Been Tested?
Windows 10, various containers tested with mouse / mousepad and touchscreen

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
