### PR TITLE
[linux] TestSysfsPath: Use unique file name for every test

### DIFF
--- a/xbmc/platform/linux/test/TestSysfsPath.cpp
+++ b/xbmc/platform/linux/test/TestSysfsPath.cpp
@@ -8,24 +8,44 @@
 
 #include "platform/linux/SysfsPath.h"
 
+#include <chrono>
+#include <string>
+#include <sstream>
 #include <fstream>
 
 #include <gtest/gtest.h>
 
 struct TestSysfsPath : public ::testing::Test
 {
-  ~TestSysfsPath() { std::remove("/tmp/kodi-test"); }
+  std::string GetTestFilePath()
+  {
+    using namespace std::chrono;
 
-  std::ofstream m_output{"/tmp/kodi-test"};
+    std::string tmpdir{"/tmp"};
+    const char *test_tmpdir = getenv("TMPDIR");
+    if (test_tmpdir && test_tmpdir[0] != '\0') {
+      tmpdir.assign(test_tmpdir);
+    }
+
+    std::stringstream ss;
+    unsigned long long timestamp = duration_cast< nanoseconds >(
+      system_clock::now().time_since_epoch()).count();
+
+    ss << tmpdir << "/kodi-test-" << timestamp;
+    return ss.str();
+  }
 };
 
 TEST_F(TestSysfsPath, SysfsPathTestInt)
 {
+  std::string filepath = GetTestFilePath();
+  std::ofstream m_output(filepath);
+
   int temp{1234};
   m_output << temp;
   m_output.close();
 
-  CSysfsPath path("/tmp/kodi-test");
+  CSysfsPath path(filepath);
   ASSERT_TRUE(path.Exists());
   EXPECT_EQ(path.Get<int>(), 1234);
   EXPECT_EQ(path.Get<float>(), 1234);
@@ -34,28 +54,40 @@ TEST_F(TestSysfsPath, SysfsPathTestInt)
   EXPECT_EQ(path.Get<uint16_t>(), 1234);
   EXPECT_EQ(path.Get<unsigned int>(), 1234);
   EXPECT_EQ(path.Get<unsigned long int>(), 1234);
+
+  std::remove(filepath.c_str());
 }
 
 TEST_F(TestSysfsPath, SysfsPathTestString)
 {
+  std::string filepath = GetTestFilePath();
+  std::ofstream m_output{filepath};
+
   std::string temp{"test"};
   m_output << temp;
   m_output.close();
 
-  CSysfsPath path("/tmp/kodi-test");
+  CSysfsPath path(filepath);
   ASSERT_TRUE(path.Exists());
   EXPECT_EQ(path.Get<std::string>(), "test");
+
+  std::remove(filepath.c_str());
 }
 
 TEST_F(TestSysfsPath, SysfsPathTestLongString)
 {
+  std::string filepath = GetTestFilePath();
+  std::ofstream m_output{filepath};
+
   std::string temp{"test with spaces"};
   m_output << temp;
   m_output.close();
 
-  CSysfsPath path("/tmp/kodi-test");
+  CSysfsPath path(filepath);
   ASSERT_TRUE(path.Exists());
   EXPECT_EQ(path.Get<std::string>(), "test with spaces");
+
+  std::remove(filepath.c_str());
 }
 
 TEST_F(TestSysfsPath, SysfsPathTestPathDoesNotExist)


### PR DESCRIPTION
## Description

Fixes #18000 

## Motivation and Context

The hard-coded file name in TestSysfsPath introdices random test failures
on data race.

## How Has This Been Tested?

Build Debian package using pbuilder 

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed