### PR TITLE
Proposal to increase A/V demux queues slightly

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -63,7 +63,7 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent
   m_maxspeedadjust = 0.0;
 
   m_messageQueue.SetMaxDataSize(6 * 1024 * 1024);
-  m_messageQueue.SetMaxTimeSize(8.0);
+  m_messageQueue.SetMaxTimeSize(10.0);
 }
 
 CVideoPlayerAudio::~CVideoPlayerAudio()

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -68,7 +68,7 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
   m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
   m_messageQueue.SetMaxDataSize(40 * 1024 * 1024);
-  m_messageQueue.SetMaxTimeSize(8.0);
+  m_messageQueue.SetMaxTimeSize(10.0);
 
   m_iDroppedFrames = 0;
   m_fFrameRate = 25;


### PR DESCRIPTION
## Description
This proposal is based on a change already implemented by @davilla for MrMC which also fixes known issues with specific HLS streams.

Whereas @davilla's changes for MrMC go a lot further than we need to fix the known issues increasing the `SetMaxTimeSize` of Audio *and* Video demux queues from a value of 8 seconds to 10 seconds is sufficient. @peak3d proposed 12 seconds for both.

This PR is the same changes as PR #17608 but against the master branch.

## Motivation and Context
While these streams have issues, we are in no position to fix those streams. Other tools (ffplay, THEOplayer, Shakaplayer, OMXplayer) behave perfectly fine on these streams as well and with this small fix the streams behave well in Kodi as well.

For Matrix we are looking into a more extensive fix in the player, but while we do not expect large changes in the VideoPlayer in Leia to be accepted and we like to see this fixed in the next release of Leia we are proposing this here.

Relates to:
- MrMC: [fix: bump up max demux time and data limits for hdr/atmos](https://github.com/MrMC/mrmc/commit/8ebf9052618d911adb72511cf4b11f7dd8659181)
- [Fix from @peak3d](https://github.com/peak3d/xbmc/commit/9b633ec87be189edb4413a5a60aeebf7868e228c)
- Retrospect: [Skipping frames for Vier.be](https://github.com/retrospect-addon/plugin.video.retrospect/issues/1089)
- VIER-VIJF-ZES: [Playback issues (skips in the video) of some streams](https://github.com/add-ons/plugin.video.viervijfzes/issues/4)
- Kodi: [Automatic rewind when streaming online content](https://github.com/xbmc/xbmc/issues/16003)


## How Has This Been Tested?
This has been tested by various people over the past 2 years which have suffered from the existing streaming issues and has proven to overcome those.

And this is the default `setMaxTimeSize` setting for MrMC.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed