### PR TITLE
[PVR] Fix EPG grid container crash

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1643,6 +1643,8 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement* layout)
     m_rulerLayouts.back().LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     itemElement = itemElement->NextSiblingElement("rulerlayout");
   }
+
+  UpdateLayout();
 }
 
 std::string CGUIEPGGridContainer::GetDescription() const
@@ -1774,7 +1776,6 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
   {
     CSingleLock lock(m_critSection);
 
-    UpdateLayout();
     iRulerUnit = m_rulerUnit;
     iFirstChannel = m_channelOffset;
     iChannelsPerPage = m_channelsPerPage;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1862,6 +1862,8 @@ void CGUIEPGGridContainer::UpdateLayout()
       oldRulerLayout == m_rulerLayout && oldRulerDateLayout == m_rulerDateLayout)
     return; // nothing has changed, so don't update stuff
 
+  CSingleLock lock(m_critSection);
+
   m_channelHeight = m_channelLayout->Size(VERTICAL);
   m_channelWidth = m_channelLayout->Size(HORIZONTAL);
 


### PR DESCRIPTION
This PR fixes a crash.

```
06-11 20:35:41.700 25210 25547 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x1dc in tid 25547 (Thread-3), pid 25210 (org.xbmc.kodi)
06-11 20:35:41.852 25711 25711 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
06-11 20:35:41.852 25711 25711 F DEBUG   : Build fingerprint: 'NVIDIA/mdarcy/mdarcy:9/PPR1.180610.011/4199437_1915.8582:user/release-keys'
06-11 20:35:41.852 25711 25711 F DEBUG   : Revision: '0'
06-11 20:35:41.852 25711 25711 F DEBUG   : ABI: 'arm64'
06-11 20:35:41.852 25711 25711 F DEBUG   : pid: 25210, tid: 25547, name: Thread-3  >>> org.xbmc.kodi <<<
06-11 20:35:41.852 25711 25711 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x1dc
06-11 20:35:41.852 25711 25711 F DEBUG   : Cause: null pointer dereference
06-11 20:35:41.852 25711 25711 F DEBUG   :     x0  0000000000000000  x1  0000000000000001  x2  000000216030e300  x3  0000002156f274f0
06-11 20:35:41.852 25711 25711 F DEBUG   :     x4  0000000000000031  x5  000000215e538cf8  x6  0000002156f26740  x7  0000002156f26788
06-11 20:35:41.852 25711 25711 F DEBUG   :     x8  00000000000001dc  x9  00000000000001d8  x10 00000021475b0558  x11 00000021475b0548
06-11 20:35:41.852 25711 25711 F DEBUG   :     x12 0000000000000000  x13 00000000002fffff  x14 aaaaaaaaaaaaaaab  x15 000000000000000f
06-11 20:35:41.852 25711 25711 F DEBUG   :     x16 000000215b9e5310  x17 0000002158bf6630  x18 0000000000000018  x19 000000216bddd200
06-11 20:35:41.852 25711 25711 F DEBUG   :     x20 0000000000000001  x21 0000002156f26df0  x22 0000000000000000  x23 0000000000000012
06-11 20:35:41.852 25711 25711 F DEBUG   :     x24 000000216bddd700  x25 000000216bddd690  x26 0000002156f27588  x27 0000000000000001
06-11 20:35:41.852 25711 25711 F DEBUG   :     x28 0000007ffe1a0390  x29 0000002156f26de0
06-11 20:35:41.852 25711 25711 F DEBUG   :     sp  0000002156f26d20  lr  0000002158f21160  pc  0000002158bf6640
06-11 20:35:41.902 25711 25711 F DEBUG   : 
06-11 20:35:41.902 25711 25711 F DEBUG   : backtrace:
06-11 20:35:41.902 25711 25711 F DEBUG   :     #00 pc 0000000001751640  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIListItemLayout::Size(ORIENTATION) const+16)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #01 pc 0000000001a7c15c  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (PVR::CGUIEPGGridContainer::HandleChannels(bool, unsigned int, std::__ndk1::vector<CDirtyRegion, std::__ndk1::allocator<CDirtyRegion>>&)+832)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #02 pc 0000000001a7bbb8  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (PVR::CGUIEPGGridContainer::RenderChannels()+56)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #03 pc 0000000001a7bb4c  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (PVR::CGUIEPGGridContainer::Render()+16)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #04 pc 000000000170dd34  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControl::DoRender()+280)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #05 pc 000000000171a348  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControlGroup::Render()+188)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #06 pc 000000000170dd34  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControl::DoRender()+280)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #07 pc 000000000171a348  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControlGroup::Render()+188)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #08 pc 000000000170dd34  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControl::DoRender()+280)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #09 pc 000000000171a348  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControlGroup::Render()+188)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #10 pc 000000000170dd34  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControl::DoRender()+280)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #11 pc 000000000171a348  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControlGroup::Render()+188)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #12 pc 000000000170dd34  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControl::DoRender()+280)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #13 pc 000000000171a348  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControlGroup::Render()+188)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #14 pc 000000000170dd34  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIControl::DoRender()+280)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #15 pc 0000000001772fc0  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIWindow::DoRender()+60)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #16 pc 000000000177bf00  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIWindowManager::RenderPass() const+84)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #17 pc 000000000177c2f4  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CGUIWindowManager::Render()+712)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #18 pc 0000000001902e2c  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CApplication::Render()+276)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #19 pc 00000000019921ec  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CXBApplicationEx::Run(CAppParamParser const&)+200)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #20 pc 00000000016660a0  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (XBMC_Run+108)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #21 pc 0000000001203218  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (CXBMCApp::run()+80)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #22 pc 0000000001208568  /data/app/org.xbmc.kodi-ubGBVapMP9NEFfpaf5OgqQ==/lib/arm64/libkodi.so (_Z10thread_runI8CXBMCAppXadL_ZNS0_3runEvEEEPvS1_+8)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #23 pc 0000000000081978  /system/lib64/libc.so (__pthread_start(void*)+36)
06-11 20:35:41.902 25711 25711 F DEBUG   :     #24 pc 00000000000234b8  /system/lib64/libc.so (__start_thread+68)
```

PVR Guide window uses two threads, the GUI thread and a custom thread to refresh the EPG time line. Cause of the crash was that `CGUIEPGGridContainer::UpdateLayout`, which recalculates a lot of member vars was called from both threads, without proper thread sync mechanisms.

<img width="835" alt="Screenshot 2020-06-11 at 23 00 29" src="https://user-images.githubusercontent.com/3226626/84575843-97273580-adb0-11ea-8263-57d0644ec437.png">

The fix was to make CGUIEPGGridContainer::UpdateLayout thread-safe and not to call it anymore from the time line refresh thread as it turned out that this not needed, because the layout will never change when timeline changes. `UpdateLayout` must be thread-safe nevertheless, because some of the member vars it changes will still be read by the timeline refresh thread.

Runtime-tested on latest master, macOS and Android.

@phunkyfish when you have some time...

We should also fix this for Leia. PR follows.
