### PR TITLE
Correct on-screen keyboard behaviour for Arabic characters

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -261,7 +261,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     {
       m_edit.clear();
       std::wstring str;
-      g_charsetConverter.utf8ToW(action.GetText(), str);
+      g_charsetConverter.utf8ToW(action.GetText(), str, false);
       m_text2.insert(m_cursorPos, str);
       m_cursorPos += str.size();
       UpdateText();
@@ -587,7 +587,7 @@ void CGUIEditControl::SetLabel2(const std::string &text)
 {
   m_edit.clear();
   std::wstring newText;
-  g_charsetConverter.utf8ToW(text, newText);
+  g_charsetConverter.utf8ToW(text, newText, false);
   if (newText != m_text2)
   {
     m_isMD5 = (m_inputType == INPUT_TYPE_PASSWORD_MD5 || m_inputType == INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -565,7 +565,7 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   // show the cursor
   unsigned int ch = L'|';
   if ((++m_cursorBlink % 64) > 32)
-    ch |= (3 << 16);
+    ch = L' ';
   styled.insert(styled.begin() + m_cursorPos, ch);
 
   return m_label2.SetStyledText(styled, colors);


### PR DESCRIPTION
### Description of changes and context
1- Prevent Arabic characters from being dis-joined when using the on-screen keyboard
2- Prevent the flipping of existing Arabic text when editing (ex. renaming something) using the on-screen keyboard

Both the above points are cleared by turning off character flipping in calls to utf8ToW charset conversion function for ACTION_INPUT_TEXT and GUI_MSG_SET_TEXT (SetLabel2 function)

This fixes #16040

### How Has This Been Tested?
The changes were tested using Kodi on Windows 10 x64 (1909)
The on-screen keyboard was tested using a RTL language (Arabic) and a LTR language (English) and behave correctly for both languages after the changes. Kodi's interface language was alternated between Arabic and English during the test and didn't affect the results.

### Screenshots
![kodi_KB_AR_Issue](https://user-images.githubusercontent.com/63805744/79560383-d0d90a00-80a7-11ea-90a8-25c6bf3848e0.png)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
