### PR TITLE
[Windows] Enable alpha blending for the Player

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -210,8 +210,9 @@ void CWinRenderer::RenderUpdate(int index, int index2, bool clear, unsigned int 
   DX::Windowing()->SetAlphaBlendEnable(alpha < 255);
 
   ManageRenderArea();
-  m_renderer->Render(index, index2, DX::Windowing()->GetBackBuffer(), 
-                     m_sourceRect, m_destRect, GetScreenRect(), flags);
+  m_renderer->Render(index, index2, DX::Windowing()->GetBackBuffer(), m_sourceRect, m_destRect,
+                     GetScreenRect(), flags);
+  DX::Windowing()->SetAlphaBlendEnable(true);
 }
 
 bool CWinRenderer::RenderCapture(CRenderCapture* capture)

--- a/xbmc/utils/ColorUtils.cpp
+++ b/xbmc/utils/ColorUtils.cpp
@@ -15,5 +15,5 @@
 UTILS::Color ColorUtils::ChangeOpacity(const UTILS::Color color, const float opacity)
 {
   int newAlpha = ceil( ((color >> 24) & 0xff) * opacity);
-  return color + (newAlpha << 24);
+  return (color & 0x00FFFFFF) | (newAlpha << 24);
 };


### PR DESCRIPTION
## Description
Authored by @afedchin and @Paxxi this PR fixes 2 issues:

- https://github.com/xbmc/xbmc/commit/2269e071c6ae1f3a44300ff2d7122eaea76875a7 - fixes the calculation of the alpha values when changing opacity (if the original color already has alpha values)

- https://github.com/xbmc/xbmc/commit/80e46180c28d27dfc89e57a2b0d01e15efeafd66 - enables alpha blending for the player thus fixing https://github.com/xbmc/xbmc/issues/18117

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18117

## How Has This Been Tested?
Tested by @da-anda and @jjd-uk in #windows. A regression has been found for stereoscopic playback but it was not introduced by this PR.
