### PR TITLE
[docs][python] Improve documentation for xbmc.sleep and xbmc.Monitor(…

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -212,14 +212,22 @@ namespace XBMCAddon
     /// \ingroup python_xbmc
     /// @brief \python_func{ xbmc.sleep(time) }
     ///-----------------------------------------------------------------------
-    /// Sleeps for 'time' msec.
+    /// Sleeps for 'time' (msec).
+    /// \anchor xbmc_Sleep
     ///
     /// @param time                 integer - number of msec to sleep.
     ///
     /// @throws PyExc_TypeError     If time is not an integer.
     ///
-    /// @note This is useful if you have for example a Player class that is
-    ///       waiting for onPlayBackEnded() calls.
+    /// @warning This is useful if you need to sleep for a small amount of time
+    /// (milisecond range) somewhere in your addon logic. Please note that Kodi
+    /// will attempt to stop any running scripts when signaled to exit and wait for a maximum
+    /// of 5 seconds before trying to force stop your script. If your addon makes use
+    /// of \ref xbmc_Sleep "xbmc.sleep()" incorrectly (long periods of time, e.g. that exceed
+    /// the force stop waiting time) it may lead to Kodi hanging on shutdown.
+    /// In case your addon needs long sleep/idle periods use
+    /// \ref xbmc_Monitor_waitForAbort "xbmc.Monitor().waitForAbort(secs)"
+    /// instead.
     ///
     ///
     /// ------------------------------------------------------------------------

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -257,6 +257,7 @@ namespace XBMCAddon
       /// @brief \python_func{ waitForAbort([timeout]) }
       ///-----------------------------------------------------------------------
       /// Wait for Abort
+      /// \anchor xbmc_Monitor_waitForAbort
       ///
       /// Block until abort is requested, or until timeout occurs. If an
       /// abort requested have already been made, return immediately.
@@ -271,6 +272,17 @@ namespace XBMCAddon
       ///
       ///-----------------------------------------------------------------------
       /// @python_v14 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// monitor = xbmc.Monitor()
+      /// # do something
+      /// monitor.waitForAbort(10) # sleeps for 10 secs or returns early if kodi aborts
+      /// if monitor.abortRequested():
+      ///     # abort was requested to Kodi (e.g. shutdown), do your cleanup logic
+      /// ..
+      /// ~~~~~~~~~~~~~
       ///
       waitForAbort(...);
 #else


### PR DESCRIPTION
…).waitForAbort

## Description
The note provided in the `xbmc.sleep()` method doesn't make sense anymore since `xbmc.Monitor().waitForAbort()` was introduced and actually encourages addon devs to do it wrong.
We have been suggesting during reviews to only use `xbmc.sleep()` in cases where the addon needs to sleep for really small ammounts of time - to avoid Kodi hanging on shutdown. For long periods of time, a `Monitor` (and `waitForAbort()`) should be used instead.

## Motivation and Context
Improve docs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
