### PR TITLE
remove unnecessary call to GetUsedPercentage in Application.cpp

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4131,9 +4131,6 @@ void CApplication::Process()
     m_slowTimer.Reset();
     ProcessSlow();
   }
-#if !defined(TARGET_DARWIN)
-  CServiceBroker::GetCPUInfo()->GetUsedPercentage(); // must call it to recalculate pct values
-#endif
 }
 
 // We get called every 500ms

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -34,12 +34,14 @@ const CoreInfo CCPUInfo::GetCoreInfo(int coreId)
   return coreInfo;
 }
 
-std::string CCPUInfo::GetCoresUsageString() const
+std::string CCPUInfo::GetCoresUsageString()
 {
   std::string strCores;
 
   if (SupportsCPUUsage())
   {
+	GetUsedPercentage(); // must call it to recalculate pct values
+
     if (!m_cores.empty())
     {
       for (const auto& core : m_cores)

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -40,7 +40,7 @@ std::string CCPUInfo::GetCoresUsageString()
 
   if (SupportsCPUUsage())
   {
-	GetUsedPercentage(); // must call it to recalculate pct values
+    GetUsedPercentage(); // must call it to recalculate pct values
 
     if (!m_cores.empty())
     {

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -83,7 +83,7 @@ public:
 
   bool HasCoreId(int coreId) const;
   const CoreInfo GetCoreInfo(int coreId);
-  std::string GetCoresUsageString() const;
+  std::string GetCoresUsageString();
 
   unsigned int GetCPUFeatures() const { return m_cpuFeatures; }
   int GetCPUCount() const { return m_cpuCount; }


### PR DESCRIPTION
## Description
Removing what seems to be an unnecessary call to `CServiceBroker::GetCPUInfo()->GetUsedPercentage();` inside `Application.cpp`.

I seems that `GetUsedPercentage()` only updates the field `m_lastUsedPercentage` which is used in `CPUInfo::GetCoresUsageString()` method.

`CPUInfo::GetCoresUsageString()` is then called within `GUIWindowDebugInfo.cpp` as well as `SystemGUIInfo.cpp` but in both places is preceded by a call to `GetUsedPercentage()` to update the needed `m_lastUsedPercentage` field.

Thus to me it looks like the call to `GetUsedPercentage()` within the main loop of `Application.cpp` is not needed.

## Motivation and Context
Was investigating an issue with the CPU load on my RPi3B+/Libreelec and had to strace the Kodi binary to see what's going on.
While the bulk of the CPU load was a plugin, I did notice this repetitive read (twice per minute) of the `/proc/cpuinfo`. It seemed unnecessary as I was not on the System info / Summary page (where load is displayed).

## How Has This Been Tested?
I did test, but by applying a patch to Libreelec so that it would remove the lines in Application.cpp before building Kodi. System info / Summary page does show the correct CPU usage and the repetitive call is gone.
However, since now I plan to move to RPi4, I had to rebuild Libreelec for RPi4 with the same patch, thus, I thought is better to come to the source :) instead of constantly patching Libreelec.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
