### PR TITLE
[GBM] add VirtualBox

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -600,7 +600,8 @@ bool CDRMUtils::OpenDrm(bool needConnector)
     "vc4",
     "virtio_gpu",
     "sun4i-drm",
-    "meson"
+    "meson",
+    "vboxvideo",
   };
 
   for (auto module : modules)


### PR DESCRIPTION
## Description
Enables running GBM/DRM in VirtualBox / Vagrant, provided that Vbox `vboxvideo` guest additions are installed.

## Motivation and Context
Enables debugging GBM in virtual machine easier

## How Has This Been Tested?
Tested in Ubuntu/Precise and Debian/Sid Vagrant boxes, with 3d accel turned on and guest additions installed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2791653/82749918-6039a300-9d61-11ea-87c5-2892e75ee5cc.png)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
