### PR TITLE
[settings] move CSettingList::FindIntInList() to CSettingUtils::FindIntInList()

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -25,6 +25,7 @@
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "playlists/PlayList.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -351,15 +352,14 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         {
           std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>( 
             CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
-          if (tag->m_type != MediaTypeTvShow &&
-              tag->m_type != MediaTypeVideoCollection &&
-              tag->GetPlayCount() == 0 &&
-              setting &&
-              (
-               (tag->m_type == MediaTypeMovie && (!setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES))) ||  
-               (tag->m_type == MediaTypeEpisode && (!setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES)))
-              )
-             ) 
+          if (tag->m_type != MediaTypeTvShow && tag->m_type != MediaTypeVideoCollection &&
+              tag->GetPlayCount() == 0 && setting &&
+              ((tag->m_type == MediaTypeMovie &&
+                !CSettingUtils::FindIntInList(
+                    setting, CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES)) ||
+               (tag->m_type == MediaTypeEpisode &&
+                !CSettingUtils::FindIntInList(
+                    setting, CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES))))
           {
             value = g_localizeStrings.Get(20370);
           }

--- a/xbmc/settings/SettingUtils.cpp
+++ b/xbmc/settings/SettingUtils.cpp
@@ -12,6 +12,8 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
+#include <algorithm>
+
 std::vector<CVariant> CSettingUtils::GetList(std::shared_ptr<const CSettingList> settingList)
 {
   return ListToValues(settingList, settingList->GetValue());
@@ -117,4 +119,17 @@ bool CSettingUtils::ValuesToList(std::shared_ptr<const CSettingList> setting, co
   }
 
   return true;
+}
+
+bool CSettingUtils::FindIntInList(std::shared_ptr<const CSettingList> settingList, int value)
+{
+  if (settingList == nullptr || settingList->GetElementType() != SettingType::Integer)
+    return false;
+
+  const auto values = settingList->GetValue();
+  const auto matchingValue =
+      std::find_if(values.begin(), values.end(), [value](const SettingPtr& setting) {
+        return std::static_pointer_cast<CSettingInt>(setting)->GetValue() == value;
+      });
+  return matchingValue != values.end();
 }

--- a/xbmc/settings/SettingUtils.h
+++ b/xbmc/settings/SettingUtils.h
@@ -36,4 +36,13 @@ public:
 
   static std::vector<CVariant> ListToValues(std::shared_ptr<const CSettingList> setting, const std::vector< std::shared_ptr<CSetting> > &values);
   static bool ValuesToList(std::shared_ptr<const CSettingList> setting, const std::vector<CVariant> &values, std::vector< std::shared_ptr<CSetting> > &newValues);
+
+  /*!
+   \brief Search in a list of Ints for a given value.
+
+   \param settingList CSettingList instance
+   \param value value to search for
+   \return True if value was found in list, false otherwise
+  */
+  static bool FindIntInList(std::shared_ptr<const CSettingList> settingList, int value);
 };

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -167,14 +167,6 @@ void CSettingsBase::UnregisterCallback(ISettingCallback* callback)
   m_settingsManager->UnregisterCallback(callback);
 }
 
-bool CSettingsBase::FindIntInList(const std::string &id, int value) const
-{
-  if (id.empty())
-    return false;
-
-  return m_settingsManager->FindIntInList(id, value);
-}
-
 SettingPtr CSettingsBase::GetSetting(const std::string& id) const
 {
   if (id.empty())

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -100,15 +100,6 @@ public:
   void UnregisterCallback(ISettingCallback* callback);
 
   /*!
-  \brief Search in a list of Ints for a given value.
-
-  \param id Setting identifier
-  \param value value to search for
-  \return True if value was found in list, false otherwise
-  */
-  bool FindIntInList(const std::string &id, int value) const;
-
-  /*!
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -16,7 +16,6 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
-#include <algorithm>
 #include <sstream>
 
 template<typename TKey, typename TValue>
@@ -482,14 +481,6 @@ void CSettingList::Reset()
     values.push_back(it->Clone(it->GetId()));
 
   SetValue(values);
-}
-
-bool CSettingList::FindIntInList(int value) const
-{
-  return std::find_if(m_values.cbegin(), m_values.cend(), [&](const SettingPtr& setting)
-  {
-    return setting->GetType() == SettingType::Integer && std::static_pointer_cast<CSettingInt>(setting)->GetValue() == value;
-  }) != m_values.cend();
 }
 
 bool CSettingList::FromString(const std::vector<std::string> &value)

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -191,7 +191,6 @@ public:
   bool SetValue(const SettingList &values);
   const SettingList& GetDefault() const { return m_defaults; }
   void SetDefault(const SettingList &values);
-  bool FindIntInList(int value) const;
 
 protected:
   void copy(const CSettingList &setting);

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -685,14 +685,6 @@ bool CSettingsManager::SetList(const std::string &id, const std::vector< std::sh
   return std::static_pointer_cast<CSettingList>(setting)->SetValue(value);
 }
 
-bool CSettingsManager::FindIntInList(const std::string &id, int value) const
-{
-  CSharedLock lock(m_settingsCritical);
-  std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(GetSetting(id)));
-
-  return setting && setting->FindIntInList(value);
-}
-
 bool CSettingsManager::SetDefault(const std::string &id)
 {
   CSharedLock lock(m_settingsCritical);

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -406,15 +406,6 @@ public:
   bool SetList(const std::string &id, const std::vector< std::shared_ptr<CSetting> > &value);
 
   /*!
-   \brief Search in a list of Ints for a given value.
-
-   \param id Setting identifier
-   \param value value to search for
-   \return True if value was found in list, false otherwise
-  */
-  bool FindIntInList(const std::string &id, int value) const;
-
-  /*!
    \brief Sets the value of the setting to its default.
 
    \param id Setting identifier

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -23,6 +23,7 @@
 #include "guilib/StereoscopicsManager.h"
 #include "music/MusicDatabase.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -356,10 +357,8 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
     CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
   if (pItem->HasArt("thumb") && pItem->HasVideoInfoTag() &&
       pItem->GetVideoInfoTag()->m_type == MediaTypeEpisode &&
-      pItem->GetVideoInfoTag()->GetPlayCount() == 0 &&
-      setting && 
-      !setting->FindIntInList(CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE)
-     )
+      pItem->GetVideoInfoTag()->GetPlayCount() == 0 && setting &&
+      !CSettingUtils::FindIntInList(setting, CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE))
   {
     // use fanart if available
     if (pItem->HasArt("fanart"))

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -37,6 +37,7 @@
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -402,13 +403,13 @@ void CGUIDialogVideoInfo::Update()
     CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
   std::string strTmp = m_movieItem->GetVideoInfoTag()->m_strPlot;
   if (m_movieItem->GetVideoInfoTag()->m_type != MediaTypeTvShow)
-    if (m_movieItem->GetVideoInfoTag()->GetPlayCount() == 0 && 
-        setting &&
-        (
-         (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeMovie && (!setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES))) || 
-         (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeEpisode && (!setting->FindIntInList(CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES)))
-        )
-       )
+    if (m_movieItem->GetVideoInfoTag()->GetPlayCount() == 0 && setting &&
+        ((m_movieItem->GetVideoInfoTag()->m_type == MediaTypeMovie &&
+          !CSettingUtils::FindIntInList(setting,
+                                        CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES)) ||
+         (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeEpisode &&
+          !CSettingUtils::FindIntInList(
+              setting, CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES))))
       strTmp = g_localizeStrings.Get(20370);
 
   StringUtils::Trim(strTmp);

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -34,8 +34,10 @@
 #include "pvr/windows/GUIViewStatePVR.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "utils/URIUtils.h"
 #include "video/GUIViewStateVideo.h"
 #include "view/ViewState.h"
@@ -509,7 +511,12 @@ bool CGUIViewState::AutoPlayNextVideoItem() const
   else
     settingValue = SETTING_AUTOPLAYNEXT_UNCATEGORIZED;
 
-  return settingValue >= 0 && CServiceBroker::GetSettingsComponent()->GetSettings()->FindIntInList(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM, settingValue);
+  const auto setting = std::dynamic_pointer_cast<CSettingList>(
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
+          CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM));
+
+  return settingValue >= 0 && setting != nullptr &&
+         CSettingUtils::FindIntInList(setting, settingValue);
 }
 
 void CGUIViewState::LoadViewState(const std::string &path, int windowID)


### PR DESCRIPTION
## Description
This refactors, cleans up and improves the method `CSettingList::FindIntInList()` introduced in #13992 and reworked in #14815 to `CSettingUtils::FindIntInList()`. `CSettingUtils` is exactly there to hold such helper methods.

## Motivation and Context
The settings library and its integration into Kodi is as generic as possible and we want as little (type) specific logic in the library as possible.

## How Has This Been Tested?
Manually

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
