### PR TITLE
[xbmc.gui] drop backward compatibility for Leia skins

### DIFF
--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.gui" version="5.15.0" provider-name="Team Kodi">
-  <backwards-compatibility abi="5.14.0"/>
+  <backwards-compatibility abi="5.15.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
xbmc.gui was set to 5.15.0 for Matrix skins a few months ago.

it's now to to drop BW compatibility for Leia skin (5.14.0)
those skins will either not work correctly due to changes in the GUI engine,
or fail to install as many Leia skins depend on (py2) addons that have not been ported to py3.