### PR TITLE
Artist discography  - Use  Musicbrainz releasegroup ids for matching

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -796,8 +796,11 @@ void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
   {
     std::stringstream prefix;
     prefix << "artist.album" << i + 1;
-    artist.discography.emplace_back(FromString(item, prefix.str() + ".title"),
-                                    FromString(item, prefix.str() + ".year"));
+    CDiscoAlbum discoAlbum;
+    discoAlbum.strAlbum = FromString(item, prefix.str() + ".title");
+    discoAlbum.strYear = FromString(item, prefix.str() + ".year");
+    discoAlbum.strReleaseGroupMBID = FromString(item, prefix.str() + ".musicbrainzreleasegroupid");
+    artist.discography.emplace_back(discoAlbum);
   }
 
   int nThumbs = item.GetProperty("artist.thumbs").asInteger32();

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -118,17 +118,17 @@ bool CArtist::Load(const TiXmlElement *artist, bool append, bool prioritise)
 
   // Discography
   const TiXmlElement* node = artist->FirstChildElement("album");
+  if (node)
+    discography.clear();
   while (node)
   {
-    const TiXmlNode* title = node->FirstChild("title");
-    if (title && title->FirstChild())
+    if (node->FirstChild())
     {
-      std::string strTitle = title->FirstChild()->Value();
-      std::string strYear;
-      const TiXmlNode* year = node->FirstChild("year");
-      if (year && year->FirstChild())
-        strYear = year->FirstChild()->Value();
-      discography.emplace_back(strTitle, strYear);
+      CDiscoAlbum album;
+      XMLUtils::GetString(node, "title", album.strAlbum);
+      XMLUtils::GetString(node, "year", album.strYear);
+      XMLUtils::GetString(node, "musicbrainzreleasegroupid", album.strReleaseGroupMBID);
+      discography.push_back(album);
     }
     node = node->NextSiblingElement("album");
   }
@@ -215,16 +215,11 @@ bool CArtist::Save(TiXmlNode *node, const std::string &tag, const std::string& s
   for (const auto& it : discography)
   {
     // add a <album> tag
-    TiXmlElement cast("album");
-    TiXmlNode *node = artist->InsertEndChild(cast);
-    TiXmlElement title("title");
-    TiXmlNode *titleNode = node->InsertEndChild(title);
-    TiXmlText name(it.first);
-    titleNode->InsertEndChild(name);
-    TiXmlElement year("year");
-    TiXmlNode *yearNode = node->InsertEndChild(year);
-    TiXmlText name2(it.second);
-    yearNode->InsertEndChild(name2);
+    TiXmlElement discoElement("album");
+    TiXmlNode* node = artist->InsertEndChild(discoElement);
+    XMLUtils::SetString(node, "title", it.strAlbum);
+    XMLUtils::SetString(node, "year", it.strYear);
+    XMLUtils::SetString(node, "musicbrainzreleasegroupid", it.strReleaseGroupMBID);
   }
 
   return true;

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -22,6 +22,14 @@ class TiXmlNode;
 class CAlbum;
 class CMusicDatabase;
 
+class CDiscoAlbum
+{
+public:
+  std::string strAlbum;
+  std::string strYear;
+  std::string strReleaseGroupMBID;
+};
+
 class CArtist
 {
 public:
@@ -105,7 +113,7 @@ public:
   CScraperUrl thumbURL; // Data for available thumbs
   CFanart fanart;  // Data for available fanart, urls etc.
   std::map<std::string, std::string> art;  // Current artwork - thumb, fanart etc.
-  std::vector<std::pair<std::string,std::string> > discography;
+  std::vector<CDiscoAlbum> discography;
   CDateTime dateAdded; // From related file creation or modification times, or when (re-)scanned
   CDateTime dateUpdated; // Time db record Last modified
   CDateTime dateNew;  // Time db record created

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -343,7 +343,7 @@ public:
   void SetTranslateBlankArtist(bool translate) { m_translateBlankArtist = translate; }
   bool HasArtistBeenScraped(int idArtist);
   bool ClearArtistLastScrapedTime(int idArtist);
-  int  AddArtistDiscography(int idArtist, const std::string& strAlbum, const std::string& strYear);
+  int AddArtistDiscography(int idArtist, const CDiscoAlbum& discoAlbum);
   bool DeleteArtistDiscography(int idArtist);
   bool GetArtistDiscography(int idArtist, CFileItemList& items);
 


### PR DESCRIPTION
Improve artist discography matching to albums in users music library by using Musicbrainz release group id when the artist scraper provides it.

Bump music db to v79 for change to discography table

---
Sometimes artist and album title are not enough to uniquely identify an album e.g. there are 5 different albums (with totally different tracks) by Peter Gabriel called "Peter Gabriel". In Musicbrainz these are referenced different release groups, and collectors that have name duplicate albums like these can add them all to their music library providing that they tag the music files with mbid tags. 

However the artist discography facility - a scraped list of albums by the artist independant of what albums the user has in their library - was not able to handle these name duplicates when matching them to those that where in the library. This PR fixes that.

