### PR TITLE
[Android] Make m_activityResultEvents access thread safe

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -240,6 +240,7 @@ private:
   bool m_exiting;
   pthread_t m_thread;
   static CCriticalSection m_applicationsMutex;
+  static CCriticalSection m_activityResultMutex;
   static std::vector<androidPackage> m_applications;
   static std::vector<CActivityResultEvent*> m_activityResultEvents;
 


### PR DESCRIPTION
## Description
From playstore crashes m_activityResultEvents is accessed from different threads and must therefore be synchronized.

## Motivation and Context
Remove another crash report reason. 

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
