### PR TITLE
[GBM] CVideoBufferDMA: add class to use CBufferObject

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
@@ -2,8 +2,12 @@ set(SOURCES VideoBuffer.cpp)
 set(HEADERS VideoBuffer.h)
 
 if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
-  list(APPEND SOURCES VideoBufferDRMPRIME.cpp)
-  list(APPEND HEADERS VideoBufferDRMPRIME.h)
+  list(APPEND SOURCES VideoBufferDMA.cpp
+                      VideoBufferDRMPRIME.cpp
+                      VideoBufferPoolDMA.cpp)
+  list(APPEND HEADERS VideoBufferDMA.h
+                      VideoBufferDRMPRIME.h
+                      VideoBufferPoolDMA.h)
 endif()
 
 core_add_library(videoplayer-buffers)

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoBufferDMA.h"
+
+#include "ServiceBroker.h"
+#include "utils/BufferObject.h"
+#include "utils/log.h"
+
+extern "C"
+{
+#include <libavutil/imgutils.h>
+#include <libavutil/pixdesc.h>
+}
+
+CVideoBufferDMA::CVideoBufferDMA(IVideoBufferPool& pool, int id, uint32_t fourcc, uint64_t size)
+  : CVideoBufferDRMPRIMEFFmpeg(pool, id),
+    m_bo(CBufferObject::GetBufferObject(true)),
+    m_fourcc(fourcc),
+    m_size(size)
+{
+}
+
+CVideoBufferDMA::~CVideoBufferDMA()
+{
+  Destroy();
+}
+
+AVDRMFrameDescriptor* CVideoBufferDMA::GetDescriptor() const
+{
+  return const_cast<AVDRMFrameDescriptor*>(&m_descriptor);
+}
+
+uint8_t* CVideoBufferDMA::GetMemPtr()
+{
+  return m_addr;
+}
+
+void CVideoBufferDMA::GetPlanes(uint8_t* (&planes)[YuvImage::MAX_PLANES])
+{
+  for (uint32_t i = 0; i < YuvImage::MAX_PLANES; i++)
+    planes[i] = m_addr + m_offsets[i];
+}
+
+void CVideoBufferDMA::GetStrides(int (&strides)[YuvImage::MAX_PLANES])
+{
+  for (uint32_t i = 0; i < YuvImage::MAX_PLANES; i++)
+    strides[i] = m_strides[i];
+}
+
+void CVideoBufferDMA::SetDimensions(int width, int height)
+{
+  SetDimensions(width, height, m_strides, m_offsets);
+}
+
+void CVideoBufferDMA::SetDimensions(int width,
+                                    int height,
+                                    const int (&strides)[YuvImage::MAX_PLANES])
+{
+  SetDimensions(width, height, strides, m_offsets);
+}
+
+void CVideoBufferDMA::SetDimensions(int width,
+                                    int height,
+                                    const int (&strides)[YuvImage::MAX_PLANES],
+                                    const int (&planeOffsets)[YuvImage::MAX_PLANES])
+{
+  m_width = width;
+  m_height = height;
+
+  AVDRMFrameDescriptor* descriptor = &m_descriptor;
+  descriptor->nb_objects = 1;
+  descriptor->objects[0].fd = m_fd;
+  descriptor->nb_layers = 1;
+
+  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
+  layer->format = m_fourcc;
+  layer->nb_planes = m_planes;
+
+  for (uint32_t i = 0; i < m_planes; i++)
+  {
+    layer->planes[i].offset = planeOffsets[i];
+    layer->planes[i].pitch = strides[i];
+  }
+
+  if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
+  {
+    std::string planeStr;
+    for (uint32_t plane = 0; plane < m_planes; plane++)
+      planeStr.append(fmt::format("\nplane[{}]: stride={}\toffset={}", plane, strides[plane],
+                                  planeOffsets[plane]));
+
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
+              __FUNCTION__, m_id, m_fourcc, planeStr);
+  }
+}
+
+bool CVideoBufferDMA::Alloc()
+{
+  if (!m_bo->CreateBufferObject(m_size))
+    return false;
+
+  m_fd = m_bo->GetFd();
+  m_addr = m_bo->GetMemory();
+  m_planes = 3; // CAddonVideoCodec only requests AV_PIX_FMT_YUV420P for now
+
+  CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - id={} fourcc={} fd={} size={} addr={}",
+            __FUNCTION__, m_id, m_fourcc, m_fd, m_size, fmt::ptr(m_addr));
+
+  return true;
+}
+
+void CVideoBufferDMA::Export(AVFrame* frame, uint32_t width, uint32_t height)
+{
+  m_planes = av_pix_fmt_count_planes(static_cast<AVPixelFormat>(frame->format));
+
+  if (m_planes < 2)
+    throw std::runtime_error(
+        "non-planar formats not supported: " +
+        std::string(av_get_pix_fmt_name(static_cast<AVPixelFormat>(frame->format))));
+
+  for (uint32_t plane = 0; plane < m_planes; plane++)
+  {
+    m_strides[plane] =
+        av_image_get_linesize(static_cast<AVPixelFormat>(frame->format), width, plane);
+    m_offsets[plane] =
+        plane == 0 ? 0 : (m_offsets[plane - 1] + m_strides[plane - 1] * (height >> (plane - 1)));
+  }
+
+  if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
+  {
+    std::string planeStr;
+    for (uint32_t plane = 0; plane < m_planes; plane++)
+      planeStr.append(fmt::format("\nplane[{}]: stride={}\toffset={}", plane, m_strides[plane],
+                                  m_offsets[plane]));
+
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVideoBufferDMA::{} - frame layout id={} fourcc={}{}",
+              __FUNCTION__, m_id, m_fourcc, planeStr);
+  }
+
+  for (uint32_t i = 0; i < AV_NUM_DATA_POINTERS; i++)
+  {
+    frame->data[i] = i < m_planes ? m_addr + m_offsets[i] : nullptr;
+    frame->linesize[i] = i < m_planes ? m_strides[i] : 0;
+    frame->buf[i] = i == 0 ? frame->opaque_ref : nullptr;
+  }
+
+  frame->extended_data = frame->data;
+  frame->opaque_ref = nullptr;
+}
+
+void CVideoBufferDMA::SyncStart()
+{
+  m_bo->SyncStart();
+}
+
+void CVideoBufferDMA::SyncEnd()
+{
+  m_bo->SyncEnd();
+}
+
+void CVideoBufferDMA::Destroy()
+{
+  m_bo->ReleaseMemory();
+  m_bo->DestroyBufferObject();
+
+  for (auto& offset : m_offsets)
+    offset = 0;
+
+  for (auto& stride : m_strides)
+    stride = 0;
+
+  m_planes = 0;
+  m_width = 0;
+  m_height = 0;
+  m_fourcc = 0;
+  m_size = 0;
+  m_addr = nullptr;
+  m_fd = -1;
+}

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.h
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
+
+#include <memory>
+
+class IBufferObject;
+
+class CVideoBufferDMA : public CVideoBufferDRMPRIMEFFmpeg
+{
+public:
+  CVideoBufferDMA(IVideoBufferPool& pool, int id, uint32_t fourcc, uint64_t size);
+  ~CVideoBufferDMA() override;
+
+  // implementation of CVideoBufferDRMPRIME via CVideoBufferDRMPRIMEFFmpeg
+  uint32_t GetWidth() const override { return m_width; }
+  uint32_t GetHeight() const override { return m_height; }
+  AVDRMFrameDescriptor* GetDescriptor() const override;
+
+  // implementation of CVideoBuffer via CVideoBufferDRMPRIMEFFmpeg
+  void GetPlanes(uint8_t* (&planes)[YuvImage::MAX_PLANES]) override;
+  void GetStrides(int (&strides)[YuvImage::MAX_PLANES]) override;
+  uint8_t* GetMemPtr() override;
+  void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) override;
+  void SetDimensions(int width,
+                     int height,
+                     const int (&strides)[YuvImage::MAX_PLANES],
+                     const int (&planeOffsets)[YuvImage::MAX_PLANES]) override;
+
+  void SetDimensions(int width, int height);
+  bool Alloc();
+  void Export(AVFrame* frame, uint32_t width, uint32_t height);
+
+  void SyncStart();
+  void SyncEnd();
+
+private:
+  void Destroy();
+
+  std::unique_ptr<IBufferObject> m_bo;
+
+  int m_offsets[YuvImage::MAX_PLANES]{0};
+  int m_strides[YuvImage::MAX_PLANES]{0};
+
+  AVDRMFrameDescriptor m_descriptor{};
+  uint32_t m_planes{0};
+  uint32_t m_width{0};
+  uint32_t m_height{0};
+  uint32_t m_fourcc{0};
+  uint64_t m_size{0};
+  uint8_t* m_addr{nullptr};
+  int m_fd{-1};
+};

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -63,8 +63,8 @@ public:
 
   virtual void SetPictureParams(const VideoPicture& picture) { m_picture.SetParams(picture); }
   virtual const VideoPicture& GetPicture() const { return m_picture; }
-  uint32_t GetWidth() const { return GetPicture().iWidth; }
-  uint32_t GetHeight() const { return GetPicture().iHeight; }
+  virtual uint32_t GetWidth() const { return GetPicture().iWidth; }
+  virtual uint32_t GetHeight() const { return GetPicture().iHeight; }
 
   virtual AVDRMFrameDescriptor* GetDescriptor() const = 0;
   virtual bool IsValid() const { return true; }

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoBufferPoolDMA.h"
+
+#include "cores/VideoPlayer/Buffers/VideoBufferDMA.h"
+#include "threads/SingleLock.h"
+#include "utils/BufferObjectFactory.h"
+
+#include <drm_fourcc.h>
+
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
+
+CVideoBufferPoolDMA::~CVideoBufferPoolDMA()
+{
+  CSingleLock lock(m_critSection);
+
+  for (auto buf : m_all)
+    delete buf;
+}
+
+CVideoBuffer* CVideoBufferPoolDMA::Get()
+{
+  CSingleLock lock(m_critSection);
+
+  CVideoBufferDMA* buf = nullptr;
+  if (!m_free.empty())
+  {
+    int idx = m_free.front();
+    m_free.pop_front();
+    m_used.push_back(idx);
+    buf = m_all[idx];
+  }
+  else
+  {
+    int id = m_all.size();
+    buf = new CVideoBufferDMA(*this, id, m_fourcc, m_size);
+
+    if (!buf->Alloc())
+    {
+      delete buf;
+      return nullptr;
+    }
+
+    m_all.push_back(buf);
+    m_used.push_back(id);
+  }
+
+  buf->Acquire(GetPtr());
+  return buf;
+}
+
+void CVideoBufferPoolDMA::Return(int id)
+{
+  CSingleLock lock(m_critSection);
+
+  m_all[id]->Unref();
+  auto it = m_used.begin();
+  while (it != m_used.end())
+  {
+    if (*it == id)
+    {
+      m_used.erase(it);
+      break;
+    }
+    else
+      ++it;
+  }
+  m_free.push_back(id);
+}
+
+void CVideoBufferPoolDMA::Configure(AVPixelFormat format, int size)
+{
+  CSingleLock lock(m_critSection);
+
+  m_fourcc = TranslateFormat(format);
+  m_size = static_cast<uint64_t>(size);
+}
+
+bool CVideoBufferPoolDMA::IsConfigured()
+{
+  CSingleLock lock(m_critSection);
+
+  return (m_fourcc != 0 && m_size != 0);
+}
+
+bool CVideoBufferPoolDMA::IsCompatible(AVPixelFormat format, int size)
+{
+  CSingleLock lock(m_critSection);
+
+  if (m_fourcc != TranslateFormat(format) || m_size != static_cast<uint64_t>(size))
+    return false;
+
+  return true;
+}
+
+void CVideoBufferPoolDMA::Released(CVideoBufferManager& videoBufferManager)
+{
+  if (!CBufferObjectFactory::CreateBufferObject(true))
+    return;
+
+  videoBufferManager.RegisterPool(std::make_shared<CVideoBufferPoolDMA>());
+}
+
+std::shared_ptr<IVideoBufferPool> CVideoBufferPoolDMA::CreatePool()
+{
+  return std::make_shared<CVideoBufferPoolDMA>();
+}
+
+uint32_t CVideoBufferPoolDMA::TranslateFormat(AVPixelFormat format)
+{
+  switch (format)
+  {
+    case AV_PIX_FMT_YUV420P:
+    case AV_PIX_FMT_YUVJ420P:
+      return DRM_FORMAT_YUV420;
+    default:
+      return 0;
+  }
+}

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+
+#include <memory>
+
+class CVideoBufferDMA;
+
+class CVideoBufferPoolDMA : public IVideoBufferPool
+{
+public:
+  CVideoBufferPoolDMA() = default;
+  ~CVideoBufferPoolDMA() override;
+
+  // implementation of IVideoBufferPool
+  CVideoBuffer* Get() override;
+  void Return(int id) override;
+  void Configure(AVPixelFormat format, int size) override;
+  bool IsConfigured() override;
+  bool IsCompatible(AVPixelFormat format, int size) override;
+  void Released(CVideoBufferManager& videoBufferManager) override;
+
+  static std::shared_ptr<IVideoBufferPool> CreatePool();
+
+protected:
+  CCriticalSection m_critSection;
+  std::vector<CVideoBufferDMA*> m_all;
+  std::deque<int> m_used;
+  std::deque<int> m_free;
+
+private:
+  uint32_t TranslateFormat(AVPixelFormat format);
+
+  uint32_t m_fourcc = 0;
+  uint64_t m_size = 0;
+};

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -8,6 +8,8 @@
 
 #include "ProcessInfoGBM.h"
 
+#include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
+
 using namespace VIDEOPLAYER;
 
 CProcessInfo* CProcessInfoGBM::Create()
@@ -18,6 +20,11 @@ CProcessInfo* CProcessInfoGBM::Create()
 void CProcessInfoGBM::Register()
 {
   CProcessInfo::RegisterProcessControl("gbm", CProcessInfoGBM::Create);
+}
+
+CProcessInfoGBM::CProcessInfoGBM()
+{
+  m_videoBufferManager.RegisterPool(std::make_shared<CVideoBufferPoolDMA>());
 }
 
 EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
@@ -17,9 +17,10 @@ namespace VIDEOPLAYER
 class CProcessInfoGBM : public CProcessInfo
 {
 public:
-  CProcessInfoGBM() = default;
   static CProcessInfo* Create();
   static void Register();
+
+  CProcessInfoGBM();
   EINTERLACEMETHOD GetFallbackDeintMethod() override;
 };
 


### PR DESCRIPTION
This has been in the works for a while and we are almost there 😄 

This PR adds two new classes `CVideoBufferDMA` and `CVideoBufferPoolDMA`.

These two classes act as the interface between VideoPlayer's `CVideoBuffer` and the recently added `CBufferObject` class. This has been designed to be used with both `CDVDVideoCodecDRMPRIME` and `CAddonVideoCodec` however this PR only include support for the latter at this time to reduce the overall line count to review. The code can be found [here](https://github.com/lrusak/xbmc/commits/drm-prime-sw-buffer-object). The idea here is to allow using dma-bufs with VideoPlayer via software decoding (in the case that hardware decoding isn't available).

There is a few design requirements to keep in mind:
 - `CAddonVideoCodec` requires creating a buffer by format and size
 - `SetDimensions()` is used to describe the buffer _after_ data has been placed into it. This is specifically needed for `CAddonVideoCodec`.
 - `Export()` is used to describe the buffer _before_ data has been placed into it. This will be used in conjunction with FFmpeg's get_buffer2 callback in CDVDVideoCodecDRMPRIME`.
 - If there are no `CBufferObjects` registered then the `CVideoBufferPoolDMA` won't be registered either. This makes it so we don't try and use the incorrect renderer if specialized buffers aren't available.

The entire DRMPRIME buffer declarations could use doxygen but I'd rather do that at a later time so I can cover all of the inherited classes at once.