### PR TITLE
[ios] Runtime fix after spdlog merge

### DIFF
--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -90,7 +90,7 @@ using namespace KODI::MESSAGING;
 
 - (CGFloat)getScreenScale:(UIScreen *)screen
 {
-  CLog::Log(LOGDEBUG, "nativeScale {}, scale {}, traitScale {}", screen.nativeScale, screen.scale,
+  LOG(@"nativeScale %lf, scale %lf, traitScale %lf", screen.nativeScale, screen.scale,
             screen.traitCollection.displayScale);
   return std::max({screen.nativeScale, screen.scale, screen.traitCollection.displayScale});
 }


### PR DESCRIPTION
## Description
IOS init process is not considered a standard Kodi init process.
This Log call is now being called prior to the Logger creation in CApplication::Create()

This is more a quick fix to get running builds. Further investigation of how DarwinEmbedded
platforms init would need to be done to potentially fix/change the init process to insure
CApplication::Create() is called earlier in the process, and windowing init is done in
windowing instead of outside prior as is the current case.

## Motivation and Context
Fix nightly runtime

## How Has This Been Tested?
Ios device

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
