### PR TITLE
[macos] allow portable mode to run

### DIFF
--- a/xbmc/settings/SettingsComponent.cpp
+++ b/xbmc/settings/SettingsComponent.cpp
@@ -296,7 +296,6 @@ bool CSettingsComponent::InitDirectoriesOSX(bool bPlatformDirectories)
   std::string frameworksPath = CUtil::GetFrameworksPath();
   CSpecialProtocol::SetXBMCFrameworksPath(frameworksPath);
 
-  // OSX always runs with bPlatformDirectories == true
   if (bPlatformDirectories)
   {
     // map our special drives
@@ -347,6 +346,7 @@ bool CSettingsComponent::InitDirectoriesOSX(bool bPlatformDirectories)
     std::string strTempPath = URIUtils::AddFileToFolder(appPath, "portable_data/temp");
     CSpecialProtocol::SetTempPath(strTempPath);
     CSpecialProtocol::SetLogPath(strTempPath);
+    CreateUserDirs();
   }
   CSpecialProtocol::SetXBMCBinAddonPath(appPath + "/addons");
   return true;


### PR DESCRIPTION
## Description
Allows portable mode to run from an osx app bundle.
OSX 10.6.2 introduced the ability to provide arguments using open to execute an app bundle

In a terminal window execute
```
open <location_to_app_bundle>/Kodi.app --args -p
```

Note: portable mode is recommended only to be used for testing/dev on macos. During updates, app bundles will replace the entire existing bundle, and any portable data will be lost.

## Motivation and Context
Slack request

## How Has This Been Tested?
run locally

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
