### PR TITLE
Run CGUIDialogProgress ONLY in GUI thread

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -109,7 +109,7 @@ CGUIDialogBusy::CGUIDialogBusy(void)
 
 CGUIDialogBusy::~CGUIDialogBusy(void) = default;
 
-void CGUIDialogBusy::Open_Internal(const std::string &param /* = "" */)
+void CGUIDialogBusy::Open_Internal(bool bProcessRenderLoop, const std::string& param /* = "" */)
 {
   m_bCanceled = false;
   m_bLastVisible = true;

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -47,7 +47,7 @@ public:
    */
   static bool WaitOnEvent(CEvent &event, unsigned int displaytime = 100, bool allowCancel = true);
 protected:
-  void Open_Internal(const std::string &param = "") override;
+  void Open_Internal(bool bProcessRenderLoop, const std::string& param = "") override;
   bool m_bCanceled;
   bool m_bLastVisible = false;
   float m_progress; ///< current progress

--- a/xbmc/dialogs/GUIDialogBusyNoCancel.cpp
+++ b/xbmc/dialogs/GUIDialogBusyNoCancel.cpp
@@ -26,7 +26,8 @@ CGUIDialogBusyNoCancel::CGUIDialogBusyNoCancel(void)
 
 CGUIDialogBusyNoCancel::~CGUIDialogBusyNoCancel(void) = default;
 
-void CGUIDialogBusyNoCancel::Open_Internal(const std::string &param /* = "" */)
+void CGUIDialogBusyNoCancel::Open_Internal(bool bProcessRenderLoop,
+                                           const std::string& param /* = "" */)
 {
   m_bLastVisible = true;
   m_progress = -1;

--- a/xbmc/dialogs/GUIDialogBusyNoCancel.h
+++ b/xbmc/dialogs/GUIDialogBusyNoCancel.h
@@ -19,7 +19,7 @@ public:
   void Render() override;
 
 protected:
-  void Open_Internal(const std::string &param = "") override;
+  void Open_Internal(bool bProcessRenderLoop, const std::string& param = "") override;
   bool m_bLastVisible = false;
   float m_progress;
 };

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -70,7 +70,7 @@ void CGUIDialogProgress::Open(const std::string &param /* = "" */)
     ShowProgressBar(true);
   }
 
-  CGUIDialog::Open_Internal(false, param);
+  CGUIDialog::Open(false, param);
 
   while (m_active && IsAnimating(ANIM_TYPE_WINDOW_OPEN))
   {

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -162,11 +162,6 @@ void CGUIDialog::UpdateVisibility()
   }
 }
 
-void CGUIDialog::Open_Internal(const std::string &param /* = "" */)
-{
-  CGUIDialog::Open_Internal(m_modalityType != DialogModalityType::MODELESS, param);
-}
-
 void CGUIDialog::Open_Internal(bool bProcessRenderLoop, const std::string &param /* = "" */)
 {
   // Lock graphic context here as it is sometimes called from non rendering threads
@@ -207,14 +202,21 @@ void CGUIDialog::Open_Internal(bool bProcessRenderLoop, const std::string &param
 
 void CGUIDialog::Open(const std::string &param /* = "" */)
 {
+  CGUIDialog::Open(m_modalityType != DialogModalityType::MODELESS, param);
+}
+
+
+void CGUIDialog::Open(bool bProcessRenderLoop, const std::string& param /* = "" */)
+{
   if (!g_application.IsCurrentThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(CServiceBroker::GetWinSystem()->GetGfxContext());
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OPEN, -1, -1, static_cast<void*>(this), param);
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OPEN, -1, bProcessRenderLoop,
+                                                 static_cast<void*>(this), param);
   }
   else
-    Open_Internal(param);
+    Open_Internal(bProcessRenderLoop, param);
 }
 
 void CGUIDialog::Render()

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -164,10 +164,6 @@ void CGUIDialog::UpdateVisibility()
 
 void CGUIDialog::Open_Internal(bool bProcessRenderLoop, const std::string &param /* = "" */)
 {
-  // Lock graphic context here as it is sometimes called from non rendering threads
-  // maybe we should have a critical section per window instead??
-  CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-
   if (!CServiceBroker::GetGUI()->GetWindowManager().Initialized() ||
       (m_active && !m_closing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE)))
     return;
@@ -189,8 +185,6 @@ void CGUIDialog::Open_Internal(bool bProcessRenderLoop, const std::string &param
   {
     if (!m_windowLoaded)
       Close(true);
-
-    lock.Leave();
 
     while (m_active)
     {

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -45,6 +45,7 @@ public:
   void Render() override;
 
   void Open(const std::string &param = "");
+  void Open(bool bProcessRenderLoop, const std::string& param = "");
 
   bool OnBack(int actionID) override;
 
@@ -67,7 +68,6 @@ protected:
   using CGUIWindow::UpdateVisibility;
   virtual void UpdateVisibility();
 
-  virtual void Open_Internal(const std::string &param = "");
   virtual void Open_Internal(bool bProcessRenderLoop, const std::string &param = "");
   void OnDeinitWindow(int nextWindowID) override;
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -886,7 +886,7 @@ void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)
   case TMSG_GUI_DIALOG_OPEN:
   {
     if (pMsg->lpVoid)
-      static_cast<CGUIDialog*>(pMsg->lpVoid)->Open(pMsg->strParam);
+      static_cast<CGUIDialog*>(pMsg->lpVoid)->Open(pMsg->param2, pMsg->strParam);
     else
     {
       CGUIDialog* pDialog = static_cast<CGUIDialog*>(GetWindow(pMsg->param1));

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -711,8 +711,6 @@ void CGraphicContext::GetGUIScaling(const RESOLUTION_INFO &res, float &scaleX, f
 
 void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool needsScaling)
 {
-  CSingleLock lock(*this);
-
   m_windowResolution = res;
   if (needsScaling && m_Resolution != RES_INVALID)
     GetGUIScaling(res, m_guiTransform.scaleX, m_guiTransform.scaleY, &m_guiTransform.matrix);


### PR DESCRIPTION
## Description
This PR takes care that CGUIDialogProgress::Open call from e.g. python is routed to the GUI thread.
CGUIDialog::Open_Internal() is not designed to run on other threads as GUI thread and lead to the issues described below.

## Motivation and Context
Backtrace (Python thread):

```
#00  pc 0000000000bffee8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (std::__ndk1::deque<CPointGen<float>, std::__ndk1::allocator<CPointGen<float> > >::push_back(CPointGen<float>&&)+96)
  #01  pc 0000000000bfe724  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGraphicContext::SetScalingResolution(RESOLUTION_INFO const&, bool)+284)
  #02  pc 0000000000dc586c  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIWindow::Load(TiXmlElement*)+68)
  #03  pc 0000000000d83f64  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIDialog::Load(TiXmlElement*)+12)
  #04  pc 0000000000dc549c  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIWindow::LoadXML(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+396)
  #05  pc 0000000000dc5214  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIWindow::Load(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, bool)+604)
  #06  pc 0000000000dc8718  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIWindow::AllocResources(bool)+520)
  #07  pc 0000000000dc7928  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIWindow::OnMessage(CGUIMessage&)+336)
  #08  pc 0000000000d84158  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIDialog::OnMessage(CGUIMessage&)+64)
  #09  pc 0000000000d8471c  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIDialog::Open_Internal(bool, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+236)
  #10  pc 0000000000e186ac  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CGUIDialogProgress::Open(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&)+168)
  #11  pc 00000000009cdd38  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #12  pc 00000000016fdae0  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+17708)
  #13  pc 0000000001700900  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #14  pc 00000000016fc918  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13156)
  #15  pc 0000000001700900  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #16  pc 00000000016fc918  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13156)
  #17  pc 0000000001700900  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #18  pc 00000000016fc918  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13156)
  #19  pc 00000000016f92d4  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalCodeEx+1676)
  #20  pc 0000000001700860  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #21  pc 00000000016fc918  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13156)
  #22  pc 0000000001700900  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #23  pc 00000000016fc918  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13156)
  #24  pc 00000000016f92d4  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalCodeEx+1676)
  #25  pc 00000000017e9620  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #26  pc 000000000168b7c8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyObject_Call+116)
  #27  pc 00000000016961bc  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #28  pc 000000000168b7c8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyObject_Call+116)
  #29  pc 000000000168b950  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #30  pc 000000000168bafc  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyObject_CallMethod+188)
  #31  pc 0000000000979088  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PythonBindings::XBMCAddon_xbmcgui_WindowXMLDialog_Director::onInit()+36)
  #32  pc 00000000009c21b4  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (XBMCAddon::RetardedAsyncCallbackHandler::makePendingCalls()+560)
  #33  pc 00000000009e79e0  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (XBMCAddon::xbmcgui::Window::doModal()+148)
  #34  pc 0000000000970b78  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #35  pc 00000000016fdae0  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+17708)
  #36  pc 0000000001700900  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #37  pc 00000000016fc918  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13156)
  #38  pc 00000000016f92d4  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalCodeEx+1676)
  #39  pc 00000000017e9620  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #40  pc 000000000168b7c8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyObject_Call+116)
  #41  pc 00000000016961bc  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #42  pc 000000000168b7c8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyObject_Call+116)
  #43  pc 00000000017000c8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_CallObjectWithKeywords+188)
  #44  pc 0000000001693b58  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyInstance_New+128)
  #45  pc 000000000168b7c8  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyObject_Call+116)
  #46  pc 00000000016fc8fc  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalFrameEx+13128)
  #47  pc 00000000016f92d4  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalCodeEx+1676)
  #48  pc 00000000016f8c3c  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyEval_EvalCode+44)
  #49  pc 000000000171be94  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so
  #50  pc 000000000171bf58  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (PyRun_FileExFlags+140)
  #51  pc 00000000009b0f7c  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CPythonInvoker::executeScript(void*, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, void*, void*)+104)
  #52  pc 00000000009afdac  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CPythonInvoker::execute(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::vector<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::allocator<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>> const&)+1128)
  #53  pc 0000000001319190  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CLanguageInvokerThread::Process()+108)
  #54  pc 0000000000cc9bc0  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CThread::Action()+40)
  #55  pc 0000000000cc8c50  /data/app/org.xbmc.kodi-3dXZEnsmODJqik_yEIEZ_A==/lib/arm/libkodi.so (CThread::staticThread(void*)+200)
  #56  pc 0000000000048811  /system/lib/libc.so (__pthread_start(void*)+24)
  #57  pc 000000000001b369  /system/lib/libc.so (__start_thread+32)
```
CGraphicContext::SetScalingResolution is called from python thread, while all the other camera / transform /stereoFactor calls are processed from GUIThread. This is wrong by concept (see discussion below)

## How Has This Been Tested?
Started kodi, opened some dialogs, played video stream.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
