### PR TITLE
[Backport] Don't send UNFOCUS_ALL after touch action

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -418,12 +418,6 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
         CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(actionId)));
     }
 
-    // Post an unfocus message for touch device after the action.
-    if (newEvent.touch.action == ACTION_GESTURE_END || newEvent.touch.action == ACTION_TOUCH_TAP)
-    {
-      CGUIMessage msg(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
-      CApplicationMessenger::GetInstance().SendGUIMessage(msg);
-    }
     break;
   } //case
   case XBMC_BUTTON:


### PR DESCRIPTION
## Description
Backport of #17618 

Remove code part where GUI_MSG_UNFOCUS_ALL is send after touch action finishes.

## Motivation and Context
After touch tap / gesture end on Android the current code fires a GUI_MSG_UNFOCUS_ALL which removes the focus from the toched element. The missing feedback is a very bad user experience.

This PR removes this piece of code and assumes, that touch / mouse events focus / unfocus the correct elements.

## How Has This Been Tested?
Launch kodi (skin estouchy) on any Android phone, click on any element.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
