### PR TITLE
[Estuary] Changes for sets in set-info-screen

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -411,14 +411,15 @@
 							</control>
 						</control>
 					</focusedlayout>
-					<itemlayout height="317" width="245" condition="Container.Content(Sets)">
+					<itemlayout height="317" width="210" condition="Container.Content(Sets)">
 						<control type="group">
+							<left>-10</left>
 							<top>10</top>
 							<control type="image">
 								<top>0</top>
-								<width>264</width>
+								<width>224</width>
 								<height>317</height>
-								<texture>DefaultActorSolid.png</texture>
+								<texture>DefaultMovies.png</texture>
 								<aspectratio aligny="center">scale</aspectratio>
 								<bordertexture border="21">overlays/shadow.png</bordertexture>
 								<bordersize>20</bordersize>
@@ -426,40 +427,41 @@
 							<control type="image">
 								<top>20</top>
 								<left>20</left>
-								<width>224</width>
+								<width>204</width>
 								<height>277</height>
-								<texture background="true">$INFO[ListItem.Thumb]</texture>
-								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[ListItem.Art(poster)]</texture>
+								<aspectratio aligny="center">keep</aspectratio>
 							</control>
 							<control type="image">
-								<left>20</left>
-								<width>224</width>
+								<left>30</left>
+								<width>184</width>
 								<height>180</height>
 								<bottom>10</bottom>
 								<texture>overlays/overlayfade.png</texture>
 								<animation effect="fade" start="100" end="80" time="0" condition="true">Conditional</animation>
 							</control>
 							<control type="textbox">
-								<left>25</left>
-								<width>214</width>
+								<left>30</left>
+								<width>182</width>
 								<height>84</height>
 								<top>210</top>
 								<align>center</align>
 								<aligny>center</aligny>
 								<font>font23_narrow</font>
 								<label>$INFO[ListItem.Label]</label>
+								<visible>String.IsEmpty(ListItem.Art(poster))</visible>
 							</control>
 						</control>
 					</itemlayout>
-					<focusedlayout height="317" width="245" condition="Container.Content(Sets)">
+					<focusedlayout height="317" width="210" condition="Container.Content(Sets)">
 						<control type="group">
-							<left>0</left>
+							<left>-10</left>
 							<top>10</top>
 							<control type="image">
 								<top>0</top>
-								<width>264</width>
+								<width>224</width>
 								<height>317</height>
-								<texture>DefaultActorSolid.png</texture>
+								<texture>DefaultMovies.png</texture>
 								<aspectratio aligny="center">scale</aspectratio>
 								<bordertexture border="21">overlays/shadow.png</bordertexture>
 								<bordersize>20</bordersize>
@@ -467,33 +469,34 @@
 							<control type="image">
 								<top>20</top>
 								<left>20</left>
-								<width>224</width>
+								<width>204</width>
 								<height>277</height>
-								<texture background="true">$INFO[ListItem.Thumb]</texture>
-								<aspectratio aligny="center">scale</aspectratio>
+								<texture background="true">$INFO[ListItem.Art(poster)]</texture>
+								<aspectratio aligny="center">keep</aspectratio>
 							</control>
 							<control type="image">
-								<left>20</left>
-								<width>224</width>
+								<left>30</left>
+								<width>184</width>
 								<height>180</height>
 								<bottom>10</bottom>
 								<texture>overlays/overlayfade.png</texture>
 								<animation effect="fade" start="100" end="80" time="0" condition="true">Conditional</animation>
 							</control>
 							<control type="textbox">
-								<left>25</left>
-								<width>214</width>
+								<left>30</left>
+								<width>182</width>
 								<height>84</height>
 								<top>210</top>
 								<align>center</align>
 								<aligny>center</aligny>
 								<font>font23_narrow</font>
 								<label>$INFO[ListItem.Label]</label>
+								<visible>String.IsEmpty(ListItem.Art(poster)</visible>
 							</control>
 							<control type="image">
-								<left>16</left>
+								<left>27</left>
 								<top>16</top>
-								<width>232</width>
+								<width>190</width>
 								<height>285</height>
 								<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
 							</control>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This PR changes the following:
* show movie posters instead of thumbs
* small changes to the aspect ratio as normally we show actors there and those do have another width/height than movie posters
* changed the default fallback image to `DefaulMovies.png`
* ~change the text in case the top group is empty. Before it was "Cast not available". Now it's "No movies in set" and I created a different group with different conditions for that, so it won't break movies/tv-shows. where we still show actors~

I'm not sure if this is too hacky. So I'm happy to follow any hints if we can do that better ;)

I might need some help or a hint because currently I moved the label for the moviename to be hidden behind the poster. My thought was, that this label is not needed if we have a poster for that movie which shows the name anyway. But if there's no poster shown we have the fallback image (DefaultMovies.png) and one should at least see the name of the movie then. Anyway...I tried to make a visible condition for that textbox: `String.IsEmpty($INFO[ListItem.Art(poster)])` which didn't work. So I might need a hint for that if that's even possible at all. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
My thought was, that it's probably way more interesting to see the posters of the movies which do belong to a set rather than showing some screenshots. ~By doing that, I noticed that "Cast not available" does not make any sense for that section.~

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
Before:
![thumb](https://user-images.githubusercontent.com/7235787/86822990-98384380-c08c-11ea-8111-5425651f6585.png)

After:
![image](https://user-images.githubusercontent.com/7235787/86823067-ac7c4080-c08c-11ea-9f4a-12d27d437148.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
