### PR TITLE
fix addon label2

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -146,7 +146,7 @@
 	</variable>
 	<variable name="AddonsLabel2Var">
 		<value condition="ListItem.Property(addon.downloading)">$INFO[ListItem.Property(addon.status)]</value>
-		<value condition="Container.SortMethod(1)">$INFO[ListItem.Label2]</value>
+		<value condition="!Container.SortMethod(1)">$INFO[ListItem.Label2]</value>
 		<value>$INFO[ListItem.AddonCreator,, - ]$INFO[ListItem.AddonVersion]</value>
 	</variable>
 	<variable name="RatingSettingLabel2Var">


### PR DESCRIPTION
i made a mistake when changing estuary to use Container.SortMethod() infobools.

the `Container.SortMethod(1)` should have been inverted here:
https://github.com/xbmc/xbmc/pull/17725/files#diff-a765f63a28ab6ae4c4f7aae306ba110c

as a result label2 is now set to enabled status instead of author/version.

@ksooo 