### PR TITLE
Music artwork  improvements - GUI settings, optionally use all image files

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21673,7 +21673,7 @@ msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
 msgctxt "#38307"
-msgid "Include art work such as thumbnails and fanart"
+msgid "Include artwork such as thumbnails and fanart"
 msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -22228,20 +22228,23 @@ msgstr ""
 #. Description of setting with label #39137 "Artwork level"
 #: system/settings/settings.xml
 msgctxt "#39138"
-msgid "The amount of artwork automatically selected - [Maximum] all local images and remote art [Minimum] save space on limited devices when using a simple skin [User Configuration] customized for detailed control"
+msgid "The amount of artwork automatically selected - [Maximum] all local images and remote art; [Basic] save space on limited devices or when using a simple skin; [Custom] configured by user for detailed control; [None] no art"
 msgstr ""
 
+#. Value of setting with label #39137 "Artwork level"
 #: system/settings/settings.xml
 msgctxt "#39140"
 msgid "Maximum"
 msgstr ""
 
+#. Value of setting with label #39137 "Artwork level"
 #: system/settings/settings.xml
 msgctxt "#39141"
-msgid "Minimum"
+msgid "Basic"
 msgstr ""
 
+#. Value of setting with label #39137 "Artwork level"
 #: system/settings/settings.xml
 msgctxt "#39142"
-msgid "User Configuration"
+msgid "Custom"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6875,7 +6875,7 @@ msgctxt "#13386"
 msgid "Use time based seeking"
 msgstr ""
 
-#: system/settings/settings.xml
+#. unused?
 msgctxt "#13387"
 msgid "Track naming template - right"
 msgstr ""
@@ -7338,6 +7338,7 @@ msgstr ""
 #. Button to add a new type of art e.g. "thumb", "poster", "fanart" etc.
 #: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+#: system/settings/settings.xml
 msgctxt "#13516"
 msgid "Add art type"
 msgstr ""
@@ -19217,44 +19218,41 @@ msgctxt "#36273"
 msgid "Select the visualisation that will be displayed while listening to music."
 msgstr ""
 
-#. Description of setting with label #258 "Enable tag reading"
+#. Description of setting with label #39125 "Enable tag reading in file view"
 #: system/settings/settings.xml
 msgctxt "#36274"
-msgid "Read the tag information from song files. For large directories this can increase read time, especially over a network."
+msgid "When browsing music files in file view read the tags of those not in the music library as you go. This can make large directories slow to display, especially over a network."
 msgstr ""
 
-#. Description of setting with label #13307 "Track naming template"
+#. Description of setting with label #13307 "Track naming template" for musicfiles.trackformat
 #: system/settings/settings.xml
 msgctxt "#36275"
 msgid "Control the way that the names of songs are displayed in the user interface. In order to function properly, tag reading needs to be enabled."
 msgstr ""
 
-#. Description of setting with label #13387 "Track naming template - right"
-#: system/settings/settings.xml
+#. unused?
 msgctxt "#36276"
 msgid "Used for formatting the second column in file lists."
 msgstr ""
 
-#. Description of setting with label #13307 "Now Playing - Track naming template"
+#. Description of setting with label #13307 "Track naming template" in musicfiles.nowplayingtrackformat
 #: system/settings/settings.xml
 msgctxt "#36277"
 msgid "Control the way that the names of songs are displayed in the now playing list."
 msgstr ""
 
-#. Description of setting with label #13387 "Now Playing - Track naming template - right"
-#: system/settings/settings.xml
+#. unused?
 msgctxt "#36278"
 msgid "Used for formatting the second column in the now playing list."
 msgstr ""
 
-#. Description of setting with label #13307 "Library - Track naming template"
+#. Description of setting with label #13307 "Track naming template" in musicfiles.librarytrackformat
 #: system/settings/settings.xml
 msgctxt "#36279"
 msgid "Control the way that the names of songs are displayed in library lists."
 msgstr ""
 
-#. Description of setting with label #13387 "Library - Track naming template - right"
-#: system/settings/settings.xml
+#. unused?
 msgctxt "#36280"
 msgid "Used for formatting the second column in library lists."
 msgstr ""
@@ -19289,7 +19287,7 @@ msgctxt "#36285"
 msgid "Select the location on your hard drive where ripped tracks will be saved to."
 msgstr ""
 
-#. Description of setting with label #13307 "Track naming template"
+#. Description of setting with label #13307 "Track naming template" in audiocds.trackpathformat
 #: system/settings/settings.xml
 msgctxt "#36286"
 msgid "Control how saved music is named from the tags. Tags: [B]%N[/B]: TrackNumber, [B]%S[/B]: DiscNumber, [B]%A[/B]: Artist, [B]%T[/B]: Title, [B]%B[/B]: Album, [B]%G[/B]: Genre, [B]%Y[/B]: Year, [B]%F[/B]: FileName, [B]%D[/B]: Duration, [B]%J[/B]: Date, [B]%R[/B]: Rating, [B]%I[/B]: FileSize."
@@ -20697,7 +20695,7 @@ msgctxt "#36602"
 msgid "This category contains the settings for how the AirPlay service is handled."
 msgstr ""
 
-#. Description of settings category with label #14216 Display
+#. Description of settings category with label #14220 Display
 #: system/settings/settings.xml
 msgctxt "#36603"
 msgid "This category contains the settings for displays."
@@ -21866,7 +21864,7 @@ msgstr ""
 #. Description of category "Library" with label #14202
 #: system/settings/settings.xml
 msgctxt "#39004"
-msgid "This category provides access to the windows for source management and the Library settings for the databases"
+msgid "This category provides access to the windows for source management and library management facilities"
 msgstr ""
 
 #. Description of setting "Videos... with label #14242
@@ -22142,4 +22140,108 @@ msgstr ""
 #: xbmc/settings/dialogs/GUIDialogContentSettings.cpp
 msgctxt "#39120"
 msgid "Skip filename matching for external audio tracks"
+msgstr ""
+
+#. Label for section of settings controling what is shown on the library windows
+#: system/settings/settings.xml
+msgctxt "#39121"
+msgid "Library Display and Navigation"
+msgstr ""
+
+#. Label for section of settings controling how library is populated
+#: system/settings/settings.xml
+msgctxt "#39122"
+msgid "Library Information Sources"
+msgstr ""
+
+#. Label for section of settings
+#: system/settings/settings.xml
+msgctxt "#39123"
+msgid "Artwork"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39125"
+msgid "Enable tag reading in file view"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39127"
+msgid "Use all local image files as artwork"
+msgstr ""
+
+#. Description of setting with label #39127 "Use all local image files as artwork"
+#: system/settings/settings.xml
+msgctxt "#39128"
+msgid "All image files located alongside the media files are picked up as artwork during library scan, with the file name as the art type."
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39129"
+msgid "Use all remote artwork fetched by scrapers"
+msgstr ""
+
+#. Description of setting with label #39129 "Use all remote artwork fetched by scrapers"
+#: system/settings/settings.xml
+msgctxt "#39130"
+msgid "Use the first of each art type of the remote artwork in scraper results to fill any missing art not populated with local art."
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39131"
+msgid "Artist art types whitelist"
+msgstr ""
+
+#. Description of setting with label #39131 "Artist art types whitelist"
+#: system/settings/settings.xml
+msgctxt "#39132"
+msgid "Limit the artist artwork fetched locally or applied from scraper remote art results to just those art types in the whitelist"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39133"
+msgid "Album art types whitelist"
+msgstr ""
+
+#. Description of setting with label #39133 "Album art types whitelist"
+#: system/settings/settings.xml
+msgctxt "#39134"
+msgid "Limit the album artwork fetched locally or applied from scraper remote art results to just those art types in the whitelist"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39135"
+msgid "Thumbnail image files"
+msgstr ""
+
+#. Description of setting with label #39135 "Thumbnail image files"
+#: system/settings/settings.xml
+msgctxt "#39136"
+msgid "The names of files that contain primary artwork (thumbnails), generally square and used both full and in reduced size to visually identify a folder, artist, album or song"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39137"
+msgid "Artwork level"
+msgstr ""
+
+#. Description of setting with label #39137 "Artwork level"
+#: system/settings/settings.xml
+msgctxt "#39138"
+msgid "The amount of artwork automatically selected - [Maximum] all local images and remote art [Minimum] save space on limited devices when using a simple skin [User Configuration] customized for detailed control"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39140"
+msgid "Maximum"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39141"
+msgid "Minimum"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39142"
+msgid "User Configuration"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1072,11 +1072,6 @@
         </setting>
       </group>
       <group id="3" label="39123">
-        <setting id="musiclibrary.preferonlinealbumart" type="boolean" label="20224" help="20225">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <!-- Hidden setting indicating music art settings have been migrated from old advancedsettings.xml format-->
         <setting id="musiclibrary.artsettings" type="boolean" label="0" help="">
           <level>4</level>
@@ -1091,6 +1086,7 @@
               <option label="39140">0</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_ALL -->
               <option label="39141">1</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_BASIC -->
               <option label="39142">2</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_CUSTOM -->
+              <option label="231">3</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_NONE -->
             </options>
           </constraints>
           <control type="list" format="string" />
@@ -1182,9 +1178,20 @@
             <allowempty>true</allowempty>
             <allownewoption>true</allownewoption>
           </constraints>
+		  <dependencies>
+            <dependency type="enable" setting="musiclibrary.artworklevel" operator="!is">3</dependency>
+          </dependencies>
           <control type="list" format="string">
             <multiselect>true</multiselect>
           </control>
+        </setting>
+        <setting id="musiclibrary.preferonlinealbumart" type="boolean" label="20224" help="20225">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+		  <dependencies>
+            <dependency type="enable" setting="musiclibrary.artworklevel" operator="!is">3</dependency>
+          </dependencies>		  
         </setting>
       </group>
       <group id="4" label="128">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1002,7 +1002,192 @@
       </group>
     </category>
     <category id="music" label="14216" help="38108">
-      <group id="1" label="593">
+      <group id="1" label="39121">
+        <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.showcompilationartists" type="boolean" label="13414" help="36255">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.showdiscs" type="boolean" label="13522" help="13523">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.useartistsortname" type="boolean" label="20228" help="36294">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.useoriginaldate" type="boolean" label="13524" help="13525">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="2" label="39122">
+        <setting id="musiclibrary.downloadinfo" type="boolean" label="20192" help="36256">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.artistsfolder" type="path" label="20223" help="36293">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
+        </setting>
+        <setting id="musiclibrary.albumsscraper" type="addon" label="20193" help="36257">
+          <level>1</level>
+          <default>metadata.generic.albums</default>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.albums</addontype>
+          </constraints>
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
+        </setting>
+        <setting id="musiclibrary.artistsscraper" type="addon" label="20194" help="36258">
+          <level>1</level>
+          <default>metadata.generic.artists</default>
+          <constraints>
+            <addontype>xbmc.metadata.scraper.artists</addontype>
+          </constraints>
+          <control type="button" format="addon">
+            <show more="true" details="true">installed</show>
+          </control>
+        </setting>
+        <setting id="musiclibrary.overridetags" type="boolean" label="20220" help="20221">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="3" label="39123">
+        <setting id="musiclibrary.preferonlinealbumart" type="boolean" label="20224" help="20225">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <!-- Hidden setting indicating music art settings have been migrated from old advancedsettings.xml format-->
+        <setting id="musiclibrary.artsettings" type="boolean" label="0" help="">
+          <level>4</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="musiclibrary.artworklevel" type="integer" label="39137" help="39138">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="39140">0</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_ALL -->
+              <option label="39141">1</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_BASIC -->
+              <option label="39142">2</option> <!-- MUSICLIBRARY_ARTWORK_LEVEL_CUSTOM -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="musiclibrary.usealllocalart" type="boolean" parent="musiclibrary.artworklevel" label="39127" help="39128">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="visible" setting="musiclibrary.artworklevel" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+        <setting id="musiclibrary.useallremoteart" type="boolean" parent="musiclibrary.artworklevel" label="39129" help="39130">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="visible" setting="musiclibrary.artworklevel" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+        <setting id="musiclibrary.artistartwhitelist" type="list[string]" parent="musiclibrary.artworklevel" label="39131" help="39132">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <options>
+              <option>banner</option>
+              <option>clearart</option>
+              <option>clearlogo</option>
+              <option>landscape</option>
+              <option>fanart</option>
+            </options>
+            <delimiter>, </delimiter>
+            <allownewoption>true</allownewoption>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="musiclibrary.artworklevel" operator="is">2</dependency>
+            <dependency type="enable">
+              <or>
+                <condition setting="musiclibrary.usealllocalart" operator="is" >false</condition>
+                <condition setting="musiclibrary.useallremoteart" operator="is">false</condition>
+              </or>
+            </dependency>
+          </dependencies>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+            <addbuttonlabel>13516</addbuttonlabel>
+          </control>
+        </setting>
+        <setting id="musiclibrary.albumartwhitelist" type="list[string]" parent="musiclibrary.artworklevel" label="39133" help="39134">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <options>
+              <option>discart</option>
+              <option>back</option>
+              <option>spine</option>
+              <option>3dcase</option>
+              <option>3dflat</option>
+              <option>3dface</option>
+            </options>
+            <delimiter>, </delimiter>
+            <allownewoption>true</allownewoption>
+          </constraints>
+          <dependencies>
+            <dependency type="visible" setting="musiclibrary.artworklevel" operator="is">2</dependency>
+            <dependency type="enable">
+              <or>
+                <condition setting="musiclibrary.usealllocalart" operator="is" >false</condition>
+                <condition setting="musiclibrary.useallremoteart" operator="is">false</condition>
+              </or>
+            </dependency>
+          </dependencies>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+            <addbuttonlabel>13516</addbuttonlabel>
+          </control>
+        </setting>
+        <setting id="musiclibrary.musicthumbs" type="list[string]" label="39135" help="39136">
+          <level>3</level>
+          <default>folder.jpg, cover.jpg, cover.jpeg, thumb.jpg</default>
+          <constraints>
+            <options>
+              <option>folder.jpg</option>
+              <option>cover.jpg</option>
+              <option>cover.jpeg</option>
+              <option>thumb.jpg</option>
+            </options>
+            <delimiter>, </delimiter>
+            <allowempty>true</allowempty>
+            <allownewoption>true</allownewoption>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+          </control>
+        </setting>
+      </group>
+      <group id="4" label="128">
         <setting id="musicfiles.selectaction" type="boolean" label="12381" help="38112">
           <level>0</level>
           <default>false</default>
@@ -1040,84 +1225,10 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-      </group>
-      <group id="2" label="744">
-        <setting id="musicfiles.usetags" type="boolean" label="258" help="36274">
+        <setting id="musicfiles.usetags" type="boolean" label="39125" help="36274">
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
-        </setting>
-      </group>
-      <group id="3" label="14022">
-        <setting id="musiclibrary.showallitems" type="boolean" label="38011" help="38012">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.showcompilationartists" type="boolean" label="13414" help="36255">
-          <level>0</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.showdiscs" type="boolean" label="13522" help="13523">
-          <level>0</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.useartistsortname" type="boolean" label="20228" help="36294">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.useoriginaldate" type="boolean" label="13524" help="13525">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.overridetags" type="boolean" label="20220" help="20221">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.downloadinfo" type="boolean" label="20192" help="36256">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.artistsfolder" type="path" label="20223" help="36293">
-          <level>1</level>
-          <default></default>
-          <constraints>
-            <allowempty>true</allowempty>
-          </constraints>
-          <control type="button" format="path">
-            <heading>657</heading>
-          </control>
-        </setting>
-        <setting id="musiclibrary.preferonlinealbumart" type="boolean" label="20224" help="20225">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="musiclibrary.albumsscraper" type="addon" label="20193" help="36257">
-          <level>1</level>
-          <default>metadata.generic.albums</default>
-          <constraints>
-            <addontype>xbmc.metadata.scraper.albums</addontype>
-          </constraints>
-          <control type="button" format="addon">
-            <show more="true" details="true">installed</show>
-          </control>
-        </setting>
-        <setting id="musiclibrary.artistsscraper" type="addon" label="20194" help="36258">
-          <level>1</level>
-          <default>metadata.generic.artists</default>
-          <constraints>
-            <addontype>xbmc.metadata.scraper.artists</addontype>
-          </constraints>
-          <control type="button" format="addon">
-            <show more="true" details="true">installed</show>
-          </control>
         </setting>
       </group>
     </category>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3045,13 +3045,40 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
   // if a folder, check for folder.jpg
   if (m_bIsFolder && !IsFileFolder() && (!IsRemote() || alwaysCheckRemote || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICFILES_FINDREMOTETHUMBS)))
   {
-    std::vector<std::string> thumbs = StringUtils::Split(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicThumbs, "|");
-    for (std::vector<std::string>::const_iterator i = thumbs.begin(); i != thumbs.end(); ++i)
+    std::vector<CVariant> thumbs = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+        CSettings::SETTING_MUSICLIBRARY_MUSICTHUMBS);
+    for (const auto& i : thumbs)
     {
-      std::string folderThumb(GetFolderThumb(*i));
-      if (CFile::Exists(folderThumb))
-      {
+      std::string strFileName = i.asString();
+      std::string folderThumb(GetFolderThumb(strFileName));
+      if (CFile::Exists(folderThumb))   // folder.jpg
         return folderThumb;
+      size_t period = strFileName.find_last_of(".");
+      if (period != std::string::npos)
+      {
+        std::string ext;
+        std::string name = strFileName;
+        std::string folderThumb1 = folderThumb;
+        name.erase(period);
+        ext = strFileName.substr(period);
+        StringUtils::ToUpper(ext);
+        StringUtils::Replace(folderThumb1, strFileName, name + ext);
+        if (CFile::Exists(folderThumb1)) // folder.JPG
+          return folderThumb1;
+        
+        folderThumb1 = folderThumb;
+        std::string firstletter = name.substr(0, 1);
+        StringUtils::ToUpper(firstletter);
+        name.replace(0, 1, firstletter);
+        StringUtils::Replace(folderThumb1, strFileName, name + ext);
+        if (CFile::Exists(folderThumb1)) // Folder.JPG
+          return folderThumb1;
+        
+        folderThumb1 = folderThumb;
+        StringUtils::ToLower(ext);
+        StringUtils::Replace(folderThumb1, strFileName, name + ext);
+        if (CFile::Exists(folderThumb1)) // Folder.jpg
+          return folderThumb1;
       }
     }
   }

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -770,7 +770,11 @@ void DetailsFromFileItem<CAlbum>(const CFileItem &item, CAlbum &album)
   album.fRating = item.GetProperty("album.rating").asFloat();
   album.iUserrating = item.GetProperty("album.user_rating").asInteger32();
   album.iVotes = item.GetProperty("album.votes").asInteger32();
-  album.art = item.GetArt();
+  
+  /* Scrapers fetch a list of possible art but do not set the current images used because art
+     selection depends on other preferences so is handled by CMusicInfoScanner
+     album.art = item.GetArt();
+  */
 
   int nThumbs = item.GetProperty("album.thumbs").asInteger32();
   ParseThumbs(album.thumbURL, item, nThumbs, "album.thumb");
@@ -794,7 +798,11 @@ void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
   artist.strBiography = FromString(item, "artist.biography");
   artist.strDied = FromString(item, "artist.died");
   artist.strDisbanded = FromString(item, "artist.disbanded");
-  artist.art = item.GetArt();
+
+  /* Scrapers fetch a list of possible art but do not set the current images used because art
+     selection depends on other preferences so is handled by CMusicInfoScanner
+     artist.art = item.GetArt();
+  */
 
   int nAlbums = item.GetProperty("artist.albums").asInteger32();
   artist.discography.reserve(nAlbums);

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -380,4 +380,12 @@ namespace MUSIC_UTILS
     return arttypes;
   }
 
-}
+  bool IsValidArtType(const std::string& potentialArtType)
+  {
+    // Check length and is ascii
+    return potentialArtType.length() <= 25 &&
+                 std::find_if_not(potentialArtType.begin(), potentialArtType.end(),
+                                  StringUtils::isasciialphanum) == potentialArtType.end();
+  }
+
+  } // namespace MUSIC_UTILS

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -358,16 +358,26 @@ namespace MUSIC_UTILS
     // Get default types of art that are to be automatically fetched during scanning
     if (mediaType == MediaTypeArtist)
     {
-      arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicArtistExtraArt;
-      arttypes.emplace_back("thumb");
-      arttypes.emplace_back("fanart");
+      arttypes = { "thumb", "fanart" };
+      for (auto& artType : CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+        CSettings::SETTING_MUSICLIBRARY_ARTISTART_WHITELIST))
+      {
+        if (find(arttypes.begin(), arttypes.end(), artType.asString()) == arttypes.end())
+          arttypes.emplace_back(artType.asString());
+      }
     }
     else if (mediaType == MediaTypeAlbum)
     {
-      arttypes = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicAlbumExtraArt;
-      arttypes.emplace_back("thumb");
+      arttypes = { "thumb" };
+      for (auto& artType :
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+          CSettings::SETTING_MUSICLIBRARY_ALBUMART_WHITELIST))
+      {
+        if (find(arttypes.begin(), arttypes.end(), artType.asString()) == arttypes.end())
+          arttypes.emplace_back(artType.asString());
+      }
     }
-
     return arttypes;
   }
+
 }

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -63,4 +63,12 @@ namespace MUSIC_UTILS
   \return vector of art types that are to be fetched during scanning
   */
   std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
-}
+
+  /*! \brief Validate string is acceptable as the name of an additional art type
+  - limited length, and ascii alphanumberic charaters only
+  \param potentialArtType [in] potential art type name
+ \return true if the art type is valid
+ */
+  bool IsValidArtType(const std::string& potentialArtType);
+
+  } // namespace MUSIC_UTILS

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -147,7 +147,10 @@ void CMusicInfoScanner::Process()
           if (m_albumsAdded.size() > 0)
           {
             // Set local art for added album disc sets and primary album artists
-            RetrieveLocalArt();
+            if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                    CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL) !=
+                CSettings::MUSICLIBRARY_ARTWORK_LEVEL_NONE)
+              RetrieveLocalArt();
 
             if (m_flags & SCAN_ONLINE)
               // Download additional album and artist information for the recently added albums.
@@ -1321,8 +1324,11 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
   // Check album art.
   // Fill any gaps with local art files or use first available from scraped URL list (when it has
   // been successfuly scraped) as controlled by whitelist. Do this even when no info added
-  // (cancelled, not found or error), there may be new local art files.  
-  if (AddAlbumArtwork(album))
+  // (cancelled, not found or error), there may be new local art files.
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL) !=
+          CSettings::MUSICLIBRARY_ARTWORK_LEVEL_NONE &&
+      AddAlbumArtwork(album))
     albumDownloadStatus = INFO_ADDED; // Local art added
 
   return albumDownloadStatus;
@@ -1378,6 +1384,11 @@ CMusicInfoScanner::UpdateDatabaseArtistInfo(CArtist& artist,
     m_musicDatabase.UpdateArtist(artist);
     artistInfo.SetLoaded();
   }
+
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL) ==
+      CSettings::MUSICLIBRARY_ARTWORK_LEVEL_NONE)
+    return artistDownloadStatus;
 
   // Check artist art.
   // Fill any gaps with local art files, or use first available from scraped

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -14,6 +14,7 @@
 #include "music/MusicDatabase.h"
 #include "threads/IRunnable.h"
 #include "threads/Thread.h"
+#include "utils/ScraperUrl.h"
 
 class CAlbum;
 class CArtist;
@@ -151,6 +152,63 @@ protected:
    \return vector of art types that are missing from the set
    */
   std::vector<std::string> GetMissingArtTypes(const MediaType& mediaType, const std::map<std::string, std::string>& art);
+
+  /*! \brief Add extra local artwork for albums and artists
+  This common utility scans the given folder for local (non-thumb) art.
+  The art types checked are determined by whitelist and usealllocalart settings.
+  \param art [in/out] map of art type and file location (URL or path) pairs
+  \param mediaType [in] artist or album
+  \param mediaName [in] artist or album name that may be stripped from image file names
+  \param artfolder [in] path of folder containing local image files
+  \return true when art is added
+  */
+  bool AddLocalArtwork(std::map<std::string, std::string>& art,
+                       const std::string& mediaType,
+                       const std::string& mediaName,
+                       const std::string& artfolder,
+                       int discnum = 0);
+
+  /*! \brief Add extra remote artwork for albums and artists
+  This common utility fills the gaps in artwork using the first available art of each type from the
+  possibile art URL results of previous scraping.
+  The art types applied are determined by whitelist and usealllocalart settings.
+  \param art [in/out] map of art type and file location (URL or path) pairs
+  \param mediaType [in] artist or album
+  \param thumbURL [in] URLs for potential remote artwork (provided by scrapers)
+  \return true when art is added
+  */
+  bool AddRemoteArtwork(std::map<std::string, std::string>& art,
+                        const std::string& mediaType,
+                        const CScraperUrl& thumbURL);
+
+  /*! \brief Add art for an artist
+  This scans the given folder for local art and/or applies the first available art of each type
+  from the possibile art URLs previously scraped. Art is added to any already stored by previous
+  scanning etc.The art types processed are determined by whitelist and other art settings. 
+  When usealllocalart is enabled then all local image files are applied as art (providing name is
+  valid for an art type), and then the URL list of remote art is checked adding the first available
+  image of each art type not yet in the art map.
+  Art found is saved in the album structure and the music database. The images found are cached.
+  \param artist [in/out] an artist, the art is set
+  \param artfolder [in] path of the location to search for local art files
+  \return true when art is added
+  */
+  bool AddArtistArtwork(CArtist& artist, const std::string& artfolder);
+
+  /*! \brief Add art for an album
+  This scans the album folder, and any disc set subfolders, for local art and/or applies the first
+  available art of each type from the possibile art URLs previously scraped. Only those subfolders
+  beneath the album folder containing music files tagged with same unique disc number are scanned.
+  Art is added to any already stored by previous scanning, only "thumb" is optionally replaced.
+  The art types processed are determined by whitelist and other art settings. When usealllocalart is
+  enabled then all local image files are applied as art (providing name is valid for an art type),
+  and then the URL list of remote art is checked adding the first available image of each art type
+  not yet in the art map. 
+  Art found is saved in the album structure and the music database. The images found are cached. 
+  \param artist [in/out] an album, the art is set 
+  \return true when art is added
+  */
+  bool AddAlbumArtwork(CAlbum& album);
 
   /*! \brief Set art for an artist
   Checks for the missing types of art in the given folder. If none is found

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1187,6 +1187,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   // load in the settings overrides
   CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(pRootElement);
+
+  // Migration of old style art options from advanced setting to GUI setting
+  MigrateOldArtSettings();
 }
 
 void CAdvancedSettings::Clear()
@@ -1371,5 +1374,65 @@ void CAdvancedSettings::SetExtraArtwork(const TiXmlElement* arttypes, std::vecto
     if (arttype->FirstChild())
       artworkMap.push_back(arttype->FirstChild()->ValueStr());
     arttype = arttype->NextSibling("arttype");
+  }
+}
+
+void ConvertToWhitelist(const std::vector<std::string>& oldlist, std::vector<CVariant>& whitelist)
+{
+  for (auto& it : oldlist)
+  {
+    size_t last_index = it.find_last_not_of("0123456789");
+    std::string strFamilyType = it.substr(0, last_index + 1); // "fanart" of "fanart16"
+    if (std::find(whitelist.begin(), whitelist.end(), strFamilyType) == whitelist.end())
+      whitelist.emplace_back(strFamilyType);
+  }
+}
+
+void CAdvancedSettings::MigrateOldArtSettings()
+{
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  if (!settings->GetBool(CSettings::SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED))
+  {
+    CLog::Log(LOGINFO, "Migrating old music library artwork settings to new GUI settings");
+    // Convert numeric art type variants into simple art type family entry
+    // e.g. {"banner", "fanart1", "fanart2", "fanart3"... } into { "banner", "fanart"}
+    if (!m_musicArtistExtraArt.empty())
+    {
+      std::vector<CVariant> whitelist;
+      ConvertToWhitelist(m_musicArtistExtraArt, whitelist);
+      settings->SetList(CSettings::SETTING_MUSICLIBRARY_ARTISTART_WHITELIST, whitelist);
+    }
+    if (!m_musicAlbumExtraArt.empty())
+    {
+      std::vector<CVariant> whitelist;
+      ConvertToWhitelist(m_musicAlbumExtraArt, whitelist);
+      settings->SetList(CSettings::SETTING_MUSICLIBRARY_ALBUMART_WHITELIST, whitelist);
+    }
+
+    // Convert value like "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|
+    // cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG" into case-insensitive unique elements
+    // e.g. {"folder.jpg", "cover.jpg", "cover.jpeg", "thumb.jpg"}
+    if (!m_musicThumbs.empty())
+    {
+      std::vector<std::string> thumbs1 = StringUtils::Split(m_musicThumbs, "|");
+      std::vector<std::string> thumbs2;
+      for (auto& it : thumbs1)
+      {
+        StringUtils::ToLower(it);
+        if (std::find(thumbs2.begin(), thumbs2.end(), it) == thumbs2.end())
+          thumbs2.emplace_back(it);
+      }
+      std::vector<CVariant> thumbs;
+      for (const auto& it : thumbs2)
+        thumbs.emplace_back(it);
+      settings->SetList(CSettings::SETTING_MUSICLIBRARY_MUSICTHUMBS, thumbs);
+    }
+
+    // Whitelists configured, set artwork level to custom
+    if (!m_musicAlbumExtraArt.empty() || !m_musicArtistExtraArt.empty())
+      settings->SetInt(CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL, 2);
+
+    // Flag migration of settings so not done again
+    settings->SetBool(CSettings::SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED, true);
   }
 }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -369,4 +369,5 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void Initialize();
     void Clear();
     void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap);
+    void MigrateOldArtSettings();
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -234,6 +234,15 @@ const std::string CSettings::SETTING_MUSICLIBRARY_USEARTISTSORTNAME = "musiclibr
 const std::string CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO = "musiclibrary.downloadinfo";
 const std::string CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER = "musiclibrary.artistsfolder";
 const std::string CSettings::SETTING_MUSICLIBRARY_PREFERONLINEALBUMART = "musiclibrary.preferonlinealbumart";
+const std::string CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL = "musiclibrary.artworklevel";
+const std::string CSettings::SETTING_MUSICLIBRARY_USEALLLOCALART = "musiclibrary.usealllocalart";
+const std::string CSettings::SETTING_MUSICLIBRARY_USEALLREMOTEART = "musiclibrary.useallremoteart";
+const std::string CSettings::SETTING_MUSICLIBRARY_ARTISTART_WHITELIST =
+    "musiclibrary.artistartwhitelist";
+const std::string CSettings::SETTING_MUSICLIBRARY_ALBUMART_WHITELIST =
+    "musiclibrary.albumartwhitelist";
+const std::string CSettings::SETTING_MUSICLIBRARY_MUSICTHUMBS = "musiclibrary.musicthumbs";
+const std::string CSettings::SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED = "musiclibrary.artsettings";
 const std::string CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER = "musiclibrary.albumsscraper";
 const std::string CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER = "musiclibrary.artistsscraper";
 const std::string CSettings::SETTING_MUSICLIBRARY_OVERRIDETAGS = "musiclibrary.overridetags";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -400,6 +400,7 @@ public:
   static const int MUSICLIBRARY_ARTWORK_LEVEL_ALL = 0;
   static const int MUSICLIBRARY_ARTWORK_LEVEL_BASIC = 1;
   static const int MUSICLIBRARY_ARTWORK_LEVEL_CUSTOM = 2;
+  static const int MUSICLIBRARY_ARTWORK_LEVEL_NONE = 3;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -202,6 +202,13 @@ public:
   static const std::string SETTING_MUSICLIBRARY_DOWNLOADINFO;
   static const std::string SETTING_MUSICLIBRARY_ARTISTSFOLDER;
   static const std::string SETTING_MUSICLIBRARY_PREFERONLINEALBUMART;
+  static const std::string SETTING_MUSICLIBRARY_ARTWORKLEVEL;
+  static const std::string SETTING_MUSICLIBRARY_USEALLLOCALART;
+  static const std::string SETTING_MUSICLIBRARY_USEALLREMOTEART;
+  static const std::string SETTING_MUSICLIBRARY_ARTISTART_WHITELIST;
+  static const std::string SETTING_MUSICLIBRARY_ALBUMART_WHITELIST;
+  static const std::string SETTING_MUSICLIBRARY_MUSICTHUMBS;
+  static const std::string SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED;
   static const std::string SETTING_MUSICLIBRARY_ALBUMSSCRAPER;
   static const std::string SETTING_MUSICLIBRARY_ARTISTSSCRAPER;
   static const std::string SETTING_MUSICLIBRARY_OVERRIDETAGS;
@@ -388,6 +395,11 @@ public:
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES = 0;
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES = 1;
   static const int VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE = 2;
+
+  // values for SETTING_MUSICLIBRARY_ARTWORKLEVEL
+  static const int MUSICLIBRARY_ARTWORK_LEVEL_ALL = 0;
+  static const int MUSICLIBRARY_ARTWORK_LEVEL_BASIC = 1;
+  static const int MUSICLIBRARY_ARTWORK_LEVEL_CUSTOM = 2;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.


### PR DESCRIPTION
Improvements to the extended album and artist artwork handling to make it easier for users to get great results if they switch to using any of the art rich skins.

The flexible artwork facility introduced in v18 was only a first step, it removed the hard coded limits on what art Kodi would handle (pick up automatically from local files or scraper results, cache, and make availlable to skins, set using JSON etc.), and allowed the user to manually add art types,  select art etc.  But it is not easy for users to configure or understand, especially the automated aspects of scanning local art and integration with scrapers, the aim of this PR is to improve that.  

This adds new GUI settings to allow users to control what local image files are picked up by Kodi during scanning or scraping. This includes:

 - whitelists of art types. This replaces the whitelist settings in advancedsettings.xml completely and simplify what the user needs to enter. Old style settings get migrated.
- a new option to  have Kodi grab all lcal image files it finds or returned by the scrapers. 
- nominate the file names used as music thumbs . Again replacing the thumbs settings in advancedsettings.xml 

Screen shots of settings etc. to follow.

As discussed with @rmrector and @ronie a long time ago, and on #18072 which is WIP for video artwork and this PR has gained from the ideas there. Hopefully it can borrow from this in return. The idea will be to have a consistent user experience for both music an video. 

(In case anyone is wondering why one of us doesn't just deal with both music and video artwork, there are fundamental differences between scraping of video files to make a library, compared to scraping artist and album info to add to the music library).

May want to split the control addition in the first few commits into a separate PR, not sure. This is still WIP, but raised PR to give it visibility