### PR TITLE
[Fix][Backport] Fix playback of bus encryption enabled bluray discs

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1199,6 +1199,16 @@ bool CFileItem::IsBluray() const
   return item.IsBDFile();
 }
 
+bool CFileItem::IsProtectedBlurayDisc() const
+{
+  std::string path;
+  path = URIUtils::AddFileToFolder(GetPath(), "AACS", "Unit_Key_RO.inf");
+  if (CFile::Exists(path))
+    return true;
+
+  return false;
+}
+
 bool CFileItem::IsCDDA() const
 {
   return URIUtils::IsCDDA(m_strPath);

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -202,6 +202,7 @@ public:
   bool IsDVDFile(bool bVobs = true, bool bIfos = true) const;
   bool IsBDFile() const;
   bool IsBluray() const;
+  bool IsProtectedBlurayDisc() const;
   bool IsRAR() const;
   bool IsAPK() const;
   bool IsZIP() const;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -139,6 +139,7 @@ bool CDVDInputStreamBluray::Open()
   std::string root;
 
   bool openStream = false;
+  bool openDisc = false;
 
   // The item was selected via the simple menu
   if (URIUtils::IsProtocol(strPath, "bluray"))
@@ -146,6 +147,11 @@ bool CDVDInputStreamBluray::Open()
     CURL url(strPath);
     root = url.GetHostName();
     filename = URIUtils::GetFileName(url.GetFileName());
+
+    // Check whether disc is AACS protected
+    CURL url3(root);
+    CFileItem base(url3, false);
+    openDisc = base.IsProtectedBlurayDisc();
 
     // check for a menu call for an image file
     if (StringUtils::EqualsNoCase(filename, "menu"))
@@ -155,6 +161,11 @@ bool CDVDInputStreamBluray::Open()
       std::string root2 = url2.GetHostName();
       CURL url(root2);
       CFileItem item(url, false);
+
+      // Check whether disc is AACS protected
+      if (!openDisc)
+        openDisc = item.IsProtectedBlurayDisc();
+
       if (item.IsDiscImage())
       {
         if (!OpenStream(item))
@@ -170,6 +181,10 @@ bool CDVDInputStreamBluray::Open()
       return false;
 
     openStream = true;
+  }
+  else if (m_item.IsProtectedBlurayDisc())
+  {
+    openDisc = true;
   }
   else
   {
@@ -217,12 +232,25 @@ bool CDVDInputStreamBluray::Open()
       return false;
     }
   }
+  else if (openDisc)
+  {
+    // This special case is required for opening original AACS protected Blu-ray discs. Otherwise
+    // things like Bus Encryption might not be handled properly and playback will fail.
+    m_rootPath = root;
+    if (!bd_open_disc(m_bd, root.c_str(), nullptr))
+    {
+      CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to open %s in disc mode",
+                CURL::GetRedacted(root).c_str());
+      return false;
+    }
+  }
   else
   {
     m_rootPath = root;
     if (!bd_open_files(m_bd, &m_rootPath, CBlurayCallback::dir_open, CBlurayCallback::file_open))
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to open %s", CURL::GetRedacted(root).c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to open %s in files mode",
+                CURL::GetRedacted(root).c_str());
       return false;
     }
   }


### PR DESCRIPTION
Fix playback of bus encryption enabled bluray discs.  Backport of [#17145](https://github.com/xbmc/xbmc/pull/17145)

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Bus encryption is a "protection" that is built in to newer drives, which makes the drives re-encrypt the already encrypted content on-the-fly using something called "data key" (when disc enables BE). Data key is something that drive generates using some secret key and metadata from the disc and it needs to be read from the drive in a special way during AACS authentication (see AACS specifications for details). Then that key must be used for decrypting the bus encryption before the actual content can be decrypted.

When disc is opened using bd_open_files(), libbluray doesn't call aacs_decrypt_bus() which leads in to playback failure because content remains encrypted. This can be fixed by opening discs using bd_open_disc() instead. The old bd_open() which was used in <= Krypton is just a shortcut for bd_open_disc().

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
