### PR TITLE
[buildsteps/tvos] remove deb target from make-xbmc step

### DIFF
--- a/tools/buildsteps/tvos/make-xbmc
+++ b/tools/buildsteps/tvos/make-xbmc
@@ -2,6 +2,6 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=tvos
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-cd $WORKSPACE/build;xcodebuild -target deb -configuration $Configuration build \
+cd $WORKSPACE/build;xcodebuild -configuration $Configuration build \
   SDKROOT=appletvos$SDK_VERSION XBMC_DEPENDS_ROOT=$XBMC_DEPENDS_ROOT \
   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" -CODE_SIGNING_ALLOWED="NO"


### PR DESCRIPTION
## Description
Currently a deb is being created twice for a tvos build on jenkins. No need for this.

## Motivation and Context
looking into reducing jenkins times for tvos builds

## How Has This Been Tested?
its about to be on jenkins ;)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
