### PR TITLE
Use HEVC_NAL_CRA_NUT as KeyFrame

### DIFF
--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -834,7 +834,8 @@ bool CBitstreamConverter::IsIDR(uint8_t unit_type)
       return unit_type == AVC_NAL_IDR_SLICE;
     case AV_CODEC_ID_HEVC:
       return unit_type == HEVC_NAL_IDR_W_RADL ||
-             unit_type == HEVC_NAL_IDR_N_LP;
+             unit_type == HEVC_NAL_IDR_N_LP ||
+             unit_type == HEVC_NAL_CRA_NUT;
     default:
       return false;
   }


### PR DESCRIPTION
## Description
If searching for stream start (e.g. after seek) handle the new clean random access (CRA) NAL unit as frame where decoder can continue.

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp#L868

## Motivation and Context
If HEVC streams contain CRA NAL units, Kodi currently fails to find a recovery frame to continue / start the stream -> stream terminates. This is true at least for Android and ARM, because both h/w platform decoder uses our BitstreamConverter to convert codec-extra-data into annex_b.

## How Has This Been Tested?
Play a test HEVC stream (exodus trailer) and seek 10 seconds forward

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
