### PR TITLE
[Windows] Enable alpha blending for the Player (BackPort)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -290,6 +290,7 @@ void CWinRenderer::RenderUpdate(int index, int index2, bool clear, unsigned int 
   ManageTextures();
   ManageRenderArea();
   Render(flags, DX::Windowing()->GetBackBuffer());
+  DX::Windowing()->SetAlphaBlendEnable(true);
 }
 
 void CWinRenderer::PreInit()

--- a/xbmc/utils/ColorUtils.cpp
+++ b/xbmc/utils/ColorUtils.cpp
@@ -13,5 +13,5 @@
 UTILS::Color ColorUtils::ChangeOpacity(const UTILS::Color color, const float opacity)
 {
   int newAlpha = ceil( ((color >> 24) & 0xff) * opacity);
-  return color + (newAlpha << 24);
+  return (color & 0x00FFFFFF) | (newAlpha << 24);
 };


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/18143

@afedchin looks like the `BaseRenderer` method signatures are different in Leia when compared to matrix (the alpha value used to be passed as an argument and alpha blending was enabled depending on its value). Can you check if this is correct?

@DaveTBlake for the final merge. This is the only fix I'd like to get into the final release of Leia. If you guys consider the risk is higher than the relevance of the bug (it was only reported quite recently) feel free to close. 