### PR TITLE
[linux] drop drm folder from drm includes

### DIFF
--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -14,7 +14,7 @@
 
 #include <array>
 
-#include <drm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include <linux/dma-heap.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -14,7 +14,7 @@
 #include "windowing/gbm/WinSystemGbm.h"
 #include "windowing/gbm/WinSystemGbmEGLContext.h"
 
-#include <drm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include <sys/mman.h>
 
 using namespace KODI::WINDOWING::GBM;

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -11,7 +11,7 @@
 #include "utils/BufferObjectFactory.h"
 #include "utils/log.h"
 
-#include <drm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include <linux/udmabuf.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
Using cmake we query the proper include folder for libdrm so we don't need to include the folder name. There may be multiple locations of libdrm on system and we want to make sure we are using the correct one from the libdrm pkg-config.

This should fix the issue @jernejsk was experiencing