### PR TITLE
[Backport][LanguageCodes] Add "Swiss german" and "Portuguese (Brazil)"

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2020 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -22,8 +22,8 @@ typedef struct LCENTRY
   const char *name;
 } LCENTRY;
 
-extern const std::array<struct LCENTRY, 185> g_iso639_1;
-extern const std::array<struct LCENTRY, 538> g_iso639_2;
+extern const std::array<struct LCENTRY, 186> g_iso639_1;
+extern const std::array<struct LCENTRY, 540> g_iso639_2;
 
 struct ISO639
 {
@@ -40,7 +40,7 @@ struct ISO3166_1
 };
 
 // declared as extern to allow forward declaration
-extern const std::array<ISO639, 189> LanguageCodes;
+extern const std::array<ISO639, 190> LanguageCodes;
 extern const std::array<ISO3166_1, 245> RegionCodes;
 
 CLangCodeExpander::CLangCodeExpander() = default;
@@ -535,7 +535,7 @@ std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
   return lang;
 }
 
-const std::array<struct LCENTRY, 185> g_iso639_1 =
+const std::array<struct LCENTRY, 186> g_iso639_1 =
 { {
   { MAKECODE('\0','\0','a','a'), "Afar" },
   { MAKECODE('\0','\0','a','b'), "Abkhazian" },
@@ -668,6 +668,8 @@ const std::array<struct LCENTRY, 185> g_iso639_1 =
   { MAKECODE('\0','\0','p','l'), "Polish" },
   { MAKECODE('\0','\0','p','s'), "Pashto, Pushto" },
   { MAKECODE('\0','\0','p','t'), "Portuguese" },
+  // pb = unofficial language code for Brazilian Portuguese
+  { MAKECODE('\0','\0','p','b'), "Portuguese (Brazil)" },
   { MAKECODE('\0','\0','q','u'), "Quechua" },
   { MAKECODE('\0','\0','r','m'), "Romansh" },
   { MAKECODE('\0','\0','r','n'), "Kirundi" },
@@ -724,7 +726,7 @@ const std::array<struct LCENTRY, 185> g_iso639_1 =
   { MAKECODE('\0','\0','z','u'), "Zulu" },
 } };
 
-const std::array<struct LCENTRY, 538> g_iso639_2 =
+const std::array<struct LCENTRY, 540> g_iso639_2 =
 { {
   { MAKECODE('\0','a','b','k'), "Abkhaz" },
   { MAKECODE('\0','a','b','k'), "Abkhazian" },
@@ -901,6 +903,7 @@ const std::array<struct LCENTRY, 538> g_iso639_2 =
   { MAKECODE('\0','n','d','s'), "German, Low" },
   { MAKECODE('\0','g','m','h'), "German, Middle High (ca.1050-1500)" },
   { MAKECODE('\0','g','o','h'), "German, Old High (ca.750-1050)" },
+  { MAKECODE('\0','g','s','w'), "German, Swiss German"},
   { MAKECODE('\0','g','e','m'), "Germanic (Other)" },
   { MAKECODE('\0','k','i','k'), "Gikuyu" },
   { MAKECODE('\0','g','i','l'), "Gilbertese" },
@@ -1121,6 +1124,8 @@ const std::array<struct LCENTRY, 538> g_iso639_2 =
   { MAKECODE('\0','p','o','n'), "Pohnpeian" },
   { MAKECODE('\0','p','o','l'), "Polish" },
   { MAKECODE('\0','p','o','r'), "Portuguese" },
+  // pob = unofficial language code for Brazilian Portuguese
+  { MAKECODE('\0','p','o','b'), "Portuguese (Brazil)" },
   { MAKECODE('\0','p','r','a'), "Prakrit languages" },
   { MAKECODE('\0','o','c','i'), "Proven\xC3\xA7""al" },
   { MAKECODE('\0','p','r','o'), "Proven\xC3\xA7""al, Old (to 1500)" },
@@ -1268,7 +1273,7 @@ const std::array<struct LCENTRY, 538> g_iso639_2 =
 } };
 
 
-const std::array<ISO639, 189> LanguageCodes =
+const std::array<ISO639, 190> LanguageCodes =
 { {
   { "aa", "aar", NULL, NULL },
   { "ab", "abk", NULL, NULL },
@@ -1397,6 +1402,8 @@ const std::array<ISO639, 189> LanguageCodes =
   { "om", "orm", NULL, NULL },
   { "os", "oss", NULL, NULL },
   { "pa", "pan", NULL, NULL },
+  // pb / pob = unofficial language code for Brazilian Portuguese
+  { "pb", "pob", NULL, NULL },
   { "pi", "pli", NULL, NULL },
   { "pl", "pol", "plk", NULL },
   { "pt", "por", "ptg", NULL },


### PR DESCRIPTION
Backport of #17626 and #17689 to Leia

adds the "swiss german" and also "portuguese (brazil)" language code
to the language code expander

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document