### PR TITLE
[GBM] CVideoLayerBridgeDRMPRIME: query supported values before setting them

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -154,12 +154,11 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   const VideoPicture& picture = buffer->GetPicture();
 
   struct plane* plane = m_DRM->GetVideoPlane();
-  if (m_DRM->SupportsProperty(plane, "COLOR_ENCODING") &&
-      m_DRM->SupportsProperty(plane, "COLOR_RANGE"))
-  {
+  if (m_DRM->SupportsPropertyAndValue(plane, "COLOR_ENCODING", GetColorEncoding(picture)))
     m_DRM->AddProperty(plane, "COLOR_ENCODING", GetColorEncoding(picture));
+
+  if (m_DRM->SupportsPropertyAndValue(plane, "COLOR_RANGE", GetColorRange(picture)))
     m_DRM->AddProperty(plane, "COLOR_RANGE", GetColorRange(picture));
-  }
 
   struct connector* connector = m_DRM->GetConnector();
   if (m_DRM->SupportsProperty(connector, "HDR_OUTPUT_METADATA"))

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -197,6 +197,32 @@ bool CDRMUtils::SupportsProperty(struct drm_object *object, const char *name)
   return false;
 }
 
+bool CDRMUtils::SupportsPropertyAndValue(struct drm_object* object,
+                                         const char* name,
+                                         uint64_t value)
+{
+  for (uint32_t i = 0; i < object->props->count_props; i++)
+  {
+    if (!StringUtils::EqualsNoCase(object->props_info[i]->name, name))
+      continue;
+
+    if (drm_property_type_is(object->props_info[i], DRM_MODE_PROP_ENUM) != 0)
+    {
+      for (int j = 0; j < object->props_info[i]->count_enums; j++)
+      {
+        if (object->props_info[i]->enums[j].value == value)
+          return true;
+      }
+    }
+
+    CLog::Log(LOGDEBUG, "CDRMUtils::{} - property '{}' does not support value '{}'", __FUNCTION__,
+              name, value);
+    break;
+  }
+
+  return false;
+}
+
 uint32_t CDRMUtils::GetPropertyId(struct drm_object *object, const char *name)
 {
   for (uint32_t i = 0; i < object->props->count_props; i++)

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -118,6 +118,7 @@ public:
   virtual bool SetMode(const RESOLUTION_INFO& res);
 
   bool SupportsProperty(struct drm_object *object, const char *name);
+  bool SupportsPropertyAndValue(struct drm_object* object, const char* name, uint64_t value);
   virtual bool AddProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
   virtual bool SetProperty(struct drm_object *object, const char *name, uint64_t value) { return false; }
 


### PR DESCRIPTION
We are currently blindly setting enums without checking if they accept the specified value. This PR adds the ability to not only check if the property is supported but also if the value is supported (for appropriate types).

For example:
```
	34 COLOR_ENCODING:
		flags: enum
		enums: ITU-R BT.601 YCbCr=0 ITU-R BT.709 YCbCr=1 ITU-R BT.2020 YCbCr=2
		value: 2
```
Not all connectors support bt2020, so we need to check that enum value before setting it.

The problem I see is that not all properties have values to query (like `DRM_MODE_PROP_BLOB`) so the value is optional in this case. I could add separate methods for each type but I would like to avoid that if possible or I could call the method `SupportsPropertyWithOptionalValue` but that's getting a bit long :confused: thoughts?

