### PR TITLE
[python] Support multi-line text in dialogs

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -53,11 +53,10 @@ namespace XBMCAddon
       if (pDialog == NULL)
         throw WindowException("Error: Window is NULL, this is not possible :-)");
 
-      // get lines, last 4 lines are optional.
       if (!heading.empty())
         pDialog->SetHeading(CVariant{heading});
       if (!message.empty())
-        pDialog->SetLine(0, CVariant{message});
+        pDialog->SetText(CVariant{message});
 
       if (!nolabel.empty())
         pDialog->SetChoice(0, CVariant{nolabel});
@@ -449,7 +448,7 @@ namespace XBMCAddon
       pDialog->SetHeading(CVariant{heading});
 
       if (!message.empty())
-        pDialog->SetLine(0, CVariant{message});
+        pDialog->SetText(CVariant{message});
 
       pDialog->Open();
     }
@@ -473,7 +472,7 @@ namespace XBMCAddon
       }
 
       if (!message.empty())
-        pDialog->SetLine(0, CVariant{message});
+        pDialog->SetText(CVariant{message});
     }
 
     void DialogProgress::close()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This fixes support for multi-line text in the `message` parameter of the following Python API functions:
```
xbmcgui.Dialog().yesno()
xbmcgui.DialogProgress().create()
xbmcgui.DialogProgress().update()
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
After replacing the `line1`, `line2` and `line3` method parameters with a single `message` parameter of some Python API methods in https://github.com/xbmc/xbmc/pull/17456, updating a DialogProgress message broke down. Updating the DialogProgress message with a multi-line text (with` \n` newline characters) didn't work as expected.
The multi-line text got wrongly added above the existing text, replacing the first line.  So the other lines didn't update, they were added and after some updates, the  DialogProgress became filled with multiple lines of the same old text.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on Kodi 19 master branch with a small add-on that implements the Python API xbmcgui.Dialog() functions.


## Screenshots (if appropriate):
Wrong `xbmcgui.DialogProgress().update()` behaviour
![Screenshot at 2020-04-15 22-08-32](https://user-images.githubusercontent.com/45148099/79384475-3a053400-7f67-11ea-9f5b-37447d6e2cdd.png)

Correct `xbmcgui.DialogProgress().update()` behaviour with this fix
![Screenshot at 2020-04-15 22-11-37](https://user-images.githubusercontent.com/45148099/79384476-3a9dca80-7f67-11ea-8904-77b6dea57079.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
