### PR TITLE
Return early in case of maximum ammount of plugin resolution attempts

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2672,14 +2672,18 @@ void CApplication::Stop(int exitCode)
 
 bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPlaylist)
 {
-  //If item is a plugin, expand out
+  // If item is a plugin, expand out
   for (int i=0; URIUtils::IsPlugin(item.GetDynPath()) && i<5; ++i)
   {
     bool resume = item.m_lStartOffset == STARTOFFSET_RESUME;
 
-    if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume))
+    if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume) ||
+        item.GetDynPath() == item.GetPath()) // GetPluginResult resolved to an empty path
       return false;
   }
+  // if after the 5 resolution attempts the item is still a plugin just return, it isn't playable
+  if (URIUtils::IsPlugin(item.GetDynPath()))
+    return false;
 
   if (item.IsSmartPlayList())
   {
@@ -2821,9 +2825,13 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   { // we modify the item so that it becomes a real URL
     bool resume = item.m_lStartOffset == STARTOFFSET_RESUME;
 
-    if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume))
+    if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume) ||
+        item.GetDynPath() == item.GetPath()) // GetPluginResult resolved to an empty path
       return false;
   }
+  // if after the 5 resolution attempts the item is still a plugin just return, it isn't playable
+  if (URIUtils::IsPlugin(item.GetDynPath()))
+    return false;
 
 #ifdef HAS_UPNP
   if (URIUtils::IsUPnP(item.GetPath()))


### PR DESCRIPTION
## Description
At the moment kodi crashes if playing a plugin `CFileItem` that still has a `plugin://` path in the `dynPath` after the limit of 5 resolution attempts has been reached. 

Also, if the `plugin://` path being played sets the resolved to an empty path (thus `GetDynPath()` falls back to `path`) same issue will occur.

## Motivation and Context
Kodi should not crash :)

## How Has This Been Tested?
Easiest way to reproduce the problem in Kodi master:
- Install IMDb Trailers video addon from the official repo
- Enter the plugin
- Navigate to coming soon
- Play the trailer of "Trolls: Tour Mundial"

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
