### PR TITLE
[PVR] EPG container: Do not fetch EPG updates from the clients while …

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -587,12 +587,16 @@ void CPVRManager::OnSleep()
 
   SetWakeupCommand();
 
+  m_epgContainer.OnSystemSleep();
+
   m_addons->OnSystemSleep();
 }
 
 void CPVRManager::OnWake()
 {
   m_addons->OnSystemWake();
+
+  m_epgContainer.OnSystemWake();
 
   PublishEvent(PVREvent::SystemWake);
 

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -16,6 +16,7 @@
 #include "threads/Thread.h"
 #include "utils/EventStream.h"
 
+#include <atomic>
 #include <list>
 #include <map>
 #include <memory>
@@ -196,6 +197,16 @@ namespace PVR
      */
     void OnPlaybackStopped();
 
+    /*!
+     * @brief Inform the epg container that the system is going to sleep
+     */
+    void OnSystemSleep();
+
+    /*!
+     * @brief Inform the epg container that the system gets awake from sleep
+     */
+    void OnSystemWake();
+
   private:
     /*!
      * @brief Notify EPG table observers when the currently active tag changed.
@@ -286,5 +297,7 @@ namespace PVR
     bool m_bUpdateNotificationPending = false; /*!< true while an epg updated notification to observers is pending. */
     CPVRSettings m_settings;
     CEventSource<PVREvent> m_events;
+
+    std::atomic<bool> m_bSuspended = {false};
   };
 }


### PR DESCRIPTION
EPG container: Do not fetch EPG updates from the clients while the system is suspended.

On Android, when putting the system to sleep (for example using the off button on your remote), the system does not suspend to ram/disk, but does something else, which technically keeps running processes alive.

This PR prevents Kodi from periodically fetching EPG from the PVR addons while being in "suspended" mode. Most PVR addons will close the connection to their backend when receiving a "suspend" notification so any addon calls requiring backend access will raise an error while system is "suspended".

Tested on my two Shield devices and on macOS (to see it does not break real suspend-to-ram/disk modes).

@phunkyfish mind looking at the code change?