### PR TITLE
[PVR] Guide window: Fix an issue with very short programmes

### DIFF
--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -762,7 +762,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMinStartTime(
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
-                 "WHERE idEpg = %u AND iStartTime > %u ORDER BY iStartTime ASC LIMIT 1;",
+                 "WHERE idEpg = %u AND iStartTime >= %u ORDER BY iStartTime ASC LIMIT 1;",
                  iEpgID, static_cast<unsigned int>(minStart));
 
   if (ResultQuery(strQuery))
@@ -867,7 +867,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinEnd
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
-                 "WHERE idEpg = %u AND iEndTime > %u AND iStartTime <= %u ORDER BY iStartTime;",
+                 "WHERE idEpg = %u AND iEndTime >= %u AND iStartTime <= %u ORDER BY iStartTime;",
                  iEpgID, static_cast<unsigned int>(minEnd), static_cast<unsigned int>(maxStart));
 
   if (ResultQuery(strQuery))
@@ -907,7 +907,7 @@ bool CPVREpgDatabase::DeleteEpgTagsByMinEndMaxStartTime(int iEpgID,
   Filter filter;
 
   CSingleLock lock(m_critSection);
-  filter.AppendWhere(PrepareSQL("idEpg = %u AND iEndTime > %u AND iStartTime <= %u", iEpgID,
+  filter.AppendWhere(PrepareSQL("idEpg = %u AND iEndTime >= %u AND iStartTime <= %u", iEpgID,
                                 static_cast<unsigned int>(minEnd),
                                 static_cast<unsigned int>(maxStart)));
   return DeleteValues("epgtags", filter);

--- a/xbmc/pvr/epg/EpgTagsCache.cpp
+++ b/xbmc/pvr/epg/EpgTagsCache.cpp
@@ -94,7 +94,7 @@ void CPVREpgTagsCache::Refresh(bool bUpdateIfNeeded)
     if (!m_nowActiveTag && m_database)
     {
       const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags =
-          m_database->GetEpgTagsByMinEndMaxStartTime(m_iEpgID, activeTime, activeTime);
+          m_database->GetEpgTagsByMinEndMaxStartTime(m_iEpgID, activeTime + ONE_SECOND, activeTime);
       if (!tags.empty())
       {
         if (tags.size() > 1)
@@ -114,12 +114,12 @@ void CPVREpgTagsCache::Refresh(bool bUpdateIfNeeded)
     {
       // we're in a gap. remember start and end time of that gap to avoid unneeded db load.
       if (m_lastEndedTag)
-        m_nowActiveStart = m_lastEndedTag->EndAsUTC() + ONE_SECOND;
+        m_nowActiveStart = m_lastEndedTag->EndAsUTC();
       else
         m_nowActiveStart = activeTime - CDateTimeSpan(1000, 0, 0, 0); // fake start far in the past
 
       if (m_nextStartingTag)
-        m_nowActiveEnd = m_nextStartingTag->StartAsUTC() - ONE_SECOND;
+        m_nowActiveEnd = m_nextStartingTag->StartAsUTC();
       else
         m_nowActiveEnd = activeTime + CDateTimeSpan(1000, 0, 0, 0); // fake end far in the future
     }

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateGapItem(int iChannel
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CGUIEPGGridContainerModel::GetEPGTimeline(
     int iChannel, const CDateTime& minEventEnd, const CDateTime& maxEventStart) const
 {
-  CDateTime min = minEventEnd - CDateTimeSpan(0, 0, MINSPERBLOCK, 0);
+  CDateTime min = minEventEnd - CDateTimeSpan(0, 0, MINSPERBLOCK, 0) + CDateTimeSpan(0, 0, 0, 1);
   CDateTime max = maxEventStart + CDateTimeSpan(0, 0, MINSPERBLOCK, 0);
 
   if (min < m_gridStart)


### PR DESCRIPTION
This PR fixes a (sorry, a bit hard to explain) problem with very small EPG tags, which were not handled correctly, if they were completely located within a single EPG grid block. "Wholes" in the grid were the visual consequences of this bug.

Before:

![screenshot003](https://user-images.githubusercontent.com/3226626/83628337-9c0e0d00-a598-11ea-8510-3f521adbe514.png)

After:
![screenshot004](https://user-images.githubusercontent.com/3226626/83628495-db3c5e00-a598-11ea-8576-5976bb6cb0f9.png)

I've tested the changes for some weeks in my living room (NVidia Shield) - did not spot any negative side effects.

@phunkyfish mind looking at the code change?