### PR TITLE
Fix movie posters in leanback

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -75,7 +75,7 @@ public class XBMCJsonRPC
                   "{\"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovies\", "
                   + "\"params\": { \"filter\": {\"field\": \"playcount\", \"operator\": \"is\", \"value\": \"0\"}, "
                   + "\"limits\": { \"start\" : 0, \"end\": 10}, "
-                  + "\"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\", \"file\", \"plot\"], "
+                  + "\"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"art\", \"year\", \"runtime\", \"file\", \"plot\"], "
                   + "\"sort\": { \"order\": \"descending\", \"method\": \"random\", \"ignorearticle\": true } }, "
                   + "\"id\": \"1\"}";
 
@@ -103,7 +103,7 @@ public class XBMCJsonRPC
                  "{\"jsonrpc\": \"2.0\", \"method\": \"AudioLibrary.GetArtists\", \"params\": {\"filter\":{%s},\"limits\": { \"start\" : 0, \"end\": 10}, \"properties\" : [\"description\", \"thumbnail\", \"fanart\"], \"sort\": { \"order\": \"descending\", \"method\": \"dateadded\", \"ignorearticle\": true } }, \"id\": \"%s\"}";
 
   private String RETRIEVE_MOVIE_DETAILS =
-          "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovieDetails\", \"params\": { \"movieid\" : %s, \"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"year\", \"runtime\", \"file\", \"plot\", \"trailer\", \"rating\"] }, \"id\": \"%s\" }";
+          "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetMovieDetails\", \"params\": { \"movieid\" : %s, \"properties\" : [\"imdbnumber\", \"title\", \"tagline\", \"thumbnail\", \"fanart\", \"art\", \"year\", \"runtime\", \"file\", \"plot\", \"trailer\", \"rating\"] }, \"id\": \"%s\" }";
 
   private String RETRIEVE_EPISODE_DETAILS =
           "{ \"jsonrpc\": \"2.0\", \"method\": \"VideoLibrary.GetEpisodeDetails\", \"params\": { \"episodeid\" : %s, \"properties\" : [\"title\", \"tvshowid\", \"showtitle\", \"season\", \"episode\", \"thumbnail\", \"fanart\", \"file\", \"plot\", \"rating\", \"runtime\", \"firstaired\"] }, \"id\": \"%s\" }";
@@ -581,13 +581,21 @@ public class XBMCJsonRPC
                     .setDescription(movie.get("tagline").getAsString())
                     .setIntent(buildPendingMovieIntent(ctx, movie));
 
-            if (movie.has("fanart") && !movie.get("fanart").getAsString().isEmpty())
-              notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
-                      getDownloadUrl(movie.get("fanart").getAsString())).toString());
-            if (movie.has("thumbnail") && !movie.get("thumbnail").getAsString().isEmpty())
+            if (movie.has("art"))
             {
-              Bitmap bitmap = getBitmap(ctx, movie.get("thumbnail").getAsString());
-              notificationBuilder.setBitmap(bitmap);
+              JsonObject art = movie.get("art").getAsJsonObject();
+
+              if (art.has("fanart") && !art.get("fanart").getAsString().isEmpty())
+              {
+                notificationBuilder.setBackground(XBMCFileContentProvider.buildUri(
+                        getDownloadUrl(art.get("fanart").getAsString())).toString());
+              }
+
+              if (art.has("poster") && !art.get("poster").getAsString().isEmpty())
+              {
+                Bitmap bitmap = getBitmap(ctx,art.get("poster").getAsString());
+                notificationBuilder.setBitmap(bitmap);
+              }
             }
             Notification notification = notificationBuilder.build();
             mNotificationManager.notify(id, notification);
@@ -804,11 +812,23 @@ public class XBMCJsonRPC
           med.setCardImageUrl(XBMCFileContentProvider.buildUri(url).toString());
       }
       med.setCardImageAspectRatio("2:3");
-      if (details.has("fanart") && !details.get("fanart").getAsString().isEmpty())
+      if (details.has("art"))
       {
-        String url = getDownloadUrl(details.get("fanart").getAsString());
-        if (url != null && !url.isEmpty())
-          med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+        JsonObject art = details.get("art").getAsJsonObject();
+
+        if (art.has("fanart") && !art.get("fanart").getAsString().isEmpty())
+        {
+            String url = getDownloadUrl(art.get("fanart").getAsString());
+            if (url != null && !url.isEmpty())
+              med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+        }
+
+        if (art.has("poster") && !art.get("poster").getAsString().isEmpty())
+        {
+            String url = getDownloadUrl(art.get("poster").getAsString());
+            if (url != null && !url.isEmpty())
+              med.setBackgroundImageUrl(XBMCFileContentProvider.buildUri(url).toString());
+        }
       }
       med.setXbmcUrl("videodb://movies/titles/" + details.get("movieid").getAsString() + "?showinfo=true");
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Movie posters in leanback were showing thumbnails, which also used the wrong aspect ratio.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Movie posters looked weird.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I will test this, after jenkins produces some builds.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
