### PR TITLE
Remove F-Droid badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@
 <a href="https://play.google.com/store/apps/details?id=org.xbmc.kodi" target="_blank">
   <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" height="80"/>
 </a>
-<a href="https://f-droid.org/en/packages/org.xbmc.kodi/" target="_blank">
-  <img src="https://f-droid.org/badge/get-it-on.png" height="80"/>
-</a>
 
 <h1 align="center">
   Welcome to Kodi Home Theater Software!


### PR DESCRIPTION
F-Droid is unfortunately unmaintained and ships a version half a year
old, so it is difficult to feature it prominently on the front page of
the repository.