### PR TITLE
[PVR] APIv7 crash when EPG_TAG structure contains null pointers

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/pvr/EPG.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/pvr/EPG.h
@@ -434,19 +434,19 @@ private:
 
   void SetData(const EPG_TAG* tag)
   {
-    m_title = tag->strTitle;
-    m_plotOutline = tag->strPlotOutline;
-    m_plot = tag->strPlot;
-    m_originalTitle = tag->strOriginalTitle;
-    m_cast = tag->strCast;
-    m_director = tag->strDirector;
-    m_writer = tag->strWriter;
-    m_IMDBNumber = tag->strIMDBNumber;
-    m_iconPath = tag->strIconPath;
-    m_genreDescription = tag->strGenreDescription;
-    m_episodeName = tag->strEpisodeName;
-    m_seriesLink = tag->strSeriesLink;
-    m_firstAired = tag->strFirstAired;
+    m_title = tag->strTitle == nullptr ? "" : tag->strTitle;
+    m_plotOutline = tag->strPlotOutline == nullptr ? "" : tag->strPlotOutline;
+    m_plot = tag->strPlot == nullptr ? "" : tag->strPlot;
+    m_originalTitle = tag->strOriginalTitle == nullptr ? "" : tag->strOriginalTitle;
+    m_cast = tag->strCast == nullptr ? "" : tag->strCast;
+    m_director = tag->strDirector == nullptr ? "" : tag->strDirector;
+    m_writer = tag->strWriter == nullptr ? "" : tag->strWriter;
+    m_IMDBNumber = tag->strIMDBNumber == nullptr ? "" : tag->strIMDBNumber;
+    m_iconPath = tag->strIconPath == nullptr ? "" : tag->strIconPath;
+    m_genreDescription = tag->strGenreDescription == nullptr ? "" : tag->strGenreDescription;
+    m_episodeName = tag->strEpisodeName == nullptr ? "" : tag->strEpisodeName;
+    m_seriesLink = tag->strSeriesLink == nullptr ? "" : tag->strSeriesLink;
+    m_firstAired = tag->strFirstAired == nullptr ? "" : tag->strFirstAired;
   }
 };
 ///@}


### PR DESCRIPTION
## Description
PVR API v7 introduced a set of new helper classes to wrap around the legacy C API structures.  In the case of the EPG_TAG wrapper, if the addon uses the EPG_TAG* constructor and the structure contains null pointers, the application will crash when these null pointer(s) are assigned to an std::string instance. 

## Motivation and Context
If PVR addon uses provided EPG_TAG* constructor and does not provide valid pointers for all char* fields, the application will crash when those pointer(s) are used via an assignment to an std::string instance.

Please let me know if you would prefer to see blank lines after each if() statement, will update accordingly.

## How Has This Been Tested?
Tested on Windows x64 desktop, master branch current as of 2020.06.22.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
