### PR TITLE
[Album Scaper] provide detailed album selection dialog

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -617,16 +617,22 @@ CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem &item)
   else
     sAlbumName = sTitle;
 
-  std::string sYear = item.GetProperty("album.year").asString();
-  if (!sYear.empty())
-    sAlbumName = StringUtils::Format("%s (%s)", sAlbumName.c_str(), sYear.c_str());
-
   CScraperUrl url;
   url.AppendUrl(CScraperUrl::SUrlEntry(item.GetDynPath()));
 
   info = CMusicAlbumInfo(sTitle, sArtist, sAlbumName, url);
   if (item.HasProperty("relevance"))
     info.SetRelevance(item.GetProperty("relevance").asFloat());
+
+  if (item.HasProperty("album.releasestatus"))
+    info.GetAlbum().strReleaseStatus = item.GetProperty("album.releasestatus").asString();
+  if (item.HasProperty("album.type"))
+    info.GetAlbum().strType = item.GetProperty("album.type").asString();
+  if (item.HasProperty("album.year"))
+    info.GetAlbum().strReleaseDate = item.GetProperty("album.year").asString();
+  if (item.HasProperty("album.label"))
+    info.GetAlbum().strLabel = item.GetProperty("album.label").asString();
+  info.GetAlbum().art = item.GetArt();
 
   return info;
 }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1561,8 +1561,10 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
           pDlg->SetHeading(CVariant{g_localizeStrings.Get(181)});
           pDlg->Reset();
           pDlg->EnableButton(true, 413); // manual
+          pDlg->SetUseDetails(true);
         }
 
+        CFileItemList items;
         for (int i = 0; i < scraper.GetAlbumCount(); ++i)
         {
           CMusicAlbumInfo& info = scraper.GetAlbum(i);
@@ -1583,9 +1585,23 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
           {
             // set the label to [relevance]  album - artist
             std::string strTemp = StringUtils::Format("[%0.2f]  %s", relevance, info.GetTitle2().c_str());
-            CFileItem item(strTemp);
-            item.m_idepth = i; // use this to hold the index of the album in the scraper
-            pDlg->Add(item);
+            CFileItemPtr item(new CFileItem("", false));
+            item->SetLabel(strTemp);
+
+            std::string strTemp2;
+            if (!scraper.GetAlbum(i).GetAlbum().strType.empty())
+              strTemp2 += scraper.GetAlbum(i).GetAlbum().strType;
+            if (!scraper.GetAlbum(i).GetAlbum().strReleaseDate.empty())
+              strTemp2 += " - " + scraper.GetAlbum(i).GetAlbum().strReleaseDate;
+            if (!scraper.GetAlbum(i).GetAlbum().strReleaseStatus.empty())
+              strTemp2 += " - " + scraper.GetAlbum(i).GetAlbum().strReleaseStatus;
+            if (!scraper.GetAlbum(i).GetAlbum().strLabel.empty())
+              strTemp2 += " - " + scraper.GetAlbum(i).GetAlbum().strLabel;
+            item->SetLabel2(strTemp2);
+
+            item->SetArt(scraper.GetAlbum(i).GetAlbum().art);
+
+            items.Add(item);
           }
           if (relevance > .99f) // we're so close, no reason to search further
             break;
@@ -1594,6 +1610,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
         if (pDialog && bestRelevance < THRESHOLD)
         {
           pDlg->Sort(false);
+          pDlg->SetItems(items);
           pDlg->Open();
 
           // and wait till user selects one
@@ -1623,7 +1640,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 
             return DownloadAlbumInfo(newAlbum, info, albumInfo, bUseScrapedMBID, pDialog);
           }
-          iSelectedAlbum = pDlg->GetSelectedFileItem()->m_idepth;
+          iSelectedAlbum = pDlg->GetSelectedItem();
         }
       }
       else


### PR DESCRIPTION
## Description
provide a more detailed selection dialog when re-scraping an album

## Motivation and Context
the info shown in the current selection dialog is too minimal to be able to pick the correct release 

## How Has This Been Tested?
tested using the metadata.generic.albums (v1.0.6) scraper

## Screenshots (if appropriate):

before:
![select-minimal](https://user-images.githubusercontent.com/687265/84556436-19691880-ad23-11ea-94bc-c2eab6967521.jpg)


after:
![select-detailed](https://user-images.githubusercontent.com/687265/84556226-44eb0380-ad21-11ea-938b-29efbf120cbc.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
