### PR TITLE
Fixing faulty thumbnail hashing for binary add-ons

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -301,10 +301,9 @@ char* Interface_Filesystem::get_cache_thumb_name(void* kodiBase, const char* fil
     return nullptr;
   }
 
-  Crc32 crc;
-  crc.ComputeFromLowerCase(filename);
-  std::string string = StringUtils::Format("%08x.tbn", static_cast<unsigned int>(crc));
-  char* buffer = strdup(string.c_str());
+  const auto crc = Crc32::ComputeFromLowerCase(filename);
+  const auto hex = StringUtils::Format("%08x.tbn", crc);
+  char* buffer = strdup(hex.c_str());
   return buffer;
 }
 


### PR DESCRIPTION
## Description
This PR fixes a fault in the thumbnail hashing for binary add-ons.

## Motivation and Context
When calling "kodi::vfs::GetCacheThumbName()", it would return "ffffffff.tbn" no matter what input. The patch corrects that. I have zero clue why the old code failed, but copying this from a similar function fixed it.

## How Has This Been Tested?
I'm a total newb. I can't say for sure what would be affected. My guess would be just on the binary add-on interface.

I don't know how to test it other than via my wip visualization.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
