### PR TITLE
[addon] prevent publicate of C++ functions / classes from headers, fix old to new pvr update and cleanup General parts

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -18,54 +18,55 @@ namespace ADDON
 
 typedef struct
 {
-  const char* name;
+  std::string name;
+  std::string old_name;
   TYPE type;
   int pretty;
-  const char* icon;
+  std::string icon;
 } TypeMapping;
 
 // clang-format off
 static const TypeMapping types[] =
-  {{"unknown",                           ADDON_UNKNOWN,                 0, "" },
-   {"xbmc.metadata.scraper.albums",      ADDON_SCRAPER_ALBUMS,      24016, "DefaultAddonAlbumInfo.png" },
-   {"xbmc.metadata.scraper.artists",     ADDON_SCRAPER_ARTISTS,     24017, "DefaultAddonArtistInfo.png" },
-   {"xbmc.metadata.scraper.movies",      ADDON_SCRAPER_MOVIES,      24007, "DefaultAddonMovieInfo.png" },
-   {"xbmc.metadata.scraper.musicvideos", ADDON_SCRAPER_MUSICVIDEOS, 24015, "DefaultAddonMusicVideoInfo.png" },
-   {"xbmc.metadata.scraper.tvshows",     ADDON_SCRAPER_TVSHOWS,     24014, "DefaultAddonTvInfo.png" },
-   {"xbmc.metadata.scraper.library",     ADDON_SCRAPER_LIBRARY,     24083, "DefaultAddonInfoLibrary.png" },
-   {"xbmc.ui.screensaver",               ADDON_SCREENSAVER,         24008, "DefaultAddonScreensaver.png" },
-   {"xbmc.player.musicviz",              ADDON_VIZ,                 24010, "DefaultAddonVisualization.png" },
-   {"xbmc.python.pluginsource",          ADDON_PLUGIN,              24005, "" },
-   {"xbmc.python.script",                ADDON_SCRIPT,              24009, "" },
-   {"xbmc.python.weather",               ADDON_SCRIPT_WEATHER,      24027, "DefaultAddonWeather.png" },
-   {"xbmc.python.lyrics",                ADDON_SCRIPT_LYRICS,       24013, "DefaultAddonLyrics.png" },
-   {"xbmc.python.library",               ADDON_SCRIPT_LIBRARY,      24081, "DefaultAddonHelper.png" },
-   {"xbmc.python.module",                ADDON_SCRIPT_MODULE,       24082, "DefaultAddonLibrary.png" },
-   {"xbmc.subtitle.module",              ADDON_SUBTITLE_MODULE,     24012, "DefaultAddonSubtitles.png" },
-   {"kodi.context.item",                 ADDON_CONTEXT_ITEM,        24025, "DefaultAddonContextItem.png" },
-   {"kodi.game.controller",              ADDON_GAME_CONTROLLER,     35050, "DefaultAddonGame.png" },
-   {"xbmc.gui.skin",                     ADDON_SKIN,                  166, "DefaultAddonSkin.png" },
-   {"xbmc.webinterface",                 ADDON_WEB_INTERFACE,         199, "DefaultAddonWebSkin.png" },
-   {"xbmc.addon.repository",             ADDON_REPOSITORY,          24011, "DefaultAddonRepository.png" },
-   {"kodi.pvrclient",                    ADDON_PVRDLL,              24019, "DefaultAddonPVRClient.png" },
-   {"kodi.gameclient",                   ADDON_GAMEDLL,             35049, "DefaultAddonGame.png" },
-   {"kodi.peripheral",                   ADDON_PERIPHERALDLL,       35010, "DefaultAddonPeripheral.png" },
-   {"xbmc.addon.video",                  ADDON_VIDEO,                1037, "DefaultAddonVideo.png" },
-   {"xbmc.addon.audio",                  ADDON_AUDIO,                1038, "DefaultAddonMusic.png" },
-   {"xbmc.addon.image",                  ADDON_IMAGE,                1039, "DefaultAddonPicture.png" },
-   {"xbmc.addon.executable",             ADDON_EXECUTABLE,           1043, "DefaultAddonProgram.png" },
-   {"kodi.addon.game",                   ADDON_GAME,                35049, "DefaultAddonGame.png" },
-   {"kodi.audioencoder",                 ADDON_AUDIOENCODER,         200,  "DefaultAddonAudioEncoder.png" },
-   {"kodi.audiodecoder",                 ADDON_AUDIODECODER,         201,  "DefaultAddonAudioDecoder.png" },
-   {"xbmc.service",                      ADDON_SERVICE,             24018, "DefaultAddonService.png" },
-   {"kodi.resource.images",              ADDON_RESOURCE_IMAGES,     24035, "DefaultAddonImages.png" },
-   {"kodi.resource.language",            ADDON_RESOURCE_LANGUAGE,   24026, "DefaultAddonLanguage.png" },
-   {"kodi.resource.uisounds",            ADDON_RESOURCE_UISOUNDS,   24006, "DefaultAddonUISounds.png" },
-   {"kodi.resource.games",               ADDON_RESOURCE_GAMES,      35209, "DefaultAddonGame.png" },
-   {"kodi.resource.font",                ADDON_RESOURCE_FONT,       13303, "DefaultAddonFont.png" },
-   {"kodi.inputstream",                  ADDON_INPUTSTREAM,         24048, "DefaultAddonInputstream.png" },
-   {"kodi.vfs",                          ADDON_VFS,                 39013, "DefaultAddonVfs.png" },
-   {"kodi.imagedecoder",                 ADDON_IMAGEDECODER,        39015, "DefaultAddonImageDecoder.png" },
+  {{"unknown",                           "", ADDON_UNKNOWN,                 0, "" },
+   {"xbmc.metadata.scraper.albums",      "", ADDON_SCRAPER_ALBUMS,      24016, "DefaultAddonAlbumInfo.png" },
+   {"xbmc.metadata.scraper.artists",     "", ADDON_SCRAPER_ARTISTS,     24017, "DefaultAddonArtistInfo.png" },
+   {"xbmc.metadata.scraper.movies",      "", ADDON_SCRAPER_MOVIES,      24007, "DefaultAddonMovieInfo.png" },
+   {"xbmc.metadata.scraper.musicvideos", "", ADDON_SCRAPER_MUSICVIDEOS, 24015, "DefaultAddonMusicVideoInfo.png" },
+   {"xbmc.metadata.scraper.tvshows",     "", ADDON_SCRAPER_TVSHOWS,     24014, "DefaultAddonTvInfo.png" },
+   {"xbmc.metadata.scraper.library",     "", ADDON_SCRAPER_LIBRARY,     24083, "DefaultAddonInfoLibrary.png" },
+   {"xbmc.ui.screensaver",               "", ADDON_SCREENSAVER,         24008, "DefaultAddonScreensaver.png" },
+   {"xbmc.player.musicviz",              "", ADDON_VIZ,                 24010, "DefaultAddonVisualization.png" },
+   {"xbmc.python.pluginsource",          "", ADDON_PLUGIN,              24005, "" },
+   {"xbmc.python.script",                "", ADDON_SCRIPT,              24009, "" },
+   {"xbmc.python.weather",               "", ADDON_SCRIPT_WEATHER,      24027, "DefaultAddonWeather.png" },
+   {"xbmc.python.lyrics",                "", ADDON_SCRIPT_LYRICS,       24013, "DefaultAddonLyrics.png" },
+   {"xbmc.python.library",               "", ADDON_SCRIPT_LIBRARY,      24081, "DefaultAddonHelper.png" },
+   {"xbmc.python.module",                "", ADDON_SCRIPT_MODULE,       24082, "DefaultAddonLibrary.png" },
+   {"xbmc.subtitle.module",              "", ADDON_SUBTITLE_MODULE,     24012, "DefaultAddonSubtitles.png" },
+   {"kodi.context.item",                 "", ADDON_CONTEXT_ITEM,        24025, "DefaultAddonContextItem.png" },
+   {"kodi.game.controller",              "", ADDON_GAME_CONTROLLER,     35050, "DefaultAddonGame.png" },
+   {"xbmc.gui.skin",                     "", ADDON_SKIN,                  166, "DefaultAddonSkin.png" },
+   {"xbmc.webinterface",                 "", ADDON_WEB_INTERFACE,         199, "DefaultAddonWebSkin.png" },
+   {"xbmc.addon.repository",             "", ADDON_REPOSITORY,          24011, "DefaultAddonRepository.png" },
+   {"kodi.pvrclient",      "xbmc.pvrclient", ADDON_PVRDLL,              24019, "DefaultAddonPVRClient.png" },
+   {"kodi.gameclient",                   "", ADDON_GAMEDLL,             35049, "DefaultAddonGame.png" },
+   {"kodi.peripheral",                   "", ADDON_PERIPHERALDLL,       35010, "DefaultAddonPeripheral.png" },
+   {"xbmc.addon.video",                  "", ADDON_VIDEO,                1037, "DefaultAddonVideo.png" },
+   {"xbmc.addon.audio",                  "", ADDON_AUDIO,                1038, "DefaultAddonMusic.png" },
+   {"xbmc.addon.image",                  "", ADDON_IMAGE,                1039, "DefaultAddonPicture.png" },
+   {"xbmc.addon.executable",             "", ADDON_EXECUTABLE,           1043, "DefaultAddonProgram.png" },
+   {"kodi.addon.game",                   "", ADDON_GAME,                35049, "DefaultAddonGame.png" },
+   {"kodi.audioencoder",                 "", ADDON_AUDIOENCODER,         200,  "DefaultAddonAudioEncoder.png" },
+   {"kodi.audiodecoder",                 "", ADDON_AUDIODECODER,         201,  "DefaultAddonAudioDecoder.png" },
+   {"xbmc.service",                      "", ADDON_SERVICE,             24018, "DefaultAddonService.png" },
+   {"kodi.resource.images",              "", ADDON_RESOURCE_IMAGES,     24035, "DefaultAddonImages.png" },
+   {"kodi.resource.language",            "", ADDON_RESOURCE_LANGUAGE,   24026, "DefaultAddonLanguage.png" },
+   {"kodi.resource.uisounds",            "", ADDON_RESOURCE_UISOUNDS,   24006, "DefaultAddonUISounds.png" },
+   {"kodi.resource.games",               "", ADDON_RESOURCE_GAMES,      35209, "DefaultAddonGame.png" },
+   {"kodi.resource.font",                "", ADDON_RESOURCE_FONT,       13303, "DefaultAddonFont.png" },
+   {"kodi.inputstream",                  "", ADDON_INPUTSTREAM,         24048, "DefaultAddonInputstream.png" },
+   {"kodi.vfs",                          "", ADDON_VFS,                 39013, "DefaultAddonVfs.png" },
+   {"kodi.imagedecoder",                 "", ADDON_IMAGEDECODER,        39015, "DefaultAddonImageDecoder.png" },
   };
 // clang-format on
 
@@ -93,7 +94,7 @@ TYPE CAddonInfo::TranslateType(const std::string& string)
 {
   for (const TypeMapping& map : types)
   {
-    if (string == map.name)
+    if (string == map.name || (!map.old_name.empty() && string == map.old_name))
       return map.type;
   }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -81,7 +81,7 @@ struct IRenderHelper;
 /// @note The asked type should match the type used on settings.xml.
 ///
 ///@{
-class CSettingValue
+class ATTRIBUTE_HIDDEN CSettingValue
 {
 public:
   explicit CSettingValue(const void* settingValue) : m_settingValue(settingValue) {}
@@ -148,7 +148,7 @@ namespace addon
  * @note This class is not need to know during add-on development thats why
  * commented with "*".
  */
-class IAddonInstance
+class ATTRIBUTE_HIDDEN IAddonInstance
 {
 public:
   explicit IAddonInstance(ADDON_TYPE type, const std::string& version)
@@ -567,7 +567,7 @@ private:
 /// @param[in] type The wanted type of @ref ADDON_TYPE to ask
 /// @return The version string about type in MAJOR.MINOR.PATCH style.
 ///
-inline std::string GetKodiTypeVersion(int type)
+inline std::string ATTRIBUTE_HIDDEN GetKodiTypeVersion(int type)
 {
   using namespace kodi::addon;
 
@@ -581,7 +581,7 @@ inline std::string GetKodiTypeVersion(int type)
 
 //==============================================================================
 ///
-inline std::string GetAddonPath(const std::string& append = "")
+inline std::string ATTRIBUTE_HIDDEN GetAddonPath(const std::string& append = "")
 {
   using namespace kodi::addon;
 
@@ -605,7 +605,7 @@ inline std::string GetAddonPath(const std::string& append = "")
 
 //==============================================================================
 ///
-inline std::string GetBaseUserPath(const std::string& append = "")
+inline std::string ATTRIBUTE_HIDDEN GetBaseUserPath(const std::string& append = "")
 {
   using namespace kodi::addon;
 
@@ -629,7 +629,7 @@ inline std::string GetBaseUserPath(const std::string& append = "")
 
 //==============================================================================
 ///
-inline std::string GetLibPath()
+inline std::string ATTRIBUTE_HIDDEN GetLibPath()
 {
   using namespace kodi::addon;
 
@@ -660,7 +660,7 @@ inline std::string GetLibPath()
 ///
 /// ~~~~~~~~~~~~~
 ///
-inline void Log(const AddonLog loglevel, const char* format, ...)
+inline void ATTRIBUTE_HIDDEN Log(const AddonLog loglevel, const char* format, ...)
 {
   using namespace kodi::addon;
 
@@ -711,7 +711,8 @@ inline void Log(const AddonLog loglevel, const char* format, ...)
 ///   value = "my_default_if_setting_not_work";
 /// ~~~~~~~~~~~~~
 ///
-inline bool CheckSettingString(const std::string& settingName, std::string& settingValue)
+inline bool ATTRIBUTE_HIDDEN CheckSettingString(const std::string& settingName,
+                                                std::string& settingValue)
 {
   using namespace kodi::addon;
 
@@ -747,8 +748,8 @@ inline bool CheckSettingString(const std::string& settingName, std::string& sett
 /// std::string value = kodi::GetSettingString("my_string_value");
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetSettingString(const std::string& settingName,
-                                    const std::string& defaultValue = "")
+inline std::string ATTRIBUTE_HIDDEN GetSettingString(const std::string& settingName,
+                                                     const std::string& defaultValue = "")
 {
   std::string settingValue = defaultValue;
   CheckSettingString(settingName, settingValue);
@@ -775,7 +776,8 @@ inline std::string GetSettingString(const std::string& settingName,
 /// kodi::SetSettingString("my_string_value", value);
 /// ~~~~~~~~~~~~~
 ///
-inline void SetSettingString(const std::string& settingName, const std::string& settingValue)
+inline void ATTRIBUTE_HIDDEN SetSettingString(const std::string& settingName,
+                                              const std::string& settingValue)
 {
   using namespace kodi::addon;
 
@@ -807,7 +809,7 @@ inline void SetSettingString(const std::string& settingName, const std::string& 
 ///   value = 123; // My default of them
 /// ~~~~~~~~~~~~~
 ///
-inline bool CheckSettingInt(const std::string& settingName, int& settingValue)
+inline bool ATTRIBUTE_HIDDEN CheckSettingInt(const std::string& settingName, int& settingValue)
 {
   using namespace kodi::addon;
 
@@ -835,7 +837,7 @@ inline bool CheckSettingInt(const std::string& settingName, int& settingValue)
 /// int value = kodi::GetSettingInt("my_integer_value");
 /// ~~~~~~~~~~~~~
 ///
-inline int GetSettingInt(const std::string& settingName, int defaultValue = 0)
+inline int ATTRIBUTE_HIDDEN GetSettingInt(const std::string& settingName, int defaultValue = 0)
 {
   int settingValue = defaultValue;
   CheckSettingInt(settingName, settingValue);
@@ -862,7 +864,7 @@ inline int GetSettingInt(const std::string& settingName, int defaultValue = 0)
 /// kodi::SetSettingInt("my_integer_value", value);
 /// ~~~~~~~~~~~~~
 ///
-inline void SetSettingInt(const std::string& settingName, int settingValue)
+inline void ATTRIBUTE_HIDDEN SetSettingInt(const std::string& settingName, int settingValue)
 {
   using namespace kodi::addon;
 
@@ -894,7 +896,7 @@ inline void SetSettingInt(const std::string& settingName, int settingValue)
 ///   value = true; // My default of them
 /// ~~~~~~~~~~~~~
 ///
-inline bool CheckSettingBoolean(const std::string& settingName, bool& settingValue)
+inline bool ATTRIBUTE_HIDDEN CheckSettingBoolean(const std::string& settingName, bool& settingValue)
 {
   using namespace kodi::addon;
 
@@ -922,7 +924,8 @@ inline bool CheckSettingBoolean(const std::string& settingName, bool& settingVal
 /// bool value = kodi::GetSettingBoolean("my_boolean_value");
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetSettingBoolean(const std::string& settingName, bool defaultValue = false)
+inline bool ATTRIBUTE_HIDDEN GetSettingBoolean(const std::string& settingName,
+                                               bool defaultValue = false)
 {
   bool settingValue = defaultValue;
   CheckSettingBoolean(settingName, settingValue);
@@ -949,7 +952,7 @@ inline bool GetSettingBoolean(const std::string& settingName, bool defaultValue 
 /// kodi::SetSettingBoolean("my_boolean_value", value);
 /// ~~~~~~~~~~~~~
 ///
-inline void SetSettingBoolean(const std::string& settingName, bool settingValue)
+inline void ATTRIBUTE_HIDDEN SetSettingBoolean(const std::string& settingName, bool settingValue)
 {
   using namespace kodi::addon;
 
@@ -981,7 +984,7 @@ inline void SetSettingBoolean(const std::string& settingName, bool settingValue)
 ///   value = 1.0f; // My default of them
 /// ~~~~~~~~~~~~~
 ///
-inline bool CheckSettingFloat(const std::string& settingName, float& settingValue)
+inline bool ATTRIBUTE_HIDDEN CheckSettingFloat(const std::string& settingName, float& settingValue)
 {
   using namespace kodi::addon;
 
@@ -1009,7 +1012,8 @@ inline bool CheckSettingFloat(const std::string& settingName, float& settingValu
 /// float value = kodi::GetSettingFloat("my_float_value");
 /// ~~~~~~~~~~~~~
 ///
-inline float GetSettingFloat(const std::string& settingName, float defaultValue = 0.0f)
+inline float ATTRIBUTE_HIDDEN GetSettingFloat(const std::string& settingName,
+                                              float defaultValue = 0.0f)
 {
   float settingValue = defaultValue;
   CheckSettingFloat(settingName, settingValue);
@@ -1036,7 +1040,7 @@ inline float GetSettingFloat(const std::string& settingName, float defaultValue 
 /// kodi::SetSettingFloat("my_float_value", value);
 /// ~~~~~~~~~~~~~
 ///
-inline void SetSettingFloat(const std::string& settingName, float settingValue)
+inline void ATTRIBUTE_HIDDEN SetSettingFloat(const std::string& settingName, float settingValue)
 {
   using namespace kodi::addon;
 
@@ -1077,7 +1081,8 @@ inline void SetSettingFloat(const std::string& settingName, float settingValue)
 /// ~~~~~~~~~~~~~
 ///
 template<typename enumType>
-inline bool CheckSettingEnum(const std::string& settingName, enumType& settingValue)
+inline bool ATTRIBUTE_HIDDEN CheckSettingEnum(const std::string& settingName,
+                                              enumType& settingValue)
 {
   using namespace kodi::addon;
 
@@ -1119,8 +1124,8 @@ inline bool CheckSettingEnum(const std::string& settingName, enumType& settingVa
 /// ~~~~~~~~~~~~~
 ///
 template<typename enumType>
-inline enumType GetSettingEnum(const std::string& settingName,
-                               enumType defaultValue = static_cast<enumType>(0))
+inline enumType ATTRIBUTE_HIDDEN GetSettingEnum(const std::string& settingName,
+                                                enumType defaultValue = static_cast<enumType>(0))
 {
   enumType settingValue = defaultValue;
   CheckSettingEnum(settingName, settingValue);
@@ -1157,7 +1162,7 @@ inline enumType GetSettingEnum(const std::string& settingName,
 /// ~~~~~~~~~~~~~
 ///
 template<typename enumType>
-inline void SetSettingEnum(const std::string& settingName, enumType settingValue)
+inline void ATTRIBUTE_HIDDEN SetSettingEnum(const std::string& settingName, enumType settingValue)
 {
   using namespace kodi::addon;
 
@@ -1171,7 +1176,7 @@ inline void SetSettingEnum(const std::string& settingName, enumType settingValue
 
 //============================================================================
 ///
-inline std::string TranslateAddonStatus(ADDON_STATUS status)
+inline std::string ATTRIBUTE_HIDDEN TranslateAddonStatus(ADDON_STATUS status)
 {
   switch (status)
   {

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AudioEngine.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AudioEngine.h
@@ -99,7 +99,8 @@ namespace audioengine
 /// accordingly.
 ///
 //@{
-class AudioEngineFormat : public addon::CStructHdl<AudioEngineFormat, AUDIO_ENGINE_FORMAT>
+class ATTRIBUTE_HIDDEN AudioEngineFormat
+  : public addon::CStructHdl<AudioEngineFormat, AUDIO_ENGINE_FORMAT>
 {
 public:
   /*! \cond PRIVATE */
@@ -252,7 +253,7 @@ public:
 /// included to enjoy it.
 ///
 //----------------------------------------------------------------------------
-class CAEStream
+class ATTRIBUTE_HIDDEN CAEStream
 {
 public:
   //==========================================================================
@@ -601,7 +602,7 @@ private:
 ///
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetCurrentSinkFormat(AudioEngineFormat& format)
+inline bool ATTRIBUTE_HIDDEN GetCurrentSinkFormat(AudioEngineFormat& format)
 {
   using namespace kodi::addon;
   return CAddonBase::m_interface->toKodi->kodi_audioengine->get_current_sink_format(

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -92,7 +92,7 @@ namespace vfs
 /// Used on kodi::vfs::StatFile() to get detailed information about a file.
 ///
 //@{
-class FileStatus : public kodi::addon::CStructHdl<FileStatus, STAT_STRUCTURE>
+class ATTRIBUTE_HIDDEN FileStatus : public kodi::addon::CStructHdl<FileStatus, STAT_STRUCTURE>
 {
 public:
   /*! \cond PRIVATE */
@@ -180,7 +180,8 @@ public:
 /// status of proccessed stream.
 ///
 //@{
-class CacheStatus : public kodi::addon::CStructHdl<CacheStatus, VFS_CACHE_STATUS_DATA>
+class ATTRIBUTE_HIDDEN CacheStatus
+  : public kodi::addon::CStructHdl<CacheStatus, VFS_CACHE_STATUS_DATA>
 {
 public:
   /*! \cond PRIVATE */
@@ -249,7 +250,7 @@ public:
 /// @copydetails cpp_kodi_vfs_Defs_HttpHeader_Help
 ///
 ///@{
-class HttpHeader
+class ATTRIBUTE_HIDDEN HttpHeader
 {
 public:
   //==========================================================================
@@ -496,7 +497,7 @@ public:
 /// to enjoy it.
 ///
 //@{
-class CDirEntry
+class ATTRIBUTE_HIDDEN CDirEntry
 {
 public:
   //============================================================================
@@ -727,7 +728,7 @@ private:
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool CreateDirectory(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN CreateDirectory(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -759,7 +760,7 @@ inline bool CreateDirectory(const std::string& path)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool DirectoryExists(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN DirectoryExists(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -792,7 +793,7 @@ inline bool DirectoryExists(const std::string& path)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool RemoveDirectory(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN RemoveDirectory(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -837,9 +838,9 @@ inline bool RemoveDirectory(const std::string& path)
 ///             items[i].Path().c_str());
 /// }
 /// ~~~~~~~~~~~~~
-inline bool GetDirectory(const std::string& path,
-                         const std::string& mask,
-                         std::vector<kodi::vfs::CDirEntry>& items)
+inline bool ATTRIBUTE_HIDDEN GetDirectory(const std::string& path,
+                                          const std::string& mask,
+                                          std::vector<kodi::vfs::CDirEntry>& items)
 {
   using namespace kodi::addon;
 
@@ -889,7 +890,7 @@ inline bool GetDirectory(const std::string& path,
 /// fprintf(stderr, "Log file should be always present, is it present? %s\n", exists ? "yes" : "no");
 /// ~~~~~~~~~~~~~
 ///
-inline bool FileExists(const std::string& filename, bool usecache = false)
+inline bool ATTRIBUTE_HIDDEN FileExists(const std::string& filename, bool usecache = false)
 {
   using namespace kodi::addon;
 
@@ -944,7 +945,7 @@ inline bool FileExists(const std::string& filename, bool usecache = false)
 ///                      ret);
 /// ~~~~~~~~~~~~~
 ///
-inline bool StatFile(const std::string& filename, kodi::vfs::FileStatus& buffer)
+inline bool ATTRIBUTE_HIDDEN StatFile(const std::string& filename, kodi::vfs::FileStatus& buffer)
 {
   using namespace kodi::addon;
 
@@ -982,7 +983,7 @@ inline bool StatFile(const std::string& filename, kodi::vfs::FileStatus& buffer)
 /// }
 /// ~~~~~~~~~~~~~
 ///
-inline bool DeleteFile(const std::string& filename)
+inline bool ATTRIBUTE_HIDDEN DeleteFile(const std::string& filename)
 {
   using namespace kodi::addon;
 
@@ -1000,7 +1001,7 @@ inline bool DeleteFile(const std::string& filename)
 /// @return true if successfully renamed
 ///
 ///
-inline bool RenameFile(const std::string& filename, const std::string& newFileName)
+inline bool ATTRIBUTE_HIDDEN RenameFile(const std::string& filename, const std::string& newFileName)
 {
   using namespace kodi::addon;
 
@@ -1018,7 +1019,7 @@ inline bool RenameFile(const std::string& filename, const std::string& newFileNa
 /// @return true if successfully copied
 ///
 ///
-inline bool CopyFile(const std::string& filename, const std::string& destination)
+inline bool ATTRIBUTE_HIDDEN CopyFile(const std::string& filename, const std::string& destination)
 {
   using namespace kodi::addon;
 
@@ -1059,7 +1060,7 @@ inline bool CopyFile(const std::string& filename, const std::string& destination
 /// }
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetFileMD5(const std::string& path)
+inline std::string ATTRIBUTE_HIDDEN GetFileMD5(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -1102,7 +1103,7 @@ inline std::string GetFileMD5(const std::string& path)
 /// }
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetCacheThumbName(const std::string& filename)
+inline std::string ATTRIBUTE_HIDDEN GetCacheThumbName(const std::string& filename)
 {
   using namespace kodi::addon;
 
@@ -1145,7 +1146,7 @@ inline std::string GetCacheThumbName(const std::string& filename)
 /// /* Returns as legal: 'jk___lj____.mpg' */
 /// ~~~~~~~~~~~~~
 ///
-inline std::string MakeLegalFileName(const std::string& filename)
+inline std::string ATTRIBUTE_HIDDEN MakeLegalFileName(const std::string& filename)
 {
   using namespace kodi::addon;
 
@@ -1188,7 +1189,7 @@ inline std::string MakeLegalFileName(const std::string& filename)
 /// /* Returns as legal: '/jk___lj____/hgjkg' */
 /// ~~~~~~~~~~~~~
 ///
-inline std::string MakeLegalPath(const std::string& path)
+inline std::string ATTRIBUTE_HIDDEN MakeLegalPath(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -1236,7 +1237,7 @@ inline std::string MakeLegalPath(const std::string& path)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string TranslateSpecialProtocol(const std::string& source)
+inline std::string ATTRIBUTE_HIDDEN TranslateSpecialProtocol(const std::string& source)
 {
   using namespace kodi::addon;
 
@@ -1290,10 +1291,10 @@ inline std::string TranslateSpecialProtocol(const std::string& source)
 /// fprintf(stderr, " - available: %lu MByte\n", available / 1024 / 1024);
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetDiskSpace(const std::string& path,
-                         uint64_t& capacity,
-                         uint64_t& free,
-                         uint64_t& available)
+inline bool ATTRIBUTE_HIDDEN GetDiskSpace(const std::string& path,
+                                          uint64_t& capacity,
+                                          uint64_t& free,
+                                          uint64_t& available)
 {
   using namespace kodi::addon;
 
@@ -1320,7 +1321,7 @@ inline bool GetDiskSpace(const std::string& path,
 /// fprintf(stderr, "File name is '%s'\n", fileName.c_str());
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetFileName(const std::string& path)
+inline std::string ATTRIBUTE_HIDDEN GetFileName(const std::string& path)
 {
   /* find the last slash */
   const size_t slash = path.find_last_of("/\\");
@@ -1346,7 +1347,7 @@ inline std::string GetFileName(const std::string& path)
 /// fprintf(stderr, "Directory name is '%s'\n", dirName.c_str());
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetDirectoryName(const std::string& path)
+inline std::string ATTRIBUTE_HIDDEN GetDirectoryName(const std::string& path)
 {
   // Will from a full filename return the directory the file resides in.
   // Keeps the final slash at end and possible |option=foo options.
@@ -1381,7 +1382,7 @@ inline std::string GetDirectoryName(const std::string& path)
 /// fprintf(stderr, "Directory name is '%s'\n", dirName.c_str());
 /// ~~~~~~~~~~~~~
 ///
-inline void RemoveSlashAtEnd(std::string& path)
+inline void ATTRIBUTE_HIDDEN RemoveSlashAtEnd(std::string& path)
 {
   if (!path.empty())
   {
@@ -1401,7 +1402,7 @@ inline void RemoveSlashAtEnd(std::string& path)
 /// @param[in] minimum The minimum size (or maybe the minimum number of chunks?)
 /// @return The aligned size
 ///
-inline unsigned int GetChunkSize(unsigned int chunk, unsigned int minimum)
+inline unsigned int ATTRIBUTE_HIDDEN GetChunkSize(unsigned int chunk, unsigned int minimum)
 {
   if (chunk)
     return chunk * ((minimum + chunk - 1) / chunk);
@@ -1458,7 +1459,7 @@ inline unsigned int GetChunkSize(unsigned int chunk, unsigned int minimum)
 ///                     kodi::vfs::IsInternetStream("ftp://do-somewhere.com/the-file.mkv") ? "yes" : "no", true);
 /// ~~~~~~~~~~~~~
 ///
-inline bool IsInternetStream(const std::string& path, bool strictCheck = false)
+inline bool ATTRIBUTE_HIDDEN IsInternetStream(const std::string& path, bool strictCheck = false)
 {
   using namespace kodi::addon;
 
@@ -1490,7 +1491,7 @@ inline bool IsInternetStream(const std::string& path, bool strictCheck = false)
 /// bool lan = kodi::vfs::IsOnLAN("smb://path/to/file");
 /// ~~~~~~~~~~~~~
 ///
-inline bool IsOnLAN(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN IsOnLAN(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -1519,7 +1520,7 @@ inline bool IsOnLAN(const std::string& path)
 /// bool remote = kodi::vfs::IsRemote("http://path/to/file");
 /// ~~~~~~~~~~~~~
 ///
-inline bool IsRemote(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN IsRemote(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -1535,7 +1536,7 @@ inline bool IsRemote(const std::string& path)
 /// @param[in] path To checked path
 /// @return True if path is local, false otherwise
 ///
-inline bool IsLocal(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN IsLocal(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -1566,7 +1567,7 @@ inline bool IsLocal(const std::string& path)
 /// isURL = kodi::vfs::IsURL("/path/to/file");
 /// ~~~~~~~~~~~~~
 ///
-inline bool IsURL(const std::string& path)
+inline bool ATTRIBUTE_HIDDEN IsURL(const std::string& path)
 {
   using namespace kodi::addon;
 
@@ -1599,7 +1600,7 @@ inline bool IsURL(const std::string& path)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetHttpHeader(const std::string& url, HttpHeader& header)
+inline bool ATTRIBUTE_HIDDEN GetHttpHeader(const std::string& url, HttpHeader& header)
 {
   using namespace ::kodi::addon;
 
@@ -1630,9 +1631,9 @@ inline bool GetHttpHeader(const std::string& url, HttpHeader& header)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetMimeType(const std::string& url,
-                        std::string& mimeType,
-                        const std::string& useragent = "")
+inline bool ATTRIBUTE_HIDDEN GetMimeType(const std::string& url,
+                                         std::string& mimeType,
+                                         const std::string& useragent = "")
 {
   using namespace ::kodi::addon;
 
@@ -1671,9 +1672,9 @@ inline bool GetMimeType(const std::string& url,
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetContentType(const std::string& url,
-                           std::string& content,
-                           const std::string& useragent = "")
+inline bool ATTRIBUTE_HIDDEN GetContentType(const std::string& url,
+                                            std::string& content,
+                                            const std::string& useragent = "")
 {
   using namespace ::kodi::addon;
 
@@ -1713,7 +1714,7 @@ inline bool GetContentType(const std::string& url,
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetCookies(const std::string& url, std::string& cookies)
+inline bool ATTRIBUTE_HIDDEN GetCookies(const std::string& url, std::string& cookies)
 {
   using namespace ::kodi::addon;
 
@@ -1777,7 +1778,7 @@ inline bool GetCookies(const std::string& url, std::string& cookies)
 /// ~~~~~~~~~~~~~
 ///
 //@{
-class CFile
+class ATTRIBUTE_HIDDEN CFile
 {
 public:
   //============================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -147,7 +147,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetAddonInfo(const std::string& id)
+inline std::string ATTRIBUTE_HIDDEN GetAddonInfo(const std::string& id)
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
 
@@ -183,7 +183,7 @@ namespace kodi {
 /// ..
 /// ~~~~~~~~~~~~~
 ///
-inline bool OpenSettings()
+inline bool ATTRIBUTE_HIDDEN OpenSettings()
 {
   return ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->open_settings_dialog(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
 }
@@ -219,7 +219,8 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetLocalizedString(uint32_t labelId, const std::string& defaultStr = "")
+inline std::string ATTRIBUTE_HIDDEN GetLocalizedString(uint32_t labelId,
+                                                       const std::string& defaultStr = "")
 {
   std::string retString = defaultStr;
   char* strMsg = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_localized_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, labelId);
@@ -258,7 +259,9 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool UnknownToUTF8(const std::string& stringSrc, std::string& utf8StringDst, bool failOnBadChar = false)
+inline bool ATTRIBUTE_HIDDEN UnknownToUTF8(const std::string& stringSrc,
+                                           std::string& utf8StringDst,
+                                           bool failOnBadChar = false)
 {
   bool ret = false;
   char* retString = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->unknown_to_utf8(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase,
@@ -300,7 +303,8 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetLanguage(LangFormats format = LANG_FMT_ENGLISH_NAME, bool region = false)
+inline std::string ATTRIBUTE_HIDDEN GetLanguage(LangFormats format = LANG_FMT_ENGLISH_NAME,
+                                                bool region = false)
 {
   std::string language;
   char* retString = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_language(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, format, region);
@@ -393,7 +397,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline void QueueFormattedNotification(QueueMsg type, const char* format, ... )
+inline void ATTRIBUTE_HIDDEN QueueFormattedNotification(QueueMsg type, const char* format, ...)
 {
   va_list args;
   char buffer[16384];
@@ -453,10 +457,13 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline void QueueNotification(QueueMsg type, const std::string& header,
-                              const std::string& message, const std::string& imageFile = "",
-                              unsigned int displayTime = 5000, bool withSound = true,
-                              unsigned int messageTime = 1000)
+inline void ATTRIBUTE_HIDDEN QueueNotification(QueueMsg type,
+                                               const std::string& header,
+                                               const std::string& message,
+                                               const std::string& imageFile = "",
+                                               unsigned int displayTime = 5000,
+                                               bool withSound = true,
+                                               unsigned int messageTime = 1000)
 {
   ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->queue_notification(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase,
                                                                            type, header.c_str(), message.c_str(), imageFile.c_str(), displayTime,
@@ -486,7 +493,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetMD5(const std::string& text)
+inline std::string ATTRIBUTE_HIDDEN GetMD5(const std::string& text)
 {
   char* md5ret = static_cast<char*>(malloc(40*sizeof(char))); // md5 size normally 32 bytes
   ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_md5(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, text.c_str(), md5ret);
@@ -510,7 +517,7 @@ namespace kodi {
 /// @param[in] append A string to append to returned temporary path
 /// @return Individual path for the addon
 ///
-inline std::string GetTempAddonPath(const std::string& append = "")
+inline std::string ATTRIBUTE_HIDDEN GetTempAddonPath(const std::string& append = "")
 {
   char* str = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_temp_path(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
   std::string ret = str;
@@ -556,7 +563,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetRegion(const std::string& id)
+inline std::string ATTRIBUTE_HIDDEN GetRegion(const std::string& id)
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
 
@@ -598,7 +605,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline void GetFreeMem(long& free, long& total, bool asBytes = false)
+inline void ATTRIBUTE_HIDDEN GetFreeMem(long& free, long& total, bool asBytes = false)
 {
   free = -1;
   total = -1;
@@ -627,7 +634,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline int GetGlobalIdleTime()
+inline int ATTRIBUTE_HIDDEN GetGlobalIdleTime()
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
   return toKodi->kodi->get_global_idle_time(toKodi->kodiBase);
@@ -658,7 +665,7 @@ namespace kodi {
 /// ..
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetCurrentSkinId()
+inline std::string ATTRIBUTE_HIDDEN GetCurrentSkinId()
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
 
@@ -700,7 +707,9 @@ namespace kodi
 ///            ret ? version.c_str() : "not installed", enabled ? "yes" : "no");
 /// ~~~~~~~~~~~~~
 ///
-inline bool IsAddonAvailable(const std::string& id, std::string& version, bool& enabled)
+inline bool ATTRIBUTE_HIDDEN IsAddonAvailable(const std::string& id,
+                                              std::string& version,
+                                              bool& enabled)
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
 
@@ -758,7 +767,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline void KodiVersion(kodi_version_t& version)
+inline void ATTRIBUTE_HIDDEN KodiVersion(kodi_version_t& version)
 {
   char* compile_name = nullptr;
   char* revision = nullptr;
@@ -830,7 +839,9 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool GetKeyboardLayout(int modifierKey, std::string& layout_name, std::vector<std::vector<std::string>>& layout)
+inline bool ATTRIBUTE_HIDDEN GetKeyboardLayout(int modifierKey,
+                                               std::string& layout_name,
+                                               std::vector<std::vector<std::string>>& layout)
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
   AddonKeyboardKeyTable c_layout;
@@ -900,7 +911,7 @@ namespace kodi {
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool ChangeKeyboardLayout(std::string& layout_name)
+inline bool ATTRIBUTE_HIDDEN ChangeKeyboardLayout(std::string& layout_name)
 {
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
   char* c_layout_name = nullptr;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -9,94 +9,9 @@
 #pragma once
 
 #include "AddonBase.h"
+#include "c-api/general.h"
 
-//==============================================================================
-/// \ingroup cpp_kodi_Defs
-/// @brief For kodi::CurrentKeyboardLayout used defines
-///
-typedef enum StdKbButtons
-{
-  /// The quantity of buttons per row on Kodi's standard keyboard
-  STD_KB_BUTTONS_PER_ROW = 20,
-  /// The quantity of rows on Kodi's standard keyboard
-  STD_KB_BUTTONS_MAX_ROWS = 4,
-  /// Keyboard layout type, this for initial standard
-  STD_KB_MODIFIER_KEY_NONE = 0x00,
-  /// Keyboard layout type, this for shift controled layout (uppercase)
-  STD_KB_MODIFIER_KEY_SHIFT = 0x01,
-  /// Keyboard layout type, this to show symbols
-  STD_KB_MODIFIER_KEY_SYMBOL = 0x02
-} StdKbButtons;
-//------------------------------------------------------------------------------
-
-/*
- * For interface between add-on and kodi.
- *
- * This structure defines the addresses of functions stored inside Kodi which
- * are then available for the add-on to call
- *
- * All function pointers there are used by the C++ interface functions below.
- * You find the set of them on xbmc/addons/interfaces/General.cpp
- *
- * Note: For add-on development itself this is not needed
- */
-typedef struct AddonKeyboardKeyTable
-{
-  char* keys[STD_KB_BUTTONS_MAX_ROWS][STD_KB_BUTTONS_PER_ROW];
-} AddonKeyboardKeyTable;
-typedef struct AddonToKodiFuncTable_kodi
-{
-  char* (*get_addon_info)(void* kodiBase, const char* id);
-  bool (*open_settings_dialog)(void* kodiBase);
-  char* (*unknown_to_utf8)(void* kodiBase, const char* source, bool* ret, bool failOnBadChar);
-  char* (*get_localized_string)(void* kodiBase, long label_id);
-  char* (*get_language)(void* kodiBase, int format, bool region);
-  bool (*queue_notification)(void* kodiBase, int type, const char* header, const char* message, const char* imageFile, unsigned int displayTime, bool withSound, unsigned int messageTime);
-  void (*get_md5)(void* kodiBase, const char* text, char* md5);
-  char* (*get_temp_path)(void* kodiBase);
-  char* (*get_region)(void* kodiBase, const char* id);
-  void (*get_free_mem)(void* kodiBase, long* free, long* total, bool as_bytes);
-  int  (*get_global_idle_time)(void* kodiBase);
-  bool (*is_addon_avilable)(void* kodiBase, const char* id, char** version, bool* enabled);
-  void (*kodi_version)(void* kodiBase, char** compile_name, int* major, int* minor, char** revision, char** tag, char** tagversion);
-  char* (*get_current_skin_id)(void* kodiBase);
-  bool (*get_keyboard_layout)(void* kodiBase, char** layout_name, int modifier_key, AddonKeyboardKeyTable* layout);
-  bool (*change_keyboard_layout)(void* kodiBase, char** layout_name);
-} AddonToKodiFuncTable_kodi;
-
-//==============================================================================
-/// \ingroup cpp_kodi_Defs
-/// @brief For kodi::QueueNotification() used message types
-///
-typedef enum QueueMsg
-{
-  /// Show info notification message
-  QUEUE_INFO,
-  /// Show warning notification message
-  QUEUE_WARNING,
-  /// Show error notification message
-  QUEUE_ERROR,
-  /// Show with own given image and parts if set on values
-  QUEUE_OWN_STYLE
-} QueueMsg;
-//------------------------------------------------------------------------------
-
-//==============================================================================
-/// \ingroup cpp_kodi_Defs
-/// @brief Format codes to get string from them.
-///
-/// Used on kodi::GetLanguage().
-///
-typedef enum LangFormats
-{
-  /// two letter code as defined in ISO 639-1
-  LANG_FMT_ISO_639_1,
-  /// three letter code as defined in ISO 639-2/T or ISO 639-2/B
-  LANG_FMT_ISO_639_2,
-  /// full language name in English
-  LANG_FMT_ENGLISH_NAME
-} LangFormats;
-//------------------------------------------------------------------------------
+#ifdef __cplusplus
 
 //==============================================================================
 /// \ingroup cpp_kodi_Defs
@@ -878,3 +793,5 @@ inline bool ATTRIBUTE_HIDDEN ChangeKeyboardLayout(std::string& layout_name)
 //------------------------------------------------------------------------------
 
 } /* namespace kodi */
+
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -65,7 +65,9 @@ namespace kodi
 ///
 inline std::string ATTRIBUTE_HIDDEN GetAddonInfo(const std::string& id)
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
 
   std::string strReturn;
   char* strMsg = toKodi->kodi->get_addon_info(toKodi->kodiBase, id.c_str());
@@ -98,7 +100,9 @@ inline std::string ATTRIBUTE_HIDDEN GetAddonInfo(const std::string& id)
 ///
 inline bool ATTRIBUTE_HIDDEN OpenSettings()
 {
-  return ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->open_settings_dialog(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
+  using namespace kodi::addon;
+  return CAddonBase::m_interface->toKodi->kodi->open_settings_dialog(
+      CAddonBase::m_interface->toKodi->kodiBase);
 }
 //------------------------------------------------------------------------------
 
@@ -132,13 +136,16 @@ inline bool ATTRIBUTE_HIDDEN OpenSettings()
 inline std::string ATTRIBUTE_HIDDEN GetLocalizedString(uint32_t labelId,
                                                        const std::string& defaultStr = "")
 {
+  using namespace kodi::addon;
+
   std::string retString = defaultStr;
-  char* strMsg = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_localized_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, labelId);
+  char* strMsg = CAddonBase::m_interface->toKodi->kodi->get_localized_string(
+      CAddonBase::m_interface->toKodi->kodiBase, labelId);
   if (strMsg != nullptr)
   {
     if (std::strlen(strMsg))
       retString = strMsg;
-    ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, strMsg);
+    CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, strMsg);
   }
   return retString;
 }
@@ -170,14 +177,17 @@ inline bool ATTRIBUTE_HIDDEN UnknownToUTF8(const std::string& stringSrc,
                                            std::string& utf8StringDst,
                                            bool failOnBadChar = false)
 {
+  using namespace kodi::addon;
+
   bool ret = false;
-  char* retString = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->unknown_to_utf8(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase,
-                                                                                          stringSrc.c_str(), &ret, failOnBadChar);
+  char* retString = CAddonBase::m_interface->toKodi->kodi->unknown_to_utf8(
+      CAddonBase::m_interface->toKodi->kodiBase, stringSrc.c_str(), &ret, failOnBadChar);
   if (retString != nullptr)
   {
     if (ret)
       utf8StringDst = retString;
-    ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, retString);
+    CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase,
+                                                 retString);
   }
   return ret;
 }
@@ -210,13 +220,17 @@ inline bool ATTRIBUTE_HIDDEN UnknownToUTF8(const std::string& stringSrc,
 inline std::string ATTRIBUTE_HIDDEN GetLanguage(LangFormats format = LANG_FMT_ENGLISH_NAME,
                                                 bool region = false)
 {
+  using namespace kodi::addon;
+
   std::string language;
-  char* retString = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_language(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, format, region);
+  char* retString = CAddonBase::m_interface->toKodi->kodi->get_language(
+      CAddonBase::m_interface->toKodi->kodiBase, format, region);
   if (retString != nullptr)
   {
     if (std::strlen(retString))
       language = retString;
-    ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, retString);
+    CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase,
+                                                 retString);
   }
   return language;
 }
@@ -300,13 +314,15 @@ inline std::string ATTRIBUTE_HIDDEN GetLanguage(LangFormats format = LANG_FMT_EN
 ///
 inline void ATTRIBUTE_HIDDEN QueueFormattedNotification(QueueMsg type, const char* format, ...)
 {
+  using namespace kodi::addon;
+
   va_list args;
   char buffer[16384];
   va_start(args, format);
   vsprintf(buffer, format, args);
   va_end(args);
-  ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->queue_notification(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase,
-                                                                           type, "", buffer, "", 5000, false, 1000);
+  CAddonBase::m_interface->toKodi->kodi->queue_notification(
+      CAddonBase::m_interface->toKodi->kodiBase, type, "", buffer, "", 5000, false, 1000);
 }
 //------------------------------------------------------------------------------
 
@@ -363,9 +379,11 @@ inline void ATTRIBUTE_HIDDEN QueueNotification(QueueMsg type,
                                                bool withSound = true,
                                                unsigned int messageTime = 1000)
 {
-  ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->queue_notification(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase,
-                                                                           type, header.c_str(), message.c_str(), imageFile.c_str(), displayTime,
-                                                                           withSound, messageTime);
+  using namespace kodi::addon;
+
+  CAddonBase::m_interface->toKodi->kodi->queue_notification(
+      CAddonBase::m_interface->toKodi->kodiBase, type, header.c_str(), message.c_str(),
+      imageFile.c_str(), displayTime, withSound, messageTime);
 }
 //------------------------------------------------------------------------------
 
@@ -390,8 +408,11 @@ inline void ATTRIBUTE_HIDDEN QueueNotification(QueueMsg type,
 ///
 inline std::string ATTRIBUTE_HIDDEN GetMD5(const std::string& text)
 {
-  char* md5ret = static_cast<char*>(malloc(40*sizeof(char))); // md5 size normally 32 bytes
-  ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_md5(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, text.c_str(), md5ret);
+  using namespace kodi::addon;
+
+  char* md5ret = static_cast<char*>(malloc(40 * sizeof(char))); // md5 size normally 32 bytes
+  CAddonBase::m_interface->toKodi->kodi->get_md5(CAddonBase::m_interface->toKodi->kodiBase,
+                                                 text.c_str(), md5ret);
   std::string md5 = md5ret;
   free(md5ret);
   return md5;
@@ -411,13 +432,15 @@ inline std::string ATTRIBUTE_HIDDEN GetMD5(const std::string& text)
 ///
 inline std::string ATTRIBUTE_HIDDEN GetTempAddonPath(const std::string& append = "")
 {
-  char* str = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_temp_path(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
+  using namespace kodi::addon;
+
+  char* str = CAddonBase::m_interface->toKodi->kodi->get_temp_path(
+      CAddonBase::m_interface->toKodi->kodiBase);
   std::string ret = str;
-  ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, str);
+  CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, str);
   if (!append.empty())
   {
-    if (append.at(0) != '\\' &&
-        append.at(0) != '/')
+    if (append.at(0) != '\\' && append.at(0) != '/')
 #ifdef TARGET_WINDOWS
       ret.append("\\");
 #else
@@ -454,7 +477,9 @@ inline std::string ATTRIBUTE_HIDDEN GetTempAddonPath(const std::string& append =
 ///
 inline std::string ATTRIBUTE_HIDDEN GetRegion(const std::string& id)
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
 
   std::string strReturn;
   char* strMsg = toKodi->kodi->get_region(toKodi->kodiBase, id.c_str());
@@ -493,9 +518,11 @@ inline std::string ATTRIBUTE_HIDDEN GetRegion(const std::string& id)
 ///
 inline void ATTRIBUTE_HIDDEN GetFreeMem(long& free, long& total, bool asBytes = false)
 {
+  using namespace kodi::addon;
+
   free = -1;
   total = -1;
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
   toKodi->kodi->get_free_mem(toKodi->kodiBase, &free, &total, asBytes);
 }
 //------------------------------------------------------------------------------
@@ -519,7 +546,9 @@ inline void ATTRIBUTE_HIDDEN GetFreeMem(long& free, long& total, bool asBytes = 
 ///
 inline int ATTRIBUTE_HIDDEN GetGlobalIdleTime()
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
   return toKodi->kodi->get_global_idle_time(toKodi->kodiBase);
 }
 //------------------------------------------------------------------------------
@@ -547,7 +576,9 @@ inline int ATTRIBUTE_HIDDEN GetGlobalIdleTime()
 ///
 inline std::string ATTRIBUTE_HIDDEN GetCurrentSkinId()
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
 
   std::string strReturn;
   char* strMsg = toKodi->kodi->get_current_skin_id(toKodi->kodiBase);
@@ -587,7 +618,9 @@ inline bool ATTRIBUTE_HIDDEN IsAddonAvailable(const std::string& id,
                                               std::string& version,
                                               bool& enabled)
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
 
   char* cVersion = nullptr;
   bool ret = toKodi->kodi->is_addon_avilable(toKodi->kodiBase, id.c_str(), &cVersion, &enabled);
@@ -641,21 +674,20 @@ inline bool ATTRIBUTE_HIDDEN IsAddonAvailable(const std::string& id,
 ///
 inline void ATTRIBUTE_HIDDEN KodiVersion(kodi_version_t& version)
 {
+  using namespace kodi::addon;
+
   char* compile_name = nullptr;
   char* revision = nullptr;
   char* tag = nullptr;
   char* tag_revision = nullptr;
 
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
-  toKodi->kodi->kodi_version(toKodi->kodiBase, &compile_name, &version.major, &version.minor, &revision, &tag, &tag_revision);
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
+  toKodi->kodi->kodi_version(toKodi->kodiBase, &compile_name, &version.major, &version.minor,
+                             &revision, &tag, &tag_revision);
   if (compile_name != nullptr)
   {
-    version.compile_name  = compile_name;
-    toKodi->free_string
-    (
-      toKodi->kodiBase,
-      compile_name
-    );
+    version.compile_name = compile_name;
+    toKodi->free_string(toKodi->kodiBase, compile_name);
   }
   if (revision != nullptr)
   {
@@ -712,10 +744,13 @@ inline bool ATTRIBUTE_HIDDEN GetKeyboardLayout(int modifierKey,
                                                std::string& layout_name,
                                                std::vector<std::vector<std::string>>& layout)
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
   AddonKeyboardKeyTable c_layout;
   char* c_layout_name = nullptr;
-  bool ret = toKodi->kodi->get_keyboard_layout(toKodi->kodiBase, &c_layout_name, modifierKey, &c_layout);
+  bool ret =
+      toKodi->kodi->get_keyboard_layout(toKodi->kodiBase, &c_layout_name, modifierKey, &c_layout);
   if (ret)
   {
     if (c_layout_name)
@@ -779,7 +814,9 @@ inline bool ATTRIBUTE_HIDDEN GetKeyboardLayout(int modifierKey,
 ///
 inline bool ATTRIBUTE_HIDDEN ChangeKeyboardLayout(std::string& layout_name)
 {
-  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+  using namespace kodi::addon;
+
+  AddonToKodiFuncTable_Addon* toKodi = CAddonBase::m_interface->toKodi;
   char* c_layout_name = nullptr;
   bool ret = toKodi->kodi->change_keyboard_layout(toKodi->kodiBase, &c_layout_name);
   if (c_layout_name)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -119,9 +119,10 @@ typedef struct kodi_version_t
 } kodi_version_t;
 //------------------------------------------------------------------------------
 
+namespace kodi
+{
+
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Returns the value of an addon property as a string
 ///
@@ -161,12 +162,9 @@ inline std::string ATTRIBUTE_HIDDEN GetAddonInfo(const std::string& id)
   }
   return strReturn;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Opens this Add-Ons settings dialog.
 ///
@@ -187,12 +185,9 @@ inline bool ATTRIBUTE_HIDDEN OpenSettings()
 {
   return ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->open_settings_dialog(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Returns an addon's localized 'unicode string'.
 ///
@@ -232,12 +227,9 @@ inline std::string ATTRIBUTE_HIDDEN GetLocalizedString(uint32_t labelId,
   }
   return retString;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Translate a string with an unknown encoding to UTF8.
 ///
@@ -274,12 +266,9 @@ inline bool ATTRIBUTE_HIDDEN UnknownToUTF8(const std::string& stringSrc,
   }
   return ret;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Returns the active language as a string.
 ///
@@ -316,12 +305,9 @@ inline std::string ATTRIBUTE_HIDDEN GetLanguage(LangFormats format = LANG_FMT_EN
   }
   return language;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Writes the C string pointed by format in the GUI. If format includes
 /// format specifiers (subsequences beginning with %), the additional arguments
@@ -407,12 +393,9 @@ inline void ATTRIBUTE_HIDDEN QueueFormattedNotification(QueueMsg type, const cha
   ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->queue_notification(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase,
                                                                            type, "", buffer, "", 5000, false, 1000);
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Queue a notification in the GUI.
 ///
@@ -469,12 +452,9 @@ inline void ATTRIBUTE_HIDDEN QueueNotification(QueueMsg type,
                                                                            type, header.c_str(), message.c_str(), imageFile.c_str(), displayTime,
                                                                            withSound, messageTime);
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Get the MD5 digest of the given text
 ///
@@ -501,12 +481,9 @@ inline std::string ATTRIBUTE_HIDDEN GetMD5(const std::string& text)
   free(md5ret);
   return md5;
 }
-} /* namespace kodi */
 //----------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief To get a temporary path for the addon
 ///
@@ -535,12 +512,9 @@ inline std::string ATTRIBUTE_HIDDEN GetTempAddonPath(const std::string& append =
   }
   return ret;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Returns your regions setting as a string for the specified id
 ///
@@ -577,12 +551,9 @@ inline std::string ATTRIBUTE_HIDDEN GetRegion(const std::string& id)
   }
   return strReturn;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Returns the amount of free memory in MByte (or as bytes) as an long
 /// integer
@@ -612,12 +583,9 @@ inline void ATTRIBUTE_HIDDEN GetFreeMem(long& free, long& total, bool asBytes = 
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
   toKodi->kodi->get_free_mem(toKodi->kodiBase, &free, &total, asBytes);
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Returns the elapsed idle time in seconds as an integer
 ///
@@ -639,12 +607,9 @@ inline int ATTRIBUTE_HIDDEN GetGlobalIdleTime()
   AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
   return toKodi->kodi->get_global_idle_time(toKodi->kodiBase);
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Get the currently used skin identification name from Kodi
 ///
@@ -679,11 +644,7 @@ inline std::string ATTRIBUTE_HIDDEN GetCurrentSkinId()
   }
   return strReturn;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
-
-namespace kodi
-{
 
 //==============================================================================
 /// @brief To check another addon is available and usable inside Kodi.
@@ -724,11 +685,7 @@ inline bool ATTRIBUTE_HIDDEN IsAddonAvailable(const std::string& id,
 }
 //------------------------------------------------------------------------------
 
-} /* namespace kodi */
-
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief Get current Kodi informations and versions, returned data from the following
 /// <b><tt>kodi_version_t version; kodi::KodiVersion(version);</tt></b>
@@ -801,12 +758,9 @@ inline void ATTRIBUTE_HIDDEN KodiVersion(kodi_version_t& version)
     toKodi->free_string(toKodi->kodiBase, tag_revision);
   }
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief To get keyboard layout characters
 ///
@@ -872,12 +826,9 @@ inline bool ATTRIBUTE_HIDDEN GetKeyboardLayout(int modifierKey,
   }
   return ret;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
 
 //==============================================================================
-namespace kodi {
-///
 /// \ingroup cpp_kodi
 /// @brief To change keyboard layout characters
 ///
@@ -924,5 +875,6 @@ inline bool ATTRIBUTE_HIDDEN ChangeKeyboardLayout(std::string& layout_name)
 
   return ret;
 }
-} /* namespace kodi */
 //------------------------------------------------------------------------------
+
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Network.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Network.h
@@ -36,7 +36,7 @@ namespace network
 /// @param[in] mac Network address of the host to wake.
 /// @return True if the magic packet was successfully sent, false otherwise.
 ///
-inline bool WakeOnLan(const std::string& mac)
+inline bool ATTRIBUTE_HIDDEN WakeOnLan(const std::string& mac)
 {
   using namespace ::kodi::addon;
 
@@ -63,7 +63,7 @@ inline bool WakeOnLan(const std::string& mac)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetIPAddress()
+inline std::string ATTRIBUTE_HIDDEN GetIPAddress()
 {
   using namespace ::kodi::addon;
 
@@ -97,7 +97,7 @@ inline std::string GetIPAddress()
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline std::string GetHostname()
+inline std::string ATTRIBUTE_HIDDEN GetHostname()
 {
   using namespace ::kodi::addon;
 
@@ -132,7 +132,7 @@ inline std::string GetHostname()
 /// example output:
 ///   Kodi/19.0-ALPHA1 (X11; Linux x86_64) Ubuntu/20.04 App_Bitness/64 Version/19.0-ALPHA1-Git:20200522-0076d136d3-dirty
 ///
-inline std::string GetUserAgent()
+inline std::string ATTRIBUTE_HIDDEN GetUserAgent()
 {
   using namespace ::kodi::addon;
 
@@ -167,7 +167,7 @@ inline std::string GetUserAgent()
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool IsLocalHost(const std::string& hostname)
+inline bool ATTRIBUTE_HIDDEN IsLocalHost(const std::string& hostname)
 {
   using namespace ::kodi::addon;
 
@@ -184,7 +184,7 @@ inline bool IsLocalHost(const std::string& hostname)
 /// @param[in] offLineCheck Check if in private range, see https://en.wikipedia.org/wiki/Private_network
 /// @return True if host is on a LAN, false otherwise
 ///
-inline bool IsHostOnLAN(const std::string& hostname, bool offLineCheck = false)
+inline bool ATTRIBUTE_HIDDEN IsHostOnLAN(const std::string& hostname, bool offLineCheck = false)
 {
   using namespace kodi::addon;
 
@@ -218,7 +218,7 @@ inline bool IsHostOnLAN(const std::string& hostname, bool offLineCheck = false)
 /// ~~~~~~~~~~~~~
 /// For example, the string: François ,would be encoded as: Fran%C3%A7ois
 ///
-inline std::string URLEncode(const std::string& url)
+inline std::string ATTRIBUTE_HIDDEN URLEncode(const std::string& url)
 {
   using namespace ::kodi::addon;
 
@@ -260,7 +260,7 @@ inline std::string URLEncode(const std::string& url)
 /// ...
 /// ~~~~~~~~~~~~~
 ///
-inline bool DNSLookup(const std::string& hostName, std::string& ipAddress)
+inline bool ATTRIBUTE_HIDDEN DNSLookup(const std::string& hostName, std::string& ipAddress)
 {
   using namespace ::kodi::addon;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -191,7 +191,7 @@ namespace addon
 /// The destruction of the example class `CMyAudioDecoder` is called from
 /// Kodi's header. Manually deleting the add-on instance is not required.
 ///
-class CInstanceAudioDecoder : public IAddonInstance
+class ATTRIBUTE_HIDDEN CInstanceAudioDecoder : public IAddonInstance
 {
 public:
   //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioEncoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioEncoder.h
@@ -55,7 +55,7 @@ namespace kodi
 namespace addon
 {
 
-  class CInstanceAudioEncoder : public IAddonInstance
+  class ATTRIBUTE_HIDDEN CInstanceAudioEncoder : public IAddonInstance
   {
   public:
     //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Game.h
@@ -1294,7 +1294,7 @@ namespace addon
 /// This class is created at addon by Kodi.
 ///
 //------------------------------------------------------------------------------
-class CInstanceGame : public IAddonInstance
+class ATTRIBUTE_HIDDEN CInstanceGame : public IAddonInstance
 {
 public:
   //============================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ImageDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ImageDecoder.h
@@ -195,7 +195,7 @@ namespace addon
 /// Kodi's header. Manually deleting the add-on instance is not required.
 ///
 //------------------------------------------------------------------------------
-class CInstanceImageDecoder : public IAddonInstance
+class ATTRIBUTE_HIDDEN CInstanceImageDecoder : public IAddonInstance
 {
 public:
   //============================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -385,7 +385,7 @@ namespace kodi
 namespace addon
 {
 
-class CInstanceInputStream : public IAddonInstance
+class ATTRIBUTE_HIDDEN CInstanceInputStream : public IAddonInstance
 {
 public:
   explicit CInstanceInputStream(KODI_HANDLE instance, const std::string& kodiVersion = "")

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/PVR.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/PVR.h
@@ -381,7 +381,7 @@ namespace addon
 /// The destruction of the example class `CMyPVRClient` is called from
 /// Kodi's header. Manually deleting the add-on instance is not required.
 ///
-class CInstancePVRClient : public IAddonInstance
+class ATTRIBUTE_HIDDEN CInstancePVRClient : public IAddonInstance
 {
 public:
   //============================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Peripheral.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Peripheral.h
@@ -453,7 +453,7 @@ namespace kodi
 namespace addon
 {
 
-  class CInstancePeripheral : public IAddonInstance
+  class ATTRIBUTE_HIDDEN CInstancePeripheral : public IAddonInstance
   {
   public:
     CInstancePeripheral()

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -219,7 +219,7 @@ namespace addon
   /// Kodi's header. Manually deleting the add-on instance is not required.
   ///
   //----------------------------------------------------------------------------
-  class CInstanceScreensaver : public IAddonInstance
+  class ATTRIBUTE_HIDDEN CInstanceScreensaver : public IAddonInstance
   {
   public:
     //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
@@ -547,7 +547,7 @@ namespace addon
 /// Kodi's header. Manually deleting the add-on instance is not required.
 ///
 //----------------------------------------------------------------------------
-class CInstanceVFS : public IAddonInstance
+class ATTRIBUTE_HIDDEN CInstanceVFS : public IAddonInstance
 {
 public:
   //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -143,7 +143,7 @@ namespace kodi
   namespace addon
   {
 
-    class CInstanceVideoCodec : public IAddonInstance
+    class ATTRIBUTE_HIDDEN CInstanceVideoCodec : public IAddonInstance
     {
     public:
       explicit CInstanceVideoCodec(KODI_HANDLE instance, const std::string& kodiVersion = "")

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Visualization.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Visualization.h
@@ -298,7 +298,7 @@ namespace addon
   /// Kodi's header. Manually deleting the add-on instance is not required.
   ///
   //----------------------------------------------------------------------------
-  class CInstanceVisualization : public IAddonInstance
+  class ATTRIBUTE_HIDDEN CInstanceVisualization : public IAddonInstance
   {
   public:
     //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HEADERS addon_base.h
             audio_engine.h
             filesystem.h
+            general.h
             network.h)
 
 if(NOT ENABLE_STATIC_LIBS)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/general.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/general.h
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+  //============================================================================
+  /// \ingroup cpp_kodi_Defs
+  /// @brief For kodi::CurrentKeyboardLayout used defines
+  ///
+  typedef enum StdKbButtons
+  {
+    /// The quantity of buttons per row on Kodi's standard keyboard
+    STD_KB_BUTTONS_PER_ROW = 20,
+    /// The quantity of rows on Kodi's standard keyboard
+    STD_KB_BUTTONS_MAX_ROWS = 4,
+    /// Keyboard layout type, this for initial standard
+    STD_KB_MODIFIER_KEY_NONE = 0x00,
+    /// Keyboard layout type, this for shift controled layout (uppercase)
+    STD_KB_MODIFIER_KEY_SHIFT = 0x01,
+    /// Keyboard layout type, this to show symbols
+    STD_KB_MODIFIER_KEY_SYMBOL = 0x02
+  } StdKbButtons;
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// \ingroup cpp_kodi_Defs
+  /// @brief For kodi::QueueNotification() used message types
+  ///
+  typedef enum QueueMsg
+  {
+    /// Show info notification message
+    QUEUE_INFO,
+    /// Show warning notification message
+    QUEUE_WARNING,
+    /// Show error notification message
+    QUEUE_ERROR,
+    /// Show with own given image and parts if set on values
+    QUEUE_OWN_STYLE
+  } QueueMsg;
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// \ingroup cpp_kodi_Defs
+  /// @brief Format codes to get string from them.
+  ///
+  /// Used on kodi::GetLanguage().
+  ///
+  typedef enum LangFormats
+  {
+    /// two letter code as defined in ISO 639-1
+    LANG_FMT_ISO_639_1,
+    /// three letter code as defined in ISO 639-2/T or ISO 639-2/B
+    LANG_FMT_ISO_639_2,
+    /// full language name in English
+    LANG_FMT_ENGLISH_NAME
+  } LangFormats;
+  //----------------------------------------------------------------------------
+
+  /*
+   * For interface between add-on and kodi.
+   *
+   * This structure defines the addresses of functions stored inside Kodi which
+   * are then available for the add-on to call
+   *
+   * All function pointers there are used by the C++ interface functions below.
+   * You find the set of them on xbmc/addons/interfaces/General.cpp
+   *
+   * Note: For add-on development itself this is not needed
+   */
+  typedef struct AddonKeyboardKeyTable
+  {
+    char* keys[STD_KB_BUTTONS_MAX_ROWS][STD_KB_BUTTONS_PER_ROW];
+  } AddonKeyboardKeyTable;
+  typedef struct AddonToKodiFuncTable_kodi
+  {
+    char* (*get_addon_info)(void* kodiBase, const char* id);
+    bool (*open_settings_dialog)(void* kodiBase);
+    char* (*unknown_to_utf8)(void* kodiBase, const char* source, bool* ret, bool failOnBadChar);
+    char* (*get_localized_string)(void* kodiBase, long label_id);
+    char* (*get_language)(void* kodiBase, int format, bool region);
+    bool (*queue_notification)(void* kodiBase,
+                               int type,
+                               const char* header,
+                               const char* message,
+                               const char* imageFile,
+                               unsigned int displayTime,
+                               bool withSound,
+                               unsigned int messageTime);
+    void (*get_md5)(void* kodiBase, const char* text, char* md5);
+    char* (*get_temp_path)(void* kodiBase);
+    char* (*get_region)(void* kodiBase, const char* id);
+    void (*get_free_mem)(void* kodiBase, long* free, long* total, bool as_bytes);
+    int (*get_global_idle_time)(void* kodiBase);
+    bool (*is_addon_avilable)(void* kodiBase, const char* id, char** version, bool* enabled);
+    void (*kodi_version)(void* kodiBase,
+                         char** compile_name,
+                         int* major,
+                         int* minor,
+                         char** revision,
+                         char** tag,
+                         char** tagversion);
+    char* (*get_current_skin_id)(void* kodiBase);
+    bool (*get_keyboard_layout)(void* kodiBase,
+                                char** layout_name,
+                                int modifier_key,
+                                struct AddonKeyboardKeyTable* layout);
+    bool (*change_keyboard_layout)(void* kodiBase, char** layout_name);
+  } AddonToKodiFuncTable_kodi;
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h
@@ -37,7 +37,7 @@ namespace gui
   /// \ingroup cpp_kodi_gui
   /// @brief Performs a graphical lock of rendering engine
   ///
-  inline void Lock()
+  inline void ATTRIBUTE_HIDDEN Lock()
   {
     using namespace ::kodi::addon;
     CAddonBase::m_interface->toKodi->kodi_gui->general->lock();
@@ -50,7 +50,7 @@ namespace gui
   /// \ingroup cpp_kodi_gui
   /// @brief Performs a graphical unlock of previous locked rendering engine
   ///
-  inline void Unlock()
+  inline void ATTRIBUTE_HIDDEN Unlock()
   {
     using namespace ::kodi::addon;
     CAddonBase::m_interface->toKodi->kodi_gui->general->unlock();
@@ -62,7 +62,7 @@ namespace gui
   /// \ingroup cpp_kodi_gui
   /// @brief Return the the current screen height with pixel
   ///
-  inline int GetScreenHeight()
+  inline int ATTRIBUTE_HIDDEN GetScreenHeight()
   {
     using namespace ::kodi::addon;
     return CAddonBase::m_interface->toKodi->kodi_gui->general->get_screen_height(CAddonBase::m_interface->toKodi->kodiBase);
@@ -74,7 +74,7 @@ namespace gui
   /// \ingroup cpp_kodi_gui
   /// @brief Return the the current screen width with pixel
   ///
-  inline int GetScreenWidth()
+  inline int ATTRIBUTE_HIDDEN GetScreenWidth()
   {
     using namespace ::kodi::addon;
     return CAddonBase::m_interface->toKodi->kodi_gui->general->get_screen_width(CAddonBase::m_interface->toKodi->kodiBase);
@@ -86,7 +86,7 @@ namespace gui
   /// \ingroup cpp_kodi_gui
   /// @brief Return the the current screen rendering resolution
   ///
-  inline int GetVideoResolution()
+  inline int ATTRIBUTE_HIDDEN GetVideoResolution()
   {
     using namespace ::kodi::addon;
     return CAddonBase::m_interface->toKodi->kodi_gui->general->get_video_resolution(CAddonBase::m_interface->toKodi->kodiBase);
@@ -110,7 +110,7 @@ namespace gui
   /// ..
   /// ~~~~~~~~~~~~~
   ///
-  inline int GetCurrentWindowDialogId()
+  inline int ATTRIBUTE_HIDDEN GetCurrentWindowDialogId()
   {
     using namespace ::kodi::addon;
     return CAddonBase::m_interface->toKodi->kodi_gui->general->get_current_window_dialog_id(CAddonBase::m_interface->toKodi->kodiBase);
@@ -134,7 +134,7 @@ namespace gui
   /// ..
   /// ~~~~~~~~~~~~~
   ///
-  inline int GetCurrentWindowId()
+  inline int ATTRIBUTE_HIDDEN GetCurrentWindowId()
   {
     using namespace ::kodi::addon;
     return CAddonBase::m_interface->toKodi->kodi_gui->general->get_current_window_id(CAddonBase::m_interface->toKodi->kodiBase);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
@@ -20,7 +20,7 @@ namespace gui
 
   class CWindow;
 
-  class CAddonGUIControlBase
+  class ATTRIBUTE_HIDDEN CAddonGUIControlBase
   {
   public:
     GUIHANDLE GetControlHandle() const { return m_controlHandle; }
@@ -69,7 +69,7 @@ namespace gui
   /// @brief **Library definition values**
   ///
 
-  class CListItem : public CAddonGUIControlBase
+  class ATTRIBUTE_HIDDEN CListItem : public CAddonGUIControlBase
   {
   public:
     //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/Window.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/Window.h
@@ -60,7 +60,7 @@ namespace gui
   /// @brief <b>Library definition values</b>
   ///
 
-  class CWindow : public CAddonGUIControlBase
+  class ATTRIBUTE_HIDDEN CWindow : public CAddonGUIControlBase
   {
   public:
     //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Button.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Button.h
@@ -18,147 +18,153 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CButton Control Button
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CButton }
+/// **Standard push button control for window**
+///
+/// The  button  control  is used for creating push buttons  in Kodi.  You can
+/// choose the position,  size,  and look of the button,  as well as  choosing
+/// what action(s) should be performed when pushed.
+///
+/// It has the header \ref Button.h "#include <kodi/gui/controls/Button.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref skin_Button_control "button control"
+///
+/// @note The call of the control is  only  possible  from  the  corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CButton : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CButton Control Button
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CButton }
-  /// **Standard push button control for window**
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief Construct a new control
   ///
-  /// The  button  control  is used for creating push buttons  in Kodi.  You can
-  /// choose the position,  size,  and look of the button,  as well as  choosing
-  /// what action(s) should be performed when pushed.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref Button.h "#include <kodi/gui/controls/Button.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref skin_Button_control "button control"
-  ///
-  /// @note The call of the control is  only  possible  from  the  corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CButton : public CAddonGUIControlBase
+  CButton(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CButton(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_button(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::CButton can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_button(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL, "kodi::gui::CButton can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Destructor
-    ///
-    ~CButton() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief Destructor
+  ///
+  ~CButton() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_button->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_button->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                       visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Set's the control's enabled/disabled state
-    ///
-    /// @param[in] enabled              If true enabled, otherwise disabled
-    ///
-    void SetEnabled(bool enabled)
-    {
-      m_interface->kodi_gui->control_button->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief Set's the control's enabled/disabled state
+  ///
+  /// @param[in] enabled              If true enabled, otherwise disabled
+  ///
+  void SetEnabled(bool enabled)
+  {
+    m_interface->kodi_gui->control_button->set_enabled(m_interface->kodiBase, m_controlHandle,
+                                                       enabled);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief To set the text string on button
-    ///
-    /// @param[in] label                Text to show
-    ///
-    void SetLabel(const std::string& label)
-    {
-      m_interface->kodi_gui->control_button->set_label(m_interface->kodiBase, m_controlHandle, label.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief To set the text string on button
+  ///
+  /// @param[in] label                Text to show
+  ///
+  void SetLabel(const std::string& label)
+  {
+    m_interface->kodi_gui->control_button->set_label(m_interface->kodiBase, m_controlHandle,
+                                                     label.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Get the used text from button
-    ///
-    /// @return                         Text shown
-    ///
-    std::string GetLabel() const
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief Get the used text from button
+  ///
+  /// @return                         Text shown
+  ///
+  std::string GetLabel() const
+  {
+    std::string label;
+    char* ret =
+        m_interface->kodi_gui->control_button->get_label(m_interface->kodiBase, m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_button->get_label(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      if (std::strlen(ret))
+        label = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return label;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief If two labels are used for button becomes it set with them
-    ///
-    /// @param[in] label                Text for second label
-    ///
-    void SetLabel2(const std::string& label)
-    {
-      m_interface->kodi_gui->control_button->set_label2(m_interface->kodiBase, m_controlHandle, label.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief If two labels are used for button becomes it set with them
+  ///
+  /// @param[in] label                Text for second label
+  ///
+  void SetLabel2(const std::string& label)
+  {
+    m_interface->kodi_gui->control_button->set_label2(m_interface->kodiBase, m_controlHandle,
+                                                      label.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Get the second label if present
-    ///
-    /// @return                         Second label
-    ///
-    std::string GetLabel2() const
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_gui_control_CButton
+  /// @brief Get the second label if present
+  ///
+  /// @return                         Second label
+  ///
+  std::string GetLabel2() const
+  {
+    std::string label;
+    char* ret =
+        m_interface->kodi_gui->control_button->get_label2(m_interface->kodiBase, m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_button->get_label2(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      if (std::strlen(ret))
+        label = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
-  };
+    return label;
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Edit.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Edit.h
@@ -95,170 +95,180 @@ namespace gui
 namespace controls
 {
 
-  class CEdit : public CAddonGUIControlBase
+class ATTRIBUTE_HIDDEN CEdit : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Construct a new control
+  ///
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
+  ///
+  CEdit(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CEdit(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_edit(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::control::CEdit can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_edit(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::control::CEdit can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Destructor
-    ///
-    ~CEdit() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Destructor
+  ///
+  ~CEdit() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_edit->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_edit->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                     visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Set's the control's enabled/disabled state
-    ///
-    /// @param[in] enabled              If true enabled, otherwise disabled
-    ///
-    void SetEnabled(bool enabled)
-    {
-      m_interface->kodi_gui->control_edit->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Set's the control's enabled/disabled state
+  ///
+  /// @param[in] enabled              If true enabled, otherwise disabled
+  ///
+  void SetEnabled(bool enabled)
+  {
+    m_interface->kodi_gui->control_edit->set_enabled(m_interface->kodiBase, m_controlHandle,
+                                                     enabled);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief To set the text string on edit control
-    ///
-    /// @param[in] label                Text to show
-    ///
-    void SetLabel(const std::string& label)
-    {
-      m_interface->kodi_gui->control_edit->set_label(m_interface->kodiBase, m_controlHandle, label.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief To set the text string on edit control
+  ///
+  /// @param[in] label                Text to show
+  ///
+  void SetLabel(const std::string& label)
+  {
+    m_interface->kodi_gui->control_edit->set_label(m_interface->kodiBase, m_controlHandle,
+                                                   label.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Returns the text heading for this edit control.
-    ///
-    /// @return                         Heading text
-    ///
-    std::string GetLabel() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Returns the text heading for this edit control.
+  ///
+  /// @return                         Heading text
+  ///
+  std::string GetLabel() const
+  {
+    std::string label;
+    char* ret =
+        m_interface->kodi_gui->control_edit->get_label(m_interface->kodiBase, m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_edit->get_label(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      if (std::strlen(ret))
+        label = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return label;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Set's text heading for this edit control.
-    ///
-    /// @param[in] text                 string or unicode - text string.
-    ///
-    void SetText(const std::string& text)
-    {
-      m_interface->kodi_gui->control_edit->set_text(m_interface->kodiBase, m_controlHandle, text.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Set's text heading for this edit control.
+  ///
+  /// @param[in] text                 string or unicode - text string.
+  ///
+  void SetText(const std::string& text)
+  {
+    m_interface->kodi_gui->control_edit->set_text(m_interface->kodiBase, m_controlHandle,
+                                                  text.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Returns the text value for this edit control.
-    ///
-    /// @return                         Text value of control
-    ///
-    std::string GetText() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Returns the text value for this edit control.
+  ///
+  /// @return                         Text value of control
+  ///
+  std::string GetText() const
+  {
+    std::string text;
+    char* ret =
+        m_interface->kodi_gui->control_edit->get_text(m_interface->kodiBase, m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string text;
-      char* ret = m_interface->kodi_gui->control_edit->get_text(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          text = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return text;
+      if (std::strlen(ret))
+        text = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return text;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief Set the cursor position on text.
-    ///
-    /// @param[in] iPosition            The position to set
-    ///
-    void SetCursorPosition(unsigned int iPosition)
-    {
-      m_interface->kodi_gui->control_edit->set_cursor_position(m_interface->kodiBase, m_controlHandle, iPosition);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief Set the cursor position on text.
+  ///
+  /// @param[in] iPosition            The position to set
+  ///
+  void SetCursorPosition(unsigned int iPosition)
+  {
+    m_interface->kodi_gui->control_edit->set_cursor_position(m_interface->kodiBase, m_controlHandle,
+                                                             iPosition);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief To get current cursor position on text field
-    ///
-    /// @return                         The current cursor position
-    ///
-    unsigned int GetCursorPosition()
-    {
-      return m_interface->kodi_gui->control_edit->get_cursor_position(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief To get current cursor position on text field
+  ///
+  /// @return                         The current cursor position
+  ///
+  unsigned int GetCursorPosition()
+  {
+    return m_interface->kodi_gui->control_edit->get_cursor_position(m_interface->kodiBase,
+                                                                    m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CEdit
-    /// @brief To set field input type which are defined on \ref AddonGUIInputType
-    ///
-    /// @param[in] type                 The \ref AddonGUIInputType "Add-on input type"
-    ///                                 to use
-    /// @param[in] heading              The heading text for related keyboard
-    ///                                 dialog
-    ///
-    void SetInputType(AddonGUIInputType type, const std::string& heading)
-    {
-      m_interface->kodi_gui->control_edit->set_input_type(m_interface->kodiBase, m_controlHandle, static_cast<int>(type), heading.c_str());
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief To set field input type which are defined on \ref AddonGUIInputType
+  ///
+  /// @param[in] type                 The \ref AddonGUIInputType "Add-on input type"
+  ///                                 to use
+  /// @param[in] heading              The heading text for related keyboard
+  ///                                 dialog
+  ///
+  void SetInputType(AddonGUIInputType type, const std::string& heading)
+  {
+    m_interface->kodi_gui->control_edit->set_input_type(m_interface->kodiBase, m_controlHandle,
+                                                        static_cast<int>(type), heading.c_str());
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/FadeLabel.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/FadeLabel.h
@@ -18,130 +18,135 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CFadeLabel Control Fade Label
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CFadeLabel }
+/// **Window control used to show multiple pieces of text in the same position,
+/// by fading from one to the other**
+///
+/// The fade label  control is used for displaying multiple pieces  of text in
+/// the same  space in  Kodi. You can choose  the font, size, colour, location
+/// and contents  of the text to be displayed.  The first piece of information
+/// to display fades in over 50 frames, then scrolls off to the left.  Once it
+/// is  finished scrolling off screen,  the second piece  of information fades
+/// in and  the process repeats.  A fade label  control is not  supported in a
+/// list container.
+///
+/// It has the header \ref FadeLabel.h "#include <kodi/gui/controls/FadeLabel.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Fade_Label_Control "fade label control"
+///
+/// @note The  call of the  control is only  possible from  the  corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CFadeLabel : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CFadeLabel Control Fade Label
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CFadeLabel }
-  /// **Window control used to show multiple pieces of text in the same position,
-  /// by fading from one to the other**
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief Construct a new control.
   ///
-  /// The fade label  control is used for displaying multiple pieces  of text in
-  /// the same  space in  Kodi. You can choose  the font, size, colour, location
-  /// and contents  of the text to be displayed.  The first piece of information
-  /// to display fades in over 50 frames, then scrolls off to the left.  Once it
-  /// is  finished scrolling off screen,  the second piece  of information fades
-  /// in and  the process repeats.  A fade label  control is not  supported in a
-  /// list container.
+  /// @param[in] window     related window control class
+  /// @param[in] controlId  Used skin xml control id
   ///
-  /// It has the header \ref FadeLabel.h "#include <kodi/gui/controls/FadeLabel.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Fade_Label_Control "fade label control"
-  ///
-  /// @note The  call of the  control is only  possible from  the  corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CFadeLabel : public CAddonGUIControlBase
+  CFadeLabel(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief Construct a new control.
-    ///
-    /// @param[in] window     related window control class
-    /// @param[in] controlId  Used skin xml control id
-    ///
-    CFadeLabel(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_fade_label(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CFadeLabel can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_fade_label(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CFadeLabel can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief Destructor.
-    ///
-    ~CFadeLabel() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief Destructor.
+  ///
+  ~CFadeLabel() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief Set the control on window to visible.
-    ///
-    /// @param[in] visible    If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_fade_label->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief Set the control on window to visible.
+  ///
+  /// @param[in] visible    If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_fade_label->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                           visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief To add additional text string on fade label.
-    ///
-    /// @param[in] label      Text to show
-    ///
-    void AddLabel(const std::string& label)
-    {
-      m_interface->kodi_gui->control_fade_label->add_label(m_interface->kodiBase, m_controlHandle, label.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief To add additional text string on fade label.
+  ///
+  /// @param[in] label      Text to show
+  ///
+  void AddLabel(const std::string& label)
+  {
+    m_interface->kodi_gui->control_fade_label->add_label(m_interface->kodiBase, m_controlHandle,
+                                                         label.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief Get the used text from button
-    ///
-    /// @return               Text shown
-    ///
-    std::string GetLabel() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief Get the used text from button
+  ///
+  /// @return               Text shown
+  ///
+  std::string GetLabel() const
+  {
+    std::string label;
+    char* ret = m_interface->kodi_gui->control_fade_label->get_label(m_interface->kodiBase,
+                                                                     m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_fade_label->get_label(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      if (std::strlen(ret))
+        label = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return label;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief To enable or disable scrolling on fade label
-    ///
-    /// @param[in] scroll     To  enable scrolling  set  to true,  otherwise  is
-    ///                       disabled
-    ///
-    void SetScrolling(bool scroll)
-    {
-      m_interface->kodi_gui->control_fade_label->set_scrolling(m_interface->kodiBase, m_controlHandle, scroll);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief To enable or disable scrolling on fade label
+  ///
+  /// @param[in] scroll     To  enable scrolling  set  to true,  otherwise  is
+  ///                       disabled
+  ///
+  void SetScrolling(bool scroll)
+  {
+    m_interface->kodi_gui->control_fade_label->set_scrolling(m_interface->kodiBase, m_controlHandle,
+                                                             scroll);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
-    /// @brief To reset al inserted labels.
-    ///
-    void Reset()
-    {
-      m_interface->kodi_gui->control_fade_label->reset(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+  /// @brief To reset al inserted labels.
+  ///
+  void Reset()
+  {
+    m_interface->kodi_gui->control_fade_label->reset(m_interface->kodiBase, m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Image.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Image.h
@@ -18,94 +18,98 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CImage Control Image
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CImage }
+/// **Window control used to show an image.**
+///
+/// The  image control is used  for displaying  images in Kodi. You can choose
+/// the position, size, transparency and contents of the image to be displayed.
+///
+/// It has the header \ref Image.h "#include <kodi/gui/controls/Image.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Image_Control "image control"
+///
+/// @note The  call of  the control is  only possible  from the  corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CImage : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CImage Control Image
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CImage }
-  /// **Window control used to show an image.**
+  /// \ingroup cpp_kodi_gui_controls_CImage
+  /// @brief Construct a new control
   ///
-  /// The  image control is used  for displaying  images in Kodi. You can choose
-  /// the position, size, transparency and contents of the image to be displayed.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref Image.h "#include <kodi/gui/controls/Image.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Image_Control "image control"
-  ///
-  /// @note The  call of  the control is  only possible  from the  corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CImage : public CAddonGUIControlBase
+  CImage(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CImage
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CImage(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_image(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CImage can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_image(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CImage can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CImage
-    /// @brief Destructor
-    ///
-    ~CImage() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CImage
+  /// @brief Destructor
+  ///
+  ~CImage() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CImage
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_image->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CImage
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_image->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                      visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CImage
-    /// @brief To set the filename used on image control.
-    ///
-    /// @param[in] filename             Image file to use
-    /// @param[in] useCache             To define  storage of image,  default is
-    ///                                 in  cache,  if false  becomes it  loaded
-    ///                                 always on changes again
-    ///
-    void SetFileName(const std::string& filename, bool useCache = true)
-    {
-      m_interface->kodi_gui->control_image->set_filename(m_interface->kodiBase, m_controlHandle, filename.c_str(), useCache);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CImage
+  /// @brief To set the filename used on image control.
+  ///
+  /// @param[in] filename             Image file to use
+  /// @param[in] useCache             To define  storage of image,  default is
+  ///                                 in  cache,  if false  becomes it  loaded
+  ///                                 always on changes again
+  ///
+  void SetFileName(const std::string& filename, bool useCache = true)
+  {
+    m_interface->kodi_gui->control_image->set_filename(m_interface->kodiBase, m_controlHandle,
+                                                       filename.c_str(), useCache);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CImage
-    /// @brief To set set the diffuse color on image.
-    ///
-    /// @param[in] colorDiffuse         Color to use for diffuse
-    ///
-    void SetColorDiffuse(uint32_t colorDiffuse)
-    {
-      m_interface->kodi_gui->control_image->set_color_diffuse(m_interface->kodiBase, m_controlHandle, colorDiffuse);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CImage
+  /// @brief To set set the diffuse color on image.
+  ///
+  /// @param[in] colorDiffuse         Color to use for diffuse
+  ///
+  void SetColorDiffuse(uint32_t colorDiffuse)
+  {
+    m_interface->kodi_gui->control_image->set_color_diffuse(m_interface->kodiBase, m_controlHandle,
+                                                            colorDiffuse);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Label.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Label.h
@@ -18,99 +18,103 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CLabel Control Label
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CLabel }
+/// **Window control used to show some lines of text.**
+///
+/// The  label control  is used for  displaying text  in Kodi.  You can choose
+/// the font, size, colour, location and contents of the text to be displayed.
+///
+/// It has the header \ref Label.h "#include <kodi/gui/controls/Label.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Label_Control "label control"
+///
+/// @note The  call  of the control  is only possible  from the  corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CLabel : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CLabel Control Label
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CLabel }
-  /// **Window control used to show some lines of text.**
+  /// \ingroup cpp_kodi_gui_controls_CLabel
+  /// @brief Construct a new control
   ///
-  /// The  label control  is used for  displaying text  in Kodi.  You can choose
-  /// the font, size, colour, location and contents of the text to be displayed.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref Label.h "#include <kodi/gui/controls/Label.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Label_Control "label control"
-  ///
-  /// @note The  call  of the control  is only possible  from the  corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CLabel : public CAddonGUIControlBase
+  CLabel(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CLabel
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CLabel(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_label(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CLabel can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_label(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CLabel can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CLabel
-    /// @brief Destructor
-    ///
-    ~CLabel() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CLabel
+  /// @brief Destructor
+  ///
+  ~CLabel() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CLabel
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_label->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CLabel
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_label->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                      visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CLabel
-    /// @brief To set the text string on label
-    ///
-    /// @param[in] text                 Text to show
-    ///
-    void SetLabel(const std::string& text)
-    {
-      m_interface->kodi_gui->control_label->set_label(m_interface->kodiBase, m_controlHandle, text.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CLabel
+  /// @brief To set the text string on label
+  ///
+  /// @param[in] text                 Text to show
+  ///
+  void SetLabel(const std::string& text)
+  {
+    m_interface->kodi_gui->control_label->set_label(m_interface->kodiBase, m_controlHandle,
+                                                    text.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CLabel
-    /// @brief Get the used text from control
-    ///
-    /// @return                         Used text on label control
-    ///
-    std::string GetLabel() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CLabel
+  /// @brief Get the used text from control
+  ///
+  /// @return                         Used text on label control
+  ///
+  std::string GetLabel() const
+  {
+    std::string label;
+    char* ret =
+        m_interface->kodi_gui->control_label->get_label(m_interface->kodiBase, m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_label->get_label(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      if (std::strlen(ret))
+        label = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
-  };
+    return label;
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Progress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Progress.h
@@ -18,92 +18,96 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CProgress Control Progress
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CProgress }
+/// **Window control to show the progress of a particular operation**
+///
+/// The progress control is used to show the progress of an item that may take
+/// a long time,  or to show how far  through a movie you are.  You can choose
+/// the position, size, and look of the progress control.
+///
+/// It has the header \ref Progress.h "#include <kodi/gui/controls/Progress.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Progress_Control "progress control"
+///
+/// @note The call of the control is only possible from the corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CProgress : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CProgress Control Progress
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CProgress }
-  /// **Window control to show the progress of a particular operation**
+  /// \ingroup cpp_kodi_gui_controls_CProgress
+  /// @brief Construct a new control
   ///
-  /// The progress control is used to show the progress of an item that may take
-  /// a long time,  or to show how far  through a movie you are.  You can choose
-  /// the position, size, and look of the progress control.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref Progress.h "#include <kodi/gui/controls/Progress.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Progress_Control "progress control"
-  ///
-  /// @note The call of the control is only possible from the corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CProgress : public CAddonGUIControlBase
+  CProgress(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CProgress
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CProgress(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_progress(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CProgress can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_progress(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CProgress can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CProgress
-    /// @brief Destructor
-    ///
-    ~CProgress() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CProgress
+  /// @brief Destructor
+  ///
+  ~CProgress() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CProgress
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_progress->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CProgress
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_progress->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                         visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CProgress
-    /// @brief To set Percent position of control
-    ///
-    /// @param[in] percent              The percent position to use
-    ///
-    void SetPercentage(float percent)
-    {
-      m_interface->kodi_gui->control_progress->set_percentage(m_interface->kodiBase, m_controlHandle, percent);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CProgress
+  /// @brief To set Percent position of control
+  ///
+  /// @param[in] percent              The percent position to use
+  ///
+  void SetPercentage(float percent)
+  {
+    m_interface->kodi_gui->control_progress->set_percentage(m_interface->kodiBase, m_controlHandle,
+                                                            percent);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CProgress
-    /// @brief Get the active percent position of progress bar
-    ///
-    /// @return                         Progress position as percent
-    ///
-    float GetPercentage() const
-    {
-      return m_interface->kodi_gui->control_progress->get_percentage(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CProgress
+  /// @brief Get the active percent position of progress bar
+  ///
+  /// @return                         Progress position as percent
+  ///
+  float GetPercentage() const
+  {
+    return m_interface->kodi_gui->control_progress->get_percentage(m_interface->kodiBase,
+                                                                   m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/RadioButton.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/RadioButton.h
@@ -18,142 +18,149 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CRadioButton Control Radio Button
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CRadioButton }
+/// **Window control for a radio button (as used for on/off settings)**
+///
+/// The radio  button control is used for creating push button on/off settings
+/// in Kodi. You can choose the position,  size,  and look of the button. When
+/// the user clicks on the radio button,  the state will change,  toggling the
+/// extra  textures  (textureradioon and textureradiooff).  Used  for settings
+/// controls.
+///
+/// It has the header \ref RadioButton.h "#include <kodi/gui/controls/RadioButton.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Radio_button_control "radio button control"
+///
+/// @note The  call  of the  control is  only possible  from the corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CRadioButton : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CRadioButton Control Radio Button
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CRadioButton }
-  /// **Window control for a radio button (as used for on/off settings)**
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief Construct a new control
   ///
-  /// The radio  button control is used for creating push button on/off settings
-  /// in Kodi. You can choose the position,  size,  and look of the button. When
-  /// the user clicks on the radio button,  the state will change,  toggling the
-  /// extra  textures  (textureradioon and textureradiooff).  Used  for settings
-  /// controls.
+  /// @param[in] window     related window control class
+  /// @param[in] controlId  Used skin xml control id
   ///
-  /// It has the header \ref RadioButton.h "#include <kodi/gui/controls/RadioButton.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Radio_button_control "radio button control"
-  ///
-  /// @note The  call  of the  control is  only possible  from the corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CRadioButton : public CAddonGUIControlBase
+  CRadioButton(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window     related window control class
-    /// @param[in] controlId  Used skin xml control id
-    ///
-    CRadioButton(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_radio_button(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CRadioButton can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_radio_button(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CRadioButton can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief Destructor
-    ///
-    ~CRadioButton() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief Destructor
+  ///
+  ~CRadioButton() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible    If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_radio_button->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible    If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_radio_button->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                             visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief Set's the control's enabled/disabled state
-    ///
-    /// @param[in] enabled    If true enabled, otherwise disabled
-    ///
-    void SetEnabled(bool enabled)
-    {
-      m_interface->kodi_gui->control_radio_button->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief Set's the control's enabled/disabled state
+  ///
+  /// @param[in] enabled    If true enabled, otherwise disabled
+  ///
+  void SetEnabled(bool enabled)
+  {
+    m_interface->kodi_gui->control_radio_button->set_enabled(m_interface->kodiBase, m_controlHandle,
+                                                             enabled);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief To set the text string on radio button
-    ///
-    /// @param[in] label      Text to show
-    ///
-    void SetLabel(const std::string& label)
-    {
-      m_interface->kodi_gui->control_radio_button->set_label(m_interface->kodiBase, m_controlHandle, label.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief To set the text string on radio button
+  ///
+  /// @param[in] label      Text to show
+  ///
+  void SetLabel(const std::string& label)
+  {
+    m_interface->kodi_gui->control_radio_button->set_label(m_interface->kodiBase, m_controlHandle,
+                                                           label.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief Get the used text from control
-    ///
-    /// @return               Text shown
-    ///
-    std::string GetLabel() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief Get the used text from control
+  ///
+  /// @return               Text shown
+  ///
+  std::string GetLabel() const
+  {
+    std::string label;
+    char* ret = m_interface->kodi_gui->control_radio_button->get_label(m_interface->kodiBase,
+                                                                       m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_radio_button->get_label(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      if (std::strlen(ret))
+        label = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return label;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief To set radio button condition to on or off
-    ///
-    /// @param[in] selected   true set radio button to  selection on,  otherwise
-    ///                       off
-    ///
-    void SetSelected(bool selected)
-    {
-      m_interface->kodi_gui->control_radio_button->set_selected(m_interface->kodiBase, m_controlHandle, selected);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief To set radio button condition to on or off
+  ///
+  /// @param[in] selected   true set radio button to  selection on,  otherwise
+  ///                       off
+  ///
+  void SetSelected(bool selected)
+  {
+    m_interface->kodi_gui->control_radio_button->set_selected(m_interface->kodiBase,
+                                                              m_controlHandle, selected);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRadioButton
-    /// @brief Get the current selected condition of radio button
-    ///
-    /// @return               Selected condition
-    ///
-    bool IsSelected() const
-    {
-      return m_interface->kodi_gui->control_radio_button->is_selected(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRadioButton
+  /// @brief Get the current selected condition of radio button
+  ///
+  /// @return               Selected condition
+  ///
+  bool IsSelected() const
+  {
+    return m_interface->kodi_gui->control_radio_button->is_selected(m_interface->kodiBase,
+                                                                    m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h
@@ -19,193 +19,186 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
-  ///
-  /// \defgroup cpp_kodi_gui_controls_CRendering Control Rendering
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CRendering }
-  /// **Window control for rendering own parts**
-  ///
-  /// This rendering control is used  when own parts are needed.  You  have  the
-  /// control  over them  to render direct  OpenGL or  DirectX  content  to  the
-  /// screen set by the size of them.
-  ///
-  /// Alternative  can be  the virtual  functions from t his been ignored if the
-  /// callbacks are  defined  by the  \ref CRendering_SetIndependentCallbacks function  and
-  /// class is used as single and not as a parent class.
-  ///
-  /// It has the header \ref Rendering.h "#include <kodi/gui/controls/Rendering.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Addon_Rendering_control "rendering control"
-  ///
-  /// @note The  call of  the control is only  possible  from  the corresponding
-  /// window as its class and identification number is required.
-  ///
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CRendering Control Rendering
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CRendering }
+/// **Window control for rendering own parts**
+///
+/// This rendering control is used  when own parts are needed.  You  have  the
+/// control  over them  to render direct  OpenGL or  DirectX  content  to  the
+/// screen set by the size of them.
+///
+/// Alternative  can be  the virtual  functions from t his been ignored if the
+/// callbacks are  defined  by the  \ref CRendering_SetIndependentCallbacks function  and
+/// class is used as single and not as a parent class.
+///
+/// It has the header \ref Rendering.h "#include <kodi/gui/controls/Rendering.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Addon_Rendering_control "rendering control"
+///
+/// @note The  call of  the control is only  possible  from  the corresponding
+/// window as its class and identification number is required.
+///
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CRendering_Defs Definitions, structures and enumerators
+/// \ingroup cpp_kodi_gui_controls_CRendering
+/// @brief **Library definition values**
+///
+
+class ATTRIBUTE_HIDDEN CRendering : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CRendering_Defs Definitions, structures and enumerators
   /// \ingroup cpp_kodi_gui_controls_CRendering
-  /// @brief **Library definition values**
+  /// @brief Construct a new control
   ///
-
-  class CRendering : public CAddonGUIControlBase
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
+  ///
+  CRendering(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CRendering(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
+    m_controlHandle = m_interface->kodi_gui->window->get_control_render_addon(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (m_controlHandle)
+      m_interface->kodi_gui->control_rendering->set_callbacks(m_interface->kodiBase,
+                                                              m_controlHandle, this, OnCreateCB,
+                                                              OnRenderCB, OnStopCB, OnDirtyCB);
+    else
+      kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::%s can't create control class from Kodi !!!",
+                __FUNCTION__);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// @brief Destructor
+  ///
+  ~CRendering() override
+  {
+    m_interface->kodi_gui->control_rendering->destroy(m_interface->kodiBase, m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// @brief To create rendering control on Add-on
+  ///
+  /// Function  creates the  needed rendering  control for Kodi  which becomes
+  /// handled and processed from Add-on
+  ///
+  /// @note This is  callback  function  from Kodi  to  Add-on and  not to use
+  /// for calls from add-on to this function.
+  ///
+  /// @param[in] x                    Horizontal position
+  /// @param[in] y                    Vertical position
+  /// @param[in] w                    Width of control
+  /// @param[in] h                    Height of control
+  /// @param[in] device               The device to use.  For OpenGL  is empty
+  ///                                 on Direct X is the needed device send.
+  /// @return                         Add-on needs to return true if successed,
+  ///                                 otherwise false.
+  ///
+  virtual bool Create(int x, int y, int w, int h, void* device) { return false; }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// @brief Render process call from Kodi
+  ///
+  /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
+  /// for calls from add-on to this function.
+  ///
+  virtual void Render() {}
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// @brief Call from Kodi to stop rendering process
+  ///
+  /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
+  /// for calls from add-on to this function.
+  ///
+  virtual void Stop() {}
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// @brief Call from Kodi where add-on  becomes asked about  dirty rendering
+  /// region.
+  ///
+  /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
+  /// for calls from add-on to this function.
+  ///
+  virtual bool Dirty() { return false; }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// \anchor CRendering_SetIndependentCallbacks
+  /// @brief If the  class is used  independent (with "new CRendering")
+  /// and not as  parent (with "cCLASS_own : CRendering") from own must
+  /// be the callback from Kodi to add-on overdriven with own functions!
+  ///
+  void SetIndependentCallbacks(
+      GUIHANDLE cbhdl,
+      bool (*CBCreate)(GUIHANDLE cbhdl, int x, int y, int w, int h, void* device),
+      void (*CBRender)(GUIHANDLE cbhdl),
+      void (*CBStop)(GUIHANDLE cbhdl),
+      bool (*CBDirty)(GUIHANDLE cbhdl))
+  {
+    if (!cbhdl || !CBCreate || !CBRender || !CBStop || !CBDirty)
     {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_render_addon(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (m_controlHandle)
-        m_interface->kodi_gui->control_rendering->set_callbacks(m_interface->kodiBase, m_controlHandle, this,
-                                                                OnCreateCB, OnRenderCB, OnStopCB, OnDirtyCB);
-      else
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::%s can't create control class from Kodi !!!", __FUNCTION__);
-    }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// @brief Destructor
-    ///
-    ~CRendering() override
-    {
-      m_interface->kodi_gui->control_rendering->destroy(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// @brief To create rendering control on Add-on
-    ///
-    /// Function  creates the  needed rendering  control for Kodi  which becomes
-    /// handled and processed from Add-on
-    ///
-    /// @note This is  callback  function  from Kodi  to  Add-on and  not to use
-    /// for calls from add-on to this function.
-    ///
-    /// @param[in] x                    Horizontal position
-    /// @param[in] y                    Vertical position
-    /// @param[in] w                    Width of control
-    /// @param[in] h                    Height of control
-    /// @param[in] device               The device to use.  For OpenGL  is empty
-    ///                                 on Direct X is the needed device send.
-    /// @return                         Add-on needs to return true if successed,
-    ///                                 otherwise false.
-    ///
-    virtual bool Create(int x, int y, int w, int h, void* device) { return false; }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// @brief Render process call from Kodi
-    ///
-    /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
-    /// for calls from add-on to this function.
-    ///
-    virtual void Render() { }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// @brief Call from Kodi to stop rendering process
-    ///
-    /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
-    /// for calls from add-on to this function.
-    ///
-    virtual void Stop() { }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// @brief Call from Kodi where add-on  becomes asked about  dirty rendering
-    /// region.
-    ///
-    /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
-    /// for calls from add-on to this function.
-    ///
-    virtual bool Dirty() { return false; }
-    //--------------------------------------------------------------------------
-
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CRendering
-    /// \anchor CRendering_SetIndependentCallbacks
-    /// @brief If the  class is used  independent (with "new CRendering")
-    /// and not as  parent (with "cCLASS_own : CRendering") from own must
-    /// be the callback from Kodi to add-on overdriven with own functions!
-    ///
-    void SetIndependentCallbacks(
-        GUIHANDLE             cbhdl,
-        bool      (*CBCreate)(GUIHANDLE cbhdl,
-                              int       x,
-                              int       y,
-                              int       w,
-                              int       h,
-                              void*     device),
-        void      (*CBRender)(GUIHANDLE cbhdl),
-        void      (*CBStop)  (GUIHANDLE cbhdl),
-        bool      (*CBDirty) (GUIHANDLE cbhdl))
-    {
-      if (!cbhdl ||
-          !CBCreate || !CBRender || !CBStop || !CBDirty)
-      {
-        kodi::Log(ADDON_LOG_ERROR, "kodi::gui::controls::%s called with nullptr !!!", __FUNCTION__);
-        return;
-      }
-
-      m_interface->kodi_gui->control_rendering->set_callbacks(m_interface->kodiBase, m_controlHandle, cbhdl,
-                                          CBCreate, CBRender, CBStop, CBDirty);
-    }
-    //--------------------------------------------------------------------------
-
-  private:
-    /*
-     * Defined callback functions from Kodi to add-on, for use in parent / child system
-     * (is private)!
-     */
-    static bool OnCreateCB(void* cbhdl, int x, int y, int w, int h, void* device)
-    {
-      static_cast<CRendering*>(cbhdl)->m_renderHelper = kodi::gui::GetRenderHelper();
-      return static_cast<CRendering*>(cbhdl)->Create(x, y, w, h, device);
+      kodi::Log(ADDON_LOG_ERROR, "kodi::gui::controls::%s called with nullptr !!!", __FUNCTION__);
+      return;
     }
 
-    static void OnRenderCB(void* cbhdl)
-    {
-      if (!static_cast<CRendering*>(cbhdl)->m_renderHelper)
-        return;
-      static_cast<CRendering*>(cbhdl)->m_renderHelper->Begin();
-      static_cast<CRendering*>(cbhdl)->Render();
-      static_cast<CRendering*>(cbhdl)->m_renderHelper->End();
-    }
+    m_interface->kodi_gui->control_rendering->set_callbacks(
+        m_interface->kodiBase, m_controlHandle, cbhdl, CBCreate, CBRender, CBStop, CBDirty);
+  }
+  //--------------------------------------------------------------------------
 
-    static void OnStopCB(void* cbhdl)
-    {
-      static_cast<CRendering*>(cbhdl)->Stop();
-      static_cast<CRendering*>(cbhdl)->m_renderHelper = nullptr;
-    }
+private:
+  /*
+   * Defined callback functions from Kodi to add-on, for use in parent / child system
+   * (is private)!
+   */
+  static bool OnCreateCB(void* cbhdl, int x, int y, int w, int h, void* device)
+  {
+    static_cast<CRendering*>(cbhdl)->m_renderHelper = kodi::gui::GetRenderHelper();
+    return static_cast<CRendering*>(cbhdl)->Create(x, y, w, h, device);
+  }
 
-    static bool OnDirtyCB(void* cbhdl)
-    {
-      return static_cast<CRendering*>(cbhdl)->Dirty();
-    }
+  static void OnRenderCB(void* cbhdl)
+  {
+    if (!static_cast<CRendering*>(cbhdl)->m_renderHelper)
+      return;
+    static_cast<CRendering*>(cbhdl)->m_renderHelper->Begin();
+    static_cast<CRendering*>(cbhdl)->Render();
+    static_cast<CRendering*>(cbhdl)->m_renderHelper->End();
+  }
 
-    std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
-  };
+  static void OnStopCB(void* cbhdl)
+  {
+    static_cast<CRendering*>(cbhdl)->Stop();
+    static_cast<CRendering*>(cbhdl)->m_renderHelper = nullptr;
+  }
+
+  static bool OnDirtyCB(void* cbhdl) { return static_cast<CRendering*>(cbhdl)->Dirty(); }
+
+  std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/SettingsSlider.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/SettingsSlider.h
@@ -18,294 +18,308 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CSettingsSlider Control Settings Slider
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CSettingsSlider }
+/// **Window control for moveable slider with text name**
+///
+/// The settings slider control is  used in the settings  screens for  when an
+/// option is best  specified on a sliding scale. You can choose the position,
+/// size, and look of the slider control.  It is basically a cross between the
+/// button control  and a slider  control.  It has a  label and  focus and non
+/// focus textures, as well as a slider control on the right.
+///
+/// It has the header \ref SettingsSlider.h "#include <kodi/gui/controls/SettingsSlider.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Settings_Slider_Control "settings slider control"
+///
+/// @note The call  of the control  is only  possible  from the  corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CSettingsSlider : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CSettingsSlider Control Settings Slider
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CSettingsSlider }
-  /// **Window control for moveable slider with text name**
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Construct a new control
   ///
-  /// The settings slider control is  used in the settings  screens for  when an
-  /// option is best  specified on a sliding scale. You can choose the position,
-  /// size, and look of the slider control.  It is basically a cross between the
-  /// button control  and a slider  control.  It has a  label and  focus and non
-  /// focus textures, as well as a slider control on the right.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref SettingsSlider.h "#include <kodi/gui/controls/SettingsSlider.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Settings_Slider_Control "settings slider control"
-  ///
-  /// @note The call  of the control  is only  possible  from the  corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CSettingsSlider : public CAddonGUIControlBase
+  CSettingsSlider(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CSettingsSlider(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_settings_slider(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CSettingsSlider can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_settings_slider(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CSettingsSlider can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Destructor
-    ///
-    ~CSettingsSlider() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Destructor
+  ///
+  ~CSettingsSlider() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_visible(m_interface->kodiBase,
+                                                                m_controlHandle, visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Set's the control's enabled/disabled state
-    ///
-    /// @param[in] enabled              If true enabled, otherwise disabled
-    ///
-    void SetEnabled(bool enabled)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Set's the control's enabled/disabled state
+  ///
+  /// @param[in] enabled              If true enabled, otherwise disabled
+  ///
+  void SetEnabled(bool enabled)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_enabled(m_interface->kodiBase,
+                                                                m_controlHandle, enabled);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To set the text string on settings slider
-    ///
-    /// @param[in] text                 Text to show
-    ///
-    void SetText(const std::string& text)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_text(m_interface->kodiBase, m_controlHandle, text.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To set the text string on settings slider
+  ///
+  /// @param[in] text                 Text to show
+  ///
+  void SetText(const std::string& text)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_text(m_interface->kodiBase, m_controlHandle,
+                                                             text.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To reset slider on defaults
-    ///
-    void Reset()
-    {
-      m_interface->kodi_gui->control_settings_slider->reset(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To reset slider on defaults
+  ///
+  void Reset()
+  {
+    m_interface->kodi_gui->control_settings_slider->reset(m_interface->kodiBase, m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To set the the range as integer of slider, e.g. -10 is the slider
-    /// start and e.g. +10 is  the from here defined position where it reach the
-    /// end.
-    ///
-    /// Ad default is the range from 0 to 100.
-    ///
-    /// The integer interval is as default 1 and can be changed with
-    /// @ref SetIntInterval.
-    ///
-    /// @param[in] start                Integer start value
-    /// @param[in] end                  Integer end value
-    ///
-    /// @note Percent, floating point  or integer are alone possible.  Combining
-    /// these different  values  can be not  together  and can, therefore,  only
-    /// one each can be used.
-    ///
-    void SetIntRange(int start, int end)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_int_range(m_interface->kodiBase, m_controlHandle, start, end);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To set the the range as integer of slider, e.g. -10 is the slider
+  /// start and e.g. +10 is  the from here defined position where it reach the
+  /// end.
+  ///
+  /// Ad default is the range from 0 to 100.
+  ///
+  /// The integer interval is as default 1 and can be changed with
+  /// @ref SetIntInterval.
+  ///
+  /// @param[in] start                Integer start value
+  /// @param[in] end                  Integer end value
+  ///
+  /// @note Percent, floating point  or integer are alone possible.  Combining
+  /// these different  values  can be not  together  and can, therefore,  only
+  /// one each can be used.
+  ///
+  void SetIntRange(int start, int end)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_int_range(m_interface->kodiBase,
+                                                                  m_controlHandle, start, end);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Set the slider position  with the given integer value.  The Range
-    /// must be defined with a call from \ref SetIntRange before.
-    ///
-    /// @param[in] value                Position in range to set with integer
-    ///
-    /// @note Percent, floating point  or integer are alone possible.  Combining
-    /// these different  values ​​can  be not  together and  can, therefore,  only
-    /// one each can be used.
-    ///
-    void SetIntValue(int value)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_int_value(m_interface->kodiBase, m_controlHandle, value);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Set the slider position  with the given integer value.  The Range
+  /// must be defined with a call from \ref SetIntRange before.
+  ///
+  /// @param[in] value                Position in range to set with integer
+  ///
+  /// @note Percent, floating point  or integer are alone possible.  Combining
+  /// these different  values ​​can  be not  together and  can, therefore,  only
+  /// one each can be used.
+  ///
+  void SetIntValue(int value)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_int_value(m_interface->kodiBase,
+                                                                  m_controlHandle, value);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To get the current position as integer value.
-    ///
-    /// @return                         The position as integer
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these different  values ​​can  be not  together and can,  therefore,  only
-    /// one each can be used.
-    ///
-    int GetIntValue() const
-    {
-      return m_interface->kodi_gui->control_settings_slider->get_int_value(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To get the current position as integer value.
+  ///
+  /// @return                         The position as integer
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these different  values ​​can  be not  together and can,  therefore,  only
+  /// one each can be used.
+  ///
+  int GetIntValue() const
+  {
+    return m_interface->kodi_gui->control_settings_slider->get_int_value(m_interface->kodiBase,
+                                                                         m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To set the  interval steps of slider,  as default is it 1.  If it
-    /// becomes  changed with  this function  will a step  of the user  with the
-    /// value fixed here be executed.
-    ///
-    /// @param[in] interval             Intervall step to set.
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these different values  ​​can  be not  together and can,  therefore,  only
-    /// one each can be used.
-    ///
-    void SetIntInterval(int interval)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_int_interval(m_interface->kodiBase, m_controlHandle, interval);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To set the  interval steps of slider,  as default is it 1.  If it
+  /// becomes  changed with  this function  will a step  of the user  with the
+  /// value fixed here be executed.
+  ///
+  /// @param[in] interval             Intervall step to set.
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these different values  ​​can  be not  together and can,  therefore,  only
+  /// one each can be used.
+  ///
+  void SetIntInterval(int interval)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_int_interval(m_interface->kodiBase,
+                                                                     m_controlHandle, interval);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Sets the percent of the slider.
-    ///
-    /// @param[in] percent              float - Percent value of slide
-    ///
-    /// @note Percent, floating point  or integer are alone possible.  Combining
-    /// these different  values ​​can  be not together  and can,  therefore,  only
-    /// one each can be used.
-    ///
-    void SetPercentage(float percent)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_percentage(m_interface->kodiBase, m_controlHandle, percent);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Sets the percent of the slider.
+  ///
+  /// @param[in] percent              float - Percent value of slide
+  ///
+  /// @note Percent, floating point  or integer are alone possible.  Combining
+  /// these different  values ​​can  be not together  and can,  therefore,  only
+  /// one each can be used.
+  ///
+  void SetPercentage(float percent)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_percentage(m_interface->kodiBase,
+                                                                   m_controlHandle, percent);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Returns a float of the percent of the slider.
-    ///
-    /// @return                         float - Percent of slider
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these different  values ​​can be  not together  and can,  therefore,  only
-    /// one each can be used.
-    ///
-    float GetPercentage() const
-    {
-      return m_interface->kodi_gui->control_settings_slider->get_percentage(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Returns a float of the percent of the slider.
+  ///
+  /// @return                         float - Percent of slider
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these different  values ​​can be  not together  and can,  therefore,  only
+  /// one each can be used.
+  ///
+  float GetPercentage() const
+  {
+    return m_interface->kodi_gui->control_settings_slider->get_percentage(m_interface->kodiBase,
+                                                                          m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To set the the range as float of slider, e.g. -25.0 is the slider
-    /// start and  e.g.  +25.0 is the from  here defined position where it reach
-    /// the end.
-    ///
-    /// As default is the range 0.0 to 1.0.
-    ///
-    /// The float interval is as default 0.1 and can be changed with
-    /// @ref SetFloatInterval.
-    ///
-    /// @param[in] start                Integer start value
-    /// @param[in] end                  Integer end value
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these different values ​​ can be not  together  and can,  therefore,  only
-    /// one each can be used.
-    ///
-    void SetFloatRange(float start, float end)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_float_range(m_interface->kodiBase, m_controlHandle, start, end);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To set the the range as float of slider, e.g. -25.0 is the slider
+  /// start and  e.g.  +25.0 is the from  here defined position where it reach
+  /// the end.
+  ///
+  /// As default is the range 0.0 to 1.0.
+  ///
+  /// The float interval is as default 0.1 and can be changed with
+  /// @ref SetFloatInterval.
+  ///
+  /// @param[in] start                Integer start value
+  /// @param[in] end                  Integer end value
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these different values ​​ can be not  together  and can,  therefore,  only
+  /// one each can be used.
+  ///
+  void SetFloatRange(float start, float end)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_float_range(m_interface->kodiBase,
+                                                                    m_controlHandle, start, end);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief Set  the slider position  with the given  float value.  The Range
-    /// can be defined with a  call from \ref SetIntRange before,  as default it
-    /// is 0.0 to 1.0.
-    ///
-    /// @param[in] value                Position in range to set with float
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these different  values ​​can be not  together  and can,  therefore,  only
-    /// one each can be used.
-    ///
-    void SetFloatValue(float value)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_float_value(m_interface->kodiBase, m_controlHandle, value);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief Set  the slider position  with the given  float value.  The Range
+  /// can be defined with a  call from \ref SetIntRange before,  as default it
+  /// is 0.0 to 1.0.
+  ///
+  /// @param[in] value                Position in range to set with float
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these different  values ​​can be not  together  and can,  therefore,  only
+  /// one each can be used.
+  ///
+  void SetFloatValue(float value)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_float_value(m_interface->kodiBase,
+                                                                    m_controlHandle, value);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To get the current position as float value.
-    ///
-    /// @return                         The position as float
-    ///
-    float GetFloatValue() const
-    {
-      return m_interface->kodi_gui->control_settings_slider->get_float_value(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To get the current position as float value.
+  ///
+  /// @return                         The position as float
+  ///
+  float GetFloatValue() const
+  {
+    return m_interface->kodi_gui->control_settings_slider->get_float_value(m_interface->kodiBase,
+                                                                           m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
-    /// @brief To set  the interval steps of slider,  as default is it 0.1 If it
-    /// becomes changed with this function will a step of the user with the
-    /// value fixed here be executed.
-    ///
-    /// @param[in] interval             Intervall step to set.
-    ///
-    /// @note Percent, floating point or  integer are alone possible.  Combining
-    /// these different values ​​can be not together and can, therefore, only
-    /// one each can be used.
-    ///
-    void SetFloatInterval(float interval)
-    {
-      m_interface->kodi_gui->control_settings_slider->set_float_interval(m_interface->kodiBase, m_controlHandle, interval);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+  /// @brief To set  the interval steps of slider,  as default is it 0.1 If it
+  /// becomes changed with this function will a step of the user with the
+  /// value fixed here be executed.
+  ///
+  /// @param[in] interval             Intervall step to set.
+  ///
+  /// @note Percent, floating point or  integer are alone possible.  Combining
+  /// these different values ​​can be not together and can, therefore, only
+  /// one each can be used.
+  ///
+  void SetFloatInterval(float interval)
+  {
+    m_interface->kodi_gui->control_settings_slider->set_float_interval(m_interface->kodiBase,
+                                                                       m_controlHandle, interval);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Slider.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Slider.h
@@ -18,307 +18,321 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CSlider Control Slider
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CSlider }
+/// **Window control for moveable slider**
+///
+/// The slider control is used for things where a sliding bar best  represents
+/// the operation at hand (such as a volume control or seek control).  You can
+/// choose the position, size, and look of the slider control.
+///
+/// It has the header \ref Slider.h "#include <kodi/gui/controls/Slider.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Slider_Control "slider control"
+///
+/// @note The  call of the  control  is only  possible from  the corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CSlider : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CSlider Control Slider
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CSlider }
-  /// **Window control for moveable slider**
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Construct a new control
   ///
-  /// The slider control is used for things where a sliding bar best  represents
-  /// the operation at hand (such as a volume control or seek control).  You can
-  /// choose the position, size, and look of the slider control.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref Slider.h "#include <kodi/gui/controls/Slider.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Slider_Control "slider control"
-  ///
-  /// @note The  call of the  control  is only  possible from  the corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CSlider : public CAddonGUIControlBase
+  CSlider(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CSlider(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_slider(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CSlider can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_slider(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CSlider can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Destructor
-    ///
-    ~CSlider() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Destructor
+  ///
+  ~CSlider() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_slider->set_visible(m_interface->kodiBase, m_controlHandle, visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_slider->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                       visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Set's the control's enabled/disabled state
-    ///
-    /// @param[in] enabled              If true enabled, otherwise disabled
-    ///
-    void SetEnabled(bool enabled)
-    {
-      m_interface->kodi_gui->control_slider->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Set's the control's enabled/disabled state
+  ///
+  /// @param[in] enabled              If true enabled, otherwise disabled
+  ///
+  void SetEnabled(bool enabled)
+  {
+    m_interface->kodi_gui->control_slider->set_enabled(m_interface->kodiBase, m_controlHandle,
+                                                       enabled);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To reset slider on defaults
-    ///
-    void Reset()
-    {
-      m_interface->kodi_gui->control_slider->reset(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To reset slider on defaults
+  ///
+  void Reset()
+  {
+    m_interface->kodi_gui->control_slider->reset(m_interface->kodiBase, m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief With GetDescription becomes a string value of position returned.
-    ///
-    /// @return                        Text string about current slider position
-    ///
-    /// The following are the text definition returned from this:
-    /// | Value     | Without range selection | With range selection           |
-    /// |:---------:|:------------------------|:-------------------------------|
-    /// | float     | <c>%2.2f</c>            | <c>[%2.2f, %2.2f]</c>          |
-    /// | integer   | <c>%i</c>               | <c>[%i, %i]</c>                |
-    /// | percent   | <c>%i%%</c>             | <c>[%i%%, %i%%]</c>            |
-    ///
-    std::string GetDescription() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief With GetDescription becomes a string value of position returned.
+  ///
+  /// @return                        Text string about current slider position
+  ///
+  /// The following are the text definition returned from this:
+  /// | Value     | Without range selection | With range selection           |
+  /// |:---------:|:------------------------|:-------------------------------|
+  /// | float     | <c>%2.2f</c>            | <c>[%2.2f, %2.2f]</c>          |
+  /// | integer   | <c>%i</c>               | <c>[%i, %i]</c>                |
+  /// | percent   | <c>%i%%</c>             | <c>[%i%%, %i%%]</c>            |
+  ///
+  std::string GetDescription() const
+  {
+    std::string text;
+    char* ret = m_interface->kodi_gui->control_slider->get_description(m_interface->kodiBase,
+                                                                       m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string text;
-      char* ret = m_interface->kodi_gui->control_slider->get_description(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          text = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return text;
+      if (std::strlen(ret))
+        text = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return text;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To set the the range as integer of slider, e.g. -10 is the slider
-    /// start and e.g. +10 is the from here defined position where it  reach the
-    /// end.
-    ///
-    /// Ad default is the range from 0 to 100.
-    ///
-    /// The integer interval is as default 1 and can be changed with
-    /// @ref SetIntInterval.
-    ///
-    /// @param[in] start                Integer start value
-    /// @param[in] end                  Integer end value
-    ///
-    /// @note Percent, floating point or  integer are alone possible.  Combining
-    /// these different values can be not together and can, therefore,  only one
-    /// each can be used.
-    ///
-    void SetIntRange(int start, int end)
-    {
-      m_interface->kodi_gui->control_slider->set_int_range(m_interface->kodiBase, m_controlHandle, start, end);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To set the the range as integer of slider, e.g. -10 is the slider
+  /// start and e.g. +10 is the from here defined position where it  reach the
+  /// end.
+  ///
+  /// Ad default is the range from 0 to 100.
+  ///
+  /// The integer interval is as default 1 and can be changed with
+  /// @ref SetIntInterval.
+  ///
+  /// @param[in] start                Integer start value
+  /// @param[in] end                  Integer end value
+  ///
+  /// @note Percent, floating point or  integer are alone possible.  Combining
+  /// these different values can be not together and can, therefore,  only one
+  /// each can be used.
+  ///
+  void SetIntRange(int start, int end)
+  {
+    m_interface->kodi_gui->control_slider->set_int_range(m_interface->kodiBase, m_controlHandle,
+                                                         start, end);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup CSlider
-    /// @brief Set the slider position  with the given integer value.  The Range
-    /// must be defined with a call from \ref SetIntRange before.
-    ///
-    /// @param[in] value                Position in range to set with integer
-    ///
-    /// @note Percent, floating point or integer  are alone possible.  Combining
-    /// these different values can be not together and can, therefore,  only one
-    /// each can be used.
-    ///
-    void SetIntValue(int value)
-    {
-      m_interface->kodi_gui->control_slider->set_int_value(m_interface->kodiBase, m_controlHandle, value);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup CSlider
+  /// @brief Set the slider position  with the given integer value.  The Range
+  /// must be defined with a call from \ref SetIntRange before.
+  ///
+  /// @param[in] value                Position in range to set with integer
+  ///
+  /// @note Percent, floating point or integer  are alone possible.  Combining
+  /// these different values can be not together and can, therefore,  only one
+  /// each can be used.
+  ///
+  void SetIntValue(int value)
+  {
+    m_interface->kodi_gui->control_slider->set_int_value(m_interface->kodiBase, m_controlHandle,
+                                                         value);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To get the current position as integer value.
-    ///
-    /// @return                         The position as integer
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these  different  values  can be not together and can,  therefore,  only
-    /// one each can be used.
-    ///
-    int GetIntValue() const
-    {
-      return m_interface->kodi_gui->control_slider->get_int_value(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To get the current position as integer value.
+  ///
+  /// @return                         The position as integer
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these  different  values  can be not together and can,  therefore,  only
+  /// one each can be used.
+  ///
+  int GetIntValue() const
+  {
+    return m_interface->kodi_gui->control_slider->get_int_value(m_interface->kodiBase,
+                                                                m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To set the interval  steps of slider,  as default is it 1.  If it
-    /// becomes  changed  with this function  will a step  of the  user with the
-    /// value fixed here be executed.
-    ///
-    /// @param[in] interval             Intervall step to set.
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these different values can be not together and can, therefore,  only one
-    /// each can be used.
-    ///
-    void SetIntInterval(int interval)
-    {
-      m_interface->kodi_gui->control_slider->set_int_interval(m_interface->kodiBase, m_controlHandle, interval);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To set the interval  steps of slider,  as default is it 1.  If it
+  /// becomes  changed  with this function  will a step  of the  user with the
+  /// value fixed here be executed.
+  ///
+  /// @param[in] interval             Intervall step to set.
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these different values can be not together and can, therefore,  only one
+  /// each can be used.
+  ///
+  void SetIntInterval(int interval)
+  {
+    m_interface->kodi_gui->control_slider->set_int_interval(m_interface->kodiBase, m_controlHandle,
+                                                            interval);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Sets the percent of the slider.
-    ///
-    /// @param[in] percent              float - Percent value of slide
-    ///
-    /// @note Percent, floating point or  integer are alone possible.  Combining
-    /// these different values can be not together and can, therefore,  only one
-    /// each can be used.
-    ///
-    void SetPercentage(float percent)
-    {
-      m_interface->kodi_gui->control_slider->set_percentage(m_interface->kodiBase, m_controlHandle, percent);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Sets the percent of the slider.
+  ///
+  /// @param[in] percent              float - Percent value of slide
+  ///
+  /// @note Percent, floating point or  integer are alone possible.  Combining
+  /// these different values can be not together and can, therefore,  only one
+  /// each can be used.
+  ///
+  void SetPercentage(float percent)
+  {
+    m_interface->kodi_gui->control_slider->set_percentage(m_interface->kodiBase, m_controlHandle,
+                                                          percent);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Returns a float of the percent of the slider.
-    ///
-    /// @return                         float - Percent of slider
-    ///
-    /// @note Percent, floating point or integer  are alone possible.  Combining
-    /// these different values can be not together and can, therefore,  only one
-    /// each can be used.
-    ///
-    float GetPercentage() const
-    {
-      return m_interface->kodi_gui->control_slider->get_percentage(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Returns a float of the percent of the slider.
+  ///
+  /// @return                         float - Percent of slider
+  ///
+  /// @note Percent, floating point or integer  are alone possible.  Combining
+  /// these different values can be not together and can, therefore,  only one
+  /// each can be used.
+  ///
+  float GetPercentage() const
+  {
+    return m_interface->kodi_gui->control_slider->get_percentage(m_interface->kodiBase,
+                                                                 m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To set the the range as float of slider, e.g. -25.0 is the slider
-    /// start and e.g. +25.0 is  the from here  defined position  where it reach
-    /// the end.
-    ///
-    /// As default is the range 0.0 to 1.0.
-    ///
-    /// The float interval is as default 0.1 and can be changed with
-    /// @ref SetFloatInterval.
-    ///
-    /// @param[in] start                Integer start value
-    /// @param[in] end                  Integer end value
-    ///
-    /// @note Percent,  floating point or integer are alone possible.  Combining
-    /// these  different  values  can be not together and can,  therefore,  only
-    /// one each can be used.
-    ///
-    void SetFloatRange(float start, float end)
-    {
-      m_interface->kodi_gui->control_slider->set_float_range(m_interface->kodiBase, m_controlHandle, start, end);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To set the the range as float of slider, e.g. -25.0 is the slider
+  /// start and e.g. +25.0 is  the from here  defined position  where it reach
+  /// the end.
+  ///
+  /// As default is the range 0.0 to 1.0.
+  ///
+  /// The float interval is as default 0.1 and can be changed with
+  /// @ref SetFloatInterval.
+  ///
+  /// @param[in] start                Integer start value
+  /// @param[in] end                  Integer end value
+  ///
+  /// @note Percent,  floating point or integer are alone possible.  Combining
+  /// these  different  values  can be not together and can,  therefore,  only
+  /// one each can be used.
+  ///
+  void SetFloatRange(float start, float end)
+  {
+    m_interface->kodi_gui->control_slider->set_float_range(m_interface->kodiBase, m_controlHandle,
+                                                           start, end);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief Set the slider  position with the  given float value.  The  Range
-    /// can be defined with a call from  \ref SetIntRange before,  as default it
-    /// is 0.0 to 1.0.
-    ///
-    /// @param[in] value                Position in range to set with float
-    ///
-    /// @note Percent, floating  point or integer are alone possible.  Combining
-    /// these different values can be not together and can, therefore,  only one
-    /// each can be used.
-    ///
-    void SetFloatValue(float value)
-    {
-      m_interface->kodi_gui->control_slider->set_float_value(m_interface->kodiBase, m_controlHandle, value);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief Set the slider  position with the  given float value.  The  Range
+  /// can be defined with a call from  \ref SetIntRange before,  as default it
+  /// is 0.0 to 1.0.
+  ///
+  /// @param[in] value                Position in range to set with float
+  ///
+  /// @note Percent, floating  point or integer are alone possible.  Combining
+  /// these different values can be not together and can, therefore,  only one
+  /// each can be used.
+  ///
+  void SetFloatValue(float value)
+  {
+    m_interface->kodi_gui->control_slider->set_float_value(m_interface->kodiBase, m_controlHandle,
+                                                           value);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To get the current position as float value.
-    ///
-    /// @return                         The position as float
-    ///
-    float GetFloatValue() const
-    {
-      return m_interface->kodi_gui->control_slider->get_float_value(m_interface->kodiBase, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To get the current position as float value.
+  ///
+  /// @return                         The position as float
+  ///
+  float GetFloatValue() const
+  {
+    return m_interface->kodi_gui->control_slider->get_float_value(m_interface->kodiBase,
+                                                                  m_controlHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CSlider
-    /// @brief To set the interval  steps of slider, as default is it 0.1  If it
-    /// becomes changed  with this  function  will a step  of the user  with the
-    /// value fixed here be executed.
-    ///
-    /// @param[in] interval             Intervall step to set.
-    ///
-    /// @note Percent, floating point or integer  are alone possible.  Combining
-    /// these different  values can be  not together  and can,  therefore,  only
-    /// one each can be used.
-    ///
-    void SetFloatInterval(float interval)
-    {
-      m_interface->kodi_gui->control_slider->set_float_interval(m_interface->kodiBase, m_controlHandle, interval);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSlider
+  /// @brief To set the interval  steps of slider, as default is it 0.1  If it
+  /// becomes changed  with this  function  will a step  of the user  with the
+  /// value fixed here be executed.
+  ///
+  /// @param[in] interval             Intervall step to set.
+  ///
+  /// @note Percent, floating point or integer  are alone possible.  Combining
+  /// these different  values can be  not together  and can,  therefore,  only
+  /// one each can be used.
+  ///
+  void SetFloatInterval(float interval)
+  {
+    m_interface->kodi_gui->control_slider->set_float_interval(m_interface->kodiBase,
+                                                              m_controlHandle, interval);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Spin.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Spin.h
@@ -61,7 +61,7 @@ namespace controls
   } AddonGUISpinControlType;
   //----------------------------------------------------------------------------
 
-  class CSpin : public CAddonGUIControlBase
+  class ATTRIBUTE_HIDDEN CSpin : public CAddonGUIControlBase
   {
   public:
     //==========================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/TextBox.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/TextBox.h
@@ -18,147 +18,150 @@ namespace gui
 namespace controls
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_controls_CTextBox Control Text Box
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::controls::CTextBox }
+/// **Used to show a multi-page piece of text**
+///
+/// The text box control  can be used to display  descriptions,  help texts or
+/// other larger texts.  It corresponds to the representation which is also to
+/// be seen on the CDialogTextViewer.
+///
+/// It has the header \ref TextBox.h "#include <kodi/gui/controls/TextBox.h>"
+/// be included to enjoy it.
+///
+/// Here you find the needed skin part for a \ref Text_Box "textbox control".
+///
+/// @note The call  of the  control is  only possible  from the  corresponding
+/// window as its class and identification number is required.
+///
+class ATTRIBUTE_HIDDEN CTextBox : public CAddonGUIControlBase
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CTextBox Control Text Box
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CTextBox }
-  /// **Used to show a multi-page piece of text**
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief Construct a new control
   ///
-  /// The text box control  can be used to display  descriptions,  help texts or
-  /// other larger texts.  It corresponds to the representation which is also to
-  /// be seen on the CDialogTextViewer.
+  /// @param[in] window               related window control class
+  /// @param[in] controlId            Used skin xml control id
   ///
-  /// It has the header \ref TextBox.h "#include <kodi/gui/controls/TextBox.h>"
-  /// be included to enjoy it.
-  ///
-  /// Here you find the needed skin part for a \ref Text_Box "textbox control".
-  ///
-  /// @note The call  of the  control is  only possible  from the  corresponding
-  /// window as its class and identification number is required.
-  ///
-  class CTextBox : public CAddonGUIControlBase
+  CTextBox(CWindow* window, int controlId) : CAddonGUIControlBase(window)
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief Construct a new control
-    ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
-    ///
-    CTextBox(CWindow* window, int controlId)
-      : CAddonGUIControlBase(window)
-    {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_text_box(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
-      if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CTextBox can't create control class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    m_controlHandle = m_interface->kodi_gui->window->get_control_text_box(
+        m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+    if (!m_controlHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::controls::CTextBox can't create control class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief Destructor
-    ///
-    ~CTextBox() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief Destructor
+  ///
+  ~CTextBox() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief Set the control on window to visible
-    ///
-    /// @param[in] visible              If true visible, otherwise hidden
-    ///
-    void SetVisible(bool visible)
-    {
-      m_interface->kodi_gui->control_text_box->set_visible(m_interface->kodiBase, m_controlHandle,  visible);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief Set the control on window to visible
+  ///
+  /// @param[in] visible              If true visible, otherwise hidden
+  ///
+  void SetVisible(bool visible)
+  {
+    m_interface->kodi_gui->control_text_box->set_visible(m_interface->kodiBase, m_controlHandle,
+                                                         visible);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief To reset box an remove all the text
-    ///
-    void Reset()
-    {
-      m_interface->kodi_gui->control_text_box->reset(m_controlHandle, m_controlHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief To reset box an remove all the text
+  ///
+  void Reset() { m_interface->kodi_gui->control_text_box->reset(m_controlHandle, m_controlHandle); }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief To set the text on box
-    ///
-    /// @param[in] text                 Text to show
-    ///
-    void SetText(const std::string& text)
-    {
-      m_interface->kodi_gui->control_text_box->set_text(m_interface->kodiBase, m_controlHandle,  text.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief To set the text on box
+  ///
+  /// @param[in] text                 Text to show
+  ///
+  void SetText(const std::string& text)
+  {
+    m_interface->kodi_gui->control_text_box->set_text(m_interface->kodiBase, m_controlHandle,
+                                                      text.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief Get the used text from control
-    ///
-    /// @return                         Text shown
-    ///
-    std::string GetText() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief Get the used text from control
+  ///
+  /// @return                         Text shown
+  ///
+  std::string GetText() const
+  {
+    std::string text;
+    char* ret =
+        m_interface->kodi_gui->control_text_box->get_text(m_interface->kodiBase, m_controlHandle);
+    if (ret != nullptr)
     {
-      std::string text;
-      char* ret = m_interface->kodi_gui->control_text_box->get_text(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          text = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return text;
+      if (std::strlen(ret))
+        text = ret;
+      m_interface->free_string(m_interface->kodiBase, ret);
     }
-    //--------------------------------------------------------------------------
+    return text;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief To scroll text on other position
-    ///
-    /// @param[in] position             The line position to scroll to
-    ///
-    void Scroll(unsigned int position)
-    {
-      m_interface->kodi_gui->control_text_box->scroll(m_interface->kodiBase, m_controlHandle, position);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief To scroll text on other position
+  ///
+  /// @param[in] position             The line position to scroll to
+  ///
+  void Scroll(unsigned int position)
+  {
+    m_interface->kodi_gui->control_text_box->scroll(m_interface->kodiBase, m_controlHandle,
+                                                    position);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_controls_CTextBox
-    /// @brief To set automatic scrolling of textbox
-    ///
-    /// Specifies the timing  and conditions of  any autoscrolling  this textbox
-    /// should have. Times are in milliseconds.  The content is delayed  for the
-    /// given delay,  then scrolls at a rate of one line per time interval until
-    /// the end.  If the repeat tag is present,  it then  delays for  the repeat
-    /// time,  fades out over 1 second,  and repeats.  It does not wrap or reset
-    /// to the top at the end of the scroll.
-    ///
-    /// @param[in] delay                Content delay
-    /// @param[in] time                 One line per time interval
-    /// @param[in] repeat               Delays with given time, fades out over 1
-    ///                                 second, and repeats
-    ///
-    void SetAutoScrolling(int delay, int time, int repeat)
-    {
-      m_interface->kodi_gui->control_text_box->set_auto_scrolling(m_interface->kodiBase, m_controlHandle, delay, time, repeat);
-    }
-    //--------------------------------------------------------------------------
-  };
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CTextBox
+  /// @brief To set automatic scrolling of textbox
+  ///
+  /// Specifies the timing  and conditions of  any autoscrolling  this textbox
+  /// should have. Times are in milliseconds.  The content is delayed  for the
+  /// given delay,  then scrolls at a rate of one line per time interval until
+  /// the end.  If the repeat tag is present,  it then  delays for  the repeat
+  /// time,  fades out over 1 second,  and repeats.  It does not wrap or reset
+  /// to the top at the end of the scroll.
+  ///
+  /// @param[in] delay                Content delay
+  /// @param[in] time                 One line per time interval
+  /// @param[in] repeat               Delays with given time, fades out over 1
+  ///                                 second, and repeats
+  ///
+  void SetAutoScrolling(int delay, int time, int repeat)
+  {
+    m_interface->kodi_gui->control_text_box->set_auto_scrolling(
+        m_interface->kodiBase, m_controlHandle, delay, time, repeat);
+  }
+  //--------------------------------------------------------------------------
+};
 
 } /* namespace controls */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/ContextMenu.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/ContextMenu.h
@@ -66,16 +66,18 @@ namespace dialogs
     ///   fprintf(stderr, "Selected item is: %i\n", selected);
     /// ~~~~~~~~~~~~~
     ///
-    inline int Show(const std::string& heading, const std::vector<std::string>& entries)
+    inline int ATTRIBUTE_HIDDEN Show(const std::string& heading,
+                                     const std::vector<std::string>& entries)
     {
       using namespace ::kodi::addon;
       unsigned int size = static_cast<unsigned int>(entries.size());
-      const char** cEntries = static_cast<const char**>(malloc(size*sizeof(const char**)));
+      const char** cEntries = static_cast<const char**>(malloc(size * sizeof(const char**)));
       for (unsigned int i = 0; i < size; ++i)
       {
         cEntries[i] = entries[i].c_str();
       }
-      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogContextMenu->open(CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), cEntries, size);
+      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogContextMenu->open(
+          CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), cEntries, size);
       free(cEntries);
       return ret;
     }
@@ -113,7 +115,8 @@ namespace dialogs
     ///   fprintf(stderr, "Selected item is: %i\n", selected);
     /// ~~~~~~~~~~~~~
     ///
-    inline int Show(const std::string& heading, const std::vector<std::pair<std::string, std::string>>& entries)
+    inline int ATTRIBUTE_HIDDEN Show(
+        const std::string& heading, const std::vector<std::pair<std::string, std::string>>& entries)
     {
       using namespace ::kodi::addon;
       unsigned int size = static_cast<unsigned int>(entries.size());
@@ -160,7 +163,8 @@ namespace dialogs
     ///   fprintf(stderr, "Selected item is: %i\n", selected);
     /// ~~~~~~~~~~~~~
     ///
-    inline int Show(const std::string& heading, const std::vector<std::pair<int, std::string>>& entries)
+    inline int ATTRIBUTE_HIDDEN Show(const std::string& heading,
+                                     const std::vector<std::pair<int, std::string>>& entries)
     {
       using namespace ::kodi::addon;
       unsigned int size = static_cast<unsigned int>(entries.size());

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/ExtendedProgress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/ExtendedProgress.h
@@ -18,218 +18,232 @@ namespace gui
 namespace dialogs
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_dialogs_CExtendedProgress Dialog Extended Progress
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::dialogs::ExtendedProgress }
+/// **Progress dialog shown for background work**
+///
+/// The with \ref ExtendedProgress.h "#include <kodi/gui/dialogs/ExtendedProgress.h>"
+/// given class are basically used to create Kodi's extended progress.
+///
+///
+/// --------------------------------------------------------------------------
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/gui/dialogs/ExtendedProgress.h>
+///
+/// kodi::gui::dialogs::CExtendedProgress *ext_progress = new kodi::gui::dialogs::CExtendedProgress("Test Extended progress");
+/// ext_progress->SetText("Test progress");
+/// for (unsigned int i = 0; i < 50; i += 10)
+/// {
+///   ext_progress->SetProgress(i, 100);
+///   sleep(1);
+/// }
+///
+/// ext_progress->SetTitle("Test Extended progress - Second round");
+/// ext_progress->SetText("Test progress - Step 2");
+///
+/// for (unsigned int i = 50; i < 100; i += 10)
+/// {
+///   ext_progress->SetProgress(i, 100);
+///   sleep(1);
+/// }
+/// delete ext_progress;
+/// ~~~~~~~~~~~~~
+///
+class ATTRIBUTE_HIDDEN CExtendedProgress
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_dialogs_CExtendedProgress Dialog Extended Progress
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::dialogs::ExtendedProgress }
-  /// **Progress dialog shown for background work**
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// Construct a new dialog
   ///
-  /// The with \ref ExtendedProgress.h "#include <kodi/gui/dialogs/ExtendedProgress.h>"
-  /// given class are basically used to create Kodi's extended progress.
+  /// @param[in] title  Title string
   ///
-  ///
-  /// --------------------------------------------------------------------------
-  ///
-  /// **Example:**
-  /// ~~~~~~~~~~~~~{.cpp}
-  /// #include <kodi/gui/dialogs/ExtendedProgress.h>
-  ///
-  /// kodi::gui::dialogs::CExtendedProgress *ext_progress = new kodi::gui::dialogs::CExtendedProgress("Test Extended progress");
-  /// ext_progress->SetText("Test progress");
-  /// for (unsigned int i = 0; i < 50; i += 10)
-  /// {
-  ///   ext_progress->SetProgress(i, 100);
-  ///   sleep(1);
-  /// }
-  ///
-  /// ext_progress->SetTitle("Test Extended progress - Second round");
-  /// ext_progress->SetText("Test progress - Step 2");
-  ///
-  /// for (unsigned int i = 50; i < 100; i += 10)
-  /// {
-  ///   ext_progress->SetProgress(i, 100);
-  ///   sleep(1);
-  /// }
-  /// delete ext_progress;
-  /// ~~~~~~~~~~~~~
-  ///
-  class CExtendedProgress
+  explicit CExtendedProgress(const std::string& title = "")
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// Construct a new dialog
-    ///
-    /// @param[in] title  Title string
-    ///
-    explicit CExtendedProgress(const std::string& title = "")
-    {
-      using namespace ::kodi::addon;
-      m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->new_dialog(CAddonBase::m_interface->toKodi->kodiBase, title.c_str());
-      if (!m_DialogHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::CDialogExtendedProgress can't create window class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    using namespace ::kodi::addon;
+    m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->new_dialog(
+        CAddonBase::m_interface->toKodi->kodiBase, title.c_str());
+    if (!m_DialogHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::CDialogExtendedProgress can't create window class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// Destructor
-    ///
-    ~CExtendedProgress()
-    {
-      using namespace ::kodi::addon;
-      if (m_DialogHandle)
-        CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->delete_dialog(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// Destructor
+  ///
+  ~CExtendedProgress()
+  {
+    using namespace ::kodi::addon;
+    if (m_DialogHandle)
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->delete_dialog(
+          CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief Get the used title
-    ///
-    /// @return Title string
-    ///
-    std::string Title() const
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief Get the used title
+  ///
+  /// @return Title string
+  ///
+  std::string Title() const
+  {
+    using namespace ::kodi::addon;
+    std::string text;
+    char* strMsg = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_title(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    if (strMsg != nullptr)
     {
-      using namespace ::kodi::addon;
-      std::string text;
-      char* strMsg = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_title(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-      if (strMsg != nullptr)
-      {
-        if (std::strlen(strMsg))
-          text = strMsg;
-        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, strMsg);
-      }
-      return text;
+      if (std::strlen(strMsg))
+        text = strMsg;
+      CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase,
+                                                   strMsg);
     }
-    //--------------------------------------------------------------------------
+    return text;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief To set the title of dialog
-    ///
-    /// @param[in] title     Title string
-    ///
-    void SetTitle(const std::string& title)
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief To set the title of dialog
+  ///
+  /// @param[in] title     Title string
+  ///
+  void SetTitle(const std::string& title)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_title(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, title.c_str());
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief Get the used text information string
+  ///
+  /// @return Text string
+  ///
+  std::string Text() const
+  {
+    using namespace ::kodi::addon;
+    std::string text;
+    char* strMsg = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_text(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    if (strMsg != nullptr)
     {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_title(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, title.c_str());
+      if (std::strlen(strMsg))
+        text = strMsg;
+      CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase,
+                                                   strMsg);
     }
-    //--------------------------------------------------------------------------
+    return text;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief Get the used text information string
-    ///
-    /// @return Text string
-    ///
-    std::string Text() const
-    {
-      using namespace ::kodi::addon;
-      std::string text;
-      char* strMsg = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_text(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-      if (strMsg != nullptr)
-      {
-        if (std::strlen(strMsg))
-          text = strMsg;
-        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, strMsg);
-      }
-      return text;
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief To set the used text information string
+  ///
+  /// @param[in] text         information text to set
+  ///
+  void SetText(const std::string& text)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_text(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, text.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief To set the used text information string
-    ///
-    /// @param[in] text         information text to set
-    ///
-    void SetText(const std::string& text)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_text(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, text.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief To ask dialog is finished
+  ///
+  /// @return True if on end
+  ///
+  bool IsFinished() const
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->is_finished(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief To ask dialog is finished
-    ///
-    /// @return True if on end
-    ///
-    bool IsFinished() const
-    {
-      using namespace ::kodi::addon;
-      return CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->is_finished(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief Mark progress finished
+  ///
+  void MarkFinished()
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->mark_finished(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief Mark progress finished
-    ///
-    void MarkFinished()
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->mark_finished(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief Get the current progress position as percent
+  ///
+  /// @return Position
+  ///
+  float Percentage() const
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_percentage(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief Get the current progress position as percent
-    ///
-    /// @return Position
-    ///
-    float Percentage() const
-    {
-      using namespace ::kodi::addon;
-      return CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief To set the current progress position as percent
+  ///
+  /// @param[in] percentage   Position to use from 0.0 to 100.0
+  ///
+  void SetPercentage(float percentage)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_percentage(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, percentage);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief To set the current progress position as percent
-    ///
-    /// @param[in] percentage   Position to use from 0.0 to 100.0
-    ///
-    void SetPercentage(float percentage)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, percentage);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
+  /// @brief To set progress position with predefined places
+  ///
+  /// @param[in] currentItem    Place position to use
+  /// @param[in] itemCount      Amount of used places
+  ///
+  void SetProgress(int currentItem, int itemCount)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_progress(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, currentItem, itemCount);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CExtendedProgress
-    /// @brief To set progress position with predefined places
-    ///
-    /// @param[in] currentItem    Place position to use
-    /// @param[in] itemCount      Amount of used places
-    ///
-    void SetProgress(int currentItem, int itemCount)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_progress(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, currentItem, itemCount);
-    }
-    //--------------------------------------------------------------------------
-
-  private:
-    void* m_DialogHandle;
-  };
+private:
+  void* m_DialogHandle;
+};
 
 } /* namespace dialogs */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/FileBrowser.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/FileBrowser.h
@@ -71,17 +71,22 @@ namespace dialogs
     /// fprintf(stderr, "Selected directory is : %s and was %s\n", directory.c_str(), ret ? "OK" : "Canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetDirectory(const std::string& shares, const std::string& heading, std::string& path, bool writeOnly = false)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetDirectory(const std::string& shares,
+                                                     const std::string& heading,
+                                                     std::string& path,
+                                                     bool writeOnly = false)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
-      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_directory(CAddonBase::m_interface->toKodi->kodiBase,
-                                                                                                      shares.c_str(), heading.c_str(), path.c_str(), &retString, writeOnly);
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_directory(
+          CAddonBase::m_interface->toKodi->kodiBase, shares.c_str(), heading.c_str(), path.c_str(),
+          &retString, writeOnly);
       if (retString != nullptr)
       {
         if (std::strlen(retString))
           path = retString;
-        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase,
+                                                     retString);
       }
       return ret;
     }
@@ -104,8 +109,12 @@ namespace dialogs
     ///                                 handled as directories.
     /// @return                         False if selection becomes canceled.
     ///
-    inline bool ShowAndGetFile(const std::string& shares, const std::string& mask, const std::string& heading,
-                               std::string& path, bool useThumbs = false, bool useFileDirectories = false)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetFile(const std::string& shares,
+                                                const std::string& mask,
+                                                const std::string& heading,
+                                                std::string& path,
+                                                bool useThumbs = false,
+                                                bool useFileDirectories = false)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -141,8 +150,13 @@ namespace dialogs
     /// @param[in] singleList
     /// @return                         False if selection becomes canceled.
     ///
-    inline bool ShowAndGetFileFromDir(const std::string& directory, const std::string& mask, const std::string& heading, std::string& path,
-                                      bool useThumbs = false, bool useFileDirectories = false, bool singleList = false)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetFileFromDir(const std::string& directory,
+                                                       const std::string& mask,
+                                                       const std::string& heading,
+                                                       std::string& path,
+                                                       bool useThumbs = false,
+                                                       bool useFileDirectories = false,
+                                                       bool singleList = false)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -176,8 +190,12 @@ namespace dialogs
     ///                               handled as directories.
     /// @return False if selection becomes canceled.
     ///
-    inline bool ShowAndGetFileList(const std::string& shares, const std::string& mask, const std::string& heading,
-                                   std::vector<std::string>& fileList, bool useThumbs = false, bool useFileDirectories = false)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetFileList(const std::string& shares,
+                                                    const std::string& mask,
+                                                    const std::string& heading,
+                                                    std::vector<std::string>& fileList,
+                                                    bool useThumbs = false,
+                                                    bool useFileDirectories = false)
     {
       using namespace ::kodi::addon;
       char** list = nullptr;
@@ -208,7 +226,10 @@ namespace dialogs
     /// @param[in] type
     /// @return                       False if selection becomes canceled.
     ///
-    inline bool ShowAndGetSource(std::string& path, bool allowNetworkShares, const std::string& additionalShare = "", const std::string& type = "")
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetSource(std::string& path,
+                                                  bool allowNetworkShares,
+                                                  const std::string& additionalShare = "",
+                                                  const std::string& type = "")
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -235,7 +256,9 @@ namespace dialogs
     /// @param[out] path      Return value about selected image
     /// @return               False if selection becomes canceled.
     ///
-    inline bool ShowAndGetImage(const std::string& shares, const std::string& heading, std::string& path)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetImage(const std::string& shares,
+                                                 const std::string& heading,
+                                                 std::string& path)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -262,7 +285,9 @@ namespace dialogs
     /// @param[out] file_list   Return value about selected images
     /// @return                 False if selection becomes canceled.
     ///
-    inline bool ShowAndGetImageList(const std::string& shares, const std::string& heading, std::vector<std::string>& file_list)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetImageList(const std::string& shares,
+                                                     const std::string& heading,
+                                                     std::vector<std::string>& file_list)
     {
       using namespace ::kodi::addon;
       char** list = nullptr;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Keyboard.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Keyboard.h
@@ -76,17 +76,23 @@ namespace dialogs
     ///                   text.c_str(), bRet ? "OK" : "Canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetInput(std::string& text, const std::string& heading, bool allowEmptyResult, bool hiddenInput = false, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetInput(std::string& text,
+                                                 const std::string& heading,
+                                                 bool allowEmptyResult,
+                                                 bool hiddenInput = false,
+                                                 unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
-      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_input_with_head(CAddonBase::m_interface->toKodi->kodiBase,
-                                                                                                         text.c_str(), &retString, heading.c_str(), allowEmptyResult,
-                                                                                                         hiddenInput, autoCloseMs);
+      bool ret =
+          CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_input_with_head(
+              CAddonBase::m_interface->toKodi->kodiBase, text.c_str(), &retString, heading.c_str(),
+              allowEmptyResult, hiddenInput, autoCloseMs);
       if (retString != nullptr)
       {
         text = retString;
-        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase,
+                                                     retString);
       }
       return ret;
     }
@@ -108,7 +114,9 @@ namespace dialogs
     ///                             false  if  unsuccessful   display,  no  user
     ///                             input, or canceled editing.
     ///
-    inline bool ShowAndGetInput(std::string& text, bool allowEmptyResult, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetInput(std::string& text,
+                                                 bool allowEmptyResult,
+                                                 unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -140,7 +148,10 @@ namespace dialogs
     ///                              false  if  unsuccessful  display,  no  user
     ///                              input, or canceled editing.
     ///
-    inline bool ShowAndGetNewPassword(std::string& newPassword, const std::string& heading, bool allowEmptyResult, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetNewPassword(std::string& newPassword,
+                                                       const std::string& heading,
+                                                       bool allowEmptyResult,
+                                                       unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -170,7 +181,8 @@ namespace dialogs
     ///                               false  if  unsuccessful  display,  no  user
     ///                               input, or canceled editing.
     ///
-    inline bool ShowAndGetNewPassword(std::string& newPassword, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetNewPassword(std::string& newPassword,
+                                                       unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -251,7 +263,10 @@ namespace dialogs
     /// }
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndVerifyNewPassword(std::string& newPassword, const std::string& heading, bool allowEmptyResult, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndVerifyNewPassword(std::string& newPassword,
+                                                          const std::string& heading,
+                                                          bool allowEmptyResult,
+                                                          unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -281,7 +296,8 @@ namespace dialogs
     ///                            false  if  unsuccessful   display,   no  user
     ///                            input, or canceled editing.
     ///
-    inline bool ShowAndVerifyNewPassword(std::string& newPassword, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndVerifyNewPassword(std::string& newPassword,
+                                                          unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -313,7 +329,10 @@ namespace dialogs
     ///                            unsuccessful input. -1 if no user  input  or
     ///                            canceled editing.
     ///
-    inline int ShowAndVerifyPassword(std::string& password, const std::string& heading, int retries, unsigned int autoCloseMs = 0)
+    inline int ATTRIBUTE_HIDDEN ShowAndVerifyPassword(std::string& password,
+                                                      const std::string& heading,
+                                                      int retries,
+                                                      unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -347,7 +366,9 @@ namespace dialogs
     ///                            false   if  unsuccessful  display,   no  user
     ///                            input, or canceled editing.
     ///
-    inline bool ShowAndGetFilter(std::string& text, bool searching, unsigned int autoCloseMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetFilter(std::string& text,
+                                                  bool searching,
+                                                  unsigned int autoCloseMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -372,7 +393,8 @@ namespace dialogs
     /// @return                    true   if    successful   done,    false   if
     ///                            unsuccessful or keyboard not present.
     ///
-    inline bool SendTextToActiveKeyboard(const std::string& text, bool closeKeyboard = false)
+    inline bool ATTRIBUTE_HIDDEN SendTextToActiveKeyboard(const std::string& text,
+                                                          bool closeKeyboard = false)
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->send_text_to_active_keyboard(CAddonBase::m_interface->toKodi->kodiBase,
@@ -387,7 +409,7 @@ namespace dialogs
     ///
     /// @return  true if keyboard present, false if not present
     ///
-    inline bool IsKeyboardActivated()
+    inline bool ATTRIBUTE_HIDDEN IsKeyboardActivated()
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->is_keyboard_activated(CAddonBase::m_interface->toKodi->kodiBase);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Numeric.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Numeric.h
@@ -50,11 +50,13 @@ namespace dialogs
     ///                                false if unsuccessful display, no user
     ///                                input, or canceled editing.
     ///
-    inline bool ShowAndVerifyNewPassword(std::string& newPassword)
+    inline bool ATTRIBUTE_HIDDEN ShowAndVerifyNewPassword(std::string& newPassword)
     {
       using namespace ::kodi::addon;
       char* pw = nullptr;
-      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_verify_new_password(CAddonBase::m_interface->toKodi->kodiBase, &pw);
+      bool ret =
+          CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_verify_new_password(
+              CAddonBase::m_interface->toKodi->kodiBase, &pw);
       if (pw != nullptr)
       {
         newPassword = pw;
@@ -131,7 +133,9 @@ namespace dialogs
     /// }
     /// ~~~~~~~~~~~~~
     ///
-    inline int ShowAndVerifyPassword(const std::string& password, const std::string& heading, int retries)
+    inline int ATTRIBUTE_HIDDEN ShowAndVerifyPassword(const std::string& password,
+                                                      const std::string& heading,
+                                                      int retries)
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_verify_password(CAddonBase::m_interface->toKodi->kodiBase,
@@ -152,7 +156,9 @@ namespace dialogs
     ///                                 input. false if unsuccessful display, no
     ///                                 user input, or canceled editing.
     ///
-    inline bool ShowAndVerifyInput(std::string& toVerify, const std::string& heading, bool verifyInput)
+    inline bool ATTRIBUTE_HIDDEN ShowAndVerifyInput(std::string& toVerify,
+                                                    const std::string& heading,
+                                                    bool verifyInput)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -199,7 +205,7 @@ namespace dialogs
     /// printf("Selected time it's %s and was on Dialog %s\n", buffer, bRet ? "OK" : "Canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetTime(tm& time, const std::string& heading)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetTime(tm& time, const std::string& heading)
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_time(CAddonBase::m_interface->toKodi->kodiBase, &time, heading.c_str());
@@ -238,7 +244,7 @@ namespace dialogs
     /// printf("Selected date it's %s and was on Dialog %s\n", buffer, bRet ? "OK" : "Canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetDate(tm& date, const std::string& heading)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetDate(tm& date, const std::string& heading)
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_date(CAddonBase::m_interface->toKodi->kodiBase, &date, heading.c_str());
@@ -258,7 +264,8 @@ namespace dialogs
     ///                                 display, no user input, or canceled
     ///                                 editing.
     ///
-    inline bool ShowAndGetIPAddress(std::string& ipAddress, const std::string& heading)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetIPAddress(std::string& ipAddress,
+                                                     const std::string& heading)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -304,7 +311,9 @@ namespace dialogs
     ///                  strtoull(number.c_str(), nullptr, 0), bRet ? "OK" : "Canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetNumber(std::string& input, const std::string& heading, unsigned int autoCloseTimeoutMs = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetNumber(std::string& input,
+                                                  const std::string& heading,
+                                                  unsigned int autoCloseTimeoutMs = 0)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;
@@ -331,7 +340,7 @@ namespace dialogs
     ///                         if unsuccessful display, no user input, or
     ///                         canceled editing.
     ///
-    inline bool ShowAndGetSeconds(std::string& time, const std::string& heading)
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetSeconds(std::string& time, const std::string& heading)
     {
       using namespace ::kodi::addon;
       char* retString = nullptr;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/OK.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/OK.h
@@ -52,11 +52,11 @@ namespace dialogs
     /// kodi::gui::dialogs::OK::ShowAndGetInput("Test dialog", "Hello World!\nI'm a call from add-on\n :) :D");
     /// ~~~~~~~~~~~~~
     ///
-    inline void ShowAndGetInput(const std::string& heading, const std::string& text)
+    inline void ATTRIBUTE_HIDDEN ShowAndGetInput(const std::string& heading, const std::string& text)
     {
       using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogOK->show_and_get_input_single_text(CAddonBase::m_interface->toKodi->kodiBase,
-                                                                                          heading.c_str(), text.c_str());
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogOK->show_and_get_input_single_text(
+          CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), text.c_str());
     }
     //--------------------------------------------------------------------------
 
@@ -80,7 +80,10 @@ namespace dialogs
     /// kodi::gui::dialogs::OK::ShowAndGetInput("Test dialog", "Hello World!", "I'm a call from add-on", " :) :D");
     /// ~~~~~~~~~~~~~
     ///
-    inline void ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2)
+    inline void ATTRIBUTE_HIDDEN ShowAndGetInput(const std::string& heading,
+                                                 const std::string& line0,
+                                                 const std::string& line1,
+                                                 const std::string& line2)
     {
       using namespace ::kodi::addon;
       CAddonBase::m_interface->toKodi->kodi_gui->dialogOK->show_and_get_input_line_text(CAddonBase::m_interface->toKodi->kodiBase,

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Progress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Progress.h
@@ -18,223 +18,237 @@ namespace gui
 namespace dialogs
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \defgroup cpp_kodi_gui_dialogs_CProgress Dialog Progress
+/// \ingroup cpp_kodi_gui
+/// @brief \cpp_class{ kodi::gui::dialogs::CProgress }
+/// **Progress dialog shown in center**
+///
+/// The with \ref DialogProgress.h "#include <kodi/gui/dialogs/Progress.h>"
+/// given class are basically used to create Kodi's progress dialog with named
+/// text fields.
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/gui/dialogs/Progress.h>
+///
+/// kodi::gui::dialogs::CProgress *progress = new kodi::gui::dialogs::CProgress;
+/// progress->SetHeading("Test progress");
+/// progress->SetLine(1, "line 1");
+/// progress->SetLine(2, "line 2");
+/// progress->SetLine(3, "line 3");
+/// progress->SetCanCancel(true);
+/// progress->ShowProgressBar(true);
+/// progress->Open();
+/// for (unsigned int i = 0; i < 100; i += 10)
+/// {
+///   progress->SetPercentage(i);
+///   sleep(1);
+/// }
+/// delete progress;
+/// ~~~~~~~~~~~~~
+///
+class ATTRIBUTE_HIDDEN CProgress
+{
+public:
+  //==========================================================================
   ///
-  /// \defgroup cpp_kodi_gui_dialogs_CProgress Dialog Progress
-  /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::dialogs::CProgress }
-  /// **Progress dialog shown in center**
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief Construct a new dialog
   ///
-  /// The with \ref DialogProgress.h "#include <kodi/gui/dialogs/Progress.h>"
-  /// given class are basically used to create Kodi's progress dialog with named
-  /// text fields.
-  ///
-  /// **Example:**
-  /// ~~~~~~~~~~~~~{.cpp}
-  /// #include <kodi/gui/dialogs/Progress.h>
-  ///
-  /// kodi::gui::dialogs::CProgress *progress = new kodi::gui::dialogs::CProgress;
-  /// progress->SetHeading("Test progress");
-  /// progress->SetLine(1, "line 1");
-  /// progress->SetLine(2, "line 2");
-  /// progress->SetLine(3, "line 3");
-  /// progress->SetCanCancel(true);
-  /// progress->ShowProgressBar(true);
-  /// progress->Open();
-  /// for (unsigned int i = 0; i < 100; i += 10)
-  /// {
-  ///   progress->SetPercentage(i);
-  ///   sleep(1);
-  /// }
-  /// delete progress;
-  /// ~~~~~~~~~~~~~
-  ///
-  class CProgress
+  CProgress()
   {
-  public:
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief Construct a new dialog
-    ///
-    CProgress()
-    {
-      using namespace ::kodi::addon;
-      m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->new_dialog(CAddonBase::m_interface->toKodi->kodiBase);
-      if (!m_DialogHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::dialogs::CProgress can't create window class from Kodi !!!");
-    }
-    //--------------------------------------------------------------------------
+    using namespace ::kodi::addon;
+    m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->new_dialog(
+        CAddonBase::m_interface->toKodi->kodiBase);
+    if (!m_DialogHandle)
+      kodi::Log(ADDON_LOG_FATAL,
+                "kodi::gui::dialogs::CProgress can't create window class from Kodi !!!");
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief Destructor
-    ///
-    ~CProgress()
-    {
-      using namespace ::kodi::addon;
-      if (m_DialogHandle)
-        CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->delete_dialog(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief Destructor
+  ///
+  ~CProgress()
+  {
+    using namespace ::kodi::addon;
+    if (m_DialogHandle)
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->delete_dialog(
+          CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To open the dialog
-    ///
-    void Open()
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->open(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To open the dialog
+  ///
+  void Open()
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->open(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief Set the heading title of dialog
-    ///
-    /// @param[in] heading Title string to use
-    ///
-    void SetHeading(const std::string& heading)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_heading(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, heading.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief Set the heading title of dialog
+  ///
+  /// @param[in] heading Title string to use
+  ///
+  void SetHeading(const std::string& heading)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_heading(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, heading.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To set the line text field on dialog from 0 - 2
-    ///
-    /// @param[in] iLine Line number
-    /// @param[in] line Text string
-    ///
-    void SetLine(unsigned int iLine, const std::string& line)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_line(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, iLine, line.c_str());
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To set the line text field on dialog from 0 - 2
+  ///
+  /// @param[in] iLine Line number
+  /// @param[in] line Text string
+  ///
+  void SetLine(unsigned int iLine, const std::string& line)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_line(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, iLine, line.c_str());
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To enable and show cancel button on dialog
-    ///
-    /// @param[in] canCancel if true becomes it shown
-    ///
-    void SetCanCancel(bool canCancel)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_can_cancel(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, canCancel);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To enable and show cancel button on dialog
+  ///
+  /// @param[in] canCancel if true becomes it shown
+  ///
+  void SetCanCancel(bool canCancel)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_can_cancel(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, canCancel);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To check dialog for clicked cancel button
-    ///
-    /// @return True if canceled
-    ///
-    bool IsCanceled() const
-    {
-      using namespace ::kodi::addon;
-      return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->is_canceled(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To check dialog for clicked cancel button
+  ///
+  /// @return True if canceled
+  ///
+  bool IsCanceled() const
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->is_canceled(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief Get the current progress position as percent
-    ///
-    /// @param[in] percentage Position to use from 0 to 100
-    ///
-    void SetPercentage(int percentage)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, percentage);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief Get the current progress position as percent
+  ///
+  /// @param[in] percentage Position to use from 0 to 100
+  ///
+  void SetPercentage(int percentage)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_percentage(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, percentage);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To set the current progress position as percent
-    ///
-    /// @return Current Position used from 0 to 100
-    ///
-    int GetPercentage() const
-    {
-      using namespace ::kodi::addon;
-      return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->get_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To set the current progress position as percent
+  ///
+  /// @return Current Position used from 0 to 100
+  ///
+  int GetPercentage() const
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->get_percentage(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To show or hide progress bar dialog
-    ///
-    /// @param[in] onOff If true becomes it shown
-    ///
-    void ShowProgressBar(bool onOff)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->show_progress_bar(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, onOff);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To show or hide progress bar dialog
+  ///
+  /// @param[in] onOff If true becomes it shown
+  ///
+  void ShowProgressBar(bool onOff)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->show_progress_bar(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, onOff);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief Set the maximum position of progress, needed if `SetProgressAdvance(...)` is used
-    ///
-    /// @param[in] max Biggest usable position to use
-    ///
-    void SetProgressMax(int max)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_progress_max(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, max);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief Set the maximum position of progress, needed if `SetProgressAdvance(...)` is used
+  ///
+  /// @param[in] max Biggest usable position to use
+  ///
+  void SetProgressMax(int max)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_progress_max(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, max);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To increase progress bar by defined step size until reach of maximum position
-    ///
-    /// @param[in] steps Step size to increase, default is 1
-    ///
-    void SetProgressAdvance(int steps=1)
-    {
-      using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_progress_advance(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, steps);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To increase progress bar by defined step size until reach of maximum position
+  ///
+  /// @param[in] steps Step size to increase, default is 1
+  ///
+  void SetProgressAdvance(int steps = 1)
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_progress_advance(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, steps);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \ingroup cpp_kodi_gui_dialogs_CProgress
-    /// @brief To check progress was canceled on work
-    ///
-    /// @return True if aborted
-    ///
-    bool Abort()
-    {
-      using namespace ::kodi::addon;
-      return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->abort(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
-    }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_dialogs_CProgress
+  /// @brief To check progress was canceled on work
+  ///
+  /// @return True if aborted
+  ///
+  bool Abort()
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->abort(
+        CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+  }
+  //--------------------------------------------------------------------------
 
-  private:
-    void* m_DialogHandle;
-  };
+private:
+  void* m_DialogHandle;
+};
 
 } /* namespace dialogs */
 } /* namespace gui */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Select.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/Select.h
@@ -104,16 +104,21 @@ namespace dialogs
     ///   fprintf(stderr, "Selected item is: %i\n", selected);
     /// ~~~~~~~~~~~~~
     ///
-    inline int Show(const std::string& heading, const std::vector<std::string>& entries, int selected = -1, unsigned int autoclose = 0)
+    inline int ATTRIBUTE_HIDDEN Show(const std::string& heading,
+                                     const std::vector<std::string>& entries,
+                                     int selected = -1,
+                                     unsigned int autoclose = 0)
     {
       using namespace ::kodi::addon;
       unsigned int size = static_cast<unsigned int>(entries.size());
-      const char** cEntries = (const char**)malloc(size*sizeof(const char**));
+      const char** cEntries = (const char**)malloc(size * sizeof(const char**));
       for (unsigned int i = 0; i < size; ++i)
       {
         cEntries[i] = entries[i].c_str();
       }
-      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogSelect->open(CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), cEntries, size, selected, autoclose);
+      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogSelect->open(
+          CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), cEntries, size, selected,
+          autoclose);
       free(cEntries);
       return ret;
     }
@@ -159,7 +164,10 @@ namespace dialogs
     ///   fprintf(stderr, "Selected item is: %i\n", selected);
     /// ~~~~~~~~~~~~~
     ///
-    inline int Show(const std::string& heading, std::vector<SSelectionEntry>& entries, int selected = -1, unsigned int autoclose = 0)
+    inline int ATTRIBUTE_HIDDEN Show(const std::string& heading,
+                                     std::vector<SSelectionEntry>& entries,
+                                     int selected = -1,
+                                     unsigned int autoclose = 0)
     {
       using namespace ::kodi::addon;
       unsigned int size = static_cast<unsigned int>(entries.size());
@@ -224,7 +232,9 @@ namespace dialogs
     /// }
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowMultiSelect(const std::string& heading, std::vector<SSelectionEntry>& entries, int autoclose = 0)
+    inline bool ATTRIBUTE_HIDDEN ShowMultiSelect(const std::string& heading,
+                                                 std::vector<SSelectionEntry>& entries,
+                                                 int autoclose = 0)
     {
       using namespace ::kodi::addon;
       unsigned int size = static_cast<unsigned int>(entries.size());

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/TextViewer.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/TextViewer.h
@@ -93,10 +93,11 @@ namespace dialogs
     ///  "interspersed renderings from classical composers.\n");
     /// ~~~~~~~~~~~~~
     ///
-    inline void Show(const std::string& heading, const std::string& text)
+    inline void ATTRIBUTE_HIDDEN Show(const std::string& heading, const std::string& text)
     {
       using namespace ::kodi::addon;
-      CAddonBase::m_interface->toKodi->kodi_gui->dialogTextViewer->open(CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), text.c_str());
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogTextViewer->open(
+          CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), text.c_str());
     }
     //--------------------------------------------------------------------------
   };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/YesNo.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/YesNo.h
@@ -73,14 +73,16 @@ namespace dialogs
     ///          canceled ? "canceled" : "not canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetInput(const std::string& heading, const std::string& text,
-                                bool& canceled, const std::string& noLabel = "",
-                                const std::string& yesLabel = "")
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetInput(const std::string& heading,
+                                                 const std::string& text,
+                                                 bool& canceled,
+                                                 const std::string& noLabel = "",
+                                                 const std::string& yesLabel = "")
     {
       using namespace ::kodi::addon;
-      return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_single_text(CAddonBase::m_interface->toKodi->kodiBase,
-                                                                                                    heading.c_str(), text.c_str(), &canceled,
-                                                                                                    noLabel.c_str(), yesLabel.c_str());
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_single_text(
+          CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), text.c_str(), &canceled,
+          noLabel.c_str(), yesLabel.c_str());
     }
     //--------------------------------------------------------------------------
 
@@ -115,9 +117,12 @@ namespace dialogs
     ///          ret ? "yes" : "no");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1,
-                                const std::string& line2, const std::string& noLabel = "",
-                                const std::string& yesLabel = "")
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetInput(const std::string& heading,
+                                                 const std::string& line0,
+                                                 const std::string& line1,
+                                                 const std::string& line2,
+                                                 const std::string& noLabel = "",
+                                                 const std::string& yesLabel = "")
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_line_text(CAddonBase::m_interface->toKodi->kodiBase,
@@ -161,9 +166,13 @@ namespace dialogs
     ///          canceled ? "canceled" : "not canceled");
     /// ~~~~~~~~~~~~~
     ///
-    inline bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1,
-                                const std::string& line2, bool& canceled, const std::string& noLabel = "",
-                                const std::string& yesLabel = "")
+    inline bool ATTRIBUTE_HIDDEN ShowAndGetInput(const std::string& heading,
+                                                 const std::string& line0,
+                                                 const std::string& line1,
+                                                 const std::string& line2,
+                                                 bool& canceled,
+                                                 const std::string& noLabel = "",
+                                                 const std::string& yesLabel = "")
     {
       using namespace ::kodi::addon;
       return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_line_button_text(CAddonBase::m_interface->toKodi->kodiBase,

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/GLonDX.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/gl/GLonDX.h
@@ -29,7 +29,7 @@ namespace gui
 namespace gl
 {
 
-class CGLonDX : public kodi::gui::IRenderHelper
+class ATTRIBUTE_HIDDEN CGLonDX : public kodi::gui::IRenderHelper
 {
 public:
   explicit CGLonDX() : m_pContext(reinterpret_cast<ID3D11DeviceContext*>(kodi::gui::GetHWContext())) {}

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/renderHelper.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/renderHelper.h
@@ -14,7 +14,7 @@ namespace kodi
 {
 namespace gui
 {
-struct IRenderHelper
+struct ATTRIBUTE_HIDDEN IRenderHelper
 {
   virtual ~IRenderHelper() = default;
   virtual bool Init() = 0;
@@ -34,7 +34,7 @@ namespace kodi
 {
 namespace gui
 {
-struct CRenderHelperStub : public IRenderHelper
+struct ATTRIBUTE_HIDDEN CRenderHelperStub : public IRenderHelper
 {
   bool Init() override { return true; }
   void Begin() override { }
@@ -59,7 +59,7 @@ namespace gui
  *
  * Function defines here and not in CAddonBase because of a hen and egg problem.
  */
-inline std::shared_ptr<IRenderHelper> GetRenderHelper()
+inline std::shared_ptr<IRenderHelper> ATTRIBUTE_HIDDEN GetRenderHelper()
 {
   using namespace ::kodi::addon;
   if (static_cast<CAddonBase*>(CAddonBase::m_interface->addonBase)->m_renderHelper)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h
@@ -47,67 +47,68 @@ namespace kodi
 {
 namespace platform
 {
-  class CInterfaceAndroidSystem
+class ATTRIBUTE_HIDDEN CInterfaceAndroidSystem
+{
+public:
+  CInterfaceAndroidSystem()
+    : m_interface(static_cast<AddonToKodiFuncTable_android_system*>(
+          GetInterface(INTERFACE_ANDROID_SYSTEM_NAME, INTERFACE_ANDROID_SYSTEM_VERSION))){};
+
+  //============================================================================
+  ///
+  /// \ingroup cpp_kodi_platform
+  /// @brief request an JNI env pointer for the calling thread.
+  /// JNI env has to be controlled by kodi because of the underlying
+  /// threading concep.
+  ///
+  /// @param[in]:
+  /// @return JNI env pointer for the calling thread
+  ///
+  inline void* GetJNIEnv()
   {
-  public:
-    CInterfaceAndroidSystem()
-     : m_interface(static_cast<AddonToKodiFuncTable_android_system*>(GetInterface(INTERFACE_ANDROID_SYSTEM_NAME, INTERFACE_ANDROID_SYSTEM_VERSION)))
-     {};
+    if (m_interface)
+      return m_interface->get_jni_env();
 
-    //============================================================================
-    ///
-    /// \ingroup cpp_kodi_platform
-    /// @brief request an JNI env pointer for the calling thread.
-    /// JNI env has to be controlled by kodi because of the underlying
-    /// threading concep.
-    ///
-    /// @param[in]:
-    /// @return JNI env pointer for the calling thread
-    ///
-    inline void * GetJNIEnv()
-    {
-      if (m_interface)
-        return m_interface->get_jni_env();
-
-      return nullptr;
-    }
-    //----------------------------------------------------------------------------
-
-    //============================================================================
-    ///
-    /// \ingroup cpp_kodi_platform
-    /// @brief request the android sdk version to e.g. initialize JNIBase.
-    ///
-    /// @param[in]:
-    /// @return Android SDK version
-    ///
-    inline int GetSDKVersion()
-    {
-      if (m_interface)
-        return m_interface->get_sdk_version();
-
-      return 0;
-    }
-
-    //============================================================================
-    ///
-    /// \ingroup cpp_kodi_platform
-    /// @brief request the android main class name e.g. org.xbmc.kodi.
-    ///
-    /// @param[in]:
-    /// @return package class name
-    ///
-    inline std::string GetClassName()
-    {
-      if (m_interface)
-        return m_interface->get_class_name();
-
-      return std::string();
-    }
-
-  private:
-    AddonToKodiFuncTable_android_system *m_interface;
-  };
+    return nullptr;
+  }
   //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  /// \ingroup cpp_kodi_platform
+  /// @brief request the android sdk version to e.g. initialize JNIBase.
+  ///
+  /// @param[in]:
+  /// @return Android SDK version
+  ///
+  inline int GetSDKVersion()
+  {
+    if (m_interface)
+      return m_interface->get_sdk_version();
+
+    return 0;
+  }
+
+  //============================================================================
+  ///
+  /// \ingroup cpp_kodi_platform
+  /// @brief request the android main class name e.g. org.xbmc.kodi.
+  ///
+  /// @param[in]:
+  /// @return package class name
+  ///
+  inline std::string GetClassName()
+  {
+    if (m_interface)
+      return m_interface->get_class_name();
+
+    return std::string();
+  }
+
+private:
+  AddonToKodiFuncTable_android_system* m_interface;
+};
+//----------------------------------------------------------------------------
+
 } /* namespace platform */
 } /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/tools/DllHelper.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/tools/DllHelper.h
@@ -89,7 +89,7 @@ namespace tools
 /// ~~~~~~~~~~~~~
 ///
 ///@{
-class CDllHelper
+class ATTRIBUTE_HIDDEN CDllHelper
 {
 public:
   //============================================================================

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -34,31 +34,31 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.2"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.3"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.2.0"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \
                                                       "addon-instance/" \
                                                       "c-api/addon_base.h"
 
-#define ADDON_GLOBAL_VERSION_GENERAL                  "1.0.4"
+#define ADDON_GLOBAL_VERSION_GENERAL                  "1.0.5"
 #define ADDON_GLOBAL_VERSION_GENERAL_MIN              "1.0.4"
 #define ADDON_GLOBAL_VERSION_GENERAL_XML_ID           "kodi.binary.global.general"
 #define ADDON_GLOBAL_VERSION_GENERAL_DEPENDS          "General.h"
 
-#define ADDON_GLOBAL_VERSION_GUI                      "5.14.0"
+#define ADDON_GLOBAL_VERSION_GUI                      "5.14.1"
 #define ADDON_GLOBAL_VERSION_GUI_MIN                  "5.14.0"
 #define ADDON_GLOBAL_VERSION_GUI_XML_ID               "kodi.binary.global.gui"
 #define ADDON_GLOBAL_VERSION_GUI_DEPENDS              "ActionIDs.h" \
                                                       "gui/"
 
-#define ADDON_GLOBAL_VERSION_AUDIOENGINE              "1.1.0"
+#define ADDON_GLOBAL_VERSION_AUDIOENGINE              "1.1.1"
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_MIN          "1.1.0"
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_XML_ID       "kodi.binary.global.audioengine"
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.3"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.4"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.0"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \
@@ -66,49 +66,49 @@
                                                       "gui/gl/Shader.h" \
                                                       "tools/DllHelper.h"
 
-#define ADDON_GLOBAL_VERSION_NETWORK                  "1.0.3"
+#define ADDON_GLOBAL_VERSION_NETWORK                  "1.0.4"
 #define ADDON_GLOBAL_VERSION_NETWORK_MIN              "1.0.0"
 #define ADDON_GLOBAL_VERSION_NETWORK_XML_ID           "kodi.binary.global.network"
 #define ADDON_GLOBAL_VERSION_NETWORK_DEPENDS          "Network.h" \
                                                       "c-api/network.h"
 
-#define ADDON_GLOBAL_VERSION_TOOLS                    "1.0.0"
+#define ADDON_GLOBAL_VERSION_TOOLS                    "1.0.1"
 #define ADDON_GLOBAL_VERSION_TOOLS_MIN                "1.0.0"
 #define ADDON_GLOBAL_VERSION_TOOLS_XML_ID             "kodi.binary.global.tools"
 #define ADDON_GLOBAL_VERSION_TOOLS_DEPENDS            "tools/DllHelper.h"
 
-#define ADDON_INSTANCE_VERSION_AUDIODECODER           "2.0.1"
+#define ADDON_INSTANCE_VERSION_AUDIODECODER           "2.0.2"
 #define ADDON_INSTANCE_VERSION_AUDIODECODER_MIN       "2.0.1"
 #define ADDON_INSTANCE_VERSION_AUDIODECODER_XML_ID    "kodi.binary.instance.audiodecoder"
 #define ADDON_INSTANCE_VERSION_AUDIODECODER_DEPENDS   "addon-instance/AudioDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_AUDIOENCODER           "2.0.1"
+#define ADDON_INSTANCE_VERSION_AUDIOENCODER           "2.0.2"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_MIN       "2.0.1"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_XML_ID    "kodi.binary.instance.audioencoder"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "2.0.1"
+#define ADDON_INSTANCE_VERSION_GAME                   "2.0.2"
 #define ADDON_INSTANCE_VERSION_GAME_MIN               "2.0.1"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 
-#define ADDON_INSTANCE_VERSION_IMAGEDECODER           "2.1.0"
+#define ADDON_INSTANCE_VERSION_IMAGEDECODER           "2.1.1"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_MIN       "2.1.0"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.3.2"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.3.3"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.3.1"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 
-#define ADDON_INSTANCE_VERSION_PERIPHERAL             "1.3.8"
+#define ADDON_INSTANCE_VERSION_PERIPHERAL             "1.3.9"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_MIN         "1.3.8"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_XML_ID      "kodi.binary.instance.peripheral"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "7.0.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "7.0.1"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "7.0.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \
@@ -133,22 +133,22 @@
                                                       "addon-instance/pvr/Stream.h" \
                                                       "addon-instance/pvr/Timers.h"
 
-#define ADDON_INSTANCE_VERSION_SCREENSAVER            "2.0.1"
+#define ADDON_INSTANCE_VERSION_SCREENSAVER            "2.0.2"
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_MIN        "2.0.1"
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_XML_ID     "kodi.binary.instance.screensaver"
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "addon-instance/Screensaver.h"
 
-#define ADDON_INSTANCE_VERSION_VFS                    "2.3.1"
+#define ADDON_INSTANCE_VERSION_VFS                    "2.3.2"
 #define ADDON_INSTANCE_VERSION_VFS_MIN                "2.3.1"
 #define ADDON_INSTANCE_VERSION_VFS_XML_ID             "kodi.binary.instance.vfs"
 #define ADDON_INSTANCE_VERSION_VFS_DEPENDS            "addon-instance/VFS.h"
 
-#define ADDON_INSTANCE_VERSION_VISUALIZATION          "2.0.3"
+#define ADDON_INSTANCE_VERSION_VISUALIZATION          "2.0.4"
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_MIN      "2.0.3"
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_XML_ID   "kodi.binary.instance.visualization"
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "1.0.2"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "1.0.3"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "1.0.2"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "addon-instance/VideoCodec.h" \


### PR DESCRIPTION
## Description
This fix the stupid clang feature about export of C++ parts within addon headers, where a on addon A compiled class or function becomes public on addon B and this call A instead his.

Further is the General part cleaned up and "C++" / "C" parts separated.

Also is a change added to allow two different addon type ID's, to allow better change and update of it.

**Addons not need a recompile!** only want to have them in before the rest of PVR's becomes updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
