### PR TITLE
[depends] patch spdlog to require at least fmt 5.3.0

### DIFF
--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -38,6 +38,7 @@ if(ENABLE_INTERNAL_SPDLOG)
   externalproject_add(spdlog
                       URL ${SPDLOG_URL}
                       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/tools/depends/target/libspdlog/0001-fix_fmt_version.patch
                       PREFIX ${CORE_BUILD_DIR}/spdlog
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -35,6 +35,7 @@ if(ENABLE_INTERNAL_SPDLOG)
 
   set(SPDLOG_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libspdlog.a)
   set(SPDLOG_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+
   externalproject_add(spdlog
                       URL ${SPDLOG_URL}
                       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
@@ -49,6 +50,7 @@ if(ENABLE_INTERNAL_SPDLOG)
                                  -DSPDLOG_BUILD_TESTS=OFF
                                  -DSPDLOG_BUILD_BENCH=OFF
                                  -DSPDLOG_FMT_EXTERNAL=ON
+                                 -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  "${EXTRA_ARGS}"
                       BUILD_BYPRODUCTS ${SPDLOG_LIBRARY})
   set_target_properties(spdlog PROPERTIES FOLDER "External Projects")

--- a/tools/depends/target/libspdlog/0001-fix_fmt_version.patch
+++ b/tools/depends/target/libspdlog/0001-fix_fmt_version.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -147,7 +147,7 @@
+ #---------------------------------------------------------------------------------------
+ if(SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
+     if (NOT TARGET fmt::fmt)
+-        find_package(fmt REQUIRED)
++        find_package(fmt 5.3.0 REQUIRED)
+     endif ()
+     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
+     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)

--- a/tools/depends/target/libspdlog/Makefile
+++ b/tools/depends/target/libspdlog/Makefile
@@ -1,5 +1,5 @@
 -include ../../Makefile.include
-DEPS = Makefile
+DEPS = Makefile 0001-fix_fmt_version.patch
 
 # lib name, version
 LIBNAME=spdlog
@@ -52,6 +52,7 @@ endif
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); rm -rf build; mkdir -p build
+	cd $(PLATFORM); patch -p1 -i ../0001-fix_fmt_version.patch
 	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_OPTIONS) ..
 
 $(LIBDYLIB): $(PLATFORM)

--- a/tools/depends/target/libspdlog/Makefile
+++ b/tools/depends/target/libspdlog/Makefile
@@ -28,7 +28,7 @@ else
     RETRIEVE_TOOL_FLAGS := -Ls --create-dirs -f -O
     ARCHIVE_TOOL := tar
     ARCHIVE_TOOL_FLAGS := --strip-components=1 -xf
-    CMAKE := cmake -DCMAKE_INSTALL_PREFIX=$(PREFIX)
+    CMAKE := cmake -DCMAKE_INSTALL_PREFIX=$(PREFIX) -DCMAKE_PREFIX_PATH=$(PREFIX)
   endif
 endif
 


### PR DESCRIPTION
## Description
`spdlog` links against the `fmt::fmt` CMake target which was introduced with `fmt 5.3.0`.

## Motivation and Context
Right now Kodi might pick up `fmt` versions installed on the system (e.g. through `apt-get`)  which are older `3.X.Y` on Ubuntu 16.04 or `4.0.0` on Ubuntu 18.04 which are not compatible at all.

I'm trying to get this upstreamed, see https://github.com/gabime/spdlog/pull/1525.

## How Has This Been Tested?
* I have manually built on Ubuntu 18.04 with and without `libfmt-dev 4.0.0` on my system
* @MilhouseVH has tested this on Ubuntu 19.10 with `libfmt3-dev` installed on his system

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
