### PR TITLE
[PVR] Home screen widgets context menu fixes/improvements

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11113,7 +11113,19 @@ msgctxt "#19326"
 msgid "Navigate..."
 msgstr ""
 
-#empty strings from id 19327 to 19498
+#. Label for a context menu entry to delete alle watched recordings contained in a folder
+#: xbmc/pvr/PVRContextMenus.cpp
+msgctxt "#19327"
+msgid "Delete watched"
+msgstr ""
+
+#. delete multiple recordings confirmation message box text
+#: xbmc/pvr/PVRGUIActions.cpp
+msgctxt "#19328"
+msgid "Delete all watched recordings in this folder?"
+msgstr ""
+
+#empty strings from id 19329 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -76,16 +76,19 @@ std::string CAddRemoveFavourite::GetLabel(const CFileItem& item) const
 
 bool CAddRemoveFavourite::IsVisible(const CFileItem& item) const
 {
-  return !item.IsParentFolder() &&
-         !item.IsPath("add") &&
-         !item.IsPath("newplaylist://") &&
-         !URIUtils::IsProtocol(item.GetPath(), "favourites") &&
-         !URIUtils::IsProtocol(item.GetPath(), "newsmartplaylist") &&
-         !URIUtils::IsProtocol(item.GetPath(), "newtag") &&
-         !URIUtils::IsProtocol(item.GetPath(), "musicsearch") &&
-         !StringUtils::StartsWith(item.GetPath(), "pvr://guide/") &&
-         !StringUtils::StartsWith(item.GetPath(), "pvr://timers/") &&
-         !item.GetPath().empty();
+  return (!item.GetPath().empty() && !item.IsParentFolder() && !item.IsPath("add") &&
+          !item.IsPath("newplaylist://") && !URIUtils::IsProtocol(item.GetPath(), "favourites") &&
+          !URIUtils::IsProtocol(item.GetPath(), "newsmartplaylist") &&
+          !URIUtils::IsProtocol(item.GetPath(), "newtag") &&
+          !URIUtils::IsProtocol(item.GetPath(), "musicsearch") &&
+          // hide this item for all PVR timers/EPG except timer/timer rules/EPG root folders
+          !StringUtils::StartsWith(item.GetPath(), "pvr://guide/") &&
+          !StringUtils::StartsWith(item.GetPath(), "pvr://timers/")) ||
+         item.GetPath() == "pvr://guide/tv/" || item.GetPath() == "pvr://guide/radio/" ||
+         item.GetPath() == "pvr://timers/tv/timers/" ||
+         item.GetPath() == "pvr://timers/radio/timers/" ||
+         item.GetPath() == "pvr://timers/tv/rules/" ||
+         item.GetPath() == "pvr://timers/radio/rules/";
 }
 
 bool CAddRemoveFavourite::Execute(const CFileItemPtr& item) const

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -67,6 +67,7 @@ namespace PVR
     DECL_STATICCONTEXTMENUITEM(RenameRecording);
     DECL_CONTEXTMENUITEM(DeleteRecording);
     DECL_STATICCONTEXTMENUITEM(UndeleteRecording);
+    DECL_STATICCONTEXTMENUITEM(DeleteWatchedRecordings);
     DECL_CONTEXTMENUITEM(ToggleTimerState);
     DECL_STATICCONTEXTMENUITEM(RenameTimer);
     DECL_STATICCONTEXTMENUITEM(AddReminder);
@@ -404,6 +405,23 @@ namespace PVR
     }
 
     ///////////////////////////////////////////////////////////////////////////////
+    // Delete watched recordings
+
+    bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
+    {
+      // recordings folder?
+      if (item.m_bIsFolder)
+        return CPVRRecordingsPath(item.GetPath()).IsValid();
+
+      return false;
+    }
+
+    bool DeleteWatchedRecordings::Execute(const std::shared_ptr<CFileItem>& item) const
+    {
+      return CServiceBroker::GetPVRManager().GUIActions()->DeleteWatchedRecordings(item);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
     // Add reminder
 
     bool AddReminder::IsVisible(const CFileItem& item) const
@@ -678,27 +696,27 @@ namespace PVR
 
   CPVRContextMenuManager::CPVRContextMenuManager()
   {
-    m_items =
-    {
-      std::make_shared<CONTEXTMENUITEM::PlayEpgTag>(19190), /* Play programme */
-      std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
-      std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
-      std::make_shared<CONTEXTMENUITEM::ShowChannelGuide>(19686), /* Channel guide */
-      std::make_shared<CONTEXTMENUITEM::FindSimilar>(19003), /* Find similar */
-      std::make_shared<CONTEXTMENUITEM::ToggleTimerState>(),
-      std::make_shared<CONTEXTMENUITEM::AddTimerRule>(19061), /* Add timer */
-      std::make_shared<CONTEXTMENUITEM::EditTimerRule>(),
-      std::make_shared<CONTEXTMENUITEM::DeleteTimerRule>(19295), /* Delete timer rule */
-      std::make_shared<CONTEXTMENUITEM::EditTimer>(),
-      std::make_shared<CONTEXTMENUITEM::RenameTimer>(118), /* Rename */
-      std::make_shared<CONTEXTMENUITEM::DeleteTimer>(),
-      std::make_shared<CONTEXTMENUITEM::StartRecording>(264), /* Record */
-      std::make_shared<CONTEXTMENUITEM::StopRecording>(19059), /* Stop recording */
-      std::make_shared<CONTEXTMENUITEM::EditRecording>(21450), /* Edit */
-      std::make_shared<CONTEXTMENUITEM::RenameRecording>(118), /* Rename */
-      std::make_shared<CONTEXTMENUITEM::DeleteRecording>(),
-      std::make_shared<CONTEXTMENUITEM::UndeleteRecording>(19290), /* Undelete */
-      std::make_shared<CONTEXTMENUITEM::AddReminder>(826), /* Set reminder */
+    m_items = {
+        std::make_shared<CONTEXTMENUITEM::PlayEpgTag>(19190), /* Play programme */
+        std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
+        std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
+        std::make_shared<CONTEXTMENUITEM::ShowChannelGuide>(19686), /* Channel guide */
+        std::make_shared<CONTEXTMENUITEM::FindSimilar>(19003), /* Find similar */
+        std::make_shared<CONTEXTMENUITEM::ToggleTimerState>(),
+        std::make_shared<CONTEXTMENUITEM::AddTimerRule>(19061), /* Add timer */
+        std::make_shared<CONTEXTMENUITEM::EditTimerRule>(),
+        std::make_shared<CONTEXTMENUITEM::DeleteTimerRule>(19295), /* Delete timer rule */
+        std::make_shared<CONTEXTMENUITEM::EditTimer>(),
+        std::make_shared<CONTEXTMENUITEM::RenameTimer>(118), /* Rename */
+        std::make_shared<CONTEXTMENUITEM::DeleteTimer>(),
+        std::make_shared<CONTEXTMENUITEM::StartRecording>(264), /* Record */
+        std::make_shared<CONTEXTMENUITEM::StopRecording>(19059), /* Stop recording */
+        std::make_shared<CONTEXTMENUITEM::EditRecording>(21450), /* Edit */
+        std::make_shared<CONTEXTMENUITEM::RenameRecording>(118), /* Rename */
+        std::make_shared<CONTEXTMENUITEM::DeleteRecording>(),
+        std::make_shared<CONTEXTMENUITEM::UndeleteRecording>(19290), /* Undelete */
+        std::make_shared<CONTEXTMENUITEM::DeleteWatchedRecordings>(19327), /* Delete watched */
+        std::make_shared<CONTEXTMENUITEM::AddReminder>(826), /* Set reminder */
     };
   }
 

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -375,7 +375,7 @@ namespace PVR
       if (item.m_bIsFolder)
       {
         const CPVRRecordingsPath path(item.GetPath());
-        return path.IsValid();
+        return path.IsValid() && !path.IsRecordingsRoot();
       }
 
       return false;

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -380,6 +380,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
 
     newTag->SetGenre(m_pDS->fv("iGenreType").get_asInt(), m_pDS->fv("iGenreSubType").get_asInt(),
                      m_pDS->fv("sGenre").get_asString().c_str());
+    newTag->UpdatePath();
+
     return newTag;
   }
   return {};

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -232,6 +232,13 @@ namespace PVR
     bool DeleteRecording(const std::shared_ptr<CFileItem>& item) const;
 
     /*!
+     * @brief Delete all watched recordings contained in the given folder, always showing a confirmation dialog.
+     * @param item containing a recording folder containing the items to delete.
+     * @return true, if the recordings were deleted successfully, false otherwise.
+     */
+    bool DeleteWatchedRecordings(const std::shared_ptr<CFileItem>& item) const;
+
+    /*!
      * @brief Delete all recordings from trash, always showing a confirmation dialog.
      * @return true, if the recordings were permanently deleted successfully, false otherwise.
      */
@@ -485,6 +492,13 @@ namespace PVR
      * @return true, to proceed with delete, false otherwise.
      */
     bool ConfirmDeleteRecording(const std::shared_ptr<CFileItem>& item) const;
+
+    /*!
+     * @brief Open a dialog to confirm delete all watched recordings contained in the given folder.
+     * @param item containing a recording folder containing the items to delete.
+     * @return true, to proceed with delete, false otherwise.
+     */
+    bool ConfirmDeleteWatchedRecordings(const std::shared_ptr<CFileItem>& item) const;
 
     /*!
      * @brief Open a dialog to confirm to permanently remove all deleted recordings.


### PR DESCRIPTION
This PR fixes the context menus for the PVR Home screen "Categories" widget and introduces a new context menu item for the "Recordings" home screen widget and all recordings folders. 

Home screen widget fixes:
* "Delete" no longer visible for "Recordings"
* "Add to favourites", "Remove from favourites" visible for "Guide", "Timers" and "Timer rules"

![screenshot001](https://user-images.githubusercontent.com/3226626/82705834-b252c980-9c78-11ea-8332-fdee44459c04.png)
![screenshot000](https://user-images.githubusercontent.com/3226626/82705842-b5e65080-9c78-11ea-8847-d933f88929d5.png)

As always, I runtime-tested the changes on Android and macOS, latest Kodi master.


@phunkyfish mind taking a look at the code change?
