### PR TITLE
[Android] Implement MediaCodec::Reconfigure to reduce codec setups

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1005,12 +1005,14 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
 
 bool CDVDVideoCodecAndroidMediaCodec::Reconfigure(CDVDStreamInfo &hints)
 {
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Reconfigure called");
-  if (m_hints.Equal(hints, false))
+  if (m_hints.Equal(hints, CDVDStreamInfo::COMPARE_ALL &
+                               ~(CDVDStreamInfo::COMPARE_ID | CDVDStreamInfo::COMPARE_EXTRADATA)))
   {
+    CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Reconfigure: true");
     m_hints = hints;
     return true;
   }
+  CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Reconfigure: false");
   return false;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -834,12 +834,8 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
   size_t iSize(packet.iSize);
 
   if (m_state == MEDIACODEC_STATE_ENDOFSTREAM)
-  {
-    // We received a packet but already reached EOS. Flush...
-    FlushInternal();
-    m_codec->flush();
-    m_state = MEDIACODEC_STATE_FLUSHED;
-  }
+    // We received a packet but already reached EOS. Reset...
+    Reset();
 
   if (pData && iSize)
   {
@@ -1010,6 +1006,11 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
 bool CDVDVideoCodecAndroidMediaCodec::Reconfigure(CDVDStreamInfo &hints)
 {
   CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Reconfigure called");
+  if (m_hints.Equal(hints, false))
+  {
+    m_hints = hints;
+    return true;
+  }
   return false;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -73,17 +73,15 @@ void CDVDStreamInfo::Clear()
   orientation = 0;
 }
 
-bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
+bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, int compare)
 {
-  if( codec     != right.codec
-  ||  type      != right.type
-  ||  uniqueId  != right.uniqueId
-  ||  demuxerId != right.demuxerId
-  ||  codec_tag != right.codec_tag
-  ||  flags     != right.flags)
+  if (codec != right.codec || type != right.type ||
+      ((compare & COMPARE_ID) && uniqueId != right.uniqueId) ||
+      ((compare & COMPARE_ID) && demuxerId != right.demuxerId) || codec_tag != right.codec_tag ||
+      flags != right.flags)
     return false;
 
-  if( withextradata )
+  if (compare & COMPARE_EXTRADATA)
   {
     if( extrasize != right.extrasize ) return false;
     if( extrasize )
@@ -171,7 +169,7 @@ bool CDVDStreamInfo::Equal(const CDemuxStream& right, bool withextradata)
 {
   CDVDStreamInfo info;
   info.Assign(right, withextradata);
-  return Equal(info, withextradata);
+  return Equal(info, withextradata ? COMPARE_ALL : COMPARE_ALL & ~COMPARE_EXTRADATA);
 }
 
 

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -30,11 +30,18 @@ public:
   ~CDVDStreamInfo();
 
   void Clear(); // clears current information
-  bool Equal(const CDVDStreamInfo &right, bool withextradata);
+  bool Equal(const CDVDStreamInfo& right, int compare);
   bool Equal(const CDemuxStream &right, bool withextradata);
 
   void Assign(const CDVDStreamInfo &right, bool withextradata);
   void Assign(const CDemuxStream &right, bool withextradata);
+
+  enum
+  {
+    COMPARE_EXTRADATA = 1,
+    COMPARE_ID = 2,
+    COMPARE_ALL = 3,
+  };
 
   AVCodecID codec;
   StreamType type;
@@ -86,8 +93,8 @@ public:
   std::shared_ptr<DemuxCryptoSession> cryptoSession;
   std::shared_ptr<ADDON::IAddonProvider> externalInterfaces;
 
-  bool operator==(const CDVDStreamInfo& right)      { return Equal(right, true);}
-  bool operator!=(const CDVDStreamInfo& right)      { return !Equal(right, true);}
+  bool operator==(const CDVDStreamInfo& right) { return Equal(right, COMPARE_ALL); }
+  bool operator!=(const CDVDStreamInfo& right) { return !Equal(right, COMPARE_ALL); }
 
   CDVDStreamInfo& operator=(const CDVDStreamInfo& right)
   {
@@ -97,8 +104,14 @@ public:
     return *this;
   }
 
-  bool operator==(const CDemuxStream& right)      { return Equal( CDVDStreamInfo(right, true), true);}
-  bool operator!=(const CDemuxStream& right)      { return !Equal( CDVDStreamInfo(right, true), true);}
+  bool operator==(const CDemuxStream& right)
+  {
+    return Equal(CDVDStreamInfo(right, true), COMPARE_ALL);
+  }
+  bool operator!=(const CDemuxStream& right)
+  {
+    return !Equal(CDVDStreamInfo(right, true), COMPARE_ALL);
+  }
 
   CDVDStreamInfo& operator=(const CDemuxStream& right)
   {


### PR DESCRIPTION
## Description
If VP gets informed about stream changes, it asks the decoder if it can be reconfigured "on the fly".
This PR compares DVDStreamInfo without codec extradata, and if it matches the open decoder will be reused (after injecting the possible different new codec extradata)

## Motivation and Context
- Increase performance when switching between chapters
- Avoid HDR sign on TV to appear / disappear / appear on chapter changes if chapters are both HDR and codec / dimensions matches

## How Has This Been Tested?
Play Disney+ Mandalorian on Amazon FireTV Stick 4K

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
