### PR TITLE
Fix setting layout for "videolibrary.groupsingleitemsets" 

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -929,7 +929,7 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="videolibrary.groupsingleitemsets" type="boolean" parent="videolibrary.groupmoviesets" label="20470" help="36157">
+        <setting id="videolibrary.groupsingleitemsets" type="boolean" label="20470" help="36157">
           <level>1</level>
           <default>false</default>
           <control type="toggle" />


### PR DESCRIPTION
In settings>media>video the  "Include sets containing a single movie" setting is indented incorrectly and  appears to be dependent on "Show movie sets" setting. These settings are independant of each other, they do different things to different parts of the library.

Note this does not change setting behaviour, simply corrects the visual appearence.

Old
![Imgur](https://i.imgur.com/WNK4D60.jpg)

New 
![Imgur](https://i.imgur.com/wwR5eu0.jpg)

@KarellenX mentioned this indended layout has been causing users confusion. 
@jjd-uk of interest perhaps