### PR TITLE
[upnp] Prefer movie posters to thumbs when serving the library items …

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -580,7 +580,13 @@ BuildObject(CFileItem&                    item,
             thumb_loader->LoadItem(&item);
 
         // finally apply the found artwork
-        thumb = item.GetArt("thumb");
+        // note: movies should use poster as the preferred "thumb" image
+        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_type == MediaTypeMovie &&
+            item.HasArt("poster"))
+          thumb = item.GetArt("poster");
+        else
+          thumb = item.GetArt("thumb");
+
         if (!thumb.empty()) {
             PLT_AlbumArtInfo art;
             art.uri = upnp_server->BuildSafeResourceUri(


### PR DESCRIPTION
…over upnp

In https://github.com/xbmc/xbmc/pull/17127 we removed the old fallback for the default filling of movie thumbs with poster images. Reason was that thumb itself is a legit art type and it was up to the client (skins, apps, webinterfaces, etc) to choose which art types to display (provided the whole art map). However, this caused a regression in library sharing over upnp where it now uses thumb as the `albumArtURI` for movies.
This PR thus make it prefer posters for that property instead of thumbs for movies only.

@Montellese and @rmrector for review

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/17587

## How Has This Been Tested?
Compile and tested using vlc as a client in android.

## Screenshots (if appropriate):

**Before:**

![alt text](https://i.imgur.com/LDnibXG.jpg "old")


**After:**

![alt text](https://i.imgur.com/Jeo8G5O.jpg "after")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
