### PR TITLE
[estuary] handle up/down in fullscreeninfo

### DIFF
--- a/addons/skin.estuary/xml/DialogFullScreenInfo.xml
+++ b/addons/skin.estuary/xml/DialogFullScreenInfo.xml
@@ -11,6 +11,8 @@
 			<texturenofocus />
 			<onright>StepForward</onright>
 			<onleft>StepBack</onleft>
+			<onup>ChapterOrBigStepForward</onup>
+			<ondown>ChapterOrBigStepBack</ondown>
 			<onclick>OSD</onclick>
 		</control>
 	</controls>


### PR DESCRIPTION
fix another side effect of #16878, handle the input commands ‘up’ & ‘down’ as well when the fullscreeninfo dialog is visible.

@ksooo 