### PR TITLE
[addons] Show both enabled and disabled incompatbile addons when performing a migration

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -794,7 +794,7 @@ bool CApplication::Initialize()
 
     // Addon migration
     std::vector<AddonInfoPtr> incompatible;
-    if (CServiceBroker::GetAddonMgr().GetIncompatibleAddons(incompatible))
+    if (CServiceBroker::GetAddonMgr().GetIncompatibleEnabledAddonInfos(incompatible))
     {
       if (CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_ON)
       {
@@ -2331,7 +2331,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     }
   }
   break;
-    
+
   default:
     CLog::Log(LOGERROR, "%s: Unhandled threadmessage sent, %u", __FUNCTION__, msg);
     break;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -364,9 +364,17 @@ bool CAddonMgr::GetAddonsInternal(const TYPE& type,
   return addons.size() > 0;
 }
 
-bool CAddonMgr::GetIncompatibleAddons(std::vector<AddonInfoPtr>& incompatible) const
+bool CAddonMgr::GetIncompatibleEnabledAddonInfos(std::vector<AddonInfoPtr>& incompatible) const
+{
+  return GetIncompatibleAddonInfos(incompatible, false);
+}
+
+bool CAddonMgr::GetIncompatibleAddonInfos(std::vector<AddonInfoPtr>& incompatible,
+                                          bool includeDisabled) const
 {
   GetAddonInfos(incompatible, true, ADDON_UNKNOWN);
+  if (includeDisabled)
+    GetDisabledAddonInfos(incompatible, ADDON_UNKNOWN, AddonDisabledReason::INCOMPATIBLE);
   incompatible.erase(std::remove_if(incompatible.begin(), incompatible.end(),
                                     [this](const AddonInfoPtr& a) { return IsCompatible(a); }),
                      incompatible.end());
@@ -384,7 +392,7 @@ std::vector<std::string> CAddonMgr::MigrateAddons()
 
   // get addons that became incompatible and disable them
   std::vector<AddonInfoPtr> incompatible;
-  GetIncompatibleAddons(incompatible);
+  GetIncompatibleAddonInfos(incompatible, true);
 
   return DisableIncompatibleAddons(incompatible);
 }
@@ -944,14 +952,14 @@ bool CAddonMgr::GetAddonInfos(AddonInfos& addonInfos, bool enabledOnly, TYPE typ
   return !addonInfos.empty();
 }
 
-bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos, TYPE type)
+bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos, TYPE type) const
 {
   return GetDisabledAddonInfos(addonInfos, type, AddonDisabledReason::NONE);
 }
 
 bool CAddonMgr::GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
                                       TYPE type,
-                                      AddonDisabledReason disabledReason)
+                                      AddonDisabledReason disabledReason) const
 {
   CSingleLock lock(m_critSection);
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -126,17 +126,17 @@ namespace ADDON
 
     /*!
      * @brief Fills the the provided vector with the list of incompatible
-     * addons and returns if there's any.
+     * enabled addons and returns if there's any.
      *
      * @param[out] incompatible List of incompatible addons
      * @return true if there are incompatible addons
      */
-    bool GetIncompatibleAddons(std::vector<AddonInfoPtr>& incompatible) const;
+    bool GetIncompatibleEnabledAddonInfos(std::vector<AddonInfoPtr>& incompatible) const;
 
     /*!
      * @brief Disable addons in given list.
      *
-     * @param[in] incompatible List of incompatible addons
+     * @param[in] incompatible List of incompatible addon infos
      * @return list of all addon **names** that were disabled
      */
     std::vector<std::string> DisableIncompatibleAddons(
@@ -291,7 +291,7 @@ namespace ADDON
      *                        returned who match them. Default is for all types.
      * @return true if the list contains entries
      */
-    bool GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos, TYPE type);
+    bool GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos, TYPE type) const;
 
     /*!
      * @brief Get a list of disabled add-on's with info's for the on system
@@ -311,7 +311,7 @@ namespace ADDON
      */
     bool GetDisabledAddonInfos(std::vector<AddonInfoPtr>& addonInfos,
                                TYPE type,
-                               AddonDisabledReason disabledReason);
+                               AddonDisabledReason disabledReason) const;
 
     const AddonInfoPtr GetAddonInfo(const std::string& id, TYPE type = ADDON_UNKNOWN) const;
 
@@ -336,6 +336,17 @@ namespace ADDON
     bool EnableSingle(const std::string& id);
 
     void FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path);
+
+    /*!
+     * @brief Fills the the provided vector with the list of incompatible
+     * addons and returns if there's any.
+     *
+     * @param[out] incompatible List of incompatible addons
+     * @param[in] whether or not to include incompatible addons that are disabled
+     * @return true if there are incompatible addons
+     */
+    bool GetIncompatibleAddonInfos(std::vector<AddonInfoPtr>& incompatible,
+                                   bool includeDisabled) const;
 
     /*!
      * Get the list of of available updates


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Follow on from https://github.com/xbmc/xbmc/pull/18087

As incompatible addons are now disabled with a reason these would have been missing from the incompatible list when migrating and the user would not be shown which addons would be disabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

To make it clear to users which addons will be disabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Still needs to be tested.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
