### PR TITLE
[video] ** CID 1463261:  Resource leaks  (RESOURCE_LEAK)

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -165,7 +165,7 @@ void AddRecordingsToPlayListAndSort(const std::shared_ptr<CFileItem>& item,
     const int windowId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
     if (windowId == WINDOW_TV_RECORDINGS || windowId == WINDOW_RADIO_RECORDINGS)
     {
-      const CGUIViewState* viewState = CGUIViewState::GetViewState(windowId, queuedItems);
+      std::unique_ptr<CGUIViewState> viewState(CGUIViewState::GetViewState(windowId, queuedItems));
       if (viewState)
         queuedItems.Sort(viewState->GetSortMethod());
     }


### PR DESCRIPTION
*** CID 1463261:  Resource leaks  (RESOURCE_LEAK)
/xbmc/video/ContextMenus.cpp: 171 in CONTEXTMENU::<unnamed>::AddRecordingsToPlayListAndSort(const std::shared_ptr<CFileItem> &, CFileItemList &)()

```
165         const int windowId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
166         if (windowId == WINDOW_TV_RECORDINGS || windowId == WINDOW_RADIO_RECORDINGS)
167         {
168           const CGUIViewState* viewState = CGUIViewState::GetViewState(windowId, queuedItems);
169           if (viewState)
170             queuedItems.Sort(viewState->GetSortMethod());
>>>     CID 1463261:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "viewState" going out of scope leaks the storage it points to.
171         }
172       }
173     }
174     
175     void QueueRecordings(const std::shared_ptr<CFileItem>& item, bool bPlayNext)
176     {
```

Introduced with #17809