### PR TITLE
[PlayerControl] allow tempo to be set directly

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -179,6 +179,26 @@ static int PlayerControl(const std::vector<std::string>& params)
       g_application.GetAppPlayer().SetTempo(playTempo);
     }
   }
+  else if (StringUtils::StartsWithNoCase(params[0], "tempo"))
+  {
+    if (params[0].size() == 5)
+      CLog::Log(LOGERROR, "PlayerControl(tempo(n)) called with no argument");
+    else if (params[0].size() < 8) // arg must be at least "(N)"
+      CLog::Log(LOGERROR, "PlayerControl(tempo(n)) called with invalid argument: \"%s\"",
+                params[0].substr(6).c_str());
+    else
+    {
+      CApplicationPlayer& player = g_application.GetAppPlayer();
+      if (player.SupportsTempo() && player.IsPlaying() && !player.IsPaused())
+      {
+        std::string strTempo = params[0].substr(6);
+        StringUtils::TrimRight(strTempo, ")");
+        float playTempo = strtof(strTempo.c_str(), nullptr);
+
+        player.SetTempo(playTempo);
+      }
+    }
+  }
   else if (paramlow == "next")
   {
     g_application.OnAction(CAction(ACTION_NEXT_ITEM));
@@ -538,6 +558,7 @@ static int Seek(const std::vector<std::string>& params)
 ///     | Previous                | Previous chapter or movie in playlists | Previous track              |             |
 ///     | TempoUp                 | Increases playback speed               | none                        | Kodi v18    |
 ///     | TempoDown               | Decreases playback speed               | none                        | Kodi v18    |
+///     | Tempo(n)                | Sets playback speed to given value     | none                        | Kodi v19    |
 ///     | BigSkipForward          | Big Skip Forward                       | Big Skip Forward            | Kodi v15    |
 ///     | BigSkipBackward         | Big Skip Backward                      | Big Skip Backward           | Kodi v15    |
 ///     | SmallSkipForward        | Small Skip Forward                     | Small Skip Forward          | Kodi v15    |


### PR DESCRIPTION
@jjd-uk is currently working on adding Tempo support to the video osd in Estuary (https://github.com/xbmc/xbmc/pull/18155)

one of the suggested implementations is to add a 'youtube-like' menu similar to this:

![mockup](https://user-images.githubusercontent.com/687265/87836008-fb955300-c88e-11ea-83f0-270c7cb36ef8.jpg)

Kodi currently only offers a TempoUp or TempoDown function, but it was not possible to specify the speed value directly.
This PR extends the existing PlayerControl() function, to allow that:
`PlayerControl(Tempo(1.5))`

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
