### PR TITLE
[filemanger] reset to root if directory is inaccessible

### DIFF
--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1245,11 +1245,13 @@ void CGUIWindowFileManager::OnInitWindow()
   else if (!bResult0)
   {
     ShowShareErrorMessage(m_Directory[0]); //show the error message after window is loaded!
+    Update(0, ""); // reset view to root
   }
 
   if (!bResult1)
   {
     ShowShareErrorMessage(m_Directory[1]); //show the error message after window is loaded!
+    Update(1, ""); // reset view to root
   }
 }
 


### PR DESCRIPTION
the filemanger can get stuck in no man's land when it's trying to re-enter a folder that has been deleted in the meantime.
it should load the root folder when such a situation is encountered.

fixes #18119
