### PR TITLE
[Leia] [webserver] Compatibility with libmicrohttpd 0.9.71

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -86,7 +86,7 @@ static MHD_Response* create_response(size_t size, const void* data, int free, in
   return MHD_create_response_from_buffer(size, const_cast<void*>(data), mode);
 }
 
-int CWebServer::AskForAuthentication(const HTTPRequest& request) const
+MHD_RESULT CWebServer::AskForAuthentication(const HTTPRequest& request) const
 {
   struct MHD_Response *response = create_response(0, nullptr, MHD_NO, MHD_NO);
   if (!response)
@@ -95,7 +95,7 @@ int CWebServer::AskForAuthentication(const HTTPRequest& request) const
     return MHD_NO;
   }
 
-  int ret = AddHeader(response, MHD_HTTP_HEADER_CONNECTION, "close");
+  MHD_RESULT ret = AddHeader(response, MHD_HTTP_HEADER_CONNECTION, "close");
   if (!ret)
   {
     CLog::Log(LOGERROR, "CWebServer[%hu]: unable to prepare HTTP Unauthorized response", m_port);
@@ -105,7 +105,10 @@ int CWebServer::AskForAuthentication(const HTTPRequest& request) const
 
   LogResponse(request, MHD_HTTP_UNAUTHORIZED);
 
-  ret = MHD_queue_basic_auth_fail_response(request.connection, "XBMC", response);
+  // This MHD_RESULT cast is only necessary for libmicrohttpd 0.9.71
+  // The return type of MHD_queue_basic_auth_fail_response was fixed for future versions
+  // See https://git.gnunet.org/libmicrohttpd.git/commit/?id=860b42e9180da4dcd7e8690a3fcdb4e37e5772c5
+  ret = static_cast<MHD_RESULT>(MHD_queue_basic_auth_fail_response(request.connection, "XBMC", response));
   MHD_destroy_response(response);
 
   return ret;
@@ -135,7 +138,7 @@ bool CWebServer::IsAuthenticated(const HTTPRequest& request) const
   return authenticated;
 }
 
-int CWebServer::AnswerToConnection(void *cls, struct MHD_Connection *connection,
+MHD_RESULT CWebServer::AnswerToConnection(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method,
                       const char *version, const char *upload_data,
                       size_t *upload_data_size, void **con_cls)
@@ -163,7 +166,7 @@ int CWebServer::AnswerToConnection(void *cls, struct MHD_Connection *connection,
   return webServer->HandlePartialRequest(connection, connectionHandler, request, upload_data, upload_data_size, con_cls);
 }
 
-int CWebServer::HandlePartialRequest(struct MHD_Connection *connection, ConnectionHandler* connectionHandler, const HTTPRequest& request, const char *upload_data, size_t *upload_data_size, void **con_cls)
+MHD_RESULT CWebServer::HandlePartialRequest(struct MHD_Connection *connection, ConnectionHandler* connectionHandler, const HTTPRequest& request, const char *upload_data, size_t *upload_data_size, void **con_cls)
 {
   std::unique_ptr<ConnectionHandler> conHandler(connectionHandler);
 
@@ -276,7 +279,7 @@ int CWebServer::HandlePartialRequest(struct MHD_Connection *connection, Connecti
   return SendErrorResponse(request, MHD_HTTP_NOT_FOUND, request.method);
 }
 
-int CWebServer::HandlePostField(void *cls, enum MHD_ValueKind kind, const char *key,
+MHD_RESULT CWebServer::HandlePostField(void *cls, enum MHD_ValueKind kind, const char *key,
                                 const char *filename, const char *content_type,
                                 const char *transfer_encoding, const char *data, uint64_t off,
                                 size_t size)
@@ -294,13 +297,13 @@ int CWebServer::HandlePostField(void *cls, enum MHD_ValueKind kind, const char *
   return MHD_YES;
 }
 
-int CWebServer::HandleRequest(const std::shared_ptr<IHTTPRequestHandler>& handler)
+MHD_RESULT CWebServer::HandleRequest(const std::shared_ptr<IHTTPRequestHandler>& handler)
 {
   if (handler == nullptr)
     return MHD_NO;
 
   HTTPRequest request = handler->GetRequest();
-  int ret = handler->HandleRequest();
+  MHD_RESULT ret = handler->HandleRequest();
   if (ret == MHD_NO)
   {
     CLog::Log(LOGERROR, "CWebServer[%hu]: failed to handle HTTP request for %s", m_port, request.pathUrl.c_str());
@@ -348,7 +351,7 @@ int CWebServer::HandleRequest(const std::shared_ptr<IHTTPRequestHandler>& handle
   return FinalizeRequest(handler, responseDetails.status, response);
 }
 
-int CWebServer::FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler>& handler, int responseStatus, struct MHD_Response *response)
+MHD_RESULT CWebServer::FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler>& handler, int responseStatus, struct MHD_Response *response)
 {
   if (handler == nullptr || response == nullptr)
     return MHD_NO;
@@ -562,7 +565,7 @@ void CWebServer::FinalizePostDataProcessing(ConnectionHandler *connectionHandler
   MHD_destroy_post_processor(connectionHandler->postprocessor);
 }
 
-int CWebServer::CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const
+MHD_RESULT CWebServer::CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const
 {
   if (handler == nullptr)
     return MHD_NO;
@@ -620,7 +623,7 @@ int CWebServer::CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestH
   return CreateRangedMemoryDownloadResponse(handler, response);
 }
 
-int CWebServer::CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const
+MHD_RESULT CWebServer::CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const
 {
   if (handler == nullptr)
     return MHD_NO;
@@ -700,7 +703,7 @@ int CWebServer::CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRe
   return CreateMemoryDownloadResponse(request.connection, result.c_str(), result.size(), false, true, response);
 }
 
-int CWebServer::CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response) const
+MHD_RESULT CWebServer::CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response) const
 {
   response = create_response(0, nullptr, MHD_NO, MHD_NO);
   if (response == nullptr)
@@ -713,7 +716,7 @@ int CWebServer::CreateRedirect(struct MHD_Connection *connection, const std::str
   return MHD_YES;
 }
 
-int CWebServer::CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const
+MHD_RESULT CWebServer::CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const
 {
   if (handler == nullptr)
     return MHD_NO;
@@ -850,7 +853,7 @@ int CWebServer::CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHan
   return MHD_YES;
 }
 
-int CWebServer::CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response) const
+MHD_RESULT CWebServer::CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response) const
 {
   size_t payloadSize = 0;
   const void *payload = nullptr;
@@ -881,7 +884,7 @@ int CWebServer::CreateErrorResponse(struct MHD_Connection *connection, int respo
   return MHD_YES;
 }
 
-int CWebServer::CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response) const
+MHD_RESULT CWebServer::CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response) const
 {
   response = create_response(size, const_cast<void*>(data), free ? MHD_YES : MHD_NO, copy ? MHD_YES : MHD_NO);
   if (response == nullptr)
@@ -893,20 +896,20 @@ int CWebServer::CreateMemoryDownloadResponse(struct MHD_Connection *connection, 
   return MHD_YES;
 }
 
-int CWebServer::SendResponse(const HTTPRequest& request, int responseStatus, MHD_Response *response) const
+MHD_RESULT CWebServer::SendResponse(const HTTPRequest& request, int responseStatus, MHD_Response *response) const
 {
   LogResponse(request, responseStatus);
 
-  int ret = MHD_queue_response(request.connection, responseStatus, response);
+  MHD_RESULT ret = MHD_queue_response(request.connection, responseStatus, response);
   MHD_destroy_response(response);
 
   return ret;
 }
 
-int CWebServer::SendErrorResponse(const HTTPRequest& request, int errorType, HTTPMethod method) const
+MHD_RESULT CWebServer::SendErrorResponse(const HTTPRequest& request, int errorType, HTTPMethod method) const
 {
   struct MHD_Response *response = nullptr;
-  int ret = CreateErrorResponse(request.connection, errorType, method, response);
+  MHD_RESULT ret = CreateErrorResponse(request.connection, errorType, method, response);
   if (ret == MHD_NO)
     return MHD_NO;
 
@@ -1296,10 +1299,10 @@ std::string CWebServer::CreateMimeTypeFromExtension(const char *ext)
   return CMime::GetMimeType(ext);
 }
 
-int CWebServer::AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value) const
+MHD_RESULT CWebServer::AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value) const
 {
   if (response == nullptr || name.empty())
-    return 0;
+    return MHD_NO;
 
   CLog::Log(LOGDEBUG, LOGWEBSERVER, "CWebServer[%hu] [OUT] %s: %s", m_port, name.c_str(), value.c_str());
 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -56,17 +56,17 @@ protected:
 
   virtual void LogRequest(const char* uri) const;
 
-  virtual int HandlePartialRequest(struct MHD_Connection *connection, ConnectionHandler* connectionHandler, const HTTPRequest& request,
+  virtual MHD_RESULT HandlePartialRequest(struct MHD_Connection *connection, ConnectionHandler* connectionHandler, const HTTPRequest& request,
                                    const char *upload_data, size_t *upload_data_size, void **con_cls);
-  virtual int HandleRequest(const std::shared_ptr<IHTTPRequestHandler>& handler);
-  virtual int FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler>& handler, int responseStatus, struct MHD_Response *response);
+  virtual MHD_RESULT HandleRequest(const std::shared_ptr<IHTTPRequestHandler>& handler);
+  virtual MHD_RESULT FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler>& handler, int responseStatus, struct MHD_Response *response);
 
 private:
   struct MHD_Daemon* StartMHD(unsigned int flags, int port);
 
   std::shared_ptr<IHTTPRequestHandler> FindRequestHandler(const HTTPRequest& request) const;
 
-  int AskForAuthentication(const HTTPRequest& request) const;
+  MHD_RESULT AskForAuthentication(const HTTPRequest& request) const;
   bool IsAuthenticated(const HTTPRequest& request) const;
 
   bool IsRequestCacheable(const HTTPRequest& request) const;
@@ -76,18 +76,18 @@ private:
   bool ProcessPostData(const HTTPRequest& request, ConnectionHandler *connectionHandler, const char *upload_data, size_t *upload_data_size, void **con_cls) const;
   void FinalizePostDataProcessing(ConnectionHandler *connectionHandler) const;
 
-  int CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
-  int CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
+  MHD_RESULT CreateMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
+  MHD_RESULT CreateRangedMemoryDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
 
-  int CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response) const;
-  int CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
-  int CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response) const;
-  int CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response) const;
+  MHD_RESULT CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response) const;
+  MHD_RESULT CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHandler>& handler, struct MHD_Response *&response) const;
+  MHD_RESULT CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response) const;
+  MHD_RESULT CreateMemoryDownloadResponse(struct MHD_Connection *connection, const void *data, size_t size, bool free, bool copy, struct MHD_Response *&response) const;
 
-  int SendResponse(const HTTPRequest& request, int responseStatus, MHD_Response *response) const;
-  int SendErrorResponse(const HTTPRequest& request, int errorType, HTTPMethod method) const;
+  MHD_RESULT SendResponse(const HTTPRequest& request, int responseStatus, MHD_Response *response) const;
+  MHD_RESULT SendErrorResponse(const HTTPRequest& request, int errorType, HTTPMethod method) const;
 
-  int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value) const;
+  MHD_RESULT AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value) const;
 
   void LogRequest(const HTTPRequest& request) const;
   void LogResponse(const HTTPRequest& request, int responseStatus) const;
@@ -100,11 +100,11 @@ private:
   static ssize_t ContentReaderCallback (void *cls, uint64_t pos, char *buf, size_t max);
   static void ContentReaderFreeCallback(void *cls);
 
-  static int AnswerToConnection (void *cls, struct MHD_Connection *connection,
+  static MHD_RESULT AnswerToConnection (void *cls, struct MHD_Connection *connection,
                         const char *url, const char *method,
                         const char *version, const char *upload_data,
                         size_t *upload_data_size, void **con_cls);
-  static int HandlePostField(void *cls, enum MHD_ValueKind kind, const char *key,
+  static MHD_RESULT HandlePostField(void *cls, enum MHD_ValueKind kind, const char *key,
                              const char *filename, const char *content_type,
                              const char *transfer_encoding, const char *data, uint64_t off,
                              size_t size);

--- a/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
@@ -23,7 +23,7 @@ CHTTPFileHandler::CHTTPFileHandler(const HTTPRequest &request)
     m_lastModified()
 { }
 
-int CHTTPFileHandler::HandleRequest()
+MHD_RESULT CHTTPFileHandler::HandleRequest()
 {
   return !m_url.empty() ? MHD_YES : MHD_NO;
 }

--- a/xbmc/network/httprequesthandler/HTTPFileHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPFileHandler.h
@@ -19,7 +19,7 @@ class CHTTPFileHandler : public IHTTPRequestHandler
 public:
   ~CHTTPFileHandler() override = default;
 
-  int HandleRequest() override;
+  MHD_RESULT HandleRequest() override;
 
   bool CanHandleRanges() const override { return m_canHandleRanges; }
   bool CanBeCached() const override { return m_canBeCached; }

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -104,7 +104,7 @@ bool CHTTPImageTransformationHandler::CanHandleRequest(const HTTPRequest &reques
           options.find(TRANSFORMATION_OPTION_HEIGHT) != options.end());
 }
 
-int CHTTPImageTransformationHandler::HandleRequest()
+MHD_RESULT CHTTPImageTransformationHandler::HandleRequest()
 {
   if (m_response.type == HTTPError)
     return MHD_YES;

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.h
@@ -23,7 +23,7 @@ public:
   IHTTPRequestHandler* Create(const HTTPRequest &request) const override { return new CHTTPImageTransformationHandler(request); }
   bool CanHandleRequest(const HTTPRequest &request)const  override;
 
-  int HandleRequest() override;
+  MHD_RESULT HandleRequest() override;
 
   bool CanHandleRanges() const override { return true; }
   bool CanBeCached() const override { return true; }

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -25,7 +25,7 @@ bool CHTTPJsonRpcHandler::CanHandleRequest(const HTTPRequest &request) const
   return (request.pathUrl.compare("/jsonrpc") == 0);
 }
 
-int CHTTPJsonRpcHandler::HandleRequest()
+MHD_RESULT CHTTPJsonRpcHandler::HandleRequest()
 {
   CHTTPClient client(m_request.method);
   bool isRequest = false;

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -24,7 +24,7 @@ public:
   IHTTPRequestHandler* Create(const HTTPRequest &request) const override { return new CHTTPJsonRpcHandler(request); }
   bool CanHandleRequest(const HTTPRequest &request) const override;
 
-  int HandleRequest() override;
+  MHD_RESULT HandleRequest() override;
 
   HttpResponseRanges GetResponseData() const override;
 

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
@@ -112,7 +112,7 @@ bool CHTTPPythonHandler::CanHandleRequest(const HTTPRequest &request) const
   return true;
 }
 
-int CHTTPPythonHandler::HandleRequest()
+MHD_RESULT CHTTPPythonHandler::HandleRequest()
 {
   if (m_response.type == HTTPError || m_response.type == HTTPRedirect)
     return MHD_YES;

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.h
@@ -25,7 +25,7 @@ public:
   bool CanBeCached() const override { return false; }
   bool GetLastModifiedDate(CDateTime &lastModified) const override;
 
-  int HandleRequest() override;
+  MHD_RESULT HandleRequest() override;
 
   HttpResponseRanges GetResponseData() const override { return m_responseRanges; }
 

--- a/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.cpp
+++ b/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.cpp
@@ -61,7 +61,7 @@ bool HTTPRequestHandlerUtils::GetRequestedRanges(struct MHD_Connection *connecti
   return ranges.Parse(GetRequestHeaderValue(connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_RANGE), totalLength);
 }
 
-int HTTPRequestHandlerUtils::FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
+MHD_RESULT HTTPRequestHandlerUtils::FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
   if (cls == nullptr || key == nullptr)
     return MHD_NO;
@@ -72,7 +72,7 @@ int HTTPRequestHandlerUtils::FillArgumentMap(void *cls, enum MHD_ValueKind kind,
   return MHD_YES;
 }
 
-int HTTPRequestHandlerUtils::FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
+MHD_RESULT HTTPRequestHandlerUtils::FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
   if (cls == nullptr || key == nullptr)
     return MHD_NO;

--- a/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.h
+++ b/xbmc/network/httprequesthandler/HTTPRequestHandlerUtils.h
@@ -25,6 +25,6 @@ public:
 private:
   HTTPRequestHandlerUtils() = delete;
 
-  static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
-  static int FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+  static MHD_RESULT FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+  static MHD_RESULT FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 };

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -18,7 +18,7 @@ bool CHTTPWebinterfaceAddonsHandler::CanHandleRequest(const HTTPRequest &request
   return (request.pathUrl.compare("/addons") == 0 || request.pathUrl.compare("/addons/") == 0);
 }
 
-int CHTTPWebinterfaceAddonsHandler::HandleRequest()
+MHD_RESULT CHTTPWebinterfaceAddonsHandler::HandleRequest()
 {
   m_responseData = ADDON_HEADER;
   ADDON::VECADDONS addons;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -21,7 +21,7 @@ public:
   IHTTPRequestHandler* Create(const HTTPRequest &request) const override { return new CHTTPWebinterfaceAddonsHandler(request); }
   bool CanHandleRequest(const HTTPRequest &request) const override;
 
-  int HandleRequest() override;
+  MHD_RESULT HandleRequest() override;
 
   HttpResponseRanges GetResponseData() const override;
 

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -22,6 +22,12 @@
 
 #include "utils/HttpRangeUtils.h"
 
+#if MHD_VERSION >= 0x00097002
+using MHD_RESULT = MHD_Result;
+#else
+using MHD_RESULT = int;
+#endif
+
 class CDateTime;
 class CWebServer;
 
@@ -114,7 +120,7 @@ public:
    *
    * \return MHD_NO if a severe error has occurred otherwise MHD_YES.
    */
-  virtual int HandleRequest() = 0;
+  virtual MHD_RESULT HandleRequest() = 0;
 
   /*!
    * \brief Whether the HTTP response could also be provided in ranges.


### PR DESCRIPTION
From the libmicrohttpd 0.9.71 release notes:

The release introduces an 'enum MHD_Result' instead of
for certain API misuse bugs by providing better types (not everything is
an 'int').  While this does NOT change the binary API, this change
_will_ cause compiler warnings for all legacy code -- until 'int' is
replaced with 'enum MHD_Result'.

Backport of https://github.com/xbmc/xbmc/pull/18131