### PR TITLE
[python] move xbmc.makeLegalFilename() to xbmcvfs module

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -213,6 +213,11 @@ web applications or frameworks for the Python programming language.
       "",
       <b>xbmcgui.Window().setCoordinateResolution()</b> function was removed completely.
 }
+\python_removed_function{
+      makeLegalFilename,
+      "",
+      <b>xbmc.makeLegalFilename()</b> function was moved to the xbmcvfs module.
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -377,12 +377,6 @@ namespace XBMCAddon
       return StringUtils::Format("%08x.tbn", crc);
     }
 
-    String makeLegalFilename(const String& filename, bool fatX)
-    {
-      XBMC_TRACE;
-      return CUtil::MakeLegalPath(filename);
-    }
-
     String translatePath(const String& path)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -633,39 +633,6 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmc
-    /// @brief \python_func{ xbmc.makeLegalFilename(filename[, fatX]) }
-    ///-----------------------------------------------------------------------
-    /// Returns a legal filename or path as a string.
-    ///
-    /// @param filename              string or unicode - filename/path to
-    ///                              make legal
-    /// @param fatX                  [opt] bool - True=Xbox file system(Default)
-    /// @return                      Legal filename or path as a string
-    ///
-    ///
-    /// @note If fatX is true you should pass a full path. If fatX is false only pass
-    ///       the basename of the path.\n\n
-    ///       You can use the above as keywords for arguments and skip certain optional arguments.
-    ///       Once you use a keyword, all following arguments require the keyword.
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// filename = xbmc.makeLegalFilename('F:\\Trailers\\Ice Age: The Meltdown.avi')
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    makeLegalFilename(...);
-#else
-    String makeLegalFilename(const String& filename,bool fatX = true);
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmc
     /// @brief \python_func{ xbmc.translatePath(path)  }
     ///-----------------------------------------------------------------------
     /// Returns the translated path.

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -50,6 +50,13 @@ namespace XBMCAddon
       return XFILE::CFile::Exists(path, false);
     }
 
+    // make legal file name
+    String makeLegalFilename(const String& filename)
+    {
+      XBMC_TRACE;
+      return CUtil::MakeLegalPath(filename);
+    }
+
     // make a directory
     bool mkdir(const String& path)
     {

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -138,6 +138,43 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmcvfs
+    /// @brief \python_func{ xbmcvfs.makeLegalFilename(filename) }
+    ///-----------------------------------------------------------------------
+    /// Returns a legal filename or path as a string.
+    ///
+    /// @param filename              string - filename/path to make legal
+    /// @return              Legal filename or path as a string
+    ///
+    ///
+    /// @note The returned value is platform-specific. This is due to the fact that
+    /// the chars that need to be replaced to make a path legal depend on the
+    /// underlying OS filesystem. This is useful, for example, if you want to create
+    /// a file or folder based on data over which you have no control (e.g. an external API).
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v19 New function added (replaces old **xbmc.makeLegalFilename**)
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// # windows
+    /// >> xbmcvfs.makeLegalFilename('C://Trailers/Ice Age: The Meltdown.avi')
+    /// C:\Trailers\Ice Age_ The Meltdown.avi
+    /// # non-windows
+    /// >> xbmcvfs.makeLegalFilename("///\\jk???lj????.mpg")
+    /// /jk___lj____.mpg
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    makeLegalFilename(...);
+#else
+    String makeLegalFilename(const String& filename);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcvfs
     /// @brief \python_func{ xbmcvfs.mkdir(path) }
     ///-------------------------------------------------------------------------
     /// Create a folder.


### PR DESCRIPTION
## Description
I was not familiar with this method so decided to take a look at what it does to improve the documentation.
- The method was using an argument (`fatX`) that still dates back from the original xbox days (and that was ignored internally)
- The examples were not clear
- Almost no-one uses it (see affected addons below)
- The same method is exposed to binary addons in kodivfs

For consistency I think it makes more sense in xbmcvfs. It's a filesystem related (or at least helper) method anyway. Another good candidate is `xbmc.translatePath` (although that one is used by a lot of addons...)

This affects a total of 4 addons, none of which are yet in matrix:

```
(repo-scripts/helix) script.filecleaner/default.py:551:  dest_folder = xbmc.makeLegalFilename(dest_folder)
(repo-scripts/krypton) script.service.janitor/default.py:564: dest_folder = xbmc.makeLegalFilename(dest_folder)
(repo-scripts/leia) script.service.janitor/default.py:552:  dest_folder = unicode(xbmc.makeLegalFilename(dest_folder), encoding="utf-8")

(repo-plugins/helix) plugin.video.infowars/default.py:173:    xbmc.makeLegalFilename(filename)
(repo-plugins/helix) plugin.video.infowars/default.py:243:    final_path = xbmc.makeLegalFilename(final_path)
(repo-plugins/helix) plugin.video.infowars/default.py:268:    final_path = xbmc.makeLegalFilename(final_path)

(repo-plugins/jarvis) plugin.video.infowars/default.py:201:   xbmc.makeLegalFilename(filename)
(repo-plugins/jarvis) plugin.video.infowars/default.py:270:        final_path = xbmc.makeLegalFilename(final_path)
(repo-plugins/jarvis) plugin.video.infowars/default.py:293:        final_path = xbmc.makeLegalFilename(final_path)
(repo-plugins/jarvis) plugin.video.dailymotion_com/resources/lib/dailymotion.py:465:    vidfile = xbmc.makeLegalFilename(downloadDir + title + '.mp4')
(repo-plugins/jarvis) plugin.video.dailymotion_com/resources/lib/dailymotion.py:468:        tmp_file = xbmc.makeLegalFilename(tmp_file)
```

## Motivation and Context
Improve the python api and its docs now that a breaking change is happening.

## How Has This Been Tested?
Compile and tested in a sample addon. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
