### PR TITLE
[Windows] Correction to Windows date/time calculations after PR 17358

### DIFF
--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -96,7 +96,7 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     // so DIR_FLAG_NO_FILE_INFO flag is ignored
     KODI::TIME::FileTime fileTime;
     fileTime.lowDateTime = findData.ftLastWriteTime.dwLowDateTime;
-    fileTime.lowDateTime = findData.ftLastWriteTime.dwHighDateTime;
+    fileTime.highDateTime = findData.ftLastWriteTime.dwHighDateTime;
     KODI::TIME::FileTime localTime;
     if (KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime) == TRUE)
       pItem->m_dateTime = localTime;

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -170,7 +170,7 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     // so DIR_FLAG_NO_FILE_INFO flag is ignored
     KODI::TIME::FileTime fileTime;
     fileTime.lowDateTime = findData.ftLastWriteTime.dwLowDateTime;
-    fileTime.lowDateTime = findData.ftLastWriteTime.dwHighDateTime;
+    fileTime.highDateTime = findData.ftLastWriteTime.dwHighDateTime;
     KODI::TIME::FileTime localTime;
     if (KODI::TIME::FileTimeToLocalFileTime(&fileTime, &localTime) == TRUE)
       pItem->m_dateTime = localTime;


### PR DESCRIPTION
## Description
This PR corrects what appears to be a simple typographical error made during PR [17358](https://github.com/xbmc/xbmc/pull/17358) causing date/time stamp calculation errors to occur on the Windows platform.  When converting between Win32 FILETIME and KODI::TIME::FileTime, the low DWORD of the original value is being assigned to both the low and high portions of the new value.

## Motivation and Context
I happened to be browsing the Issues and noted Issue [17607](https://github.com/xbmc/xbmc/issues/17607), which appeared to be relatively easy to reproduce and track down, given the context provided.

## How Has This Been Tested?
Tested on Windows x64 against local build of latest master branch available at the time of authoring.  Confirmed incorrect behavior prior to making corrections, confirmed accurate date/time stamps after correction.

## Screenshots (if appropriate):
Before the change:
![before](https://user-images.githubusercontent.com/706055/78625200-6c24e080-7859-11ea-9cf5-87a81ed90202.png)

After the change:
![after](https://user-images.githubusercontent.com/706055/78625207-6f1fd100-7859-11ea-9819-eee0da9fd228.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
