### PR TITLE
[depends] gnutls 3.6.14 and nettle 3.6 bump - Leia

### DIFF
--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -10,7 +10,7 @@ ARCHIVE=$(SOURCE).tar.bz2
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-shared --disable-ldap \
           --without-libssh2 --disable-ntlm-wb --enable-ipv6 --without-librtmp \
-          --with-ca-fallback --with-ssl=$(PREFIX) --with-nghttp2=$(PREFIX)
+          --without-libidn2 --with-ca-fallback --with-ssl=$(PREFIX) --with-nghttp2=$(PREFIX)
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 

--- a/tools/depends/target/gnutls/02-darwin-getentropy.patch
+++ b/tools/depends/target/gnutls/02-darwin-getentropy.patch
@@ -1,7 +1,6 @@
-diff -Naur a/configure.ac b/configure.ac
---- a/configure.ac	2019-12-02 08:32:16.000000000 -0800
-+++ b/configure.ac	2020-01-31 10:25:36.473631501 -0800
-@@ -278,6 +278,7 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -299,6 +299,7 @@
  
  AM_CONDITIONAL(HAVE_KERN_ARND, test "$rnd_variant" = "kern_arnd")
  
@@ -9,7 +8,7 @@ diff -Naur a/configure.ac b/configure.ac
  AC_MSG_CHECKING([for getentropy])
  AC_LINK_IFELSE([AC_LANG_PROGRAM([
  	   #include <unistd.h>
-@@ -294,6 +295,7 @@
+@@ -315,6 +316,7 @@
  		   AC_DEFINE([HAVE_GETENTROPY], 1, [Enable the OpenBSD getentropy function])
  		   rnd_variant=getentropy],
  		  [AC_MSG_RESULT(no)])

--- a/tools/depends/target/gnutls/03-support-correct-cisdigit.patch
+++ b/tools/depends/target/gnutls/03-support-correct-cisdigit.patch
@@ -1,0 +1,10 @@
+--- a/gl/c-ctype.h
++++ b/gl/c-ctype.h
+@@ -229,6 +229,7 @@
+     }
+ }
+
++__attribute__((always_inline))
+ C_CTYPE_INLINE bool
+ c_isdigit (int c)
+ {

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile size-max.patch 02-darwin-getentropy.patch remove-weak_import-check-for-osx.patch add-dl-as-private-lib.patch
+DEPS= ../../Makefile.include Makefile size-max.patch 02-darwin-getentropy.patch remove-weak_import-check-for-osx.patch add-dl-as-private-lib.patch 03-support-correct-cisdigit.patch
 
 # lib name, version
 LIBNAME=gnutls
-VERSION=3.6.11.1
+VERSION=3.6.14
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
 
@@ -33,6 +33,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p1 -i ../02-darwin-getentropy.patch
 	cd $(PLATFORM); patch -p1 -i ../remove-weak_import-check-for-osx.patch
 	cd $(PLATFORM); patch -p1 -i ../add-dl-as-private-lib.patch
+	cd $(PLATFORM); patch -p1 -i ../03-support-correct-cisdigit.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 

--- a/tools/depends/target/gnutls/add-dl-as-private-lib.patch
+++ b/tools/depends/target/gnutls/add-dl-as-private-lib.patch
@@ -1,26 +1,22 @@
-diff --git a/configure.ac b/configure.ac
-index db1ce841f..264712b56 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -512,6 +512,9 @@ LT_INIT([disable-static,win32-dll,shared])
+@@ -547,6 +547,9 @@
  
  
  AC_LIB_HAVE_LINKFLAGS(dl,, [#include <dlfcn.h>], [dladdr (0, 0);])
 +if test "x$HAVE_LIBDL" = "xyes"; then
-+      AC_SUBST([LIBDL], [-ldl])
++  AC_SUBST([LIBDL], [-ldl])
 +fi
  
  AC_ARG_ENABLE(fips140-mode,
    AS_HELP_STRING([--enable-fips140-mode], [enable FIPS140-2 mode]),
-diff --git a/lib/gnutls.pc.in b/lib/gnutls.pc.in
-index ffad3e168..15b990764 100644
 --- a/lib/gnutls.pc.in
 +++ b/lib/gnutls.pc.in
-@@ -19,6 +19,6 @@ Description: Transport Security Layer implementation for the GNU system
+@@ -19,6 +19,6 @@
  URL: https://www.gnutls.org/
  Version: @VERSION@
  Libs: -L${libdir} -lgnutls
--Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBIDN2_LIBS@ @LIBATOMIC_LIBS@
-+Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBIDN2_LIBS@ @LIBATOMIC_LIBS@ @LIBDL@
+-Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBATOMIC_LIBS@ @LIB_CRYPT32@ @LIBNCRYPT@ @LIBBCRYPT@
++Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBATOMIC_LIBS@ @LIB_CRYPT32@ @LIBNCRYPT@ @LIBBCRYPT@ @LIBDL@
  @GNUTLS_REQUIRES_PRIVATE@
  Cflags: -I${includedir}

--- a/tools/depends/target/gnutls/remove-weak_import-check-for-osx.patch
+++ b/tools/depends/target/gnutls/remove-weak_import-check-for-osx.patch
@@ -1,6 +1,6 @@
---- a/configure.ac	2020-01-25 08:26:59.223068640 -0800
-+++ b/configure.ac	2020-01-25 08:26:38.846233553 -0800
-@@ -122,14 +122,6 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -141,14 +141,6 @@
    ;;
    *darwin*)
      have_macosx=yes
@@ -10,7 +10,7 @@
 -    dnl intended minimum runtime version.
 -    LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
 -    AC_MSG_CHECKING([whether the linker supports -Wl,-no_weak_imports])
--    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+-    AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <sys/select.h>], [fd_set rfds; FD_ZERO(&rfds); FD_SET(0, &rfds);])],
 -      [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no); LDFLAGS="$save_LDFLAGS"])
    ;;
    *solaris*)

--- a/tools/depends/target/mariadb/02-symbol_rename-gnutls_clash.patch
+++ b/tools/depends/target/mariadb/02-symbol_rename-gnutls_clash.patch
@@ -1,0 +1,13 @@
+--- a/include/ma_hash.h
++++ b/include/ma_hash.h
+@@ -33,6 +33,10 @@
+   /* flags for hash_init */
+ #define HASH_CASE_INSENSITIVE	1
+
++#define hash_free libmariadb_hash_free
++#define hash_insert libmariadb_hash_insert
++#define hash_delete libmariadb_hash_delete
++
+ typedef struct st_hash_info {
+   uint next;					/* index to next key */
+   uchar *data;					/* data for current entry */

--- a/tools/depends/target/mariadb/Makefile
+++ b/tools/depends/target/mariadb/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile 01-android.patch
+DEPS= ../../Makefile.include Makefile 01-android.patch 02-symbol_rename-gnutls_clash.patch
 
 LIBNAME=mariadb
 VERSION=3.0.3
@@ -16,6 +16,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)/build
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../01-android.patch
+	cd $(PLATFORM); patch -p1 -i ../02-symbol_rename-gnutls_clash.patch
 	sed -ie 's| "DYNAMIC" | "STATIC" |' $(PLATFORM)/cmake/plugins.cmake
 	cd $(PLATFORM)/build; $(CMAKE) -DAUTH_GSSAPI=OFF -DWITH_UNITTEST:BOOL=OFF -DWITH_EXTERNAL_ZLIB:BOOL=ON -DWITH_CURL:BOOL=OFF ..
 

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile 01-disable_testsuite.patch
 
 # lib name, version
 LIBNAME=nettle
-VERSION=3.5.1
+VERSION=3.6
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Backport of https://github.com/xbmc/xbmc/pull/18178

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Security issues in gnutls which are fixed in 3.6.14

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
