### PR TITLE
Disable 5s polling for Linux CEC adapters

### DIFF
--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -50,6 +50,10 @@ bool CPeripheralBusCEC::PerformDeviceScan(PeripheralScanResults& results)
         /** the Pi's adapter cannot be removed, no need to rescan */
         m_bNeedsPolling = false;
         break;
+      case ADAPTERTYPE_LINUX:
+        /** the Linux adapter cannot be removed, no need to rescan */
+        m_bNeedsPolling = false;
+        break;
       default:
         break;
     }


### PR DESCRIPTION
Patch from: https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/mediacenter/kodi/patches/cec-framework/kodi-100.17-tinker-s-cec-disable-polling.patch

## Description
Disable polling on CEC Linux adapter.

## Motivation and Context
The Linux adapter cannot be removed, no need to rescan.

## How Has This Been Tested?
It's already being used in all LibreELEC images.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
