### PR TITLE
[addons][pvr][stream] fix nullset init of PVR_STREAM_TIMES in inputstream

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -102,7 +102,7 @@ int CInputStreamPVRBase::GetBlockSize()
 
 bool CInputStreamPVRBase::GetTimes(Times &times)
 {
-  PVR_STREAM_TIMES streamTimes;
+  PVR_STREAM_TIMES streamTimes = {};
   if (m_client && m_client->GetStreamTimes(&streamTimes) == PVR_ERROR_NO_ERROR)
   {
     times.startTime = streamTimes.startTime;


### PR DESCRIPTION
## Description
Before was this value given like it was to addons, if they not write then
all parts or makes a memset about a wrong data can be used.

This add a `= {}` to makes a 0 set and to confirm nothing wrong comes.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
By the C++ class is the typical null set like on pvr.hts was with this https://github.com/kodi-pvr/pvr.hts/blob/Matrix/src/Tvheadend.cpp#L3066 no more possilble, also do I expect for such calls that a empty structure is given.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
On reworked PVR before:
![Bildschirmfoto vom 2020-05-24 16-41-34](https://user-images.githubusercontent.com/6879739/82756944-88ff7e00-9ddd-11ea-8e7b-6d7324d2ba19.png)

After this:
![Bildschirmfoto vom 2020-05-24 16-37-43](https://user-images.githubusercontent.com/6879739/82756951-9452a980-9ddd-11ea-9d0d-3c48bf343ea2.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
