### PR TITLE
[Estuary] PVR side blade: Fix label for PVR quick navigation button list

### DIFF
--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -60,7 +60,7 @@
 					<height>50</height>
 					<control type="label">
 						<include>MediaMenuLabelCommon</include>
-						<label>$LOCALIZE[31063]</label>
+						<label>$LOCALIZE[31148]</label>
 					</control>
 					<control type="label">
 						<width>470</width>


### PR DESCRIPTION
Fixes small inconsistency in labeling "Categories" on home screen vs. in Estuary side blade.

On home screen, we always use "Categories".
![screenshot001](https://user-images.githubusercontent.com/3226626/82354417-0f444a80-9a01-11ea-8d05-d851b5059dd1.png)

Before, in side blade before we used "Sections":
![screenshot002](https://user-images.githubusercontent.com/3226626/82354624-57fc0380-9a01-11ea-80a7-078c6befde0e.png)

After, in side blade we use "Categories":
![screenshot000](https://user-images.githubusercontent.com/3226626/82354641-5cc0b780-9a01-11ea-9bdd-dc171269f9b4.png)

@ronie do the skin changes look good to you? ;-)