### PR TITLE
[PVR] Timer settings dialog: Fix visibility conditions for pre/post margins

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1231,9 +1231,9 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string& condit
     else if (cond == SETTING_TMR_NEW_EPISODES)
       return entry->second->SupportsRecordOnlyNewEpisodes();
     else if (cond == SETTING_TMR_BEGIN_PRE)
-      return entry->second->SupportsStartEndMargin() && entry->second->SupportsStartTime();
+      return entry->second->SupportsStartEndMargin();
     else if (cond == SETTING_TMR_END_POST)
-      return entry->second->SupportsStartEndMargin() && entry->second->SupportsEndTime();
+      return entry->second->SupportsStartEndMargin();
     else if (cond == SETTING_TMR_PRIORITY)
       return entry->second->SupportsPriority();
     else if (cond == SETTING_TMR_LIFETIME)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

In Matrix with pvr.nextpvr PVR Timers start and end margin values are not displayed on EPG based recordings

Comparing with Leia, in Matrix constraints on margins were added that limited margin settings to function
only if the timer allowed changing the timer start and stop time.

This reverts the logic to Leia functionality


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Testing pvr.nextpvr for the C++ change two issues were identified in the backend code for PVR timers. This addresses one of these

Users must be able to edit margins on any timer when the start and stop time cannot be changed, including but not limited to EPG
based recordings.

Any addon requiring changed Matrix logic could implement a custom timer rule.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

It has been tested on all the PVR timer screens in C and C++ interfaces with pvr.nextpvr

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

Marked as breaking since I don't know the rationale for the change.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed