### PR TITLE
fix creating unique index for actors on MySQL after #17094

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -267,7 +267,7 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE UNIQUE INDEX ix_actor_1 ON actor (name(255))");
   m_pDS->exec("CREATE INDEX ix_actor_link_1 ON actor_link (media_type(20))");
   m_pDS->exec("CREATE UNIQUE INDEX ix_actor_link_2 ON "
-              "actor_link (actor_id, media_id, media_type, role)");
+              "actor_link (actor_id, media_id, media_type(20), role(255))");
 
   CreateLinkIndex("tag");
   CreateForeignLinkIndex("director", "actor");


### PR DESCRIPTION
My changes in #17094 result in MySQL not being able to create the unique index for actors anymore. Thanks @mkreisl for the report and the proposed fix.

Since I don't have a MySQL setup available for testing I was not able to verify if this actually fixes the issue.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
