### PR TITLE
[GUI] Fix ActivateWindow if 'return' is defined

### DIFF
--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -419,21 +419,23 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     @param[in] loop                  Send "loop" to loop the alarm.
 ///   }
 ///   \table_row2_l{
-///     <b>`ActivateWindow(window[\,dir])`</b>
+///     <b>`ActivateWindow(window[\,dir\, return])`</b>
 ///     ,
 ///     Opens the given window. The parameter window can either be the window's id\,
-///     or in the case of a standard window\, the window's name. See here for a list
-///     of window names\, and their respective ids. If\, furthermore\, the window is
+///     or in the case of a standard window\, the window's name. See \ref window_ids "here" for a list
+///     of window names\, and their respective ids.
+///     If\, furthermore\, the window is
 ///     Music\, Video\, Pictures\, or Program files\, then the optional dir parameter
 ///     specifies which folder Kodi should default to once the window is opened.
 ///     This must be a source as specified in sources.xml\, or a subfolder of a
-///     valid source. For some windows (MusicLibrary and VideoLibrary)\, the return
-///     parameter may be specified\, which indicates that Kodi should use this
+///     valid source. For some windows (MusicLibrary and VideoLibrary)\, a third
+///     parameter (return) may be specified\, which indicates that Kodi should use this
 ///     folder as the "root" of the level\, and thus the "parent directory" action
 ///     from within this folder will return the user to where they were prior to
 ///     the window activating.
 ///     @param[in] window                The window name.
 ///     @param[in] dir                   Window starting folder (optional).
+///     @param[in] return                if dir should be used as the rootfolder of the level
 ///   }
 ///   \table_row2_l{
 ///     <b>`ActivateWindowAndFocus(id1\, id2\,item1\, id3\,item2)`</b>

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -553,12 +553,22 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         if (resetHistory)
         {
           m_vecItems->RemoveDiscCache(GetID());
-          SetHistoryForPath(m_vecItems->GetPath());
+          // only compute the history for the provided path if "return" is not defined
+          // (otherwise the root level for the path will be added by default to the path history
+          // and we won't be able to move back to the path we came from)
+          if (!returning)
+            SetHistoryForPath(m_vecItems->GetPath());
         }
       }
       if (message.GetParam1() != WINDOW_INVALID)
-      { // first time to this window - make sure we set the root path
-        m_startDirectory = returning ? dir : GetRootPath();
+      {
+        // if this is the first time to this window - make sure we set the root path
+        // if "return" is defined make sure we set the startDirectory to the directory we are
+        // moving to (so that we can move back to where we were onBack). If we are activating
+        // the same window but with a different path, do nothing - we are simply adding to the
+        // window history.
+        if (message.GetParam1() != message.GetParam2())
+          m_startDirectory = returning ? dir : GetRootPath();
       }
       if (message.GetParam2() == PLUGIN_REFRESH_DELAY)
       {


### PR DESCRIPTION
## Description
This pull request fixes the usage of `ActivateWindow(window, dir, return)` if the action is executed from context menu items (which according to the bug report is there since krypton).

This is mainly the case in python addons where listitems are created (for example) with the `ActivateWindow(xxxx, plugin://plugin.video.foo/bar, return)` as context menu actions. Other examples are any other `dir` paths to MusicLibrary and VideoLibrary.

According to the documentation, it is expected that Kodi moves back to the plugin directory from which the action was executed. However this doesn't work because:

- Kodi always computes the history for the provided path even if we specify the return parameter (e.g. we provide "plugin://plugin.video.foo/bar" as `dir`, Kodi will create the respective history: `plugin://plugin.video.foo/bar` ../ `plugin://plugin.video.foo`)

- Kodi always defines the provided `dir` as the root folder. This works well if we are activating a different window than the one that is already active. If they are the same, the root folder of `dir` should be set to the `path` that was on the media window before activating this new one otherwise we won't be able to move back to where we were.

@mediaminister @dagwieers since you were the ones reporting the issue, it'd be nice if you guys could test it.

I am unsure who I should ping for review, this seems no-man's code by now.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/16492

## How Has This Been Tested?
Context menu item created in a plugin that pointed to another plugin:
```python
    myitem = xbmcgui.ListItem("TEST")
    myitem.addContextMenuItems([("move to programs", "ActivateWindow(Videos,plugin://plugin.video.vrt.nu/programs/emma/allseasons, return)")])
    xbmcplugin.addDirectoryItem(handle=plugin.handle, listitem=myitem, isFolder=True, url=plugin.url_for(live))
```
Confirmed the `onBack` action moved back to where I was before. Also tested library navigation (movies and tvshows) in estuary and confirmed the behaviour is still the same.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
