### PR TITLE
Fix initialising song count for later use to reserve results vector

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6573,6 +6573,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     // (includes xsp limits from filter, but not sort limits)
     total = static_cast<int>(strtol(
         GetSingleValue("SELECT COUNT(1) FROM song " + strSQLExtra, m_pDS).c_str(), nullptr, 10));
+    resultcount = static_cast<size_t>(total);
 
     int iAddedFields = GetOrderFilter(MediaTypeSong, sortDescription, extFilter);
     // Replace songview field names in order by with song, album path table field names


### PR DESCRIPTION
Follow up to https://github.com/xbmc/xbmc/pull/17746
Line got lost somewhere in rebasing, oops. 