### PR TITLE
[addons][base][filesystem][gui] improvement and fixes.

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -305,7 +305,7 @@ ADDON_STATUS CAddonDll::CreateInstance(ADDON_TYPE instanceType,
                                                 kodi::addon::GetTypeVersion(instanceType),
                                                 &addonInstance, parentInstance);
 
-  if (status == ADDON_STATUS_OK)
+  if (addonInstance)
   {
     m_usedInstances[instanceClass] = std::make_pair(instanceType, addonInstance);
   }

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -195,7 +195,7 @@ void Interface_Base::addon_log_msg(void* kodiBase, const int addonLogLevel, cons
       break;
   }
 
-  CLog::Log(logLevel, "AddOnLog: {}: {}", addon->Name(), strMessage);
+  CLog::Log(logLevel, "AddOnLog: {}: {}", addon->ID(), strMessage);
 }
 
 bool Interface_Base::get_setting_bool(void* kodiBase, const char* id, bool* value)

--- a/xbmc/addons/interfaces/Filesystem.h
+++ b/xbmc/addons/interfaces/Filesystem.h
@@ -58,6 +58,8 @@ struct Interface_Filesystem
   static char* make_legal_filename(void* kodiBase, const char* filename);
   static char* make_legal_path(void* kodiBase, const char* path);
   static char* translate_special_protocol(void* kodiBase, const char* strSource);
+  static bool get_disk_space(
+      void* kodiBase, const char* path, uint64_t* capacity, uint64_t* free, uint64_t* available);
   static bool is_internet_stream(void* kodiBase, const char* path, bool strictCheck);
   static bool is_on_lan(void* kodiBase, const char* path);
   static bool is_remote(void* kodiBase, const char* path);

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -145,19 +145,21 @@ void* Interface_GUIWindow::create(void* kodiBase, const char* xml_filename,
     if (XFILE::CFile::Exists(basePath))
     {
       addonInfo->SetPath(basePath);
-      ADDON::CSkinInfo skinInfo(addonInfo, res);
-      skinInfo.Start();
-      strSkinPath = skinInfo.GetSkinPath(xml_filename, &res);
+      const std::shared_ptr<ADDON::CSkinInfo> skinInfo =
+          std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
+      skinInfo->Start();
+      strSkinPath = skinInfo->GetSkinPath(xml_filename, &res);
     }
 
     if (!XFILE::CFile::Exists(strSkinPath))
     {
       // Finally fallback to the DefaultSkin as it didn't exist in either the Kodi Skin folder or the fallback skin folder
       addonInfo->SetPath(URIUtils::AddFileToFolder(fallbackPath, default_skin));
-      ADDON::CSkinInfo skinInfo(addonInfo, res);
+      const std::shared_ptr<ADDON::CSkinInfo> skinInfo =
+          std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
 
-      skinInfo.Start();
-      strSkinPath = skinInfo.GetSkinPath(xml_filename, &res);
+      skinInfo->Start();
+      strSkinPath = skinInfo->GetSkinPath(xml_filename, &res);
       if (!XFILE::CFile::Exists(strSkinPath))
       {
         CLog::Log(LOGERROR, "Interface_GUIWindow::%s: %s/%s - XML File '%s' for Window is missing, contact Developer '%s' of this addon",

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -734,6 +734,7 @@ inline bool CheckSettingString(const std::string& settingName, std::string& sett
 /// The setting name relate to names used in his <b>settings.xml</b> file.
 ///
 /// @param[in] settingName The name of asked setting
+/// @param[in] defaultValue [opt] Default value if not found
 /// @return The value of setting, empty if not found;
 ///
 ///
@@ -746,9 +747,10 @@ inline bool CheckSettingString(const std::string& settingName, std::string& sett
 /// std::string value = kodi::GetSettingString("my_string_value");
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetSettingString(const std::string& settingName)
+inline std::string GetSettingString(const std::string& settingName,
+                                    const std::string& defaultValue = "")
 {
-  std::string settingValue;
+  std::string settingValue = defaultValue;
   CheckSettingString(settingName, settingValue);
   return settingValue;
 }
@@ -820,7 +822,8 @@ inline bool CheckSettingInt(const std::string& settingName, int& settingValue)
 /// The setting name relate to names used in his <b>settings.xml</b> file.
 ///
 /// @param[in] settingName The name of asked setting
-/// @return The value of setting, <b>`0`</b> if not found;
+/// @param[in] defaultValue [opt] Default value if not found
+/// @return The value of setting, <b>`0`</b> or defaultValue if not found
 ///
 ///
 /// ----------------------------------------------------------------------------
@@ -832,9 +835,9 @@ inline bool CheckSettingInt(const std::string& settingName, int& settingValue)
 /// int value = kodi::GetSettingInt("my_integer_value");
 /// ~~~~~~~~~~~~~
 ///
-inline int GetSettingInt(const std::string& settingName)
+inline int GetSettingInt(const std::string& settingName, int defaultValue = 0)
 {
-  int settingValue = 0;
+  int settingValue = defaultValue;
   CheckSettingInt(settingName, settingValue);
   return settingValue;
 }
@@ -906,7 +909,8 @@ inline bool CheckSettingBoolean(const std::string& settingName, bool& settingVal
 /// The setting name relate to names used in his <b>settings.xml</b> file.
 ///
 /// @param[in] settingName The name of asked setting
-/// @return The value of setting, <b>`false`</b> if not found;
+/// @param[in] defaultValue [opt] Default value if not found
+/// @return The value of setting, <b>`false`</b> or defaultValue if not found
 ///
 ///
 /// ----------------------------------------------------------------------------
@@ -918,9 +922,9 @@ inline bool CheckSettingBoolean(const std::string& settingName, bool& settingVal
 /// bool value = kodi::GetSettingBoolean("my_boolean_value");
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetSettingBoolean(const std::string& settingName)
+inline bool GetSettingBoolean(const std::string& settingName, bool defaultValue = false)
 {
-  bool settingValue = false;
+  bool settingValue = defaultValue;
   CheckSettingBoolean(settingName, settingValue);
   return settingValue;
 }
@@ -992,7 +996,8 @@ inline bool CheckSettingFloat(const std::string& settingName, float& settingValu
 /// The setting name relate to names used in his <b>settings.xml</b> file.
 ///
 /// @param[in] settingName The name of asked setting
-/// @return The value of setting, <b>`0.0`</b> if not found;
+/// @param[in] defaultValue [opt] Default value if not found
+/// @return The value of setting, <b>`0.0`</b> or defaultValue if not found
 ///
 ///
 /// ----------------------------------------------------------------------------
@@ -1004,9 +1009,9 @@ inline bool CheckSettingFloat(const std::string& settingName, float& settingValu
 /// float value = kodi::GetSettingFloat("my_float_value");
 /// ~~~~~~~~~~~~~
 ///
-inline float GetSettingFloat(const std::string& settingName)
+inline float GetSettingFloat(const std::string& settingName, float defaultValue = 0.0f)
 {
-  float settingValue = 0.0f;
+  float settingValue = defaultValue;
   CheckSettingFloat(settingName, settingValue);
   return settingValue;
 }
@@ -1091,7 +1096,8 @@ inline bool CheckSettingEnum(const std::string& settingName, enumType& settingVa
 /// The setting name relate to names used in his <b>settings.xml</b> file.
 ///
 /// @param[in] settingName The name of asked setting
-/// @return The value of setting, forced to <b>`0`</b> if not found;
+/// @param[in] defaultValue [opt] Default value if not found
+/// @return The value of setting, forced to <b>`0`</b> or defaultValue if not found
 ///
 /// @remark The enums are used as integer inside settings.xml.
 ///
@@ -1113,9 +1119,10 @@ inline bool CheckSettingEnum(const std::string& settingName, enumType& settingVa
 /// ~~~~~~~~~~~~~
 ///
 template<typename enumType>
-inline enumType GetSettingEnum(const std::string& settingName)
+inline enumType GetSettingEnum(const std::string& settingName,
+                               enumType defaultValue = static_cast<enumType>(0))
 {
-  enumType settingValue = static_cast<enumType>(0);
+  enumType settingValue = defaultValue;
   CheckSettingEnum(settingName, settingValue);
   return settingValue;
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -1857,7 +1857,7 @@ public:
   ///
   /// @return True on open or false on closed or failure
   ///
-  bool IsOpen() { return m_file != nullptr; }
+  bool IsOpen() const { return m_file != nullptr; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -2086,7 +2086,7 @@ public:
   ///
   /// @return The requested offset. On error, the value -1 is returned.
   ///
-  int64_t GetPosition()
+  int64_t GetPosition() const
   {
     using namespace kodi::addon;
 
@@ -2103,7 +2103,7 @@ public:
   ///
   /// @return The requested size. On error, the value -1 is returned.
   ///
-  int64_t GetLength()
+  int64_t GetLength() const
   {
     using namespace kodi::addon;
 
@@ -2120,7 +2120,7 @@ public:
   ///
   /// @return If you've reached the end of the file, AtEnd() returns true.
   ///
-  bool AtEnd()
+  bool AtEnd() const
   {
     using namespace kodi::addon;
 
@@ -2140,7 +2140,7 @@ public:
   ///
   /// @return The requested size. On error, the value -1 is returned.
   ///
-  int GetChunkSize()
+  int GetChunkSize() const
   {
     using namespace kodi::addon;
 
@@ -2157,7 +2157,7 @@ public:
   ///
   /// @return true if seek possible, false if not
   ///
-  bool IoControlGetSeekPossible()
+  bool IoControlGetSeekPossible() const
   {
     using namespace kodi::addon;
 
@@ -2178,7 +2178,7 @@ public:
   ///
   /// @copydetails cpp_kodi_vfs_Defs_CacheStatus_Help
   ///
-  bool IoControlGetCacheStatus(CacheStatus& status)
+  bool IoControlGetCacheStatus(CacheStatus& status) const
   {
     using namespace kodi::addon;
 
@@ -2295,7 +2295,7 @@ public:
   ///
   /// @return The current download speed.
   ///
-  double GetFileDownloadSpeed()
+  double GetFileDownloadSpeed() const
   {
     using namespace kodi::addon;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -1256,6 +1256,54 @@ inline std::string TranslateSpecialProtocol(const std::string& source)
 
 //==============================================================================
 /// @ingroup cpp_kodi_vfs_General
+/// @brief Retrieves information about the amount of space that is available on
+/// a disk volume.
+///
+/// Path can be also with Kodi's special protocol.
+///
+/// @param[in] path Path for where to check
+/// @param[out] capacity The total number of bytes in the file system
+/// @param[out] free The total number of free bytes in the file system
+/// @param[out] available The total number of free bytes available to a
+///                       non-privileged process
+/// @return true if successfully done and set
+///
+/// @warning This only works with paths belonging to OS. If <b>"special://"</b>
+/// is used, it must point to a place on your own OS.
+///
+///
+/// ------------------------------------------------------------------------
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <climits> // for ULLONG_MAX
+/// #include <kodi/Filesystem.h>
+/// ...
+/// std::string path = "special://temp";
+/// uint64_t capacity = ULLONG_MAX;
+/// uint64_t free = ULLONG_MAX;
+/// uint64_t available = ULLONG_MAX;
+/// kodi::vfs::GetDiskSpace(path, capacity, free, available);
+/// fprintf(stderr, "Path '%s' sizes:\n", path.c_str());
+/// fprintf(stderr, " - capacity:  %lu MByte\n", capacity / 1024 / 1024);
+/// fprintf(stderr, " - free:      %lu MByte\n", free / 1024 / 1024);
+/// fprintf(stderr, " - available: %lu MByte\n", available / 1024 / 1024);
+/// ~~~~~~~~~~~~~
+///
+inline bool GetDiskSpace(const std::string& path,
+                         uint64_t& capacity,
+                         uint64_t& free,
+                         uint64_t& available)
+{
+  using namespace kodi::addon;
+
+  return CAddonBase::m_interface->toKodi->kodi_filesystem->get_disk_space(
+      CAddonBase::m_interface->toKodi->kodiBase, path.c_str(), &capacity, &free, &available);
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @ingroup cpp_kodi_vfs_General
 /// @brief Return the file name from given complate path string.
 ///
 /// @param[in] path The complete path include file and directory
@@ -1314,7 +1362,6 @@ inline std::string GetDirectoryName(const std::string& path)
   return path.substr(0, iPosSlash + 1) + path.substr(iPosBar); // Path + options
 }
 //------------------------------------------------------------------------------
-
 
 //==============================================================================
 /// @ingroup cpp_kodi_vfs_General

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/filesystem.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -286,6 +287,9 @@ extern "C"
     bool (*curl_add_option)(
         void* kodiBase, void* file, int type, const char* name, const char* value);
     bool (*curl_open)(void* kodiBase, void* file, unsigned int flags);
+
+    bool (*get_disk_space)(
+        void* kodiBase, const char* path, uint64_t* capacity, uint64_t* free, uint64_t* available);
   } AddonToKodiFuncTable_kodi_filesystem;
 
   //}}}

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -34,7 +34,7 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.1"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.2"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.2.0"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -60,7 +60,7 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.2"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.3"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.0"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \


### PR DESCRIPTION
## Description

Commit 1:
-----------------
**[addons][filesystem] add function to get available disc space**

This add a function to ask about available and total disc space.
For cases where e.g. inputstream addon use a file storage for timeshift in livestream

Commit 2:
-----------------
**[addons] fix and improve instance creation calls**

Before was there some not good parts:
- To use "throw" inside "C" ABI on other side is not correct
- Fix mem leak if CreateInstance returned other value as ADDON_STATUS_OK
  - If other was it not stored in Kodi and the DestroyInstance not called
  - This stores now in all cases if present
- Make CreateInstance with ADDON_STATUS_NOT_IMPLEMENTED optional
  - Thought for case where a addon without instances is used
  - If e.g. a new addon type is added for background works (and not Kodi call itself)

Seen this on PVR rework where by CreateInstance in some cases another return values
as ADDON_STATUS_OK given.

Commit 3:
-----------------
**[addons][gui] fix crash by wrong shared_from_this call**

There it was set before as temporary stack value where it was not available
as shared_ptr.

This use the make_shared about and the crash is fixed.

Crash Log:
```
    at /usr/include/c++/9/bits/shared_ptr_base.h:900
    (this=0x7fffffff9dc0, __r=...) at /usr/include/c++/9/bits/shared_ptr_base.h:1193
    (this=0x7fffffff9dc0, __r=std::weak_ptr<class ADDON::IAddon> (empty) = {...}) at /usr/include/c++/9/bits/shared_ptr.h:276
    (kodiBase=0x7fff4c023760, xml_filename=0x55555b3c9350 "DialogRecordSettings.xml", default_skin=0x7fffffffabc0 "skin.fallback", as_dialog=false, is_media=true)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/addons/interfaces/gui/Window.cpp:159
```

Commit 4:
-----------------
**[addons] use addon ID instead of Name for Log**

Before was the addon name written in Kodi log, this can be a bit
confusing as it is more easy to identify by ID as by name.

Commit 5:
-----------------
**[addons][filesystem] use const on CFile get calls**

Some addons takes them with this inside a parent protected class entries.
This allow the read then.

*Also API version increase inside them*

Commit 6:
-----------------
**[addons][base] allow optional set of default value on GetSetting... calls**

This to prevent on addon a extra "if (!...)" to set the default if not found.

*Also API version increase inside them*

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
All older compiled addons are still operational after this change.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
