### PR TITLE
[Estaury] add missing font definitions

### DIFF
--- a/addons/skin.estuary/xml/Font.xml
+++ b/addons/skin.estuary/xml/Font.xml
@@ -49,7 +49,7 @@
 		<font>
 			<name>font27_narrow</name>
 			<filename>NotoSans-Regular.ttf</filename>
-			<size>25</size>
+			<size>27</size>
 			<style>lighten</style>
 			<linespacing>0.8</linespacing>
 		</font>
@@ -174,6 +174,12 @@
 			<size>27</size>
 		</font>
 		<font>
+			<name>font27_narrow</name>
+			<filename>arial.ttf</filename>
+			<size>27</size>
+			<linespacing>0.8</linespacing>
+		</font>
+		<font>
 			<name>font37</name>
 			<filename>arial.ttf</filename>
 			<size>37</size>
@@ -217,6 +223,13 @@
 			<name>font30_title</name>
 			<filename>arial.ttf</filename>
 			<size>30</size>
+			<style>bold</style>
+		</font>
+
+		<font>
+			<name>font32_title</name>
+			<filename>arial.ttf</filename>
+			<size>32</size>
 			<style>bold</style>
 		</font>
 		<font>


### PR DESCRIPTION
## Description
the arial fontset was missing 2 font definitions.
also, the default fontset had one font definition with an incorrect font size. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
