### PR TITLE
Revert "[Backport][Android] pause audio playback when headphone is disconnected"

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -214,7 +214,6 @@ void CXBMCApp::onStart()
     intentFilter.addAction("android.intent.action.BATTERY_CHANGED");
     intentFilter.addAction("android.intent.action.SCREEN_ON");
     intentFilter.addAction("android.intent.action.HEADSET_PLUG");
-    intentFilter.addAction("android.media.AUDIO_BECOMING_NOISY");
     // We currently use HDMI_AUDIO_PLUG for mode switch, don't use it on TV's (device_type = "0"
     if (m_hdmiSource)
       intentFilter.addAction("android.media.action.HDMI_AUDIO_PLUG");
@@ -1028,12 +1027,6 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   {
     if (m_playback_state & PLAYBACK_STATE_VIDEO)
       CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
-  }
-  else if (action == "android.media.AUDIO_BECOMING_NOISY")
-  {
-    if ((m_playback_state & PLAYBACK_STATE_PLAYING) && (m_playback_state & PLAYBACK_STATE_AUDIO))
-      CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
-                                                   static_cast<void*>(new CAction(ACTION_PAUSE)));
   }
   else if (action == "android.intent.action.MEDIA_BUTTON")
   {


### PR DESCRIPTION
This reverts commit 46d79a9543461bd4b71958d6381c886857f1fc14.
from the PR here: https://github.com/xbmc/xbmc/pull/17541
which is a backport of this PR: https://github.com/xbmc/xbmc/pull/17030

This commit is causing Kodi to pause playback on frame-rate switches after content is playing (late switch)

Discussion here
https://github.com/peak3d/inputstream.adaptive/pull/440#issuecomment-628810495

Confirmed fix here:
https://github.com/peak3d/inputstream.adaptive/pull/440#issuecomment-628877029
https://www.kodinerds.net/index.php/Thread/67624-Disney-Addon/?postID=590508#post590508

To reproduce the issue - use either Leia or Matrix nightly on Android.
Set frame-rate switch time to 6 seconds.
Play content with different frame-rate - observe kodi pauses after the framerate switch

You can also get same behaviour when content is playing, going into kodi settings and changing frame-rate

**Test builds with this commit reverted**

ARM:
https://jenkins.kodi.tv/job/Android-ARM/18067/artifact/kodi-20200514-ee2959ce-PR17868-merge-armeabi-v7a.apk

ARM64:
https://jenkins.kodi.tv/job/Android-ARM64/14703/artifact/kodi-20200514-ee2959ce-PR17868-merge-arm64-v8a.apk

Should I also do PR to revert the Matrix commit?
Or leave it and give the author a chance to update?
18.7 is close - so think it's safer to remove from Leia


## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Kodi 18.7 built without the commit tested vs Kodi 18.7 with the commit by user on Nvidia shield.
Confirmed using the build without the commit (and also Kodi 18.6) that the issue does not happen

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
