### PR TITLE
[tools/depends] bump gnutls 3.6.13 enable asm for darwinembedded platforms

### DIFF
--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -4,12 +4,12 @@ DEPS= ../../Makefile.include Makefile size-max.patch add-dl-as-private-lib.patch
 # lib name, version
 LIBNAME=gnutls
 VERSION=3.6.11.1
+ifeq ($(OS),darwin_embedded)
+VERSION=3.6.13
+BASE_URL := https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6
+endif
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
-
-ifeq ($(OS),darwin_embedded)
-CONFIGURE_OPTIONS = --disable-hardware-acceleration
-endif
 
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX) --disable-shared --without-p11-kit --disable-nls --with-included-unistring \
@@ -28,6 +28,10 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../size-max.patch
 	cd $(PLATFORM); patch -p1 -i ../add-dl-as-private-lib.patch
+ifeq ($(OS),darwin_embedded)
+	# Apple CCAS requires stripping ; from comment block # to build successfully
+	cd $(PLATFORM); sed -ie "s|\(^# .*\)[;]\(.*\)|\1\2|g" lib/accelerated/aarch64/macosx/*.s
+endif
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -3,11 +3,8 @@ DEPS= ../../Makefile.include Makefile size-max.patch add-dl-as-private-lib.patch
 
 # lib name, version
 LIBNAME=gnutls
-VERSION=3.6.11.1
-ifeq ($(OS),darwin_embedded)
 VERSION=3.6.13
 BASE_URL := https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6
-endif
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
 

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -7,10 +7,6 @@ VERSION=3.5.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
-ifeq ($(OS),darwin_embedded)
-  CONFIGURE_FLAGS=-disable-assembler
-endif
-
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-shared --disable-openssl $(CONFIGURE_FLAGS)

--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -15,9 +15,9 @@ endif
 ifeq ($(OS), darwin_embedded)
   ifeq ($(TARGET_PLATFORM),appletvos)
     # Need to add "no-async" to avoid "'setcontext' is unavailable: not available on tvOS" error
-    CONFIGURE=./Configure iphoneos-cross no-shared zlib no-asm no-async --prefix=$(PREFIX)
+    CONFIGURE=./Configure iphoneos-cross no-shared zlib no-async --prefix=$(PREFIX)
   else
-    CONFIGURE=./Configure iphoneos-cross no-shared zlib no-asm --prefix=$(PREFIX)
+    CONFIGURE=./Configure iphoneos-cross no-shared zlib --prefix=$(PREFIX)
   endif
 endif
 ifeq ($(OS), osx)


### PR DESCRIPTION
## Description
Enables building aarch64 assembly for darwinembedded platforms.

- openssl
- nettle
- gnutls

Bumps gnutls to 3.6.13. Existing 3.6.11.1 tars on mirror do not package the lib/accelerated/aarch64/macosx folder, however it is available via gnutls gitlab repo. Figure we just take the opportunity to bump to latest version whilst at it.

I've split the bump from the darwinembedded asm change to allow rollback of the gnutls bump if any specific issues with that are raised in the future on other platforms because of the gnutls bump.

Note: Need to upload tar to mirrors, and remove BASE_URL usage for gnutls

## Motivation and Context
Now that ios host triplets have been corrected, we can easily build aarch64 asm for darwinembedded platforms. Might as well make use of it.

## How Has This Been Tested?
Built and runtime tested on iOS/tvOS

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
