### PR TITLE
[TVOSTopShelf.mm] Use posters before thumbnails

### DIFF
--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -124,7 +124,14 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& movies, CFileItemList& tv)
         };
 
     fillSharedDicts(movies, @"movies", @"moviesTitle", 20386,
-                    [](CFileItemPtr videoItem) { return videoItem->GetArt("thumb"); },
+                    [](CFileItemPtr videoItem) {
+                      if (videoItem->HasArt("poster"))
+                      {
+                        return videoItem->GetArt("poster");
+                      }
+                      else
+                        return videoItem->GetArt("thumb");
+                    },
                     [](CFileItemPtr videoItem) { return videoItem->GetLabel(); });
 
     CVideoDatabase videoDb;


### PR DESCRIPTION
## Description
Use the poster before attempting to use a thumbnail for the top shelf.

## Motivation and Context
To put movies more in line with tv shows in the top shelf.

## How Has This Been Tested?
I have deployed to an Apple TV 4K and it uses the poster icons.

## Screenshots (if appropriate):
![Topshelf](https://user-images.githubusercontent.com/5656510/81613262-20aba800-93ac-11ea-9835-ad9548cf2d6d.jpg)
The artwork on the far right is a thumbnail while the rest are posters.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
