### PR TITLE
[Python] Fix ControlTextBox actions before control is added to the window

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -129,17 +129,21 @@ namespace XBMCAddon
 
     void ControlTextBox::setText(const String& text)
     {
-      // create message
-      CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
-      msg.SetLabel(text);
+      if (pGUIControl)
+      {
+        // create message
+        CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
+        msg.SetLabel(text);
 
-      // send message
-      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
+        // send message
+        CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
+      }
     }
 
     String ControlTextBox::getText()
     {
-      if (!pGUIControl) return NULL;
+      if (!pGUIControl)
+        return nullptr;
 
       XBMCAddonUtils::GuiLock lock(languageHook, false);
       return static_cast<CGUITextBox*>(pGUIControl)->GetDescription();
@@ -147,19 +151,24 @@ namespace XBMCAddon
 
     void ControlTextBox::reset()
     {
-      // create message
-      CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
-      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
+      if (pGUIControl)
+      {
+        // create message
+        CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
+        CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
+      }
     }
 
     void ControlTextBox::scroll(long position)
     {
-      static_cast<CGUITextBox*>(pGUIControl)->Scroll((int)position);
+      if (pGUIControl)
+        static_cast<CGUITextBox*>(pGUIControl)->Scroll((int)position);
     }
 
     void ControlTextBox::autoScroll(int delay, int time, int repeat)
     {
-      static_cast<CGUITextBox*>(pGUIControl)->SetAutoScrolling(delay, time, repeat);
+      if (pGUIControl)
+        static_cast<CGUITextBox*>(pGUIControl)->SetAutoScrolling(delay, time, repeat);
     }
 
     CGUIControl* ControlTextBox::Create()

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -1842,6 +1842,21 @@ namespace XBMCAddon
     /// ...
     /// ~~~~~~~~~~~~~
     ///
+    /// As stated above, the GUI control is only created once added to a window. The example
+    /// below shows how a ControlTextBox can be created, added to the current window and
+    /// have some of its properties changed.
+    ///
+    /// /// **Extended example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// textbox = xbmcgui.ControlTextBox(100, 250, 300, 300, textColor='0xFFFFFFFF')
+    /// window = xbmcgui.Window(xbmcgui.getCurrentWindowId())
+    /// window.addControl(textbox)
+    /// textbox.setText("My Text Box")
+    /// textbox.scroll()
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
     class ControlTextBox : public Control
     {
     public:
@@ -1856,9 +1871,11 @@ namespace XBMCAddon
       /// @brief \python_func{ setText(text) }
       ///-----------------------------------------------------------------------
       /// Set's the text for this textbox.
+      /// \anchor python_xbmcgui_control_textbox_settext
       ///
-      /// @param text                 string or unicode - text string.
+      /// @param text                 string  - text string.
       ///
+      /// @note setText only has effect after the control is added to a window
       ///
       ///--------------------------------------------------------------------------
       ///
@@ -1885,6 +1902,9 @@ namespace XBMCAddon
       ///
       /// @return                       To get text from box
       ///
+      /// @note getText only works after you add the control to a window
+      /// and set the control text (using \ref python_xbmcgui_control_textbox_settext
+      /// "setText").
       ///
       ///-----------------------------------------------------------------------
       ///
@@ -1909,6 +1929,7 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// Clear's this textbox.
       ///
+      /// @note reset only works after you add the control to a window.
       ///
       ///-----------------------------------------------------------------------
       ///
@@ -1935,6 +1956,7 @@ namespace XBMCAddon
       ///
       /// @param id                 integer - position to scroll to.
       ///
+      /// @note scroll() only works after the control is added to a window.
       ///
       ///-----------------------------------------------------------------------
       ///
@@ -1963,6 +1985,7 @@ namespace XBMCAddon
       /// @param time                  integer - Scroll time (in ms)
       /// @param repeat                integer - Repeat time
       ///
+      /// @note autoScroll only works after you add the control to a window.
       ///
       ///-----------------------------------------------------------------------
       /// @python_v15 New function added.

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -704,7 +704,7 @@ namespace XBMCAddon
       if(pControl->iControlId != 0)
         throw WindowException("Control is already used");
 
-      // lock xbmc GUI before accessing data from it
+      // lock kodi GUI before accessing data from it
       pControl->iParentId = iWindowId;
 
       {


### PR DESCRIPTION
## Description
Kodi shows some odd behaviour when `ControlTextBox` and its properties are changed (like using `setText()`) before being added to the window. This happens because the GUIControl is only created when the control object is effectively added to the window (see: https://github.com/xbmc/xbmc/blob/master/xbmc/interfaces/legacy/Window.cpp#L717) (as stated briefly in the docs for the `ControlTextBox` initializer). However, if an addon uses `setText` before adding to the window, a `GUIMessage` is sent to windowmanager anyway and will result in Kodi rewriting the infolabel values of the controls associated with the current window (see pics below). 

Also some of the other methods like `scroll()`, `autoscroll()`, etc were also not validating the `pGUIControl`  pointer although using it in a static_cast, which could result in a nullptr dereference (kodi crash).

Also improved the docs a bit.

## Reproduce and test
Use the snippet below:

```python
import xbmcgui, xbmc
windowID = xbmcgui.getCurrentWindowId()
window = xbmcgui.Window(windowID)
textbox = xbmcgui.ControlTextBox(900,600,200,200)
textbox.setText("MY STRING A")
window.addControl(textbox)
xbmc.sleep(3000)
textbox.setText("MY STRING B")
xbmc.sleep(3000)
window.removeControl(textbox)
```

The only control that should show is "MY STRING B" since it was defined after the control was added to the window. For "MY STRING A" to be shown, it should be moved below the `addControl` call.

## How Has This Been Tested?
Compile and manual testing. See snippet above.

## Screenshots (if appropriate):
**Master:**
Note how the infolabels (like the current hour) are filled with "My String A"
![pr](https://i.imgur.com/o1vulu8.png "master")

**PR:**
Only shows "My String B"
![pr](https://i.imgur.com/VJzHXb4.png "pr")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
