### PR TITLE
[CurlFile] Disable CURLOPT_AUTOREFERER (default value)

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -538,7 +538,8 @@ void CCurlFile::SetCommonOptions(CReadState* state, bool failOnError /* = true *
   else
   {
     g_curlInterface.easy_setopt(h, CURLOPT_REFERER, NULL);
-    g_curlInterface.easy_setopt(h, CURLOPT_AUTOREFERER, CURL_ON);
+    // Do not send referer header on redirects (same behaviour as ffmpeg and browsers)
+    g_curlInterface.easy_setopt(h, CURLOPT_AUTOREFERER, CURL_OFF);
   }
 
   // setup any requested authentication


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
https://curl.haxx.se/libcurl/c/CURLOPT_AUTOREFERER.html
"When enabled, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect."
Default: Disabled

All browsers that I have tested with do not send a referrer header after a redirect.

I have found some services actually block based on referer.
eg. A 302 redirect from SiteA to a SiteB m3u8 playlist - kodi is sending a referer on the request to the playlist using the SiteA url. That playlist is then 404'ing. Without the referer, it works fine.

As the referer behavior differs between programs, it's more likely a site blocks a referer and allows no referer. Especially if the big browsers don't send one.
No referer just simulates an initial request to that site - which is true as it's been redirected there.

Yes, I can add a | with Referer=%20 but that's a bit of a hacky workaround

Ffmpeg in Kodi also doesn't send referer on redirects.
Using ffmpeg to play a redirected playlist works OK.
But using Inputstream Adaptive which uses curl fails.

**This PR makes the referer behavior across ffmpeg, curl and major browsers the same.** 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
