### PR TITLE
[VideoPlayer][DXVA] Timeout waiting for buffer after interlaced content seek operation

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -110,13 +110,13 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
 bool CRendererDXVA::NeedBuffer(int idx)
 {
-  if (m_renderBuffers[idx]->IsLoaded())
+  if (m_renderBuffers[idx]->IsLoaded() && m_renderBuffers[idx]->pictureFlags & DVP_FLAG_INTERLACED)
   {
-    const int numPast = m_processor->PastRefs();
-    if (m_renderBuffers[idx]->pictureFlags & DVP_FLAG_INTERLACED &&
-      m_renderBuffers[idx]->frameIdx + numPast * 2 >=
-      m_renderBuffers[m_iBufferIndex]->frameIdx)
-      return true;
+    const uint64_t currentFrameIndex = m_renderBuffers[m_iBufferIndex]->frameIdx;
+    const uint64_t bufferFrameIndex = m_renderBuffers[idx]->frameIdx;
+
+    return bufferFrameIndex < currentFrameIndex &&
+           bufferFrameIndex + (m_processor->PastRefs() * 2) >= currentFrameIndex;
   }
   return false;
 }


### PR DESCRIPTION
## Description
This PR attempts to resolve the problem report in Issue [17521](https://github.com/xbmc/xbmc/issues/17521).  The report is that with DXVA rendering enabled playback of interlaced content will halt after a seek operation.  Issue was reported in conjunction with TVHeadEnd PVR Recordings, I have had the same problem with an external PVR with both Recorded and seekable Live TV 1080i content.

## Motivation and Context
Please review discussion in Issue [17521](https://github.com/xbmc/xbmc/issues/17521), the determination was that the DXVA renderer is flagging both past and future frames as needed for de-interlacing via the NeedBuffer() member function.  This leads to a condition where all frames may be reported as needed, causing RenderManager to time out waiting for one to be free.

Proposed change modifies the logic so that only past frame(s) required to satisfy de-interlacing requirements will be flagged as needed.

## How Has This Been Tested?
Tested on Windows x64, master branch current as of 2020.04.26.  Intel GPUs were used.  Logic was confirmed via breakpoint examination and temporary logging to ensure that only the required number of past frames were flagged.

Runtime behavior was confirmed by using both Recorded and seekable Live TV 1080i streams via aforementioned external PVR.  Before the change, approximately 90% of the seek operations would halt playback and buffer, after the change 0% exhibited this behavior.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
