### PR TITLE
[Estuary] handle input in the fullscreeninfo dialog

### DIFF
--- a/addons/skin.estuary/xml/DialogFullScreenInfo.xml
+++ b/addons/skin.estuary/xml/DialogFullScreenInfo.xml
@@ -1,3 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<defaultcontrol always="true">999</defaultcontrol>
+	<controls>
+		<control type="button" id="999">
+			<left>0</left>
+			<top>0</top>
+			<width>100%</width>
+			<height>100%</height>
+			<texturefocus />
+			<texturenofocus />
+			<onright>StepForward</onright>
+			<onleft>StepBack</onleft>
+			<onclick>OSD</onclick>
+		</control>
+	</controls>
 </window>


### PR DESCRIPTION
as a side effect of https://github.com/xbmc/xbmc/pull/16878, input commands like 'left' / 'right' / 'enter' are not handled when the fullscreeninfo dialog is visible.

this PR implements a hidden button in the skin that's maps those input commands to the related actions.

@ksooo 
