### PR TITLE
[Settings] PVR timer dialogs show incorrect default list box values

### DIFF
--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -566,6 +566,7 @@ CGUIControlListSetting::CGUIControlListSetting(CGUIButtonControl* pButton,
     return;
 
   m_pButton->SetID(id);
+  UpdateFromSetting();
 }
 
 CGUIControlListSetting::~CGUIControlListSetting() = default;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

This PR is to address the issue identified in https://github.com/xbmc/xbmc/issues/18010

Currently when a PVR timer is opened two list box items which default to item 0 continue to display the row 0 text
when a dynamic settings dialogs is opened.  When saved the actual values are passed not the display value.

Comparing with Leia I noticed there were two passed, the first populating the defaults, the second populating the changes.
The first pass was found to occur here
https://github.com/xbmc/xbmc/blob/Leia/xbmc/settings/windows/GUIControlSettings.cpp#L416

In Matrix there was no update occurring at that location so the second update location was only populating the default list items values.  This PR ports that update logic to Matrix

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Testing pvr.nextpvr for the C++ change two issues were identified in the backend code for PVR timers. This addresses one of these

Having the text on the dialog not match the values expected by the user or actually send to the backend is confusing and incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

It has been tested on all the PVR timer screens in C and C++ interfaces with pvr.nextpvr  Note that there are other locations in Matrix where  UpdateFromSettings() may need to be ported from Leia for other controls

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

Marked as breaking since I don't know where to test this with dialogs outside PVR

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed