### PR TITLE
[CURL] Add verifyHost

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -521,6 +521,9 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   if (!m_verifyPeer)
     g_curlInterface.easy_setopt(h, CURLOPT_SSL_VERIFYPEER, 0);
 
+  if (!m_verifyHost)
+    g_curlInterface.easy_setopt(h, CURLOPT_SSL_VERIFYHOST, 0);
+
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_URL, m_url.c_str());
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_TRANSFERTEXT, CURL_OFF);
 
@@ -743,6 +746,11 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
       if (url2.GetProtocolOption("verifypeer") == "false")
         m_verifyPeer = false;
     }
+    if (url2.HasProtocolOption("verifyhost"))
+    {
+      if (url2.GetProtocolOption("verifyhost") == "false")
+        m_verifyHost = false;
+    }
     m_ftppasvip = url2.HasProtocolOption("pasvip") && url2.GetProtocolOption("pasvip") != "0";
   }
   else if(url2.IsProtocol("http") ||
@@ -829,6 +837,11 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         {
           if (value == "false")
             m_verifyPeer = false;
+        }
+        else if (name == "verifyhost")
+        {
+          if (value == "false")
+            m_verifyHost = false;
         }
         else
         {

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -184,6 +184,7 @@ namespace XFILE
       bool m_postdataset;
       bool m_allowRetry;
       bool m_verifyPeer = true;
+      bool m_verifyHost = true;
       bool m_failOnError = true;
 
       CRingBuffer m_buffer; // our ringhold buffer


### PR DESCRIPTION
## Description
Add option to set CURLOPT_SSL_VERIFYHOST using verifyhost=[true/false] in URL header.

## Motivation and Context
We already support verifypeer (setting CURLOPT_SSL_VERIFYPEER), butthis is not sufficient to connect to servers with self signed certificates. To simulate the curl --insecure option, both PEER and HOST must be set to false.

## How Has This Been Tested?
Access a stream using HTTPS protocol on a server with a self signed certificate.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
