### PR TITLE
Direct3D 11 and DXVA updates

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -69,6 +69,7 @@ protected:
   HANDLE handle = INVALID_HANDLE_VALUE;
   Microsoft::WRL::ComPtr<ID3D11Resource> m_sharedRes;
 };
+
 class CVideoBufferCopy : public CVideoBufferShared
 {
   template<typename TBuffer>
@@ -83,6 +84,8 @@ protected:
       : CVideoBufferShared(id) {}
 
   Microsoft::WRL::ComPtr<ID3D11Resource> m_copyRes;
+  Microsoft::WRL::ComPtr<ID3D11Resource> m_pResource;
+  Microsoft::WRL::ComPtr<ID3D11DeviceContext> m_pDeviceContext;
 };
 
 class CContext
@@ -96,7 +99,7 @@ public:
   static shared_ptr EnsureContext(CDecoder* decoder);
   bool GetFormatAndConfig(AVCodecContext* avctx, D3D11_VIDEO_DECODER_DESC& format, D3D11_VIDEO_DECODER_CONFIG& config) const;
   bool CreateSurfaces(const D3D11_VIDEO_DECODER_DESC& format, uint32_t count, uint32_t alignment,
-                      ID3D11VideoDecoderOutputView** surfaces, HANDLE* pHandle) const;
+                      ID3D11VideoDecoderOutputView** surfaces, HANDLE* pHandle, bool trueShared) const;
   bool CreateDecoder(const D3D11_VIDEO_DECODER_DESC& format, const D3D11_VIDEO_DECODER_CONFIG& config,
                      ID3D11VideoDecoder** decoder, ID3D11VideoContext** context);
   void Release(CDecoder* decoder);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -15,7 +15,7 @@
 
 #include <vector>
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <dxgi1_5.h>
 extern "C" {
 #include <libavutil/mastering_display_metadata.h>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -12,7 +12,7 @@
 
 #include <map>
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <libavutil/pixfmt.h>
 
 enum RenderMethod;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
@@ -12,7 +12,7 @@
 
 #include <map>
 
-#include <d3d11.h>
+#include <d3d11_4.h>
 #include <libavutil/pixfmt.h>
 
 #define PLANE_Y 0

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1497,17 +1497,12 @@ HDR_STATUS CWIN32Util::GetWindowsHDRStatus()
     if (CServiceBroker::IsServiceManagerUp())
       CLog::LogF(LOGDEBUG, "Display is not HDR capable or cannot be detected");
   }
-  else if (advancedColorSupported && !advancedColorEnabled)
+  else
   {
-    status = HDR_STATUS::HDR_OFF;
+    status = advancedColorEnabled ? HDR_STATUS::HDR_ON : HDR_STATUS::HDR_OFF;
     if (CServiceBroker::IsServiceManagerUp())
-      CLog::LogF(LOGDEBUG, "Display HDR capable and current HDR status is OFF");
-  }
-  else if (advancedColorSupported && advancedColorEnabled)
-  {
-    status = HDR_STATUS::HDR_ON;
-    if (CServiceBroker::IsServiceManagerUp())
-      CLog::LogF(LOGDEBUG, "Display HDR capable and current HDR status is ON");
+      CLog::LogF(LOGDEBUG, "Display HDR capable and current HDR status is {}",
+                 advancedColorEnabled ? "ON" : "OFF");
   }
 
   return status;

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -586,6 +586,7 @@ void DX::DeviceResources::ResizeBuffers()
     swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     // HDR 60 fps needs 6 buffers to avoid frame drops but it's good for all
     swapChainDesc.BufferCount = 6;
+    // FLIP_DISCARD improves performance (needed in some systems for 4K HDR 60 fps)
     swapChainDesc.SwapEffect = (m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_12_0)
                                    ? DXGI_SWAP_EFFECT_FLIP_DISCARD
                                    : DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
@@ -640,9 +641,11 @@ void DX::DeviceResources::ResizeBuffers()
     m_IsHDROutput = (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) && isHdrEnabled;
 
     const int bits = (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) ? 10 : 8;
+    std::string flip =
+        (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD) ? "discard" : "sequential";
 
-    CLog::LogF(LOGINFO, "{} bit swapchain is used with {} buffers and {} output", bits,
-               swapChainDesc.BufferCount, m_IsHDROutput ? "HDR" : "SDR");
+    CLog::LogF(LOGINFO, "{} bit swapchain is used with {} flip {} buffers and {} output", bits,
+               swapChainDesc.BufferCount, flip, m_IsHDROutput ? "HDR" : "SDR");
 
     hr = swapChain.As(&m_swapChain); CHECK_ERR();
     m_stereoEnabled = bHWStereoEnabled;

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -106,7 +106,7 @@ namespace DX
     void SetWindow(const winrt::Windows::UI::Core::CoreWindow& window);
     void SetWindowPos(winrt::Windows::Foundation::Rect rect);
 #endif // TARGET_WINDOWS_STORE
-    bool DoesTextureSharingWork();
+    bool IsNV12SharedTexturesSupported() const { return m_NV12SharedTexturesSupport; }
 
   private:
     class CBackBuffer : public CD3DTexture
@@ -126,6 +126,7 @@ namespace DX
     void OnDeviceRestored();
     void HandleOutputChange(const std::function<bool(DXGI_OUTPUT_DESC)>& cmpFunc);
     bool CreateFactory();
+    void CheckNV12SharedTexturesSupport();
 
     HWND m_window{ nullptr };
 #if defined(TARGET_WINDOWS_STORE)
@@ -166,5 +167,6 @@ namespace DX
     bool m_stereoEnabled;
     bool m_bDeviceCreated;
     bool m_IsHDROutput;
+    bool m_NV12SharedTexturesSupport{false};
   };
 }

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -13,7 +13,7 @@
 
 #include "platform/win32/CharsetConverter.h"
 
-#include <d3d11_1.h>
+#include <d3d11_4.h>
 #include <ppltasks.h> // For create_task
 
 namespace DX
@@ -84,6 +84,14 @@ namespace DX
     DXGetErrorDescriptionW(hr, buff, 2048);
 
     return FromW(StringUtils::Format(L"%X - %s (%s)", hr, DXGetErrorStringW(hr), buff));
+  }
+
+  inline std::string GetFeatureLevelDescription(D3D_FEATURE_LEVEL featureLevel)
+  {
+    uint32_t fl_major = (featureLevel & 0xF000u) >> 12;
+    uint32_t fl_minor = (featureLevel & 0x0F00u) >> 8;
+
+    return StringUtils::Format("D3D_FEATURE_LEVEL_{}_{}", fl_major, fl_minor);
   }
 
   template <typename T> struct SizeGen

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -411,9 +411,6 @@ void CAdvancedSettings::Initialize()
   m_stereoscopicregex_sbs = "[-. _]h?sbs[-. _]";
   m_stereoscopicregex_tab = "[-. _]h?tab[-. _]";
 
-  m_allowUseSeparateDeviceForDecoding = false;
-  m_disableDXVAdiscreteDecoding = false;
-
   m_videoAssFixedWorks = false;
 
   m_logLevelHint = m_logLevel = LOG_LEVEL_NORMAL;
@@ -695,9 +692,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     }
 
     m_DXVACheckCompatibilityPresent = XMLUtils::GetBoolean(pElement,"checkdxvacompatibility", m_DXVACheckCompatibility);
-
-    XMLUtils::GetBoolean(pElement, "allowdiscretedecoder", m_allowUseSeparateDeviceForDecoding);
-    XMLUtils::GetBoolean(pElement, "disableDXVAdiscretedecoder", m_disableDXVAdiscreteDecoding);
 
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -355,9 +355,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_stereoscopicregex_sbs;
     std::string m_stereoscopicregex_tab;
 
-    bool m_allowUseSeparateDeviceForDecoding;
-    bool m_disableDXVAdiscreteDecoding;
-
     /*!< @brief position behavior of ass subtitles when setting "subtitle position on screen" set to "fixed"
     True to show at the fixed position set in video calibration
     False to show at the bottom of video (default) */


### PR DESCRIPTION
## Description
List of Changes:

* Updated include headers to D3D 11.4 API and DX feature level 12_1.
* Improved detection of NV12 shared textures capability using more up to date `D3D11_FEATURE_DATA_D3D11_OPTIONS4`.
* Fixed calculation of number buffers need for DXVA HEVC decoding due lav demuxer reports always 1 reference frame in HEVC streams.
* Reworked class `CVideoBufferCopy` in order to fix NVIDIA stuttering/tearing issues playing HEVC 4K HDR content. Eliminates the inconvenience of having to disable dxva discrete decoding for some NVIDIA users.
* Removed advancedsettings options "disableDXVAdiscretedecoder" and "allowdiscretedecoder" they are no longer necessary.
* Disabled in normal conditions d3d device multi-threading protection since causes a little overload and only is necessary when is used same d3d device for rendering and dxva decoding. If system does not support shared textures/discrete decoding then it is enabled as before.
* Improved Kodi logging with graphics card model and D3D feature level used (in readable text) without need activate debug level.

NOTE: It has been tested in Windows 7 x64 for backward compatibility playing 4K HDR10 content (tone mapping) with no issues.


## Motivation and Context
Once the HDR code is already in the master branch there are still some things to improve especially for NVIDIA (Intel has always been perfect from day one).

## How Has This Been Tested?
Public test builds:
https://forum.kodi.tv/showthread.php?tid=355800

Many forum users have confirmed that the stuttering/tearing issues are gone using different hardware and Windows builds 1909-2004:

RTX 2080 Ti
RTX 2070 SUPER
RTX 2060
GTX 1660 SUPER
GTX 1650
GTX 1060 SUPER
GTX 1060
GTX 1050 Ti
GTX 1050
GT 1030   ---> https://forum.kodi.tv/showthread.php?tid=355800&pid=2965042#pid2965042
Ryzen 2200G  ---> https://forum.kodi.tv/showthread.php?tid=355800&pid=2965157#pid2965157

## Screenshots (if appropriate):
CPU and GPU usage comparison playing 4K HDR with tone mapping (tested on the desktop PC).

**Current master branch:**

![Anotación 2020-07-22 180441](https://user-images.githubusercontent.com/58434170/88201625-f9911280-cc47-11ea-9053-2678f8ebc397.png)

![Anotación 2020-07-22 184806](https://user-images.githubusercontent.com/58434170/88204731-06176a00-cc4c-11ea-915e-eb2119af3c0f.png)

**With this PR changes:**

![Anotación 2020-07-22 180915](https://user-images.githubusercontent.com/58434170/88201517-d8302680-cc47-11ea-8055-e474f1c60d93.png)

![Anotación 2020-07-22 184515](https://user-images.githubusercontent.com/58434170/88204760-0f083b80-cc4c-11ea-97f5-8d2b577d2c45.png)


**NOTE:** GPU memory usage increases because more DXVA decoder surfaces are used.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
