### PR TITLE
[python] Move xbmc.validatePath to xbmcvfs.validatePath

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -218,6 +218,11 @@ web applications or frameworks for the Python programming language.
       "",
       <b>xbmc.makeLegalFilename()</b> function was moved to the xbmcvfs module.
 }
+\python_removed_function{
+      validatePath,
+      "",
+      <b>xbmc.validatePath()</b> function was moved to the xbmcvfs module.
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -396,12 +396,6 @@ namespace XBMCAddon
       return Tuple<String,String>(strTitle,strYear);
     }
 
-    String validatePath(const String& path)
-    {
-      XBMC_TRACE;
-      return CUtil::ValidatePath(path, true);
-    }
-
     String getRegion(const char* id)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -693,34 +693,6 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmc
-    /// @brief \python_func{ xbmc.validatePath(path) }
-    ///-----------------------------------------------------------------------
-    /// Returns the validated path.
-    ///
-    /// @param path                  string or unicode - Path to format
-    /// @return                      Validated path
-    ///
-    /// @note Only useful if you are coding for both Linux and Windows for fixing slash problems.
-    ///       e.g. Corrects 'Z://something' -> 'Z:\something'
-    ///
-    ///
-    /// ------------------------------------------------------------------------
-    ///
-    /// **Example:**
-    /// ~~~~~~~~~~~~~{.py}
-    /// ..
-    /// fpath = xbmc.validatePath(somepath)
-    /// ..
-    /// ~~~~~~~~~~~~~
-    ///
-    validatePath(...);
-#else
-    String validatePath(const String& path);
-#endif
-
-#ifdef DOXYGEN_SHOULD_USE_THIS
-    ///
-    /// \ingroup python_xbmc
     /// @brief \python_func{ xbmc.getRegion(id) }
     ///-----------------------------------------------------------------------
     /// Returns your regions setting as a string for the specified id.

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -57,6 +57,13 @@ namespace XBMCAddon
       return CUtil::MakeLegalPath(filename);
     }
 
+    // validate path
+    String validatePath(const String& path)
+    {
+      XBMC_TRACE;
+      return CUtil::ValidatePath(path, true);
+    }
+
     // make a directory
     bool mkdir(const String& path)
     {

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -175,6 +175,36 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmcvfs
+    /// @brief \python_func{ xbmcvfs.validatePath(path) }
+    ///-----------------------------------------------------------------------
+    /// Returns the validated path.
+    ///
+    /// @param path                  string  - Path to format
+    /// @return            Validated path
+    ///
+    /// @note The result is platform-specific. Only useful if you are coding
+    ///       for multiple platfforms for fixing slash problems
+    ///         (e.g. Corrects 'Z://something' -> 'Z:\something').
+    ///
+    ///
+    /// ------------------------------------------------------------------------
+    /// @python_v19 New function added (replaces old **xbmc.validatePath**)
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// fpath = xbmcvfs.validatePath(somepath)
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    validatePath(...);
+#else
+    String validatePath(const String& path);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcvfs
     /// @brief \python_func{ xbmcvfs.mkdir(path) }
     ///-------------------------------------------------------------------------
     /// Create a folder.


### PR DESCRIPTION
## Description
Similar to https://github.com/xbmc/xbmc/pull/17735, this moves `xbmc.validatePath` to `xbmcvfs.validatePath` as it is another filesystem helper method.

A total of 4 addons are affected, none of which are already in matrix:
- plugin.video.reddit_viewer
- script.reddit.reader
- screensaver.instagram
- script.screensaver.multi_slideshow

Usages:
```
(repo-plugins/jarvis) plugin.video.reddit_viewer/resources/lib/actions.py:171:        loading_img = xbmc.validatePath('/'.join((addon_path, 'resources', 'skins', 'Default', 'media', 'srr_busy.gif' )))
(repo-plugins/jarvis) plugin.video.reddit_viewer/resources/lib/slideshow.py:249:        loading_img = xbmc.validatePath('/'.join((ADDON_PATH, 'resources', 'skins', 'Default', 'media', 'srr_busy.gif' )))
(repo-plugins/jarvis) plugin.video.reddit_viewer/resources/lib/slideshow.py:353:        bg_img = xbmc.validatePath('/'.join(( ADDON_PATH, 'resources', 'skins', 'Default', 'media', self.BACKGROUND_IMAGE )))


(repo-scripts/leia) screensaver.fTVscreensaver/screensaver.py:113: xbmc.validatePath('/'.join((path, directory, '')))

(repo-scripts/krypton) script.reddit.reader/resources/lib/actions.py:193:            loading_img = xbmc.validatePath('/'.join((addon_path, 'resources', 'skins', 'Default', 'media', 'srr_busy.gif' )))
(repo-scripts/krypton) script.reddit.reader/resources/lib/actions.py:224:        loading_img = xbmc.validatePath('/'.join((addon_path, 'resources', 'skins', 'Default', 'media', 'srr_busy.gif' )))
(repo-scripts/krypton) script.reddit.reader/resources/lib/slideshow.py:249:        loading_img = xbmc.validatePath('/'.join((ADDON_PATH, 'resources', 'skins', 'Default', 'media', 'srr_busy.gif' )))
(repo-scripts/krypton) script.reddit.reader/resources/lib/slideshow.py:353:        bg_img = xbmc.validatePath('/'.join(( ADDON_PATH, 'resources', 'skins', 'Default', 'media', self.BACKGROUND_IMAGE )))
(repo-scripts/krypton) screensaver.instagram/screensaver.py:95:        loading_img = xbmc.validatePath('/'.join((ADDON_PATH, 'resources', 'media', 'loading.gif')))
(repo-scripts/krypton) screensaver.instagram/screensaver.py:96:        logo_img = xbmc.validatePath('/'.join((ADDON_PATH, 'resources', 'media', 'logo.png')))
(repo-scripts/krypton) screensaver.instagram/screensaver.py:178:        bg_img = xbmc.validatePath('/'.join((ADDON_PATH, 'resources', 'media', self.background_image)))

(repo-scripts/gotham) script.screensaver.multi_slideshow/screensaver.py:119:        loading_img = xbmc.validatePath('/'.join((
(repo-scripts/gotham) script.screensaver.multi_slideshow/screensaver.py:229:                        xbmc.validatePath('/'.join((path, directory, '')))
(repo-scripts/gotham) script.screensaver.multi_slideshow/screensaver.py:236:        bg_img = xbmc.validatePath('/'.join((
```

## Motivation and Context
Cleaner API, take advantage of the current breaking change.

## How Has This Been Tested?
Manually tested with a sample script

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
