### PR TITLE
Fix matching X11 visual for GLES

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -259,6 +259,8 @@ XVisualInfo* CWinSystemX11GLESContext::GetVisual()
   }
 
   XVisualInfo x11_visual_info_template;
+  memset(&x11_visual_info_template, 0, sizeof(XVisualInfo));
+
   if (!eglGetConfigAttrib(eglDisplay, eglConfig,
     EGL_NATIVE_VISUAL_ID, reinterpret_cast<EGLint*>(&x11_visual_info_template.visualid)))
   {


### PR DESCRIPTION
## Description
Bug fix of matching X11 visual for GLES backend.

## Motivation and Context
Application failing with: failed to find matching visual 

## How Has This Been Tested?
Snapshot build on Tegra with GLES.