### PR TITLE
CRendererDRMPRIME: check plane format support before creating renderer

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -934,3 +934,48 @@ std::string CDRMUtils::FourCCToString(uint32_t fourcc)
 
   return ss.str();
 }
+
+bool plane::SupportsFormat(uint32_t format)
+{
+  for (uint32_t i = 0; i < plane->count_formats; i++)
+    if (plane->formats[i] == format)
+      return true;
+
+  return false;
+}
+
+bool plane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
+{
+  if (modifier == DRM_FORMAT_MOD_LINEAR)
+  {
+    if (!SupportsFormat(format))
+    {
+      CLog::Log(LOGDEBUG, "plane::{} - format not supported: {}", __FUNCTION__,
+                CDRMUtils::FourCCToString(format));
+      return false;
+    }
+  }
+  else
+  {
+    auto formatModifiers = &modifiers_map[format];
+    if (formatModifiers->empty())
+    {
+      CLog::Log(LOGDEBUG, "plane::{} - format not supported: {}", __FUNCTION__,
+                CDRMUtils::FourCCToString(format));
+      return false;
+    }
+
+    auto formatModifier = std::find(formatModifiers->begin(), formatModifiers->end(), modifier);
+    if (formatModifier == formatModifiers->end())
+    {
+      CLog::Log(LOGDEBUG, "plane::{} - modifier ({:#x}) not supported for format ({})",
+                __FUNCTION__, modifier, CDRMUtils::FourCCToString(format));
+      return false;
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "plane::{} - found plane format ({}) and modifier ({:#x})", __FUNCTION__,
+            CDRMUtils::FourCCToString(format), modifier);
+
+  return true;
+}

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -16,6 +16,7 @@
 #include "windowing/GraphicContext.h"
 
 #include <errno.h>
+#include <sstream>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -921,4 +922,15 @@ bool CDRMUtils::CheckConnector(int connector_id)
   drmModeFreeConnector(connectorcheck.connector);
 
   return finalConnectionState == DRM_MODE_CONNECTED;
+}
+
+std::string CDRMUtils::FourCCToString(uint32_t fourcc)
+{
+  std::stringstream ss;
+  ss << static_cast<char>((fourcc & 0x000000FF));
+  ss << static_cast<char>((fourcc & 0x0000FF00) >> 8);
+  ss << static_cast<char>((fourcc & 0x00FF0000) >> 16);
+  ss << static_cast<char>((fourcc & 0xFF000000) >> 24);
+
+  return ss.str();
 }

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -51,7 +51,11 @@ struct plane : drm_object
   void SetFormat(uint32_t newFormat) { format = newFormat; }
   uint32_t GetFormat() { return format; }
 
+  bool SupportsFormatAndModifier(uint32_t format, uint64_t modifier);
+
 private:
+  bool SupportsFormat(uint32_t format);
+
   uint32_t format{DRM_FORMAT_XRGB8888};
 };
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -109,6 +109,7 @@ public:
 
   static uint32_t FourCCWithAlpha(uint32_t fourcc);
   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
+  static std::string FourCCToString(uint32_t fourcc);
 
 protected:
   bool OpenDrm(bool needConnector);


### PR DESCRIPTION
This change will allow us to check if the video plane supports the requested format and modifiers.

We already store the available formats and modifiers in the video plane so it's simple to do the check.

This behaviour is desired so in the future it's easier to fallback to another render method if this render method doesn't support the requested format and modifiers.

I've also included a commit that adds a helper function to `CDRMUtils` to allow reading the drm format in a human readable way. ie `842094158` -> `NV12`

I'll also be adding similar behaviour to `CRendererDRMPRIMEGLES` in the future