### PR TITLE
fix VideoPlayer.UniqueID() infolabel

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9610,6 +9610,10 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       {
         return AddMultiInfo(CGUIInfo(VIDEOPLAYER_CONTENT, prop.param(), 0));
       }
+      if (prop.name == "uniqueid" && prop.num_params())
+      {
+        return AddMultiInfo(CGUIInfo(VIDEOPLAYER_UNIQUEID, prop.param(), 0));
+      }
       return TranslateVideoPlayerString(prop.name);
     }
     else if (cat.name == "retroplayer")


### PR DESCRIPTION
call it a brainfart, call it lack of testing, but part of https://github.com/xbmc/xbmc/pull/17340 was missing, resulting in a non-functional VideoPlayer.UniqueID() infolabel.

i've now added the missing magic to GUIInfoManager to bring it back to life.