### PR TITLE
[videoplayer] Fix TS Streams by disallowing streaminfo for realtime streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -200,11 +200,12 @@ bool CDVDDemuxFFmpeg::Aborted()
   return false;
 }
 
-bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streaminfo, bool fileinfo)
+bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool fileinfo)
 {
   AVInputFormat* iformat = NULL;
   std::string strFile;
-  m_streaminfo = streaminfo;
+  m_streaminfo = !pInput->IsRealtime() && !m_reopen;
+  m_reopen = false;
   m_currentPts = DVD_NOPTS_VALUE;
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_program = UINT_MAX;
@@ -629,6 +630,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
     int64_t duration = m_pFormatContext->duration;
     std::shared_ptr<CDVDInputStream> pInputStream = m_pInput;
     Dispose();
+    m_reopen = true;
     if (!Open(pInputStream, false))
       return false;
     m_pFormatContext->duration = duration;
@@ -678,7 +680,7 @@ bool CDVDDemuxFFmpeg::Reset()
 {
   std::shared_ptr<CDVDInputStream> pInputStream = m_pInput;
   Dispose();
-  return Open(pInputStream, m_streaminfo);
+  return Open(pInputStream, false);
 }
 
 void CDVDDemuxFFmpeg::Flush()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -83,7 +83,7 @@ public:
   CDVDDemuxFFmpeg();
   ~CDVDDemuxFFmpeg() override;
 
-  bool Open(std::shared_ptr<CDVDInputStream> pInput, bool streaminfo = true, bool fileinfo = false);
+  bool Open(std::shared_ptr<CDVDInputStream> pInput, bool fileinfo);
   void Dispose();
   bool Reset() override ;
   void Flush() override;
@@ -169,6 +169,7 @@ protected:
   }m_pkt;
 
   bool m_streaminfo;
+  bool m_reopen = false;
   bool m_checkTransportStream;
   int m_displayTime = 0;
   double m_dtsAtDisplayTime;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -65,7 +65,7 @@ bool CDVDDemuxVobsub::Open(const std::string& filename, int source, const std::s
     return false;
 
   m_Demuxer.reset(new CDVDDemuxFFmpeg());
-  if(!m_Demuxer->Open(m_Input))
+  if (!m_Demuxer->Open(m_Input, false))
     return false;
 
   CDVDStreamInfo hints;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -60,20 +60,6 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(std::shared_ptr<CDVDInputStream> pI
       return nullptr;
   }
 
-  bool streaminfo = true; /* Look for streams before playback */
-  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
-  {
-    /* Don't parse the streaminfo for some cases of streams to reduce the channel switch time */
-    bool useFastswitch = URIUtils::IsUsingFastSwitch(pInputStream->GetFileName());
-    streaminfo = !useFastswitch;
-  }
-
-  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
-  {
-    bool useFastswitch = URIUtils::IsUsingFastSwitch(pInputStream->GetFileName());
-    streaminfo = !useFastswitch;
-  }
-
   // Try to open the MultiFiles demuxer
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_MULTIFILES))
   {
@@ -85,7 +71,7 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(std::shared_ptr<CDVDInputStream> pI
   }
 
   std::unique_ptr<CDVDDemuxFFmpeg> demuxer(new CDVDDemuxFFmpeg());
-  if(demuxer->Open(pInputStream, streaminfo, fileinfo))
+  if (demuxer->Open(pInputStream, fileinfo))
     return demuxer.release();
   else
     return NULL;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1439,8 +1439,3 @@ bool URIUtils::UpdateUrlEncoding(std::string &strFilename)
   strFilename = newFilename;
   return true;
 }
-
-bool URIUtils::IsUsingFastSwitch(const std::string& strFile)
-{
-  return IsUDP(strFile) || IsTCP(strFile) || IsPVRChannel(strFile);
-}

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -157,7 +157,6 @@ public:
   static bool IsPVRChannel(const std::string& strFile);
   static bool IsPVRChannelGroup(const std::string& strFile);
   static bool IsPVRGuideItem(const std::string& strFile);
-  static bool IsUsingFastSwitch(const std::string& strFile);
 
   static std::string AppendSlash(std::string strFolder);
   static void AddSlashAtEnd(std::string& strFolder);


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Some TS Streams failed to play as they would incorrectly attempt to find stream info in the demuxer. Realtime TS streams should never try to find streaminfo.

The fix is to disable finding stream info for all realtime streams. This changes the logic slightly for PVR in that enabling fastswitch is not automatic it is instead dictated by setting / returning the correct value for `IsRealtimeStream`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Fix for: https://github.com/xbmc/xbmc/issues/17783

and

https://github.com/kodi-pvr/pvr.iptvsimple/issues/350

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

OSX using IPTV Simple

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
