### PR TITLE
[Android] MediaCodec: reimplement JNI (instead NDK)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -25,17 +25,17 @@
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
 #include <androidjni/Surface.h>
-#include <media/NdkMediaCodec.h>
 
 class CJNISurface;
 class CJNISurfaceTexture;
 class CJNIMediaCodec;
+class CJNIMediaCrypto;
 class CJNIMediaFormat;
+class CJNIMediaCodecBufferInfo;
 class CDVDMediaCodecOnFrameAvailable;
 class CJNIByteBuffer;
 class CBitstreamConverter;
 
-struct AMediaCrypto;
 struct DemuxCryptoInfo;
 struct mpeg2_sequence;
 
@@ -47,17 +47,6 @@ typedef struct amc_demux
   double dts;
   double pts;
 } amc_demux;
-
-struct CMediaCodec
-{
-  CMediaCodec(const char* name);
-  virtual ~CMediaCodec();
-
-  AMediaCodec* codec() const { return m_codec; };
-
-private:
-  AMediaCodec* m_codec;
-};
 
 class CMediaCodecVideoBufferPool;
 
@@ -101,22 +90,20 @@ private:
 class CMediaCodecVideoBufferPool : public IVideoBufferPool
 {
 public:
-  CMediaCodecVideoBufferPool(std::shared_ptr<CMediaCodec> mediaCodec)
-    : m_codec(mediaCodec){};
+  CMediaCodecVideoBufferPool(std::shared_ptr<CJNIMediaCodec> mediaCodec) : m_codec(mediaCodec){};
 
   ~CMediaCodecVideoBufferPool() override;
 
   CVideoBuffer* Get() override;
   void Return(int id) override;
 
-  std::shared_ptr<CMediaCodec> GetMediaCodec();
+  std::shared_ptr<CJNIMediaCodec> GetMediaCodec();
   void ResetMediaCodec();
   void ReleaseMediaCodecBuffers();
 
 private:
   CCriticalSection m_criticalSection;
-  ;
-  std::shared_ptr<CMediaCodec> m_codec;
+  std::shared_ptr<CJNIMediaCodec> m_codec;
 
   std::vector<CMediaCodecVideoBuffer*> m_videoBuffers;
   std::vector<int> m_freeBuffers;
@@ -146,11 +133,11 @@ protected:
   void Dispose();
   void FlushInternal(void);
   void SignalEndOfStream();
-  void InjectExtraData(AMediaFormat* mediaformat);
+  void InjectExtraData(CJNIMediaFormat& mediaformat);
   std::vector<uint8_t> GetHDRStaticMetadata();
   bool ConfigureMediaCodec(void);
   int GetOutputPicture(void);
-  void ConfigureOutputFormat(AMediaFormat* mediaformat);
+  void ConfigureOutputFormat(CJNIMediaFormat& mediaformat);
   void UpdateFpsDuration();
 
   // surface handling functions
@@ -172,10 +159,9 @@ protected:
   std::shared_ptr<CJNIXBMCVideoView> m_jnivideoview;
   CJNISurface* m_jnisurface;
   CJNISurface m_jnivideosurface;
-  AMediaCrypto* m_crypto;
   unsigned int m_textureId;
-  std::shared_ptr<CMediaCodec> m_codec;
-  ANativeWindow* m_surface;
+  std::shared_ptr<CJNIMediaCodec> m_codec;
+  CJNIMediaCrypto* m_crypto = nullptr;
   std::shared_ptr<CJNISurfaceTexture> m_surfaceTexture;
   std::shared_ptr<CDVDMediaCodecOnFrameAvailable> m_frameAvailable;
 


### PR DESCRIPTION
## Description
Switch back from NDK to JNI in MediaCodec video decoder (android)

## Motivation and Context
~2years ago we switched from JNI to NDK in MediaCodec video decoder.
Because some things are missing / not working in NDK, we still use partitialy JNI.

Latest example is MediaCodec::setVideoScalingMode. It is not implemented in NDK but we use it for e.g. AFTV devices which have videos stretched (https://forum.kodi.tv/showthread.php?tid=336151&pid=2936959#pid2936959)

The discussion with the NDK devs (github issue: https://github.com/android/ndk/issues/1224#issuecomment-608544889) was not very fruitful, so I decided to go back to JNI and have everything available.

## How Has This Been Tested?
Play h.264 video with 1920x882px on AFTV. Without this JNI / setVideoScalingMode implementation the video was stretched in height, the PR fixes the issue.

Beside this I crosschecked on NVIDIA shield, video AR is still fine.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
