### PR TITLE
[clang] set ReflowComments to false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,7 +71,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60000
 PointerAlignment: Left
-ReflowComments:  true
+ReflowComments:  false
 SortIncludes:    true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: false


### PR DESCRIPTION
## Description

This breaks doxygen documenation where on some parts a line break is not allowed.

There are few parts where no line breaks allowed for e.g. a table or there the `@defgroup`:
```cpp
  /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata_Help Value Help
  /// @ingroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata
  ///
  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata :</b>
  /// | Name | Type | Set call | Get call
  /// |------|------|----------|----------
  /// | **Chromaticity X coordinates of the red** | `double` | @ref InputstreamMasteringMetadata::SetPrimaryR_ChromaticityX "SetPrimaryR_ChromaticityX" | @ref InputstreamMasteringMetadata::GetPrimaryR_ChromaticityX "GetPrimaryR_ChromaticityX"
  /// | **Chromaticity Y coordinates of the red** | `double` | @ref InputstreamMasteringMetadata::SetPrimaryR_ChromaticityY "SetPrimaryR_ChromaticityY" | @ref InputstreamMasteringMetadata::GetPrimaryR_ChromaticityY "GetPrimaryR_ChromaticityY"
  /// | **Chromaticity X coordinates of the green** | `double` | @ref InputstreamMasteringMetadata::SetPrimaryG_ChromaticityX "SetPrimaryG_ChromaticityX" | @ref InputstreamMasteringMetadata::GetPrimaryG_ChromaticityX "GetPrimaryG_ChromaticityX"
  /// | **Chromaticity Y coordinates of the green** | `double` | @ref InputstreamMasteringMetadata::SetPrimaryG_ChromaticityY "SetPrimaryG_ChromaticityY" | @ref InputstreamMasteringMetadata::GetPrimaryG_ChromaticityY "GetPrimaryG_ChromaticityY"
  /// | **Chromaticity X coordinates of the blue** | `double` | @ref InputstreamMasteringMetadata::SetPrimaryB_ChromaticityX "SetPrimaryB_ChromaticityX" | @ref InputstreamMasteringMetadata::GetPrimaryB_ChromaticityX "GetPrimaryB_ChromaticityX"
  /// | **Chromaticity Y coordinates of the blue** | `double` | @ref InputstreamMasteringMetadata::SetPrimaryB_ChromaticityY "SetPrimaryB_ChromaticityY" | @ref InputstreamMasteringMetadata::GetPrimaryB_ChromaticityY "GetPrimaryB_ChromaticityY"
  /// | **Chromaticity X coordinates of the white point** | `double` | @ref InputstreamMasteringMetadata::SetWhitePoint_ChromaticityX "SetWhitePoint_ChromaticityX" | @ref InputstreamMasteringMetadata::GetWhitePoint_ChromaticityX "GetWhitePoint_ChromaticityX"
  /// | **Chromaticity Y coordinates of the white point** | `double` | @ref InputstreamMasteringMetadata::SetWhitePoint_ChromaticityY "SetWhitePoint_ChromaticityY" | @ref InputstreamMasteringMetadata::GetWhitePoint_ChromaticityY "GetWhitePoint_ChromaticityY"
  /// | **Maximum number of bits of the display** | `double` | @ref InputstreamMasteringMetadata::SetLuminanceMax "SetLuminanceMax" | @ref InputstreamMasteringMetadata::GetLuminanceMax "GetLuminanceMax"
  /// | **Minimum number of bits of the display** | `double` | @ref InputstreamMasteringMetadata::SetLuminanceMin "SetLuminanceMin" | @ref InputstreamMasteringMetadata::GetLuminanceMin "GetLuminanceMin"
```

Also by links it becomes not good:
```cpp
//==============================================================================
/// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata class InputstreamMasteringMetadata
/// @ingroup cpp_kodi_addon_inputstream_Defs_Interface
/// @brief **Mastering metadata.**\n
/// Describes the metadata for [HDR10](https://en.wikipedia.org/wiki/High-dynamic-range_video).
///
/// Used when video is compressed using [High Efficiency Video Coding (HEVC)](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding).
/// This is used to describe the capabilities  of the display used to master the
/// content and the luminance values of the content.
///
/// Used on @ref kodi::addon::InputstreamInfo::SetMasteringMetadata and @ref kodi::addon::InputstreamInfo::GetMasteringMetadata.
///
/// ----------------------------------------------------------------------------
///
/// @copydetails cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata_Help
///
```

Here how its was after the clang call:
```cpp
  /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata_Help Value
  /// Help
  /// @ingroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata
  ///
  /// <b>The following table contains values that can be set with @ref
  /// cpp_kodi_addon_inputstream_Defs_Interface_InputstreamMasteringMetadata :</b> | Name | Type |
  /// Set call | Get call
  /// |------|------|----------|----------
  /// | **Chromaticity X coordinates of the red** | `double` | @ref
  /// InputstreamMasteringMetadata::SetPrimaryR_ChromaticityX "SetPrimaryR_ChromaticityX" | @ref
  /// InputstreamMasteringMetadata::GetPrimaryR_ChromaticityX "GetPrimaryR_ChromaticityX" |
  /// **Chromaticity Y coordinates of the red** | `double` | @ref
  /// InputstreamMasteringMetadata::SetPrimaryR_ChromaticityY "SetPrimaryR_ChromaticityY" | @ref
  /// InputstreamMasteringMetadata::GetPrimaryR_ChromaticityY "GetPrimaryR_ChromaticityY" |
  /// **Chromaticity X coordinates of the green** | `double` | @ref
  /// InputstreamMasteringMetadata::SetPrimaryG_ChromaticityX "SetPrimaryG_ChromaticityX" | @ref
  /// InputstreamMasteringMetadata::GetPrimaryG_ChromaticityX "GetPrimaryG_ChromaticityX" |
  /// **Chromaticity Y coordinates of the green** | `double` | @ref
  /// InputstreamMasteringMetadata::SetPrimaryG_ChromaticityY "SetPrimaryG_ChromaticityY" | @ref
  /// InputstreamMasteringMetadata::GetPrimaryG_ChromaticityY "GetPrimaryG_ChromaticityY" |
  /// **Chromaticity X coordinates of the blue** | `double` | @ref
  /// InputstreamMasteringMetadata::SetPrimaryB_ChromaticityX "SetPrimaryB_ChromaticityX" | @ref
  /// InputstreamMasteringMetadata::GetPrimaryB_ChromaticityX "GetPrimaryB_ChromaticityX" |
  /// **Chromaticity Y coordinates of the blue** | `double` | @ref
  /// InputstreamMasteringMetadata::SetPrimaryB_ChromaticityY "SetPrimaryB_ChromaticityY" | @ref
  /// InputstreamMasteringMetadata::GetPrimaryB_ChromaticityY "GetPrimaryB_ChromaticityY" |
  /// **Chromaticity X coordinates of the white point** | `double` | @ref
  /// InputstreamMasteringMetadata::SetWhitePoint_ChromaticityX "SetWhitePoint_ChromaticityX" | @ref
  /// InputstreamMasteringMetadata::GetWhitePoint_ChromaticityX "GetWhitePoint_ChromaticityX" |
  /// **Chromaticity Y coordinates of the white point** | `double` | @ref
  /// InputstreamMasteringMetadata::SetWhitePoint_ChromaticityY "SetWhitePoint_ChromaticityY" | @ref
  /// InputstreamMasteringMetadata::GetWhitePoint_ChromaticityY "GetWhitePoint_ChromaticityY" |
  /// **Maximum number of bits of the display** | `double` | @ref
  /// InputstreamMasteringMetadata::SetLuminanceMax "SetLuminanceMax" | @ref
  /// InputstreamMasteringMetadata::GetLuminanceMax "GetLuminanceMax" | **Minimum number of bits of
  /// the display** | `double` | @ref InputstreamMasteringMetadata::SetLuminanceMin
  /// "SetLuminanceMin" | @ref InputstreamMasteringMetadata::GetLuminanceMin "GetLuminanceMin"
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
