### PR TITLE
Addons: Move migration and addon updates to AddonManager

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -783,26 +783,39 @@ bool CApplication::Initialize()
 
     std::vector<std::string> incompatibleAddons;
     event.Reset();
-    std::atomic<bool> isMigratingAddons(false);
-    CJobManager::GetInstance().Submit([&event, &incompatibleAddons, &isMigratingAddons]() {
-        incompatibleAddons = CAddonSystemSettings::GetInstance().MigrateAddons([&isMigratingAddons]() {
-          isMigratingAddons = true;
-        });
-        event.Set();
-      }, CJob::PRIORITY_DEDICATED);
-    localizedStr = g_localizeStrings.Get(24151);
-    iDots = 1;
-    while (!event.WaitMSec(1000))
+
+    // Addon migration
+    ADDON::VECADDONS incompatible;
+    if (CServiceBroker::GetAddonMgr().GetIncompatibleAddons(incompatible))
     {
-      if (isMigratingAddons)
-        CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr + std::string(iDots, '.'));
-      if (iDots == 3)
+      if (CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_ON)
+      {
+        CJobManager::GetInstance().Submit(
+            [&event, &incompatibleAddons]() {
+              if (CServiceBroker::GetRepositoryUpdater().CheckForUpdates())
+                CServiceBroker::GetRepositoryUpdater().Await();
+
+              incompatibleAddons = CServiceBroker::GetAddonMgr().MigrateAddons();
+              event.Set();
+            },
+            CJob::PRIORITY_DEDICATED);
+        localizedStr = g_localizeStrings.Get(24151);
         iDots = 1;
-      else
-        ++iDots;
+        while (!event.WaitMSec(1000))
+        {
+          CServiceBroker::GetRenderSystem()->ShowSplash(std::string(iDots, ' ') + localizedStr +
+                                                        std::string(iDots, '.'));
+          if (iDots == 3)
+            iDots = 1;
+          else
+            ++iDots;
+        }
+        m_incompatibleAddons = incompatibleAddons;
+      }
     }
+
+    // Start splashscreen and load skin
     CServiceBroker::GetRenderSystem()->ShowSplash("");
-    m_incompatibleAddons = incompatibleAddons;
     m_confirmSkinChange = true;
 
     std::string defaultSkin = std::static_pointer_cast<const CSettingString>(settings->GetSetting(CSettings::SETTING_LOOKANDFEEL_SKIN))->GetDefault();

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -557,12 +557,12 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
   return false;
 }
 
-bool CAddonDatabase::GetRepositoryContent(VECADDONS& addons)
+bool CAddonDatabase::GetRepositoryContent(VECADDONS& addons) const
 {
   return GetRepositoryContent("", addons);
 }
 
-bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addons)
+bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addons) const
 {
   try
   {

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -52,10 +52,10 @@ public:
    \param id id of the repository
    \returns true on success, false on error or if repository have never been synced.
    */
-  bool GetRepositoryContent(const std::string& id, ADDON::VECADDONS& addons);
+  bool GetRepositoryContent(const std::string& id, ADDON::VECADDONS& addons) const;
 
   /*! Get addons across all repositories */
-  bool GetRepositoryContent(ADDON::VECADDONS& addons);
+  bool GetRepositoryContent(ADDON::VECADDONS& addons) const;
 
   /*!
    \brief Set repo last checked date, and create the repo if needed

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -416,30 +416,24 @@ void CAddonInstaller::PrunePackageCache()
     delete it->second;
 }
 
-void CAddonInstaller::InstallUpdates()
+void CAddonInstaller::InstallAddons(const VECADDONS& addons, bool wait)
 {
-  auto updates = CServiceBroker::GetAddonMgr().GetAvailableUpdates();
-  for (const auto& addon : updates)
+  for (const auto& addon : addons)
   {
-    if (!CServiceBroker::GetAddonMgr().IsBlacklisted(addon->ID()))
-    {
-      AddonPtr toInstall;
-      RepositoryPtr repo;
-      if (CAddonInstallJob::GetAddon(addon->ID(), repo, toInstall))
-        DoInstall(toInstall, repo, true, false, true);
-    }
+    AddonPtr toInstall;
+    RepositoryPtr repo;
+    if (CAddonInstallJob::GetAddon(addon->ID(), repo, toInstall))
+      DoInstall(toInstall, repo, true, false, true);
   }
-}
-
-void CAddonInstaller::InstallUpdatesAndWait()
-{
-  InstallUpdates();
-  CSingleLock lock(m_critSection);
-  if (!m_downloadJobs.empty())
+  if (wait)
   {
-    m_idle.Reset();
-    lock.Leave();
-    m_idle.Wait();
+    CSingleLock lock(m_critSection);
+    if (!m_downloadJobs.empty())
+    {
+      m_idle.Reset();
+      lock.Leave();
+      m_idle.Wait();
+    }
   }
 }
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -48,6 +48,13 @@ public:
    */
   bool InstallOrUpdate(const std::string &addonID, bool background = true, bool modal = false);
 
+  /*! \brief Installs a vector of addons
+   \param addons the list of addons to install
+   \param wait if the method should wait for all the DoInstall jobs to finish or if it should return right away
+   \sa DoInstall
+   */
+  void InstallAddons(const ADDON::VECADDONS& addons, bool wait);
+
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from
    \return true if successful, false otherwise
@@ -82,10 +89,6 @@ public:
    *  \return true if a job exists, false otherwise
    */
   bool HasJob(const std::string& ID) const;
-
-  /*! Install update and block until all updates have installed. */
-  void InstallUpdatesAndWait();
-  void InstallUpdates();
 
   void OnJobComplete(unsigned int jobID, bool success, CJob* job) override;
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job) override;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -76,7 +76,10 @@ namespace ADDON
      \param enabledOnly whether we only want enabled addons - set to false to allow both enabled and disabled addons - defaults to true.
      \return true if an addon matching the id of the given type is available and is enabled (if enabledOnly is true).
      */
-    bool GetAddon(const std::string &id, AddonPtr &addon, const TYPE &type = ADDON_UNKNOWN, bool enabledOnly = true);
+    bool GetAddon(const std::string& id,
+                  AddonPtr& addon,
+                  const TYPE& type = ADDON_UNKNOWN,
+                  bool enabledOnly = true) const;
 
     bool HasType(const std::string &id, const TYPE &type);
 
@@ -85,7 +88,7 @@ namespace ADDON
     bool HasInstalledAddons(const TYPE &type);
 
     /*! Returns all installed, enabled add-ons. */
-    bool GetAddons(VECADDONS& addons);
+    bool GetAddons(VECADDONS& addons) const;
 
     /*! Returns enabled add-ons with given type. */
     bool GetAddons(VECADDONS& addons, const TYPE& type);
@@ -137,7 +140,7 @@ namespace ADDON
     bool ReloadSettings(const std::string &id);
 
     /*! Get addons with available updates */
-    VECADDONS GetAvailableUpdates();
+    VECADDONS GetAvailableUpdates() const;
 
     /*! Returns true if there is any addon with available updates, otherwise false */
     bool HasAvailableUpdates();
@@ -148,6 +151,27 @@ namespace ADDON
      \return True if everything went ok, false otherwise
      */
     bool FindAddons();
+
+    /*!
+     * Fills the the provided vector with the list of incompatible addons and returns if there's any.
+     *
+     * @return true if there are incompatible addons
+     */
+    bool GetIncompatibleAddons(VECADDONS& incompatible) const;
+
+    /*!
+     * Migrate all the addons (updates all addons that have an update pending and disables those
+     * that got incompatible)
+     *
+     * @return list of all addons that were modified.
+     */
+    std::vector<std::string> MigrateAddons();
+
+    /*!
+     * Install available addon updates, if any.
+     * @param wait If kodi should wait for all updates to download and install before returning
+     */
+    void CheckAndInstallAddonUpdates(bool wait) const;
 
     /*!
      * @note: should only be called by AddonInstaller
@@ -180,7 +204,7 @@ namespace ADDON
      \param ID id of the addon
      \sa DisableAddon
      */
-    bool IsAddonDisabled(const std::string& ID);
+    bool IsAddonDisabled(const std::string& ID) const;
 
     /* \brief Checks whether an addon can be disabled via DisableAddon.
      \param ID id of the addon
@@ -229,14 +253,14 @@ namespace ADDON
 
     bool ServicesHasStarted() const;
 
-    bool IsCompatible(const IAddon& addon);
+    bool IsCompatible(const IAddon& addon) const;
 
     /*! \brief Recursively get dependencies for an add-on
      */
     std::vector<DependencyInfo> GetDepsRecursive(const std::string& id);
 
-    bool GetAddonInfos(AddonInfos& addonInfos, TYPE type);
-    const AddonInfoPtr GetAddonInfo(const std::string& id, TYPE type = ADDON_UNKNOWN);
+    bool GetAddonInfos(AddonInfos& addonInfos, TYPE type) const;
+    const AddonInfoPtr GetAddonInfo(const std::string& id, TYPE type = ADDON_UNKNOWN) const;
 
     /*!
      * @brief Get the path where temporary add-on files are stored
@@ -252,7 +276,7 @@ namespace ADDON
 
     VECADDONS m_updateableAddons;
 
-    bool GetAddonsInternal(const TYPE &type, VECADDONS &addons, bool enabledOnly);
+    bool GetAddonsInternal(const TYPE& type, VECADDONS& addons, bool enabledOnly) const;
     bool EnableSingle(const std::string& id);
 
     void FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path);

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -9,9 +9,7 @@
 #include "AddonSystemSettings.h"
 
 #include "ServiceBroker.h"
-#include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
-#include "addons/RepositoryUpdater.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "messaging/helpers/DialogHelper.h"
@@ -118,51 +116,9 @@ bool CAddonSystemSettings::UnsetActive(const AddonPtr& addon)
   return true;
 }
 
-
-std::vector<std::string> CAddonSystemSettings::MigrateAddons(std::function<void(void)> onMigrate)
+int CAddonSystemSettings::GetAddonAutoUpdateMode() const
 {
-  auto getIncompatible = [](){
-    VECADDONS incompatible;
-    CServiceBroker::GetAddonMgr().GetAddons(incompatible);
-    incompatible.erase(std::remove_if(incompatible.begin(), incompatible.end(),
-        [](const AddonPtr a){ return CServiceBroker::GetAddonMgr().IsCompatible(*a); }), incompatible.end());
-    return incompatible;
-  };
-
-  if (getIncompatible().empty())
-    return std::vector<std::string>();
-
-  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON)
-  {
-    onMigrate();
-
-    if (CServiceBroker::GetRepositoryUpdater().CheckForUpdates())
-      CServiceBroker::GetRepositoryUpdater().Await();
-
-    CLog::Log(LOGINFO, "ADDON: waiting for add-ons to update...");
-    CAddonInstaller::GetInstance().InstallUpdatesAndWait();
-  }
-
-  auto incompatible = getIncompatible();
-  for (const auto& addon : incompatible)
-    CLog::Log(LOGINFO, "ADDON: %s version %s is incompatible", addon->ID().c_str(),
-              addon->Version().asString().c_str());
-
-  std::vector<std::string> changed;
-  for (const auto& addon : incompatible)
-  {
-    if (!UnsetActive(addon))
-    {
-      CLog::Log(LOGWARNING, "ADDON: failed to unset %s", addon->ID().c_str());
-      continue;
-    }
-    if (!CServiceBroker::GetAddonMgr().DisableAddon(addon->ID()))
-    {
-      CLog::Log(LOGWARNING, "ADDON: failed to disable %s", addon->ID().c_str());
-    }
-    changed.push_back(addon->Name());
-  }
-
-  return changed;
+  return CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_ADDONS_AUTOUPDATES);
 }
 }

--- a/xbmc/addons/AddonSystemSettings.h
+++ b/xbmc/addons/AddonSystemSettings.h
@@ -33,25 +33,22 @@ public:
   bool IsActive(const IAddon& addon);
 
   /*!
+   * Gets Kodi addon auto update mode
+   *
+   * @return the autoupdate mode value
+  */
+  int GetAddonAutoUpdateMode() const;
+
+  /*!
    * Attempt to unset addon as active. Returns true if addon is no longer active,
    * false if it could not be unset (e.g. if the addon is the default)
    */
   bool UnsetActive(const AddonPtr& addon);
 
-  /*!
-   * Check compatibility of installed addons and attempt to migrate.
-   *
-   * @param onMigrate Called when a long running migration task takes place.
-   * @return list of addons that was modified.
-   */
-  std::vector<std::string> MigrateAddons(std::function<void(void)> onMigrate);
-
 private:
   CAddonSystemSettings();
-  CAddonSystemSettings(const CAddonSystemSettings&) = default;
+  CAddonSystemSettings(const CAddonSystemSettings&) = delete;
   CAddonSystemSettings& operator=(const CAddonSystemSettings&) = delete;
-  CAddonSystemSettings(CAddonSystemSettings&&);
-  CAddonSystemSettings& operator=(CAddonSystemSettings&&);
   ~CAddonSystemSettings() override = default;
 
   const std::map<ADDON::TYPE, std::string> m_activeSettings;

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -79,7 +79,7 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
 
     VECADDONS updates = m_addonMgr.GetAvailableUpdates();
 
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_NOTIFY)
+    if (CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_NOTIFY)
     {
       if (!updates.empty())
       {
@@ -97,9 +97,9 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
       }
     }
 
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON)
+    if (CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_ON)
     {
-      CAddonInstaller::GetInstance().InstallUpdates();
+      m_addonMgr.CheckAndInstallAddonUpdates(false);
     }
 
     ScheduleUpdate();
@@ -207,7 +207,7 @@ void CRepositoryUpdater::ScheduleUpdate()
   CSingleLock lock(m_criticalSection);
   m_timer.Stop(true);
 
-  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_NEVER)
+  if (CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_NEVER)
     return;
 
   if (!m_addonMgr.HasAddons(ADDON_REPOSITORY))


### PR DESCRIPTION
## Description
Sort of a dependency to finish my work in https://github.com/xbmc/xbmc/pull/17703

This PR moves the addon migration and addon update functionalities to `AddonManager`. Previously, addon migration was happening in `CAddonSystemSettings` (a settings-related class) and addon updates were being done by the `AddonInstaller`. IMHO, the `AddonInstaller` component doesn't need to know the concept of an update. It should only install addons. The notion of an addon update should likely be a level above, in the component that manages addons and actually request their installation (via `AddonInstaller`). 
At the same time, there's another component (`RepositoryUpdater`) that has the `AddonManager` as a member and that is calling `AddonInstaller` directly after the repository manifest is updated.

The main problem here is that if we want to block addon updates during the addon migration phase (new kodi version), the component that is responsible to migrate addons must be also the same that updates addons - otherwise we need to expose functionality or information (e.g. `IsMigrating`) to components that doesn't need to know about what a migration is. So better to take a step backwards (refactor this first) and actually fix the problem afterwards.

Note that this PR doesn't change functionality, just "moves it around".

## Motivation and Context
@yol comment about `IsMigrating` exposure being a sign of a fragile design. Finish the work to fix addon migration from leia to matrix in https://github.com/xbmc/xbmc/pull/17703

## How Has This Been Tested?
Compile and runtime test. Updated a few addons, restarted kodi to check for updates in repo, did addon migration (which fails as expected), etc.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
