### PR TITLE
[Addons] Always use lowercase addon versions

### DIFF
--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -27,7 +27,13 @@ const std::string VALID_ADDON_VERSION_CHARACTERS = "abcdefghijklmnopqrstuvwxyzAB
 namespace ADDON
 {
   AddonVersion::AddonVersion(const std::string& version)
-  : mEpoch(0), mUpstream(version.empty() ? "0.0.0" : version)
+  : mEpoch(0), mUpstream(version.empty() ?
+                         "0.0.0" :
+                         [&version] {
+                             auto versionLowerCase = std::string(version);
+                             StringUtils::ToLower(versionLowerCase);
+                             return versionLowerCase;
+                         }())
   {
     size_t pos = mUpstream.find(':');
     if (pos != std::string::npos)

--- a/xbmc/addons/test/TestAddonVersion.cpp
+++ b/xbmc/addons/test/TestAddonVersion.cpp
@@ -168,19 +168,6 @@ TEST_F(TestAddonVersion, Equals)
   EXPECT_EQ(v1_0_0_alpha10, AddonVersion("1.0.0~alpha10"));
 }
 
-TEST_F(TestAddonVersion, Equivalent)
-{
-  EXPECT_FALSE(v1_0 != v1_00);
-  EXPECT_FALSE(v1_0 < v1_00);
-  EXPECT_FALSE(v1_0 > v1_00);
-  EXPECT_TRUE(v1_0 == v1_00);
-
-  EXPECT_FALSE(v1_01 != v1_1);
-  EXPECT_FALSE(v1_01 < v1_1);
-  EXPECT_FALSE(v1_01 > v1_1);
-  EXPECT_TRUE(v1_01 == v1_1);
-}
-
 TEST_F(TestAddonVersion, LessThan)
 {
   EXPECT_LT(v1_0, v1_0_0);
@@ -239,4 +226,46 @@ TEST_F(TestAddonVersion, LessThan)
   EXPECT_LT(v1_0_0_alpha3, v1_0_0_alpha10);
   EXPECT_LT(v1_0_0_alpha10, v1_0_0);
   EXPECT_LT(v1_0_0_alpha10, v1_0_0_beta);
+  
+  // pep-0440/local-version-identifiers
+  // ref: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
+  // Python addons use this kind of versioning particularly for script.module
+  // addons. The "same" version number may exist in different branches or
+  // targetting different kodi versions while keeping consistency with the
+  // upstream module version. The addon version available in upper repos
+  // (let's say matrix) must have a higher version than the one stored in
+  // lower branches (e.g. leia) so that users receive the addon update
+  // when upgrading kodi.
+  // So, for instance, we use version x.x.x or version x.x.x+kodiversion.r to
+  // refer to the same upstream version x.x.x of the module.
+  // Eg: script.module.foo-1.0.0 or script.module.foo-1.0.0+leia.1 for upstream
+  // module foo (version 1.0.0) available for leia; and
+  // script.module.foo-1.0.0+matrix.1 for upstream module foo (1.0.0) for matrix.
+  // In summary, 1.0.0 or 1.0.0+leia.1 must be < than 1.0.0+matrix.1
+  // tests below assure this won't get broken inadvertently
+  EXPECT_LT(AddonVersion("1.0.0"), AddonVersion("1.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+leia.1"), AddonVersion("1.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.0.0+matrix.2"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.0.1+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.1.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("2.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+matrix.1"), AddonVersion("1.0.0.1"));
+  EXPECT_LT(AddonVersion("1.0.0+Leia.1"), AddonVersion("1.0.0+matrix.1"));
+  EXPECT_LT(AddonVersion("1.0.0+leia.1"), AddonVersion("1.0.0+Matrix.1"));
+}
+
+TEST_F(TestAddonVersion, Equivalent)
+{
+  EXPECT_FALSE(v1_0 != v1_00);
+  EXPECT_FALSE(v1_0 < v1_00);
+  EXPECT_FALSE(v1_0 > v1_00);
+  EXPECT_TRUE(v1_0 == v1_00);
+
+  EXPECT_FALSE(v1_01 != v1_1);
+  EXPECT_FALSE(v1_01 < v1_1);
+  EXPECT_FALSE(v1_01 > v1_1);
+  EXPECT_TRUE(v1_01 == v1_1);
+  
+  // pep-0440/local-version-identifiers
+  EXPECT_TRUE(AddonVersion("1.0.0+leia.1") == AddonVersion("1.0.0+Leia.1"));
 }


### PR DESCRIPTION
## Description
This PR makes sure `AddonVersion` always stores the upstream version of the addon as lowercase. Before the PR, for instance version `1.1.0+foo` was being considered not equivalent (in fact higher than) to `1.0.0+Foo`.

 https://github.com/xbmc/xbmc/commit/3a5bd4c8a09daa0de5b50cf139e00474938f5ec5 - Adds a lambda to ensure the version is always lowercase

https://github.com/xbmc/xbmc/commit/f85d660a02186ec85cc9d81bf13810e9725978f3 - Extends tests to support pep-0440/local-version-identifiers

Superseeds https://github.com/xbmc/xbmc/pull/17619
@AlwinEsch new iteration

## Motivation and Context
Comment in TestAddonVersion.cpp explains the reason:

```
pep-0440/local-version-identifiers
ref: https://www.python.org/dev/peps/pep-0440/#local-version-identifiers
Python addons use this kind of versioning particularly for script.module
addons. The "same" version number may exist in different branches or
targetting different kodi versions while keeping consistency with the
upstream module version. The addon version available in upper repos
(let's say matrix) must have a higher version than the one stored in
lower branches (e.g. leia) so that users receive the addon update
when upgrading kodi.
So, for instance, we use version x.x.x or version x.x.x+kodiversion.r to
refer to the same upstream version x.x.x of the module.

Eg: script.module.foo-1.0.0 or script.module.foo-1.0.0+leia.1 for upstream
module foo (version 1.0.0) available for leia; and
script.module.foo-1.0.0+matrix.1 for upstream module foo (1.0.0) for matrix.
In summary, 1.0.0 or 1.0.0+leia.1 must be < than 1.0.0+matrix.1
tests below assure this won't get broken inadvertently
```

## How Has This Been Tested?
Manually and executing the tests

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
