### PR TITLE
[GUI] Don't touch plugin:// urls

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -523,12 +523,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     {
       if (m_vecItems->GetPath() == "?")
         m_vecItems->SetPath("");
-      std::string path, fileName;
       std::string dir = message.GetStringParam(0);
-      URIUtils::Split(dir, path, fileName);
-      URIUtils::RemoveExtension(fileName);
-      if (StringUtils::IsInteger(fileName))
-        dir = path;
       const std::string &ret = message.GetStringParam(1);
       bool returning = StringUtils::EqualsNoCase(ret, "return");
       if (!dir.empty())
@@ -2174,6 +2169,21 @@ std::string CGUIMediaWindow::GetStartFolder(const std::string &dir)
   if (StringUtils::EqualsNoCase(dir, "$root") ||
       StringUtils::EqualsNoCase(dir, "root"))
     return "";
+
+  // Let plugins handle their own urls themselves
+  if (StringUtils::StartsWith(dir, "plugin://"))
+    return dir;
+
+//! @todo This ifdef block probably belongs somewhere else. Move it to a better place!
+#if defined(TARGET_ANDROID)
+  // Hack for Android items (numbered id's) on the leanback screen
+  std::string path;
+  std::string fileName;
+  URIUtils::Split(dir, path, fileName);
+  URIUtils::RemoveExtension(fileName);
+  if (StringUtils::IsInteger(fileName))
+    return path;
+#endif
 
   return dir;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Kodi should pass untouched `plugin://` urls when getting the start folder of a GUIMediaWindow with `GetStartFolder`.
Changes to the dir parameter of `ActivateWindow()` should be done in `GetStartFolder`. (in this case a hack for the Android leanback  screen)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Plugins can independently create their own `plugin://` urls and Kodi shouldn't change these urls when a plugin calls a builtin function like `ActivateWindow()`. This solves an issue where Kodi removes numbers from `plugin://` urls.
For instance, when a plugin needs to list Season 25 of a TV show "Thuis" using  `ActivateWindow()`, the plugin calls `plugin://plugin.video.vrt.nu/programs/thuis/25` but Kodi removes the number `25` and wrongly navigates to `plugin://plugin.video.vrt.nu/programs/thuis/`
<!--- If it fixes an open issue, please link to the issue here -->
This fixes https://github.com/xbmc/xbmc/issues/16516

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I tested this with **autoexec.py**:
```
import xbmc
xbmc.executebuiltin('ActivateWindow(videos, plugin://plugin.video.vrt.nu/programs/thuis/25)')
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
