### PR TITLE
[PVR][Estuary] Recordings Playlist Actions

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4818,6 +4818,7 @@ msgid "System information"
 msgstr ""
 
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
+#: xbmc/video/ContextMenus.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#10008"
 msgid "Play next"
@@ -6752,6 +6753,8 @@ msgid "Movie information"
 msgstr ""
 
 #: system/settings/settings.xml
+#: xbmc/video/ContextMenus.cpp
+#: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#13347"
 msgid "Queue item"
 msgstr ""

--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -198,6 +198,18 @@
 					<label>$LOCALIZE[19077]</label>
 					<visible>Window.IsActive(MyPVRTimers.xml)</visible>
 				</control>
+				<control type="label" id="301">
+					<include>MediaMenuLabelCommon</include>
+					<label>$LOCALIZE[31020]</label>
+					<visible>Control.IsVisible(302)</visible>
+				</control>
+				<control type="button" id="302">
+					<description>Go to playlist</description>
+					<include>MediaMenuItemsCommon</include>
+					<label>$LOCALIZE[31056]</label>
+					<onclick>ActivateWindow(videoplaylist)</onclick>
+					<visible>Window.IsActive(MyPVRRecordings.xml) + Integer.IsGreater(Playlist.Length(video),0)</visible>
+				</control>
 				<control type="group" id="141000">
 					<control type="grouplist" id="14100">
 						<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
@@ -207,7 +219,7 @@
 						<itemgap>-17</itemgap>
 						<left>5</left>
 						<onleft>14100</onleft>
-						<onup>8</onup>
+						<onup>302</onup>
 						<ondown>6056</ondown>
 						<visible>Player.HasMedia + [$EXP[sidebar_visible]]</visible>
 						<visible>!System.HasActiveModalDialog</visible>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -78,6 +78,7 @@
 	<variable name="ListLabelVar">
 		<value condition="String.IsEqual(ListItem.DbType,episode) + Window.IsActive(videoplaylist)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
 		<value condition="String.IsEqual(ListItem.DbType,musicvideo) + Window.IsActive(videoplaylist)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>
+		<value condition="[!String.IsEmpty(ListItem.Season) | !String.IsEmpty(ListItem.Episode) | !String.IsEmpty(ListItem.EpisodeName)] + Window.IsActive(videoplaylist)">$INFO[ListItem.Title,,: ]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName]</value>
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
 	<variable name="ListLabel2Var">

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -55,6 +55,8 @@ void CContextMenuManager::Init()
   m_items = {
       std::make_shared<CONTEXTMENU::CResume>(),
       std::make_shared<CONTEXTMENU::CPlay>(),
+      std::make_shared<CONTEXTMENU::CPlayNext>(),
+      std::make_shared<CONTEXTMENU::CQueue>(),
       std::make_shared<CONTEXTMENU::CAddonInfo>(),
       std::make_shared<CONTEXTMENU::CEnableAddon>(),
       std::make_shared<CONTEXTMENU::CDisableAddon>(),

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -55,6 +55,7 @@ void CContextMenuManager::Init()
   m_items = {
       std::make_shared<CONTEXTMENU::CResume>(),
       std::make_shared<CONTEXTMENU::CPlay>(),
+      std::make_shared<CONTEXTMENU::CPlayAndQueue>(),
       std::make_shared<CONTEXTMENU::CPlayNext>(),
       std::make_shared<CONTEXTMENU::CQueue>(),
       std::make_shared<CONTEXTMENU::CAddonInfo>(),

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -93,4 +93,11 @@ struct CPlayNext : CStaticContextMenuAction
   bool Execute(const CFileItemPtr& item) const override;
 };
 
+struct CPlayAndQueue : CStaticContextMenuAction
+{
+  CPlayAndQueue() : CStaticContextMenuAction(13412) {} // Play from here
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+};
+
 }

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -78,4 +78,19 @@ struct CPlay : IContextMenuItem
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const CFileItemPtr& _item) const override;
 };
+
+struct CQueue : CStaticContextMenuAction
+{
+  CQueue() : CStaticContextMenuAction(13347) {} // Queue item
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+};
+
+struct CPlayNext : CStaticContextMenuAction
+{
+  CPlayNext() : CStaticContextMenuAction(10008) {} // Play next
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+};
+
 }

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -44,6 +44,7 @@ protected:
   bool HideExtensions() override;
   bool HideParentDirItems() override;
   VECSOURCES& GetSources() override;
+  bool AutoPlayNextItem() override { return false; }
 };
 
 class CGUIViewStateVideoMovies : public CGUIViewStateWindowVideo


### PR DESCRIPTION
This PR enhances recording folders and recordings with some play/playlist actions. Those actions are already available for normal videos and video folders and with this PR PVR catches up on this.

* Recording folders now have 'Play', 'Play next' and 'Queue item' context menu entries.
* Recordings now have Play next' and 'Queue item' context menu entries.
* PVR Recordings window side blade now has a button 'Go to playlist'

![screenshot000](https://user-images.githubusercontent.com/3226626/81184027-30904a00-8fb0-11ea-8b67-541760c88088.png)
![screenshot001](https://user-images.githubusercontent.com/3226626/81184036-32f2a400-8fb0-11ea-847e-15d407574e63.png)
![screenshot002](https://user-images.githubusercontent.com/3226626/81184044-3554fe00-8fb0-11ea-891e-6daf34de4722.png)

All changes are runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you find some time for a code review.
@ronie could you take a look at the skin changes?