### PR TITLE
[JSON-RPC] Return player properties when an other player is active

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1280,10 +1280,7 @@ PlayerType CPlayerOperations::GetPlayer(const CVariant &player)
       break;
   }
 
-  if (GetPlaylist(playerID) == iPlayer)
-    return playerID;
-  else
-    return None;
+  return playerID;
 }
 
 int CPlayerOperations::GetPlaylist(PlayerType player)
@@ -1295,10 +1292,10 @@ int CPlayerOperations::GetPlaylist(PlayerType player)
   switch (player)
   {
     case Video:
-      return playlist == PLAYLIST_NONE ? PLAYLIST_VIDEO : playlist;
+      return PLAYLIST_VIDEO;
 
     case Audio:
-      return playlist == PLAYLIST_NONE ? PLAYLIST_MUSIC : playlist;
+      return PLAYLIST_MUSIC;
 
     case Picture:
       return PLAYLIST_PICTURE;
@@ -1395,7 +1392,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        result = g_application.GetAppPlayer().IsPausedPlayback() ? 0 : (int)lrint(g_application.GetAppPlayer().GetPlaySpeed());
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = (int)lrint(g_application.GetAppPlayer().GetPlaySpeed());
+        else
+          result = 0;
         break;
 
       case Picture:
@@ -1419,7 +1419,12 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
       {
         int ms = 0;
         if (!IsPVRChannel())
-          ms = (int)(g_application.GetTime() * 1000.0);
+        {
+          if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+            ms = (int)(g_application.GetTime() * 1000.0);
+          else
+            ms = 0;
+        }
         else
         {
           std::shared_ptr<CPVREpgInfoTag> epg(GetCurrentEpg());
@@ -1448,7 +1453,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
       case Audio:
       {
         if (!IsPVRChannel())
-          result = g_application.GetPercentage();
+          if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+            result = g_application.GetPercentage();
+          else
+            result = 0.0;
         else
         {
           std::shared_ptr<CPVREpgInfoTag> epg(GetCurrentEpg());
@@ -1478,10 +1486,11 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-      {
-        result = g_application.GetCachePercentage();
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = g_application.GetCachePercentage();
+        else
+          result = 0.0;
         break;
-      }
 
       case Picture:
       {
@@ -1502,7 +1511,12 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
       {
         int ms = 0;
         if (!IsPVRChannel())
-          ms = (int)(g_application.GetTotalTime() * 1000.0);
+        {
+          if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+            ms = (int)(g_application.GetTotalTime() * 1000.0);
+          else
+            ms = 0;
+        }
         else
         {
           std::shared_ptr<CPVREpgInfoTag> epg(GetCurrentEpg());
@@ -1558,7 +1572,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        if (IsPVRChannel())
+        if (IsPVRChannel() || CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != playlist)
         {
           result = "off";
           break;
@@ -1591,7 +1605,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        if (IsPVRChannel())
+        if (IsPVRChannel() || CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != playlist)
         {
           result = false;
           break;
@@ -1619,7 +1633,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        result = g_application.GetAppPlayer().CanSeek();
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = g_application.GetAppPlayer().CanSeek();
+        else
+          result = false;
         break;
 
       case Picture:
@@ -1634,7 +1651,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        result = !IsPVRChannel();
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = !IsPVRChannel();
+        else
+          result = false;
         break;
 
       case Picture:
@@ -1695,7 +1715,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
       case Video:
       case Audio:
       case Picture:
-        result = !IsPVRChannel();
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = !IsPVRChannel();
+        else
+          result = false;
         break;
 
       default:
@@ -1709,7 +1732,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        result = !IsPVRChannel();
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = !IsPVRChannel();
+        else
+          result = false;
         break;
 
       case Picture:
@@ -1724,7 +1750,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        if (g_application.GetAppPlayer().HasPlayer())
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist && g_application.GetAppPlayer().HasPlayer())
         {
           result = CVariant(CVariant::VariantTypeObject);
           int index = g_application.GetAppPlayer().GetAudioStream();
@@ -1760,7 +1786,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        if (g_application.GetAppPlayer().HasPlayer())
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist && g_application.GetAppPlayer().HasPlayer())
         {
           for (int index = 0; index < g_application.GetAppPlayer().GetAudioStreamCount(); index++)
           {
@@ -1793,19 +1819,22 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
     case Video:
     {
-      int index = g_application.GetAppPlayer().GetVideoStream();
-      if (index >= 0)
+      if (g_application.GetAppPlayer().HasVideo())
       {
         result = CVariant(CVariant::VariantTypeObject);
-        VideoStreamInfo info;
-        g_application.GetAppPlayer().GetVideoStreamInfo(index, info);
+        int index = g_application.GetAppPlayer().GetVideoStream();
+        if (index >= 0)
+        {
+          VideoStreamInfo info;
+          g_application.GetAppPlayer().GetVideoStreamInfo(index, info);
 
-        result["index"] = index;
-        result["name"] = info.name;
-        result["language"] = info.language;
-        result["codec"] = info.codecName;
-        result["width"] = info.width;
-        result["height"] = info.height;
+          result["index"] = index;
+          result["name"] = info.name;
+          result["language"] = info.language;
+          result["codec"] = info.codecName;
+          result["width"] = info.width;
+          result["height"] = info.height;
+        }
       }
       else
         result = CVariant(CVariant::VariantTypeNull);
@@ -1872,7 +1901,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     switch (player)
     {
       case Video:
-        if (g_application.GetAppPlayer().HasPlayer())
+        if (g_application.GetAppPlayer().HasVideo())
         {
           result = CVariant(CVariant::VariantTypeObject);
           int index = g_application.GetAppPlayer().GetSubtitle();
@@ -1904,7 +1933,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     switch (player)
     {
       case Video:
-        if (g_application.GetAppPlayer().HasPlayer())
+        if (g_application.GetAppPlayer().HasVideo())
         {
           for (int index = 0; index < g_application.GetAppPlayer().GetSubtitleCount(); index++)
           {
@@ -1929,7 +1958,10 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     }
   }
   else if (property == "live")
-    result = IsPVRChannel();
+    if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+      result = IsPVRChannel();
+    else
+      result = false;
   else
     return InvalidParams;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Don't check if an other player is active to return properties of a player ([`Player.GetProperties`](https://kodi.wiki/view/JSON-RPC_API/v10#Player.GetProperties)).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Pull request to fix https://github.com/xbmc/xbmc/issues/17897.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
1. In Kodi, *Allow remote control via HTTP* (*Settings* / *Services* / *Control*).
2. Play a music (with audio player).
3. Execute (by changing the IP address) : `curl -d '{ "jsonrpc": "2.0", "method": "Player.GetProperties", "params": { "playerid": 1, "properties": ["position"] }, "id": 1 }' -H 'Content-type: application/json' -X POST 127.0.0.1:8080/jsonrpc`
4. Kodi returns `"position":-1`.

## Screenshots (if appropriate):
NA

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
