### PR TITLE
[videoplayer] Fix HLS selecting lowest quality stream & Live HLS always play from start

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -636,13 +636,6 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool fileinf
     m_pFormatContext->duration = duration;
   }
 
-  // seems to be a bug in ffmpeg, hls jumps back to start after a couple of seconds
-  // this cures the issue
-  if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls") == 0)
-  {
-    SeekTime(0);
-  }
-
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -588,7 +588,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool fileinf
           }
         }
       }
-      else if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls,applehttp") == 0)
+      else if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls") == 0)
       {
         nProgram = HLSSelectProgram();
       }
@@ -638,7 +638,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool fileinf
 
   // seems to be a bug in ffmpeg, hls jumps back to start after a couple of seconds
   // this cures the issue
-  if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls,applehttp") == 0)
+  if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls") == 0)
   {
     SeekTime(0);
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
To fix issue of kodi selecting lowest quality stream instead of highest.
https://github.com/xbmc/xbmc/issues/17664

newer ffmpeg now returns 'hls' not 'hls,applehttp' for hls format name
https://github.com/FFmpeg/FFmpeg/commit/abfeba97241e3cd485580b66b8b712d9a9779888

Therefore, the kodi if statement to selectprogram was never being run

Also noticed the seek(0) work-around and knew of an existing issue where kodi ffmpeg would always play live hls streams from the start. Have had to use Inpustream Adaptive to play them.

Removed the work-around and tested.
Confirmed live streams now play correctly from live and that an existing troublesome hls file also still playback correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Confirm HLS playlists (test strm in above issue) now selects highest quality.
Also confirmed reducing Bandwidth Limitation setting results in lower quality stream being selected

Tested work-around removal with http://open.http.mp.streamamg.com/p/2000012/playManifest/entryId/0_4tzhwpm1/format/applehttp  
Confirm it plays normally and doesn't jump backwards.

Also confirmed that Live HLS now play from live - not from start.
You can now also use kodi ResumeFrom=1 to make it start from beginning.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
