### PR TITLE
[Music]Fix check that another artist with this mbid not already exist 

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1813,7 +1813,7 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       strMoods.c_str(), strStyles.c_str(), strInstruments.c_str(),
                       strBiography.c_str(), strDied.c_str(), strDisbanded.c_str(),
                       strYearsActive.c_str(), strImage.c_str(), strFanart.c_str(),
-                      CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), bScrapedMBID);
+                      CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), isScrapedMBID);
   if (useMBIDNull)
     strSQL += PrepareSQL(", strMusicBrainzArtistID = NULL");
   else


### PR DESCRIPTION
Follow up to #18068 - Fix constraint violation on Artist Update.
Fix save isScrapedMBID false when updating an artist by scraping and when another artist with this mbid already exists. 

Eagle-eyed @the-black-eagle spotted I had missed using the internal bool, thanks. 

