### PR TITLE
[docs] fix typo CODE_GUIDELINES.md

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -44,7 +44,7 @@
   * [11.3. Overriding virtual functions](#113-overriding-virtual-functions)
   * [11.4. Default member initialization](#114-default-member-initialization)
   * [11.5. Destructors in interfaces](#115-destructors-in-interfaces)
-  * [11.6. Constructor Initialzation Lists](#116-constructor-initialzation-lists)
+  * [11.6. Constructor Initialization Lists](#116-constructor-initialization-lists)
 * [12. Other conventions](#12-other-conventions)
   * [12.1. Output parameters](#121-output-parameters)
   * [12.2. Casts](#122-casts)
@@ -653,7 +653,7 @@ class Foo
 
 A class with any virtual functions should have a destructor that is either public and virtual or else protected and non-virtual (cf. [ISO C++ guidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual)).
 
-### 11.6. Constructor Initialzation Lists
+### 11.6. Constructor Initialization Lists
 
 For lines up to [line length](#line-length) everything stays on one line, excluding the braces which must be on the following lines.
 


### PR DESCRIPTION
## Description
typo correction in docs

## Motivation and Context
caught my eye ;)

## Types of change
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly
