### PR TITLE
Remove unused Inputstream addon functions and increase max props

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -598,7 +598,9 @@ public:
   virtual int GetBlockSize() { return 0; }
 
   /*!
-     * @brief Notify the InputStream addon that Kodi (un)paused the currently playing stream
+     * @brief Notify the InputStream addon that Kodi (un)paused the currently playing stream.
+     * Only called when an inpustream DOES NOT have its own demuxer.
+     * @param time The time that Kodi (un)paused the stream
      */
   virtual void PauseStream(double time) {}
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -69,7 +69,7 @@ extern "C"
    */
   struct INPUTSTREAM
   {
-    static const unsigned int MAX_INFO_COUNT = 8;
+    static const unsigned int MAX_INFO_COUNT = 30;
 
     const char* m_strURL;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -349,10 +349,6 @@ extern "C"
     // IPosTime
     bool(__cdecl* pos_time)(const AddonInstance_InputStream* instance, int ms);
 
-    // Seekable (mandatory)
-    bool(__cdecl* can_pause_stream)(const AddonInstance_InputStream* instance);
-    bool(__cdecl* can_seek_stream)(const AddonInstance_InputStream* instance);
-
     int(__cdecl* read_stream)(const AddonInstance_InputStream* instance,
                               uint8_t* buffer,
                               unsigned int bufferSize);
@@ -566,20 +562,6 @@ public:
   virtual bool SeekChapter(int ch) { return false; };
 
   /*!
-     * Check if the backend support pausing the currently playing stream
-     * This will enable/disable the pause button in Kodi based on the return value
-     * @return false if the InputStream addon/backend does not support pausing, true if possible
-     */
-  virtual bool CanPauseStream() { return false; }
-
-  /*!
-     * Check if the backend supports seeking for the currently playing stream
-     * This will enable/disable the rewind/forward buttons in Kodi based on the return value
-     * @return false if the InputStream addon/backend does not support seeking, true if possible
-     */
-  virtual bool CanSeekStream() { return false; }
-
-  /*!
      * Read from an open stream.
      * @param buffer The buffer to store the data in.
      * @param bufferSize The amount of bytes to read.
@@ -698,9 +680,6 @@ private:
 
     m_instanceData->toAddon.get_times = ADDON_GetTimes;
     m_instanceData->toAddon.pos_time = ADDON_PosTime;
-
-    m_instanceData->toAddon.can_pause_stream = ADDON_CanPauseStream;
-    m_instanceData->toAddon.can_seek_stream = ADDON_CanSeekStream;
 
     m_instanceData->toAddon.read_stream = ADDON_ReadStream;
     m_instanceData->toAddon.seek_stream = ADDON_SeekStream;
@@ -861,18 +840,6 @@ private:
   {
     return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->SeekChapter(ch);
   }
-
-  // Seekable (mandatory)
-  inline static bool ADDON_CanPauseStream(const AddonInstance_InputStream* instance)
-  {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->CanPauseStream();
-  }
-
-  inline static bool ADDON_CanSeekStream(const AddonInstance_InputStream* instance)
-  {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->CanSeekStream();
-  }
-
 
   inline static int ADDON_ReadStream(const AddonInstance_InputStream* instance,
                                      uint8_t* buffer,

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -85,8 +85,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.12"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.7"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.1.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.1.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

- Remove the unused function CanPauseStream and CanSeekStream from the Inputstream addon API.
- Increases the max number of stream properties 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Not enough properties for inputstream.ffmpegdirect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On  inputstream.ffmpegdirect on OSX

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
