### PR TITLE
Revert "Revert "AESinkAudioTrack: Support multi channel float""

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -78,6 +78,7 @@ private:
   static bool m_hasIEC;
   static std::set<unsigned int>       m_sink_sampleRates;
   static bool m_sinkSupportsFloat;
+  static bool m_sinkSupportsMultiChannelFloat;
 
   AEAudioFormat      m_format;
   int16_t           *m_alignedS16;


### PR DESCRIPTION
This reverts commit 9ac14260d61d5659b35bace0e9baa8aeb4e395c7.

The original intention of the Revert of the multi-channel float was, that there are some devices that still cannot do it properly until today. Though many can. One nice argument to have it is, that on FireTV 4K the DD+ encoder (feature of FireTV) can cope with multi-channel int, which means: if you don't send float in multi-channel that thingy will kill your multi-channel experience.

As v19 is still long way to go and FW gets better and better use float again. There is no reason to reduce quality for everyone out there, because some boxes cannot cope with it but announce they would ...