### PR TITLE
[videodb] improve (unique) indices on actor_link table after bffa7bb5

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -265,9 +265,11 @@ void CVideoDatabase::CreateAnalytics()
   m_pDS->exec("CREATE INDEX ix_uniqueid2 ON uniqueid(media_type(20), value(20))");
 
   m_pDS->exec("CREATE UNIQUE INDEX ix_actor_1 ON actor (name(255))");
-  m_pDS->exec("CREATE INDEX ix_actor_link_1 ON actor_link (media_type(20))");
-  m_pDS->exec("CREATE UNIQUE INDEX ix_actor_link_2 ON "
-              "actor_link (actor_id, media_id, media_type(20), role(255))");
+  m_pDS->exec("CREATE UNIQUE INDEX ix_actor_link_1 ON "
+              "actor_link (actor_id, media_type(20), media_id, role(255))");
+  m_pDS->exec("CREATE INDEX ix_actor_link_2 ON "
+              "actor_link (media_id, media_type(20), actor_id)");
+  m_pDS->exec("CREATE INDEX ix_actor_link_3 ON actor_link (media_type(20))");
 
   CreateLinkIndex("tag");
   CreateForeignLinkIndex("director", "actor");
@@ -5670,7 +5672,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 117;
+  return 118;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)


### PR DESCRIPTION
## Description
Due to the missing `CREATE INDEX ix_actor_link_2 ON actor_link (media_id, media_type(20), actor_id)` the performance of queries which JOIN the actor_link table against a media item table on `media_id` and `media_type` drastically decreased.

I initially dropped this index because I was confused by the fact that the old code creates two `UNIQUE` indices across the same columns but in a different order. I thought that this was unnecessary because the first `UNIQUE INDEX` already ensured the uniqueness across all columns. But the second(`UNIQUE`) `INDEX` was due to performance reasons but in retrospect it probably wouldn't have to be a `UNIQUE INDEX`.

## How Has This Been Tested?
Manually by @MilhouseVH, see https://github.com/xbmc/xbmc/pull/17094#issuecomment-659523276.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed