### PR TITLE
Don't automatically enable debug logging in debug builds

### DIFF
--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -159,16 +159,10 @@ void CLog::SetLogLevel(int level)
   m_logLevel = level;
 
   auto spdLevel = spdlog::level::info;
-#if defined(_DEBUG) || defined(PROFILE)
-  spdLevel = spdlog::level::trace;
-#else
   if (level <= LOG_LEVEL_NONE)
     spdLevel = spdlog::level::off;
   else if (level >= LOG_LEVEL_DEBUG)
     spdLevel = spdlog::level::trace;
-  else
-    spdLevel = spdlog::level::info;
-#endif
 
   if (m_defaultLogger != nullptr && m_defaultLogger->level() == spdLevel)
     return;

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -168,7 +168,7 @@ void CLog::SetLogLevel(int level)
     return;
 
   spdlog::set_level(spdLevel);
-  FormatAndLogInternal(spdlog::level::info, "Log level changed to \"%s\"",
+  FormatAndLogInternal(spdlog::level::info, "Log level changed to \"{}\"",
                        spdlog::level::to_string_view(spdLevel));
 }
 


### PR DESCRIPTION
## Description
With #17498 I accidentally changed the behaviour of the logging framework to always enable debug logging when using a debug build. This was not the case before and this PR should fix this. Thanks for @phunkyfish for pointing this out.

I've tested it on Windows and Ubuntu and it works. @phunkyfish claims that this is not enough for OSX and that https://github.com/xbmc/xbmc/pull/17723/files#diff-b7ab0e9f01171ac7da6f30e8337abebfR167-R168 has to be removed for it to work on OSX but I don't understand why OSX should be any different than Windows or Ubuntu... So that needs to be figured out / fixed before this PR can be merged.

## How Has This Been Tested?
Manually on Windows and Ubuntu.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
