### PR TITLE
Fix build with x11/gles

### DIFF
--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -12,9 +12,7 @@
 #endif
 
 #include <clocale>
-#include <GL/gl.h>
-#include <GL/glu.h>
-#include <GL/glext.h>
+#include "system_gl.h"
 #include "GLContextEGL.h"
 #include "utils/log.h"
 #include <EGL/eglext.h>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
Build is on Linux broken with the following configure options:
-DCORE_PLATFORM_NAME=x11 -DX11_RENDER_SYSTEM=gles

xbmc/windowing/X11/GLContextEGL.cpp:15:10: fatal error: GL/gl.h:
 No such file or directory
 #include <GL/gl.h>

<!--- Describe your change in detail here -->
Include the proper header which takes care of opengl vs. gles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Build fix.
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Build-tested using buildroot.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
