### PR TITLE
IBufferObject: allow creating by size

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -20,7 +20,7 @@ using namespace RETRO;
 CRenderBufferDMA::CRenderBufferDMA(CRenderContext& context, int fourcc)
   : m_context(context),
     m_fourcc(fourcc),
-    m_bo(CBufferObject::GetBufferObject())
+    m_bo(CBufferObject::GetBufferObject(false))
 {
   auto winSystemEGL =
       dynamic_cast<KODI::WINDOWING::LINUX::CWinSystemEGL*>(CServiceBroker::GetWinSystem());

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
@@ -15,7 +15,7 @@
 #include "system_gl.h"
 
 class CEGLImage;
-class CBufferObject;
+class IBufferObject;
 
 namespace KODI
 {
@@ -60,7 +60,7 @@ namespace RETRO
     void DeleteTexture();
 
     std::unique_ptr<CEGLImage> m_egl;
-    std::unique_ptr<CBufferObject> m_bo;
+    std::unique_ptr<IBufferObject> m_bo;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
@@ -35,7 +35,7 @@ CRPBaseRenderer* CRendererFactoryDMA::CreateRenderer(const CRenderSettings& sett
 
 RenderBufferPoolVector CRendererFactoryDMA::CreateBufferPools(CRenderContext& context)
 {
-  if (!CBufferObjectFactory::CreateBufferObject())
+  if (!CBufferObjectFactory::CreateBufferObject(false))
     return {};
 
   return {std::make_shared<CRenderBufferPoolDMA>(context)};

--- a/xbmc/utils/BufferObject.cpp
+++ b/xbmc/utils/BufferObject.cpp
@@ -10,9 +10,9 @@
 
 #include "BufferObjectFactory.h"
 
-std::unique_ptr<CBufferObject> CBufferObject::GetBufferObject()
+std::unique_ptr<CBufferObject> CBufferObject::GetBufferObject(bool needsCreateBySize)
 {
-  return CBufferObjectFactory::CreateBufferObject();
+  return CBufferObjectFactory::CreateBufferObject(needsCreateBySize);
 }
 
 int CBufferObject::GetFd()

--- a/xbmc/utils/BufferObject.h
+++ b/xbmc/utils/BufferObject.h
@@ -26,7 +26,9 @@ public:
    *
    * @return std::unique_ptr<CBufferObject>
    */
-  static std::unique_ptr<CBufferObject> GetBufferObject();
+  static std::unique_ptr<CBufferObject> GetBufferObject(bool needsCreateBySize);
+
+  virtual bool CreateBufferObject(uint64_t size) override { return false; }
 
   virtual int GetFd() override;
   virtual uint32_t GetStride() override;

--- a/xbmc/utils/BufferObjectFactory.cpp
+++ b/xbmc/utils/BufferObjectFactory.cpp
@@ -10,11 +10,21 @@
 
 std::list<std::function<std::unique_ptr<CBufferObject>()>> CBufferObjectFactory::m_bufferObjects;
 
-std::unique_ptr<CBufferObject> CBufferObjectFactory::CreateBufferObject()
+std::unique_ptr<CBufferObject> CBufferObjectFactory::CreateBufferObject(bool needsCreateBySize)
 {
   for (const auto bufferObject : m_bufferObjects)
   {
-    return bufferObject();
+    auto bo = bufferObject();
+
+    if (needsCreateBySize)
+    {
+      if (!bo->CreateBufferObject(1))
+        continue;
+
+      bo->DestroyBufferObject();
+    }
+
+    return bo;
   }
 
   return nullptr;

--- a/xbmc/utils/BufferObjectFactory.h
+++ b/xbmc/utils/BufferObjectFactory.h
@@ -29,7 +29,7 @@ public:
    *
    * @return std::unique_ptr<CBufferObject>
    */
-  static std::unique_ptr<CBufferObject> CreateBufferObject();
+  static std::unique_ptr<CBufferObject> CreateBufferObject(bool needsCreateBySize);
 
   /**
    * @brief Registers a CBufferObject class to class to the factory.

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -90,8 +90,14 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint32_t format, uint32_t width, u
       throw std::system_error(errno, std::generic_category(), "pixel format not implemented");
   }
 
-  m_size = width * height * bpp;
   m_stride = width * bpp;
+
+  return CreateBufferObject(width * height * bpp);
+}
+
+bool CDMAHeapBufferObject::CreateBufferObject(uint64_t size)
+{
+  m_size = size;
 
   if (m_dmaheapfd < 0)
   {

--- a/xbmc/utils/DMAHeapBufferObject.h
+++ b/xbmc/utils/DMAHeapBufferObject.h
@@ -25,6 +25,7 @@ public:
 
   // IBufferObject overrides via CBufferObject
   bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
+  bool CreateBufferObject(uint64_t size) override;
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;

--- a/xbmc/utils/IBufferObject.h
+++ b/xbmc/utils/IBufferObject.h
@@ -41,16 +41,27 @@ public:
   virtual ~IBufferObject() = default;
 
   /**
-   * @brief Create a BufferObject.
+   * @brief Create a BufferObject based on the format, width, and height of the desired buffer
    *
    * @param format framebuffer pixel formats are described using the fourcc codes defined in
    *               https://github.com/torvalds/linux/blob/master/include/uapi/drm/drm_fourcc.h
-   * @param width width of the requested buffer object.
-   * @param height height of the requested buffer object.
+   * @param width width of the requested buffer.
+   * @param height height of the requested buffer.
    * @return true BufferObject creation was successful.
    * @return false BufferObject creation was unsuccessful.
    */
   virtual bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) = 0;
+
+  /**
+   * @brief Create a BufferObject based only on the size of the desired buffer. Not all
+   *        CBufferObject implementations may support this. This method is required for
+   *        use with the CAddonVideoCodec as it only knows the decoded buffer size.
+   *
+   * @param size of the requested buffer.
+   * @return true BufferObject creation was successful.
+   * @return false BufferObject creation was unsuccessful.
+   */
+  virtual bool CreateBufferObject(uint64_t size) = 0;
 
   /**
    * @brief Destroy a BufferObject.

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -79,9 +79,15 @@ bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
       throw std::system_error(errno, std::generic_category(), "pixel format not implemented");
   }
 
-  // Must be rounded to the system page size
-  m_size = RoundUp(width * height * bpp, PAGESIZE);
   m_stride = width * bpp;
+
+  return CreateBufferObject(width * height * bpp);
+}
+
+bool CUDMABufferObject::CreateBufferObject(uint64_t size)
+{
+  // Must be rounded to the system page size
+  m_size = RoundUp(size, PAGESIZE);
 
   m_memfd = memfd_create("kodi", MFD_CLOEXEC | MFD_ALLOW_SEALING);
   if (m_memfd < 0)

--- a/xbmc/utils/UDMABufferObject.h
+++ b/xbmc/utils/UDMABufferObject.h
@@ -25,6 +25,7 @@ public:
 
   // IBufferObject overrides via CBufferObject
   bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override;
+  bool CreateBufferObject(uint64_t size) override;
   void DestroyBufferObject() override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;


### PR DESCRIPTION
This is to further the work I'm doing to allow `CBufferObject`'s to work with VideoPlayer. You can see the implementation of this change here https://github.com/lrusak/xbmc/commit/2fea52b51539d7c0dc169d567391acbb7c3a27f4

This was designed to be able to be used with the `CAddonVideoCodec` which requests buffers only by size.

Some `CBufferObjects` may not be able to work with this new method so we have to add a criteria to the `CBufferObjectFactory` to allow choosing a buffer that implements this method.

This works but I'm not sure if it's better to add a method such as `bool CanCreateBySize()` or similar. Currently I just check if the buffer creation works or not and either returns the buffer type or tries the next registered method. If no methods are available `nullptr` is returned and the requesting class can deal with that.