### PR TITLE
[addons] add callback to check setting is default and improve setting call performance

### DIFF
--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -210,7 +210,7 @@ bool Interface_Base::is_setting_using_default(void* kodiBase, const char* id)
     return false;
   }
 
-  if (!addon->ReloadSettings())
+  if (!addon->HasSettings())
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - couldn't get settings for add-on '{}'", __func__,
               addon->Name());
@@ -239,7 +239,7 @@ bool Interface_Base::get_setting_bool(void* kodiBase, const char* id, bool* valu
     return false;
   }
 
-  if (!addon->ReloadSettings())
+  if (!addon->HasSettings())
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - couldn't get settings for add-on '{}'", __func__,
               addon->Name());
@@ -276,7 +276,7 @@ bool Interface_Base::get_setting_int(void* kodiBase, const char* id, int* value)
     return false;
   }
 
-  if (!addon->ReloadSettings())
+  if (!addon->HasSettings())
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - couldn't get settings for add-on '{}'", __func__,
               addon->Name());
@@ -316,7 +316,7 @@ bool Interface_Base::get_setting_float(void* kodiBase, const char* id, float* va
     return false;
   }
 
-  if (!addon->ReloadSettings())
+  if (!addon->HasSettings())
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - couldn't get settings for add-on '{}'", __func__,
               addon->Name());
@@ -353,7 +353,7 @@ bool Interface_Base::get_setting_string(void* kodiBase, const char* id, char** v
     return false;
   }
 
-  if (!addon->ReloadSettings())
+  if (!addon->HasSettings())
   {
     CLog::Log(LOGERROR, "Interface_Base::{} - couldn't get settings for add-on '{}'", __func__,
               addon->Name());

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -50,6 +50,7 @@ bool Interface_Base::InitInterface(CAddonDll* addon,
   addonInterface.toKodi->get_addon_path = get_addon_path;
   addonInterface.toKodi->get_base_user_path = get_base_user_path;
   addonInterface.toKodi->addon_log_msg = addon_log_msg;
+  addonInterface.toKodi->is_setting_using_default = is_setting_using_default;
   addonInterface.toKodi->get_setting_bool = get_setting_bool;
   addonInterface.toKodi->get_setting_int = get_setting_int;
   addonInterface.toKodi->get_setting_float = get_setting_float;
@@ -196,6 +197,35 @@ void Interface_Base::addon_log_msg(void* kodiBase, const int addonLogLevel, cons
   }
 
   CLog::Log(logLevel, "AddOnLog: {}: {}", addon->ID(), strMessage);
+}
+
+bool Interface_Base::is_setting_using_default(void* kodiBase, const char* id)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (addon == nullptr || id == nullptr)
+  {
+    CLog::Log(LOGERROR, "Interface_Base::{} - invalid data (addon='{}', id='{}')", __func__,
+              kodiBase, static_cast<const void*>(id));
+
+    return false;
+  }
+
+  if (!addon->ReloadSettings())
+  {
+    CLog::Log(LOGERROR, "Interface_Base::{} - couldn't get settings for add-on '{}'", __func__,
+              addon->Name());
+    return false;
+  }
+
+  auto setting = addon->GetSettings()->GetSetting(id);
+  if (setting == nullptr)
+  {
+    CLog::Log(LOGERROR, "Interface_Base::{} - can't find setting '{}' in '{}'", __func__, id,
+              addon->Name());
+    return false;
+  }
+
+  return setting->IsDefault();
 }
 
 bool Interface_Base::get_setting_bool(void* kodiBase, const char* id, bool* value)

--- a/xbmc/addons/interfaces/AddonBase.h
+++ b/xbmc/addons/interfaces/AddonBase.h
@@ -55,6 +55,7 @@ struct Interface_Base
   static char* get_addon_path(void* kodiBase);
   static char* get_base_user_path(void* kodiBase);
   static void addon_log_msg(void* kodiBase, const int addonLogLevel, const char* strMessage);
+  static bool is_setting_using_default(void* kodiBase, const char* id);
   static bool get_setting_bool(void* kodiBase, const char* id, bool* value);
   static bool get_setting_int(void* kodiBase, const char* id, int* value);
   static bool get_setting_float(void* kodiBase, const char* id, float* value);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -689,6 +689,22 @@ inline void ATTRIBUTE_HIDDEN Log(const AddonLog loglevel, const char* format, ..
 /*!@{*/
 
 //==============================================================================
+/// @brief Check the given setting name is set to default value.
+///
+/// The setting name relate to names used in his <b>settings.xml</b> file.
+///
+/// @param[in] settingName The name of asked setting
+/// @return true if setting is the default
+///
+inline bool ATTRIBUTE_HIDDEN IsSettingUsingDefault(const std::string& settingName)
+{
+  using namespace kodi::addon;
+  return CAddonBase::m_interface->toKodi->is_setting_using_default(
+      CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str());
+}
+//------------------------------------------------------------------------------
+
+//==============================================================================
 /// @brief Check and get a string setting value.
 ///
 /// The setting name relate to names used in his <b>settings.xml</b> file.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon_base.h
@@ -190,6 +190,9 @@ extern "C"
     struct AddonToKodiFuncTable_kodi_filesystem* kodi_filesystem;
     struct AddonToKodiFuncTable_kodi_gui* kodi_gui;
     struct AddonToKodiFuncTable_kodi_network* kodi_network;
+
+    // Move up by min version change about
+    bool (*is_setting_using_default)(void* kodiBase, const char* id);
   } AddonToKodiFuncTable_Addon;
 
   /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -34,7 +34,7 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.3"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.4"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.2.0"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \


### PR DESCRIPTION
## Description

Commit 1:
------------------------------
**[addons] add callback to check setting is default**

This add the function "bool kodi::IsSettingDefault(const std::string& settingName)"
to check by addon that the current settings value is only the default and not
edited by used.

Commit 2:
------------------------------
**[addons] use HasSettings instead of ReloadSettings**

The "HasSettings" to confirm available and loaded by this call.
On other before was the whole xml loaded on every call where needed
more work and has produced also problems if a settings value was
asked by a loop on addon.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
