### PR TITLE
Allow original release date for albums to be scraped

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -757,6 +757,7 @@ void DetailsFromFileItem<CAlbum>(const CFileItem &item, CAlbum &album)
   album.strReleaseDate = FromString(item, "album.releasedate");
   if (album.strReleaseDate.empty())
     album.strReleaseDate = FromString(item, "album.year");
+  album.strOrigReleaseDate = FromString(item, "album.originaldate");
   album.strLabel = FromString(item, "album.label");
   album.strType = FromString(item, "album.type");
   album.strReleaseStatus = FromString(item, "album.releasestatus");

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -761,7 +761,6 @@ void DetailsFromFileItem<CAlbum>(const CFileItem &item, CAlbum &album)
   album.strLabel = FromString(item, "album.label");
   album.strType = FromString(item, "album.type");
   album.strReleaseStatus = FromString(item, "album.releasestatus");
-  album.SetReleaseType(FromString(item, "album.release_type"));
   album.fRating = item.GetProperty("album.rating").asFloat();
   album.iUserrating = item.GetProperty("album.user_rating").asInteger32();
   album.iVotes = item.GetProperty("album.votes").asInteger32();

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -291,7 +291,6 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
   //@todo: validate ISO8601 format YYYY, YYYY-MM, or YYYY-MM-DD
   if ((override && !source.strReleaseDate.empty()) || strReleaseDate.empty())
     strReleaseDate = source.strReleaseDate;
-  //@todo: can scraper return original release date??
   if ((override && !source.strOrigReleaseDate.empty()) || strOrigReleaseDate.empty())
     strOrigReleaseDate = source.strOrigReleaseDate;
 


### PR DESCRIPTION
## Description
Allow the original release date of an album to be scraped.

## Motivation and Context
In https://github.com/xbmc/xbmc/pull/17437 support for the original release date was added.
Since this information is available at MusicBrainz, it can be scraped.

## How Has This Been Tested?
i have tested this using the metadata.generic.albums scraper, by scraping a few albums
and verifying their original release date was added to the music database.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
