### PR TITLE
CDVDVideoCodecDRMPRIME: software decoding

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7073,7 +7073,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13430"
-msgid "Allow hardware acceleration - PRIME"
+msgid "Allow using DRM PRIME decoder"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -7113,7 +7113,10 @@ msgctxt "#13437"
 msgid "Prefer VDPAU video mixer"
 msgstr ""
 
-#empty string with id 13438
+#: system/settings/settings.xml
+msgctxt "#13438"
+msgid "Allow hardware acceleration with DRM PRIME"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13439"
@@ -18568,7 +18571,7 @@ msgstr ""
 #. Description of setting with label #13430 "Allow hardware acceleration - PRIME"
 #: system/settings/settings.xml
 msgctxt "#36172"
-msgid "Enable PRIME hardware decoding of video files, used if ffmpeg PRIME hwaccel is available."
+msgid "Enable PRIME decoding of video files"
 msgstr ""
 
 #. Description of setting with label #14109 "Short date format"
@@ -18845,7 +18848,11 @@ msgctxt "#36222"
 msgid "Don't import the guide data while playing TV to minimise CPU usage."
 msgstr ""
 
-#empty string with id 36223
+#. Description of setting with label #13438 "Allow Hardware Accelleration with DRM PRIME"
+#: system/settings/settings.xml
+msgctxt "#36223"
+msgid "Enable PRIME hardware decoding of video files, used if ffmpeg PRIME hwaccel is available."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36224"

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -15,6 +15,17 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.useprimedecoderforhw" type="boolean" parent="videoplayer.useprimedecoder" label="13438" help="36172">
+          <visible>true</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.useprimedecoder" operator="is">true</condition>
+            </dependency>
+          </dependencies>
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.useprimerenderer" type="integer" label="13462" help="13463">
           <visible>false</visible>
           <level>2</level>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -16,6 +16,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"
+#include "utils/CPUInfo.h"
 #include "utils/log.h"
 #include "windowing/gbm/WinSystemGbm.h"
 
@@ -164,6 +165,8 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
   m_pCodecContext->time_base.num = 1;
   m_pCodecContext->time_base.den = DVD_TIME_BASE;
+  m_pCodecContext->thread_safe_callbacks = 1;
+  m_pCodecContext->thread_count = CServiceBroker::GetCPUInfo()->GetCPUCount();
 
   if (hints.extradata && hints.extrasize > 0)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -35,6 +35,8 @@ using namespace KODI::WINDOWING::GBM;
 namespace
 {
 
+constexpr const char* SETTING_VIDEOPLAYER_USEPRIMEDECODERFORHW{"videoplayer.useprimedecoderforhw"};
+
 static void ReleaseBuffer(void* opaque, uint8_t* data)
 {
   CVideoBufferDMA* buffer = static_cast<CVideoBufferDMA*>(opaque);
@@ -102,7 +104,10 @@ void CDVDVideoCodecDRMPRIME::Register()
 
 static bool IsSupportedHwFormat(const enum AVPixelFormat fmt)
 {
-  return fmt == AV_PIX_FMT_DRM_PRIME;
+  bool hw = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      SETTING_VIDEOPLAYER_USEPRIMEDECODERFORHW);
+
+  return fmt == AV_PIX_FMT_DRM_PRIME && hw;
 }
 
 static bool IsSupportedSwFormat(const enum AVPixelFormat fmt)
@@ -112,6 +117,10 @@ static bool IsSupportedSwFormat(const enum AVPixelFormat fmt)
 
 static const AVCodecHWConfig* FindHWConfig(const AVCodec* codec)
 {
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          SETTING_VIDEOPLAYER_USEPRIMEDECODERFORHW))
+    return nullptr;
+
   const AVCodecHWConfig* config = nullptr;
   for (int n = 0; (config = avcodec_get_hw_config(codec, n)); n++)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -36,6 +36,7 @@ protected:
   void SetPictureParams(VideoPicture* pVideoPicture);
   void UpdateProcessInfo(struct AVCodecContext* avctx, const enum AVPixelFormat fmt);
   static enum AVPixelFormat GetFormat(struct AVCodecContext* avctx, const enum AVPixelFormat* fmt);
+  static int GetBuffer(struct AVCodecContext* avctx, AVFrame* frame, int flags);
 
   std::string m_name;
   int m_codecControlFlags = 0;


### PR DESCRIPTION
This has been in the works for some time but has finally been made possible because of #17688 

This allows `CDVDVideoCodecDRMPRIME` to do sw decoding into dma-bufs. This is equivalent to the functionality that the RPi platform has where it can sw decode directly into mmal buffers.

Currently this only supports `AV_PIX_FMT_YUV420` as rendering other formats is more difficult (especially on embedded hardware). Mesa has native support to render this format into EGL (using shaders) so we can allow that easily. Other sw decoded pixel formats such as `AV_PIX_FMT_YUV420P10` do not have a mesa EGL equivalent. Typically this is because interleaved formats are much better suited for importing into the GPU such as NV12 or P010.

I've tested this on various hw such as Amd, Intel, Amlogic (odroid-c2). The odroid-c2 is the only platform that supports YUV420 (YU12) int the drm plane so that is the only platform I have tested this with using direct-to-plane rendering and it seems to be fine for 1080P H264.

I also added a setting switch to enable/disable hw decoding methods when using `CDVDVideoCodecDRMPRIME` so this can be tested easily. This will probably need to be expanded in the future to enable/disable specific codec like we have currently for VAAPI.

Also be aware that this only works with the udmabuf and dma-heap CBufferObject types so if you want to test you will need one of those methods available on your platform.