### PR TITLE
[Android] Call codec::release

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -658,6 +658,11 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       {
         m_codec = std::shared_ptr<CJNIMediaCodec>(
             new CJNIMediaCodec(CJNIMediaCodec::createByCodecName(m_codecname)));
+        if (xbmc_jnienv()->ExceptionCheck())
+        {
+          xbmc_jnienv()->ExceptionClear();
+          m_codec = nullptr;
+        }
         if (!m_codec)
         {
           CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open cannot create codec");
@@ -772,6 +777,8 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
   if (!m_opened)
     return;
 
+  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::%s", __func__);
+
   // invalidate any inflight outputbuffers
   FlushInternal();
 
@@ -786,6 +793,7 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
   if (m_codec)
   {
     m_codec->stop();
+    m_codec->release();
     m_codec = nullptr;
     m_state = MEDIACODEC_STATE_STOPPED;
   }


### PR DESCRIPTION
## Description
Call missing CJNIMediaCodec::release() when disposing the decoder

## Motivation and Context
On multi period streams Android video stack can run out of resources if we re-open a codec without having the previous one properly released. This leads to an JNI exception, which is until this PR not properly catched -> kodi terminates.

This PR calls a.) release, and b.) adds the security check. 

## How Has This Been Tested?
Disney+ addon / AFTV 4K Stick / Mandalorian (HEVC + HDR)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
