### PR TITLE
[skin.estouchy] Fix watching icons are not shown when content type is not set

### DIFF
--- a/addons/skin.estouchy/xml/ViewsList.xml
+++ b/addons/skin.estouchy/xml/ViewsList.xml
@@ -113,7 +113,7 @@
 					<width>60</width>
 					<height>40</height>
 					<texture>flagging/source/Set.png</texture>
-					<visible>[Container.Content(Movies) | Container.Content(Sets)] + ListItem.IsCollection</visible>
+					<visible>ListItem.IsCollection</visible>
 				</control>
 				<control type="image">
 					<posx>48r</posx>
@@ -122,7 +122,7 @@
 					<height>26</height>
 					<aspectratio>keep</aspectratio>
 					<texture>OverlayWatching.png</texture>
-					<visible>[Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos)] + ListItem.IsResumable</visible>
+					<visible>ListItem.IsResumable</visible>
 				</control>
 				<control type="image">
 					<posx>50r</posx>
@@ -130,7 +130,7 @@
 					<width>30</width>
 					<height>30</height>
 					<texture>$INFO[ListItem.Overlay]</texture>
-					<visible>[Container.Content(Movies) | Container.Content(TVShows) | Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos)] + !ListItem.IsResumable</visible>
+					<visible>!ListItem.IsResumable</visible>
 				</control>
 				<control type="label">
 					<posx>$PARAM[label2-posx]</posx>
@@ -255,7 +255,7 @@
 					<width>60</width>
 					<height>40</height>
 					<texture>flagging/source/Set.png</texture>
-					<visible>[Container.Content(Movies) | Container.Content(Sets)] + ListItem.IsCollection</visible>
+					<visible>ListItem.IsCollection</visible>
 				</control>
 				<control type="image">
 					<posx>48r</posx>
@@ -264,7 +264,7 @@
 					<height>26</height>
 					<aspectratio>keep</aspectratio>
 					<texture>OverlayWatching.png</texture>
-					<visible>[Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos)] + ListItem.IsResumable</visible>
+					<visible>ListItem.IsResumable</visible>
 				</control>
 				<control type="image">
 					<posx>50r</posx>
@@ -272,7 +272,7 @@
 					<width>30</width>
 					<height>30</height>
 					<texture>$INFO[ListItem.Overlay]</texture>
-					<visible>[Container.Content(Movies) | Container.Content(TVShows) | Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos)] + !ListItem.IsResumable</visible>
+					<visible>!ListItem.IsResumable</visible>
 				</control>
 				<control type="label">
 					<posx>$PARAM[label2-posx]</posx>

--- a/addons/skin.estouchy/xml/ViewsThumbnail.xml
+++ b/addons/skin.estouchy/xml/ViewsThumbnail.xml
@@ -72,6 +72,22 @@
 					<texture>OverlayWatched.png</texture>
 					<visible>Window.IsVisible(AddonBrowser) + String.IsEqual(ListItem.Label2,$LOCALIZE[305])</visible>
 				</control>
+				<control type="image">
+					<posx>182</posx>
+					<posy>4</posy>
+					<width>26</width>
+					<height>26</height>
+					<aspectratio>keep</aspectratio>
+					<texture>OverlayWatching.png</texture>
+					<visible>ListItem.IsResumable</visible>
+				</control>
+				<control type="image">
+					<posx>180</posx>
+					<posy>2</posy>
+					<width>30</width>
+					<height>30</height>
+					<texture>$INFO[ListItem.Overlay]</texture>
+				</control>
 			</itemlayout>
 			<focusedlayout condition="!Container.Content(Movies) + !Container.Content(Seasons) + !Container.Content(Episodes) + !Container.Content(TVShows) + !Container.Content(MusicVideos) + !Container.Content(Videos)" height="250" width="218">
 				<control type="image">
@@ -128,6 +144,23 @@
 					<texture>OverlayWatched.png</texture>
 					<visible>Window.IsVisible(AddonBrowser) + String.IsEqual(ListItem.Label2,$LOCALIZE[305])</visible>
 				</control>
+				<control type="image">
+					<posx>182</posx>
+					<posy>4</posy>
+					<width>26</width>
+					<height>26</height>
+					<aspectratio>keep</aspectratio>
+					<texture>OverlayWatching.png</texture>
+					<visible>ListItem.IsResumable</visible>
+				</control>
+				<control type="image">
+					<posx>180</posx>
+					<posy>2</posy>
+					<width>30</width>
+					<height>30</height>
+					<texture>$INFO[ListItem.Overlay]</texture>
+					<visible>!ListItem.IsResumable</visible>
+				</control>
 			</focusedlayout>
 			<itemlayout condition="Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows)" height="375" width="218">
 				<control type="image">
@@ -181,11 +214,21 @@
 					<visible>ListItem.IsCollection</visible>
 				</control>
 				<control type="image">
+					<posx>172</posx>
+					<posy>262</posy>
+					<width>26</width>
+					<height>26</height>
+					<aspectratio>keep</aspectratio>
+					<texture>OverlayWatching.png</texture>
+					<visible>ListItem.IsResumable</visible>
+				</control>
+				<control type="image">
 					<posx>170</posx>
 					<posy>260</posy>
 					<width>30</width>
 					<height>30</height>
 					<texture>$INFO[ListItem.Overlay]</texture>
+					<visible>!ListItem.IsResumable</visible>
 				</control>
 			</itemlayout>
 			<focusedlayout condition="Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows)" height="375" width="218">
@@ -240,11 +283,21 @@
 					<visible>ListItem.IsCollection</visible>
 				</control>
 				<control type="image">
+					<posx>172</posx>
+					<posy>262</posy>
+					<width>26</width>
+					<height>26</height>
+					<aspectratio>keep</aspectratio>
+					<texture>OverlayWatching.png</texture>
+					<visible>ListItem.IsResumable</visible>
+				</control>
+				<control type="image">
 					<posx>170</posx>
 					<posy>260</posy>
 					<width>30</width>
 					<height>30</height>
 					<texture>$INFO[ListItem.Overlay]</texture>
+					<visible>!ListItem.IsResumable</visible>
 				</control>
 			</focusedlayout>
 			<itemlayout condition="Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos)" height="250" width="$PARAM[layout-width]">
@@ -291,11 +344,21 @@
 					<texture>$INFO[ListItem.VideoResolution,flagging/resolution/,.png]</texture>
 				</control>
 				<control type="image">
+					<posx>265</posx>
+					<posy>147</posy>
+					<width>26</width>
+					<height>26</height>
+					<aspectratio>keep</aspectratio>
+					<texture>OverlayWatching.png</texture>
+					<visible>ListItem.IsResumable</visible>
+				</control>
+				<control type="image">
 					<posx>263</posx>
 					<posy>145</posy>
 					<width>30</width>
 					<height>30</height>
 					<texture>$INFO[ListItem.Overlay]</texture>
+					<visible>!ListItem.IsResumable</visible>
 				</control>
 			</itemlayout>
 			<focusedlayout condition="Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos)" height="250" width="$PARAM[layout-width]">
@@ -342,11 +405,21 @@
 					<texture>$INFO[ListItem.VideoResolution,flagging/resolution/,.png]</texture>
 				</control>
 				<control type="image">
+					<posx>265</posx>
+					<posy>147</posy>
+					<width>26</width>
+					<height>26</height>
+					<aspectratio>keep</aspectratio>
+					<texture>OverlayWatching.png</texture>
+					<visible>ListItem.IsResumable</visible>
+				</control>
+				<control type="image">
 					<posx>263</posx>
 					<posy>145</posy>
 					<width>30</width>
 					<height>30</height>
 					<texture>$INFO[ListItem.Overlay]</texture>
+					<visible>!ListItem.IsResumable</visible>
 				</control>
 			</focusedlayout>
 		</control>


### PR DESCRIPTION
## Description
Fixes #17752 (missing watching/watched icons when content type is set to None in skin Estouchy)
Also watching icon was missed in Thumbnails view even if content was specified

## Screenshots after fix:
Fix for missing icons for content None. List view:
![NoContentList](https://user-images.githubusercontent.com/22025304/80302516-2e114180-87b3-11ea-8a5a-07f10b7e756d.png)

Thumbnails view:
![NoContentThumbnails](https://user-images.githubusercontent.com/22025304/80302520-310c3200-87b3-11ea-891b-14f549938d0c.png)

Fix missing watching icon for Thumbnail view with Movies content:
![MoviesWatchingIcon](https://user-images.githubusercontent.com/22025304/80302510-29e52400-87b3-11ea-88b9-90e9545a6bba.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] All new and existing tests passed
