### PR TITLE
[Android] Move PYTHON into cache folder

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -416,8 +416,6 @@ public class Splash extends Activity
 
           if (!(sName.startsWith("assets/") || (mInstallLibs && sName.startsWith("lib/"))))
             continue;
-          if (sName.startsWith("assets/python"))
-            continue;
 
           String sFullPath = null;
           if (sName.startsWith("lib/"))

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1360,9 +1360,8 @@ void CXBMCApp::SetupEnv()
   else
     setenv("HOME", getenv("KODI_TEMP"), 0);
 
-  std::string apkPath = getenv("KODI_ANDROID_APK");
-  apkPath += "/assets/python3.7";
-  setenv("PYTHONHOME", apkPath.c_str(), 1);
+  std::string pythonPath = cacheDir + "/apk/assets/python3.7";
+  setenv("PYTHONHOME", pythonPath.c_str(), 1);
   setenv("PYTHONPATH", "", 1);
   setenv("PYTHONOPTIMIZE","", 1);
   setenv("PYTHONNOUSERSITE", "1", 1);


### PR DESCRIPTION
## Description
Copy python files from apk into android cache folder to allow pyc bytecode files.

## Motivation and Context
I investigated the poor python performance on android devices, and finally found out that all py files we bundle in the apk are not copied into the cache folder on first kodi launch.

Python is not able to create pyc bytecode files in this case, which was the reason for the poor performance. Now, with this PR and the py files in cache folder, everything runs much, much faster.

## How Has This Been Tested?
Start kodi, wait until N*****x service is launched (kodi log file)
- without PR: 8 seconds on NVIDIA Shield TV
- With this PR: < 1 second.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
