### PR TITLE
[PVR] Optimize EPG Grid Container Model.

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -115,6 +115,9 @@ namespace PVR
     std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
     std::shared_ptr<CFileItem> GetItem(int iChannel, int iBlock) const;
 
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGTimeline(
+        int iChannel, const CDateTime& minEventEnd, const CDateTime& maxEventStart) const;
+
     struct EpgTags
     {
       std::vector<std::shared_ptr<CFileItem>> tags;


### PR DESCRIPTION
Optimize EPG data load performance in EPG Guide window by always prefetching +/- data for one grid block.

I tested for more than a month in my living room (Android) and development machine (macOS). 

@phunkyfish mind taking a look at the code change?