### PR TITLE
[addons] Less debug log entries when accessing settings

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -217,8 +217,6 @@ bool CAddonSettings::Load(const CXBMCTinyXML& doc)
   if (!m_initialized)
     return false;
 
-  m_logger->debug("loading setting values");
-
   // figure out the version of the setting definitions
   uint32_t version = 0;
   if (!ParseSettingVersion(doc, version))
@@ -296,9 +294,6 @@ bool CAddonSettings::Load(const CXBMCTinyXML& doc)
     SettingPtr newSetting = GetSetting(setting.first);
     if (newSetting == nullptr)
     {
-      m_logger->debug("failed to find definition for setting {}. Creating a setting on-the-fly...",
-                      setting.first);
-
       // create a hidden/internal string setting on-the-fly
       newSetting = AddSettingWithoutDefinition<CSettingString>(*this, setting.first, setting.second,
                                                                m_logger);
@@ -408,8 +403,6 @@ void CAddonSettings::InitializeConditions()
 
 bool CAddonSettings::InitializeDefinitions(const CXBMCTinyXML& doc)
 {
-  m_logger->debug("loading setting definitions");
-
   // figure out the version of the setting definitions
   uint32_t version = 0;
   if (!ParseSettingVersion(doc, version))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
If there is a service add-on running a loop that accesses the addon settings, it can quickly fill up the debug log with essentially non-helpful messages.

**"failed to find definition for setting {}. Creating a setting on-the-fly..."**
This shows if the add-on has removed a setting but the user still has that setting in their userdata. 
They can't do anything about that and neither can the author. So can we stop logging about it?

"CSettingsManager: requested setting ({}) was not found" is still logged when a setting isn't actually in the settings.xml but tried to access via the add-on.

**"loading setting values"**
Do we need to know this? - it logs if this fails anyway.

**"loading setting definitions"**
Same as above.

**Yes, its only debug messages.
But users use debug log to find issues.
So the less "bloat" of unneeded messages - the easier to find their issue.**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
