### PR TITLE
[clang-format] disable for all arrays in LangCodeExpander.cpp

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -547,6 +547,7 @@ std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
   return lang;
 }
 
+// clang-format off
 const std::array<struct LCENTRY, 185> g_iso639_1 = {{
     {MAKECODE('\0', '\0', 'a', 'a'), "Afar"},
     {MAKECODE('\0', '\0', 'a', 'b'), "Abkhazian"},
@@ -734,7 +735,9 @@ const std::array<struct LCENTRY, 185> g_iso639_1 = {{
     {MAKECODE('\0', '\0', 'z', 'h'), "Chinese"},
     {MAKECODE('\0', '\0', 'z', 'u'), "Zulu"},
 }};
+// clang-format on
 
+// clang-format off
 const std::array<struct LCENTRY, 539> g_iso639_2 = {{
     {MAKECODE('\0', 'a', 'b', 'k'), "Abkhaz"},
     {MAKECODE('\0', 'a', 'b', 'k'), "Abkhazian"},
@@ -1279,8 +1282,9 @@ const std::array<struct LCENTRY, 539> g_iso639_2 = {{
     {MAKECODE('\0', 'z', 'u', 'l'), "Zulu"},
     {MAKECODE('\0', 'z', 'u', 'n'), "Zuni"},
 }};
+// clang-format on
 
-
+// clang-format off
 const std::array<ISO639, 189> LanguageCodes = {{
     {"aa", "aar", NULL, NULL},
     {"ab", "abk", NULL, NULL},
@@ -1474,6 +1478,7 @@ const std::array<ISO639, 189> LanguageCodes = {{
      NULL}, // Kodi intern mapping for missing "Miscellaneous languages" iso639-1 code
     {"zz", "mul", NULL, NULL} // Kodi intern mapping for missing "Multiple languages" iso639-1 code
 }};
+// clang-format on
 
 // Based on ISO 3166
 // clang-format off


### PR DESCRIPTION
## Description
follow-up pr to #17626
we need to disable clang-format on all arrays instead of only the last one

## Motivation and Context
see https://jenkins.kodi.tv/job/BuildMulti-PR/15513/artifact/PR17665.diff of
PR #17665

clang-format doesn't always work properly in those cases

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@fuzzard would you please have a quick look (real 1-liner this time)