### PR TITLE
Merge VideoInfoTag/Art data instead replace all when playback with add-ons

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1647,6 +1647,54 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
   AppendProperties(item);
 }
 
+void CFileItem::MergeInfo(const CFileItem& item)
+{
+  // TODO: Currently merge the metadata/art info is implemented for video case only
+  if (item.HasVideoInfoTag())
+  {
+    if (item.m_videoInfoTag)
+    {
+      if (m_videoInfoTag)
+        m_videoInfoTag->Merge(*item.m_videoInfoTag);
+      else
+        m_videoInfoTag = new CVideoInfoTag(*item.m_videoInfoTag);
+    }
+
+    m_pvrRecordingInfoTag = item.m_pvrRecordingInfoTag;
+
+    SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->GetPlayCount() > 0);
+    SetInvalid();
+  }
+  if (item.HasMusicInfoTag())
+  {
+    *GetMusicInfoTag() = *item.GetMusicInfoTag();
+    SetInvalid();
+  }
+  if (item.HasPictureInfoTag())
+  {
+    *GetPictureInfoTag() = *item.GetPictureInfoTag();
+    SetInvalid();
+  }
+  if (item.HasGameInfoTag())
+  {
+    *GetGameInfoTag() = *item.GetGameInfoTag();
+    SetInvalid();
+  }
+  SetDynPath(item.GetDynPath());
+  if (!item.GetLabel().empty())
+    SetLabel(item.GetLabel());
+  if (!item.GetLabel2().empty())
+    SetLabel2(item.GetLabel2());
+  if (!item.GetArt().empty())
+  {
+    if (item.IsVideo())
+      AppendArt(item.GetArt());
+    else
+      SetArt(item.GetArt());
+  }
+  AppendProperties(item);
+}
+
 void CFileItem::SetFromVideoInfoTag(const CVideoInfoTag &video)
 {
   if (!video.m_strTitle.empty())

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -510,6 +510,14 @@ public:
    */
   void UpdateInfo(const CFileItem &item, bool replaceLabels = true);
 
+  /*! \brief Merge an item with information from another item
+  We take metadata/art information from the given item and supplement the current
+  item with that info. If tags exist in the new item we only merge the missing
+  tag information. Properties are appended, and labels are updated if non-empty
+  in the given item.
+  */
+  void MergeInfo(const CFileItem &item);
+
   bool IsSamePath(const CFileItem *item) const;
 
   bool IsAlbum() const;

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -197,7 +197,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
     resultItem.SetDynPath(newDir.m_fileResult->GetPath());
     resultItem.SetMimeType(newDir.m_fileResult->GetMimeType());
     resultItem.SetContentLookup(newDir.m_fileResult->ContentLookup());
-    resultItem.UpdateInfo(*newDir.m_fileResult);
+    resultItem.MergeInfo(*newDir.m_fileResult);
     if (newDir.m_fileResult->HasVideoInfoTag() && newDir.m_fileResult->GetVideoInfoTag()->GetResumePoint().IsSet())
       resultItem.m_lStartOffset = STARTOFFSET_RESUME; // resume point set in the resume item, so force resume
   }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -322,6 +322,152 @@ bool CVideoInfoTag::Load(const TiXmlElement *element, bool append, bool prioriti
   return true;
 }
 
+void CVideoInfoTag::Merge(CVideoInfoTag& other)
+{
+  if (m_director.empty())
+    m_director = other.m_director;
+  if (m_writingCredits.empty())
+    m_writingCredits = other.m_writingCredits;
+  if (m_genre.empty())
+    m_genre = other.m_genre;
+  if (m_country.empty())
+    m_country = other.m_country;
+  if (m_strTagLine.empty())
+    m_strTagLine = other.m_strTagLine;
+  if (m_strPlotOutline.empty())
+    m_strPlotOutline = other.m_strPlotOutline;
+  if (m_strPlot.empty())
+    m_strPlot = other.m_strPlot;
+  if (!m_strPictureURL.HasData())
+    m_strPictureURL = other.m_strPictureURL;
+  if (m_strTitle.empty())
+    m_strTitle = other.m_strTitle;
+  if (m_strShowTitle.empty())
+    m_strShowTitle = other.m_strShowTitle;
+  if (m_strOriginalTitle.empty())
+    m_strOriginalTitle = other.m_strOriginalTitle;
+  if (m_strSortTitle.empty())
+    m_strSortTitle = other.m_strSortTitle;
+  if (!m_cast.size())
+    m_cast = other.m_cast;
+
+  if (m_set.title.empty())
+    m_set.title = other.m_set.title;
+  if (!m_set.id)
+    m_set.id = other.m_set.id;
+  if (m_set.overview.empty())
+    m_set.overview = other.m_set.overview;
+  if (m_tags.empty())
+    m_tags = other.m_tags;
+
+  if (m_strFile.empty())
+    m_strFile = other.m_strFile;
+  if (m_strPath.empty())
+    m_strPath = other.m_strPath;
+
+  if (m_strMPAARating.empty())
+    m_strMPAARating = other.m_strMPAARating;
+  if (m_strFileNameAndPath.empty())
+      m_strFileNameAndPath = other.m_strFileNameAndPath;
+
+  if (!m_premiered.IsValid() && other.m_premiered.IsValid())
+    SetPremiered(other.GetPremiered());
+
+  if (m_strStatus.empty())
+    m_strStatus = other.m_strStatus;
+  if (m_strProductionCode.empty())
+    m_strProductionCode = other.m_strProductionCode;
+
+  if (!m_firstAired.IsValid())
+    m_firstAired = other.m_firstAired;
+  if (m_studio.empty())
+    m_studio = other.m_studio;
+  if (m_strAlbum.empty())
+    m_strAlbum = other.m_strAlbum;
+  if (m_artist.empty())
+    m_artist = other.m_artist;
+  if (m_strTrailer.empty())
+    m_strTrailer = other.m_strTrailer;
+  if (!m_iTop250)
+    m_iTop250 = other.m_iTop250;
+  if (m_iSeason == -1)
+    m_iSeason = other.m_iSeason;
+  if (m_iEpisode == -1)
+    m_iEpisode = other.m_iEpisode;
+
+  if (m_iIdUniqueID == -1)
+    m_iIdUniqueID = other.m_iIdUniqueID;
+  if (!m_uniqueIDs.size() && other.m_uniqueIDs.size())
+  {
+    m_uniqueIDs = other.m_uniqueIDs;
+    m_strDefaultUniqueID = other.m_strDefaultUniqueID;
+  };
+  if (m_iSpecialSortSeason == -1)
+    m_iSpecialSortSeason = other.m_iSpecialSortSeason;
+  if (m_iSpecialSortEpisode == -1)
+    m_iSpecialSortEpisode = other.m_iSpecialSortEpisode;
+
+  if (m_ratings.empty() && !other.m_ratings.empty())
+  {
+    m_ratings = other.m_ratings;
+    m_strDefaultRating = other.m_strDefaultRating;
+  };
+  if (m_iIdRating == -1)
+    m_iIdRating = other.m_iIdRating;
+  if (!m_iUserRating)
+    m_iUserRating = other.m_iUserRating;
+
+  if (m_iDbId == -1)
+    m_iDbId = other.m_iDbId;
+  if (m_iFileId == -1)
+    m_iFileId = other.m_iFileId;
+  if (m_iBookmarkId == -1)
+    m_iBookmarkId = other.m_iBookmarkId;
+  if (m_iTrack == -1)
+    m_iTrack = other.m_iTrack;
+
+  if (!m_fanart.GetNumFanarts())
+    m_fanart = other.m_fanart;
+
+  if (!m_duration)
+    m_duration = other.m_duration;
+  if (!m_lastPlayed.IsValid())
+    m_lastPlayed = other.m_lastPlayed;
+
+  if (m_showLink.empty())
+    m_showLink = other.m_showLink;
+  if (!m_namedSeasons.size())
+    m_namedSeasons = other.m_namedSeasons;
+  if (!m_streamDetails.HasItems())
+    m_streamDetails = other.m_streamDetails;
+  if (!IsPlayCountSet() && other.IsPlayCountSet())
+    SetPlayCount(other.GetPlayCount());
+
+  if (!m_EpBookmark.IsSet() && other.m_EpBookmark.IsSet())
+    m_EpBookmark = other.m_EpBookmark;
+
+  if (m_basePath.empty())
+    m_basePath = other.m_basePath;
+  if (m_parentPathID == -1)
+    m_parentPathID = other.m_parentPathID;
+  if (!GetResumePoint().IsSet() && other.GetResumePoint().IsSet())
+    SetResumePoint(other.GetResumePoint());
+  if (m_iIdShow == -1)
+    m_iIdShow = other.m_iIdShow;
+  if (m_iIdSeason == -1)
+    m_iIdSeason = other.m_iIdSeason;
+
+  if (!m_dateAdded.IsValid())
+    m_dateAdded = other.m_dateAdded;
+  // m_type
+  if (m_relevance == -1)
+    m_relevance = other.m_relevance;
+  if (!m_parsedDetails)
+    m_parsedDetails = other.m_parsedDetails;
+  if (!m_coverArt.size())
+    m_coverArt = other.m_coverArt;
+}
+
 void CVideoInfoTag::Archive(CArchive& ar)
 {
   if (ar.IsStoring())

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -71,6 +71,7 @@ public:
    */
   bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
   bool Save(TiXmlNode *node, const std::string &tag, bool savePathInfo = true, const TiXmlElement *additionalNode = NULL);
+  void Merge(CVideoInfoTag& other);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   void ToSortable(SortItem& sortable, Field field) const override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The VideoInfoTag/Art data are previously replaced instead merged,

therefore when kodi perform the play path callback
(where an add-on reply with xbmcplugin.setResolvedUrl(...list_item))
will cause side effects if setInfo/setArt are set to the ListItem passed to setResolvedUrl

The side effects are:
- Video resume broken due to CBookmark value lost
- All original info data (of directory ListItem) will be lost, because are full replaced
- All original art data (of directory ListItem) will be lost, because are full replaced

This change implement a Merge method to allow addon-devs to use setInfo/setArt data without lost the previous data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
With Netflix addon time ago i had implemented the sync of watched status (and resume time) with netflix server, so every listItem is syncronized with netflix account and have the resumetime populated when value exists in the server.

The problem is that if you try to resume a video partially watched, the video starts always from beginning.

Time ago i have opened this issue https://github.com/xbmc/xbmc/issues/17426 where i tried to find the cause, after a long time i see that the CBookmark that contains the video resume data, is knot to the CVideoInfoTag and kodi instead to merge the new VideoInfoTag data replace the previous data, that cause to lose also the CBookmark value.

that happen here:
https://github.com/xbmc/xbmc/blob/ecac5a0e9b2a55d2ca8223f2d7a31707d2af8610/xbmc/filesystem/PluginDirectory.cpp#L199

How happen is explained to this post:
https://github.com/xbmc/xbmc/pull/17993#issuecomment-647172410

Also Kodi 18 is affected by this issue, you allow also backport?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
For this test need to enable in the add-on settings: `Playback` -> `Synchronize the watched status of the videos with Netflix` in order to save to netflix server the resumetime value
- opened netflix my list
- opened a tv show
- play an episode for 5 minuts
- closed kodi

then try to do this more time:
- reopened kodi
- tried to resume same episode
- closed kodi

Tested also setInfo/setArt by playing video via Kodi library and add-on

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
