### PR TITLE
[Leia] fix memory info on 32bit linux systems with more than 4GB RAM

### DIFF
--- a/xbmc/platform/linux/XMemUtils.cpp
+++ b/xbmc/platform/linux/XMemUtils.cpp
@@ -167,10 +167,10 @@ void GlobalMemoryStatusEx(LPMEMORYSTATUSEX lpBuffer)
     fflush(procMeminfoFP);
   }
   lpBuffer->dwLength        = sizeof(MEMORYSTATUSEX);
-  lpBuffer->ullAvailPageFile = (info.freeswap * info.mem_unit);
-  lpBuffer->ullAvailPhys     = ((info.freeram + info.bufferram) * info.mem_unit);
-  lpBuffer->ullAvailVirtual  = ((info.freeram + info.bufferram) * info.mem_unit);
-  lpBuffer->ullTotalPhys     = (info.totalram * info.mem_unit);
-  lpBuffer->ullTotalVirtual  = (info.totalram * info.mem_unit);
+  lpBuffer->ullAvailPageFile = (static_cast<uint64_t>(info.freeswap) * info.mem_unit);
+  lpBuffer->ullAvailPhys     = (static_cast<uint64_t>(info.freeram + info.bufferram) * info.mem_unit);
+  lpBuffer->ullAvailVirtual  = (static_cast<uint64_t>(info.freeram + info.bufferram) * info.mem_unit);
+  lpBuffer->ullTotalPhys     = (static_cast<uint64_t>(info.totalram) * info.mem_unit);
+  lpBuffer->ullTotalVirtual  = (static_cast<uint64_t>(info.totalram) * info.mem_unit);
 #endif
 }


### PR DESCRIPTION
## Description
The sysinfo members are unsigned long, cast them to uint64_t before calculating the size in bytes to prevent 32bit integer overflow on 32bit systems with 4GB or more RAM.

Note: this change is for Leia only, Matrix already does proper calculations using uint64_t

## Motivation and Context
System info screen on 8GB RPi4 shows only ~3.5 GB free/available memory instead of the expected ~7.5GB which free/top/meminfo report

## How Has This Been Tested?
Running LibreELEC 9.2 RPi4 build on 8GB RPi4

## Screenshots (if appropriate):
System info on 18.7.1:
![screenshot000](https://user-images.githubusercontent.com/3920953/84566868-e2235780-ad74-11ea-8e1b-6a7f57cee5b1.png)

System info with this change:
![screenshot001](https://user-images.githubusercontent.com/3920953/84566870-e8b1cf00-ad74-11ea-8ba6-8f2e1e9de83a.png)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
