### PR TITLE
[Addons] Migration - Hide dependency addons from the dialog of disabl…

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -473,7 +473,8 @@ protected:
 
   ReplayGainSettings m_replayGainSettings;
   std::vector<IActionListener *> m_actionListeners;
-  std::vector<std::string> m_incompatibleAddons;  /*!< Result of addon migration */
+  std::vector<ADDON::AddonInfoPtr>
+      m_incompatibleAddons; /*!< Result of addon migration (incompatible addon infos) */
 
 private:
   mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -381,7 +381,7 @@ bool CAddonMgr::GetIncompatibleAddonInfos(std::vector<AddonInfoPtr>& incompatibl
   return !incompatible.empty();
 }
 
-std::vector<std::string> CAddonMgr::MigrateAddons()
+std::vector<AddonInfoPtr> CAddonMgr::MigrateAddons()
 {
   // install all addon updates
   std::lock_guard<std::mutex> lock(m_installAddonsMutex);
@@ -397,10 +397,10 @@ std::vector<std::string> CAddonMgr::MigrateAddons()
   return DisableIncompatibleAddons(incompatible);
 }
 
-std::vector<std::string> CAddonMgr::DisableIncompatibleAddons(
+std::vector<AddonInfoPtr> CAddonMgr::DisableIncompatibleAddons(
     const std::vector<AddonInfoPtr>& incompatible)
 {
-  std::vector<std::string> changed;
+  std::vector<AddonInfoPtr> changed;
   for (const auto& addon : incompatible)
   {
     CLog::Log(LOGINFO, "ADDON: {} version {} is incompatible", addon->ID(),
@@ -415,7 +415,8 @@ std::vector<std::string> CAddonMgr::DisableIncompatibleAddons(
     {
       CLog::Log(LOGWARNING, "ADDON: failed to disable {}", addon->ID());
     }
-    changed.push_back(addon->Name());
+
+    changed.emplace_back(addon);
   }
 
   return changed;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -117,8 +117,6 @@ namespace ADDON
     /*! Returns true if there is any addon with available updates, otherwise false */
     bool HasAvailableUpdates();
 
-    static AddonPtr AddonFromProps(const AddonInfoPtr& addonInfo);
-
     /*! \brief Checks for new / updated add-ons
      \return True if everything went ok, false otherwise
      */

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -134,21 +134,21 @@ namespace ADDON
     bool GetIncompatibleEnabledAddonInfos(std::vector<AddonInfoPtr>& incompatible) const;
 
     /*!
-     * @brief Disable addons in given list.
-     *
-     * @param[in] incompatible List of incompatible addon infos
-     * @return list of all addon **names** that were disabled
-     */
-    std::vector<std::string> DisableIncompatibleAddons(
-        const std::vector<AddonInfoPtr>& incompatible);
-
-    /*!
      * Migrate all the addons (updates all addons that have an update pending and disables those
      * that got incompatible)
      *
-     * @return list of all addons that were modified.
+     * @return list of all addons (infos) that were modified.
      */
-    std::vector<std::string> MigrateAddons();
+    std::vector<AddonInfoPtr> MigrateAddons();
+
+    /*!
+     * @brief Try to disable addons in the given list.
+     *
+     * @param[in] incompatible List of incompatible addon infos
+     * @return list of all addon Infos that were disabled
+     */
+    std::vector<AddonInfoPtr> DisableIncompatibleAddons(
+        const std::vector<AddonInfoPtr>& incompatible);
 
     /*!
      * Install available addon updates, if any.

--- a/xbmc/addons/addoninfo/AddonType.cpp
+++ b/xbmc/addons/addoninfo/AddonType.cpp
@@ -11,6 +11,15 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "utils/URIUtils.h"
 
+namespace ADDON
+{
+static const std::set<TYPE> dependencyTypes = {
+    ADDON_SCRAPER_LIBRARY,
+    ADDON_SCRIPT_LIBRARY,
+    ADDON_SCRIPT_MODULE,
+};
+} /* namespace ADDON */
+
 using namespace ADDON;
 
 std::string CAddonType::LibPath() const
@@ -41,4 +50,9 @@ void CAddonType::SetProvides(const std::string& content)
         m_providedSubContent.insert(content);
     }
   }
+}
+
+bool CAddonType::IsDependencyType(TYPE type)
+{
+  return dependencyTypes.find(type) != dependencyTypes.end();
 }

--- a/xbmc/addons/addoninfo/AddonType.h
+++ b/xbmc/addons/addoninfo/AddonType.h
@@ -97,6 +97,15 @@ public:
     return m_providedSubContent.size();
   }
 
+  /*!
+   * @brief Indicates whether a given type is a dependency type (e.g. addons which the main type is
+   * a script.module)
+   *
+   * @param[in] type the provided type
+   * @return true if type is one of the dependency types
+   */
+  static bool IsDependencyType(TYPE type);
+
 private:
   friend class CAddonInfoBuilder;
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -52,12 +52,6 @@ const auto CATEGORY_GAME_PROVIDERS = "category.gameproviders";
 const auto CATEGORY_GAME_RESOURCES = "category.gameresources";
 const auto CATEGORY_GAME_SUPPORT_ADDONS = "category.gamesupport";
 
-const std::set<TYPE> dependencyTypes = {
-    ADDON_SCRAPER_LIBRARY,
-    ADDON_SCRIPT_LIBRARY,
-    ADDON_SCRIPT_MODULE,
-};
-
 const std::set<TYPE> infoProviderTypes = {
   ADDON_SCRAPER_ALBUMS,
   ADDON_SCRAPER_ARTISTS,
@@ -144,16 +138,9 @@ static bool IsGameAddon(const AddonPtr& addon)
          IsGameSupportAddon(addon);
 }
 
-static bool IsDependencyType(TYPE type)
-{
-  return dependencyTypes.find(type) != dependencyTypes.end();
-}
-
 static bool IsUserInstalled(const AddonPtr& addon)
 {
-  return std::find_if(dependencyTypes.begin(), dependencyTypes.end(), [&](TYPE type) {
-           return addon->MainType() == type;
-         }) == dependencyTypes.end();
+  return !CAddonType::IsDependencyType(addon->MainType());
 }
 
 static bool IsOrphaned(const AddonPtr& addon, const VECADDONS& all)
@@ -350,8 +337,9 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
      *   subtypes (audio, video, app or/and game) and not needed to show
      *   together in a Script or Plugin list
      */
-    if (!IsInfoProviderType(type) && !IsLookAndFeelType(type) && !IsDependencyType(type) &&
-        !IsGameType(type) && type != ADDON_SCRIPT && type != ADDON_PLUGIN)
+    if (!IsInfoProviderType(type) && !IsLookAndFeelType(type) &&
+        !CAddonType::IsDependencyType(type) && !IsGameType(type) && type != ADDON_SCRIPT &&
+        type != ADDON_PLUGIN)
       uncategorized.insert(static_cast<TYPE>(i));
   }
   GenerateTypeListing(path, uncategorized, addons, items);


### PR DESCRIPTION
…ed addons after the addon migration

## Description
Suggested by @da-anda in one of the team meetings, this PR hides dependency addons (e.g. script.modules) from the dialog containing incompatible/auto-disabled addons that is shown to the user after the addon migration.

## Motivation and Context
The incompatible addon list can easily get too big if the user has multiple addons that get disabled after the migration, mostly due to their list of dependencies. Users will not, in the vast majority of cases, recognise such addons as they were downloaded and installed automatically when they installed a "main" addon. 

## How Has This Been Tested?
Migration from Leia to Matrix in a setup containing a single (atm incompatible) addon - National geographic. As you can see in the screenshots, current master lists "cache" as one of the disabled addons.

## Screenshots (if appropriate):

**Master:**

![Mastert](https://i.imgur.com/BKlwfpG.png "Master")

**PR:**

![PR](https://i.imgur.com/jw2MEdF.png "PR")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
