### PR TITLE
PluginDirectory: Drop unused arguments in WaitOnScriptResult and StartScript

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -171,7 +171,7 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   if (id >= 0)
   { // wait for our script to finish
     std::string scriptName = m_addon->Name();
-    success = WaitOnScriptResult(file, id, scriptName, retrievingDir);
+    success = WaitOnScriptResult(id, scriptName);
   }
   else
     CLog::Log(LOGERROR, "Unable to run plugin %s", m_addon->Name().c_str());
@@ -492,7 +492,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
   return false;
 }
 
-bool CPluginDirectory::WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir)
+bool CPluginDirectory::WaitOnScriptResult(int scriptId, const std::string& scriptName)
 {
   // CPluginDirectory::GetDirectory can be called from the main and other threads.
   // If called form the main thread, we need to bring up the BusyDialog in order to

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -109,7 +109,7 @@ CPluginDirectory *CPluginDirectory::dirFromHandle(int handle)
   return NULL;
 }
 
-bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDir, bool resume)
+bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)
 {
   CURL url(strPath);
 
@@ -187,7 +187,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
   CURL url(strPath);
   CPluginDirectory newDir;
 
-  bool success = newDir.StartScript(strPath, false, resume);
+  bool success = newDir.StartScript(strPath, resume);
 
   if (success)
   { // update the play path and metadata, saving the old one as needed
@@ -442,7 +442,7 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const s
 bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   const std::string pathToUrl(url.Get());
-  bool success = StartScript(pathToUrl, true, false);
+  bool success = StartScript(pathToUrl, false);
 
   // append the items to the list
   items.Assign(*m_listItems, true); // true to keep the current items

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -70,7 +70,7 @@ public:
 
 private:
   ADDON::AddonPtr m_addon;
-  bool StartScript(const std::string& strPath, bool retrievingDir, bool resume);
+  bool StartScript(const std::string& strPath, bool resume);
   bool WaitOnScriptResult(int scriptId, const std::string& scriptName);
 
   static std::map<int,CPluginDirectory*> globalHandles;

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -71,7 +71,7 @@ public:
 private:
   ADDON::AddonPtr m_addon;
   bool StartScript(const std::string& strPath, bool retrievingDir, bool resume);
-  bool WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir);
+  bool WaitOnScriptResult(int scriptId, const std::string& scriptName);
 
   static std::map<int,CPluginDirectory*> globalHandles;
   static int getNewHandle(CPluginDirectory *cp);


### PR DESCRIPTION
## Description
While working on trying to solve another issue, found out that `PluginDirectory::WaitOnScriptResult` has 2 unused arguments and `PluginDirectory::StartScript` has one unused arg. So, decided to PR this minor change first as it is an improvement regardless I continue to work on this or not.

## Motivation and Context
Cleanup

## How Has This Been Tested?
Compile and runtime tested


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
