### PR TITLE
CBufferObject: unify logging style

### DIFF
--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -43,7 +43,8 @@ void CDMAHeapBufferObject::Register()
     int fd = open(path, O_RDWR);
     if (fd < 0)
     {
-      CLog::LogF(LOGERROR, "unable to open {}: {}", path, strerror(errno));
+      CLog::Log(LOGDEBUG, "CDMAHeapBufferObject::{} unable to open {}: {}", __FUNCTION__, path,
+                strerror(errno));
       continue;
     }
 
@@ -55,7 +56,7 @@ void CDMAHeapBufferObject::Register()
   if (!DMA_HEAP_PATH)
     return;
 
-  CLog::LogF(LOGDEBUG, "using {}: for dma-heap", DMA_HEAP_PATH);
+  CLog::Log(LOGDEBUG, "CDMAHeapBufferObject::{} - using {}", __FUNCTION__, DMA_HEAP_PATH);
 
   CBufferObjectFactory::RegisterBufferObject(CDMAHeapBufferObject::Create);
 }
@@ -86,7 +87,7 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint32_t format, uint32_t width, u
       bpp = 2;
       break;
     default:
-      throw std::system_error(errno, std::generic_category(), "pixel format not implemented");
+      throw std::runtime_error("CDMAHeapBufferObject: pixel format not implemented");
   }
 
   m_size = width * height * bpp;
@@ -108,8 +109,8 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint32_t format, uint32_t width, u
   int ret = ioctl(m_dmaheapfd, DMA_HEAP_IOCTL_ALLOC, &allocData);
   if (ret < 0)
   {
-    CLog::LogF(LOGERROR, "ioctl DMA_HEAP_IOCTL_ALLOC failed, ret={} errno={}", ret,
-               strerror(errno));
+    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - ioctl DMA_HEAP_IOCTL_ALLOC failed, errno={}",
+              __FUNCTION__, strerror(errno));
     return false;
   }
 
@@ -118,7 +119,8 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint32_t format, uint32_t width, u
 
   if (m_fd < 0 || m_size <= 0)
   {
-    CLog::LogF(LOGERROR, "invalid allocation data: fd={} len={}", m_fd, m_size);
+    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - invalid allocation data: fd={} len={}",
+              __FUNCTION__, m_fd, m_size);
     return false;
   }
 
@@ -132,7 +134,8 @@ void CDMAHeapBufferObject::DestroyBufferObject()
 
   int ret = close(m_fd);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "close failed, errno={}", __FUNCTION__, strerror(errno));
+    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - close failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_fd = -1;
   m_stride = 0;
@@ -146,14 +149,16 @@ uint8_t* CDMAHeapBufferObject::GetMemory()
 
   if (m_map)
   {
-    CLog::LogF(LOGDEBUG, "already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
+    CLog::Log(LOGDEBUG, "CDMAHeapBufferObject::{} - already mapped fd={} map={}", __FUNCTION__,
+              m_fd, fmt::ptr(m_map));
     return m_map;
   }
 
   m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
-    CLog::LogF(LOGERROR, "mmap failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - mmap failed, errno={}", __FUNCTION__,
+              strerror(errno));
     return nullptr;
   }
 
@@ -167,7 +172,8 @@ void CDMAHeapBufferObject::ReleaseMemory()
 
   int ret = munmap(m_map, m_size);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "munmap failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - munmap failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_map = nullptr;
 }

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -56,9 +56,10 @@ bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
       bpp = 16;
       break;
     case DRM_FORMAT_ARGB8888:
-    default:
       bpp = 32;
       break;
+    default:
+      throw std::runtime_error("CDumbBufferObject: pixel format not implemented");
   }
 
   struct drm_mode_create_dumb create_dumb = {.height = height, .width = width, .bpp = bpp};
@@ -66,8 +67,8 @@ bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
   int ret = drmIoctl(m_device, DRM_IOCTL_MODE_CREATE_DUMB, &create_dumb);
   if (ret < 0)
   {
-    CLog::LogF(LOGERROR, "ioctl DRM_IOCTL_MODE_CREATE_DUMB failed, ret={} errno={}", ret,
-               strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - ioctl DRM_IOCTL_MODE_CREATE_DUMB failed, errno={}",
+              __FUNCTION__, strerror(errno));
     return false;
   }
 
@@ -77,8 +78,8 @@ bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
   ret = drmPrimeHandleToFD(m_device, create_dumb.handle, 0, &m_fd);
   if (ret < 0)
   {
-    CLog::LogF(LOGERROR, "failed to get fd from prime handle, ret={} errno={}", ret,
-               strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - failed to get fd from prime handle, errno={}",
+              __FUNCTION__, strerror(errno));
     return false;
   }
 
@@ -92,7 +93,8 @@ void CDumbBufferObject::DestroyBufferObject()
 
   int ret = close(m_fd);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "close failed, errno={}", __FUNCTION__, strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - close failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_fd = -1;
   m_stride = 0;
@@ -106,7 +108,8 @@ uint8_t* CDumbBufferObject::GetMemory()
 
   if (m_map)
   {
-    CLog::LogF(LOGDEBUG, "already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
+    CLog::Log(LOGDEBUG, "CDumbBufferObject::{} - already mapped fd={} map={}", __FUNCTION__, m_fd,
+              fmt::ptr(m_map));
     return m_map;
   }
 
@@ -114,8 +117,8 @@ uint8_t* CDumbBufferObject::GetMemory()
   int ret = drmPrimeFDToHandle(m_device, m_fd, &handle);
   if (ret < 0)
   {
-    CLog::LogF(LOGERROR, "failed to get handle from prime fd, ret={} errno={}", ret,
-               strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - failed to get handle from prime fd, errno={}",
+              __FUNCTION__, strerror(errno));
     return nullptr;
   }
 
@@ -124,8 +127,8 @@ uint8_t* CDumbBufferObject::GetMemory()
   ret = drmIoctl(m_device, DRM_IOCTL_MODE_MAP_DUMB, &map_dumb);
   if (ret < 0)
   {
-    CLog::LogF(LOGERROR, "ioctl DRM_IOCTL_MODE_MAP_DUMB failed, ret={} errno={}", ret,
-               strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - ioctl DRM_IOCTL_MODE_MAP_DUMB failed, errno={}",
+              __FUNCTION__, strerror(errno));
     return nullptr;
   }
 
@@ -134,7 +137,8 @@ uint8_t* CDumbBufferObject::GetMemory()
   m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_device, m_offset));
   if (m_map == MAP_FAILED)
   {
-    CLog::LogF(LOGERROR, "mmap failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - mmap failed, errno={}", __FUNCTION__,
+              strerror(errno));
     return nullptr;
   }
 
@@ -148,7 +152,8 @@ void CDumbBufferObject::ReleaseMemory()
 
   int ret = munmap(m_map, m_size);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "munmap failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CDumbBufferObject::{} - munmap failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_map = nullptr;
   m_offset = 0;

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -38,7 +38,8 @@ void CUDMABufferObject::Register()
   int fd = open("/dev/udmabuf", O_RDWR);
   if (fd < 0)
   {
-    CLog::LogF(LOGERROR, "unable to open /dev/udmabuf (check your permissions)");
+    CLog::Log(LOGDEBUG, "CUDMABufferObject::{} - unable to open /dev/udmabuf: {}", __FUNCTION__,
+              strerror(errno));
     return;
   }
 
@@ -54,7 +55,8 @@ CUDMABufferObject::~CUDMABufferObject()
 
   int ret = close(m_udmafd);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "close /dev/udmabuf failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close /dev/udmabuf failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_udmafd = -1;
 }
@@ -76,7 +78,7 @@ bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
       bpp = 2;
       break;
     default:
-      throw std::system_error(errno, std::generic_category(), "pixel format not implemented");
+      throw std::runtime_error("CUDMABufferObject: pixel format not implemented");
   }
 
   // Must be rounded to the system page size
@@ -86,19 +88,21 @@ bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
   m_memfd = memfd_create("kodi", MFD_CLOEXEC | MFD_ALLOW_SEALING);
   if (m_memfd < 0)
   {
-    CLog::LogF(LOGERROR, "memfd_create failed: {}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - memfd_create failed: {}", __FUNCTION__,
+              strerror(errno));
     return false;
   }
 
   if (ftruncate(m_memfd, m_size) < 0)
   {
-    CLog::LogF(LOGERROR, "ftruncate failed: {}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - ftruncate failed: {}", __FUNCTION__,
+              strerror(errno));
     return false;
   }
 
   if (fcntl(m_memfd, F_ADD_SEALS, F_SEAL_SHRINK) < 0)
   {
-    CLog::LogF(LOGERROR, "fcntl failed: {}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - fcntl failed: {}", __FUNCTION__, strerror(errno));
     close(m_memfd);
     return false;
   }
@@ -108,7 +112,8 @@ bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
     m_udmafd = open("/dev/udmabuf", O_RDWR);
     if (m_udmafd < 0)
     {
-      CLog::LogF(LOGERROR, "unable to open /dev/udmabuf: {}", strerror(errno));
+      CLog::Log(LOGERROR, "CUDMABufferObject::{} - unable to open /dev/udmabuf: {}", __FUNCTION__,
+                strerror(errno));
       close(m_memfd);
       return false;
     }
@@ -123,7 +128,8 @@ bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
   m_fd = ioctl(m_udmafd, UDMABUF_CREATE, &create);
   if (m_fd < 0)
   {
-    CLog::LogF(LOGERROR, "ioctl UDMABUF_CREATE failed: {}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - ioctl UDMABUF_CREATE failed: {}", __FUNCTION__,
+              strerror(errno));
     close(m_memfd);
     return false;
   }
@@ -138,11 +144,13 @@ void CUDMABufferObject::DestroyBufferObject()
 
   int ret = close(m_fd);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "close fd failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close fd failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   ret = close(m_memfd);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "close memfd failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close memfd failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_memfd = -1;
   m_fd = -1;
@@ -157,14 +165,16 @@ uint8_t* CUDMABufferObject::GetMemory()
 
   if (m_map)
   {
-    CLog::LogF(LOGDEBUG, "already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
+    CLog::Log(LOGDEBUG, "CUDMABufferObject::{} - already mapped fd={} map={}", __FUNCTION__, m_fd,
+              fmt::ptr(m_map));
     return m_map;
   }
 
   m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_memfd, 0));
   if (m_map == MAP_FAILED)
   {
-    CLog::LogF(LOGERROR, "mmap failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - mmap failed, errno={}", __FUNCTION__,
+              strerror(errno));
     return nullptr;
   }
 
@@ -178,7 +188,8 @@ void CUDMABufferObject::ReleaseMemory()
 
   int ret = munmap(m_map, m_size);
   if (ret < 0)
-    CLog::LogF(LOGERROR, "munmap failed, errno={}", strerror(errno));
+    CLog::Log(LOGERROR, "CUDMABufferObject::{} - munmap failed, errno={}", __FUNCTION__,
+              strerror(errno));
 
   m_map = nullptr;
 }


### PR DESCRIPTION
This unifies the logging style used across the various CBufferObject types. Logging the class name and the method makes it easier to track down if there is problems.

I have also changed the registration logging to `LOGDEBUG` as it isn't an error if the path doesn't exist, it's simply a convenience to log it if the path isn't available. This is suggested by @HiassofT 