### PR TITLE
CRenderBufferDMA: log the buffer type in use

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "utils/BufferObject.h"
 #include "utils/EGLImage.h"
+#include "utils/log.h"
 #include "windowing/WinSystem.h"
 #include "windowing/linux/WinSystemEGL.h"
 
@@ -31,6 +32,8 @@ CRenderBufferDMA::CRenderBufferDMA(CRenderContext& context, int fourcc)
                              "specifically platforms that implement CWinSystemEGL");
 
   m_egl = std::make_unique<CEGLImage>(winSystemEGL->GetEGLDisplay());
+
+  CLog::Log(LOGDEBUG, "CRenderBufferDMA: using BufferObject type: {}", m_bo->GetName());
 }
 
 CRenderBufferDMA::~CRenderBufferDMA()

--- a/xbmc/utils/DMAHeapBufferObject.h
+++ b/xbmc/utils/DMAHeapBufferObject.h
@@ -28,6 +28,7 @@ public:
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
+  std::string GetName() const override { return "CDMAHeapBufferObject"; }
 
 private:
   int m_dmaheapfd{-1};

--- a/xbmc/utils/DumbBufferObject.h
+++ b/xbmc/utils/DumbBufferObject.h
@@ -28,6 +28,7 @@ public:
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
+  std::string GetName() const override { return "CDumbBufferObject"; }
 
 private:
   int m_device{-1};

--- a/xbmc/utils/GBMBufferObject.h
+++ b/xbmc/utils/GBMBufferObject.h
@@ -31,6 +31,7 @@ public:
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
+  std::string GetName() const override { return "CGBMBufferObject"; }
 
   // CBufferObject overrides
   uint64_t GetModifier() override;

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 
 /**
  * @brief Interface to describe CBufferObjects.
@@ -97,4 +98,11 @@ public:
    * @return uint64_t modifier of the BufferObject. 0 means the layout is linear (default).
    */
   virtual uint64_t GetModifier() = 0;
+
+  /**
+   * @brief Get the Name of the BufferObject type in use
+   *
+   * @return std::string name of the BufferObject type in use
+   */
+  virtual std::string GetName() const = 0;
 };

--- a/xbmc/utils/UDMABufferObject.h
+++ b/xbmc/utils/UDMABufferObject.h
@@ -28,6 +28,7 @@ public:
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
+  std::string GetName() const override { return "CUDMABufferObject"; }
 
 private:
   int m_memfd{-1};


### PR DESCRIPTION
The `IBufferObject` interface is designed to be seemless as the user shouldn't care what buffer object type is being used, however it may be useful for debugging if any problems arise or if someone is just curious about which buffer object type is being used.