### PR TITLE
[profiles] refuse to play locked videos from anywhere but VIDEO_NAV

### DIFF
--- a/xbmc/dialogs/GUIDialogKaiToast.h
+++ b/xbmc/dialogs/GUIDialogKaiToast.h
@@ -36,6 +36,7 @@ public:
 
   typedef std::queue<Notification> TOASTQUEUE;
 
+  static bool IsQueueEmpty() { return m_notifications.empty(); }
   static void QueueNotification(eMessageType eType, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime = TOAST_DISPLAY_TIME, bool withSound = true, unsigned int messageTime = TOAST_MESSAGE_TIME);
   static void QueueNotification(const std::string& aCaption, const std::string& aDescription);
   static void QueueNotification(const std::string& aImageFile, const std::string& aCaption, const std::string& aDescription, unsigned int displayTime = TOAST_DISPLAY_TIME, bool withSound = true, unsigned int messageTime = TOAST_MESSAGE_TIME);


### PR DESCRIPTION
2nd attempt on respecting locks from home-widgets / json-rpc-calls (see #17533)
videos should not be playable from anywhere if a lock is set up in profiles.

this pr silently throws a toast-message which notifies the user that the "Item is locked" and refuses to play. in this way a headless setup would not be blocked by a modal password dialog.

regarding _musicvideos_, which are scraped into both, music- and videodatabase.
if a video-lock is set up, they're still playable when started from the music-section main menu item or by json-rpc calls.
same goes for mixed playlists containing audio-tracks + musicvideos.

from musicvideos main menu item, the video would play if the user pulls up the context-menu on the desired item and hits play. i personally didn't expect this behaviour, but the user could play the video from the music-section anyways.

yes it's a fact: profiles-support is flawed and total horror...
(learned a bit about that when trying to deal with mediasource-locks)
BUT, it is there..and it's used in the wild..

thus i think we should fix what can be fixed without breaking other things.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
