### PR TITLE
Show media stubs even if there is no optical drive

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -135,7 +135,6 @@
 
 #include "video/dialogs/GUIDialogFullScreenInfo.h"
 #include "dialogs/GUIDialogCache.h"
-#include "dialogs/GUIDialogPlayEject.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "addons/AddonInstaller.h"
@@ -2802,20 +2801,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
 
   if (item.IsDiscStub())
   {
-#ifdef HAS_DVD_DRIVE
-    // Display the Play Eject dialog if there is any optical disc drive
-    if (CServiceBroker::GetMediaManager().HasOpticalDrive())
-    {
-      if (CGUIDialogPlayEject::ShowAndGetInput(item))
-        // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
-        // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
-        return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
-    }
-    else
-#endif
-      HELPERS::ShowOKDialogText(CVariant{435}, CVariant{436});
-
-    return true;
+    return CServiceBroker::GetMediaManager().playStubFile(item);
   }
 
   if (item.IsPlayList())

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -13,8 +13,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "storage/MediaManager.h"
 #include "utils/Variant.h"
-#include "utils/XMLUtils.h"
-#include "utils/log.h"
 
 #include <utility>
 
@@ -75,37 +73,16 @@ void CGUIDialogPlayEject::OnInitWindow()
   CGUIDialogYesNo::OnInitWindow();
 }
 
-bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
-  unsigned int uiAutoCloseTime /* = 0 */)
+bool CGUIDialogPlayEject::ShowAndGetInput(const std::string strLine1,
+                                          const std::string strLine2,
+                                          unsigned int uiAutoCloseTime /* = 0 */)
 {
-  // Make sure we're actually dealing with a Disc Stub
-  if (!item.IsDiscStub())
-    return false;
 
   // Create the dialog
   CGUIDialogPlayEject * pDialog = (CGUIDialogPlayEject *)CServiceBroker::GetGUI()->GetWindowManager().
     GetWindow(WINDOW_DIALOG_PLAY_EJECT);
   if (!pDialog)
     return false;
-
-  // Figure out Lines 1 and 2 of the dialog
-  std::string strLine1, strLine2;
-  CXBMCTinyXML discStubXML;
-  if (discStubXML.LoadFile(item.GetPath()))
-  {
-    TiXmlElement * pRootElement = discStubXML.RootElement();
-    if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "discstub") != 0)
-      CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.GetPath().c_str());
-    else
-    {
-      XMLUtils::GetString(pRootElement, "title", strLine1);
-      XMLUtils::GetString(pRootElement, "message", strLine2);
-    }
-  }
-
-  // Use the label for Line 1 if not defined
-  if (strLine1.empty())
-    strLine1 = item.GetLabel();
 
   // Setup dialog parameters
   pDialog->SetHeading(CVariant{219});

--- a/xbmc/dialogs/GUIDialogPlayEject.h
+++ b/xbmc/dialogs/GUIDialogPlayEject.h
@@ -19,7 +19,9 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   void FrameMove() override;
 
-  static bool ShowAndGetInput(const CFileItem & item, unsigned int uiAutoCloseTime = 0);
+  static bool ShowAndGetInput(const std::string strLine1,
+                              const std::string strLine2,
+                              unsigned int uiAutoCloseTime = 0);
 
 protected:
   void OnInitWindow() override;

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "FileItem.h"
 #include "MediaManager.h"
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
@@ -26,21 +27,22 @@
 #endif
 #endif
 #include "Autorun.h"
-#include "addons/VFSEntry.h"
+#include "AutorunMediaJob.h"
 #include "GUIUserMessages.h"
+#include "addons/VFSEntry.h"
+#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "dialogs/GUIDialogPlayEject.h"
+#include "filesystem/File.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/XBMCTinyXML.h"
 #include "threads/SingleLock.h"
-#include "utils/log.h"
-#include "dialogs/GUIDialogKaiToast.h"
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"
-#include "AutorunMediaJob.h"
-
-#include "filesystem/File.h"
-#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/log.h"
 
 #if defined(TARGET_POSIX) && !defined(TARGET_DARWIN) && !defined(TARGET_FREEBSD)
 #include <sys/ioctl.h>
@@ -759,4 +761,39 @@ void CMediaManager::RemoveDiscInfo(const std::string& devicePath)
   auto it = m_mapDiscInfo.find(strDevice);
   if (it != m_mapDiscInfo.end())
     m_mapDiscInfo.erase(it);
+}
+
+bool CMediaManager::playStubFile(const CFileItem& item)
+{
+  // Figure out Lines 1 and 2 of the dialog
+  std::string strLine1, strLine2;
+  CXBMCTinyXML discStubXML;
+  if (discStubXML.LoadFile(item.GetPath()))
+  {
+    TiXmlElement* pRootElement = discStubXML.RootElement();
+    if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "discstub") != 0)
+      CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.GetPath().c_str());
+    else
+    {
+      XMLUtils::GetString(pRootElement, "title", strLine1);
+      XMLUtils::GetString(pRootElement, "message", strLine2);
+    }
+  }
+
+  // Use the label for Line 1 if not defined
+  if (strLine1.empty())
+    strLine1 = item.GetLabel();
+
+  if (HasOpticalDrive())
+  {
+#ifdef HAS_DVD_DRIVE
+    if (CGUIDialogPlayEject::ShowAndGetInput(strLine1, strLine2))
+      return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
+#endif
+  }
+  else
+  {
+    KODI::MESSAGING::HELPERS::ShowOKDialogText(strLine1, strLine2);
+  }
+  return true;
 }

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -29,6 +29,8 @@
 #define DRIVE_CLOSED_MEDIA_PRESENT  4 // Will be send once when the drive just have closed
 #define DRIVE_NONE  5 // system doesn't have an optical drive
 
+class CFileItem;
+
 class CNetworkLocation
 {
 public:
@@ -87,6 +89,9 @@ public:
   void OnStorageUnsafelyRemoved(const std::string &label) override;
 
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override { }
+
+  bool playStubFile(const CFileItem& item);
+
 protected:
   std::vector<CNetworkLocation> m_locations;
 


### PR DESCRIPTION
## Description
Allows media stubs to be shown if there is no optical drive

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/17934

## How Has This Been Tested?
Tested on Windows x64. With an optical drive in the system it displays the stub and gives the Play and Eject buttons. With no optical drive it displays the stub and gives just an OK button

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
