### PR TITLE
[packaging iOS/tvOS] fix wrong architecture field in deb control file

### DIFF
--- a/tools/darwin/packaging/darwin_embedded/mkdeb-darwin_embedded.sh.in
+++ b/tools/darwin/packaging/darwin_embedded/mkdeb-darwin_embedded.sh.in
@@ -75,7 +75,11 @@ echo "Conflicts: $PACKAGE"                      >> $DIRNAME/$PACKAGE/DEBIAN/cont
 echo "Replaces: $PACKAGE"                       >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Priority: Extra"                            >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Version: $VERSION-$REVISION"                >> $DIRNAME/$PACKAGE/DEBIAN/control
-echo "Architecture: @CMAKE_SYSTEM_NAME@-@CPU@"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
+if [ "@PLATFORM@" == "iphoneos" ]; then
+  echo "Architecture: iphoneos-arm"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
+else
+  echo "Architecture: appletvos-arm64"                 >> $DIRNAME/$PACKAGE/DEBIAN/control
+fi
 echo "Installed-Size: $SIZE"                      >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Description: @APP_NAME@ Entertainment Center for iOS" >> $DIRNAME/$PACKAGE/DEBIAN/control
 echo "Homepage: @APP_WEBSITE@"                    >> $DIRNAME/$PACKAGE/DEBIAN/control


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

This PR fix the wrong value of the `Architecture` field in the DEB control file for iOS and tvOS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Since the initial tvOS PR (I guess) all iOS and tvOS nightly builds debs files can not be installed on jailbroken devices anymore because the `Architecture` field value in the DEB control file is wrong.

On iOS you get this error:
```shell
iPhone-de-Sylvain:/var/mobile/Downloads root# dpkg -i kodi-20200418-0e954dea-master-ios64.deb      
dpkg: error processing archive kodi-20200418-0e954dea-master-ios64.deb (--install):                
 package architecture (Darwin-arm64) does not match system (iphoneos-arm)                          
Errors were encountered while processing:        
 kodi-20200418-0e954dea-master-ios64.deb
```

And on tvOS you get (source: https://forum.kodi.tv/showthread.php?tid=353675&pid=2942310#pid2942310):
```shell
root@ (/var/root)# dpkg -i kodi-20200418-0e954dea-master-tvos.deb 
dpkg: error processing archive kodi-20200418-0e954dea-master-tvos.deb (--install):
 package architecture (Darwin-arm64) does not match system (darwin-arm64)
Errors were encountered while processing:
 kodi-20200418-0e954dea-master-tvos.deb
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I can now install the deb file on my jailbroken iPhone with the `dpkg` command.
But I don't have a jailbroken Apple TV to test on this platform.
But according to Memphiz yab branch, it should works --> https://github.com/Memphiz/xbmc/blob/968cd92bcb210bd95cfbfcc86a5cff02109e4b26/tools/darwin/packaging/tvos/mkdeb-tvos.sh.in#L73

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
