### PR TITLE
[Addons] Make linux addons not compatible with freebsd

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -579,7 +579,6 @@ bool CAddonInfoBuilder::PlatformSupportsAddon(const AddonInfoPtr& addon)
 #endif
 #elif defined(TARGET_FREEBSD)
     "freebsd",
-    "linux",
 #elif defined(TARGET_LINUX)
     "linux",
 #elif defined(TARGET_WINDOWS_DESKTOP)


### PR DESCRIPTION

## Description
@AlwinEsch as discussed yesterday on slack. At the moment, if an addon defines `linux` as a compatible platform in `addon.xml` this makes the addon automatically compatible and installable in freebsd devices. Addons can include binary components or depend on functionality only available in each of the platforms. Hence, if the addon is compatible with both linux and freebsd, it should include:

`<platform>linux freebsd</platform>`

on its addon.xml

## Motivation and Context
As long as we know, all addons that are platform specific already include `freebsd` as a possible target in addon.xml

## How Has This Been Tested?
untested

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
