### PR TITLE
[Fix]Prevent album scraping leaving artist blank

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -247,17 +247,17 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
   }
 
   /*
-   Scraping can return different album artists from the originals derived from tags, even when doing
-   a lookup on name.
+   Scraping can return different album artists from the originals derived from tags, even when
+   doing a lookup on artist name.
 
    When overwritting the data derived from tags, AND the original and scraped album have the same
    Musicbrainz album ID, then merging an album replaces both the album artsts and the song artists
-   with those scraped.
+   with those scraped (providing they are not empty).
 
    When not doing that kind of merge, for any matching artist names the Musicbrainz artist id
    returned by the scraper can be used to populate any previously missing Musicbrainz artist id values.
   */
-  if (bArtistSongMerge)
+  if (bArtistSongMerge && !source.artistCredits.empty())
   {
     artistCredits = source.artistCredits; // Replace artists and store mbid returned by scraper
     strArtistDesc.clear();  // @todo: set artist display string e.g. "artist1 & artist2" when scraped


### PR DESCRIPTION
Album scrapers should return album artist for the scraped results, but if they don't and the "prefer online information" setting is enabled then it results in the album artist being cleared in the music library.

Reported by user on forum https://forum.kodi.tv/showthread.php?tid=354433
The Universal Album Scraper is not currently returning album artist, probably because of a change at Musicbrainz and the way they format xml results, this reveals the flaw

This makes the merge process more robust and ensures that album artist is only replaced with a non-empty value.


