### PR TITLE
[PVR] Reminders: Show reminder dialogs only when GUI is fully initialized / user has logged in

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -177,7 +177,10 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
     *profileManager));
 
   m_contextMenuManager->Init();
-  m_PVRManager->Init();
+
+  // Init PVR manager after login, not already on login screen
+  if (!profileManager->UsingLoginScreen())
+    m_PVRManager->Init();
 
   m_playerCoreFactory.reset(new CPlayerCoreFactory(*profileManager));
 

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -72,10 +72,13 @@ void CPVRGUIActionListener::OnPVRManagerEvent(const PVREvent& event)
 {
   if (event == PVREvent::AnnounceReminder)
   {
-    // dispatch to GUI thread and handle the action there
-    KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID,
-                                                                  -1,
-                                                                  static_cast<void*>(new CAction(ACTION_PVR_ANNOUNCE_REMINDERS)));
+    if (g_application.IsInitialized())
+    {
+      // if GUI is ready, dispatch to GUI thread and handle the action there
+      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(
+          TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+          static_cast<void*>(new CAction(ACTION_PVR_ANNOUNCE_REMINDERS)));
+    }
   }
 }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -527,7 +527,6 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
           {
             // reminder is due / over due. announce it.
             m_remindersToAnnounce.push(timer);
-            CServiceBroker::GetPVRManager().PublishEvent(PVREvent::AnnounceReminder);
           }
 
           if (timer->EndAsUTC() >= now)
@@ -649,10 +648,10 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
 
   // announce changes
   if (bChanged)
-  {
-    lock.Leave();
     NotifyTimersEvent();
-  }
+
+  if (!m_remindersToAnnounce.empty())
+    CServiceBroker::GetPVRManager().PublishEvent(PVREvent::AnnounceReminder);
 
   return bChanged;
 }


### PR DESCRIPTION
Fixes #18006 

[PVR] Show reminder dialogs only when GUI is fully initialized / user has logged in.

Runtime-tested by me on latest master, on Android and macOS.
Fix confirmed working by issue submitter @sualfred 

@phunkyfish do you have some time for a code review?