### PR TITLE
Trigger render when scrolling (smartredraw)

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -93,6 +93,9 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
   UpdateScrollOffset(currentTime);
 
+  if (m_scroller.IsScrolling())
+    MarkDirtyRegion();
+
   int offset = (int)floorf(m_scroller.GetValue() / m_layout->Size(m_orientation));
 
   int cacheBefore, cacheAfter;


### PR DESCRIPTION
## Description
When using smartredraw, GUI is only rendered if visual changes appear. 
Currently GUI rendering with smartredraw activated is laggy because Mark DirtyRegion is missing when scrolling.

## Motivation and Context
Pan through lists on mobile devices is laggy when smartredraw is activated

## How Has This Been Tested?
Android phone, pan through any list.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
