### PR TITLE
[android] Fix crash on Kodi exit (powersyscall no more available, but called).

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -251,8 +251,11 @@ void CXBMCApp::onResume()
     RequestVisibleBehind(true);
 
   if (g_application.IsInitialized())
-    dynamic_cast<CAndroidPowerSyscall*>(CServiceBroker::GetPowerManager().GetPowerSyscall())
-        ->SetOnResume();
+  {
+    IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
+    if (syscall)
+      static_cast<CAndroidPowerSyscall*>(syscall)->SetOnResume();
+  }
 }
 
 void CXBMCApp::onPause()
@@ -274,8 +277,9 @@ void CXBMCApp::onPause()
   EnableWakeLock(false);
   m_hasReqVisible = false;
 
-  dynamic_cast<CAndroidPowerSyscall*>(CServiceBroker::GetPowerManager().GetPowerSyscall())
-      ->SetOnPause();
+  IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
+  if (syscall)
+    static_cast<CAndroidPowerSyscall*>(syscall)->SetOnPause();
 }
 
 void CXBMCApp::onStop()


### PR DESCRIPTION
Fixes a crash on Kodi exit:

```
05-03 09:01:55.024  1573  1594 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xa8 in tid 1594 (Thread-2), pid 1573 (org.xbmc.kodi)
05-03 09:01:55.225 16182 16182 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
05-03 09:01:55.225 16182 16182 F DEBUG   : Build fingerprint: 'NVIDIA/mdarcy/mdarcy:9/PPR1.180610.011/4199437_1915.8582:user/release-keys'
05-03 09:01:55.225 16182 16182 F DEBUG   : Revision: '0'
05-03 09:01:55.225 16182 16182 F DEBUG   : ABI: 'arm64'
05-03 09:01:55.225 16182 16182 F DEBUG   : pid: 1573, tid: 1594, name: Thread-2  >>> org.xbmc.kodi <<<
05-03 09:01:55.225 16182 16182 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xa8
05-03 09:01:55.225 16182 16182 F DEBUG   : Cause: null pointer dereference
05-03 09:01:55.225 16182 16182 F DEBUG   :     x0  00000000000000a8  x1  000000005c935300  x2  0000000000000000  x3  00000022a81581b7
05-03 09:01:55.225 16182 16182 F DEBUG   :     x4  00000022c09dee88  x5  0000000072ec9e31  x6  0000000000000002  x7  00000022c09dee58
05-03 09:01:55.225 16182 16182 F DEBUG   :     x8  00000022a785b800  x9  d478455c5c9353c5  x10 0000000000430000  x11 00000000000000ff
05-03 09:01:55.225 16182 16182 F DEBUG   :     x12 0000000000000000  x13 0000000000000000  x14 00000022c09de55e  x15 0000000000000000
05-03 09:01:55.225 16182 16182 F DEBUG   :     x16 00000022c5f9a140  x17 00000022c3453ed4  x18 0000000000000001  x19 00000022a7867f00
05-03 09:01:55.225 16182 16182 F DEBUG   :     x20 000000000000000d  x21 00000022c09df588  x22 0000000000000001  x23 00000022c393c688
05-03 09:01:55.225 16182 16182 F DEBUG   :     x24 00000022c09df570  x25 00000022c08e2000  x26 0000002221d9d5e0  x27 0000000000000058
05-03 09:01:55.225 16182 16182 F DEBUG   :     x28 0000007fc35a1820  x29 00000022c09df210
05-03 09:01:55.225 16182 16182 F DEBUG   :     sp  00000022c09df210  lr  00000022c3455540  pc  00000022c3455540
05-03 09:01:55.294 16182 16182 F DEBUG   : 
05-03 09:01:55.294 16182 16182 F DEBUG   : backtrace:
05-03 09:01:55.294 16182 16182 F DEBUG   :     #00 pc 0000000001955540  /data/app/org.xbmc.kodi-cdfSjogSeHYF-mP12LqBRw==/lib/arm64/libkodi.so
05-03 09:01:55.294 16182 16182 F DEBUG   :     #01 pc 00000000011ebbf8  /data/app/org.xbmc.kodi-cdfSjogSeHYF-mP12LqBRw==/lib/arm64/libkodi.so (CXBMCApp::onPause()+272)
05-03 09:01:55.294 16182 16182 F DEBUG   :     #02 pc 0000000001e3c784  /data/app/org.xbmc.kodi-cdfSjogSeHYF-mP12LqBRw==/lib/arm64/libkodi.so
05-03 09:01:55.294 16182 16182 F DEBUG   :     #03 pc 0000000001e2e09c  /data/app/org.xbmc.kodi-cdfSjogSeHYF-mP12LqBRw==/lib/arm64/libkodi.so (CEventLoop::run(IActivityHandler&, IInputHandler&)+88)
05-03 09:01:55.294 16182 16182 F DEBUG   :     #04 pc 0000000001e2c6e0  /data/app/org.xbmc.kodi-cdfSjogSeHYF-mP12LqBRw==/lib/arm64/libkodi.so (android_main+100)
05-03 09:01:55.294 16182 16182 F DEBUG   :     #05 pc 0000000001e3c730  /data/app/org.xbmc.kodi-cdfSjogSeHYF-mP12LqBRw==/lib/arm64/libkodi.so
05-03 09:01:55.294 16182 16182 F DEBUG   :     #06 pc 0000000000081978  /system/lib64/libc.so (__pthread_start(void*)+36)
05-03 09:01:55.294 16182 16182 F DEBUG   :     #07 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
```

Runtime-tested for two weeks, no more crashes on exit.

@lrusak fyi
@peak3d hope you find a minute to review the code change