### PR TITLE
[video] Re-add 'Mark watched/unwatched' context menu items to content-less video sources.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -593,7 +593,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
     CFileItemPtr pItem = items[i];
     CFileItemPtr match;
 
-    if (!content.empty() && pItem->m_bIsFolder && !pItem->IsParentFolder())
+    if (pItem->m_bIsFolder && !pItem->IsParentFolder())
     {
       // we need this for enabling the right context menu entries, like mark watched / unwatched
       pItem->SetProperty("IsVideoFolder", true);


### PR DESCRIPTION
Follow-up to #12464
Fixes https://trac.kodi.tv/ticket/17744
Discussed in the forum https://forum.kodi.tv/showthread.php?tid=311447

Runtime-tested on macOS and Android, latest master.

@phunkyfish not your playground, I know, but maybe you could review this complex code change? ;-)

@Nostalgist fyi