### PR TITLE
[Music]Fix MySQL syntax for trigger tgrInsertGenre

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -370,9 +370,8 @@ void CMusicDatabase::CreateAnalytics()
     m_pDS->exec("CREATE TRIGGER tgrUpdateArtist BEFORE UPDATE ON artist FOR EACH ROW"
                 " SET NEW.dateModified = now()");
 
-    m_pDS->exec("CREATE TRIGGER tgrInsertGenre AFTER INSERT ON genre"
-                " BEGIN UPDATE versiontagscan SET genresupdated = now();" 
-                " END");
+    m_pDS->exec("CREATE TRIGGER tgrInsertGenre AFTER INSERT ON genre FOR EACH ROW"
+                " UPDATE versiontagscan SET genresupdated = now()");
   }
 
     // Triggers to maintain recent changes to album and song artist links in removed_link table


### PR DESCRIPTION
Quick follow up to #18026 - Music library differential sync and better recentlly added handling - that does not migrate to music database v78 on MySQL/MariaDB (SQLite is fine)

Fix syntax for for trigger `tgrInsertGenre`