### PR TITLE
[addons] Fix duplicated queue and VFS types

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
@@ -17,6 +17,8 @@
 #include <stdarg.h>
 #include <time.h>
 
+#include "Filesystem.h"
+#include "General.h"
 #include "versions.h"
 #if defined(BUILD_KODI_ADDON)
 #include "IFileTypes.h"
@@ -66,24 +68,6 @@ typedef struct AddonCB
   KODIPVRLib_UnRegisterMe           PVRLib_UnRegisterMe;
 } AddonCB;
 
-struct VFSProperty
-{
-  char* name;
-  char* val;
-};
-
-struct VFSDirEntry
-{
-  char* label;             //!< item label
-  char* title;             //!< item title
-  char* path;              //!< item path
-  unsigned int num_props;  //!< Number of properties attached to item
-  VFSProperty* properties; //!< Properties
-  time_t date_time;        //!< file creation date & time
-  bool folder;             //!< Item is a folder
-  uint64_t size;           //!< Size of file represented by item
-};
-
 typedef enum addon_log
 {
   LOG_DEBUG,
@@ -92,13 +76,6 @@ typedef enum addon_log
   LOG_ERROR,
   LOG_FATAL
 } addon_log_t;
-
-typedef enum queue_msg
-{
-  QUEUE_INFO,
-  QUEUE_WARNING,
-  QUEUE_ERROR
-} queue_msg_t;
 
 namespace KodiAPI
 {
@@ -224,7 +201,7 @@ namespace ADDON
      * @param type The message type.
      * @param format The format of the message to pass to display in XBMC.
      */
-    void QueueNotification(const queue_msg_t type, const char *format, ... )
+    void QueueNotification(const QueueMsg type, const char *format, ... )
     {
       char buffer[16384];
       va_list args;


### PR DESCRIPTION
## Description

Fixes Debian packaging's header-check failure:

```
rm -f debian/kodi-addons-dev/usr/include/kodi/xbmcclient.h
g++ -c debian/headers-check.c -DBUILD_KODI_ADDON \
    -Wdate-time -D_FORTIFY_SOURCE=2 -D_XBMC -g \
    -fdebug-prefix-map=/buildroot/sources/kodi/debian-source-package=. \
    -fstack-protector-strong -Wformat -Werror=format-security -O3 \
    -Idebian/kodi-addons-dev/usr/include \
    -o /dev/null
In file included
    from debian/kodi-addons-dev/usr/include/kodi/libKODI_guilib.h:16,
    from debian/headers-check.c:40:
debian/kodi-addons-dev/usr/include/kodi/libXBMC_addon.h:81:3:
    error: 'QUEUE_INFO' conflicts with a previous declaration
   QUEUE_INFO,
   ^~~~~~~~~~
In file included from debian/headers-check.c:13:
debian/kodi-addons-dev/usr/include/kodi/General.h:73:3:
   note: previous declaration 'QueueMsg QUEUE_INFO'
   QUEUE_INFO,
   ^~~~~~~~~~
In file included
    from debian/kodi-addons-dev/usr/include/kodi/libKODI_guilib.h:16,
    from debian/headers-check.c:40:
debian/kodi-addons-dev/usr/include/kodi/libXBMC_addon.h:82:3:
    error: 'QUEUE_WARNING' conflicts with a previous declaration
   QUEUE_WARNING,
   ^~~~~~~~~~~~~
In file included from debian/headers-check.c:13:
debian/kodi-addons-dev/usr/include/kodi/General.h:75:3:
    note: previous declaration 'QueueMsg QUEUE_WARNING'
   QUEUE_WARNING,
   ^~~~~~~~~~~~~
In file included
    from debian/kodi-addons-dev/usr/include/kodi/libKODI_guilib.h:16,
    from debian/headers-check.c:40:
debian/kodi-addons-dev/usr/include/kodi/libXBMC_addon.h:83:3:
    error: 'QUEUE_ERROR' conflicts with a previous declaration
   QUEUE_ERROR
   ^~~~~~~~~~~
```
introduced [here](https://github.com/xbmc/xbmc/commit/b194adf57b26e4a06b5b77660141ccf61fbfb3b1) and [here](https://github.com/xbmc/xbmc/commit/aed73d12c66cbcefe93507bd628cecc972ad1b3c)

## Motivation and Context

This was caught by Debian packaging's [headers-check pass](https://salsa.debian.org/basilgello-guest/kodi/-/blob/master/debian/headers-check.c). This check ensures all required header files are in place, but its side-effect is that it catches type re-declarations just like in this case.

## How Has This Been Tested?

1. Clone https://salsa.debian.org/basilgello-guest/kodi without this fix
2. Try making binary package 

``` shell
DEB_BUILD_OPTIONS=nocheck \
     dpkg-buildpackage -b -j$(getconf _NPROCESSORS_ONLN)
```
3. Experience build errors
4. Apply the fix and rebuild
5. Enjoy!

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
