### PR TITLE
[application] Fix mixed pictures/videos slideshow ending after first video.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4595,10 +4595,8 @@ void CApplication::SeekPercentage(float percent)
 // SwitchToFullScreen() returns true if a switch is made, else returns false
 bool CApplication::SwitchToFullScreen(bool force /* = false */)
 {
-  const int activeWindowID = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
-
   // don't switch if the slideshow is active
-  if (activeWindowID == WINDOW_SLIDESHOW)
+  if (CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_SLIDESHOW))
     return false;
 
   // if playing from the video info window, close it first!
@@ -4626,6 +4624,7 @@ bool CApplication::SwitchToFullScreen(bool force /* = false */)
       pDialog->Close(true);
   }
 
+  const int activeWindowID = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
   int windowID = WINDOW_INVALID;
 
   // See if we're playing a game


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/xbmc/xbmc/pull/17574/commits/f8ae942b1809a9404878033b8c3584ec349d8733

I've learned that `IsWindowActive()` for a given window id might return true even if `GetActiveWindow()` for the same window id does not return this window.

Runtime-tested on macOS and Android.