### PR TITLE
[addons] remove pvr from addoncache and improve addon manager addon check

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -141,14 +141,26 @@ void CAddonMgr::DeInit()
 
 bool CAddonMgr::HasAddons(const TYPE &type)
 {
-  VECADDONS addons;
-  return GetAddonsInternal(type, addons, true);
+  CSingleLock lock(m_critSection);
+
+  for (const auto& addonInfo : m_installedAddons)
+  {
+    if (addonInfo.second->HasType(type) && !IsAddonDisabled(addonInfo.second->ID()))
+      return true;
+  }
+  return false;
 }
 
 bool CAddonMgr::HasInstalledAddons(const TYPE &type)
 {
-  VECADDONS addons;
-  return GetAddonsInternal(type, addons, false);
+  CSingleLock lock(m_critSection);
+
+  for (const auto& addonInfo : m_installedAddons)
+  {
+    if (addonInfo.second->HasType(type))
+      return true;
+  }
+  return false;
 }
 
 void CAddonMgr::AddToUpdateableAddons(AddonPtr &pAddon)

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -15,7 +15,7 @@
 namespace ADDON
 {
 
-const std::vector<TYPE> ADDONS_TO_CACHE = { ADDON_PVRDLL, ADDON_GAMEDLL };
+const std::vector<TYPE> ADDONS_TO_CACHE = {ADDON_GAMEDLL};
 
 CBinaryAddonCache::~CBinaryAddonCache()
 {

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -9,10 +9,10 @@
 #include "guilib/guiinfo/SystemGUIInfo.h"
 
 #include "Application.h"
+#include "GUIPassword.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
-#include "addons/BinaryAddonCache.h"
-#include "GUIPassword.h"
+#include "addons/AddonManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -548,13 +548,8 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = true;
       return true;
     case SYSTEM_HAS_PVR_ADDON:
-    {
-      ADDON::VECADDONS pvrAddons;
-      ADDON::CBinaryAddonCache &addonCache = CServiceBroker::GetBinaryAddonCache();
-      addonCache.GetAddons(pvrAddons, ADDON::ADDON_PVRDLL);
-      value = (pvrAddons.size() > 0);
+      value = CServiceBroker::GetAddonMgr().HasAddons(ADDON::ADDON_PVRDLL);
       return true;
-    }
     case SYSTEM_HAS_CMS:
 #if defined(HAS_GL) || defined(HAS_DX)
       value = true;


### PR DESCRIPTION
## Description

On first commit is a change to addon manager added.
Before was by `HasAddons(...)` (the enabled ones) and `HasInstalledAddon(...)` the whole addon class of all asked types created and then on end checked that his list is empty or not.
Since cpluff is removed is it more easy as a list is stored in manager.
This checks now this list and on first found addon it returns (instead of loop for all).

The second commit use then this changed functions on PVR to ask about available.
There was before the only place where the Binary addon cache was used about PVR and now removed as it is no more needed.

Have them taken from https://github.com/xbmc/xbmc/pull/18057 to have there smaller.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
