### PR TITLE
[Android] Rename deprecated getVolumeList -> getStorageVolumes

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=1f00b03d8f132a393f2d4bd5437c0042b4e4114e
+VERSION=ee5cc102101d9cb04ab4dbfd7a65db1c52345faf
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -130,7 +130,7 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
 
   if (!inError)
   {
-    CJNIStorageVolumes vols = manager.getVolumeList();
+    CJNIStorageVolumes vols = manager.getStorageVolumes();
     if (xbmc_jnienv()->ExceptionCheck())
     {
       xbmc_jnienv()->ExceptionClear();


### PR DESCRIPTION
## Description
Rename deprecated getVolumeList -> getStorageVolumes

## Motivation and Context
The current used CJNIStorageManager::getVolumeList is deprecated and not longer in the official documentation. Google playstore throws a warning that the method call can be fail in future Android versions.

## How Has This Been Tested?
- Launch Kodi on ShieldTV
- Browse for video sources

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
