### PR TITLE
[Music] Add NODE_TYPE_DISC to CMusicDatabaseDirectory::ContainsSongs()

### DIFF
--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -275,6 +275,7 @@ bool CMusicDatabaseDirectory::ContainsSongs(const std::string &path)
   if (type == MUSICDATABASEDIRECTORY::NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS) return true;
   if (type == MUSICDATABASEDIRECTORY::NODE_TYPE_ALBUM_TOP100_SONGS) return true;
   if (type == MUSICDATABASEDIRECTORY::NODE_TYPE_SONG_TOP100) return true;
+  if (type == MUSICDATABASEDIRECTORY::NODE_TYPE_DISC) return true;
   return false;
 }
 


### PR DESCRIPTION
## Description
`NODE_TYPE_DISC` was missing from `CMusicDatabaseDirectory::ContainsSongs()` which causes issues with the order of songs on the current playlist.  Specifically, it causes discs to be treated as 'All Items' when adding a compilation album to a playlist (either with the context menu or pressing [p] on a keyboard).  This ultimately results in the album being queued up in artist order rather than track order.  It also prevents using the previously used viewstate for songs and always enforces the sort order.

## Motivation and Context
Fixes the issue reported here https://forum.kodi.tv/showthread.php?tid=352907 and confirmed by @DaveTBlake here https://forum.kodi.tv/showthread.php?tid=350794&pid=2914747#pid2914747

## How Has This Been Tested?
Tested before and after the addition.  Beforehand all compilation albums with multiple artists were queued in artist order only.  After the addition, all compilation albums are queued in the order last sorted in the song view.

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
