### PR TITLE
[Backport][Android] Use releaseOutputBufferAtTime for valid frames

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=82f1a87f1d2397dd0340a9443d7feea70cc7ea3b
+VERSION=2fa473b9e21e179e7ed21b043eb300334bb5f11a
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -167,7 +167,7 @@ void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTim
   if (!render || displayTime == 0)
     codec->releaseOutputBuffer(m_bufferId, render);
   else
-    codec->releaseOutputBuffer(m_bufferId, displayTime);
+    codec->releaseOutputBufferAtTime(m_bufferId, displayTime);
   m_bufferId = -1; //mark released
 
   if (xbmc_jnienv()->ExceptionCheck())


### PR DESCRIPTION
## Description
Backport of #17943:

In our JNI implementation releaseOutputBuffer(int index, long renderTimeStampNs) was missing and compiler has cast our renderTimestamp to the bool render value of releaseOutputBuffer(int index, bool render) which causes an immediate render. This PR updates to the extended libandroidJNI library and calls the correct implementation.
The issue was introduced for master in #17611 and  fror Leia backported in #17613

## Motivation and Context
Micro stutters were reported e.g. here: https://forum.kodi.tv/showthread.php?tid=354295

## How Has This Been Tested?
Playback of 25fps videos on 50Hz display / NVIDIA Shield 2017, Micro stutters are sometimes visible.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)