### PR TITLE
[python] drop xbmc.abortRequested flag

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
+++ b/xbmc/addons/kodi-addon-dev-kit/doxygen/Modules/modules_python.dox
@@ -228,6 +228,11 @@ web applications or frameworks for the Python programming language.
       "",
       <b>xbmc.validatePath()</b> function was moved to the xbmcvfs module.
 }
+\python_removed_function{
+      abortRequested,
+      "",
+      <b>xbmc.abortRequested</b> flag was removed completely. Use xbmc.Monitor().abortRequested().
+}
 */
 /*!
 @page python_v18 Python API v18

--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -19,7 +19,6 @@
 #define RUNSCRIPT_PREAMBLE \
         "" \
         "import " MODULE "\n" \
-        "xbmc.abortRequested = False\n" \
         "class xbmcout:\n" \
         "  def __init__(self, loglevel=" MODULE ".LOGDEBUG):\n" \
         "    self.ll=loglevel\n" \

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -403,11 +403,6 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
 
   if (m_threadState)
   {
-    PyObject* m = PyImport_AddModule("xbmc");
-    if (m == NULL || PyObject_SetAttrString(m, "abortRequested", PyBool_FromLong(1)))
-      CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): failed to set abortRequested", GetId(),
-                m_sourceFile.c_str());
-
     // make sure all sub threads have finished
     for (PyThreadState* old = nullptr; m_threadState != nullptr;)
     {
@@ -498,12 +493,6 @@ bool CPythonInvoker::stop(bool abort)
                   m_sourceFile.c_str());
         AbortNotification();
       }
-
-      PyObject* m;
-      m = PyImport_AddModule("xbmc");
-      if (m == NULL || PyObject_SetAttrString(m, "abortRequested", PyBool_FromLong(1)))
-        CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): failed to set abortRequested", GetId(),
-                  m_sourceFile.c_str());
 
       PyEval_ReleaseThread(m_threadState);
     }

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -26,7 +26,6 @@
 #define RUNSCRIPT_PREAMBLE \
   "" \
   "import " MODULE "\n" \
-  "xbmc.abortRequested = False\n" \
   "class xbmcout:\n" \
   "  def __init__(self, loglevel=" MODULE ".LOGNOTICE):\n" \
   "    self.ll=loglevel\n" \


### PR DESCRIPTION
## Description
This PR removes the long deprecated (at least since xbmc.Monitor().abortRequested()) was introduced xbmc.abortRequested flag. This method is not documented in the API since the migration to doxygen/codedocs. In fact I suspect some of the errors seen in https://github.com/xbmc/xbmc/pull/17705 are in fact false positives caused by this old mechanism.

@MilhouseVH I'd probably recommend to include this in your builds and wait ~ a week to see if any regression shows.

## Motivation and Context
Cleanup, encourage to use the monitor method instead

## How Has This Been Tested?
Tested netflix, tubecast, flask-webinterface-demo addon, and kodi aborts correctly


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
