### PR TITLE
[PVR] Fix crash due to unsynchronized concurrent EPG database access.

### DIFF
--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -260,6 +260,16 @@ namespace PVR
      */
     CEventStream<PVREvent>& Events() { return m_events; }
 
+    /*!
+     * @brief Lock the instance. No other thread gets access to this EPG until Unlock was called.
+     */
+    void Lock() { m_critSection.lock(); }
+
+    /*!
+     * @brief Unlock the instance. Other threads may get access to this EPG again.
+     */
+    void Unlock() { m_critSection.unlock(); }
+
   private:
     CPVREpg() = delete;
     CPVREpg(const CPVREpg&) = delete;

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -969,31 +969,30 @@ bool CPVREpgDatabase::PersistLastEpgScanTime(int iEpgId,
   return bQueueWrite ? QueueInsertQuery(strQuery) : ExecuteQuery(strQuery);
 }
 
-int CPVREpgDatabase::Persist(int iEpgId,
-                             const std::string& name,
-                             const std::string& scraper,
-                             bool bQueueWrite)
+int CPVREpgDatabase::Persist(const CPVREpg& epg, bool bQueueWrite)
 {
-  int iReturn(-1);
+  int iReturn = -1;
   std::string strQuery;
 
   CSingleLock lock(m_critSection);
-  if (iEpgId > 0)
+  if (epg.EpgID() > 0)
     strQuery = PrepareSQL("REPLACE INTO epg (idEpg, sName, sScraperName) "
-        "VALUES (%u, '%s', '%s');", iEpgId, name.c_str(), scraper.c_str());
+                          "VALUES (%u, '%s', '%s');",
+                          epg.EpgID(), epg.Name().c_str(), epg.ScraperName().c_str());
   else
     strQuery = PrepareSQL("INSERT INTO epg (sName, sScraperName) "
-        "VALUES ('%s', '%s');", name.c_str(), scraper.c_str());
+                          "VALUES ('%s', '%s');",
+                          epg.Name().c_str(), epg.ScraperName().c_str());
 
   if (bQueueWrite)
   {
     if (QueueInsertQuery(strQuery))
-      iReturn = iEpgId <= 0 ? 0 : iEpgId;
+      iReturn = epg.EpgID() <= 0 ? 0 : epg.EpgID();
   }
   else
   {
     if (ExecuteQuery(strQuery))
-      iReturn = iEpgId <= 0 ? static_cast<int>(m_pDS->lastinsertid()) : iEpgId;
+      iReturn = epg.EpgID() <= 0 ? static_cast<int>(m_pDS->lastinsertid()) : epg.EpgID();
   }
 
   return iReturn;

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -228,13 +228,11 @@ namespace PVR
 
     /*!
      * @brief Persist an EPG table. It's entries are not persisted.
-     * @param iEpgId The ID of the EPG.
-     * @param name The name of the EPG.
-     * @param scraper The name of the scraper of the EPG.
+     * @param epg The table to persist.
      * @param bQueueWrite Don't execute the query immediately but queue it if true.
      * @return The database ID of this entry or 0 if bSingleUpdate is false and the query was queued.
      */
-    int Persist(int iEpgId, const std::string& name, const std::string& scraper, bool bQueueWrite);
+    int Persist(const CPVREpg& epg, bool bQueueWrite);
 
     /*!
      * @brief Erase all EPG tags with the given epg ID and an end time less than the given time.


### PR DESCRIPTION
https://github.com/xbmc/xbmc/commit/fcf1e5f670b7d464be2b41e21120cb51ef9913aa fixed a deadlock, but introducued a race. :-(

```
05-11 02:07:54.342  8607 10346 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x202c7473614373 in tid 10346 (Thread-6), pid 8607 (org.xbmc.kodi)
05-11 02:07:54.498 25707 25707 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
05-11 02:07:54.499 25707 25707 F DEBUG   : Build fingerprint: 'NVIDIA/mdarcy/mdarcy:9/PPR1.180610.011/4199437_1915.8582:user/release-keys'
05-11 02:07:54.499 25707 25707 F DEBUG   : Revision: '0'
05-11 02:07:54.499 25707 25707 F DEBUG   : ABI: 'arm64'
05-11 02:07:54.499 25707 25707 F DEBUG   : pid: 8607, tid: 10346, name: Thread-6  >>> org.xbmc.kodi <<<
05-11 02:07:54.499 25707 25707 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x202c7473614373
05-11 02:07:54.499 25707 25707 F DEBUG   :     x0  73202c7473614373  x1  00000022d93b9a04  x2  0000000000000000  x3  0000000000000000
05-11 02:07:54.499 25707 25707 F DEBUG   :     x4  0000000000000000  x5  8080808080808080  x6  fefefefefefefeff  x7  7f7f7f7f7f7f7f7f
05-11 02:07:54.499 25707 25707 F DEBUG   :     x8  0000000000000000  x9  d478455c5c9353c5  x10 00000022c6e30518  x11 0000000000000000
05-11 02:07:54.499 25707 25707 F DEBUG   :     x12 642065646e45206d  x13 6568636f57207265  x14 0000000000000004  x15 0000000000000000
05-11 02:07:54.499 25707 25707 F DEBUG   :     x16 00000022c9b01278  x17 000000222531e610  x18 0000000000000030  x19 00000022df43bb88
05-11 02:07:54.499 25707 25707 F DEBUG   :     x20 0000000000000000  x21 00000022d93b9ac9  x22 73202c7473614373  x23 00000022d93ba588
05-11 02:07:54.499 25707 25707 F DEBUG   :     x24 00000022d93ba588  x25 00000022c890c3ff  x26 00000022dab701c0  x27 0000000000000001
05-11 02:07:54.499 25707 25707 F DEBUG   :     x28 0000000000000001  x29 00000022d93b9a40
05-11 02:07:54.499 25707 25707 F DEBUG   :     sp  00000022d93b9a00  lr  00000022c68575b4  pc  00000022c68576b8
05-11 02:07:54.573 25707 25707 F DEBUG   : 
05-11 02:07:54.573 25707 25707 F DEBUG   : backtrace:
05-11 02:07:54.573 25707 25707 F DEBUG   :     #00 pc 00000000011f96b8  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.573 25707 25707 F DEBUG   :     #01 pc 00000000011f95b0  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.573 25707 25707 F DEBUG   :     #02 pc 0000000001a8eab4  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVREpgDatabase::CreateEpgTag(std::__ndk1::unique_ptr<dbiplus::Dataset, std::__ndk1::default_delete<dbiplus::Dataset>> const&)+848)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #03 pc 0000000001a8fee8  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVREpgDatabase::GetEpgTagByUniqueBroadcastID(int, unsigned int)+140)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #04 pc 0000000001a9aba0  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVREpgTagsContainer::GetTag(unsigned int) const+192)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #05 pc 0000000001a89b3c  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVREpg::GetTagByBroadcastId(unsigned int) const+68)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #06 pc 0000000001a2eb88  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRTimerInfoTag::GetEpgInfoTag(bool) const+384)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #07 pc 0000000001a2af84  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRTimerInfoTag::UpdateEpgInfoTag()+68)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #08 pc 0000000001a2d17c  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRTimerInfoTag::UpdateEntry(std::__ndk1::shared_ptr<PVR::CPVRTimerInfoTag> const&)+732)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #09 pc 0000000001a31fe4  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRTimers::UpdateEntries(PVR::CPVRTimersContainer const&, std::__ndk1::vector<int, std::__ndk1::allocator<int>> const&)+348)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #10 pc 0000000001a31d7c  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRTimers::Update()+200)
05-11 02:07:54.573 25707 25707 F DEBUG   :     #11 pc 0000000001b51240  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.573 25707 25707 F DEBUG   :     #12 pc 0000000001b511f8  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.573 25707 25707 F DEBUG   :     #13 pc 0000000001b4dea8  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRManagerJobQueue::ExecutePendingJobs()+204)
05-11 02:07:54.574 25707 25707 F DEBUG   :     #14 pc 0000000001b4f7d0  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (PVR::CPVRManager::Process()+628)
05-11 02:07:54.574 25707 25707 F DEBUG   :     #15 pc 00000000016307cc  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so (CThread::Action()+40)
05-11 02:07:54.574 25707 25707 F DEBUG   :     #16 pc 0000000001630d70  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.574 25707 25707 F DEBUG   :     #17 pc 0000000001630c24  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.574 25707 25707 F DEBUG   :     #18 pc 0000000001630a30  /data/app/org.xbmc.kodi-BQlqLJpuPzct5E9p0sgrrA==/lib/arm64/libkodi.so
05-11 02:07:54.574 25707 25707 F DEBUG   :     #19 pc 0000000000081978  /system/lib64/libc.so (__pthread_start(void*)+36)
05-11 02:07:54.574 25707 25707 F DEBUG   :     #20 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
```

EPG updater thread was concurrently saving EPG tags to database...

Runtime-tested on macOS and Android.

@phunkyfish when you have some time...