### PR TITLE
[cmake] remove very old no more needed part of addons

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -111,26 +111,6 @@ function(core_add_test_library name)
   endforeach()
 endfunction()
 
-# Add an addon callback library
-# Arguments:
-#   name name of the library to add
-# Implicit arguments:
-#   SOURCES the sources of the library
-#   HEADERS the headers of the library (only for IDE support)
-#   OTHERS  other library related files (only for IDE support)
-# On return:
-#   Library target is defined and added to LIBRARY_FILES
-function(core_add_addon_library name)
-  get_filename_component(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-  list(APPEND SOURCES lib${name}.cpp)
-  core_add_shared_library(${name} OUTPUT_DIRECTORY addons/${DIRECTORY})
-  set_target_properties(${name} PROPERTIES FOLDER addons)
-  target_include_directories(${name} PRIVATE
-                             ${CMAKE_CURRENT_SOURCE_DIR}
-                             ${CMAKE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi
-                             ${CMAKE_SOURCE_DIR}/xbmc)
-endfunction()
-
 # Add an dl-loaded shared library
 # Arguments:
 #   name name of the library to add


### PR DESCRIPTION
## Description

There was still a part where was since years no more needed and
from the time where the binary addons has a shared lib between.

This was some years ago removed but his cmake build function
still exists.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
