### PR TITLE
[Android] proper drain implementation

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -154,7 +154,6 @@ protected:
   bool m_needSecureDecoder = false;
   int m_codecControlFlags;
   int m_state;
-  int m_noPictureLoop;
 
   std::shared_ptr<CJNIXBMCVideoView> m_jnivideoview;
   CJNISurface* m_jnisurface;


### PR DESCRIPTION
## Description
Drain MediaCodec correctly by passing BUFFER_FLAG_END_OF_STREAM to the decoder at the first time VP signals DRAIN.

## Motivation and Context
In previous implementation we detect that the decoder is "empty" if decoder has not provided a frame for 10 times. This logic could lead a.) to not all frames drained (decoder implementation specific) and b.) not optimal switch performance on stream changes.

This PR now tells the decoder that we want to drain, and we receive the information from decoder, that we're done.

## How Has This Been Tested?
NVIDIA Shield TV, play streams with chapters (e.g. Disney+ or vtm.go)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
