### PR TITLE
Fix exception with empty string in field_value::get_asInt64

### DIFF
--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -533,7 +533,7 @@ double field_value::get_asDouble() const {
 int64_t field_value::get_asInt64() const {
     switch (field_type) {
     case ft_String: {
-      return std::stoll(str_value);
+      return std::atoll(str_value.c_str());
     }
     case ft_Boolean:{
       return (int64_t)bool_value;


### PR DESCRIPTION
## Description

This issue manifested as the statement 'record->at(song_iStartOffset)
.get_asInt64()' in xbmc/music/MusicDatabase.cpp throwing an exception
leading to the message 'out of memory loading query' being printed in
the log.

Back story: The field iStartOffset in the table song in the music db is
declared as a nullable integer and the addon jellyfin-kodi is inserting
songs into the database but not setting the iStartOffset or iEndOffset
fields meaning they are null (they are represented as an empty string ""
in the field_value type in Kodi). There are also quite a few other
integer rows that are null, and the difference is that those are
converted with .get_asInt() as opposed to .get_asInt64() .

Looking into the former, we can see the function atoi() being used which
does not check for errors and returns 0 in case of failure to convert.

However std::stoll used in get_asInt64() throws an std::invalid_argument
exception in case of an invalid input string which leads to the
conversion not succeeding.

This patch adjusts the behavior of the get_asInt64() function to the
get_asInt() (and others converting a string to a number) function by
replacing the "safe" C++ variant with the "unsafe" C variant.

This fixes the ability to play back music which have an iStartOffset or
iEndOffset of null in the database.

See also https://github.com/jellyfin/jellyfin-kodi/pull/325#issuecomment-645610075

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Music playback on kodi master with the jellyfin-kodi plugin works now, before it failed to do that.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed ¯\\\_(ツ)\_/¯
