### PR TITLE
[linux] CCPUInfoLinux: add imx_thermal_zone to default sensor names

### DIFF
--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -86,10 +86,11 @@ CCPUInfoLinux::CCPUInfoLinux()
   if (freqPath.Exists())
     m_freqPath = freqStr;
 
-  const std::array<std::string, 3> modules = {
+  const std::array<std::string, 4> modules = {
       "coretemp",
       "k10temp",
       "scpi_sensors",
+      "imx_thermal_zone",
   };
 
   for (int i = 0; i < 20; i++)


### PR DESCRIPTION
As the title says. This is used on iMX6 devices for the name of their hwmon sensors. This allows reading the cpu temperature out of the box.

Tested on iMX6QP