### PR TITLE
[PVR] Clean up API v7 warnings generated on Microsoft compilers

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -1241,7 +1241,7 @@ inline void* GetInterface(const std::string& name, const std::string& version)
  */
 #define ADDONCREATOR(AddonClass) \
   extern "C" __declspec(dllexport) ADDON_STATUS ADDON_Create( \
-      KODI_HANDLE addonInterface, const char* globalApiVersion, void* unused) \
+      KODI_HANDLE addonInterface, const char* /*globalApiVersion*/, void* /*unused*/) \
   { \
     kodi::addon::CAddonBase::m_interface = static_cast<AddonGlobalInterface*>(addonInterface); \
     kodi::addon::CAddonBase::m_interface->addonBase = new AddonClass; \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/pvr/Timers.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/pvr/Timers.h
@@ -627,7 +627,7 @@ public:
   /// @copydetails cpp_kodi_addon_pvr_Defs_PVRTypeIntValue_Help
   void SetPriorities(const std::vector<PVRTypeIntValue>& priorities, int prioritiesDefault = -1)
   {
-    m_cStructure->iPrioritiesSize = priorities.size();
+    m_cStructure->iPrioritiesSize = static_cast<unsigned int>(priorities.size());
     for (unsigned int i = 0;
          i < m_cStructure->iPrioritiesSize && i < sizeof(m_cStructure->priorities); ++i)
     {
@@ -679,7 +679,7 @@ public:
   /// @copydetails cpp_kodi_addon_pvr_Defs_PVRTypeIntValue_Help
   void SetLifetimes(const std::vector<PVRTypeIntValue>& lifetimes, int lifetimesDefault = -1)
   {
-    m_cStructure->iLifetimesSize = lifetimes.size();
+    m_cStructure->iLifetimesSize = static_cast<unsigned int>(lifetimes.size());
     for (unsigned int i = 0;
          i < m_cStructure->iLifetimesSize && i < sizeof(m_cStructure->lifetimes); ++i)
     {
@@ -735,7 +735,8 @@ public:
       const std::vector<PVRTypeIntValue>& preventDuplicateEpisodes,
       int preventDuplicateEpisodesDefault = -1)
   {
-    m_cStructure->iPreventDuplicateEpisodesSize = preventDuplicateEpisodes.size();
+    m_cStructure->iPreventDuplicateEpisodesSize =
+        static_cast<unsigned int>(preventDuplicateEpisodes.size());
     for (unsigned int i = 0; i < m_cStructure->iPreventDuplicateEpisodesSize &&
                              i < sizeof(m_cStructure->preventDuplicateEpisodes);
          ++i)
@@ -791,7 +792,7 @@ public:
   void SetRecordingGroups(const std::vector<PVRTypeIntValue>& recordingGroup,
                           int recordingGroupDefault = -1)
   {
-    m_cStructure->iRecordingGroupSize = recordingGroup.size();
+    m_cStructure->iRecordingGroupSize = static_cast<unsigned int>(recordingGroup.size());
     for (unsigned int i = 0;
          i < m_cStructure->iRecordingGroupSize && i < sizeof(m_cStructure->recordingGroup); ++i)
     {
@@ -842,7 +843,7 @@ public:
   void SetMaxRecordings(const std::vector<PVRTypeIntValue>& maxRecordings,
                         int maxRecordingsDefault = -1)
   {
-    m_cStructure->iMaxRecordingsSize = maxRecordings.size();
+    m_cStructure->iMaxRecordingsSize = static_cast<unsigned int>(maxRecordings.size());
     for (unsigned int i = 0;
          i < m_cStructure->iMaxRecordingsSize && i < sizeof(m_cStructure->maxRecordings); ++i)
     {


### PR DESCRIPTION
## Description
PVR API 7 introduced a few new compiler warnings that appear when compiling via Microsoft Visual C++.  PR addresses the warnings by issuing a few static_cast<>s and commenting out a couple unused variables in the ADDONCREATOR() macro.

Note that I didn't see any specifics in the coding guidelines about commenting out unused variables, and I noted that the macro itself is expected to be refactored at some point anyway.

## Motivation and Context
Change allows for a clean compile of a PVR addon with Microsoft Visual C++ compiler.

## How Has This Been Tested?
Tested on Windows x64 desktop, master branch from 2020.06.22.  Change does not introduce any function changes to the application, merely silences a few compiler warnings.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

- Warning clean up only; no functional changes

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
