### PR TITLE
Integer Scaling support implementation to improve the viewing quality of Pixel Art games

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22291,3 +22291,13 @@ msgstr ""
 msgctxt "#39150"
 msgid "Limit the music video artwork fetched locally or applied from scraper remote art results to just those art types in the whitelist"
 msgstr ""
+
+#.Display Hardware scaling filter setting toggle
+msgctxt "#39151"
+msgid "Display hardware scaling filter"
+msgstr ""
+
+#. Description
+msgctxt "#39152"
+msgid "Integer scaling (IS) is a Nearest-Neighbor(NN) upscaling technique using Display Engine"
+msgstr ""

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -47,6 +47,11 @@
         <setting id="videoscreen.screen">
           <visible>false</visible>
         </setting>
+        <setting id="videoscreen.hwscalingfilter" type="boolean" label="39151" help="39152">
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoscreen.limitguisize" type="integer" label="37021" help="36548">
           <visible>false</visible>
           <level>3</level>

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -284,13 +284,17 @@ void CRPRenderManager::Flush()
 
 void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO& coordsRes)
 {
+  // Get a renderer for the fullscreen window
   std::shared_ptr<CRPBaseRenderer> renderer = GetRenderer(nullptr);
   if (!renderer)
     return;
 
+  // Get a render buffer for the renderer
+  IRenderBuffer* renderBuffer = GetRenderBuffer(renderer->GetBufferPool());
+
   m_renderContext.SetRenderingResolution(m_renderContext.GetVideoResolution(), false);
 
-  RenderInternal(renderer, bClear, 255);
+  RenderInternal(renderer, renderBuffer, bClear, 255);
 
   m_renderContext.SetRenderingResolution(coordsRes, false);
 }
@@ -300,9 +304,13 @@ void CRPRenderManager::RenderControl(bool bClear,
                                      const CRect& renderRegion,
                                      const IGUIRenderSettings* renderSettings)
 {
+  // Get a renderer for the control
   std::shared_ptr<CRPBaseRenderer> renderer = GetRenderer(renderSettings);
   if (!renderer)
     return;
+
+  // Get a render buffer for the renderer
+  IRenderBuffer* renderBuffer = GetRenderBuffer(renderer->GetBufferPool());
 
   // Set fullscreen
   const bool bWasFullscreen = m_renderContext.IsFullScreenVideo();
@@ -331,7 +339,7 @@ void CRPRenderManager::RenderControl(bool bClear,
   if (bUseAlpha)
     alpha = m_renderContext.MergeAlpha(0xFF000000) >> 24;
 
-  RenderInternal(renderer, false, alpha);
+  RenderInternal(renderer, renderBuffer, false, alpha);
 
   // Restore coordinates
   m_renderContext.RemoveTransform();
@@ -373,21 +381,13 @@ bool CRPRenderManager::SupportsScalingMethod(SCALINGMETHOD method) const
 }
 
 void CRPRenderManager::RenderInternal(const std::shared_ptr<CRPBaseRenderer>& renderer,
+                                      IRenderBuffer* renderBuffer,
                                       bool bClear,
                                       uint32_t alpha)
 {
   renderer->PreRender(bClear);
 
   CSingleExit exitLock(m_renderContext.GraphicsMutex());
-
-  IRenderBuffer* renderBuffer = GetRenderBuffer(renderer->GetBufferPool());
-
-  // If our renderer has no buffer, try to create one from paused frame now
-  if (renderBuffer == nullptr)
-  {
-    CreateRenderBuffer(renderer->GetBufferPool());
-    renderBuffer = GetRenderBuffer(renderer->GetBufferPool());
-  }
 
   if (renderBuffer != nullptr)
   {
@@ -510,9 +510,18 @@ IRenderBuffer* CRPRenderManager::GetRenderBuffer(IRenderBufferPool* bufferPool)
 
   CSingleLock lock(m_bufferMutex);
 
-  auto it = std::find_if(
-      m_renderBuffers.begin(), m_renderBuffers.end(),
-      [bufferPool](IRenderBuffer* renderBuffer) { return renderBuffer->GetPool() == bufferPool; });
+  auto getRenderBuffer = [bufferPool](IRenderBuffer* renderBuffer) {
+    return renderBuffer->GetPool() == bufferPool;
+  };
+
+  auto it = std::find_if(m_renderBuffers.begin(), m_renderBuffers.end(), getRenderBuffer);
+
+  // If our renderer has no buffer, try to create one from paused frame now
+  if (it == m_renderBuffers.end())
+  {
+    CreateRenderBuffer(bufferPool);
+    it = std::find_if(m_renderBuffers.begin(), m_renderBuffers.end(), getRenderBuffer);
+  }
 
   if (it != m_renderBuffers.end())
   {

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -294,6 +294,38 @@ void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO& coordsRe
 
   m_renderContext.SetRenderingResolution(m_renderContext.GetVideoResolution(), false);
 
+  if (!m_bDisplayScaleSet && m_renderContext.DisplayHardwareScalingEnabled())
+  {
+    // If the renderer has a render buffer, get the dimensions
+    const unsigned int sourceWidth = (renderBuffer != nullptr ? renderBuffer->GetWidth() : 0);
+    const unsigned int sourceHeight = (renderBuffer != nullptr ? renderBuffer->GetHeight() : 0);
+
+    // Get render video settings for the fullscreen window
+    CRenderVideoSettings renderVideoSettings = GetEffectiveSettings(nullptr);
+
+    // Get the scaling mode of the render video settings
+    const SCALINGMETHOD scaleMode = renderVideoSettings.GetScalingMethod();
+    const STRETCHMODE stretchMode = renderVideoSettings.GetRenderStretchMode();
+
+    // Update display with video dimensions for integer scaling
+    if (scaleMode == SCALINGMETHOD::NEAREST && stretchMode == STRETCHMODE::Original &&
+        sourceWidth > 0 && sourceHeight > 0)
+    {
+      RESOLUTION_INFO gameRes = m_renderContext.GetResInfo();
+      gameRes.Overscan.left = 0;
+      gameRes.Overscan.top = 0;
+      gameRes.Overscan.right = sourceWidth;
+      gameRes.Overscan.bottom = sourceHeight;
+      gameRes.iWidth = sourceWidth;
+      gameRes.iHeight = sourceHeight;
+      gameRes.iScreenWidth = sourceWidth;
+      gameRes.iScreenHeight = sourceHeight;
+
+      m_renderContext.UpdateDisplayHardwareScaling(gameRes);
+      m_bDisplayScaleSet = true;
+    }
+  }
+
   RenderInternal(renderer, renderBuffer, bClear, 255);
 
   m_renderContext.SetRenderingResolution(coordsRes, false);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -123,6 +123,7 @@ private:
    * \brief Render a frame using the given renderer
    */
   void RenderInternal(const std::shared_ptr<CRPBaseRenderer>& renderer,
+                      IRenderBuffer* renderBuffer,
                       bool bClear,
                       uint32_t alpha);
 

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -219,6 +219,9 @@ private:
   std::set<std::string> m_failedShaderPresets;
   std::atomic<bool> m_bFlush = {false};
 
+  // Windowing state
+  bool m_bDisplayScaleSet = false;
+
   // Playback parameters
   std::atomic<double> m_speed = {1.0};
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -176,6 +176,16 @@ bool CRenderContext::UseLimitedColor()
   return m_windowing->UseLimitedColor();
 }
 
+bool CRenderContext::DisplayHardwareScalingEnabled()
+{
+  return m_windowing->DisplayHardwareScalingEnabled();
+}
+
+void CRenderContext::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+{
+  return m_windowing->UpdateDisplayHardwareScaling(resInfo);
+}
+
 int CRenderContext::GetScreenWidth()
 {
   return m_graphicsContext.GetWidth();
@@ -221,7 +231,7 @@ RESOLUTION CRenderContext::GetVideoResolution()
   return m_graphicsContext.GetVideoResolution();
 }
 
-void CRenderContext::Clear(UTILS::Color color /* = 0 */)
+void CRenderContext::Clear(::UTILS::Color color /* = 0 */)
 {
   m_graphicsContext.Clear(color);
 }
@@ -236,7 +246,7 @@ void CRenderContext::SetRenderingResolution(const RESOLUTION_INFO& res, bool nee
   m_graphicsContext.SetRenderingResolution(res, needsScaling);
 }
 
-UTILS::Color CRenderContext::MergeAlpha(UTILS::Color color)
+::UTILS::Color CRenderContext::MergeAlpha(::UTILS::Color color)
 {
   return m_graphicsContext.MergeAlpha(color);
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -65,6 +65,8 @@ public:
 
   // Windowing functions
   bool UseLimitedColor();
+  bool DisplayHardwareScalingEnabled();
+  void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo);
 
   // Graphics functions
   int GetScreenWidth();
@@ -76,7 +78,7 @@ public:
   bool IsFullScreenVideo();
   bool IsCalibrating();
   RESOLUTION GetVideoResolution();
-  void Clear(UTILS::Color color = 0);
+  void Clear(::UTILS::Color color = 0);
   RESOLUTION_INFO GetResInfo();
   void SetRenderingResolution(const RESOLUTION_INFO& res, bool needsScaling);
   UTILS::Color MergeAlpha(UTILS::Color color);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -130,6 +130,7 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   const float sourceAspectRatio =
       static_cast<float>(sourceWidth) / static_cast<float>(sourceHeight);
 
+  const SCALINGMETHOD scaleMode = m_renderSettings.VideoSettings().GetScalingMethod();
   const STRETCHMODE stretchMode = m_renderSettings.VideoSettings().GetRenderStretchMode();
   const unsigned int rotationDegCCW =
       (sourceRotationDegCCW + m_renderSettings.VideoSettings().GetRenderRotation()) % 360;
@@ -138,7 +139,18 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   float screenWidth;
   float screenHeight;
   float screenPixelRatio;
-  GetScreenDimensions(screenWidth, screenHeight, screenPixelRatio);
+
+  if (scaleMode == SCALINGMETHOD::NEAREST && stretchMode == STRETCHMODE::Original &&
+      m_context.DisplayHardwareScalingEnabled())
+  {
+    screenWidth = sourceWidth;
+    screenHeight = sourceHeight;
+    screenPixelRatio = 1.0;
+  }
+  else
+  {
+    GetScreenDimensions(screenWidth, screenHeight, screenPixelRatio);
+  }
 
   // Entire target rendering area for the video (including black bars)
   const CRect viewRect = m_context.GetViewWindow();

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -57,6 +57,8 @@ public:
   virtual bool DestroyWindow(){ return false; }
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) = 0;
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) = 0;
+  virtual bool DisplayHardwareScalingEnabled() { return false; }
+  virtual void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) { }
   virtual bool MoveWindow(int topLeft, int topRight){return false;}
   virtual void FinishModeChange(RESOLUTION res){}
   virtual void FinishWindowResize(int newWidth, int newHeight) {ResizeWindow(newWidth, newHeight, -1, -1);}

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -28,10 +28,20 @@ public:
   bool InitDrm() override;
   void DestroyDrm() override;
   bool AddProperty(struct drm_object* object, const char* name, uint64_t value) override;
+  static bool DislayHardwareScalingEnabled();
 
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
   bool ResetPlanes();
+
+  uint32_t GetScalingFilterType(const char* type);
+  uint32_t GetScalingFactor(uint32_t srcWidth,
+                            uint32_t srcHeight,
+                            uint32_t destWidth,
+                            uint32_t destHeight);
+  bool SetScalingFilter(struct drm_object *object, const char *name, const char *type);
+
+  static const std::string SETTING_VIDEOSCREEN_HW_SCALING_FILTER;
 
   bool m_need_modeset;
   bool m_active = true;

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -201,6 +201,27 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   return result;
 }
 
+bool CWinSystemGbm::DisplayHardwareScalingEnabled()
+{
+  auto drmAtomic = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
+  if (drmAtomic && drmAtomic->DislayHardwareScalingEnabled())
+    return true;
+
+  return false;
+}
+
+void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
+{
+  if (!DisplayHardwareScalingEnabled())
+    return;
+
+  //! @todo The PR that made the res struct constant was abandoned due to drama.
+  // It should be const-corrected and changed here.
+  RESOLUTION_INFO& resMutable = const_cast<RESOLUTION_INFO&>(resInfo);
+
+  SetFullScreen(true, resMutable, false);
+}
+
 void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 {
   if (m_videoLayerBridge && !videoLayer)

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -40,6 +40,8 @@ public:
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  bool DisplayHardwareScalingEnabled() override;
+  void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
 
   void FlipPage(bool rendered, bool videoLayer);
 


### PR DESCRIPTION
**Background:**
Blurry outputs during up-scaling the video buffer, is a generic problem of graphics industry. One of the major reason behind this blurriness is the interpolation of pixel values used by most of the up-scaling hardware.

Nearest-neighbor is a scaling filter type, which works by filling in the missing color values in the up-scaled image with that of the coordinate-mapped nearest source pixel value.

Nearest-neighbor can produce (almost) non-blurry scaling outputs when the scaling ratio is complete integer. For example:

input buffer resolution: 1280x720(HD)
output buffer resolution: 3840x2160(UHD/4K)
scaling ratio (h) = 3840/1280 = 3
scaling ratio (v) = 2160/720 = 3
In such scenarios, we should try to pick Nearest-neighbor as scaling method when possible.

**Some references:**

- https://tanalin.com/en/articles/integer-scaling/
- https://www.reddit.com/r/nvidia/comments/9e27wk/its_2018_nvidia_wheres_integer_scaling/
- http://www.zeus-software.com/forum/viewtopic.php?t=2065
- https://forums.geforce.com/default/topic/844905/geforce-drivers/-feature-request-nonblurry-upscaling-at-integer-ratios/20/
- https://forums.tomshardware.com/threads/does-anybody-have-a-good-solution-to-scale-1080p-onto-a-4k-monitor.3217086/
 

**This patch series:**
To address this feature kernel driver exposes new CRTC/Plane property called
"SCALING_FILTER" and gives an option to userspace to set it based on the use
cases.
Kernel RFC can be found here: https://patchwork.freedesktop.org/series/73883/#rev6

This patchset add support for utilizing CRTC/Plane scaling filter property based on
client's usecase.

Here are the patches details:
Patch 1/4 --> [Settings] adding Display Engine (DE) HW scaling filter option into setting menu
Patch 2/4 --> [RetroPlayer] videofilter and stretch setting control
Patch 3/4 --> [GameFrame] Setting Game frame to Window size, to avoid GL scaling when DE HW could do
Patch 4/4 --> [DRMAtomic] add scaling_filter property support at plane level

Awaiting your reviews and what do you think on having Integer Scaling in Kodi. Thanks
-Sameer Lattannavar