### PR TITLE
[addons][pvr] cleanups to match more coming C++ interface style and fix duplicated queue and VFS types 

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
@@ -17,6 +17,8 @@
 #include <stdarg.h>
 #include <time.h>
 
+#include "Filesystem.h"
+#include "General.h"
 #include "versions.h"
 #if defined(BUILD_KODI_ADDON)
 #include "IFileTypes.h"
@@ -66,24 +68,6 @@ typedef struct AddonCB
   KODIPVRLib_UnRegisterMe           PVRLib_UnRegisterMe;
 } AddonCB;
 
-struct VFSProperty
-{
-  char* name;
-  char* val;
-};
-
-struct VFSDirEntry
-{
-  char* label;             //!< item label
-  char* title;             //!< item title
-  char* path;              //!< item path
-  unsigned int num_props;  //!< Number of properties attached to item
-  VFSProperty* properties; //!< Properties
-  time_t date_time;        //!< file creation date & time
-  bool folder;             //!< Item is a folder
-  uint64_t size;           //!< Size of file represented by item
-};
-
 typedef enum addon_log
 {
   LOG_DEBUG,
@@ -92,13 +76,6 @@ typedef enum addon_log
   LOG_ERROR,
   LOG_FATAL
 } addon_log_t;
-
-typedef enum queue_msg
-{
-  QUEUE_INFO,
-  QUEUE_WARNING,
-  QUEUE_ERROR
-} queue_msg_t;
 
 namespace KodiAPI
 {
@@ -224,7 +201,7 @@ namespace ADDON
      * @param type The message type.
      * @param format The format of the message to pass to display in XBMC.
      */
-    void QueueNotification(const queue_msg_t type, const char *format, ... )
+    void QueueNotification(const QueueMsg& type, const char* format, ... )
     {
       char buffer[16384];
       va_list args;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -96,8 +96,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "6.4.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "6.4.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "6.5.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "6.5.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \
                                                       "xbmc_pvr_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -672,7 +672,7 @@ extern "C"
   /*!
    * Tell the client the time frame to use when notifying epg events back to Kodi. The client might push epg events asynchronously
    * to Kodi using the callback function EpgEventStateChange. To be able to only push events that are actually of interest for Kodi,
-   * client needs to know about the epg time frame Kodi uses. Kodi supplies the current epg time frame value in PVR_PROPERTIES.iEpgMaxDays
+   * client needs to know about the epg time frame Kodi uses. Kodi supplies the current epg time frame value in AddonProperties_PVR.iEpgMaxDays
    * when creating the addon and calls SetEPGTimeFrame later whenever Kodi's epg time frame value changes.
    * @param iDays number of days from "now". EPG_TIMEFRAME_UNLIMITED means that Kodi is interested in all epg events, regardless of event times.
    * @return PVR_ERROR_NO_ERROR if new value was successfully set.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -464,21 +464,23 @@ extern "C"
 
   /*!
    * Get the signal status of the stream that's currently open.
+   * @param channelUid Channel unique identifier
    * @param signalStatus The signal status.
    * @return PVR_ERROR_NO_ERROR if the signal status has been read successfully, false otherwise.
    * @remarks Optional, and only used if PVR_ADDON_CAPABILITIES::bHandlesInputStream or PVR_ADDON_CAPABILITIES::bHandlesDemuxing is set to true.
    *          Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS& signalStatus);
+  PVR_ERROR SignalStatus(int channelUid, PVR_SIGNAL_STATUS* signalStatus);
 
   /*!
    * Get the descramble information of the stream that's currently open.
+   * @param channelUid Channel unique identifier
    * @param [out] descrambleInfo The descramble information.
    * @return PVR_ERROR_NO_ERROR if the descramble information has been read successfully, false otherwise.
    * @remarks Optional, and only used if PVR_ADDON_CAPABILITIES::bSupportsDescrambleInfo is set to true.
    *          Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO* descrambleInfo);
+  PVR_ERROR GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO* descrambleInfo);
 
   /*!
    * Get the stream properties for a channel from the backend.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -30,7 +30,7 @@ extern "C"
    * @return PVR_ERROR_NO_ERROR if the properties were fetched successfully.
    * @remarks Valid implementation required.
    */
-  PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities);
+  PVR_ERROR GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities);
 
   /*!
    * @return The name reported by the backend that will be displayed in the UI.
@@ -705,7 +705,7 @@ extern "C"
 
     pClient->toAddon->addonInstance = nullptr; // used in future
 
-    pClient->toAddon->GetAddonCapabilities = GetAddonCapabilities;
+    pClient->toAddon->GetCapabilities = GetCapabilities;
     pClient->toAddon->GetStreamProperties = GetStreamProperties;
     pClient->toAddon->GetConnectionString = GetConnectionString;
     pClient->toAddon->GetBackendName = GetBackendName;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -470,7 +470,7 @@ extern "C"
    * @remarks Optional, and only used if PVR_ADDON_CAPABILITIES::bHandlesInputStream or PVR_ADDON_CAPABILITIES::bHandlesDemuxing is set to true.
    *          Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR SignalStatus(int channelUid, PVR_SIGNAL_STATUS* signalStatus);
+  PVR_ERROR GetSignalStatus(int channelUid, PVR_SIGNAL_STATUS* signalStatus);
 
   /*!
    * Get the descramble information of the stream that's currently open.
@@ -758,7 +758,7 @@ extern "C"
     pClient->toAddon->ReadLiveStream = ReadLiveStream;
     pClient->toAddon->SeekLiveStream = SeekLiveStream;
     pClient->toAddon->LengthLiveStream = LengthLiveStream;
-    pClient->toAddon->SignalStatus = SignalStatus;
+    pClient->toAddon->GetSignalStatus = GetSignalStatus;
     pClient->toAddon->GetDescrambleInfo = GetDescrambleInfo;
     pClient->toAddon->GetChannelStreamProperties = GetChannelStreamProperties;
     pClient->toAddon->GetRecordingStreamProperties = GetRecordingStreamProperties;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -815,12 +815,13 @@ extern "C" {
 
     //--==----==----==----==----==----==----==----==----==----==----==----==----==
     // Channel interface functions
+
     int(__cdecl* GetChannelsAmount)(void);
     PVR_ERROR(__cdecl* GetChannels)(ADDON_HANDLE, bool);
     PVR_ERROR(__cdecl* GetChannelStreamProperties)(const PVR_CHANNEL*,
                                                    PVR_NAMED_VALUE*,
                                                    unsigned int*);
-    PVR_ERROR(__cdecl* SignalStatus)(int, PVR_SIGNAL_STATUS*);
+    PVR_ERROR(__cdecl* GetSignalStatus)(int, PVR_SIGNAL_STATUS*);
     PVR_ERROR(__cdecl* GetDescrambleInfo)(int, PVR_DESCRAMBLE_INFO*);
 
     //--==----==----==----==----==----==----==----==----==----==----==----==----==

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -805,7 +805,7 @@ extern "C" {
 
     //--==----==----==----==----==----==----==----==----==----==----==----==----==
     // General interface functions
-    PVR_ERROR(__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
+    PVR_ERROR(__cdecl* GetCapabilities)(PVR_ADDON_CAPABILITIES*);
     const char*(__cdecl* GetBackendName)(void);
     const char*(__cdecl* GetBackendVersion)(void);
     const char*(__cdecl* GetBackendHostname)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -393,12 +393,12 @@ extern "C" {
   /*!
    * @brief Properties passed to the Create() method of an add-on.
    */
-  typedef struct PVR_PROPERTIES
+  typedef struct AddonProperties_PVR
   {
     const char* strUserPath;           /*!< @brief path to the user profile */
     const char* strClientPath;         /*!< @brief path to this add-on */
     int iEpgMaxDays;                   /*!< @brief if > EPG_TIMEFRAME_UNLIMITED, in async epg mode, deliver only events in the range from 'end time > now' to 'start time < now + iEpgMaxDays. EPG_TIMEFRAME_UNLIMITED, notify all events. */
-  } PVR_PROPERTIES;
+  } AddonProperties_PVR;
 
   /*!
    * @brief Representation of a general attribute integer value.
@@ -853,9 +853,9 @@ extern "C" {
 
   typedef struct AddonInstance_PVR
   {
-    PVR_PROPERTIES* props;
-    AddonToKodiFuncTable_PVR* toKodi;
-    KodiToAddonFuncTable_PVR* toAddon;
+    struct AddonProperties_PVR* props;
+    struct AddonToKodiFuncTable_PVR* toKodi;
+    struct KodiToAddonFuncTable_PVR* toAddon;
   } AddonInstance_PVR;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -820,8 +820,8 @@ extern "C" {
     PVR_ERROR(__cdecl* GetChannelStreamProperties)(const PVR_CHANNEL*,
                                                    PVR_NAMED_VALUE*,
                                                    unsigned int*);
-    PVR_ERROR(__cdecl* SignalStatus)(PVR_SIGNAL_STATUS&);
-    PVR_ERROR(__cdecl* GetDescrambleInfo)(PVR_DESCRAMBLE_INFO*);
+    PVR_ERROR(__cdecl* SignalStatus)(int, PVR_SIGNAL_STATUS*);
+    PVR_ERROR(__cdecl* GetDescrambleInfo)(int, PVR_DESCRAMBLE_INFO*);
 
     //--==----==----==----==----==----==----==----==----==----==----==----==----==
     // Channel group interface functions

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -742,30 +742,57 @@ extern "C" {
 
   typedef struct AddonToKodiFuncTable_PVR
   {
+    // Pointer inside Kodi where used from him to find his class
     KODI_HANDLE kodiInstance;
 
-    void (*TransferEpgEntry)(void* kodiInstance, const ADDON_HANDLE handle, const EPG_TAG *epgentry);
-    void (*TransferChannelEntry)(void* kodiInstance, const ADDON_HANDLE handle, const PVR_CHANNEL *chan);
-    void (*TransferTimerEntry)(void* kodiInstance, const ADDON_HANDLE handle, const PVR_TIMER *timer);
-    void (*TransferRecordingEntry)(void* kodiInstance, const ADDON_HANDLE handle, const PVR_RECORDING *recording);
-    void (*AddMenuHook)(void* kodiInstance, PVR_MENUHOOK *hook);
-    void (*Recording)(void* kodiInstance, const char *Name, const char *FileName, bool On);
-    void (*TriggerChannelUpdate)(void* kodiInstance);
-    void (*TriggerTimerUpdate)(void* kodiInstance);
-    void (*TriggerRecordingUpdate)(void* kodiInstance);
-    void (*TriggerChannelGroupsUpdate)(void* kodiInstance);
-    void (*TriggerEpgUpdate)(void* kodiInstance, unsigned int iChannelUid);
-
-    void (*TransferChannelGroup)(void* kodiInstance, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group);
-    void (*TransferChannelGroupMember)(void* kodiInstance, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member);
-
-    void (*FreeDemuxPacket)(void* kodiInstance, DemuxPacket* pPacket);
-    DemuxPacket* (*AllocateDemuxPacket)(void* kodiInstance, int iDataSize);
-
-    void (*ConnectionStateChange)(void* kodiInstance, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage);
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // General callback functions
+    void (*AddMenuHook)(void* kodiInstance, PVR_MENUHOOK* hook);
+    void (*Recording)(void* kodiInstance, const char* Name, const char* FileName, bool On);
+    void (*ConnectionStateChange)(void* kodiInstance,
+                                  const char* strConnectionString,
+                                  PVR_CONNECTION_STATE newState,
+                                  const char* strMessage);
     void (*EpgEventStateChange)(void* kodiInstance, EPG_TAG* tag, EPG_EVENT_STATE newState);
 
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Transfer functions where give data back to Kodi, e.g. GetChannels calls TransferChannelEntry
+    void (*TransferChannelEntry)(void* kodiInstance,
+                                 const ADDON_HANDLE handle,
+                                 const PVR_CHANNEL* chan);
+    void (*TransferChannelGroup)(void* kodiInstance,
+                                 const ADDON_HANDLE handle,
+                                 const PVR_CHANNEL_GROUP* group);
+    void (*TransferChannelGroupMember)(void* kodiInstance,
+                                       const ADDON_HANDLE handle,
+                                       const PVR_CHANNEL_GROUP_MEMBER* member);
+    void (*TransferEpgEntry)(void* kodiInstance,
+                             const ADDON_HANDLE handle,
+                             const EPG_TAG* epgentry);
+    void (*TransferRecordingEntry)(void* kodiInstance,
+                                   const ADDON_HANDLE handle,
+                                   const PVR_RECORDING* recording);
+    void (*TransferTimerEntry)(void* kodiInstance,
+                               const ADDON_HANDLE handle,
+                               const PVR_TIMER* timer);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Kodi inform interface functions
+    void (*TriggerChannelUpdate)(void* kodiInstance);
+    void (*TriggerChannelGroupsUpdate)(void* kodiInstance);
+    void (*TriggerEpgUpdate)(void* kodiInstance, unsigned int iChannelUid);
+    void (*TriggerRecordingUpdate)(void* kodiInstance);
+    void (*TriggerTimerUpdate)(void* kodiInstance);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Stream demux interface functions
+    void (*FreeDemuxPacket)(void* kodiInstance, DemuxPacket* pPacket);
+    DemuxPacket* (*AllocateDemuxPacket)(void* kodiInstance, int iDataSize);
     xbmc_codec_t (*GetCodecByName)(const void* kodiInstance, const char* strCodecName);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // New functions becomes added below and can be on another API change (where
+    // breaks min API version) moved up.
   } AddonToKodiFuncTable_PVR;
 
   /*!
@@ -773,82 +800,124 @@ extern "C" {
    */
   typedef struct KodiToAddonFuncTable_PVR
   {
+    // Pointer inside addon where used on them to find his instance class (currently unused!)
     KODI_HANDLE addonInstance;
 
-    PVR_ERROR (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
-    PVR_ERROR (__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
-    const char* (__cdecl* GetBackendName)(void);
-    const char* (__cdecl* GetBackendVersion)(void);
-    const char* (__cdecl* GetConnectionString)(void);
-    PVR_ERROR (__cdecl* GetDriveSpace)(long long*, long long*);
-    PVR_ERROR (__cdecl* MenuHook)(const PVR_MENUHOOK&, const PVR_MENUHOOK_DATA&);
-    PVR_ERROR (__cdecl* GetEPGForChannel)(ADDON_HANDLE, int, time_t, time_t);
-    PVR_ERROR (__cdecl* IsEPGTagRecordable)(const EPG_TAG*, bool*);
-    PVR_ERROR (__cdecl* IsEPGTagPlayable)(const EPG_TAG*, bool*);
-    PVR_ERROR (__cdecl* GetEPGTagEdl)(const EPG_TAG*, PVR_EDL_ENTRY[], int*);
-    PVR_ERROR (__cdecl* GetEPGTagStreamProperties)(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*);
-    int (__cdecl* GetChannelGroupsAmount)(void);
-    PVR_ERROR (__cdecl* GetChannelGroups)(ADDON_HANDLE, bool);
-    PVR_ERROR (__cdecl* GetChannelGroupMembers)(ADDON_HANDLE, const PVR_CHANNEL_GROUP&);
-    PVR_ERROR (__cdecl* OpenDialogChannelScan)(void);
-    int (__cdecl* GetChannelsAmount)(void);
-    PVR_ERROR (__cdecl* GetChannels)(ADDON_HANDLE, bool);
-    PVR_ERROR (__cdecl* DeleteChannel)(const PVR_CHANNEL&);
-    PVR_ERROR (__cdecl* RenameChannel)(const PVR_CHANNEL&);
-    PVR_ERROR (__cdecl* MoveChannel)(const PVR_CHANNEL&);
-    PVR_ERROR (__cdecl* OpenDialogChannelSettings)(const PVR_CHANNEL&);
-    PVR_ERROR (__cdecl* OpenDialogChannelAdd)(const PVR_CHANNEL&);
-    int (__cdecl* GetRecordingsAmount)(bool);
-    PVR_ERROR (__cdecl* GetRecordings)(ADDON_HANDLE, bool);
-    PVR_ERROR (__cdecl* DeleteRecording)(const PVR_RECORDING&);
-    PVR_ERROR (__cdecl* UndeleteRecording)(const PVR_RECORDING&);
-    PVR_ERROR (__cdecl* DeleteAllRecordingsFromTrash)(void);
-    PVR_ERROR (__cdecl* RenameRecording)(const PVR_RECORDING&);
-    PVR_ERROR (__cdecl* SetRecordingLifetime)(const PVR_RECORDING*);
-    PVR_ERROR (__cdecl* SetRecordingPlayCount)(const PVR_RECORDING&, int);
-    PVR_ERROR (__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING&, int);
-    int (__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING&);
-    PVR_ERROR (__cdecl* GetRecordingEdl)(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
-    PVR_ERROR (__cdecl* GetRecordingSize)(const PVR_RECORDING*, int64_t*);
-    PVR_ERROR (__cdecl* GetTimerTypes)(PVR_TIMER_TYPE[], int*);
-    int (__cdecl* GetTimersAmount)(void);
-    PVR_ERROR (__cdecl* GetTimers)(ADDON_HANDLE);
-    PVR_ERROR (__cdecl* AddTimer)(const PVR_TIMER&);
-    PVR_ERROR (__cdecl* DeleteTimer)(const PVR_TIMER&, bool);
-    PVR_ERROR (__cdecl* UpdateTimer)(const PVR_TIMER&);
-    bool (__cdecl* OpenLiveStream)(const PVR_CHANNEL&);
-    void (__cdecl* CloseLiveStream)(void);
-    int (__cdecl* ReadLiveStream)(unsigned char*, unsigned int);
-    long long (__cdecl* SeekLiveStream)(long long, int);
-    long long (__cdecl* LengthLiveStream)(void);
-    PVR_ERROR (__cdecl* SignalStatus)(PVR_SIGNAL_STATUS&);
-    PVR_ERROR (__cdecl* GetDescrambleInfo)(PVR_DESCRAMBLE_INFO*);
-    PVR_ERROR  (__cdecl* GetChannelStreamProperties)(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*);
-    PVR_ERROR  (__cdecl* GetRecordingStreamProperties)(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*);
-    bool (__cdecl* OpenRecordedStream)(const PVR_RECORDING&);
-    void (__cdecl* CloseRecordedStream)(void);
-    int (__cdecl* ReadRecordedStream)(unsigned char*, unsigned int);
-    long long (__cdecl* SeekRecordedStream)(long long, int);
-    long long (__cdecl* LengthRecordedStream)(void);
-    void (__cdecl* DemuxReset)(void);
-    void (__cdecl* DemuxAbort)(void);
-    void (__cdecl* DemuxFlush)(void);
-    DemuxPacket* (__cdecl* DemuxRead)(void);
-    bool (__cdecl* CanPauseStream)(void);
-    void (__cdecl* PauseStream)(bool);
-    bool (__cdecl* CanSeekStream)(void);
-    bool (__cdecl* SeekTime)(double, bool, double*);
-    void (__cdecl* SetSpeed)(int);
-    void (__cdecl* FillBuffer)(bool);
-    const char* (__cdecl* GetBackendHostname)(void);
-    bool (__cdecl* IsRealTimeStream)(void);
-    PVR_ERROR (__cdecl* SetEPGTimeFrame)(int);
-    void (__cdecl* OnSystemSleep)(void);
-    void (__cdecl* OnSystemWake)(void);
-    void (__cdecl* OnPowerSavingActivated)(void);
-    void (__cdecl* OnPowerSavingDeactivated)(void);
-    PVR_ERROR (__cdecl* GetStreamTimes)(PVR_STREAM_TIMES*);
-    PVR_ERROR (__cdecl* GetStreamReadChunkSize)(int*);
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // General interface functions
+    PVR_ERROR(__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
+    const char*(__cdecl* GetBackendName)(void);
+    const char*(__cdecl* GetBackendVersion)(void);
+    const char*(__cdecl* GetBackendHostname)(void);
+    const char*(__cdecl* GetConnectionString)(void);
+    PVR_ERROR(__cdecl* GetDriveSpace)(long long*, long long*);
+    PVR_ERROR(__cdecl* MenuHook)(const PVR_MENUHOOK&, const PVR_MENUHOOK_DATA&);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Channel interface functions
+    int(__cdecl* GetChannelsAmount)(void);
+    PVR_ERROR(__cdecl* GetChannels)(ADDON_HANDLE, bool);
+    PVR_ERROR(__cdecl* GetChannelStreamProperties)(const PVR_CHANNEL*,
+                                                   PVR_NAMED_VALUE*,
+                                                   unsigned int*);
+    PVR_ERROR(__cdecl* SignalStatus)(PVR_SIGNAL_STATUS&);
+    PVR_ERROR(__cdecl* GetDescrambleInfo)(PVR_DESCRAMBLE_INFO*);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Channel group interface functions
+    int(__cdecl* GetChannelGroupsAmount)(void);
+    PVR_ERROR(__cdecl* GetChannelGroups)(ADDON_HANDLE, bool);
+    PVR_ERROR(__cdecl* GetChannelGroupMembers)(ADDON_HANDLE, const PVR_CHANNEL_GROUP&);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Channel edit interface functions
+    PVR_ERROR(__cdecl* DeleteChannel)(const PVR_CHANNEL&);
+    PVR_ERROR(__cdecl* RenameChannel)(const PVR_CHANNEL&);
+    PVR_ERROR(__cdecl* OpenDialogChannelSettings)(const PVR_CHANNEL&);
+    PVR_ERROR(__cdecl* OpenDialogChannelAdd)(const PVR_CHANNEL&);
+    PVR_ERROR(__cdecl* OpenDialogChannelScan)(void);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // EPG interface functions
+    PVR_ERROR(__cdecl* GetEPGForChannel)(ADDON_HANDLE, int, time_t, time_t);
+    PVR_ERROR(__cdecl* IsEPGTagRecordable)(const EPG_TAG*, bool*);
+    PVR_ERROR(__cdecl* IsEPGTagPlayable)(const EPG_TAG*, bool*);
+    PVR_ERROR(__cdecl* GetEPGTagEdl)(const EPG_TAG*, PVR_EDL_ENTRY[], int*);
+    PVR_ERROR(__cdecl* GetEPGTagStreamProperties)(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*);
+    PVR_ERROR(__cdecl* SetEPGTimeFrame)(int);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Recording interface functions
+    int(__cdecl* GetRecordingsAmount)(bool);
+    PVR_ERROR(__cdecl* GetRecordings)(ADDON_HANDLE, bool);
+    PVR_ERROR(__cdecl* DeleteRecording)(const PVR_RECORDING&);
+    PVR_ERROR(__cdecl* UndeleteRecording)(const PVR_RECORDING&);
+    PVR_ERROR(__cdecl* DeleteAllRecordingsFromTrash)(void);
+    PVR_ERROR(__cdecl* RenameRecording)(const PVR_RECORDING&);
+    PVR_ERROR(__cdecl* SetRecordingLifetime)(const PVR_RECORDING*);
+    PVR_ERROR(__cdecl* SetRecordingPlayCount)(const PVR_RECORDING&, int);
+    PVR_ERROR(__cdecl* SetRecordingLastPlayedPosition)(const PVR_RECORDING&, int);
+    int(__cdecl* GetRecordingLastPlayedPosition)(const PVR_RECORDING&);
+    PVR_ERROR(__cdecl* GetRecordingEdl)(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*);
+    PVR_ERROR(__cdecl* GetRecordingSize)(const PVR_RECORDING*, int64_t*);
+    PVR_ERROR(__cdecl* GetRecordingStreamProperties)
+    (const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Timer interface functions
+    PVR_ERROR(__cdecl* GetTimerTypes)(PVR_TIMER_TYPE[], int*);
+    int(__cdecl* GetTimersAmount)(void);
+    PVR_ERROR(__cdecl* GetTimers)(ADDON_HANDLE);
+    PVR_ERROR(__cdecl* AddTimer)(const PVR_TIMER&);
+    PVR_ERROR(__cdecl* DeleteTimer)(const PVR_TIMER&, bool);
+    PVR_ERROR(__cdecl* UpdateTimer)(const PVR_TIMER&);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Powersaving interface functions
+    void(__cdecl* OnSystemSleep)(void);
+    void(__cdecl* OnSystemWake)(void);
+    void(__cdecl* OnPowerSavingActivated)(void);
+    void(__cdecl* OnPowerSavingDeactivated)(void);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Live stream read interface functions
+    bool(__cdecl* OpenLiveStream)(const PVR_CHANNEL&);
+    void(__cdecl* CloseLiveStream)(void);
+    int(__cdecl* ReadLiveStream)(unsigned char*, unsigned int);
+    long long(__cdecl* SeekLiveStream)(long long, int);
+    long long(__cdecl* LengthLiveStream)(void);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Recording stream read interface functions
+    bool(__cdecl* OpenRecordedStream)(const PVR_RECORDING&);
+    void(__cdecl* CloseRecordedStream)(void);
+    int(__cdecl* ReadRecordedStream)(unsigned char*, unsigned int);
+    long long(__cdecl* SeekRecordedStream)(long long, int);
+    long long(__cdecl* LengthRecordedStream)(void);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // Stream demux interface functions
+    PVR_ERROR(__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
+    DemuxPacket*(__cdecl* DemuxRead)(void);
+    void(__cdecl* DemuxReset)(void);
+    void(__cdecl* DemuxAbort)(void);
+    void(__cdecl* DemuxFlush)(void);
+    void(__cdecl* SetSpeed)(int);
+    void(__cdecl* FillBuffer)(bool);
+    bool(__cdecl* SeekTime)(double, bool, double*);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // General stream interface functions
+    bool(__cdecl* CanPauseStream)(void);
+    void(__cdecl* PauseStream)(bool);
+    bool(__cdecl* CanSeekStream)(void);
+    bool(__cdecl* IsRealTimeStream)(void);
+    PVR_ERROR(__cdecl* GetStreamTimes)(PVR_STREAM_TIMES*);
+    PVR_ERROR(__cdecl* GetStreamReadChunkSize)(int*);
+
+    //--==----==----==----==----==----==----==----==----==----==----==----==----==
+    // New functions becomes added below and can be on another API change (where
+    // breaks min API version) moved up.
   } KodiToAddonFuncTable_PVR;
 
   typedef struct AddonInstance_PVR

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1070,17 +1070,17 @@ PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t& iLength)
   });
 }
 
-PVR_ERROR CPVRClient::SignalQuality(PVR_SIGNAL_STATUS& qualityinfo)
+PVR_ERROR CPVRClient::SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo)
 {
-  return DoAddonCall(__FUNCTION__, [&qualityinfo](const AddonInstance* addon) {
-    return addon->toAddon->SignalStatus(qualityinfo);
+  return DoAddonCall(__FUNCTION__, [channelUid, &qualityinfo](const AddonInstance* addon) {
+    return addon->toAddon->SignalStatus(channelUid, &qualityinfo);
   });
 }
 
-PVR_ERROR CPVRClient::GetDescrambleInfo(PVR_DESCRAMBLE_INFO& descrambleinfo) const
+PVR_ERROR CPVRClient::GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO& descrambleinfo) const
 {
-  return DoAddonCall(__FUNCTION__, [&descrambleinfo](const AddonInstance* addon) {
-    return addon->toAddon->GetDescrambleInfo(&descrambleinfo);
+  return DoAddonCall(__FUNCTION__, [channelUid, &descrambleinfo](const AddonInstance* addon) {
+    return addon->toAddon->GetDescrambleInfo(channelUid, &descrambleinfo);
   }, m_clientCapabilities.SupportsDescrambleInfo());
 }
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1073,7 +1073,7 @@ PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t& iLength)
 PVR_ERROR CPVRClient::SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo)
 {
   return DoAddonCall(__FUNCTION__, [channelUid, &qualityinfo](const AddonInstance* addon) {
-    return addon->toAddon->SignalStatus(channelUid, &qualityinfo);
+    return addon->toAddon->GetSignalStatus(channelUid, &qualityinfo);
   });
 }
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -392,7 +392,7 @@ bool CPVRClient::GetAddonProperties()
 
   /* get the capabilities */
   PVR_ERROR retVal = DoAddonCall(__FUNCTION__, [&addonCapabilities](const AddonInstance* addon) {
-    return addon->toAddon->GetAddonCapabilities(&addonCapabilities);
+    return addon->toAddon->GetCapabilities(&addonCapabilities);
   }, true, false);
 
   if (retVal != PVR_ERROR_NO_ERROR)

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -61,7 +61,7 @@ CPVRClient::CPVRClient(const AddonInfoPtr& addonInfo)
 {
   // Create all interface parts independent to make API changes easier if
   // something is added
-  m_struct.props = new PVR_PROPERTIES();
+  m_struct.props = new AddonProperties_PVR();
   m_struct.toKodi = new AddonToKodiFuncTable_PVR();
   m_struct.toAddon = new KodiToAddonFuncTable_PVR();
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -674,17 +674,19 @@ namespace PVR
 
     /*!
      * @brief Get the signal quality of the stream that's currently open.
+     * @param channelUid Channel unique identifier
      * @param qualityinfo The signal quality.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR SignalQuality(PVR_SIGNAL_STATUS& qualityinfo);
+    PVR_ERROR SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo);
 
     /*!
      * @brief Get the descramble information of the stream that's currently open.
+     * @param channelUid Channel unique identifier
      * @param descrambleinfo The descramble information.
      * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
      */
-    PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO& descrambleinfo) const;
+    PVR_ERROR GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO& descrambleinfo) const;
 
     /*!
      * @brief Fill the given container with the properties required for playback of the given channel. Values are obtained from the PVR backend.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -1143,7 +1143,7 @@ namespace PVR
     CPVRClientCapabilities m_clientCapabilities; /*!< the cached add-on's capabilities */
     std::shared_ptr<CPVRClientMenuHooks> m_menuhooks; /*!< the menu hooks for this add-on */
 
-    /* stored strings to make sure const char* members in PVR_PROPERTIES stay valid */
+    /* stored strings to make sure const char* members in AddonProperties_PVR stay valid */
     std::string m_strUserPath; /*!< @brief translated path to the user profile */
     std::string m_strClientPath; /*!< @brief translated path to this add-on */
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -200,7 +200,7 @@ void CPVRGUIInfo::UpdateQualityData()
     {
       std::shared_ptr<CPVRClient> client;
       CServiceBroker::GetPVRManager().Clients()->GetCreatedClient(CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingClientID(), client);
-      if (client && client->SignalQuality(qualityInfo) == PVR_ERROR_NO_ERROR)
+      if (client && client->SignalQuality(channelUid, qualityInfo) == PVR_ERROR_NO_ERROR)
       {
         m_qualityInfo = qualityInfo;
       }
@@ -218,7 +218,7 @@ void CPVRGUIInfo::UpdateDescrambleData()
   {
     std::shared_ptr<CPVRClient> client;
     CServiceBroker::GetPVRManager().Clients()->GetCreatedClient(CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingClientID(), client);
-    if (client && client->GetDescrambleInfo(descrambleInfo) == PVR_ERROR_NO_ERROR)
+    if (client && client->GetDescrambleInfo(channelUid, descrambleInfo) == PVR_ERROR_NO_ERROR)
     {
       m_descrambleInfo = descrambleInfo;
     }


### PR DESCRIPTION
## Description

This include some C++ rework changes, where also be can in independent. Again thought to reduce the others size and to have only changes related for C -> C++ parts there.

Commit 1:
------------------------------------------------
**Fix duplicated queue and VFS types**

Fixes Debian packaging's header-check failure

Commit 2:
------------------------------------------------
**[addons][pvr] separate menu hook calls and remove union use**

This is thought to make the calls cleaner, with the union before
was it always a bit ugly and unsafe.

Now have every type a own function where give his related data.
Further is on EPG menu hook the whole entry given.

Commit 3:
------------------------------------------------
**[addons][pvr] rename PVR_PROPERTIES to AddonProperties_PVR**

Done to match like on other addon types and to match his function tables.
Also is inside AddonInstance_PVR the "struct" before added to have "C"
conform.

Commit 4:
------------------------------------------------
**[addons][pvr] sort API function tables**

This is to have a better overview and with videoplayer parts on end.
If videoplayer inside is kicked out in future and done my inputstream
instance does it not break API.

Commit 5:
------------------------------------------------
**[addons][pvr] rename GetAddonCapabilities to GetCapabilities**

This is done to have his name more equal to the addon types and
prepared for coming C++ interface where included inside class.

Commit 6:
------------------------------------------------
**[addons][pvr] pass channel unique id to SignalStatus and GetDescrambleInfo**

This thought that addon identify his related channel, for the case it becomes
more as one time in future used. Further can it be also if only one identify
a related inputstream class where do his work.

Commit 7:
------------------------------------------------
**[addons][pvr] increase PVR API to 6.5.0**

## Motivation and Context
Come to end where the PVR addons soon on new interface and the system becomes cleaned up,
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
