### PR TITLE
Log button name in event client

### DIFF
--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -370,7 +370,11 @@ bool CEventClient::OnPacketBUTTON(CEventPacket *packet)
   float famount = 0;
   bool active = (flags & PTB_DOWN) ? true : false;
   
-  CLog::Log(LOGDEBUG, "EventClient: button code %d %s", bcode, active ? "pressed" : "released");
+  if (flags & PTB_USE_NAME)
+    CLog::Log(LOGDEBUG, "EventClient: button name \"%s\" map \"%s\" %s",
+              button.c_str(), map.c_str(), active ? "pressed" : "released");
+  else
+    CLog::Log(LOGDEBUG, "EventClient: button code %d %s", bcode, active ? "pressed" : "released");
 
   if(flags & PTB_USE_AMOUNT)
   {


### PR DESCRIPTION
## Description

Log button's name in addition to the button's code in Event Client logging

## Motivation and Context

I was troubleshooting an iOS remote which uses event client.
It had a non-working "Select" action.
I have enabled debug logging. This was done in the hope that I can do the right mapping via .xml files.

However, whichever buttons were pressed in the app, the log always gave out (for any button):

    DEBUG: EventClient: button code 46255 pressed

(same code 46255 for any button) 

If the button names were logged, it would be much more helpful, obviously.

E.g. the actual issue I was dealing with, was later identified as #15772

## How Has This Been Tested?

Built an RPM with it in CentOS 8, logging changed from the above to:

    DEBUG: EventClient: button enter code 46255 pressed

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->

- [x] **Improvement** (non-breaking change which improves existing functionality)


## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
