### PR TITLE
Disable VAAPI/VDPAU MPEG-2 hwaccel by default

### DIFF
--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -26,7 +26,7 @@
           <requirement>HAVE_LIBVDPAU</requirement>
           <visible>false</visible>
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <dependencies>
             <dependency type="enable">
               <condition setting="videoplayer.usevdpau" operator="is">true</condition> <!-- USE VDPAU -->
@@ -74,7 +74,7 @@
             </dependency>
           </dependencies>
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.usevaapimpeg4" type="boolean" parent="videoplayer.usevaapi" label="13449" help="13450">


### PR DESCRIPTION
radeon mesa driver still seems to have issues with MPEG-2 and with
current and even older hardware hardware-decoding MPEG-2 does not give
substantial benefit.

Fixes #17651 (kind of)

See also mpv-player/mpv@3dd59db
