### PR TITLE
Addons: fix definition of IsUserInstalled addons

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -151,8 +151,9 @@ static bool IsDependencyType(TYPE type)
 
 static bool IsUserInstalled(const AddonPtr& addon)
 {
-  return std::find_if(dependencyTypes.begin(), dependencyTypes.end(),
-                      [&](TYPE type) { return addon->HasType(type); }) == dependencyTypes.end();
+  return std::find_if(dependencyTypes.begin(), dependencyTypes.end(), [&](TYPE type) {
+           return addon->MainType() == type;
+         }) == dependencyTypes.end();
 }
 
 static bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)


### PR DESCRIPTION
## Description
This PR fixes the definition of `IsUserInstalled` for kodi addons.

## Motivation and Context
Kodi assumes that an addon is user installed if it doesn't have one of the following types: `ADDON_SCRAPER_LIBRARY`, `ADDON_SCRIPT_LIBRARY` and `ADDON_SCRIPT_MODULE`. While this works well in most cases (since there is additional logic in case the addon defines its `<provides>` content types), if an addon is a service and includes a builtin `script.module` it will be automatically hidden from the addon browser interface despite `XBMC_SERVICE` being its MainType.

Fixes https://github.com/xbmc/xbmc/issues/17742

## How Has This Been Tested?
Tested by installing the `service.tvtunes` addon per the description of https://github.com/xbmc/xbmc/issues/17742. Browsed other sections in the addon browser to check if behaviour is kept. 
In fact `IsUserInstalled` is pretty well self-contained being only used for the definition of the list of installed addons or the fact that a given addon is orphaned. 

## Screenshots (if appropriate):

**Master:**

![Master](https://i.imgur.com/aoea7Y5.png "Master")

**PR:**

![PR](https://i.imgur.com/T3ixtpW.png "PR")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
