### PR TITLE
make the '1' parameter in PlayMedia() apply to music as well

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2976,31 +2976,36 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     // don't switch to fullscreen if we are not playing the first item...
     options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() &&
         CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-        CSettings::SETTING_MUSICFILES_SELECTACTION);
+        CSettings::SETTING_MUSICFILES_SELECTACTION) &&
+        !CMediaSettings::GetInstance().DoesMediaStartWindowed();
   }
   else if (item.IsVideo() && playlist == PLAYLIST_VIDEO &&
       CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
-    options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() && CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+    options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() &&
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart &&
+        !CMediaSettings::GetInstance().DoesMediaStartWindowed();
   }
   else if(m_stackHelper.IsPlayingRegularStack())
   {
     //! @todo - this will fail if user seeks back to first file in stack
     if(m_stackHelper.GetCurrentPartNumber() == 0 || m_stackHelper.GetRegisteredStack(item)->m_lStartOffset != 0)
-      options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+      options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->
+          m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesMediaStartWindowed();
     else
       options.fullscreen = false;
   }
   else
-    options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+    options.fullscreen = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->
+        m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesMediaStartWindowed();
 
   // stereo streams may have lower quality, i.e. 32bit vs 16 bit
   options.preferStereo = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoPreferStereoStream &&
                          CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
 
   // reset VideoStartWindowed as it's a temp setting
-  CMediaSettings::GetInstance().SetVideoStartWindowed(false);
+  CMediaSettings::GetInstance().SetMediaStartWindowed(false);
 
   {
     // for playing a new item, previous playing item's callback may already

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -403,7 +403,7 @@ static int PlayMedia(const std::vector<std::string>& params)
     if (StringUtils::EqualsNoCase(params[i], "isdir"))
       item.m_bIsFolder = true;
     else if (params[i] == "1") // set fullscreen or windowed
-      CMediaSettings::GetInstance().SetVideoStartWindowed(true);
+      CMediaSettings::GetInstance().SetMediaStartWindowed(true);
     else if (StringUtils::EqualsNoCase(params[i], "resume"))
     {
       // force the item to resume (if applicable) (see CApplication::PlayMedia)
@@ -586,12 +586,12 @@ static int Seek(const std::vector<std::string>& params)
 ///     ,
 ///     Plays the media. This can be a playlist\, music\, or video file\, directory\,
 ///     plugin or an Url. The optional parameter "\,isdir" can be used for playing
-///     a directory. "\,1" will start a video in a preview window\, instead of
-///     fullscreen. If media is a playlist\, you can use playoffset=xx where xx is
+///     a directory. "\,1" will start the media without switching to fullscreen.
+///     If media is a playlist\, you can use playoffset=xx where xx is
 ///     the position to start playback from.
 ///     @param[in] media                 URL to media to play (optional).
 ///     @param[in] isdir                 Set "isdir" if media is a directory (optional).
-///     @param[in] fullscreen            Set "1" to start playback in fullscreen (optional).
+///     @param[in] windowed              Set "1" to start playback without switching to fullscreen (optional).
 ///     @param[in] resume                Set "resume" to force resuming (optional).
 ///     @param[in] noresume              Set "noresume" to force not resuming (optional).
 ///     @param[in] playeroffset          Set "playoffset=<offset>" to start playback from a given position in a playlist (optional).

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -75,7 +75,7 @@ namespace XBMCAddon
       if (!item.empty())
       {
         // set fullscreen or windowed
-        CMediaSettings::GetInstance().SetVideoStartWindowed(windowed);
+        CMediaSettings::GetInstance().SetMediaStartWindowed(windowed);
 
         const AddonClass::Ref<xbmcgui::ListItem> listitem(plistitem);
 
@@ -101,7 +101,7 @@ namespace XBMCAddon
       XBMC_TRACE;
       DelayedCallGuard dc(languageHook);
       // set fullscreen or windowed
-      CMediaSettings::GetInstance().SetVideoStartWindowed(windowed);
+      CMediaSettings::GetInstance().SetMediaStartWindowed(windowed);
 
       // play current file in playlist
       if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != iPlayList)
@@ -116,7 +116,7 @@ namespace XBMCAddon
       if (playlist != NULL)
       {
         // set fullscreen or windowed
-        CMediaSettings::GetInstance().SetVideoStartWindowed(windowed);
+        CMediaSettings::GetInstance().SetMediaStartWindowed(windowed);
 
         // play a python playlist (a playlist from playlistplayer.cpp)
         iPlayList = playlist->getPlayListId();

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1247,7 +1247,7 @@ namespace PVR
 
   void CPVRGUIActions::CheckAndSwitchToFullscreen(bool bFullscreen) const
   {
-    CMediaSettings::GetInstance().SetVideoStartWindowed(!bFullscreen);
+    CMediaSettings::GetInstance().SetMediaStartWindowed(!bFullscreen);
 
     if (bFullscreen)
     {

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -51,7 +51,7 @@ CMediaSettings::CMediaSettings()
   m_videoPlaylistRepeat = false;
   m_videoPlaylistShuffle = false;
 
-  m_videoStartWindowed = false;
+  m_mediaStartWindowed = false;
   m_additionalSubtitleDirectoryChecked = 0;
 
   m_musicNeedsUpdate = 0;

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -76,8 +76,8 @@ public:
   void SetVideoPlaylistRepeat(bool repeats) { m_videoPlaylistRepeat = repeats; }
   void SetVideoPlaylistShuffled(bool shuffled) { m_videoPlaylistShuffle = shuffled; }
 
-  bool DoesVideoStartWindowed() const { return m_videoStartWindowed; }
-  void SetVideoStartWindowed(bool windowed) { m_videoStartWindowed = windowed; }
+  bool DoesMediaStartWindowed() const { return m_mediaStartWindowed; }
+  void SetMediaStartWindowed(bool windowed) { m_mediaStartWindowed = windowed; }
   int GetAdditionalSubtitleDirectoryChecked() const { return m_additionalSubtitleDirectoryChecked; }
   void SetAdditionalSubtitleDirectoryChecked(int checked) { m_additionalSubtitleDirectoryChecked = checked; }
 
@@ -108,7 +108,7 @@ private:
   bool m_videoPlaylistRepeat;
   bool m_videoPlaylistShuffle;
 
-  bool m_videoStartWindowed;
+  bool m_mediaStartWindowed;
   int m_additionalSubtitleDirectoryChecked;
 
   int m_musicNeedsUpdate; ///< if a database update means an update is required (set to the version number of the db)


### PR DESCRIPTION
follow up to https://github.com/xbmc/xbmc/pull/17225, which added the setting to automatically switch to the fullscreen visualization window on audio playback.

this setting could be problematic if a skin (or addon) wants to play audio in the background,
for instance 'tv tunes' like implementations that playback audio when you're browsing your library.

there's an existing option to prevent the switch to fullscreen on playback `PlayMedia(file, 1)` but it was only applied to video playback.

this PR implements it for audio as well.
(i'll squash the commits once approved)

fixes https://github.com/xbmc/xbmc/issues/18135

