### PR TITLE
Albumscraper: allow fine-grained relevance values

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1606,7 +1606,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 
             items.Add(item);
           }
-          if (!pDialog && relevance > .99f) // we're so close, no reason to search further
+          if (!pDialog && relevance > .999f) // we're so close, no reason to search further
             break;
         }
 


### PR DESCRIPTION
When using fine-grained relevance scoring, Kodi currently auto-picks a result that may not be the one with the highest relevance.
 
As discussed in https://github.com/xbmc/xbmc/pull/15665#issuecomment-640536974 we want a little control over the scores returned by musicbrainz.

In case there's a tie between 2 items in the search results (for ex. both have a score of 100)
and one happens to be an album and the other is a single, Kodi should pick the album as the best result.

To accomplish the, the scraper addon will lower the score for the single to 99.5, resulting in a relevance of 0.995

So Kodi should iterate over all results and not assume anything with a relevance > 0.99 is the best match.