### PR TITLE
[Python] Fix allocating buffer for a Python unicode string

### DIFF
--- a/xbmc/interfaces/python/typemaps/python.buffer.intm
+++ b/xbmc/interfaces/python/typemaps/python.buffer.intm
@@ -9,10 +9,11 @@
 %>
     if (PyUnicode_Check(${slarg}))
     {
-      const char* str = PyUnicode_AsUTF8(${slarg});
-      size_t size = (size_t)PyUnicode_GetLength(${slarg});
+      Py_ssize_t pysize;
+      const char* str = PyUnicode_AsUTF8AndSize(${slarg}, &pysize);
+      size_t size = static_cast<size_t>(pysize);
       ${api}.allocate(size);
-      ${api}.put(str,size);
+      ${api}.put(str, size);
       ${api}.flip(); // prepare the buffer for reading from
     }
     else if (PyByteArray_Check(${slarg}))


### PR DESCRIPTION
## Description
This PR fixes allocating `XbmcCommons::Buffer` when passing a Unicode `str` object from Python to Kodi.

## Motivation and Context
The current implementation uses `PyUnicode_GetLength` function that returns the number of Unicode codepoints (characters), however a buffer needs to be allocated for the actual size of a UTF-8 encoded C string. If your Python `str` contains non-ASCII characters, then the length of a UTF-8 encoded C string is greater than the number of Unicode codepoints in Python `str`. As the result a Python `str` with non-ASCII characters gets trimmed from the end, for example, when writing to disk using `xbmcfvs.File.write()`.

The bug was found and reported by @sualfred  on Slack.

## How Has This Been Tested?
The code was build in Ubuntu 18.04 and tested by writing a Undcode text using `xbmcvfs.File.write()`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
