### PR TITLE
[Android] Fix stall on stream end

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1044,7 +1044,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
   if (!m_opened)
     return VC_NONE;
 
-  if (m_state == MEDIACODEC_STATE_RUNNING &&
+  if (m_state != MEDIACODEC_STATE_FLUSHED &&
       (m_OutputDuration < m_fpsDuration || (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN) != 0))
   {
     m_videobuffer.videoBuffer = pVideoPicture->videoBuffer;


### PR DESCRIPTION
## Description
Drain correctly at stream end to avoid pause on stream end

## Motivation and Context
#17987 introduced the issue that on stream end GUI does not return immediately.
Reason is that drain of the final frames does not work properly.

## How Has This Been Tested?
Play a stream on NVIDIA Shield TV and wait until is finished

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
