### PR TITLE
[addons] Define assets and bump addon version

### DIFF
--- a/addons/audioencoder.kodi.builtin.aac/addon.xml
+++ b/addons/audioencoder.kodi.builtin.aac/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.kodi.builtin.aac"
-  version="1.0.0"
+  version="1.0.1"
   name="AAC encoder"
   provider-name="spiff">
   <extension
@@ -12,5 +12,8 @@
     <summary lang="en">AAC Audio Encoder</summary>
     <description lang="en">AAC is a set of codecs designed to provide better compression than MP3s, and are improved versions of MPEG audio.</description>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/audioencoder.kodi.builtin.wma/addon.xml
+++ b/addons/audioencoder.kodi.builtin.wma/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.kodi.builtin.wma"
-  version="1.0.0"
+  version="1.0.1"
   name="WMA encoder"
   provider-name="spiff">
   <extension
@@ -12,5 +12,8 @@
     <summary lang="en">WMA Audio Encoder</summary>
     <description lang="en">Windows Media Audio, Microsoft’s lossy audio format.</description>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/resource.images.weathericons.default/addon.xml
+++ b/addons/resource.images.weathericons.default/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="resource.images.weathericons.default"
        name="Weather Icons - Default"
-       version="1.1.8"
+       version="1.1.9"
        provider-name="Team Kodi">
   <requires>
     <import addon="kodi.resource" version="1.0.0"/>
@@ -12,5 +12,8 @@
     <summary lang="en">Default Weather Icons</summary>
     <description lang="en">Default set of Weather Icons shipped with Kodi</description>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/resource.language.en_gb/addon.xml
+++ b/addons/resource.language.en_gb/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="resource.language.en_gb"
-  version="2.0.1"
+  version="2.0.2"
   name="English"
   provider-name="Team Kodi">
   <requires>
@@ -23,5 +23,8 @@
     <description lang="en">English version of all texts used in Kodi.</description>
     <disclaimer lang="en">English is the default language for Kodi, removing it may cause issues</disclaimer>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/resource.uisounds.kodi/addon.xml
+++ b/addons/resource.uisounds.kodi/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="resource.uisounds.kodi" version="1.0.0" name="Kodi UI Sounds" provider-name="Team Kodi">
+<addon id="resource.uisounds.kodi" version="1.0.1" name="Kodi UI Sounds" provider-name="Team Kodi">
   <requires>
     <import addon="kodi.resource" version="1.0.0"/>
   </requires>
@@ -8,5 +8,8 @@
     <summary lang="en">Kodi GUI sounds</summary>
     <description lang="en">Kodi GUI sounds</description>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/screensaver.xbmc.builtin.black/addon.xml
+++ b/addons/screensaver.xbmc.builtin.black/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="screensaver.xbmc.builtin.black"
        name="Black"
-       version="1.0.33"
+       version="1.0.34"
        provider-name="Team Kodi">
   <extension point="xbmc.ui.screensaver" library="dummy.so"/>
   <extension point="xbmc.addon.metadata">
@@ -122,5 +122,8 @@
     <description lang="zh_CN">黑屏屏保是一个简单的屏幕保护程序，它使你的显示器进入黑屏状态。</description>
     <description lang="zh_TW">Black 是一個讓螢幕變全黑的螢幕保護程式。</description>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/screensaver.xbmc.builtin.dim/addon.xml
+++ b/addons/screensaver.xbmc.builtin.dim/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="screensaver.xbmc.builtin.dim"
        name="Dim"
-       version="1.0.58"
+       version="1.0.59"
        provider-name="Team Kodi">
   <extension point="xbmc.ui.screensaver" library="dummy.so"/>
   <extension point="xbmc.addon.metadata">
@@ -126,5 +126,8 @@
     <description lang="zh_CN">淡出屏保是一个简单的屏幕保护程序，它使你的屏幕显示内容变暗（淡出效果），暗化度可在20%至100%之间调节。</description>
     <description lang="zh_TW">暗化螢幕保護程式單純將螢幕變暗，暗化值可設定在20%至100%之間。</description>
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/script.module.pil/addon.xml
+++ b/addons/script.module.pil/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.pil"
        name="Python Image Library"
-       version="1.1.7"
+       version="3.0.0"
        provider-name="PythonWare">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -10,5 +10,8 @@
              library="lib" />
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>

--- a/addons/script.module.pycryptodome/addon.xml
+++ b/addons/script.module.pycryptodome/addon.xml
@@ -9,5 +9,8 @@
   <extension point="xbmc.python.module" library="lib" />
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
## Description
Picks https://github.com/xbmc/xbmc/pull/17726 since @ronie abandoned it.
This PR adjusts the addon versions of script.module.pillow and script.module.pycryptodome to be the same that we build internally (3.0.0 and 3.4.3) while appending a localversion identifier to bump the version.
Both libraries should be updated. Looks like the only versions fully supporting python 3.7 are 3.6.5 for cryptodome and 5.2.0 for pillow.

## Motivation and Context
Fix icons

## How Has This Been Tested?
compiled

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
