### PR TITLE
[addons][plugin] don't use extra ways to check "provides"

### DIFF
--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -21,20 +21,6 @@ namespace ADDON
 CPluginSource::CPluginSource(const AddonInfoPtr& addonInfo, TYPE addonType) : CAddon(addonInfo, addonType)
 {
   std::string provides = addonInfo->Type(addonType)->GetValue("provides").asString();
-  if (provides.empty())
-  {
-    /*
-     * If "provides" was empty, check about them in addon extra info. This become
-     * needed for addons from repo content where the addon is stored inside a
-     * database and the related type classes are not created on addon info.
-     * The database add then "provides" to there.
-     */
-    const auto& i = addonInfo->ExtraInfo().find("provides");
-    if (i != addonInfo->ExtraInfo().end())
-      provides = i->second;
-    else
-      provides = "executable"; // if nothing fall back to "executable"
-  }
 
   for (auto values : addonInfo->Type(addonType)->GetValues())
   {

--- a/xbmc/addons/addoninfo/AddonType.cpp
+++ b/xbmc/addons/addoninfo/AddonType.cpp
@@ -24,6 +24,16 @@ void CAddonType::SetProvides(const std::string& content)
 {
   if (!content.empty())
   {
+    /*
+     * Normally the "provides" becomes added from xml scan, but for add-ons
+     * stored in the database (e.g. repository contents) it might not be
+     * available. Since this information is available in add-on metadata for the
+     * main type (see extrainfo) we take the function contents and insert it if
+     * empty.
+     */
+    if (GetValue("provides").empty())
+      Insert("provides", content);
+
     for (auto provide : StringUtils::Split(content, ' '))
     {
       TYPE content = CAddonInfo::TranslateSubContent(provide);


### PR DESCRIPTION
## Description

Before was it separate done by addon.xml and database content and added to the addon extra info instead of extension values.

If the `<provides>` on second was empty or not available, has them taken the first type and wrongly two video addons shown.

Now becomes them added to the extension values and the extra info no need to check.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

Before with edited **plugin.video.youtube** for test, if this on xml:
```xml
    <extension point="xbmc.python.pluginsource" library="resources/lib/default.py">
        <provides>video</provides>
    </extension>
    <extension point="xbmc.python.script" library="default.py">
        <provides></provides>
    </extension>
```
![Bildschirmfoto vom 2020-05-24 22-39-48](https://user-images.githubusercontent.com/6879739/82764531-b36a2f00-9e0f-11ea-9077-6877701e7b64.png)

This then with the request changes:
![Bildschirmfoto vom 2020-05-24 22-42-57](https://user-images.githubusercontent.com/6879739/82764561-f9bf8e00-9e0f-11ea-8be3-94ac3759c379.png)

The database content stays correct:
![Bildschirmfoto vom 2020-05-24 22-44-04](https://user-images.githubusercontent.com/6879739/82764585-1bb91080-9e10-11ea-8a22-abcedb3513a7.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
