### PR TITLE
Added the option to pass arguments to add-on menu callbacks

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -52,7 +52,7 @@ bool CContextMenuItem::Execute(const CFileItemPtr& item) const
 
 #ifdef HAS_PYTHON
   LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&g_pythonParser, item));
-  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon) != -1);
+  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon, m_args) != -1);
 #else
   return false;
 #endif
@@ -66,7 +66,8 @@ bool CContextMenuItem::operator==(const CContextMenuItem& other) const
   return (IsGroup() == other.IsGroup())
       && (m_parent == other.m_parent)
       && (m_library == other.m_library)
-      && (m_addonId == other.m_addonId);
+      && (m_addonId == other.m_addonId)
+      && (m_args == other.m_args);
 }
 
 std::string CContextMenuItem::ToString() const
@@ -91,7 +92,7 @@ CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const s
 }
 
 CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const std::string& parent,
-    const std::string& library, const std::string& condition, const std::string& addonId)
+    const std::string& library, const std::string& condition, const std::string& addonId, const std::vector<std::string>& args)
 {
   CContextMenuItem menuItem;
   menuItem.m_label = label;
@@ -99,5 +100,6 @@ CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const st
   menuItem.m_library = library;
   menuItem.m_visibilityCondition = condition;
   menuItem.m_addonId = addonId;
+  menuItem.m_args = args;
   return menuItem;
 }

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -50,9 +50,13 @@ bool CContextMenuItem::Execute(const CFileItemPtr& item) const
   if (!CServiceBroker::GetAddonMgr().GetAddon(m_addonId, addon))
     return false;
 
+  bool reuseLanguageInvoker = false;
+  if (addon->ExtraInfo().find("reuselanguageinvoker") != addon->ExtraInfo().end())
+    reuseLanguageInvoker = addon->ExtraInfo().at("reuselanguageinvoker") == "true";
+
 #ifdef HAS_PYTHON
   LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&g_pythonParser, item));
-  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon, m_args) != -1);
+  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon, m_args, reuseLanguageInvoker) != -1);
 #else
   return false;
 #endif

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -69,8 +69,9 @@ public:
     const std::string& parent,
     const std::string& library,
     const std::string& condition,
-    const std::string& addonId);
-
+    const std::string& addonId, 
+    const std::vector<std::string>& args = std::vector<std::string>());
+  
   friend class ADDON::CContextMenuAddon;
 
 private:
@@ -79,6 +80,7 @@ private:
   std::string m_groupId;
   std::string m_library;
   std::string m_addonId; // The owner of this menu item
+  std::vector<std::string> m_args;
 
   std::string m_visibilityCondition;
   mutable INFO::InfoPtr m_infoBool;

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -87,10 +87,17 @@ void CContextMenuAddon::ParseMenu(
     if (StringUtils::IsNaturalNumber(label))
       label = g_localizeStrings.GetAddonString(ID(), atoi(label.c_str()));
 
+    std::vector<std::string> args;
+    args.push_back(ID());
+ 
+    std::string arg = element.second.GetValue("@args").asString();
+    if (!arg.empty())
+      args.push_back(arg);
+
     if (!label.empty() && !library.empty() && !visCondition.empty())
     {
       auto menu = CContextMenuItem::CreateItem(label, menuId,
-          URIUtils::AddFileToFolder(Path(), library), visCondition, ID());
+          URIUtils::AddFileToFolder(Path(), library), visCondition, ID(), args);
       m_items.push_back(menu);
     }
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
I added the option to pass arguments to add-on menu callbacks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The addon.xml allows the configuration of context menu items. However, only a `library` parameter can be passed to such menu items:

```xml
<item library="menu_settings.py">
    <label>30528</label>
</item>
```

With the current implementation it is only possible to specify a `library`, so each menu item needs a separate Python library for callback. This requires a single Python file for each menu item. This PR introduces an `args` property:

```xml
<item library="menu.py" args="?action=settings">
    <label>30528</label>
</item>
```

That property allows you to pass an argument to the script:

```
sys.argv=['plugin.video.pluginid', '?action=settings']
```

These arguments are similar to those passed to normal plugin runs, the only difference is that there is no _handle_ passed. 

This PR also enables the `reuselanguageinvoker` for menu callbacks. This was not there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Locally on latest sources with my add-on (Retrospect) containing context menu items.

## Screenshots (if appropriate):
n.a.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
