### PR TITLE
FFmpeg: Bump to 4.3.1-Matrix-Alpha1-1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,4 +1,4 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=4.3-Matrix-Alpha1
+VERSION=4.3.1-Matrix-Alpha1-1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz


### PR DESCRIPTION
This fixes #18153 

based on https://github.com/xbmc/FFmpeg/releases/tag/4.3.1-Matrix-Alpha1
which is based on ffmpeg release 4.3.1 https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n4.3.1