### PR TITLE
[darwin_embedded] refactor unneeded cmake vars from Toolchain

### DIFF
--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -8,25 +8,28 @@ set(PLATFORM_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/${CORE_P
 set(ARCH_DEFINES -DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_EMBEDDED)
 if(CORE_PLATFORM_NAME_LC STREQUAL tvos)
   list(APPEND ARCH_DEFINES -DTARGET_DARWIN_TVOS)
+  set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE YES)
+  set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY 3)
+  set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET 11.0)
 else()
   list(APPEND ARCH_DEFINES -DTARGET_DARWIN_IOS)
+  set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE NO)
+  set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY 1,2)
+  set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 11.0)
 endif()
 set(SYSTEM_DEFINES -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
                    -D__STDC_CONSTANT_MACROS -DHAS_IOS_NETWORK -DHAS_ZEROCONF)
 set(PLATFORM_DIR platform/darwin)
 set(PLATFORMDEFS_DIR platform/posix)
 set(CMAKE_SYSTEM_NAME Darwin)
-if(WITH_ARCH)
-  set(ARCH ${WITH_ARCH})
+if(CPU STREQUAL arm64)
+  set(ARCH aarch64)
 else()
-  if(CPU STREQUAL arm64)
-    set(ARCH aarch64)
-  else()
-    message(SEND_ERROR "Unknown CPU: ${CPU}")
-  endif()
-  set(CMAKE_OSX_ARCHITECTURES ${CPU})
-  set(NEON True)
+  message(SEND_ERROR "Unknown CPU: ${CPU}")
 endif()
+set(CMAKE_OSX_ARCHITECTURES ${CPU})
+set(NEON True)
+
 
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${NATIVEPREFIX})
 
@@ -37,7 +40,7 @@ list(APPEND DEPLIBS "-framework CoreFoundation" "-framework CoreVideo"
                     "-framework Foundation" "-framework UIKit"
                     "-framework CoreMedia" "-framework AVFoundation"
                     "-framework VideoToolbox" "-lresolv" "-ObjC"
-                    "-framework AVKit")
+                    "-framework AVKit" "-liconv")
 
 set(ENABLE_OPTICAL OFF CACHE BOOL "" FORCE)
 

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -54,16 +54,6 @@ if(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
     # complety disable code signing
     # see: https://gitlab.kitware.com/cmake/cmake/issues/19112
     set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
-    if(CORE_PLATFORM_NAME STREQUAL tvos)
-      set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
-      set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "3")
-      set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET 11.0)
-    else()
-      # set this to YES once we have a deployment target of at least iOS 6.0
-      set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")
-      set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2")
-      set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 11.0)
-    endif()
   endif()
 endif()
 


### PR DESCRIPTION
## Description
A number of these cmake settings can be moved out of Toolchain.cmake into the platform
specific Archsetup.cmake
Minor refinements of Archsetup.cmake

## Motivation and Context
Looking to cleanup toolchain.cmake regarding darwin_embedded specific settings

## How Has This Been Tested?
Local build and run for AppleTV

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
