### PR TITLE
[PVR] Fix context menu item 'Add timer' visibility conditions.

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -455,13 +455,8 @@ namespace PVR
     bool AddTimerRule::IsVisible(const CFileItem& item) const
     {
       const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
-      if (epg && !epg->IsGapTag() &&
-          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg))
-      {
-        const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
-        return client && client->GetClientCapabilities().SupportsTimers();
-      }
-      return false;
+      return (epg && !epg->IsGapTag() &&
+              !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg));
     }
 
     bool AddTimerRule::Execute(const CFileItemPtr& item) const


### PR DESCRIPTION
Fixes a small bug with "Add timer" context menu item visibility. Since we have PVR Reminders, this item should be visible for every EPG tag (not being a gap tag or already having a timer), because reminders are implemented in Kodi core, not in the PVR addons/backend. So, checking for a pvr client supporting timers is the wrong visibility condition here.

@phunkyfish mind taking a look at the code change.