### PR TITLE
[kodi-standalone.sh] Replace which with command -v

### DIFF
--- a/tools/Linux/kodi-standalone.sh.pulse
+++ b/tools/Linux/kodi-standalone.sh.pulse
@@ -1,8 +1,8 @@
-PULSE_START="$(which start-pulseaudio-x11)"
+PULSE_START="$(command -v start-pulseaudio-x11)"
 if [ -n "$PULSE_START" ]; then
   $PULSE_START
 else
-  PULSE_SESSION="$(which pulse-session)"
+  PULSE_SESSION="$(command -v pulse-session)"
   if [ -n "$PULSE_SESSION" ]; then
     XBMC="$PULSE_SESSION $XBMC"
   fi


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
`command -v`, unlike `which`, is a POSIX compatible shell-builtin. Using it is faster and doesn't require the installation of a third party utility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This allows to use `kodi-standalone` without having `which` installed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
