### PR TITLE
Revert "[Android][Backport] MediaCodec: Use JNI instead NDK"

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -18,18 +18,18 @@
 #include <memory>
 #include <vector>
 
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
 #include <androidjni/ByteBuffer.h>
-#include <androidjni/MediaCodec.h>
-#include <androidjni/MediaCodecBufferInfo.h>
-#include <androidjni/MediaCodecCryptoInfo.h>
-#include <androidjni/MediaCodecInfo.h>
 #include <androidjni/MediaCodecList.h>
+#include <androidjni/MediaCodecInfo.h>
 #include <androidjni/MediaCrypto.h>
 #include <androidjni/Surface.h>
 #include <androidjni/SurfaceTexture.h>
 #include <androidjni/UUID.h>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#include <media/NdkMediaCrypto.h>
 
 #include "Application.h"
 #include "DVDCodecs/DVDFactoryCodec.h"
@@ -126,6 +126,19 @@ private:
 
 /*****************************************************************************/
 /*****************************************************************************/
+CMediaCodec::CMediaCodec(const char *name)
+ : m_codec(AMediaCodec_createCodecByName(name))
+{
+}
+
+CMediaCodec::~CMediaCodec()
+{
+  AMediaCodec_delete(m_codec);
+};
+
+
+/*****************************************************************************/
+/*****************************************************************************/
 void CMediaCodecVideoBuffer::Set(int bufferId, int textureId,
   std::shared_ptr<CJNISurfaceTexture> surfacetexture,
   std::shared_ptr<CDVDMediaCodecOnFrameAvailable> frameready,
@@ -145,8 +158,7 @@ bool CMediaCodecVideoBuffer::WaitForFrame(int millis)
 
 void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTime, CMediaCodecVideoBufferPool* pool)
 {
-  std::shared_ptr<CJNIMediaCodec> codec(
-      static_cast<CMediaCodecVideoBufferPool*>(pool ? pool : m_pool.get())->GetMediaCodec());
+  std::shared_ptr<CMediaCodec> codec(static_cast<CMediaCodecVideoBufferPool*>(pool ? pool : m_pool.get())->GetMediaCodec());
 
   if (m_bufferId < 0 || !codec)
     return;
@@ -164,17 +176,15 @@ void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTim
     CLog::Log(LOGDEBUG, "CMediaCodecVideoBuffer::ReleaseOutputBuffer index(%d), render(%d), time:%lld, offset:%lld", m_bufferId, render, displayTime, diff);
   }
 
+  media_status_t mstat;
   if (!render || displayTime == 0)
-    codec->releaseOutputBuffer(m_bufferId, render);
+    mstat = AMediaCodec_releaseOutputBuffer(codec->codec(), m_bufferId, render);
   else
-    codec->releaseOutputBuffer(m_bufferId, displayTime);
+    mstat = AMediaCodec_releaseOutputBufferAtTime(codec->codec(), m_bufferId, displayTime);
   m_bufferId = -1; //mark released
 
-  if (xbmc_jnienv()->ExceptionCheck())
-  {
-    xbmc_jnienv()->ExceptionClear();
-    CLog::Log(LOGERROR, "CMediaCodecVideoBuffer::ReleaseOutputBuffer error in render(%d)", render);
-  }
+  if (mstat != AMEDIA_OK)
+    CLog::Log(LOGERROR, "CMediaCodecVideoBuffer::ReleaseOutputBuffer error %d in render(%d)", mstat, render);
 }
 
 int CMediaCodecVideoBuffer::GetBufferId() const
@@ -282,7 +292,7 @@ void CMediaCodecVideoBufferPool::Return(int id)
   m_freeBuffers.push_back(id);
 }
 
-std::shared_ptr<CJNIMediaCodec> CMediaCodecVideoBufferPool::GetMediaCodec()
+std::shared_ptr<CMediaCodec> CMediaCodecVideoBufferPool::GetMediaCodec()
 {
   CSingleLock lock(m_criticalSection);
   return m_codec;
@@ -312,7 +322,9 @@ CDVDVideoCodecAndroidMediaCodec::CDVDVideoCodecAndroidMediaCodec(CProcessInfo &p
 , m_opened(false)
 , m_jnivideoview(nullptr)
 , m_jnisurface(nullptr)
+, m_crypto(nullptr)
 , m_textureId(0)
+, m_surface(nullptr)
 , m_OutputDuration(0)
 , m_fpsDuration(0)
 , m_lastPTS(-1)
@@ -331,7 +343,7 @@ CDVDVideoCodecAndroidMediaCodec::~CDVDVideoCodecAndroidMediaCodec()
 
   if (m_crypto)
   {
-    delete m_crypto;
+    AMediaCrypto_delete(m_crypto);
     m_crypto = nullptr;
   }
   if (m_mpeg2_sequence)
@@ -358,7 +370,12 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 {
   int num_codecs;
   int profile(0);
-  CJNIUUID uuid(0, 0);
+
+  const AMediaUUID* uuid(nullptr);
+  const AMediaUUID wvuuid = {0xED, 0xEF, 0x8B, 0xA9, 0x79, 0xD6, 0x4A, 0xCE,
+                             0xA3, 0xC8, 0x27, 0xDC, 0xD5, 0x1D, 0x21, 0xED};
+  const AMediaUUID pruuid = {0x9A, 0x04, 0xF0, 0x79, 0x98, 0x40, 0x42, 0x86,
+                             0xAB, 0x92, 0xE6, 0x5B, 0xE0, 0x88, 0x5F, 0x95};
 
   m_opened = false;
   m_needSecureDecoder = false;
@@ -565,25 +582,32 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 
   if (m_crypto)
   {
-    delete m_crypto;
+    AMediaCrypto_delete(m_crypto);
     m_crypto = nullptr;
   }
 
   if (m_hints.cryptoSession)
   {
     if (m_hints.cryptoSession->keySystem == CRYPTO_SESSION_SYSTEM_WIDEVINE)
-      uuid = CJNIUUID(0xEDEF8BA979D64ACE, 0xA3C827DCD51D21ED);
+      uuid = &wvuuid;
     else if (m_hints.cryptoSession->keySystem == CRYPTO_SESSION_SYSTEM_PLAYREADY)
-      uuid = CJNIUUID(0x9A04F07998404286, 0xAB92E65BE0885F95);
+      uuid = &pruuid;
     else
     {
       CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open Unsupported crypto-keysystem %u",
                 m_hints.cryptoSession->keySystem);
       goto FAIL;
     }
-    CJNIMediaCrypto crypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId,
-                                                   m_hints.cryptoSession->sessionId +
-                                                       m_hints.cryptoSession->sessionIdSize));
+
+    int64_t mostSigBits(0), leastSigBits(0);
+    for (unsigned int i(0); i < 8; ++i)
+      mostSigBits = (mostSigBits << 8) | (*uuid)[i];
+    for (unsigned int i(8); i < 16; ++i)
+      leastSigBits = (leastSigBits << 8) | (*uuid)[i];
+    CJNIUUID juuid(mostSigBits, leastSigBits);
+    CJNIMediaCrypto crypto(juuid, std::vector<char>(m_hints.cryptoSession->sessionId,
+                                                    m_hints.cryptoSession->sessionId +
+                                                        m_hints.cryptoSession->sessionIdSize));
     m_needSecureDecoder =
         crypto.requiresSecureDecoderComponent(m_mime) &&
         (m_hints.cryptoSession->flags & DemuxCryptoSession::FLAG_SECURE_DECODER) != 0;
@@ -651,9 +675,8 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     {
       if (types[j] == m_mime)
       {
-        m_codec = std::shared_ptr<CJNIMediaCodec>(
-            new CJNIMediaCodec(CJNIMediaCodec::createByCodecName(m_codecname)));
-        if (!m_codec)
+        m_codec = std::shared_ptr<CMediaCodec>(new CMediaCodec(m_codecname.c_str()));
+        if (!m_codec->codec())
         {
           CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open cannot create codec");
           continue;
@@ -669,7 +692,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         break;
       }
     }
-    if (m_codec)
+    if (m_codec->codec())
       break;
   }
   if (!m_codec)
@@ -682,10 +705,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   {
     CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Open Initializing MediaCrypto");
 
-    m_crypto =
-        new CJNIMediaCrypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId,
-                                                    m_hints.cryptoSession->sessionId +
-                                                        m_hints.cryptoSession->sessionIdSize));
+    m_crypto = AMediaCrypto_new(*uuid, m_hints.cryptoSession->sessionId, m_hints.cryptoSession->sessionIdSize);
 
     if (!m_crypto)
     {
@@ -745,7 +765,7 @@ FAIL:
   m_InstanceGuard.exchange(false);
   if (m_crypto)
   {
-    delete m_crypto;
+    AMediaCrypto_delete(m_crypto);
     m_crypto = nullptr;
   }
 
@@ -778,17 +798,17 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
 
   m_videobuffer.iFlags = 0;
 
-  if (m_codec)
+  if (m_codec->codec())
   {
-    m_codec->stop();
+    AMediaCodec_stop(m_codec->codec());
     m_codec = nullptr;
     m_state = MEDIACODEC_STATE_STOPPED;
   }
   ReleaseSurfaceTexture();
 
-  if (m_jnisurface)
-    m_jnisurface->release();
-  m_jnisurface = nullptr;
+  if(m_surface)
+    ANativeWindow_release(m_surface);
+  m_surface = nullptr;
 
   m_InstanceGuard.exchange(false);
   if (m_render_surface)
@@ -824,7 +844,7 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
   {
     // We received a packet but already reached EOS. Flush...
     FlushInternal();
-    m_codec->flush();
+    AMediaCodec_flush(m_codec->codec());
     m_state = MEDIACODEC_STATE_FLUSHED;
   }
 
@@ -865,31 +885,26 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
       if (m_state == MEDIACODEC_STATE_FLUSHED)
         m_state = MEDIACODEC_STATE_RUNNING;
 
-      CJNIByteBuffer buffer = m_codec->getInputBuffer(m_indexInputBuffer);
-      size_t out_size = buffer.capacity();
+      size_t out_size;
+      uint8_t* dst_ptr = AMediaCodec_getInputBuffer(m_codec->codec(), m_indexInputBuffer, &out_size);
       if ((size_t)iSize > out_size)
       {
         CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::AddData, iSize(%d) > size(%d)", iSize, out_size);
         iSize = out_size;
       }
-      uint8_t* dst_ptr = (uint8_t*)xbmc_jnienv()->GetDirectBufferAddress(buffer.get_raw());
 
-      CJNIMediaCodecCryptoInfo* cryptoInfo(nullptr);
+      AMediaCodecCryptoInfo *cryptoInfo(0);
       if (m_crypto && packet.cryptoInfo)
       {
-        std::vector<int> clearBytes(packet.cryptoInfo->clearBytes,
-                                    packet.cryptoInfo->clearBytes +
-                                        packet.cryptoInfo->numSubSamples);
-        std::vector<int> cipherBytes(packet.cryptoInfo->cipherBytes,
-                                     packet.cryptoInfo->cipherBytes +
-                                         packet.cryptoInfo->numSubSamples);
+        std::vector<size_t> clearBytes(packet.cryptoInfo->clearBytes, packet.cryptoInfo->clearBytes + packet.cryptoInfo->numSubSamples);
+        std::vector<size_t> cipherBytes(packet.cryptoInfo->cipherBytes, packet.cryptoInfo->cipherBytes + packet.cryptoInfo->numSubSamples);
 
-        cryptoInfo = new CJNIMediaCodecCryptoInfo();
-
-        cryptoInfo->set(packet.cryptoInfo->numSubSamples, clearBytes, cipherBytes,
-                        std::vector<char>(packet.cryptoInfo->kid, packet.cryptoInfo->kid + 16),
-                        std::vector<char>(packet.cryptoInfo->iv, packet.cryptoInfo->iv + 16),
-                        CJNIMediaCodec::CRYPTO_MODE_AES_CTR);
+        cryptoInfo = AMediaCodecCryptoInfo_new(
+          packet.cryptoInfo->numSubSamples,
+          packet.cryptoInfo->kid,
+          packet.cryptoInfo->iv,
+          AMEDIACODECRYPTOINFO_MODE_AES_CTR,
+          &clearBytes[0], &cipherBytes[0]);
       }
       if (dst_ptr)
       {
@@ -942,19 +957,18 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
       int flags = 0;
       int offset = 0;
 
+      media_status_t mstat;
       if (!cryptoInfo)
-        m_codec->queueInputBuffer(m_indexInputBuffer, offset, iSize, presentationTimeUs, flags);
+        mstat = AMediaCodec_queueInputBuffer(m_codec->codec(), m_indexInputBuffer, offset, iSize, presentationTimeUs, flags);
       else
       {
-        m_codec->queueSecureInputBuffer(m_indexInputBuffer, offset, *cryptoInfo, presentationTimeUs,
-                                        flags);
-        delete cryptoInfo, cryptoInfo = nullptr;
+        mstat = AMediaCodec_queueSecureInputBuffer(m_codec->codec(), m_indexInputBuffer, offset, cryptoInfo, presentationTimeUs, flags);
+        AMediaCodecCryptoInfo_delete(cryptoInfo);
       }
-      if (xbmc_jnienv()->ExceptionCheck())
+      if (mstat != AMEDIA_OK)
       {
-        xbmc_jnienv()->ExceptionDescribe();
-        xbmc_jnienv()->ExceptionClear();
-        CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::AddData error");
+        CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::AddData error(%d)", mstat);
+        return false;
       }
       m_indexInputBuffer = -1;
     }
@@ -969,7 +983,7 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
   if (!m_opened)
     return;
 
-  if (m_codec)
+  if (m_codec->codec())
   {
     // flush all outputbuffers inflight, they will
     // become invalid on m_codec->flush and generate
@@ -979,10 +993,9 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
     // now we can flush the actual MediaCodec object
     CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Reset Current state (%d)", m_state);
     m_state = MEDIACODEC_STATE_FLUSHED;
-    m_codec->flush();
+    AMediaCodec_flush(m_codec->codec());
 
-    CJNIMediaFormat mediaFormat = m_codec->getOutputFormat();
-    InjectExtraData(mediaFormat);
+    InjectExtraData(nullptr);
 
     // Invalidate our local VideoPicture bits
     m_videobuffer.pts = DVD_NOPTS_VALUE;
@@ -1041,7 +1054,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
   {
     // try to fetch an input buffer
     if (m_indexInputBuffer < 0)
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timout*/);
+      m_indexInputBuffer = AMediaCodec_dequeueInputBuffer(m_codec->codec(), 5000 /*timout*/);
 
     if (m_indexInputBuffer >= 0)
     {
@@ -1078,7 +1091,7 @@ void CDVDVideoCodecAndroidMediaCodec::FlushInternal()
 void CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream()
 {
   CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::%s: state: %d", __func__, m_state);
-  if (m_codec && (m_state == MEDIACODEC_STATE_RUNNING || m_state == MEDIACODEC_STATE_ENDOFSTREAM))
+  if (m_codec->codec() && (m_state == MEDIACODEC_STATE_RUNNING || m_state == MEDIACODEC_STATE_ENDOFSTREAM))
   {
     // Release all mediaodec output buffers to allow drain if we don't get inputbuffer early
     if (m_videoBufferPool)
@@ -1088,70 +1101,66 @@ void CDVDVideoCodecAndroidMediaCodec::SignalEndOfStream()
     }
 
     if (m_indexInputBuffer < 0)
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(100000);
-    xbmc_jnienv()->ExceptionClear();
+      m_indexInputBuffer = AMediaCodec_dequeueInputBuffer(m_codec->codec(), 100000);
 
     if (m_indexInputBuffer >= 0)
     {
-      m_codec->queueInputBuffer(m_indexInputBuffer, 0, 0, 0,
-                                CJNIMediaCodec::BUFFER_FLAG_END_OF_STREAM);
-      if (xbmc_jnienv()->ExceptionCheck())
-      {
-        xbmc_jnienv()->ExceptionClear();
-        CLog::Log(LOGWARNING, "CDVDVideoCodecAndroidMediaCodec::%s: queueInputBuffer failed",
-                  __func__);
-      }
-      else
+      media_status_t status= AMediaCodec_queueInputBuffer(m_codec->codec(), m_indexInputBuffer, 0, 0, 0, AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM);
+      if (status == AMEDIA_OK)
       {
         m_indexInputBuffer = -1;
         CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::%s: BUFFER_FLAG_END_OF_STREAM send", __func__);
       }
+      else
+        CLog::Log(LOGWARNING, "CDVDVideoCodecAndroidMediaCodec::%s: AMediaCodec_queueInputBuffer returned: %d", __func__, status);
     }
     else
       CLog::Log(LOGWARNING, "CDVDVideoCodecAndroidMediaCodec::%s: invalid index: %d", __func__, m_indexInputBuffer);
   }
 }
 
-void CDVDVideoCodecAndroidMediaCodec::InjectExtraData(CJNIMediaFormat& mediaformat)
+void CDVDVideoCodecAndroidMediaCodec::InjectExtraData(AMediaFormat* mediaformat)
 {
   if (!m_hints.extrasize)
     return;
 
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::%s", __func__);
-  size_t size = m_hints.extrasize;
-  void* src_ptr = m_hints.extradata;
-  if (m_bitstream)
+  if (!mediaformat && m_codec->codec())
+    mediaformat = AMediaCodec_getOutputFormat(m_codec->codec());
+
+  if (mediaformat)
   {
-    size = m_bitstream->GetExtraSize();
-    src_ptr = m_bitstream->GetExtraData();
+    CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::%s", __func__);
+    size_t size = m_hints.extrasize;
+    void  *src_ptr = m_hints.extradata;
+    if (m_bitstream)
+    {
+      size = m_bitstream->GetExtraSize();
+      src_ptr = m_bitstream->GetExtraData();
+    }
+
+    AMediaFormat_setBuffer(mediaformat, "csd-0", src_ptr, size);
   }
-  // Allocate a byte buffer via allocateDirect in java instead of NewDirectByteBuffer,
-  // since the latter doesn't allocate storage of its own, and we don't know how long
-  // the codec uses the buffer.
-  CJNIByteBuffer bytebuffer = CJNIByteBuffer::allocateDirect(size);
-  void* dts_ptr = xbmc_jnienv()->GetDirectBufferAddress(bytebuffer.get_raw());
-  memcpy(dts_ptr, src_ptr, size);
-  // codec will automatically handle buffers as extradata
-  // using entries with keys "csd-0", "csd-1", etc.
-  mediaformat.setByteBuffer("csd-0", bytebuffer);
 }
 
 bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
 {
   // setup a MediaFormat to match the video content,
   // used by codec during configure
-  CJNIMediaFormat mediaformat =
-      CJNIMediaFormat::createVideoFormat(m_mime.c_str(), m_hints.width, m_hints.height);
-  mediaformat.setInteger(CJNIMediaFormat::KEY_MAX_INPUT_SIZE, 0);
+  AMediaFormat* mediaformat = AMediaFormat_new();
+  AMediaFormat_setString(mediaformat, AMEDIAFORMAT_KEY_MIME, m_mime.c_str());
+  AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_WIDTH, m_hints.width);
+  AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_HEIGHT, m_hints.height);
+  AMediaFormat_setInt32(mediaformat, AMEDIAFORMAT_KEY_MAX_INPUT_SIZE, 0);
 
   if (CJNIBase::GetSDKVersion() >= 23 && m_render_surface)
   {
     // Handle rotation
-    mediaformat.setInteger(XMEDIAFORMAT_KEY_ROTATION, m_hints.orientation);
-    mediaformat.setInteger(XMEDIAFORMAT_FEATURE_TUNNELED_PLAYBACK, 0);
+    AMediaFormat_setInt32(mediaformat, XMEDIAFORMAT_KEY_ROTATION, m_hints.orientation);
+    AMediaFormat_setInt32(mediaformat, XMEDIAFORMAT_FEATURE_TUNNELED_PLAYBACK, 0);
     if (m_needSecureDecoder)
-      mediaformat.setInteger(XMEDIAFORMAT_FEATURE_SECURE_PLAYBACK, 1);
+      AMediaFormat_setInt32(mediaformat, XMEDIAFORMAT_FEATURE_SECURE_PLAYBACK, 1);
   }
+
 
   // handle codec extradata
   InjectExtraData(mediaformat);
@@ -1166,6 +1175,8 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
       m_jnivideoview.reset();
       return false;
     }
+    m_surface = ANativeWindow_fromSurface(xbmc_jnienv(), m_jnivideosurface.get_raw());
+
     m_formatname += "(S)";
   }
   else
@@ -1176,26 +1187,19 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
   // use a null MediaCrypto, our content is not encrypted.
 
   int flags = 0;
-  m_codec->configure(mediaformat, m_jnivideosurface,
-                     m_crypto ? *m_crypto : CJNIMediaCrypto(jni::jhobject(NULL)), flags);
+  media_status_t mstat = AMediaCodec_configure(m_codec->codec(), mediaformat, m_surface, m_crypto, flags);
 
-  if (xbmc_jnienv()->ExceptionCheck())
+  if (mstat != AMEDIA_OK)
   {
-    xbmc_jnienv()->ExceptionClear();
-    CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec configure error");
+    CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec configure error: %d", mstat);
     return false;
   }
-  m_codec->setVideoScalingMode(CJNIMediaCodec::VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING);
-
   m_state = MEDIACODEC_STATE_CONFIGURED;
 
-  m_codec->start();
-
-  if (xbmc_jnienv()->ExceptionCheck())
+  mstat = AMediaCodec_start(m_codec->codec());
+  if (mstat != AMEDIA_OK)
   {
-    xbmc_jnienv()->ExceptionClear();
-    Dispose();
-    CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec start error");
+    CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec start error: %d", mstat);
     return false;
   }
   m_state = MEDIACODEC_STATE_FLUSHED;
@@ -1212,11 +1216,11 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
   int rtn = 0;
 
   int64_t timeout_us = 10000;
-  CJNIMediaCodecBufferInfo bufferInfo;
-  ssize_t index = m_codec->dequeueOutputBuffer(bufferInfo, timeout_us);
+  AMediaCodecBufferInfo bufferInfo;
+  ssize_t index = AMediaCodec_dequeueOutputBuffer(m_codec->codec(), &bufferInfo, timeout_us);
   if (index >= 0)
   {
-    int64_t pts = bufferInfo.presentationTimeUs();
+    int64_t pts = bufferInfo.presentationTimeUs;
     m_videobuffer.dts = DVD_NOPTS_VALUE;
     m_videobuffer.pts = DVD_NOPTS_VALUE;
     if (pts != AV_NOPTS_VALUE)
@@ -1231,15 +1235,14 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
     if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
     {
       m_noPictureLoop = 0;
-      m_codec->releaseOutputBuffer(index, false);
+      AMediaCodec_releaseOutputBuffer(m_codec->codec(), index, false);
       return -2;
     }
 
-    int flags = bufferInfo.flags();
-    if (flags & CJNIMediaCodec::BUFFER_FLAG_END_OF_STREAM)
+    if (bufferInfo.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM)
     {
       CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec:: BUFFER_FLAG_END_OF_STREAM");
-      m_codec->releaseOutputBuffer(index, false);
+      AMediaCodec_releaseOutputBuffer(m_codec->codec(), index, false);
       return -1;
     }
 
@@ -1251,19 +1254,15 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
 
     rtn = 1;
   }
-  else if (index == CJNIMediaCodec::INFO_OUTPUT_FORMAT_CHANGED)
+  else if (index == AMEDIACODEC_INFO_OUTPUT_FORMAT_CHANGED)
   {
-    CJNIMediaFormat mediaformat = m_codec->getOutputFormat();
-    if (xbmc_jnienv()->ExceptionCheck())
-    {
-      xbmc_jnienv()->ExceptionClear();
+    AMediaFormat* mediaformat = AMediaCodec_getOutputFormat(m_codec->codec());
+    if (!mediaformat)
       CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(INFO_OUTPUT_FORMAT_CHANGED) ExceptionCheck: getOutputBuffers");
-    }
     else
       ConfigureOutputFormat(mediaformat);
   }
-  else if (index == CJNIMediaCodec::INFO_TRY_AGAIN_LATER ||
-           index == CJNIMediaCodec::INFO_OUTPUT_BUFFERS_CHANGED)
+  else if (index == AMEDIACODEC_INFO_TRY_AGAIN_LATER || index == AMEDIACODEC_INFO_OUTPUT_BUFFERS_CHANGED)
   {
     // ignore
     rtn = 0;
@@ -1278,7 +1277,7 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
   return rtn;
 }
 
-void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& mediaformat)
+void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(AMediaFormat* mediaformat)
 {
   int width       = 0;
   int height      = 0;
@@ -1290,25 +1289,25 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
   int crop_right  = 0;
   int crop_bottom = 0;
 
-  if (mediaformat.containsKey("width"))
-    width = mediaformat.getInteger("width");
-  if (mediaformat.containsKey("height"))
-    height = mediaformat.getInteger("height");
-  if (mediaformat.containsKey("stride"))
-    stride = mediaformat.getInteger("stride");
-  if (mediaformat.containsKey(XMEDIAFORMAT_KEY_SLICE))
-    slice_height = mediaformat.getInteger(XMEDIAFORMAT_KEY_SLICE);
-  if (mediaformat.containsKey("color-format"))
-    color_format = mediaformat.getInteger("color-format");
-  if (mediaformat.containsKey(XMEDIAFORMAT_KEY_CROP_LEFT))
-    crop_left = mediaformat.getInteger(XMEDIAFORMAT_KEY_CROP_LEFT);
-  if (mediaformat.containsKey(XMEDIAFORMAT_KEY_CROP_TOP))
-    crop_top = mediaformat.getInteger(XMEDIAFORMAT_KEY_CROP_TOP);
-  if (mediaformat.containsKey(XMEDIAFORMAT_KEY_CROP_RIGHT))
-    crop_right = mediaformat.getInteger(XMEDIAFORMAT_KEY_CROP_RIGHT);
-  if (mediaformat.containsKey(XMEDIAFORMAT_KEY_CROP_BOTTOM))
-    crop_bottom = mediaformat.getInteger(XMEDIAFORMAT_KEY_CROP_BOTTOM);
-
+  int tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, AMEDIAFORMAT_KEY_WIDTH, &tmpVal))
+    width = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, AMEDIAFORMAT_KEY_HEIGHT, &tmpVal))
+    height = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, AMEDIAFORMAT_KEY_STRIDE, &tmpVal))
+    stride = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, XMEDIAFORMAT_KEY_SLICE, &tmpVal))
+    slice_height = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, AMEDIAFORMAT_KEY_COLOR_FORMAT, &tmpVal))
+    color_format = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, XMEDIAFORMAT_KEY_CROP_LEFT, &tmpVal))
+    crop_left = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, XMEDIAFORMAT_KEY_CROP_RIGHT, &tmpVal))
+    crop_right = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, XMEDIAFORMAT_KEY_CROP_TOP, &tmpVal))
+    crop_top = tmpVal;
+  if (AMediaFormat_getInt32(mediaformat, XMEDIAFORMAT_KEY_CROP_BOTTOM, &tmpVal))
+    crop_bottom = tmpVal;
 
   if (!crop_right)
     crop_right = width-1;
@@ -1385,6 +1384,7 @@ void CDVDVideoCodecAndroidMediaCodec::InitSurfaceTexture(void)
     // hook the surfaceTexture OnFrameAvailable callback
     m_frameAvailable = std::shared_ptr<CDVDMediaCodecOnFrameAvailable>(new CDVDMediaCodecOnFrameAvailable(m_surfaceTexture));
     m_jnisurface = new CJNISurface(*m_surfaceTexture);
+    m_surface = ANativeWindow_fromSurface(xbmc_jnienv(), m_jnisurface->get_raw());
   }
   else
   {
@@ -1447,8 +1447,8 @@ void CDVDVideoCodecAndroidMediaCodec::surfaceDestroyed(CJNISurfaceHolder holder)
   if (m_state != MEDIACODEC_STATE_STOPPED && m_state != MEDIACODEC_STATE_UNINITIALIZED)
   {
     m_state = MEDIACODEC_STATE_STOPPED;
-    if (m_jnisurface)
-      m_jnisurface->release();
-    m_codec->stop();
+    if(m_surface)
+      ANativeWindow_release(m_surface);
+    AMediaCodec_stop(m_codec->codec());
   }
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <atomic>
 
+#include <androidjni/Surface.h>
+
 #include "DVDVideoCodec.h"
 #include "DVDStreamInfo.h"
 #include "platform/android/activity/JNIXBMCVideoView.h"
@@ -21,16 +23,19 @@
 #include "utils/Geometry.h"
 #include "cores/VideoPlayer/Process/VideoBuffer.h"
 
+#include <media/NdkMediaCodec.h>
+#include <android/native_window.h>
+#include <android/native_window_jni.h>
+
 class CJNISurface;
 class CJNISurfaceTexture;
 class CJNIMediaCodec;
-class CJNIMediaCrypto;
 class CJNIMediaFormat;
-class CJNIMediaCodecBufferInfo;
 class CDVDMediaCodecOnFrameAvailable;
 class CJNIByteBuffer;
 class CBitstreamConverter;
 
+struct AMediaCrypto;
 struct DemuxCryptoInfo;
 struct mpeg2_sequence;
 
@@ -41,6 +46,16 @@ typedef struct amc_demux {
   double    dts;
   double    pts;
 } amc_demux;
+
+struct CMediaCodec
+{
+  CMediaCodec(const char *name);
+  virtual ~CMediaCodec();
+
+  AMediaCodec *codec() const { return m_codec; };
+private:
+  AMediaCodec *m_codec;
+};
 
 class CMediaCodecVideoBufferPool;
 
@@ -80,21 +95,20 @@ private:
 class CMediaCodecVideoBufferPool : public IVideoBufferPool
 {
 public:
-  CMediaCodecVideoBufferPool(std::shared_ptr<CJNIMediaCodec> mediaCodec)
-      : m_codec(mediaCodec){};
+  CMediaCodecVideoBufferPool(std::shared_ptr<CMediaCodec> mediaCodec) : m_codec(mediaCodec) {};
 
   virtual ~CMediaCodecVideoBufferPool();
 
   virtual CVideoBuffer* Get() override;
   virtual void Return(int id) override;
 
-  std::shared_ptr<CJNIMediaCodec> GetMediaCodec();
+  std::shared_ptr<CMediaCodec> GetMediaCodec();
   void ResetMediaCodec();
   void ReleaseMediaCodecBuffers();
 
 private:
-  CCriticalSection m_criticalSection;
-  std::shared_ptr<CJNIMediaCodec> m_codec;
+  CCriticalSection m_criticalSection;;
+  std::shared_ptr<CMediaCodec> m_codec;
 
   std::vector<CMediaCodecVideoBuffer*> m_videoBuffers;
   std::vector<int> m_freeBuffers;
@@ -121,14 +135,14 @@ public:
   virtual unsigned GetAllowedReferences() override;
 
 protected:
-  void Dispose();
-  void FlushInternal(void);
-  void SignalEndOfStream();
-  void InjectExtraData(CJNIMediaFormat& mediaformat);
-  bool ConfigureMediaCodec(void);
-  int GetOutputPicture(void);
-  void ConfigureOutputFormat(CJNIMediaFormat& mediaformat);
-  void UpdateFpsDuration();
+  void            Dispose();
+  void            FlushInternal(void);
+  void            SignalEndOfStream();
+  void            InjectExtraData(AMediaFormat* mediaformat);
+  bool            ConfigureMediaCodec(void);
+  int             GetOutputPicture(void);
+  void            ConfigureOutputFormat(AMediaFormat* mediaformat);
+  void            UpdateFpsDuration();
 
   // surface handling functions
   static void     CallbackInitSurfaceTexture(void*);
@@ -147,11 +161,12 @@ protected:
   int             m_noPictureLoop;
 
   std::shared_ptr<CJNIXBMCVideoView> m_jnivideoview;
-  CJNISurface* m_jnisurface;
-  CJNISurface m_jnivideosurface;
-  unsigned int m_textureId;
-  std::shared_ptr<CJNIMediaCodec> m_codec;
-  CJNIMediaCrypto* m_crypto = nullptr;
+  CJNISurface*    m_jnisurface;
+  CJNISurface     m_jnivideosurface;
+  AMediaCrypto   *m_crypto;
+  unsigned int    m_textureId;
+  std::shared_ptr<CMediaCodec> m_codec;
+  ANativeWindow*  m_surface;
   std::shared_ptr<CJNISurfaceTexture> m_surfaceTexture;
   std::shared_ptr<CDVDMediaCodecOnFrameAvailable> m_frameAvailable;
 


### PR DESCRIPTION
This reverts commit bea61309d7aecfc2715c8433cae3e5843e406c41.

It was meant well and fixed some aspect ratio issues, especially on FireTV 4K.
Sadly it produces massive issues among many other devices, while this was not found by any internal testers. There was one report on the forum, which we ignored (not voluntarily, but hey - 1.5 Android devs and some million users, it won't work that way): https://forum.kodi.tv/showthread.php?tid=354295

We should not try to "save the entire world" with Leia 18.8, as we broke it now twice for a wide range of people by trying to fix minor bugs of the loudly argueing minority :-)

References:
https://forum.kodi.tv/showthread.php?tid=354677
https://forum.kodi.tv/showthread.php?tid=354661
https://forum.kodi.tv/showthread.php?tid=354619
https://forum.kodi.tv/showthread.php?tid=354679

Fun-facts:
If you read a bit, you can find parties for "works" and for "does not work".

