### PR TITLE
[Android] Add WisePlay DRM

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/StreamCrypto.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/StreamCrypto.h
@@ -11,6 +11,8 @@
 #include <inttypes.h>
 #include <string.h>
 
+#define STREAMCRYPTO_VERSION_LEVEL 1
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -23,6 +25,7 @@ extern "C"
       CRYPTO_KEY_SYSTEM_NONE = 0,
       CRYPTO_KEY_SYSTEM_WIDEVINE,
       CRYPTO_KEY_SYSTEM_PLAYREADY,
+      CRYPTO_KEY_SYSTEM_WISEPLAY,
       CRYPTO_KEY_SYSTEM_COUNT
     } m_CryptoKeySystem; /*!< @brief keysystem for encrypted media, KEY_SYSTEM_NONE for unencrypted media */
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -125,6 +125,9 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
     case CRYPTO_SESSION_SYSTEM_PLAYREADY:
       initData.cryptoInfo.m_CryptoKeySystem = CRYPTO_INFO::CRYPTO_KEY_SYSTEM_PLAYREADY;
       break;
+    case CRYPTO_SESSION_SYSTEM_WISEPLAY:
+      initData.cryptoInfo.m_CryptoKeySystem = CRYPTO_INFO::CRYPTO_KEY_SYSTEM_WISEPLAY;
+      break;
     default:
       return false;
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -569,9 +569,11 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   if (m_hints.cryptoSession)
   {
     if (m_hints.cryptoSession->keySystem == CRYPTO_SESSION_SYSTEM_WIDEVINE)
-      uuid = CJNIUUID(0xEDEF8BA979D64ACE, 0xA3C827DCD51D21ED);
+      uuid = CJNIUUID(0xEDEF8BA979D64ACELL, 0xA3C827DCD51D21EDLL);
     else if (m_hints.cryptoSession->keySystem == CRYPTO_SESSION_SYSTEM_PLAYREADY)
-      uuid = CJNIUUID(0x9A04F07998404286, 0xAB92E65BE0885F95);
+      uuid = CJNIUUID(0x9A04F07998404286LL, 0xAB92E65BE0885F95LL);
+    else if (m_hints.cryptoSession->keySystem == CRYPTO_SESSION_SYSTEM_WISEPLAY)
+      uuid = CJNIUUID(0X3D5E6D359B9A41E8LL, 0XB843DD3C6E72C42CLL);
     else
     {
       CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open Unsupported crypto-keysystem %u",

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -458,11 +458,11 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   if (stream.m_cryptoInfo.m_CryptoKeySystem != CRYPTO_INFO::CRYPTO_KEY_SYSTEM_NONE &&
     stream.m_cryptoInfo.m_CryptoKeySystem < CRYPTO_INFO::CRYPTO_KEY_SYSTEM_COUNT)
   {
-    static const CryptoSessionSystem map[] =
-    {
-      CRYPTO_SESSION_SYSTEM_NONE,
-      CRYPTO_SESSION_SYSTEM_WIDEVINE,
-      CRYPTO_SESSION_SYSTEM_PLAYREADY
+    static const CryptoSessionSystem map[] = {
+        CRYPTO_SESSION_SYSTEM_NONE,
+        CRYPTO_SESSION_SYSTEM_WIDEVINE,
+        CRYPTO_SESSION_SYSTEM_PLAYREADY,
+        CRYPTO_SESSION_SYSTEM_WISEPLAY,
     };
     demuxStream->cryptoSession = std::shared_ptr<DemuxCryptoSession>(new DemuxCryptoSession(
       map[stream.m_cryptoInfo.m_CryptoKeySystem], stream.m_cryptoInfo.m_CryptoSessionIdSize, stream.m_cryptoInfo.m_CryptoSessionId, stream.m_cryptoInfo.flags));

--- a/xbmc/cores/VideoPlayer/Interface/Addon/DemuxCrypto.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/DemuxCrypto.h
@@ -13,11 +13,12 @@
 
 //CryptoSession is usually obtained once per stream, but could change if an key expires
 
-enum CryptoSessionSystem :uint8_t
+enum CryptoSessionSystem : uint8_t
 {
   CRYPTO_SESSION_SYSTEM_NONE,
   CRYPTO_SESSION_SYSTEM_WIDEVINE,
-  CRYPTO_SESSION_SYSTEM_PLAYREADY
+  CRYPTO_SESSION_SYSTEM_PLAYREADY,
+  CRYPTO_SESSION_SYSTEM_WISEPLAY,
 };
 
 struct DemuxCryptoSession

--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
@@ -53,11 +53,21 @@ CMediaDrmCryptoSession::CMediaDrmCryptoSession(const std::string& UUID, const st
   , m_hasKeys(false)
   , m_sessionId(nullptr)
 {
-  if (!StringUtils::EqualsNoCase(UUID, "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"))
-    throw std::runtime_error("mediaDrm: Invalid UUID size");
+  if (UUID.length() != 36 || UUID[8] != '-' || UUID[13] != '-' || UUID[18] != '-' ||
+      UUID[23] != '-')
+    throw std::runtime_error("MediaDrmCryptoSession: Invalid UUID format, expected "
+                             "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
 
   int64_t mostSigBits(0), leastSigBits(0);
-  const uint8_t uuidPtr[16] = {0xed,0xef,0x8b,0xa9,0x79,0xd6,0x4a,0xce,0xa3,0xc8,0x27,0xdc,0xd5,0x1d,0x21,0xed};
+  unsigned int uuidPtr[16];
+  if (sscanf(UUID.c_str(), "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             &uuidPtr[0], &uuidPtr[1], &uuidPtr[2], &uuidPtr[3], &uuidPtr[4], &uuidPtr[5],
+             &uuidPtr[6], &uuidPtr[7], &uuidPtr[8], &uuidPtr[9], &uuidPtr[10], &uuidPtr[11],
+             &uuidPtr[12], &uuidPtr[13], &uuidPtr[14], &uuidPtr[15]) != 16)
+  {
+    throw std::runtime_error("MediaDrmCryptoSession: Cannot parse UUID: " + UUID);
+  }
+
   for (unsigned int i(0); i < 8; ++i)
     mostSigBits = (mostSigBits << 8) | uuidPtr[i];
   for (unsigned int i(8); i < 16; ++i)


### PR DESCRIPTION
## Description
Add Huawei WisePlay DRM (only for Android using MediaCodec / MediaDRM)

## Motivation and Context
Wiseplay DRM is a free DRM developed / hosted by Huawei and currently mainly used in China.
Because Kodi is in Huawei App Gallery, and it is planned to enter the chinese market, we use WisePlay DRM for drm encrypted media.

## How Has This Been Tested?
Only tested partly (one sample license request) because of missing content.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
