### PR TITLE
[Subtitles] fix smi subtitles to use quoted start tags

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
@@ -35,7 +35,7 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo &hints)
   char line[1024];
 
   CRegExp reg(true);
-  if (!reg.RegComp("<SYNC START=([0-9]+)>"))
+  if (!reg.RegComp("<SYNC START=\"?([0-9]+)\"?>"))
     return false;
 
   std::string strFileName;


### PR DESCRIPTION
## Description
kodi would not pick up subtitles if tags are quoted in smi-file.

## Motivation and Context
closes #17418

## How Has This Been Tested?
i've tested this change with both smi-files provided by the reporting user
`<SYNC Start=1398403><P Class=KOKRCC></P></SYNC>` ... was working before
`<SYNC Start="1398403"><P Class="KOKRCC"></P></SYNC>` ... now also working

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
