### PR TITLE
[Android] Fix drain in flushed state

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -999,11 +999,6 @@ void CDVDVideoCodecAndroidMediaCodec::Reset()
 
   if (m_codec)
   {
-    // flush all outputbuffers inflight, they will
-    // become invalid on m_codec->flush and generate
-    // a spew of java exceptions if used
-    FlushInternal();
-
     // now we can flush the actual MediaCodec object
     CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Reset Current state (%d)", m_state);
     m_codec->flush();
@@ -1127,6 +1122,9 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
     SignalEndOfStream();
     m_state = MEDIACODEC_STATE_WAIT_ENDOFSTREAM;
   }
+  else if (m_state == MEDIACODEC_STATE_FLUSHED)
+    return VC_EOF;
+
   return VC_NONE;
 }
 


### PR DESCRIPTION
## Description
If VideoPlayer sends DRAIN state to decoder while MediaCodec is in flushed state, we currently return VC_NONE. VC_EOF is the correct return value.

## Motivation and Context
Switching between local streams without stopping the first one before can lead to the issue that the first stream is not detected as finished and the second new stream does not start.

## How Has This Been Tested?
MIBox, start stream, press back, select another stream for playback.
- Without this PR the first stream is stalled, but second stream does not start
- With this PR the second stream starts

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
