### PR TITLE
[Tests] Extend AddonVersion tests to support pep-0440/local-version-i…

### DIFF
--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -239,4 +239,30 @@ TEST_F(TestAddonVersion, LessThan)
   EXPECT_LT(v1_0_0_alpha3, v1_0_0_alpha10);
   EXPECT_LT(v1_0_0_alpha10, v1_0_0);
   EXPECT_LT(v1_0_0_alpha10, v1_0_0_beta);
+  
+  // pep-0440/local-version-identifiers
+  // ref: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
+  // Python addons use this kind of versioning particularly for script.module
+  // addons. The "same" version number may exist in different branches or
+  // targetting different kodi versions while keeping consistency with the
+  // upstream module version. The addon version available in upper repos
+  // (let's say matrix) must have a higher version than the one stored in
+  // lower branches (e.g. leia) so that users receive the addon update
+  // when upgrading kodi.
+  // So, for instance, we use version x.x.x or version x.x.x+kodiversion.r to
+  // refer to the same upstream version x.x.x of the module.
+  // Eg: script.module.foo-1.0.0 or script.module.foo-1.0.0+leia.1 for upstream
+  // module foo (version 1.0.0) available for leia; and
+  // script.module.foo-1.0.0+matrix.1 for upstream module foo (1.0.0) for matrix.
+  // In summary, 1.0.0 or 1.0.0+leia.1 must be < than 1.0.0+matrix.1
+  // tests below assure this won't get broken inadvertently
+  EXPECT_LT(AddonVersion("1.0.0"), AddonVersion("1.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+leia.1"), AddonVersion("1.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.0.0+matrix.2"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.0.1+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.1.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("2.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.0.0.1"));
+  EXPECT_LT(AddonVersion("1.0.0+Leia.1"), AddonVersion("1.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+leia.1"), AddonVersion("1.0.0+Matrix.1"));
 }


### PR DESCRIPTION
…dentifiers

## Description
This PR extends the addonversion tests to include pep-0440 local version identifiers. They are used by python addons (specially script.modules). Goal is to make sure this won't get broken in future updates.

## Motivation and Context
Comment explains it all:

```
  // pep-0440/local-version-identifiers
  // ref: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
  // Python addons use this kind of versioning particularly for script.module
  // addons. The "same" version number may exist in different branches or
  // targetting different kodi versions while keeping consistency with the
  // upstream module version. The addon version available in upper repos
  // (let's say matrix) must have a higher version than the one stored in
  // lower branches (e.g. leia) so that users receive the addon update
  // when upgrading kodi.
  // So, for instance, we use version x.x.x or version x.x.x+kodiversion.r to
  // refer to the same upstream version x.x.x of the module.
  // Eg: script.module.foo-1.0.0 or script.module.foo-1.0.0+leia.1 for upstream
  // module foo (version 1.0.0) available for leia; and
  // script.module.foo-1.0.0+matrix.1 for upstream module foo (1.0.0) for matrix.
  // In summary, 1.0.0 or 1.0.0+leia.1 must be < than 1.0.0+matrix.1
  // tests below assure this won't get broken inadvertently
```

## How Has This Been Tested?
Tested manually locally some time ago with a sample project containing only the `AddonVersion` class. Let's hope jenkins runs the tests for me and they pass.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
