### PR TITLE
[addons] allow disabled and incompatible addons to still be updated

### DIFF
--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -29,8 +29,8 @@ public:
   /*! \brief Get an addon with a specific version and repository. */
   bool GetAddon(const std::string& addonID, const ADDON::AddonVersion& version, const std::string& repoId, ADDON::AddonPtr& addon);
 
-  /*! Get the addon IDs that has been set to disabled */
-  bool GetDisabled(std::set<std::string>& addons);
+  /*! Get the addon IDs that have been set to disabled */
+  bool GetDisabled(std::map<std::string, ADDON::AddonDisabledReason>& addons);
 
   /*! @deprecated: use FindByAddonId */
   bool GetAvailableVersions(const std::string& addonId,
@@ -73,13 +73,24 @@ public:
 
   bool Search(const std::string& search, ADDON::VECADDONS& items);
 
-  /*! \brief Disable an addon.
-   Sets a flag that this addon has been disabled.  If disabled, it is usually still available on disk.
-   \param addonID id of the addon to disable
-   \param disable whether to enable or disable.  Defaults to true (disable)
-   \return true on success, false on failure
-   \sa IsAddonDisabled, HasDisabledAddons */
-  bool DisableAddon(const std::string &addonID, bool disable = true);
+  /*!
+   * \brief Disable an addon.
+   * Sets a flag that this addon has been disabled.  If disabled, it is usually still available on
+   * disk.
+   * \param addonID id of the addon to disable
+   * \param disabledReason the reason why the addon is being disabled
+   * \return true on success, false on failure
+   * \sa IsAddonDisabled, HasDisabledAddons, EnableAddon
+   */
+  bool DisableAddon(const std::string& addonID, ADDON::AddonDisabledReason disabledReason);
+
+  /*! \brief Enable an addon.
+   * Enables an addon that has previously been disabled
+   * \param addonID id of the addon to enable
+   * \return true on success, false on failure
+   * \sa DisableAddon, IsAddonDisabled, HasDisabledAddons
+   */
+  bool EnableAddon(const std::string& addonID);
 
   /*! \brief Mark an addon as broken
    Sets a flag that this addon has been marked as broken in the repository.

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -656,7 +656,7 @@ bool CAddonInstallJob::DoWork()
   if (m_isAutoUpdate && m_addon->IsBroken())
   {
     CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: auto-disabling due to being marked as broken", m_addon->ID().c_str());
-    CServiceBroker::GetAddonMgr().DisableAddon(m_addon->ID());
+    CServiceBroker::GetAddonMgr().DisableAddon(m_addon->ID(), AddonDisabledReason::USER);
     CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(m_addon, 24094)), true, false);
   }
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -223,7 +223,7 @@ VECADDONS CAddonMgr::GetAvailableUpdates() const
       last_versions[addon->ID()] = std::move(addon);
   }
 
-  GetAddons(installed);
+  GetAddonsForUpdate(installed);
   for (const auto& addon : installed)
   {
     const auto& remote = last_versions.find(addon->ID());
@@ -237,6 +237,11 @@ VECADDONS CAddonMgr::GetAvailableUpdates() const
 bool CAddonMgr::HasAvailableUpdates()
 {
   return !GetAvailableUpdates().empty();
+}
+
+bool CAddonMgr::GetAddonsForUpdate(VECADDONS& addons) const
+{
+  return GetAddonsInternal(ADDON_UNKNOWN, addons, true, true);
 }
 
 bool CAddonMgr::GetAddons(VECADDONS& addons) const
@@ -323,7 +328,10 @@ bool CAddonMgr::FindInstallableById(const std::string& addonId, AddonPtr& result
   return true;
 }
 
-bool CAddonMgr::GetAddonsInternal(const TYPE& type, VECADDONS& addons, bool enabledOnly) const
+bool CAddonMgr::GetAddonsInternal(const TYPE& type,
+                                  VECADDONS& addons,
+                                  bool enabledOnly,
+                                  bool checkIncompatible) const
 {
   CSingleLock lock(m_critSection);
 
@@ -332,7 +340,10 @@ bool CAddonMgr::GetAddonsInternal(const TYPE& type, VECADDONS& addons, bool enab
     if (type != ADDON_UNKNOWN && !addonInfo.second->HasType(type))
       continue;
 
-    if (enabledOnly && IsAddonDisabled(addonInfo.second->ID()))
+    if (enabledOnly &&
+        ((!checkIncompatible && IsAddonDisabled(addonInfo.second->ID())) ||
+         (checkIncompatible &&
+          IsAddonDisabledExcept(addonInfo.second->ID(), AddonDisabledReason::INCOMPATIBLE))))
       continue;
 
     //FIXME: hack for skipping special dependency addons (xbmc.python etc.).
@@ -392,7 +403,7 @@ std::vector<std::string> CAddonMgr::DisableIncompatibleAddons(
       CLog::Log(LOGWARNING, "ADDON: failed to unset {}", addon->ID());
       continue;
     }
-    if (!DisableAddon(addon->ID()))
+    if (!DisableAddon(addon->ID(), AddonDisabledReason::INCOMPATIBLE))
     {
       CLog::Log(LOGWARNING, "ADDON: failed to disable {}", addon->ID());
     }
@@ -532,13 +543,13 @@ bool CAddonMgr::FindAddons()
   m_installedAddons = std::move(installedAddons);
 
   // Reload caches
-  std::set<std::string> tmp;
-  m_database.GetDisabled(tmp);
-  m_disabled = std::move(tmp);
+  std::map<std::string, AddonDisabledReason> tmpDisabled;
+  m_database.GetDisabled(tmpDisabled);
+  m_disabled = std::move(tmpDisabled);
 
-  tmp.clear();
-  m_database.GetBlacklisted(tmp);
-  m_updateBlacklist = std::move(tmp);
+  std::set<std::string> tmpBlacklist;
+  m_database.GetBlacklisted(tmpBlacklist);
+  m_updateBlacklist = std::move(tmpBlacklist);
 
   return true;
 }
@@ -659,16 +670,16 @@ static void ResolveDependencies(const std::string& addonId, std::vector<std::str
   }
 }
 
-bool CAddonMgr::DisableAddon(const std::string& id)
+bool CAddonMgr::DisableAddon(const std::string& id, AddonDisabledReason disabledReason)
 {
   CSingleLock lock(m_critSection);
   if (!CanAddonBeDisabled(id))
     return false;
   if (m_disabled.find(id) != m_disabled.end())
     return true; //already disabled
-  if (!m_database.DisableAddon(id))
+  if (!m_database.DisableAddon(id, disabledReason))
     return false;
-  if (!m_disabled.insert(id).second)
+  if (!m_disabled.emplace(id, disabledReason).second)
     return false;
 
   //success
@@ -701,7 +712,7 @@ bool CAddonMgr::EnableSingle(const std::string& id)
     return false;
   }
 
-  if (!m_database.DisableAddon(id, false))
+  if (!m_database.EnableAddon(id))
     return false;
   m_disabled.erase(id);
 
@@ -732,6 +743,14 @@ bool CAddonMgr::IsAddonDisabled(const std::string& ID) const
 {
   CSingleLock lock(m_critSection);
   return m_disabled.find(ID) != m_disabled.end();
+}
+
+bool CAddonMgr::IsAddonDisabledExcept(const std::string& ID,
+                                      AddonDisabledReason disabledReason) const
+{
+  CSingleLock lock(m_critSection);
+  const auto disabledAddon = m_disabled.find(ID);
+  return disabledAddon != m_disabled.end() && disabledAddon->second != disabledReason;
 }
 
 bool CAddonMgr::CanAddonBeDisabled(const std::string& ID)
@@ -927,15 +946,24 @@ bool CAddonMgr::GetAddonInfos(AddonInfos& addonInfos, bool enabledOnly, TYPE typ
 
 bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos, TYPE type)
 {
+  return GetDisabledAddonInfos(addonInfos, type, AddonDisabledReason::NONE);
+}
+
+bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
+                                      TYPE type,
+                                      AddonDisabledReason disabledReason)
+{
   CSingleLock lock(m_critSection);
 
   bool forUnknown = type == ADDON_UNKNOWN;
   for (const auto& info : m_installedAddons)
   {
-    if (m_disabled.find(info.first) == m_disabled.end())
+    const auto disabledAddon = m_disabled.find(info.first);
+    if (disabledAddon == m_disabled.end())
       continue;
 
-    if (info.second->MainType() != ADDON_UNKNOWN && (forUnknown || info.second->HasType(type)))
+    if (info.second->MainType() != ADDON_UNKNOWN && (forUnknown || info.second->HasType(type)) &&
+        (disabledReason == AddonDisabledReason::NONE || disabledReason == disabledAddon->second))
       addonInfos.emplace_back(info.second);
   }
 

--- a/xbmc/addons/ContextMenus.cpp
+++ b/xbmc/addons/ContextMenus.cpp
@@ -74,6 +74,7 @@ bool CDisableAddon::IsVisible(const CFileItem& item) const
 
 bool CDisableAddon::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetAddonMgr().DisableAddon(item->GetAddonInfo()->ID());
+  return CServiceBroker::GetAddonMgr().DisableAddon(item->GetAddonInfo()->ID(),
+                                                    AddonDisabledReason::USER);
 }
 }

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -451,7 +451,7 @@ void CGUIDialogAddonInfo::OnEnableDisable()
     if (PromptIfDependency(24075, 24091))
       return; //required. can't disable
 
-    CServiceBroker::GetAddonMgr().DisableAddon(m_localAddon->ID());
+    CServiceBroker::GetAddonMgr().DisableAddon(m_localAddon->ID(), AddonDisabledReason::USER);
   }
   else
     CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID());

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -26,6 +26,17 @@ class CAddonInfo;
 typedef std::shared_ptr<CAddonInfo> AddonInfoPtr;
 typedef std::vector<AddonInfoPtr> AddonInfos;
 
+enum class AddonDisabledReason
+{
+  /// @brief Special reason for returning all disabled addons.
+  ///
+  /// Only used as an actual value when an addon is enabled.
+  NONE = 0,
+  USER = 1,
+  INCOMPATIBLE = 2,
+  PERMANENT_FAILURE = 3
+};
+
 struct DependencyInfo
 {
   std::string id;

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -150,15 +150,27 @@ JSONRPC_STATUS CAddonsOperations::SetAddonEnabled(const std::string &method, ITr
     return InvalidParams;
 
   bool disabled = false;
+  AddonDisabledReason disabledReason;
   if (parameterObject["enabled"].isBoolean())
+  {
     disabled = !parameterObject["enabled"].asBoolean();
+    disabledReason =
+        static_cast<AddonDisabledReason>(parameterObject["disabledReason"].asInteger());
+  }
   // we need to toggle the current disabled state of the addon
   else if (parameterObject["enabled"].isString())
+  {
     disabled = !CServiceBroker::GetAddonMgr().IsAddonDisabled(id);
+    disabledReason =
+        static_cast<AddonDisabledReason>(parameterObject["disabledReason"].asInteger());
+  }
   else
+  {
     return InvalidParams;
+  }
 
-  bool success = disabled ? CServiceBroker::GetAddonMgr().DisableAddon(id) : CServiceBroker::GetAddonMgr().EnableAddon(id);
+  bool success = disabled ? CServiceBroker::GetAddonMgr().DisableAddon(id, disabledReason)
+                          : CServiceBroker::GetAddonMgr().EnableAddon(id);
   return success ? ACK : InvalidParams;
 }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -160,7 +160,8 @@ void CPVRClients::UpdateAddons(const std::string& changedAddonId /*= ""*/)
         CLog::LogF(LOGERROR, "Failed to create add-on %s, status = %d", addon.first->Name().c_str(), status);
         if (status == ADDON_STATUS_PERMANENT_FAILURE)
         {
-          CServiceBroker::GetAddonMgr().DisableAddon(addon.first->ID());
+          CServiceBroker::GetAddonMgr().DisableAddon(addon.first->ID(),
+                                                     AddonDisabledReason::PERMANENT_FAILURE);
           CJobManager::GetInstance().AddJob(new CPVREventLogJob(true, true, addon.first->Name(), g_localizeStrings.Get(24070), addon.first->Icon()), nullptr);
         }
       }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Allow disabled and incompatible addons to still be updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Due to the python3 change in kodi 19 when users install v19 they will have a number of addons that will be disabled as either there is no Matrix version of the addon yet or the Matrix version is in a new repo.

This PR should mean that updates will still be attempted so when a compatible version of the addon becomes available it will get installed instead of users having to manually update dependencies etc. and should make the process smooth.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

It hasn't! I need to somehow to derive a test scenario for this that is reproducible. I lack the addon system knowledge to do this. Any help appreciated.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
