### PR TITLE
[Android] Replace PLAYBACK_STATE_CANNOT_PAUSE (as broken?)

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -101,7 +101,6 @@
 #define PLAYBACK_STATE_PLAYING  0x0001
 #define PLAYBACK_STATE_VIDEO    0x0100
 #define PLAYBACK_STATE_AUDIO    0x0200
-#define PLAYBACK_STATE_CANNOT_PAUSE 0x0400
 
 using namespace KODI::MESSAGING;
 using namespace ANNOUNCEMENT;
@@ -288,7 +287,7 @@ void CXBMCApp::onStop()
 
   if ((m_playback_state & PLAYBACK_STATE_PLAYING) && !m_hasReqVisible)
   {
-    if (m_playback_state & PLAYBACK_STATE_CANNOT_PAUSE)
+    if (!g_application.GetAppPlayer().CanPause())
       CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
     else if (m_playback_state & PLAYBACK_STATE_VIDEO)
       CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
@@ -751,8 +750,6 @@ void CXBMCApp::OnPlayBackStarted()
     m_playback_state |= PLAYBACK_STATE_VIDEO;
   if (g_application.GetAppPlayer().HasAudio())
     m_playback_state |= PLAYBACK_STATE_AUDIO;
-  if (!g_application.GetAppPlayer().CanPause())
-    m_playback_state |= PLAYBACK_STATE_CANNOT_PAUSE;
 
   m_mediaSession->activate(true);
   UpdateSessionState();
@@ -1184,7 +1181,7 @@ void CXBMCApp::onVisibleBehindCanceled()
   // Pressing the pause button calls OnStop() (cf. https://code.google.com/p/android/issues/detail?id=186469)
   if ((m_playback_state & PLAYBACK_STATE_PLAYING))
   {
-    if (m_playback_state & PLAYBACK_STATE_CANNOT_PAUSE)
+    if (!g_application.GetAppPlayer().CanPause())
       CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
     else if (m_playback_state & PLAYBACK_STATE_VIDEO)
       CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
@@ -1220,7 +1217,7 @@ void CXBMCApp::onAudioFocusChange(int focusChange)
   {
     if ((m_playback_state & PLAYBACK_STATE_PLAYING))
     {
-      if (m_playback_state & PLAYBACK_STATE_CANNOT_PAUSE)
+      if (!g_application.GetAppPlayer().CanPause())
         CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
       else
         CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
PLAYBACK_STATE_CANNOT_PAUSE is only set in OnPlayBackStarted.
At that stage in time, g_application.GetAppPlayer().CanPause() seems to always return False.
Therefore, PLAYBACK_STATE_CANNOT_PAUSE is always True.

I assume CanPause() eventually gets updated to return True once Kodi does some other things?
So, we can't rely on that in OnPlayBackStarted.

It also means all the places where PLAYBACK_STATE_CANNOT_PAUSE  is checked always return True.
Possibly causing unwanted behavior

We could update PLAYBACK_STATE_CANNOT_PAUSE in UpdateSessionState like the other states, but UpdateSessionState doesn't appear to always be called...

As it's not used that often, and seems a bit "out of place", why not just replace it's use with g_application.GetAppPlayer().CanPause()?

**UPDATE:**

PLAYBACK_STATE_CANNOT_PAUSE seems to be OK in 18.7 on Android TV
On shield - pressing home button or chrome-casting Pauses content

but in 19 on Shield, it Stops content (then resumes when re-open app)
Oddly, replacing with g_application.GetAppPlayer().CanPause() (this PR) doesnt make a difference.

But using g_application.GetAppPlayer().CanPause() on 19 with my headset pause PR works fine on my phone.

Confused!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
