### PR TITLE
Enable UTF-8 for JumpLetter and cleanup need for KEY_ASCII

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -215,7 +215,7 @@ bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
       CGUIControl *edit = GetControl(CTL_EDIT);
       if (edit)
         handled = edit->OnAction(action);
-      if (!handled && actionId >= KEY_VKEY && actionId < KEY_ASCII)
+      if (!handled && actionId >= KEY_VKEY && actionId < KEY_UNICODE)
       {
         unsigned char b = actionId & 0xFF;
         if (b == XBMCVK_TAB)

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -109,7 +109,7 @@ bool CGUIDialogNumeric::OnAction(const CAction &action)
     OnOK();
   else if (action.GetID() >= REMOTE_0 && action.GetID() <= REMOTE_9)
     OnNumber(action.GetID() - REMOTE_0);
-  else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
+  else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_UNICODE)
   {
     // input from the keyboard (vkey, not ascii)
     uint8_t b = action.GetID() & 0xFF;
@@ -124,7 +124,7 @@ bool CGUIDialogNumeric::OnAction(const CAction &action)
     else if (b == XBMCVK_ESCAPE)
       OnCancel();
   }
-  else if (action.GetID() >= KEY_ASCII) // FIXME make it KEY_UNICODE
+  else if (action.GetID() == KEY_UNICODE)
   { // input from the keyboard
     if (action.GetUnicode() == 10 || action.GetUnicode() == 13)
       OnOK(); // enter

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -293,7 +293,9 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
 {
   if (action.GetID() >= KEY_ASCII)
   {
-    OnJumpLetter((char)(action.GetID() & 0xff));
+    std::string letter;
+    g_charsetConverter.wToUTF8({action.GetUnicode()}, letter);
+    OnJumpLetter(std::move(letter));
     return true;
   }
   // stop the timer on any other action
@@ -557,12 +559,12 @@ void CGUIBaseContainer::OnPrevLetter()
   }
 }
 
-void CGUIBaseContainer::OnJumpLetter(char letter, bool skip /*=false*/)
+void CGUIBaseContainer::OnJumpLetter(std::string letter, bool skip /*=false*/)
 {
   if (m_matchTimer.GetElapsedMilliseconds() < letter_match_timeout)
-    m_match.push_back(letter);
+    m_match += letter;
   else
-    m_match = StringUtils::Format("%c", letter);
+    m_match = letter;
 
   m_matchTimer.StartZero();
 
@@ -586,8 +588,11 @@ void CGUIBaseContainer::OnJumpLetter(char letter, bool skip /*=false*/)
     }
     i = (i+1) % m_items.size();
   } while (i != offset);
+
   // no match found - repeat with a single letter
-  if (m_match.size() > 1)
+  std::wstring wmatch;
+  g_charsetConverter.utf8ToW(m_match, wmatch);
+  if (wmatch.length() > 1)
   {
     m_match.clear();
     OnJumpLetter(letter, true);

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -291,7 +291,7 @@ void CGUIBaseContainer::RenderItem(float posX, float posY, CGUIListItem *item, b
 
 bool CGUIBaseContainer::OnAction(const CAction &action)
 {
-  if (action.GetID() >= KEY_ASCII)
+  if (action.GetID() == KEY_UNICODE)
   {
     std::string letter;
     g_charsetConverter.wToUTF8({action.GetUnicode()}, letter);

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -172,7 +172,7 @@ protected:
   bool ScrollingUp() const { return m_scroller.IsScrollingUp(); };
   void OnNextLetter();
   void OnPrevLetter();
-  void OnJumpLetter(char letter, bool skip = false);
+  void OnJumpLetter(std::string letter, bool skip = false);
   void OnJumpSMS(int letter);
   std::vector< std::pair<int, std::string> > m_letterOffsets;
 

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -136,7 +136,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
       OnPasteClipboard();
       return true;
     }
-    else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII && m_edit.empty())
+    else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_UNICODE && m_edit.empty())
     {
       // input from the keyboard (vkey, not ascii)
       unsigned char b = action.GetID() & 0xFF;
@@ -195,7 +195,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
         return CGUIButtonControl::OnAction(action);
       }
     }
-    else if (action.GetID() >= KEY_ASCII)
+    else if (action.GetID() == KEY_UNICODE)
     {
       // input from the keyboard
       int ch = action.GetUnicode();

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -602,7 +602,7 @@ bool CInputManager::HandleKey(const CKey& key)
             action = CAction(ACTION_PASTE);
           // If the unicode is non-zero the keypress is a non-printing character
           else if (key.GetUnicode())
-            action = CAction(key.GetAscii() | KEY_ASCII, key.GetUnicode());
+            action = CAction(KEY_UNICODE, key.GetUnicode());
           // The keypress is a non-printing character
           else
             action = CAction(key.GetVKey() | KEY_VKEY);

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -548,7 +548,8 @@ bool CInputManager::HandleKey(const CKey& key)
 
         // If the key pressed is shift-A to shift-Z set usekeyboard to true.
         // This causes the keypress to be used for list navigation.
-        if (control->IsContainer() && key.GetModifiers() == CKey::MODIFIER_SHIFT && key.GetVKey() >= XBMCVK_A && key.GetVKey() <= XBMCVK_Z)
+        if (control->IsContainer() && key.GetModifiers() == CKey::MODIFIER_SHIFT &&
+            key.GetUnicode())
           useKeyboard = true;
       }
     }

--- a/xbmc/input/Key.cpp
+++ b/xbmc/input/Key.cpp
@@ -157,8 +157,8 @@ float CKey::GetRepeat() const
 
 void CKey::SetFromService(bool fromService)
 {
-  if (fromService && (m_buttonCode & KEY_ASCII))
-    m_unicode = m_buttonCode - KEY_ASCII;
+  if (fromService && (m_buttonCode & KEY_VKEY))
+    m_unicode = m_buttonCode - KEY_VKEY;
 
   m_fromService = fromService;
 }

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -67,7 +67,6 @@
 
 // 0xF000 -> 0xF200 is reserved for the keyboard; a keyboard press is either
 #define KEY_VKEY            0xF000 // a virtual key/functional key e.g. cursor left
-#define KEY_ASCII           0xF100 // a printable character in the range of TRUE ASCII (from 0 to 127) // FIXME make it clean and pure unicode! remove the need for KEY_ASCII
 #define KEY_UNICODE         0xF200 // another printable character whose range is not included in this KEY code
 
 // 0xE000 -> 0xEFFF is reserved for mouse actions

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -519,7 +519,7 @@ bool CTeletextDecoder::HandleAction(const CAction &action)
     PageInput(action.GetID() - REMOTE_0);
     return true;
   }
-  else if (action.GetID() >= KEY_ASCII) // FIXME make it KEY_UNICODE
+  else if (action.GetID() == KEY_UNICODE)
   { // input from the keyboard
     if (action.GetUnicode() >= 48 && action.GetUnicode() < 58)
     {


### PR DESCRIPTION
## Description
The JumpLetter function of containers only worked for ASCII characters.
It did not work for Cyrillic languages. 

## Motivation and Context
This change enables JumpLetter for Cyrillic languages such as russian and
cleans up the need of the KEY_ASCII constant that have been marked as TODO in several places.

## How Has This Been Tested?
Tested on Linux Ubuntu 18.04, tried to jump to cyrillic letters and latin ones.
I couldn't test stuff like Teletext which also is affected by the removal of KEY_ASCII, so it would
be nice to get more testing for this.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
