### PR TITLE
Remove Pause from Inputstream API and PauseStream from Inputstream Addons

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -89,7 +89,7 @@ extern "C"
    */
   struct INPUTSTREAM_IDS
   {
-    static const unsigned int MAX_STREAM_COUNT = 32;
+    static const unsigned int MAX_STREAM_COUNT = 256;
     unsigned int m_streamCount;
     unsigned int m_streamIds[MAX_STREAM_COUNT];
   };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -19,8 +19,10 @@
 
 #ifdef BUILD_KODI_ADDON
 #include "../DemuxPacket.h"
+#include "../InputStreamConstants.h"
 #else
 #include "cores/VideoPlayer/Interface/Addon/DemuxPacket.h"
+#include "cores/VideoPlayer/Interface/Addon/InputStreamConstants.h"
 #endif
 
 //Increment this level always if you add features which can lead to compile failures in the addon
@@ -69,8 +71,6 @@ extern "C"
    */
   struct INPUTSTREAM
   {
-    static const unsigned int MAX_INFO_COUNT = 30;
-
     const char* m_strURL;
 
     unsigned int m_nCountInfoValues;
@@ -78,7 +78,7 @@ extern "C"
     {
       const char* m_strKey;
       const char* m_strValue;
-    } m_ListItemProperties[MAX_INFO_COUNT];
+    } m_ListItemProperties[STREAM_MAX_PROPERTY_COUNT];
 
     const char* m_libFolder;
     const char* m_profileFolder;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -357,7 +357,6 @@ extern "C"
                                   int whence);
     int64_t(__cdecl* position_stream)(const AddonInstance_InputStream* instance);
     int64_t(__cdecl* length_stream)(const AddonInstance_InputStream* instance);
-    void(__cdecl* pause_stream)(const AddonInstance_InputStream* instance, double time);
     bool(__cdecl* is_real_time_stream)(const AddonInstance_InputStream* instance);
 
     // IChapter
@@ -598,14 +597,6 @@ public:
   virtual int GetBlockSize() { return 0; }
 
   /*!
-     * @brief Notify the InputStream addon that Kodi (un)paused the currently playing stream.
-     * Only called when an inpustream DOES NOT have its own demuxer.
-     * @param time The time that Kodi (un)paused the stream
-     */
-  virtual void PauseStream(double time) {}
-
-
-  /*!
      *  Check for real-time streaming
      *  @return true if current stream is real-time
      */
@@ -687,7 +678,6 @@ private:
     m_instanceData->toAddon.seek_stream = ADDON_SeekStream;
     m_instanceData->toAddon.position_stream = ADDON_PositionStream;
     m_instanceData->toAddon.length_stream = ADDON_LengthStream;
-    m_instanceData->toAddon.pause_stream = ADDON_PauseStream;
     m_instanceData->toAddon.is_real_time_stream = ADDON_IsRealTimeStream;
 
     int minChapterVersion[3] = { 2, 0, 10 };
@@ -872,11 +862,6 @@ private:
   inline static int ADDON_GetBlockSize(const AddonInstance_InputStream* instance)
   {
     return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetBlockSize();
-  }
-
-  inline static void ADDON_PauseStream(const AddonInstance_InputStream* instance, double time)
-  {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->PauseStream(time);
   }
 
   inline static bool ADDON_IsRealTimeStream(const AddonInstance_InputStream* instance)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -85,8 +85,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.1.0"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.1.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.2.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.2.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -714,15 +714,9 @@ void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
     return;
 
   if (m_speed != DVD_PLAYSPEED_PAUSE && iSpeed == DVD_PLAYSPEED_PAUSE)
-  {
-    m_pInput->Pause(m_currentPts);
     av_read_pause(m_pFormatContext);
-  }
   else if (m_speed == DVD_PLAYSPEED_PAUSE && iSpeed != DVD_PLAYSPEED_PAUSE)
-  {
-    m_pInput->Pause(m_currentPts);
     av_read_play(m_pFormatContext);
-  }
   m_speed = iSpeed;
 
   AVDiscard discard = AVDISCARD_NONE;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -59,7 +59,12 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
       return std::shared_ptr<CInputStreamAddon>(new CInputStreamAddon(addonInfo, pPlayer, fileitem));
   }
 
-  if (fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAMCLASS).asString() ==
+  if (fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAM).asString() ==
+      STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG)
+    return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(fileitem));
+
+  // TODO; Retire for the above instead prior to Matrix release
+  if (fileitem.GetProperty("inputstreamclass").asString() ==
       STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG)
     return std::shared_ptr<CDVDInputStreamFFmpeg>(new CDVDInputStreamFFmpeg(fileitem));
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -148,7 +148,6 @@ public:
   virtual void Close();
   virtual int Read(uint8_t* buf, int buf_size) = 0;
   virtual int64_t Seek(int64_t offset, int whence) = 0;
-  virtual bool Pause(double dTime) = 0;
   virtual int64_t GetLength() = 0;
   virtual std::string& GetContent() { return m_content; };
   virtual std::string GetFileName();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -54,7 +54,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override { return false; };
   void Abort() override;
   bool IsEOF() override;
   int64_t GetLength() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -20,7 +20,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override { return false; };
   bool IsEOF() override;
   int64_t GetLength() override;
   std::string GetFileName() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -19,7 +19,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override { return false; };
   bool IsEOF() override;
   int64_t GetLength() override;
   BitstreamStats GetBitstreamStats() const override ;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -49,7 +49,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override { return false; };
   int GetBlockSize() override { return DVDSTREAM_BLOCK_SIZE_DVD; }
   bool IsEOF() override { return m_bEOF; }
   int64_t GetLength() override { return 0; }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
@@ -23,7 +23,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override { return false; };
   bool IsEOF() override;
   int64_t GetLength() override;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -19,6 +19,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 
 CInputStreamProvider::CInputStreamProvider(ADDON::BinaryAddonBasePtr addonBase,
                                            KODI_HANDLE parentInstance)
@@ -137,6 +138,17 @@ bool CInputStreamAddon::Open()
     props.m_ListItemProperties[props.m_nCountInfoValues].m_strKey = pair.first.c_str();
     props.m_ListItemProperties[props.m_nCountInfoValues].m_strValue = pair.second.c_str();
     props.m_nCountInfoValues++;
+
+    if (props.m_nCountInfoValues >= STREAM_MAX_PROPERTY_COUNT)
+    {
+      CLog::Log(LOGERROR,
+                "CInputStreamAddon::%s - Hit max count of stream properties, "
+                "have %d, actual count: %d",
+                __func__,
+                STREAM_MAX_PROPERTY_COUNT,
+                propsMap.size());
+      break;
+    }
   }
 
   props.m_strURL = m_item.GetDynPath().c_str();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -220,15 +220,6 @@ int CInputStreamAddon::GetBlockSize()
   return m_struct.toAddon.block_size_stream(&m_struct);
 }
 
-bool CInputStreamAddon::Pause(double time)
-{
-  if (!m_struct.toAddon.pause_stream)
-    return false;
-
-  m_struct.toAddon.pause_stream(&m_struct, time);
-  return true;
-}
-
 bool CInputStreamAddon::CanSeek()
 {
   return (m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTS_SEEK) != 0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -69,11 +69,16 @@ CInputStreamAddon::~CInputStreamAddon()
 bool CInputStreamAddon::Supports(BinaryAddonBasePtr& addonBase, const CFileItem &fileitem)
 {
   // check if a specific inputstream addon is requested
-  CVariant addon = fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAMCLASS);
+  CVariant addon = fileitem.GetProperty(STREAM_PROPERTY_INPUTSTREAM);
   if (!addon.isNull())
     return (addon.asString() == addonBase->ID());
 
-  // TODO: to be deprecated for the above - all addons must change
+  // TODO: to be deprecated for the above prior to Matrix release - all addons must change
+  addon = fileitem.GetProperty("inputstreamclass");
+  if (!addon.isNull())
+    return (addon.asString() == addonBase->ID());
+
+  // TODO: to be deprecated for the above prior to Matrix release - all addons must change
   addon = fileitem.GetProperty("inputstreamaddon");
   if (!addon.isNull())
     return (addon.asString() == addonBase->ID());

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -53,7 +53,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override;
   int64_t GetLength() override;
   int GetBlockSize() override;
   bool IsEOF() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
@@ -32,7 +32,6 @@ public:
   bool IsEOF() override;
   CDVDInputStream::ENextStream NextStream() override;
   bool Open() override;
-  bool Pause(double dTime)override { return false; };
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
   void SetReadRate(unsigned rate) override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -36,7 +36,6 @@ public:
   void Close() override;
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
-  bool Pause(double dTime) override { return false; }
   bool IsEOF() override;
   int64_t GetLength() override;
   int GetBlockSize() override;

--- a/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
@@ -28,3 +28,8 @@
  * ffmpeg to directly play a stream URL.
  */
 #define STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG "inputstream.ffmpeg"
+
+/*!
+ * @brief Max number of properties that can be sent to an Inputstream addon
+ */
+#define STREAM_MAX_PROPERTY_COUNT 30

--- a/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/InputStreamConstants.h
@@ -14,7 +14,7 @@
  * Kodi's built-in playing capabilities or to allow ffmpeg to handle directly
  * set to STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG.
  */
-#define STREAM_PROPERTY_INPUTSTREAMCLASS "inputstreamclass"
+#define STREAM_PROPERTY_INPUTSTREAM "inputstream"
 
 /*!
  * @brief "true" to denote that the stream that should be played is a
@@ -24,7 +24,7 @@
 #define STREAM_PROPERTY_ISREALTIMESTREAM "isrealtimestream"
 
 /*!
- * @brief special value for STREAM_PROPERTY_INPUTSTREAMCLASS to use
+ * @brief special value for STREAM_PROPERTY_INPUTSTREAM to use
  * ffmpeg to directly play a stream URL.
  */
 #define STREAM_PROPERTY_VALUE_INPUTSTREAMFFMPEG "inputstream.ffmpeg"


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

The pause function is not used on the Inputstream API and so will be removed. Also PauseStream will be removed from Inputstream addons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On Mac with inputstream.rtmp

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
