### PR TITLE
[Music]Fix constraint violation on Artist Update

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1782,6 +1782,20 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
   if (idArtist < 0)
     return -1;
 
+  // Check another artist with this mbid not already exist (an alias for example)
+  bool useMBIDNull = strMusicBrainzArtistID.empty();
+  bool isScrapedMBID = bScrapedMBID;
+  std::string artistname;
+  int idArtistMbid = GetArtistFromMBID(strMusicBrainzArtistID, artistname);
+  if (idArtistMbid > 0)
+  {
+    CLog::Log(LOGDEBUG, "{0}: Updating {4} (Id: {5}) mbid {1} already assigned to {2} (Id: {3})",
+      __FUNCTION__, strMusicBrainzArtistID.c_str(), artistname.c_str(), idArtistMbid,
+      strArtist.c_str(), idArtist);
+    useMBIDNull = true;
+    isScrapedMBID = false;
+  }
+
   std::string strSQL;
   strSQL = PrepareSQL("UPDATE artist SET "
                       " strArtist = '%s', "
@@ -1800,7 +1814,7 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       strBiography.c_str(), strDied.c_str(), strDisbanded.c_str(),
                       strYearsActive.c_str(), strImage.c_str(), strFanart.c_str(),
                       CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), bScrapedMBID);
-  if (strMusicBrainzArtistID.empty())
+  if (useMBIDNull)
     strSQL += PrepareSQL(", strMusicBrainzArtistID = NULL");
   else
     strSQL += PrepareSQL(", strMusicBrainzArtistID = '%s'", strMusicBrainzArtistID.c_str());
@@ -1821,6 +1835,16 @@ bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist, const std::string& st
 {
   if (strMusicBrainzArtistID.empty() || idArtist < 0)
     return false;
+
+  // Check artist with this mbid not already exist (an alias for example)
+  std::string artistname;
+  int idArtistMbid = GetArtistFromMBID(strMusicBrainzArtistID, artistname);
+  if (idArtistMbid > 0)
+  {
+    CLog::Log(LOGDEBUG, "{0}: Artist mbid {1} already assigned to {2} (Id: {3})", __FUNCTION__,
+              strMusicBrainzArtistID.c_str(), artistname.c_str(), idArtistMbid);
+    return false;
+  }
 
   // Set scraped artist Musicbrainz ID for a previously added artist with no MusicBrainz ID
   std::string strSQL;
@@ -1925,6 +1949,40 @@ int CMusicDatabase::GetLastArtist()
       return -1;
 
   return static_cast<int>(strtol(lastArtist.c_str(), NULL, 10));
+}
+
+int CMusicDatabase::GetArtistFromMBID(const std::string& strMusicBrainzArtistID,
+                                      std::string& artistname)
+{
+  if (strMusicBrainzArtistID.empty())
+    return -1;
+
+  std::string strSQL;
+  try
+  {
+    if (nullptr == m_pDB || nullptr == m_pDS2)
+      return -1;
+    // Match on MusicBrainz ID, definitively unique
+    strSQL =
+        PrepareSQL("SELECT idArtist, strArtist FROM artist WHERE strMusicBrainzArtistID = '%s'",
+                   strMusicBrainzArtistID.c_str());
+    if (!m_pDS2->query(strSQL))
+      return -1;
+    int idArtist = -1;
+    if (m_pDS2->num_rows() > 0)
+    {
+      idArtist = m_pDS2->fv("idArtist").get_asInt();
+      artistname = m_pDS2->fv("strArtist").get_asString();
+    }
+    m_pDS2->close();
+    return idArtist;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "CMusicDatabase::{0} - failed to execute {1}", __FUNCTION__,
+              strSQL.c_str());
+  }
+  return -1;
 }
 
 bool CMusicDatabase::HasArtistBeenScraped(int idArtist)

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -327,6 +327,7 @@ public:
   bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = false);
   bool GetArtistExists(int idArtist);
   int GetLastArtist();
+  int GetArtistFromMBID(const std::string& strMusicBrainzArtistID, std::string& artistname);
   int  UpdateArtist(int idArtist,
                     const std::string& strArtist, const std::string& strSortName,
                     const std::string& strMusicBrainzArtistID, bool bScrapedMBID,


### PR DESCRIPTION
Fix update artist Musicbrainz ID constraint violation when trying to set a scraped mbid value and another artist record with that mbid already exists (probably an unmatched alias).

Say two artist table entries were created by the  following sequence:
1) Scanning music files without Musicbrainz id tags creates a artist called "Paul McCartney", ID= 1
2) Scanning music files with Musicbrainz id tags creates a artist called "McCartney", ID = 2 and mbid ba550d0e-adac-4864-b88b-407cab5e76af.

"McCartney" is an alias of "Paul McCartney" in the Musicbrainz database but Kodi has no way to identify that.

Now scrape additional artist information for artist "Paul McCartney", lookup by name at Musicbrainz will fetch mbid=ba550d0e-adac-4864-b88b-407cab5e76af, but attempting to set that as the mbid will cause a contraint violation as artist mbids are unique. 

The solution is to check there will be no violation before updating any missing mbids values with those fetched by the scraper (or imported from an NFO file). A log entry is made noting that and artist with that mbid exists. Kodi can't do more than that automatically because no way to tell which artist should become the master.

Fairly rare sequence, but could happen and woulds stop the sraced data from being saved.
