### PR TITLE
[cmake] fix FindPackageHandleStandardArgs name mismatch

### DIFF
--- a/cmake/modules/FindLibUSB.cmake
+++ b/cmake/modules/FindLibUSB.cmake
@@ -24,7 +24,7 @@ find_library(LIBUSB_LIBRARY NAMES usb
 set(LIBUSB_VERSION ${PC_LIBUSB_VERSION})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LIBUSB
+find_package_handle_standard_args(LibUSB
                                   REQUIRED_VARS LIBUSB_LIBRARY LIBUSB_INCLUDE_DIR
                                   VERSION_VAR LIBUSB_VERSION)
 

--- a/cmake/modules/FindSSE.cmake
+++ b/cmake/modules/FindSSE.cmake
@@ -141,6 +141,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(SSE
                                   REQUIRED_VARS _SSE_TRUE _SSE_OK
                                   FAIL_MESSAGE "Could not find hardware support for SSE")
+set(FPHSA_NAME_MISMATCHED ON)
 find_package_handle_standard_args(SSE2
                                   REQUIRED_VARS _SSE2_TRUE _SSE2_OK
                                   FAIL_MESSAGE "Could not find hardware support for SSE2")
@@ -162,6 +163,7 @@ find_package_handle_standard_args(AVX
 find_package_handle_standard_args(AVX2
                                   REQUIRED_VARS _AVX2_TRUE _AVX2_OK
                                   FAIL_MESSAGE "Could not find hardware support for AVX2")
+unset(FPHSA_NAME_MISMATCHED)
 
 mark_as_advanced(SSE2_FOUND SSE3_FOUND SSSE3_FOUND SSE4_1_FOUND SSE4_2_FOUND AVX_FOUND AVX2_FOUND)
 


### PR DESCRIPTION
## Motivation and Context
CMake >= 3.17 issues a warning if `<PackageName>` doesn't match `CMAKE_FIND_PACKAGE_NAME`

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
