### PR TITLE
Improve rebranding situation for binary addon building

### DIFF
--- a/cmake/addons/CMakeLists.txt
+++ b/cmake/addons/CMakeLists.txt
@@ -156,8 +156,11 @@ if(ADDON_SRC_PREFIX)
   message(STATUS "Overriding addon source directory prefix: ${ADDON_SRC_PREFIX}")
 endif()
 
+include(${CORE_SOURCE_DIR}/cmake/scripts/common/Macros.cmake)
+core_find_versions()
+
 if(NOT APP_LIB_DIR)
-  set(APP_LIB_DIR "${ADDON_DEPENDS_PATH}/lib/kodi")
+  set(APP_LIB_DIR "${ADDON_DEPENDS_PATH}/lib/${APP_NAME_LC}")
 else()
   file(TO_CMAKE_PATH "${APP_LIB_DIR}" APP_LIB_DIR)
 endif()

--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -95,7 +95,7 @@ macro (build_addon target prefix libs)
     message(STATUS "Addon dependency check ...")
     # Set defines used in addon.xml.in and read from versions.h to set add-on
     # version parts automatically
-    file(STRINGS ${KODI_INCLUDE_DIR}/versions.h BIN_ADDON_PARTS)
+    file(STRINGS ${${APP_NAME_UC}_INCLUDE_DIR}/versions.h BIN_ADDON_PARTS)
     foreach(loop_var ${BIN_ADDON_PARTS})
       # Only pass strings with "#define ADDON_" from versions.h
       if(loop_var MATCHES "#define ADDON_")
@@ -122,7 +122,7 @@ macro (build_addon target prefix libs)
             foreach(src_file ${USED_SOURCES})
               file(STRINGS ${src_file} BIN_ADDON_SRC_PARTS)
               foreach(loop_var ${BIN_ADDON_SRC_PARTS})
-                string(REGEX MATCH "^[ \t]*#[ \t]*(include|import)[ \t]*[<\"](kodi\/)?(.+)[\">]" include_name "${loop_var}")
+                string(REGEX MATCH "^[ \t]*#[ \t]*(include|import)[ \t]*[<\"](${APP_NAME_LC}\/)?(.+)[\">]" include_name "${loop_var}")
                 if(include_name AND CMAKE_MATCH_3 MATCHES ^${depend_header})
                   get_directory_property(CURRENT_DEFS COMPILE_DEFINITIONS)
                   if(NOT used_type_name IN_LIST CURRENT_DEFS)

--- a/cmake/scripts/common/PrepareEnv.cmake
+++ b/cmake/scripts/common/PrepareEnv.cmake
@@ -81,7 +81,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL windows)
 endif()
 
 # generate the proper KodiConfig.cmake file
-configure_file(${CORE_SOURCE_DIR}/cmake/KodiConfig.cmake.in ${APP_LIB_DIR}/KodiConfig.cmake @ONLY)
+configure_file(${CORE_SOURCE_DIR}/cmake/KodiConfig.cmake.in ${APP_LIB_DIR}/${APP_NAME}Config.cmake @ONLY)
 
 # copy cmake helpers to lib/kodi
 file(COPY ${CORE_SOURCE_DIR}/cmake/scripts/common/AddonHelpers.cmake

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -72,7 +72,7 @@ xbmc/assets:
 shared:
 	mkdir -p assets
 	cp -rfp $(PREFIX)/share/@APP_NAME_LC@/* ./assets
-	cp -rfp $(DEPENDS_PATH)/share/kodi/* ./assets || true
+	cp -rfp $(DEPENDS_PATH)/share/@APP_NAME_LC@/* ./assets || true
 	find `pwd`/assets/ -depth -name ".git" -exec rm -rf {} \;
 	find `pwd`/assets/ -name "*.so" -exec rm {} \;
 	find `pwd`/assets/addons/skin.*/media/* -depth -not -iname "Textures.xbt" -exec rm -rf {} \;
@@ -116,8 +116,8 @@ libs: $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so
 	cp -fp $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so xbmc/obj/local/$(CPU)/
 	find $(PREFIX)/lib/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
 	find $(PREFIX)/share/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
-	find $(DEPENDS_PATH)/share/kodi/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
-	find $(DEPENDS_PATH)/lib/kodi/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
+	find $(DEPENDS_PATH)/share/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
+	find $(DEPENDS_PATH)/lib/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
 	find $(PREFIX)/lib/@APP_NAME_LC@/system -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;
 	DIR=${CURDIR}; cd $(PREFIX)/lib/python@PYTHON_VERSION@/site-packages; for i in `find Cryptodome -name \*.so` ; do FN=`echo $$i | cut -c1- | tr "/" "_" | sed -e 's/\.cpython-[0-9]\{2\}-x86_64-linux-gnu\./\./g'` ;mv $$i $$DIR/xbmc/obj/local/$(CPU)/$$FN ; done
 	cd xbmc/obj/local/$(CPU)/; find . -name "*.so" -not -name "lib*.so" | sed "s/\.\///" | xargs -I@ mv @ lib@


### PR DESCRIPTION
## Description
This improves the ability to use binary addons in rebrands.

## How Has This Been Tested?
Tested by building a rebranded version for Android.
See following repos for an example:
https://github.com/a1rwulf/xbmc/commits/addons-rebrand-testing
https://github.com/a1rwulf/pvr.iptvsimple/commits/Playa


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
