### PR TITLE
[PVR] Use active channel name when 'Importing guide from clients'

### DIFF
--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -663,7 +663,8 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
       continue;
 
     if (bShowProgress && !bOnlyPending)
-      progressHandler->UpdateProgress(epg->Name(), ++iCounter, m_epgIdToEpgMap.size());
+      progressHandler->UpdateProgress(epg->GetChannelData()->ChannelName(), ++iCounter,
+                                      m_epgIdToEpgMap.size());
 
     if ((!bOnlyPending || epg->UpdatePending()) &&
         epg->Update(start,


### PR DESCRIPTION
## Description
This PR attempts to fix a minor annoyance with the "Importing Guide from Clients" banner notifications.

## Motivation and Context
The channel name used in the banner notifications will always be the name that was assigned to the channel when the EPG object was first created.  Both the PVR addon and the user can change the channel name, this change uses the 'active' channel name for the banner.

To overcome this limitation the user must execute a "Clear Data" on the EPG after any channel names have been changed.

If accepted, I would like the opportunity to back-port this to Leia branch as well.

## How Has This Been Tested?
Tested on Windows x64, master branch current as of 2020.04.23.  Confirmed updated behavior by deleting the EPG, TV databases and resetting the attached PVR state.  PVR originally sent 'downlevel' channel names which created the EPG objects.  PVR subsequently sent updated channel names after EPG data was retrieved from the backend.

Verified that the contents of the EPG database still contained the original 'downlevel' names as expected:

```
sqlite> select * from epg;
1|WETA World|client
2|MTV Classics|client
3|Turner Classic|client
4|FETV|client
5|Boomerang|client
```

Verified that the updated channel names are present in TV channels table:

```
sqlite> select * from channels;
1|...|WETADT4|0|1|client|...
2|...|MTVCLAS|0|1|client|...
3|...|TCM|0|1|client|...
4|...|FETV|0|1|client|...
5|...|BOOM|0|1|client|...
```

When Kodi was relaunched, the updated channel names from the TV channels table was used by the "Importing Guide from Clients" banner notifications.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
