### PR TITLE
CDMAHeapBufferObject: add /dev/dma_heap/linux,cma path

### DIFF
--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -22,8 +22,9 @@
 namespace
 {
 
-std::array<const char*, 2> DMA_HEAP_PATHS = {
+std::array<const char*, 3> DMA_HEAP_PATHS = {
     "/dev/dma_heap/reserved",
+    "/dev/dma_heap/linux,cma",
     "/dev/dma_heap/system",
 };
 


### PR DESCRIPTION
This path is used for cma access on embedded devices with dma-heaps.

Tested on Amlogic Odroid-C2
