### PR TITLE
[Leia] [test] TestCPUInfo: remove useless test as we cannot guarantee that they exist

### DIFF
--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -73,36 +73,6 @@ TEST(TestCPUInfo, getTemperature)
 }
 #endif
 
-TEST(TestCPUInfo, getCPUModel)
-{
-  std::string s = g_cpuInfo.getCPUModel();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST(TestCPUInfo, getCPUBogoMips)
-{
-  std::string s = g_cpuInfo.getCPUBogoMips();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST(TestCPUInfo, getCPUHardware)
-{
-  std::string s = g_cpuInfo.getCPUHardware();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST(TestCPUInfo, getCPURevision)
-{
-  std::string s = g_cpuInfo.getCPURevision();
-  EXPECT_STRNE("", s.c_str());
-}
-
-TEST(TestCPUInfo, getCPUSerial)
-{
-  std::string s = g_cpuInfo.getCPUSerial();
-  EXPECT_STRNE("", s.c_str());
-}
-
 TEST(TestCPUInfo, CoreInfo)
 {
   ASSERT_TRUE(g_cpuInfo.HasCoreId(0));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Backport https://github.com/xbmc/xbmc/pull/17290 and https://github.com/xbmc/xbmc/pull/17320 to Leia

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
These tests fail under some circumstances so it would be great to backport the fix for those failures to Leia.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Ran tests, they pass.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
