### PR TITLE
Plugins: Update playlist type after plugin resolution

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2680,6 +2680,17 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPl
     if (!XFILE::CPluginDirectory::GetPluginResult(item.GetDynPath(), item, resume) ||
         item.GetDynPath() == item.GetPath()) // GetPluginResult resolved to an empty path
       return false;
+
+    // we may have been called as part of a playlist without knowing what the content type of
+    // the plugin:// item was. Since we now can infer the type, compare and notify
+    // if content changed.
+    if (iPlaylist != PLAYLIST_NONE)
+    {
+      if (iPlaylist == PLAYLIST_MUSIC && item.IsVideo())
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+      else if (iPlaylist == PLAYLIST_VIDEO && item.IsAudio())
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_MUSIC);
+    }
   }
   // if after the 5 resolution attempts the item is still a plugin just return, it isn't playable
   if (URIUtils::IsPlugin(item.GetDynPath()))

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -834,7 +834,8 @@ bool CFileItem::IsVideo() const
   //! @todo If the file is a zip file, ask the game clients if any support this
   // file before assuming it is video.
 
-  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
+  return URIUtils::HasExtension(GetDynPath(),
+                                CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
 }
 
 bool CFileItem::IsEPG() const
@@ -921,7 +922,8 @@ bool CFileItem::IsAudio() const
   //! @todo If the file is a zip file, ask the game clients if any support this
   // file before assuming it is audio
 
-  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions());
+  return URIUtils::HasExtension(GetDynPath(),
+                                CServiceBroker::GetFileExtensionProvider().GetMusicExtensions());
 }
 
 bool CFileItem::IsDeleted() const

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -14,7 +14,6 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "filesystem/PluginDirectory.h"
 #include "filesystem/VideoDatabaseFile.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -29,7 +28,6 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -899,13 +897,6 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
         if (list->Size() == 1 && !(*list)[0]->IsPlayList())
         {
           CFileItemPtr item = (*list)[0];
-          // if the item is a plugin we need to resolve the URL to ensure the infotags are filled.
-          // resolve only for a maximum of 5 times to avoid deadlocks (plugin:// paths can resolve to plugin:// paths)
-          for (int i = 0; URIUtils::IsPlugin(item->GetDynPath()) && i < 5; ++i)
-          {
-            if (!XFILE::CPluginDirectory::GetPluginResult(item->GetDynPath(), *item, true))
-              return;
-          }
           if (item->IsAudio() || item->IsVideo())
             Play(item, pMsg->strParam);
           else


### PR DESCRIPTION
## Description
This pull-request reverts https://github.com/xbmc/xbmc/pull/16158 (originally as a fix for https://github.com/xbmc/xbmc/issues/16151) and purposes a different fix for the issue. Additionally, it might also fix other issues such as https://github.com/xbmc/xbmc/issues/17915 (untested).

## Motivation
I am trying to solve issues in python addons due to the concurrent busydialogs. Unfortunately, the problem is not easily solvable since `CPluginDirectory::GetPluginDirectory` (filesystem) at the moment includes and calls into GUI if called from the main thread. To be able to remove such dependency (first step into having a fix) we need to isolate and track which calls into `CPluginDirectory::GetPluginResult` may originate from Application (e.g. play a plugin:// path) vs those that are supposed to occur in the background (e.g. python scrappers). Unfortunately, while my previous solution solved the reported issue, it also brought a side-effect of including a new call into the aforementioned method. PlaylistPlayer can be called from anywhere (e.g. JSON) while PluginDirectory retrieval is supposed to be a busy process (guarded by a busydialog the user might want to cancel). Hence, different approaches to solve the original issue are required.

PlayList player may hold two types of playlists: `VIDEO` and `MUSIC`. Those are created when the list of items are passed to the player and by default it defaults to `MUSIC`. It only becomes `VIDEO` if any of the items in the file list can be identified as a video (see `CFileitem.IsVideo`). The problem is that plugins can hold any type of content while kodi can only infer the type after the plugin:// path has been expanded/resolved. When PlayListPlayer cannot infer the type, it calls generic `PlayMedia` in application (ugly but not the issue I'm trying to solve here) along with the playlist type. This was not taken into account for plugins:// and we could end up in situations where the current active playlist is music but we are actually playing a video.

To add to the problem, JSONRPC seems to link player id's with Playlist types (most likely the weigh of legacy). 

So, if a plugin item is played from json rpc (e.g. from yatse):

- PlaylistPlayer creates a music playlist (can't determine the plugin:// content type) so keeps the playlist as music and calls PlayMedia
- Videoplayer will be opened (since the item is actually a video)
- **GetActivePlayers** in JSON will return PlayerId=0 (music) as the current active player
- **GetPlayerProperties** will be called with PlayerId=0 (active player) which is a "music player"
- Most of the properties (subtitles, etc) will not be available in the response as they are invalid for music
This is the reason why situations such as the ones described in https://github.com/xbmc/xbmc/issues/17915 end up happening.

This PR updates the playlist type if PlayMedia is called with a playlist type, a plugin:// item was passed to the function and they types differ.

I know all the logic I described above (basically how kodi works...) is ugly and violates a lot of good practices (even the new fix is also ugly). This is not the issue I'm trying to solve here. My goal is to remove GUI from PluginDirectory (filesystem).

Not sure who to ping.

## How Has This Been Tested?
Manually, same test scenario as https://github.com/xbmc/xbmc/pull/16158

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
