### PR TITLE
[Addons] Ensure addon installation order when migrating to matrix

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -423,7 +423,7 @@ void CAddonInstaller::InstallAddons(const VECADDONS& addons, bool wait)
     AddonPtr toInstall;
     RepositoryPtr repo;
     if (CAddonInstallJob::GetAddon(addon->ID(), repo, toInstall))
-      DoInstall(toInstall, repo, true, false, true);
+      DoInstall(toInstall, repo, false, false, true);
   }
   if (wait)
   {

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -14,6 +14,8 @@
 #include "threads/CriticalSection.h"
 #include "utils/EventStream.h"
 
+#include <mutex>
+
 namespace ADDON
 {
   typedef std::map<TYPE, VECADDONS> MAPADDONS;
@@ -281,11 +283,32 @@ namespace ADDON
 
     void FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path);
 
+    /*!
+     * Get the list of of available updates
+     * \param[in,out] updates the vector of addons to be filled with addons that need to be updated (not blacklisted)
+     * \return if there are any addons needing updates
+     */
+    bool GetAddonUpdateCandidates(VECADDONS& updates) const;
+
     /*!\brief Sort a list of addons for installation, i.e., defines the order of installation depending
      * of each addon dependencies.
      * \param[in,out] updates the vector of addons to sort
      */
     void SortByDependencies(VECADDONS& updates) const;
+
+    /*!
+     * Install the list of addon updates via AddonInstaller
+     * \param[in,out] updates the vector of addons to install (will be sorted)
+     * \param wait if the process should wait for all addons to install
+     */
+    void InstallAddonUpdates(VECADDONS& updates, bool wait) const;
+
+    // This guards the addon installation process to make sure
+    // addon updates are not installed concurrently
+    // while the migration is running. Addon updates can be triggered
+    // as a result of a repository update event.
+    // (migration will install any available update anyway)
+    mutable std::mutex m_installAddonsMutex;
 
     std::set<std::string> m_disabled;
     std::set<std::string> m_updateBlacklist;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -281,6 +281,12 @@ namespace ADDON
 
     void FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path);
 
+    /*!\brief Sort a list of addons for installation, i.e., defines the order of installation depending
+     * of each addon dependencies.
+     * \param[in,out] updates the vector of addons to sort
+     */
+    void SortByDependencies(VECADDONS& updates) const;
+
     std::set<std::string> m_disabled;
     std::set<std::string> m_updateBlacklist;
     static std::map<TYPE, IAddonMgrCallback*> m_managers;


### PR DESCRIPTION
## Description
Despite our efforts to ensure that every single addon in the matrix branch has a higher version than those stored in lower branches (so they all get updated when migrating from leia to matrix), the reality is that right now almost all of them get disabled and won't update.

This happens because kodi doesn't enforce any control in the order of addon installations. So let's say that you have `plugin.video.foo` and `plugin.video.bar`, and `foo` depends on `bar`, if `foo` gets updated and installed before `bar` it can lead to `foo` getting disabled. This used to work just fine before matrix because if `foo` was updated before `bar`, as the installed version of `bar` was still compatible with kodi (`xbmc.python` was backwards compatible) `foo` was updated and installed and later `bar` was also updated and installed. In matrix, even though `foo` requires a minimum version of `bar` equal to the one installed before starting the migration, `bar` is invalid because it depends on a `xbmc.python` version lower than the minimum supported by kodi matrix - leading to almost any addon with dependencies to get disabled.

So, this PR does the following:
- Ensure that concurrency is avoided in bulk addon updates: if the repo manifest is updated while migrating, it will triggered another round of updates while the first one is still running
- Ensure the `InstallUpdates` function can be configured to wait for each addon to be installed before requesting the installation of another one (using only in the migration phase - first time you run a new kodi version)
- Sort the list of addons to be updated depending on their dependencies. Addons that depend on others should be the last ones to be installed.

Note that this only affects the addon migration, i.e, when running matrix for the first time. All the other updates (after first run) will be exactly the same, the list is sorted but they are installed without any order - this is faster and won't cause any issues since the version being updated is already "new-kodi" compatible.

The only drawback of this approach is that the addon migration is now a bit slower, but I guess we can live with that.

@AlwinEsch for the review
@da-anda @ronie @anxdpanic fyi

Thanks to @yol for the c++ tips

## Motivation and Context
Promote a seamless migration from Leia to Matrix for users despite all the "non-visible" work and fussle introduced with the python2 -> python3 migration

## How Has This Been Tested?
- Install kodi leia
- Install addons in leia that are known to also be in matrix
- close kodi leia
- run matrix
- check none is disabled (and if any is, it's our fault managing the repo)

## Screenshots (if appropriate):
**Leia:**
![Leia](https://i.imgur.com/XpvzYb7.png "Leia")

**Master/Matrix:**
![Matrix](https://i.imgur.com/w1O4DUe.png "Matrix - master")

**PR:**
![Leia](https://i.imgur.com/5lWvI76.png "PR")

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
