### PR TITLE
[tests] Disable TestDateTime.GetAsTimeStamp

### DIFF
--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -557,13 +557,8 @@ TEST_F(TestDateTime, GetAsTm)
   EXPECT_TRUE(dateTime == time);
 }
 
-// disabled on freebsd, I assume because the timezone isn't set properly
-// will investigate later
-#if defined(TARGET_DARWIN_OSX) || defined(TARGET_FREEBSD)
+// Disabled pending std::chrono and std::date changes.
 TEST_F(TestDateTime, DISABLED_GetAsTimeStamp)
-#else
-TEST_F(TestDateTime, GetAsTimeStamp)
-#endif
 {
   CDateTimeSpan bias = CDateTime::GetTimezoneBias();
 


### PR DESCRIPTION
Disabled pending std::chrono and std::date changes.

Fixes https://github.com/xbmc/xbmc/issues/17909

## Description
Per @lrusak:
> the reason I wrote these tests in the first place is to set a baseline for when I finish implementing std::chrono and std::date changes. It's mostly done but I haven't looked at it in a couple months do to some time constraints.
> 
> tl;dr disable the test if it's not working.
https://github.com/xbmc/xbmc/issues/17909#issuecomment-632763574

## Motivation and Context
Test failures are not good things. :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Ran tests, now they all pass.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
