### PR TITLE
CApplication::IsStopping() implementation

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -145,7 +145,8 @@ public:
   bool Create(const CAppParamParser &params);
   bool Cleanup() override;
 
-  bool IsInitialized() { return !m_bInitializing; }
+  bool IsInitialized() const { return !m_bInitializing; }
+  bool IsStopping() const { return m_bStop; }
 
   bool CreateGUI();
   bool InitWindow(RESOLUTION res = RES_INVALID);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -277,9 +277,12 @@ void CXBMCApp::onPause()
   EnableWakeLock(false);
   m_hasReqVisible = false;
 
-  IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
-  if (syscall)
-    static_cast<CAndroidPowerSyscall*>(syscall)->SetOnPause();
+  if (!g_application.IsStopping())
+  {
+    IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
+    if (syscall)
+      static_cast<CAndroidPowerSyscall*>(syscall)->SetOnPause();
+  }
 }
 
 void CXBMCApp::onStop()


### PR DESCRIPTION
## Description
CApplication::IsStopping() implementation

## Motivation and Context
On Kodi shutdown Android sends onPause() async event at the time CServiceBroker is already destroyed. This leads to a segfault accessing CServiceBroker.

This PR allows to check in onPause, if the Application / ServiceBroker are useable and avoids the segfault.

## How Has This Been Tested?
- Android Shield TV
- launch kodi
- terminate Kodi

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
