### PR TITLE
Bug Fixes (2x addon related. 1x possibly serious filesystem cache related)

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -836,7 +836,9 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
       return false;
 
     std::string strSQL;
-    strSQL=PrepareSQL("SELECT addonID FROM addons WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
+    strSQL = PrepareSQL("SELECT id FROM addons WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' "
+                  "OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
+
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
 
     if (!m_pDS->query(strSQL)) return false;
@@ -845,7 +847,7 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
     while (!m_pDS->eof())
     {
       AddonPtr addon;
-      GetAddon(m_pDS->fv(0).get_asString(),addon);
+      GetAddon(m_pDS->fv(0).get_asInt(), addon);
       if (addon->Type() >= ADDON_UNKNOWN+1 && addon->Type() < ADDON_SCRAPER_LIBRARY)
         addons.push_back(addon);
       m_pDS->next();

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -334,7 +334,10 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     // need to enable the dependency
     if (dep && CServiceBroker::GetAddonMgr().IsAddonDisabled(addonID))
       if (!CServiceBroker::GetAddonMgr().EnableAddon(addonID))
+      {
+        database.Close();
         return false;
+      }
 
     // at this point we have our dep, or the dep is optional (and we don't have it) so check that it's OK as well
     //! @todo should we assume that installed deps are OK?

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -116,6 +116,7 @@ void CDirectoryCache::ClearFile(const std::string& strFile)
 {
   // Get rid of any URL options, else the compare may be wrong
   std::string strFile2 = CURL(strFile).GetWithoutOptions();
+  URIUtils::RemoveSlashAtEnd(strFile2);
 
   ClearDirectory(URIUtils::GetDirectory(strFile2));
 }


### PR DESCRIPTION
**Fix 1**
  If you search via Add-ons > Search and there are multiple repos with a same add-on ID, 
   Kodi will show multiple entries of the same add-on.
![screenshot000](https://user-images.githubusercontent.com/6225961/79688142-617a3a80-82a0-11ea-9f3d-075bfb6e04a9.png)
![screenshot002](https://user-images.githubusercontent.com/6225961/79688141-5f17e080-82a0-11ea-80e9-7b6cbe4f1fca.png)

**Fix 2**
Noticed that the database isn't closed before this return statement.
It is returned everywhere else. Potential db is kept open.

**Fix 3**
This is quite serious. The DirectoryCache becomes out of sync with the real filesystem.
Causing kodi to think directories still exist when they don't.
Easiest way to see the behavior is
1) Install add-on from zip
2) Uninstall add-on
3) Install same add-on from zip again
4) It fails to install

When Kodi tries to install it again, it still thinks the addon path exists.
Error in log is
```
2020-04-20 01:11:40.423 T:18860   ERROR <general>: XFILE::CFile::Rename - Error renaming file C:\Kodi\addons\inputstream.adaptive
2020-04-20 01:11:40.423 T:18860   ERROR <general>: Failed to move old addon files from 'C:\Kodi\addons\inputstream.adaptive' to 'C:\Kodi\addons\temp\4b6a0f80-44c6-428b-b24d-aa9c7070ca88'
```

The below folder is removed when uninstalling
"C:\Kodi\addons\inputstream.adaptive\\"

The cache layout looks like this (key is the parent directory)
```
{
   "C:\Kodi\addons": ["inputstream.adaptive"]
}
```
We need to remove "C:\Kodi\addons" cache key.

The add-on is uninstalled here
https://github.com/xbmc/xbmc/blob/master/xbmc/addons/FilesystemInstaller.cpp#L70
That calls CFile::Rename
https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/File.cpp#L905
which calls g_directoryCache.ClearFile
https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/DirectoryCache.cpp#L115

this is where the problem is.
ClearFile assumes its getting a filepath but often it gets a directory path 
It calls URIUtils::GetDirectory to get the parent directory of the path.
However, GetDirectory on a Directory returns itself.

The current flow is:
```
CDirectoryCache::ClearFile: C:\Kodi\addons\inputstream.adaptive\
URIUtils::GetDirectory: C:\Kodi\addons\inputstream.adaptive\
CDirectoryCache::ClearDirectory: C:\Kodi\addons\inputstream.adaptive\
URIUtils::RemoveSlashAtEnd: C:\Kodi\addons\inputstream.adaptive
```
That is not in the cache so nothing is removed.
**We need ClearFile to remove any trailing slash so it works correctly on directories and files.**
That is what my last fix does.

Once that line is added, it goes:
```
CDirectoryCache::ClearFile: C:\Kodi\addons\inputstream.adaptive\
URIUtils::RemoveSlashAtEnd: C:\Kodi\addons\inputstream.adaptive
URIUtils::GetDirectory: C:\Kodi\addons\
CDirectoryCache::ClearDirectory: C:\Kodi\addons\
URIUtils::RemoveSlashAtEnd: C:\Kodi\addons
```

Filepath are unaffected as the added RemoveSlashAtEnd doesn't affect them.

Who knows where else this has been causing issues.
Any renaming of directories could cause it.
Seems to be just in Matrix