### PR TITLE
[Android] Remove VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1275,8 +1275,6 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
     CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec configure error");
     return false;
   }
-  m_codec->setVideoScalingMode(CJNIMediaCodec::VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING);
-
   m_state = MEDIACODEC_STATE_CONFIGURED;
 
   m_codec->start();


### PR DESCRIPTION
## Description
Remove the VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING mode for android MediaCodec introduced for master in #17611 and fror Leia backported in #17613

## Motivation and Context
There are issues on various devices with wrong stretching. The original issue (1920x800 video on new AFTV4K sticks) seems to be solved in the OS.

## How Has This Been Tested?
- User feedback here: https://github.com/xbmc/xbmc/issues/17963
- Play 1920x800 video on AFTV 4K stick

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)