### PR TITLE
[PVR] Timer settings dialog: Fix end margin visible for reminders.

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -110,7 +110,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "6.5.1"
+#define ADDON_INSTANCE_VERSION_PVR                    "6.5.2"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "6.5.1"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -277,6 +277,8 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE = 0x02000000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag with a series link */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_READONLY_DELETE          = 0x04000000; /*!< @brief this type allows deletion of an otherwise read-only timer */
   const unsigned int PVR_TIMER_TYPE_IS_REMINDER                       = 0x08000000; /*!< @brief timers of this type do trigger a reminder if time is up by calling the Kodi callback 'ReminderNotification'. */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_MARGIN             = 0x10000000; /*!< @brief this type supports pre record time (PVR_TIMER.iMarginStart) */
+  const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_MARGIN               = 0x20000000; /*!< @brief this type supports post record time (PVR_TIMER.iMarginEnd) */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -1231,9 +1231,9 @@ bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string& condit
     else if (cond == SETTING_TMR_NEW_EPISODES)
       return entry->second->SupportsRecordOnlyNewEpisodes();
     else if (cond == SETTING_TMR_BEGIN_PRE)
-      return entry->second->SupportsStartEndMargin();
+      return entry->second->SupportsStartMargin();
     else if (cond == SETTING_TMR_END_POST)
-      return entry->second->SupportsStartEndMargin();
+      return entry->second->SupportsEndMargin();
     else if (cond == SETTING_TMR_PRIORITY)
       return entry->second->SupportsPriority();
     else if (cond == SETTING_TMR_LIFETIME)

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -45,7 +45,7 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
                                                         PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
                                                         PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
                                                         PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN));
+                                                        PVR_TIMER_TYPE_SUPPORTS_START_MARGIN));
 
   // time-based reminder rule
   allTypes.emplace_back(std::make_shared<CPVRTimerType>(++iTypeId,
@@ -95,7 +95,7 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
                                                         PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
                                                         PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
                                                         PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                                                        PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN,
+                                                        PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
                                                         g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
 
   return allTypes;

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -259,10 +259,24 @@ namespace PVR
     bool SupportsRecordOnlyNewEpisodes() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES) > 0; }
 
     /*!
-     * @brief Check whether this type supports pre and post record time.
-     * @return True if pre and post record time is supported, false otherwise.
+     * @brief Check whether this type supports pre record time.
+     * @return True if pre record time is supported, false otherwise.
      */
-    bool SupportsStartEndMargin() const { return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0; }
+    bool SupportsStartMargin() const
+    {
+      return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_MARGIN) > 0 ||
+             (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0;
+    }
+
+    /*!
+     * @brief Check whether this type supports post record time.
+     * @return True if post record time is supported, false otherwise.
+     */
+    bool SupportsEndMargin() const
+    {
+      return (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_END_MARGIN) > 0 ||
+             (m_iAttributes & PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN) > 0;
+    }
 
     /*!
      * @brief Check whether this type supports recording priorities.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -520,7 +520,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
         }
 
         // check for due timers and announce/delete them
-        int iMarginStart = timer->GetTimerType()->SupportsStartEndMargin() ? timer->MarginStart() : 0;
+        int iMarginStart = timer->GetTimerType()->SupportsStartMargin() ? timer->MarginStart() : 0;
         if (!timer->IsTimerRule() && (timer->StartAsUTC() - CDateTimeSpan(0, 0, iMarginStart, iMaxNotificationDelay)) < now)
         {
           if (timer->IsReminder() && timer->m_state != PVR_TIMER_STATE_DISABLED)


### PR DESCRIPTION
Followup of #18015, which introduced a regression for PVR reminders, where the end margin field was errornously displayed in PVR Timer Settings dialog.

before:
![screenshot009](https://user-images.githubusercontent.com/3226626/83968901-8cf6ca00-a8cc-11ea-84b5-a55be86155ae.png)

after:
![screenshot008](https://user-images.githubusercontent.com/3226626/83968897-89fbd980-a8cc-11ea-8eb6-27df1fc6d75b.png)

Please note that this is a compatible PVR addon API change. No addon needs to be adjusted or recompiled.

I tested this change an latest Kodi master, Android and macOS.

@phunkyfish could you do the code review, please?