### PR TITLE
[Fix]Only expand iso images in music file view window to avoid GUI freezes

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -903,8 +903,13 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
   bool bResult = CGUIMediaWindow::GetDirectory(strDirectory, items);
   if (bResult)
   {
-    // We always want to expand disc images in music windows.
-    CDirectory::FilterFileDirectories(items, ".iso", true);
+    // We want to expand disc images when browsing in file view but not on library, smartplaylist
+    // or node menu music windows
+    if (!items.GetPath().empty() && 
+        !StringUtils::StartsWithNoCase(items.GetPath(), "musicdb://") &&
+        !StringUtils::StartsWithNoCase(items.GetPath(), "special://") &&
+        !StringUtils::StartsWithNoCase(items.GetPath(), "library://"))
+      CDirectory::FilterFileDirectories(items, ".iso", true);
 
     CMusicThumbLoader loader;
     loader.FillThumb(items);


### PR DESCRIPTION
Only check if music items are .iso and expand disc image when browsing in file view, and not generally for every kind of item.

`CDirectory::FilterFileDirectories` is calling the expensive `IsFileFolder()` check  for every item on every music screen and slowing down nodes with lots of items (in particular songs nodes and smartplaylists).  This takes place on the main thread so the GUI can be seen to freeze while this happens.

This is an adjustment to https://github.com/xbmc/xbmc/pull/12004 that makes iso images into file directories in the music window (added in v18 so that add-ons could provide SACD iso support).



