### PR TITLE
[tvos] Runtime fixup after spdlog

### DIFF
--- a/xbmc/platform/darwin/tvos/PreflightHandler.mm
+++ b/xbmc/platform/darwin/tvos/PreflightHandler.mm
@@ -24,6 +24,7 @@
 #include "filesystem/File.h"
 #include "utils/log.h"
 
+#import "platform/darwin/NSLogDebugHelpers.h"
 #import "platform/darwin/ios-common/DarwinNSUserDefaults.h"
 #import "platform/darwin/tvos/filesystem/TVOSFile.h"
 #import "platform/darwin/tvos/filesystem/TVOSFileUtils.h"
@@ -56,7 +57,7 @@ void CPreflightHandler::NSUserDefaultsPurge(const char* prefix)
     if ([aKey hasPrefix:@(prefix)])
     {
       [defaults removeObjectForKey:aKey];
-      CLog::Log(LOGDEBUG, "nsuserdefaults: removing {}", aKey.UTF8String);
+      LOG(@"nsuserdefaults: removing %@", aKey);
     }
   }
 }
@@ -79,10 +80,7 @@ void CPreflightHandler::CheckForRemovedCacheFolder()
 
 void CPreflightHandler::MigrateUserdataXMLToNSUserDefaults()
 {
-  CLog::Log(LOGDEBUG,
-            "MigrateUserdataXMLToNSUserDefaults: "
-            "NSUserDefaultsSize({})",
-            NSUserDefaultsSize());
+  LOG(@"MigrateUserdataXMLToNSUserDefaults: NSUserDefaultsSize(%llu)", NSUserDefaultsSize());
 
   auto defaults = [NSUserDefaults standardUserDefaults];
 
@@ -94,7 +92,7 @@ void CPreflightHandler::MigrateUserdataXMLToNSUserDefaults()
     return;
   }
 
-  CLog::Log(LOGDEBUG, "MigrateUserdataXMLToNSUserDefaults: migration starting");
+  LOG(@"MigrateUserdataXMLToNSUserDefaults: migration starting");
 
   NSUserDefaultsPurge("/userdata");
   // now search for all xxx.xml files in the
@@ -122,16 +120,14 @@ void CPreflightHandler::MigrateUserdataXMLToNSUserDefaults()
     if ([file.pathExtension isEqualToString:@"xml"])
     {
       // log what we are doing
-      CLog::Log(LOGDEBUG, "MigrateUserdataXMLToNSUserDefaults: Found -> {}}",
-                [fullPath UTF8String]);
+      LOG(@"MigrateUserdataXMLToNSUserDefaults: Found -> %@", fullPath);
 
       // we cannot use a Cfile for src, it will get mapped into a CTVOSFile
       const CURL srcUrl(fullPath.UTF8String);
       XFILE::CPosixFile srcfile;
       if (!srcfile.Open(srcUrl))
       {
-        CLog::Log(LOGDEBUG, "MigrateUserdataXMLToNSUserDefaults: Failed opening file {}",
-                  srcUrl.Get().c_str());
+        LOG(@"MigrateUserdataXMLToNSUserDefaults: Failed opening file %s", srcUrl.Get().c_str());
         continue;
       }
 
@@ -150,8 +146,8 @@ void CPreflightHandler::MigrateUserdataXMLToNSUserDefaults()
             break;
           else if (iread < 0)
           {
-            CLog::Log(LOGERROR, "MigrateUserdataXMLToNSUserDefaults: Failed read from file {}",
-                      srcUrl.Get().c_str());
+            LOG(@"MigrateUserdataXMLToNSUserDefaults: Failed read from file %s",
+                srcUrl.Get().c_str());
             break;
           }
 
@@ -167,10 +163,8 @@ void CPreflightHandler::MigrateUserdataXMLToNSUserDefaults()
 
           if (iwrite != iread)
           {
-            CLog::Log(LOGERROR,
-                      "MigrateUserdataXMLToNSUserDefaults: "
-                      "Failed write to file {}",
-                      dtsUrl.Get().c_str());
+            LOG(@"MigrateUserdataXMLToNSUserDefaults: Failed write to file %s",
+                dtsUrl.Get().c_str());
             break;
           }
         }
@@ -185,7 +179,6 @@ void CPreflightHandler::MigrateUserdataXMLToNSUserDefaults()
   [defaults setObject:@"1" forKey:migration_key];
   [defaults synchronize];
 
-  CLog::Log(LOGDEBUG, "MigrateUserdataXMLToNSUserDefaults: migration finished");
-  CLog::Log(LOGDEBUG, "MigrateUserdataXMLToNSUserDefaults: NSUserDefaultsSize({})",
-            NSUserDefaultsSize());
+  LOG(@"MigrateUserdataXMLToNSUserDefaults: migration finished");
+  LOG(@"MigrateUserdataXMLToNSUserDefaults: NSUserDefaultsSize(%llu)", NSUserDefaultsSize());
 }


### PR DESCRIPTION
## Description
Some logging done prior to app start has been converted back to using NSLOG.
Preflight handler is done prior to CApplication::Create, and therefore prior to Logger being set up.
Its unlikely this can be ever done using CLog, as the preflight handler converts/handles all xml file into NSUserDefaults keystorage, and therefore has to be done prior to core app init.

## Motivation and Context
tvos runtime failure after spdlog merge

## How Has This Been Tested?
Apple TV 4k

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
