### PR TITLE
[GUIInfo] allow infolabels in all string comparison methods

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10242,6 +10242,9 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
         else
           bReturn = GetImage(info.GetData1(), contextWindow).empty();
         break;
+      case STRING_STARTS_WITH:
+      case STRING_ENDS_WITH:
+      case STRING_CONTAINS:
       case STRING_IS_EQUAL:
         {
           std::string compare;
@@ -10272,10 +10275,23 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           { // conditional string
             compare = info.GetData3();
           }
+          StringUtils::ToLower(compare);
+
+          std::string label;
           if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
-            bReturn = StringUtils::EqualsNoCase(GetItemImage(item, contextWindow, info.GetData1()), compare);
+            label = GetItemImage(item, contextWindow, info.GetData1());
           else
-            bReturn = StringUtils::EqualsNoCase(GetImage(info.GetData1(), contextWindow), compare);
+            label = GetImage(info.GetData1(), contextWindow);
+          StringUtils::ToLower(label);
+
+          if (condition == STRING_STARTS_WITH)
+            bReturn = StringUtils::StartsWith(label, compare);
+          else if (condition == STRING_ENDS_WITH)
+            bReturn = StringUtils::EndsWith(label, compare);
+          else if (condition == STRING_CONTAINS)
+            bReturn = label.find(compare) != std::string::npos;
+          else
+            bReturn = StringUtils::EqualsNoCase(label, compare);
         }
         break;
       case INTEGER_IS_EQUAL:
@@ -10318,27 +10334,6 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
             bReturn = integer % 2 == 0;
           else if (condition == INTEGER_ODD)
             bReturn = integer % 2 != 0;
-        }
-        break;
-      case STRING_STARTS_WITH:
-      case STRING_ENDS_WITH:
-      case STRING_CONTAINS:
-        {
-          std::string compare = info.GetData3();
-          // our compare string is already in lowercase, so lower case our label as well
-          // as std::string::Find() is case sensitive
-          std::string label;
-          if (item && item->IsFileItem() && IsListItemInfo(info.GetData1()))
-            label = GetItemImage(item, contextWindow, info.GetData1());
-          else
-            label = GetImage(info.GetData1(), contextWindow);
-          StringUtils::ToLower(label);
-          if (condition == STRING_STARTS_WITH)
-            bReturn = StringUtils::StartsWith(label, compare);
-          else if (condition == STRING_ENDS_WITH)
-            bReturn = StringUtils::EndsWith(label, compare);
-          else
-            bReturn = label.find(compare) != std::string::npos;
         }
         break;
     }


### PR DESCRIPTION
## Description
currently the only string comparison method that can compare 2 infolabels, is `String.IsEqual()`.
the other methods only can compare an infolabel to a fixed string.

this change adds support for comparing 2 infolabels to the other string comparison methods:
- `String.StartsWith()`
- `String.EndsWith()`
- `String.Contains()`

## Motivation and Context
requested on the forum: https://forum.kodi.tv/showthread.php?tid=355909&pid=2964525#pid2964525

## How Has This Been Tested?
i have tested all possible combinations (and double-checked all comparisons are done case-insensitive):
```
String.IsEqual(ListItem.Label, Skin.String(test))
String.StartsWith(ListItem.Label, Skin.String(test))
String.EndsWith(ListItem.Label, Skin.String(test))
String.Contains(ListItem.Label, Skin.String(test))
String.IsEqual(ListItem.Label, Foobar)
String.StartsWith(ListItem.Label, Foobar)
String.EndsWith(ListItem.Label, Foobar))
String.Contains(ListItem.Label, Foobar)
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [C] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
