### PR TITLE
[LINUX] Fix kodi-ps3remote exceptions

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -199,7 +199,7 @@ if(ENABLE_EVENTCLIENTS)
           COMPONENT kodi-eventclients-common)
 
   # Install kodi-eventclients-common python files
-  file(WRITE ${CMAKE_BINARY_DIR}/packages/deb/defs.py ICON_PATH="usr/share/pixmaps/${APP_NAME_LC}/")
+  file(WRITE ${CMAKE_BINARY_DIR}/packages/deb/defs.py ICON_PATH="/usr/share/pixmaps/${APP_NAME_LC}/")
   install(PROGRAMS ${CMAKE_BINARY_DIR}/packages/deb/defs.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/__init__.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/PS3BDRemote/ps3_remote.py

--- a/tools/EventClients/Clients/PS3BDRemote/ps3_remote.py
+++ b/tools/EventClients/Clients/PS3BDRemote/ps3_remote.py
@@ -159,7 +159,7 @@ def process_keys(remote, xbmc):
         raise e
 
     if datalen == 13:
-        keycode = data.encode("hex")[10:12]
+        keycode = data.hex()[10:12]
         if keycode == "ff":
             xbmc.release_button()
             return done


### PR DESCRIPTION
Reported in Debian:

 * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962929
 * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962930

## Description
Fix two migration issues from Python2 to Python3 in kodi-eventclient-ps3

## Motivation and Context

They were reported in Debian:
  
     * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962929
     * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962930

## How Has This Been Tested?

First exception proven fixed by running 'kodi-ps3remote localhost 9777'
Second exception can not be tested by me because I have no BT remote.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed