### PR TITLE
[Skinning/Info] Expose Player.Progress and Player.ProgressCache as string infos

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -495,14 +495,20 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///   }
 ///   \table_row3{   <b>`Player.Progress`</b>,
 ///                  \anchor Player_Progress
-///                  _integer_,
+///                  _integer_ / _string_,
 ///     @return The progress position as percentage.
+///     <p><hr>
+///     @skinning_v19 \link Player_Progress `Player.Progress`\endlink infolabel
+///     also exposed as a string.
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.ProgressCache`</b>,
 ///                  \anchor Player_ProgressCache
-///                  _integer_,
+///                  _integer_ / _string_,
 ///     @return How much of the file is cached above current play percentage
+///     <p><hr>
+///     @skinning_v19 \link Player_ProgressCache `Player.ProgressCache`\endlink
+///     infolabel also exposed as a string.
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.Volume`</b>,

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -182,6 +182,12 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
         value = "+" + seekOffset;
       return true;
     }
+    case PLAYER_PROGRESS:
+      value = std::to_string(std::lrintf(g_application.GetPercentage()));
+      return true;
+    case PLAYER_PROGRESS_CACHE:
+      value = std::to_string(std::lrintf(g_application.GetCachePercentage()));
+      return true;
     case PLAYER_VOLUME:
       value = StringUtils::Format("%2.1f dB", CAEUtil::PercentToGain(g_application.GetVolumeRatio()));
       return true;


### PR DESCRIPTION
## Description
This PR exposes `Player.Progress` and `Player.ProgressCache` so they can be used by python's `xbmc.getInfolabel()` .

## Motivation and Context
Fix https://github.com/xbmc/xbmc/issues/17962

## How Has This Been Tested?
Loop in python while the player is running:
```python
while not self.exit_monitor.abortRequested():
    xbmc.log(xbmc.getInfoLabel("Player.Progress"))
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

