### PR TITLE
[Estuary] Fixup Topbar consistency

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -18,24 +18,27 @@
 			</control>
 			<control type="group">
 				<animation effect="slide" end="90,0" time="0" condition="Skin.HasSetting(touchmode)">conditional</animation>
-				<control type="image">
-					<left>15</left>
+				<control type="grouplist">
+					<visible>!String.IsEmpty(Player.Art(tvshow.clearlogo)) | !String.IsEmpty(Player.Art(clearlogo))</visible>
 					<top>10</top>
-					<width>300</width>
-					<height>140</height>
-					<texture>$VAR[PlayerClearLogoVar]</texture>
-					<aspectratio aligny="center" align="center">keep</aspectratio>
-				</control>
-				<control type="textbox">
-					<label>$VAR[NowPlayingBreadcrumbsVar]</label>
-					<font>font45</font>
-					<shadowcolor>text_shadow</shadowcolor>
-					<top>0</top>
-					<height>150</height>
-					<left>330</left>
+					<left>20</left>
 					<right>400</right>
-					<aligny>center</aligny>
-					<visible>!String.IsEmpty(Player.Art(tvshow.clearlogo))</visible>
+					<height>100</height>
+					<itemgap>10</itemgap>
+					<orientation>horizontal</orientation>
+					<control type="image">
+						<width>300</width>
+						<texture>$VAR[PlayerClearLogoVar]</texture>
+						<aspectratio aligny="center" align="center">keep</aspectratio>
+					</control>
+					<control type="label">
+						<align>left</align>
+						<aligny>center</aligny>
+						<font>font13</font>
+						<label>$VAR[OSDSubLabelVar]</label>
+						<shadowcolor>text_shadow</shadowcolor>
+						<scroll>true</scroll>
+					</control>
 				</control>
 				<control type="group">
 					<visible>!Window.IsActive(pvrosdchannels) + !Window.IsActive(pvrchannelguide)</visible>
@@ -50,16 +53,12 @@
 						<shadowcolor>text_shadow</shadowcolor>
 						<top>7</top>
 						<height>50</height>
-						<left>0</left>
-						<right>0</right>
 					</control>
 					<control type="label">
 						<top>60</top>
 						<label>$VAR[OSDSubLabelVar]</label>
 						<shadowcolor>text_shadow</shadowcolor>
 						<height>60</height>
-						<left>0</left>
-						<right>0</right>
 					</control>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -307,7 +307,6 @@
 	<variable name="NowPlayingBreadcrumbsVar">
   		<value condition="MusicPlayer.Content(livetv) + Player.HasAudio">$INFO[MusicPlayer.Title]</value> 
 		<value condition="VideoPlayer.Content(livetv)">$INFO[VideoPlayer.Title]</value>
-		<value condition="VideoPlayer.Content(episodes) + !String.IsEmpty(Player.Art(tvshow.clearlogo))">$INFO[VideoPlayer.Season,[COLOR button_focus]S,[/COLOR]]$INFO[VideoPlayer.Episode,[COLOR button_focus]E,: [/COLOR]]$INFO[VideoPlayer.Title]</value>
 		<value condition="VideoPlayer.Content(episodes) + Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.TVShowTitle]$INFO[VideoPlayer.Year, (,)]</value>
 		<value condition="!VideoPlayer.Content(episodes) + Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.Title]$INFO[VideoPlayer.Year, (,)]</value>
 		<value condition="MusicPartyMode.Enabled">$LOCALIZE[589]</value>
@@ -316,7 +315,7 @@
 	<variable name="OSDSubLabelVar">
 		<value condition="Window.IsActive(visualisation) + Integer.IsGreater(Playlist.Length(music),1) + Integer.IsGreater(Playlist.Position(music),0)">$LOCALIZE[554] $INFO[Playlist.Position] / $INFO[Playlist.Length]</value>
 		<value condition="VideoPlayer.Content(musicvideos)">$INFO[VideoPlayer.Artist]$INFO[VideoPlayer.Album, - ]</value>
-		<value condition="VideoPlayer.Content(episodes) + !player.chaptercount">$INFO[VideoPlayer.Season,S]$INFO[VideoPlayer.Episode,E,: ]$INFO[VideoPlayer.Title]</value>
+		<value condition="VideoPlayer.Content(episodes) + !player.chaptercount">$INFO[VideoPlayer.Season,[COLOR button_focus][CAPITALIZE]$LOCALIZE[36906][/CAPITALIZE]:[/COLOR] S]$INFO[VideoPlayer.Episode,E,: ]$INFO[VideoPlayer.Title]</value>
 		<value condition="VideoPlayer.Content(episodes) + player.chaptercount">$INFO[VideoPlayer.Season,[COLOR button_focus][CAPITALIZE]$LOCALIZE[36906][/CAPITALIZE]:[/COLOR] S]$INFO[VideoPlayer.Episode,E, - ]$INFO[VideoPlayer.Title,,[CR]]$INFO[player.chapter,[COLOR button_focus]$LOCALIZE[21396]:[/COLOR] ]$INFO[Player.ChapterCount,/]$INFO[Player.ChapterName, - ]</value>
 		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording | PVR.IsPlayingEpgTag">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR button_focus],[/COLOR]) ]$INFO[VideoPlayer.ChannelName] $INFO[VideoPlayer.EpisodeName, - ]</value>
 		<value condition="player.chaptercount + [!VideoPlayer.Content(episodes) + !VideoPlayer.Content(LiveTV)]">$INFO[player.chapter,[COLOR button_focus]$LOCALIZE[21396]:[/COLOR] ]$INFO[Player.ChapterCount,/]$INFO[Player.ChapterName, - ]</value>


### PR DESCRIPTION
## Description
Follow up to https://github.com/xbmc/xbmc/pull/17976 as this introduced some inconsistencies in the Topbar info.

At the time of PR17976  I did not have any clearlogos for any of my library items so this part was left untouched, I have now setup a test library with clearlogos so I've now been able align the Topbar info that is displayed whether these clearlogo's are present or not, and therefore to make the displayed info consistent across all scenarios.

**TV Shows**

Before PR with no clearlogo and no chapters

![image](https://user-images.githubusercontent.com/5781142/86782320-d155c100-c056-11ea-9d8d-49cc8c5bf11d.png)

Compared to a TV Show which does has chapters

![image](https://user-images.githubusercontent.com/5781142/86782986-ac158280-c057-11ea-8a4d-a71ca94786d5.png)

In PR17976 the text label "Episode" was introduced to match the "Chapter" label, however I forgot to add this "Episode" label for the case where there is no chapter. 

After PR changes with no clearlogo and no chapters

![image](https://user-images.githubusercontent.com/5781142/86783265-fd257680-c057-11ea-8146-7bc7d388cdcc.png)

What follows are other test cases I have now used to ensure consistency.

Before PR with clearlogo and no chapters

![image](https://user-images.githubusercontent.com/5781142/86783624-79b85500-c058-11ea-8f63-3419e79bad4f.png)

After PR change with clearlogo and no chapters

![image](https://user-images.githubusercontent.com/5781142/86783810-ae2c1100-c058-11ea-8a37-81461fe05ae8.png)

Before PR with clearlogo and with chapters

![image](https://user-images.githubusercontent.com/5781142/86783873-bedc8700-c058-11ea-9101-43677f8888db.png)

After PR change with clearlogo and with chapters

![image](https://user-images.githubusercontent.com/5781142/86783883-c308a480-c058-11ea-93b9-5257a3a64d36.png)

Also tested to ensure consistency (no changes were required for any of these cases)

File item without chapters

![image](https://user-images.githubusercontent.com/5781142/86784313-44603700-c059-11ea-9269-d0ed90f11605.png)

File item with chapters

![image](https://user-images.githubusercontent.com/5781142/86784331-4924eb00-c059-11ea-8dd6-3ccb65309af4.png)

**Movies**

With no clearlogo and with chapters

![image](https://user-images.githubusercontent.com/5781142/86783397-280fca80-c058-11ea-9fa5-0a36bc718fbc.png)

Before PR with clearlogo  with chapters

![image](https://user-images.githubusercontent.com/5781142/86783453-3827aa00-c058-11ea-84cd-ff5d0a02641d.png)

After PR changes with clearlogo  with chapters

![image](https://user-images.githubusercontent.com/5781142/86783501-4c6ba700-c058-11ea-8c92-d8a20efad761.png)

With no clearlogo and without chapters

![image](https://user-images.githubusercontent.com/5781142/86785920-39a6a180-c05b-11ea-9763-352edc442242.png)

Before PR with clearlogo  without chapters

![image](https://user-images.githubusercontent.com/5781142/86786191-9f932900-c05b-11ea-93bf-144b22297d02.png)

After PR changes with clearlogo  with chapters

![image](https://user-images.githubusercontent.com/5781142/86785988-4f1bcb80-c05b-11ea-8447-22c0b722f974.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
