### PR TITLE
[Estuary] use new version infolabels in sysinfo

### DIFF
--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -84,7 +84,7 @@
 				<left>420</left>
 				<right>50</right>
 				<top>100</top>
-				<bottom>315</bottom>
+				<bottom>347</bottom>
 				<pagecontrol>60</pagecontrol>
 				<autoscroll delay="5000" repeat="7500" time="5000">!Control.HasFocus(60)</autoscroll>
 			</control>
@@ -92,7 +92,7 @@
 				<right>0</right>
 				<top>93</top>
 				<width>12</width>
-				<bottom>312</bottom>
+				<bottom>340</bottom>
 				<orientation>vertical</orientation>
 				<texturesliderbackground />
 				<animation effect="slide" end="6,0" time="300" tween="sine" easing="inout" condition="!Control.HasFocus(60)">conditional</animation>
@@ -110,117 +110,6 @@
 				<right>0</right>
 				<height>3</height>
 				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
-			</control>
-			<control type="group">
-				<bottom>0</bottom>
-				<height>330</height>
-				<control type="image">
-					<left>380</left>
-					<top>20</top>
-					<right>0</right>
-					<height>3</height>
-					<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
-				</control>
-				<control type="grouplist">
-					<left>420</left>
-					<orientation>vertical</orientation>
-					<control type="label">
-						<description>Memory Text</description>
-						<width>730</width>
-						<height>80</height>
-						<label>$LOCALIZE[31030]: $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
-						<aligny>top</aligny>
-						<textoffsety>40</textoffsety>
-						<shadowcolor>black</shadowcolor>
-						<font>font27</font>
-					</control>
-					<control type="progress">
-						<description>Memory BAR</description>
-						<width>730</width>
-						<height>16</height>
-						<info>system.memory(used)</info>
-					</control>
-					<control type="label">
-						<description>CPU Text</description>
-						<width>730</width>
-						<height>40</height>
-						<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
-						<aligny>center</aligny>
-						<shadowcolor>black</shadowcolor>
-						<font>font27</font>
-						<visible>System.SupportsCPUUsage</visible>
-					</control>
-					<control type="progress">
-						<description>CPU BAR</description>
-						<width>730</width>
-						<height>16</height>
-						<info>System.CPUUsage</info>
-						<visible>System.SupportsCPUUsage</visible>
-					</control>
-				</control>
-				<control type="label">
-					<top>34</top>
-					<left>1210</left>
-					<width>auto</width>
-					<height>50</height>
-					<aligny>bottom</aligny>
-					<textoffsety>10</textoffsety>
-					<label>$LOCALIZE[31031]:</label>
-					<shadowcolor>black</shadowcolor>
-					<font>font25_title</font>
-				</control>
-				<control type="grouplist">
-					<description>Kodi build version</description>
-					<itemgap>10</itemgap>
-					<top>80</top>
-					<left>1210</left>
-					<width>820</width>
-					<height>45</height>
-					<orientation>horizontal</orientation>
-					<control type="label">
-						<description>Build label</description>
-						<width>auto</width>
-						<height>50</height>
-						<aligny>bottom</aligny>
-						<font>font12</font>
-						<textoffsety>10</textoffsety>
-						<label>$LOCALIZE[144]</label>
-						<shadowcolor>black</shadowcolor>
-					</control>
-					<control type="label" id="52">
-						<description>Kodi Build Version</description>
-						<height>50</height>
-						<aligny>bottom</aligny>
-						<textoffsety>10</textoffsety>
-						<font>font12</font>
-						<width>auto</width>
-						<textcolor>button_focus</textcolor>
-						<shadowcolor>black</shadowcolor>
-					</control>
-				</control>
-				<control type="grouplist">
-					<description>Build date</description>
-					<itemgap>10</itemgap>
-					<top>125</top>
-					<left>1210</left>
-					<width>800</width>
-					<orientation>horizontal</orientation>
-					<control type="label">
-						<description>kodi Compiled Text</description>
-						<width>auto</width>
-						<height>25</height>
-						<label>$LOCALIZE[174]</label>
-						<font>font12</font>
-						<shadowcolor>black</shadowcolor>
-					</control>
-					<control type="label" id="53">
-						<description>Kodi Build Date</description>
-						<width>auto</width>
-						<font>font12</font>
-						<textcolor>button_focus</textcolor>
-						<shadowcolor>black</shadowcolor>
-					</control>
-				</control>
 			</control>
 		</control>
 		<control type="group">
@@ -301,5 +190,143 @@
 			<param name="breadcrumbs_label" value="$LOCALIZE[130]" />
 		</include>
 		<include>BottomBar</include>
+		<control type="group">
+			<bottom>0</bottom>
+			<left>40</left>
+			<height>370</height>
+			<include>OpenClose_Right</include>
+			<control type="image">
+				<left>380</left>
+				<top>30</top>
+				<right>0</right>
+				<height>3</height>
+				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
+			</control>
+			<control type="grouplist">
+				<left>420</left>
+				<orientation>vertical</orientation>
+				<control type="label">
+					<description>Memory Text</description>
+					<width>auto</width>
+					<height>80</height>
+					<label>$LOCALIZE[31030]: $INFO[system.memory(used)] [B]/[/B] $INFO[system.memory(total)] [B]-[/B] $INFO[system.memory(used.percent)]</label>
+					<aligny>top</aligny>
+					<textoffsety>40</textoffsety>
+					<shadowcolor>black</shadowcolor>
+					<font>font12</font>
+				</control>
+				<control type="progress">
+					<description>Memory BAR</description>
+					<width>730</width>
+					<height>16</height>
+					<info>system.memory(used)</info>
+				</control>
+				<control type="label">
+					<description>CPU Text</description>
+					<width>auto</width>
+					<height>40</height>
+					<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
+					<aligny>center</aligny>
+					<shadowcolor>black</shadowcolor>
+					<font>font12</font>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+				<control type="progress">
+					<description>CPU BAR</description>
+					<width>730</width>
+					<height>16</height>
+					<info>System.CPUUsage</info>
+					<visible>System.SupportsCPUUsage</visible>
+				</control>
+			</control>
+			<control type="group">
+				<animation effect="slide" end="0,-55" time="0" condition="!System.SupportsCPUUsage">Conditional</animation>
+				<control type="label">
+					<top>155</top>
+					<left>420</left>
+					<width>auto</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<textoffsety>10</textoffsety>
+					<label>$LOCALIZE[31031]:</label>
+					<shadowcolor>black</shadowcolor>
+					<font>font25_title</font>
+				</control>
+				<control type="grouplist">
+					<description>Kodi build version</description>
+					<itemgap>10</itemgap>
+					<top>200</top>
+					<left>420</left>
+					<width>820</width>
+					<orientation>horizontal</orientation>
+					<control type="label">
+						<description>Build label</description>
+						<width>auto</width>
+						<height>40</height>
+						<font>font12</font>
+						<label>$LOCALIZE[144]</label>
+						<shadowcolor>black</shadowcolor>
+					</control>
+					<control type="label">
+						<description>Kodi Build Version</description>
+						<width>auto</width>
+						<height>40</height>
+						<font>font12</font>
+						<label>$INFO[System.BuildVersionShort]$INFO[System.BuildVersionCode, (,)]</label>
+						<textcolor>button_focus</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
+				</control>
+				<control type="grouplist">
+					<description>Git version</description>
+					<itemgap>10</itemgap>
+					<top>235</top>
+					<left>420</left>
+					<width>820</width>
+					<orientation>horizontal</orientation>
+					<control type="label">
+						<description>Git label</description>
+						<width>auto</width>
+						<height>40</height>
+						<font>font12</font>
+						<label>Git:</label>
+						<shadowcolor>black</shadowcolor>
+					</control>
+					<control type="label">
+						<description>Git version</description>
+						<width>auto</width>
+						<height>40</height>
+						<font>font12</font>
+						<label>$INFO[System.BuildVersionGit]</label>
+						<textcolor>button_focus</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
+				</control>
+				<control type="grouplist">
+					<description>Build date</description>
+					<itemgap>10</itemgap>
+					<top>270</top>
+					<left>420</left>
+					<width>820</width>
+					<orientation>horizontal</orientation>
+					<control type="label">
+						<description>kodi Compiled Text</description>
+						<width>auto</width>
+						<height>40</height>
+						<font>font12</font>
+						<label>$LOCALIZE[174]</label>
+						<shadowcolor>black</shadowcolor>
+					</control>
+					<control type="label" id="53">
+						<description>Kodi Build Date</description>
+						<width>auto</width>
+						<height>40</height>
+						<font>font12</font>
+						<textcolor>button_focus</textcolor>
+						<shadowcolor>black</shadowcolor>
+					</control>
+				</control>
+			</control>
+		</control>
 	</controls>
 </window>


### PR DESCRIPTION
## Description
Update of the SysInfo window in Estuary to make use of the new System.BuildVersionCode / System.BuildVersionGit infolabels that were introduced in https://github.com/xbmc/xbmc/pull/17994.

This can go in once https://github.com/xbmc/xbmc/pull/17994 is merged.

## Screenshots (if appropriate):

before:
![sysinfo1](https://user-images.githubusercontent.com/687265/83747781-70a32500-a661-11ea-8d13-a2618bf6050c.jpg)

after:
![sysinfo2](https://user-images.githubusercontent.com/687265/83747804-7862c980-a661-11ea-81d7-7ea64ff33d3b.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
