### PR TITLE
[Leia] Add missing cassert includes

### DIFF
--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIDialogProfileSettings.h"
 
+#include <cassert>
 #include <utility>
 
 #include "dialogs/GUIDialogFileBrowser.h"


### PR DESCRIPTION
This is a backport of https://github.com/xbmc/xbmc/pull/17000 to Leia.

Without these includes, this error occurs:
```
YPES_H=1 -DHAS_ALSA=1 -DHAS_AVAHI=1 -DHAS_ZEROCONF=1 -DHAVE_LIBBLURAY=1 -DHAVE_LIBBLURAY_BDJ=1 -DHAVE_LIBCEC=1 -DHAS_DBUS=1 -DHAVE_LCMS2=1 -DHAS_WEB_SERVER=1 -DHAS_WEB_INTERFACE=1 -DHAS_AIRPLAY=1 -DHAS_PULSEAUDIO=1 -DHAS_PYTHON=1 -DHAVE_L
IBUDEV=1 -DHAVE_LIBXSLT=1 -DHAVE_LIBVA=1 -DHAS_GLX=1 -DFFMPEG_VER_SHA=\"undef\" -I/usr/include/fribidi -DHAS_EGL=1 -DHAVE_X11=1 -DHAVE_LIBXRANDR=1 -DHAS_GL=1 -DHAS_UPNP=1 -DHAS_DVD_DRIVE -DHAS_CDDA_RIPPER -DHAS_AIRTUNES=1 -DBIN_INSTALL_PA
TH=\"/usr/lib64/kodi\" -DINSTALL_PATH=\"/usr/share/kodi\" -std=c++14 -MD -MT build/profiles/dialogs/CMakeFiles/profiles_dialogs.dir/GUIDialogProfileSettings.cpp.o -MF build/profiles/dialogs/CMakeFiles/profiles_dialogs.dir/GUIDialogProfile
Settings.cpp.o.d -o build/profiles/dialogs/CMakeFiles/profiles_dialogs.dir/GUIDialogProfileSettings.cpp.o -c /var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp: In static member function ‘static bool CGUIDialogProfileSettings::ShowForProfile(unsigned int, bool)’:
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp:174:5: error: ‘assert’ was not declared in this scope
  174 |     assert(profile);
      |     ^~~~~~
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp:33:1: note: ‘assert’ is defined in header ‘<cassert>’; did you forget to ‘#include <cassert>’?
   32 | #include "utils/log.h"
  +++ |+#include <cassert>
   33 |

```

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This include is made in other .cpp files when `assert` is used, but is missing in these places.

I believe assert.h was transitively included from another header from libfmt, but that other header no longer includes it.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I'm seeing a compilation failure and this change fixes that failure.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Compiled, ran Kodi, and it works.
## Screenshots (if appropriate):
n/a
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
