### PR TITLE
[addons][filesystem][network] fix mem crash on filesystem and add user agent ask to network

### DIFF
--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -14,6 +14,7 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/Network.h"
 #include "network/DNSNameCache.h"
 #include "network/Network.h"
+#include "utils/SystemInfo.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
@@ -27,6 +28,7 @@ void Interface_Network::Init(AddonGlobalInterface *addonInterface)
   addonInterface->toKodi->kodi_network->wake_on_lan = wake_on_lan;
   addonInterface->toKodi->kodi_network->get_ip_address = get_ip_address;
   addonInterface->toKodi->kodi_network->get_hostname = get_hostname;
+  addonInterface->toKodi->kodi_network->get_user_agent = get_user_agent;
   addonInterface->toKodi->kodi_network->is_local_host = is_local_host;
   addonInterface->toKodi->kodi_network->is_host_on_lan = is_host_on_lan;
   addonInterface->toKodi->kodi_network->dns_lookup = dns_lookup;
@@ -95,6 +97,23 @@ char* Interface_Network::get_hostname(void* kodiBase)
   char* buffer = nullptr;
   if (!hostname.empty())
     buffer = strdup(hostname.c_str());
+  return buffer;
+}
+
+char* Interface_Network::get_user_agent(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (addon == nullptr)
+  {
+    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
+              kodiBase);
+    return nullptr;
+  }
+
+  std::string string = CSysInfo::GetUserAgent();
+  char* buffer = nullptr;
+  if (!string.empty())
+    buffer = strdup(string.c_str());
   return buffer;
 }
 

--- a/xbmc/addons/interfaces/Network.h
+++ b/xbmc/addons/interfaces/Network.h
@@ -42,6 +42,7 @@ struct Interface_Network
   static bool wake_on_lan(void* kodiBase, const char* mac);
   static char* get_ip_address(void* kodiBase);
   static char* get_hostname(void* kodiBase);
+  static char* get_user_agent(void* kodiBase);
   static bool is_local_host(void* kodiBase, const char* hostname);
   static bool is_host_on_lan(void* kodiBase, const char* hostname, bool offLineCheck);
   static char* dns_lookup(void* kodiBase, const char* url, bool* ret);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -334,7 +334,7 @@ public:
     if (!m_handle.handle)
       return std::vector<std::string>();
 
-    int numValues;
+    int numValues = 0;
     char** res(m_handle.get_values(CAddonBase::m_interface->toKodi->kodiBase, m_handle.handle,
                                    param.c_str(), &numValues));
     if (res)
@@ -1589,7 +1589,7 @@ inline bool GetMimeType(const std::string& url,
 {
   using namespace ::kodi::addon;
 
-  char* cMimeType;
+  char* cMimeType = nullptr;
   bool ret = CAddonBase::m_interface->toKodi->kodi_filesystem->get_mime_type(
       CAddonBase::m_interface->toKodi->kodiBase, url.c_str(), &cMimeType, useragent.c_str());
   if (cMimeType != nullptr)
@@ -1630,7 +1630,7 @@ inline bool GetContentType(const std::string& url,
 {
   using namespace ::kodi::addon;
 
-  char* cContent;
+  char* cContent = nullptr;
   bool ret = CAddonBase::m_interface->toKodi->kodi_filesystem->get_content_type(
       CAddonBase::m_interface->toKodi->kodiBase, url.c_str(), &cContent, useragent.c_str());
   if (cContent != nullptr)
@@ -1670,7 +1670,7 @@ inline bool GetCookies(const std::string& url, std::string& cookies)
 {
   using namespace ::kodi::addon;
 
-  char* cCookies;
+  char* cCookies = nullptr;
   bool ret = CAddonBase::m_interface->toKodi->kodi_filesystem->get_cookies(
       CAddonBase::m_interface->toKodi->kodiBase, url.c_str(), &cCookies);
   if (cCookies != nullptr)
@@ -2224,7 +2224,7 @@ public:
                 "kodi::vfs::CURLCreate(...) needed to call before GetPropertyValues!");
       return std::vector<std::string>();
     }
-    int numValues;
+    int numValues = 0;
     char** res(CAddonBase::m_interface->toKodi->kodi_filesystem->get_property_values(
         CAddonBase::m_interface->toKodi->kodiBase, m_file, type, name.c_str(), &numValues));
     if (res)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Network.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Network.h
@@ -115,6 +115,41 @@ inline std::string GetHostname()
 
 //============================================================================
 /// @ingroup cpp_kodi_network
+/// @brief Returns Kodi's HTTP UserAgent string.
+///
+/// @return HTTP user agent
+///
+///
+/// ------------------------------------------------------------------------
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.py}
+/// ..
+/// std::string agent = kodi::network::GetUserAgent()
+/// ..
+/// ~~~~~~~~~~~~~
+///
+/// example output:
+///   Kodi/19.0-ALPHA1 (X11; Linux x86_64) Ubuntu/20.04 App_Bitness/64 Version/19.0-ALPHA1-Git:20200522-0076d136d3-dirty
+///
+inline std::string GetUserAgent()
+{
+  using namespace ::kodi::addon;
+
+  std::string agent;
+  char* string = CAddonBase::m_interface->toKodi->kodi_network->get_user_agent(
+      CAddonBase::m_interface->toKodi->kodiBase);
+  if (string != nullptr)
+  {
+    agent = string;
+    CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, string);
+  }
+  return agent;
+}
+//----------------------------------------------------------------------------
+
+//============================================================================
+/// @ingroup cpp_kodi_network
 /// @brief Check given name or ip address corresponds to localhost.
 ///
 /// @param[in] hostname Hostname to check

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/network.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/network.h
@@ -35,6 +35,7 @@ extern "C"
     char* (*get_hostname)(void* kodiBase);
     bool (*is_local_host)(void* kodiBase, const char* hostname);
     bool (*is_host_on_lan)(void* kodiBase, const char* hostname, bool offLineCheck);
+    char* (*get_user_agent)(void* kodiBase);
   } AddonToKodiFuncTable_kodi_network;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -60,7 +60,7 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.1"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.2"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.0"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -67,7 +67,7 @@
                                                       "c-api/filesystem.h" \
                                                       "gui/gl/Shader.h"
 
-#define ADDON_GLOBAL_VERSION_NETWORK                  "1.0.2"
+#define ADDON_GLOBAL_VERSION_NETWORK                  "1.0.3"
 #define ADDON_GLOBAL_VERSION_NETWORK_MIN              "1.0.0"
 #define ADDON_GLOBAL_VERSION_NETWORK_XML_ID           "kodi.binary.global.network"
 #define ADDON_GLOBAL_VERSION_NETWORK_DEPENDS          "Network.h" \


### PR DESCRIPTION
## Description

Patch 1:
---------------------------
**[addons][filesystem] fix missing set to nullptr**

There was on new functions a char* value used, where Kodi gives his string (strdup) to.
But if not available the the value was not set, as previous also no nullptr set, has it tried to "free" it and makes a crash.

Patch 2:
---------------------------
**[addons][network] add function to get Kodi's network user agent**

The new function is "kodi::network::GetUserAgent()" where return e.g.
- **"Kodi/19.0-ALPHA1 (X11; Linux x86_64) Ubuntu/20.04 App_Bitness/64 Version/19.0-ALPHA1-Git:20200522-0076d136d3-dirty"**

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
With modified screensaver addon to call them.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
