### PR TITLE
[addons] allow updates from official repos or their own origin only

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -374,7 +374,7 @@ std::pair<AddonVersion, std::string> CAddonDatabase::GetAddonVersion(const std::
   return std::make_pair(AddonVersion(), "");
 }
 
-bool CAddonDatabase::FindByAddonId(const std::string& addonId, ADDON::VECADDONS& result)
+bool CAddonDatabase::FindByAddonId(const std::string& addonId, ADDON::VECADDONS& result) const
 {
   try
   {

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -40,7 +40,7 @@ public:
   std::pair<ADDON::AddonVersion, std::string> GetAddonVersion(const std::string &id);
 
   /*! Returns all addons in the repositories with id `addonId`. */
-  bool FindByAddonId(const std::string& addonId, ADDON::VECADDONS& addons);
+  bool FindByAddonId(const std::string& addonId, ADDON::VECADDONS& addons) const;
 
   bool UpdateRepositoryContent(const std::string& repositoryId, const ADDON::AddonVersion& version,
       const std::string& checksum, const std::vector<ADDON::AddonPtr>& addons);

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -48,6 +48,14 @@ public:
    */
   bool InstallOrUpdate(const std::string &addonID, bool background = true, bool modal = false);
 
+  /*! \brief Install an addon from a specific repository
+   \param addon the addon to install
+   \param repo the repository to install the addon from
+   \return true on successful install, false on failure.
+   \sa DoInstall
+   */
+  bool InstallOrUpdate(const ADDON::AddonPtr& addon, const ADDON::RepositoryPtr& repo);
+
   /*! \brief Installs a vector of addons
    \param addons the list of addons to install
    \param wait if the method should wait for all the DoInstall jobs to finish or if it should return right away

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "addons/Addon.h"
 #include "addons/AddonInstaller.h"
+#include "addons/AddonRepos.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
 #include "events/AddonManagementEvent.h"
@@ -112,8 +113,6 @@ bool CAddonMgr::Init()
     CLog::Log(LOGERROR, "ADDONS: Failed to read manifest");
     return false;
   }
-
-  m_officialAddonRepos = StringUtils::Split(CCompileInfo::GetOfficialAddonRepos(), ',');
 
   if (!m_database.Open())
     CLog::Log(LOGFATAL, "ADDONS: Failed to open database");
@@ -217,58 +216,13 @@ VECADDONS CAddonMgr::GetAvailableUpdates() const
 
   VECADDONS updates;
   VECADDONS installed;
-  VECADDONS all_addons;
-  m_database.GetRepositoryContent(all_addons);
-  std::map<std::string, AddonPtr> latestPrivateVersions;
-  std::map<std::string, AddonPtr> latestOfficialVersions;
+  CAddonRepos addonRepos(*this);
 
-  const AddonRepoUpdateMode updateMode =
-      CAddonSystemSettings::GetInstance().GetAddonRepoUpdateMode();
-  CLog::Log(LOGDEBUG, "ADDONS: repo update mode set to : {}", static_cast<int>(updateMode));
-
-  for (const auto& addon : all_addons)
-  {
-    if (updateMode == AddonRepoUpdateMode::OFFICIAL_ONLY)
-    {
-      if (IsFromOfficialRepo(addon, true))
-      {
-        AddAddonIfLatest(addon, latestOfficialVersions);
-      }
-      else
-      {
-        AddAddonIfLatest(addon, latestPrivateVersions);
-      }
-    }
-    else if (updateMode == AddonRepoUpdateMode::ANY_REPOSITORY)
-    {
-      AddAddonIfLatest(addon, latestOfficialVersions);
-    }
-  }
-
-  CLog::Log(LOGDEBUG, "ADDONS: official versions count : {}", latestOfficialVersions.size());
-  CLog::Log(LOGDEBUG, "ADDONS: private versions count : {}", latestPrivateVersions.size());
+  addonRepos.LoadAddonsFromDatabase(m_database);
 
   GetAddonsForUpdate(installed);
 
-  for (const auto& addon : installed)
-  {
-    CLog::Log(LOGDEBUG, "ADDONS: update check: addonID = {} / Origin = {}", addon->ID(),
-              addon->Origin());
-
-    if (ORIGIN_SYSTEM == addon->Origin())
-    {
-      FindAddonAndCheckForUpdate(addon, latestOfficialVersions, updates);
-    }
-    else
-    {
-      // if the addon is not found in an official repo...
-      if (!FindAddonAndCheckForUpdate(addon, latestOfficialVersions, updates))
-      {
-        // ...we move on and check the private/3rd party repo(s)
-        FindAddonAndCheckForUpdate(addon, latestPrivateVersions, updates);
-      }
-    }
-  }
+  addonRepos.BuildUpdateList(installed, updates);
 
   CLog::Log(LOGDEBUG, "CAddonMgr::GetAvailableUpdates took %i ms", XbmcThreads::SystemClockMillis() - start);
   return updates;
@@ -1075,29 +1029,6 @@ void CAddonMgr::FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path)
   }
 }
 
-bool CAddonMgr::IsFromOfficialRepo(const AddonPtr& addon) const
-{
-  return IsFromOfficialRepo(addon, false);
-}
-
-bool CAddonMgr::IsFromOfficialRepo(const AddonPtr& addon, bool bCheckAddonPath) const
-{
-  auto comparator = [&](const std::string& officialRepo) {
-    const std::vector<std::string> officialRepoProps = StringUtils::Split(officialRepo, '|');
-
-    if (bCheckAddonPath)
-    {
-      return (addon->Origin() == officialRepoProps.front() &&
-              StringUtils::StartsWithNoCase(addon->Path(), officialRepoProps.back()));
-    }
-
-    return addon->Origin() == officialRepoProps.front();
-  };
-
-  return addon->Origin() == ORIGIN_SYSTEM ||
-         std::any_of(m_officialAddonRepos.begin(), m_officialAddonRepos.end(), comparator);
-}
-
 AddonOriginType CAddonMgr::GetAddonOriginType(const AddonPtr& addon) const
 {
   if (addon->Origin() == ORIGIN_SYSTEM)
@@ -1108,30 +1039,12 @@ AddonOriginType CAddonMgr::GetAddonOriginType(const AddonPtr& addon) const
     return AddonOriginType::MANUAL;
 }
 
-void CAddonMgr::AddAddonIfLatest(const AddonPtr& addonToAdd,
-                                 std::map<std::string, AddonPtr>& map) const
+bool CAddonMgr::IsAddonDisabledWithReason(const std::string& ID,
+                                          AddonDisabledReason disabledReason) const
 {
-  const auto& latestKnown = map.find(addonToAdd->ID());
-  if (latestKnown == map.end() || addonToAdd->Version() > latestKnown->second->Version())
-    map[addonToAdd->ID()] = addonToAdd;
-}
-
-bool CAddonMgr::FindAddonAndCheckForUpdate(const AddonPtr& addonToCheck,
-                                           const std::map<std::string, AddonPtr>& map,
-                                           VECADDONS& vecAddons) const
-{
-  const auto& remote = map.find(addonToCheck->ID());
-  if (remote != map.end()) // is addon in the desired map?
-  {
-    if (remote->second->Version() > addonToCheck->Version())
-    {
-      // queue addon update
-      vecAddons.emplace_back(remote->second);
-    }
-    return true;
-  }
-
-  return false;
+  CSingleLock lock(m_critSection);
+  const auto& disabledAddon = m_disabled.find(ID);
+  return disabledAddon != m_disabled.end() && disabledAddon->second == disabledReason;
 }
 
 /*!

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -64,7 +64,7 @@ namespace ADDON
 
     /*! \brief Retrieve a specific addon (of a specific type)
      \param id the id of the addon to retrieve.
-     \param addon [out] the retrieved addon pointer - only use if the function returns true.
+     \param addon[out] the retrieved addon pointer - only use if the function returns true.
      \param type type of addon to retrieve - defaults to any type.
      \param enabledOnly whether we only want enabled addons - set to false to allow both enabled and disabled addons - defaults to true.
      \return true if an addon matching the id of the given type is available and is enabled (if enabledOnly is true).
@@ -104,7 +104,18 @@ namespace ADDON
 
     bool GetInstallableAddons(VECADDONS& addons, const TYPE &type);
 
-    /*! Get the installable addon with the highest version. */
+    /*! \brief Get the installable addon depending on install rules
+     *         or fall back to highest version.
+     * \note This function gets called in different contexts. If it's
+     *       called for checking possible updates for already installed addons
+     *       our update restriction rules apply.
+     *       If it's called to (for example) populate an addon-select-dialog
+     *       the addon is not installed yet, and we have to fall back to the
+     *       highest version.
+     * \param addonId addon to check for update or installation
+     * \param addon[out] the retrieved addon pointer - only use if the function returns true.
+     * \return true if an addon matching the id is available.
+     */
     bool FindInstallableById(const std::string& addonId, AddonPtr& addon);
 
     void AddToUpdateableAddons(AddonPtr &pAddon);

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -322,14 +322,15 @@ namespace ADDON
      */
     const std::string& GetTempAddonBasePath() { return m_tempAddonBasePath; }
 
-    /*!
-     * Checks if the origin-repository of a given addon is defined as official repo
-     * but does not check the origin path (e.g. https://mirrors.kodi.tv ...)
-     * \param addon pointer to addon to be checked
-     */
-    bool IsFromOfficialRepo(const AddonPtr& addon) const;
-
     AddonOriginType GetAddonOriginType(const AddonPtr& addon) const;
+
+    /*!
+     * \brief Check whether an addon has been disabled with a special reason.
+     * \param ID id of the addon
+     * \param disabledReason reason we want to check for (NONE, USER, INCOMPATIBLE, PERMANENT_FAILURE)
+     * \return true or false 
+     */
+    bool IsAddonDisabledWithReason(const std::string& ID, AddonDisabledReason disabledReason) const;
 
     /*!
      * @brief Addon update and install management.
@@ -407,34 +408,6 @@ namespace ADDON
      */
     void InstallAddonUpdates(VECADDONS& updates, bool wait) const;
 
-    /*!
-     * Adds an addon to a repository map
-     * \param addonToAdd the addon that should be added to the map
-     * \param map the desired target map (e.g. official, private...)
-     */
-    void AddAddonIfLatest(const AddonPtr& addonToAdd, std::map<std::string, AddonPtr>& map) const;
-
-    /*!
-     * Looks up an addon in a given repository map and then
-     * queues the update if a newer version is available
-     * \param addonToCheck the addon we want to find and version-check
-     * \param map the repository-map we want to check against
-     * \param vecAddons the target vector, into which queued addons will be emplaced
-     * \return true if the addon was found in the desired map
-     * \return false if the addon does NOT exist in the map
-     */
-    bool FindAddonAndCheckForUpdate(const AddonPtr& addonToCheck,
-                                    const std::map<std::string, AddonPtr>& map,
-                                    VECADDONS& vecAddons) const;
-
-    /*!
-     * Checks if the origin-repository of a given addon is defined as official repo
-     * and verify if the origin-path is also defined and matching
-     * \param addon pointer to addon to be checked
-     * \param bCheckAddonPath also check origin path
-     */
-    bool IsFromOfficialRepo(const AddonPtr& addon, bool bCheckAddonPath) const;
-
     // This guards the addon installation process to make sure
     // addon updates are not installed concurrently
     // while the migration is running. Addon updates can be triggered
@@ -451,7 +424,6 @@ namespace ADDON
     CBlockingEventSource<AddonEvent> m_unloadEvents;
     std::set<std::string> m_systemAddons;
     std::set<std::string> m_optionalAddons;
-    std::vector<std::string> m_officialAddonRepos;
     ADDON_INFO_LIST m_installedAddons;
 
     // Temporary path given to add-ons, whose content is deleted when Kodi is stopped

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -1,0 +1,242 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AddonRepos.h"
+
+#include "Addon.h"
+#include "AddonDatabase.h"
+#include "AddonManager.h"
+#include "AddonSystemSettings.h"
+#include "CompileInfo.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <vector>
+
+using namespace ADDON;
+
+namespace ADDON
+{
+
+std::vector<RepoInfo> LoadOfficialRepoInfos()
+{
+  const std::vector<std::string> officialAddonRepos =
+      StringUtils::Split(CCompileInfo::GetOfficialAddonRepos(), ',');
+
+  std::vector<RepoInfo> officialRepoInfos;
+  RepoInfo newRepoInfo;
+
+  for (const auto& addonRepo : officialAddonRepos)
+  {
+    const std::vector<std::string> tmpRepoInfo = StringUtils::Split(addonRepo, '|');
+    newRepoInfo.m_repoId = tmpRepoInfo.front();
+    newRepoInfo.m_origin = tmpRepoInfo.back();
+    officialRepoInfos.emplace_back(newRepoInfo);
+  }
+
+  return officialRepoInfos;
+}
+
+static std::vector<RepoInfo> officialRepoInfos = LoadOfficialRepoInfos();
+
+} // namespace ADDON
+
+/**********************************************************
+ * CAddonRepos
+ *
+ */
+
+bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon)
+{
+  return IsFromOfficialRepo(addon, false);
+}
+
+bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon, bool bCheckAddonPath)
+{
+  auto comparator = [&](const RepoInfo& officialRepo) {
+    if (bCheckAddonPath)
+    {
+      return (addon->Origin() == officialRepo.m_repoId &&
+              StringUtils::StartsWithNoCase(addon->Path(), officialRepo.m_origin));
+    }
+
+    return addon->Origin() == officialRepo.m_repoId;
+  };
+
+  return addon->Origin() == ORIGIN_SYSTEM ||
+         std::any_of(officialRepoInfos.begin(), officialRepoInfos.end(), comparator);
+}
+
+void CAddonRepos::LoadAddonsFromDatabase(const CAddonDatabase& database)
+{
+  LoadAddonsFromDatabase(database, "");
+}
+
+void CAddonRepos::LoadAddonsFromDatabase(const CAddonDatabase& database, const std::string& addonId)
+{
+  m_allAddons.clear();
+
+  if (addonId.empty())
+  {
+    // load full repository content
+    database.GetRepositoryContent(m_allAddons);
+  }
+  else
+  {
+    // load specific addonId only
+    database.FindByAddonId(addonId, m_allAddons);
+  }
+
+  m_addonsByRepoMap.clear();
+  for (const auto& addon : m_allAddons)
+  {
+    if (m_addonMgr.IsCompatible(*addon))
+    {
+      m_addonsByRepoMap[addon->Origin()].insert({addon->ID(), addon});
+    }
+  }
+
+  for (const auto& map : m_addonsByRepoMap)
+    CLog::Log(LOGDEBUG, "ADDONS: repo: {} - {} addon(s) loaded", map.first, map.second.size());
+
+  SetupLatestVersionMaps();
+}
+
+void CAddonRepos::SetupLatestVersionMaps()
+{
+  m_latestOfficialVersions.clear();
+  m_latestPrivateVersions.clear();
+  m_latestVersionsByRepo.clear();
+
+  for (const auto& repo : m_addonsByRepoMap)
+  {
+    const auto& addonsPerRepo = repo.second;
+
+    for (const auto& addonMapEntry : addonsPerRepo)
+    {
+      const auto& addonToAdd = addonMapEntry.second;
+
+      if (IsFromOfficialRepo(addonToAdd, true))
+      {
+        AddAddonIfLatest(addonToAdd, m_latestOfficialVersions);
+      }
+      else
+      {
+        AddAddonIfLatest(addonToAdd, m_latestPrivateVersions);
+      }
+
+      // add to latestVersionsByRepo
+      AddAddonIfLatest(repo.first, addonToAdd, m_latestVersionsByRepo);
+    }
+  }
+}
+
+void CAddonRepos::AddAddonIfLatest(const std::shared_ptr<IAddon>& addonToAdd,
+                                   std::map<std::string, std::shared_ptr<IAddon>>& map) const
+{
+  const auto& latestKnown = map.find(addonToAdd->ID());
+  if (latestKnown == map.end() || addonToAdd->Version() > latestKnown->second->Version())
+    map[addonToAdd->ID()] = addonToAdd;
+}
+
+void CAddonRepos::AddAddonIfLatest(
+    const std::string& repoId,
+    const std::shared_ptr<IAddon>& addonToAdd,
+    std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>>>& map) const
+{
+  const auto& latestVersionByRepo = map.find(repoId);
+
+  if (latestVersionByRepo == map.end()) // repo not found
+  {
+    map[repoId].insert({addonToAdd->ID(), addonToAdd});
+  }
+  else
+  {
+    const auto& latestVersionEntryByRepo = latestVersionByRepo->second;
+    const auto& latestKnown = latestVersionEntryByRepo.find(addonToAdd->ID());
+
+    if (latestKnown == latestVersionEntryByRepo.end() ||
+        addonToAdd->Version() > latestKnown->second->Version())
+      map[repoId][addonToAdd->ID()] = addonToAdd;
+  }
+}
+
+void CAddonRepos::BuildUpdateList(const std::vector<std::shared_ptr<IAddon>>& installed,
+                                  std::vector<std::shared_ptr<IAddon>>& updates) const
+{
+  std::shared_ptr<IAddon> update;
+
+  CLog::Log(LOGDEBUG, "ADDONS: *** building update list (installed add-ons) ***");
+
+  for (const auto& addon : installed)
+  {
+    if (DoAddonUpdateCheck(addon, update))
+    {
+      updates.emplace_back(update);
+    }
+  }
+}
+
+bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
+                                     std::shared_ptr<IAddon>& update) const
+{
+  CLog::Log(LOGDEBUG, "ADDONS: update check: addonID = {} / Origin = {}", addon->ID(),
+            addon->Origin());
+
+  update.reset();
+
+  if (ORIGIN_SYSTEM == addon->Origin())
+  {
+    if (!FindAddonAndCheckForUpdate(addon, m_latestOfficialVersions, update))
+      return false;
+  }
+  else
+  {
+    // if the addon is not found in an official repo...
+    if (!FindAddonAndCheckForUpdate(addon, m_latestOfficialVersions, update))
+    {
+      // ...we move on and check the private/3rd party repo(s)
+      if (!FindAddonAndCheckForUpdate(addon, m_latestPrivateVersions, update))
+        return false;
+    }
+  }
+
+  if (update != nullptr)
+  {
+    CLog::Log(LOGDEBUG, "ADDONS: -- found -->: addonID = {} / Origin = {} / Version = {}",
+              update->ID(), update->Origin(), update->Version().asString());
+    return true;
+  }
+
+  return false;
+}
+
+bool CAddonRepos::FindAddonAndCheckForUpdate(
+    const std::shared_ptr<IAddon>& addonToCheck,
+    const std::map<std::string, std::shared_ptr<IAddon>>& map,
+    std::shared_ptr<IAddon>& update) const
+{
+  const auto& remote = map.find(addonToCheck->ID());
+  if (remote != map.end()) // is addon in the desired map?
+  {
+    if ((remote->second->Version() > addonToCheck->Version()) ||
+        m_addonMgr.IsAddonDisabledWithReason(addonToCheck->ID(), AddonDisabledReason::INCOMPATIBLE))
+    {
+      // return addon update
+      update = remote->second;
+    }
+    else
+    {
+      // addon found, but it's up to date
+      update = nullptr;
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -87,6 +87,16 @@ public:
   bool DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
                           std::shared_ptr<IAddon>& update) const;
 
+  /*!
+   * \brief Retrieves the latest version of an addon from all installed repositories
+   *        follows addon origin restriction rules
+   * \param addonId addon id we're looking the latest version for
+   * \param[out] result pointer to the found addon
+   * \return true if a version was found, false otherwise
+   */
+  bool GetLatestAddonVersionFromAllRepos(const std::string& addonId,
+                                         std::shared_ptr<IAddon>& result) const;
+
 private:
   /*!
    * \brief Looks up an addon in a given repository map and
@@ -127,6 +137,17 @@ private:
       const std::string& repoId,
       const std::shared_ptr<IAddon>& addonToAdd,
       std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>>>& map) const;
+
+  /*!
+   * \brief Looks up an addon entry in a specific map
+   * \param addonId addon we want to retrieve
+   * \param map the map we're looking into for the wanted addon
+   * \param[out] result pointer to the found addon, only use when function returns true
+   * \return true if the addon was found in the map, false otherwise
+   */
+  bool GetLatestVersionByMap(const std::string& addonId,
+                             const std::map<std::string, std::shared_ptr<IAddon>>& map,
+                             std::shared_ptr<IAddon>& result) const;
 
   const CAddonMgr& m_addonMgr;
 

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AddonDatabase.h"
+
+#include <map>
+#include <vector>
+
+namespace ADDON
+{
+/**
+ * Struct - RepoInfo
+ */
+struct RepoInfo
+{
+  std::string m_repoId;
+  std::string m_origin;
+};
+
+class CAddonMgr;
+class IAddon;
+
+/**
+ * Class - CAddonRepos
+ * Reads information about installed official/third party repos and their contained add-ons from the database.
+ * Used to check for updates for installed add-ons and dependencies while obeying permission rules.
+ * Note that this class is not responsible for refreshing the repo data stored in the database.
+ */
+class CAddonRepos
+{
+public:
+  CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr){}; // ctor
+
+  /*!
+   * \brief Load the map of all available addon versions in any installed repository
+   * \param database reference to the database to load addons from
+   */
+  void LoadAddonsFromDatabase(const CAddonDatabase& database);
+
+  /*!
+   * \brief Load the map of all available versions of an addonId in any installed repository
+   * \param database reference to the database to load addons from
+   * \param addonId the addon id we want to retrieve versions for
+   */
+  void LoadAddonsFromDatabase(const CAddonDatabase& database, const std::string& addonId);
+
+  /*!
+   * \brief Build the list of addons to be updated depending on defined rules
+   * \param installed vector of all addons installed on the system that are
+   *        checked for an update
+   * \param[out] updates list of addon versions that are going to be installed
+   */
+  void BuildUpdateList(const std::vector<std::shared_ptr<IAddon>>& installed,
+                       std::vector<std::shared_ptr<IAddon>>& updates) const;
+
+  /*!
+   * \brief Checks if the origin-repository of a given addon is defined as official repo
+   *        but does not check the origin path (e.g. https://mirrors.kodi.tv ...)
+   * \param addon pointer to addon to be checked
+   * \return true if the repository id of a given addon is defined as official
+   */
+  static bool IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon);
+
+  /*!
+   * \brief Checks if the origin-repository of a given addon is defined as official repo
+   *        and verify if the origin-path is also defined and matching
+   * \param addon pointer to addon to be checked
+   * \param bCheckAddonPath also check origin path
+   * \return true if the repository id of a given addon is defined as official
+   *         and the addons origin matches the defined official origin of the repo id
+   */
+  static bool IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon, bool bCheckAddonPath);
+
+  /*!
+   * \brief Check if an update is available for a single addon
+   * \param addon that is checked for an update
+   * \param[out] update pointer to the found update
+   * \return true if an installable update was found, false otherwise
+   */
+  bool DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
+                          std::shared_ptr<IAddon>& update) const;
+
+private:
+  /*!
+   * \brief Looks up an addon in a given repository map and
+   *        checks if an update is available
+   * \param addonToCheck the addon we want to find and version check
+   * \param map the repository map we want to check against
+   * \param[out] pointer to the found update. if the addon is
+   *              up-to-date on our system, this param will return 'nullptr'
+   * \return true if the addon was found in the desired map,
+   *         either up-to-date or newer version.
+   *         false if the addon does NOT exist in the map
+   */
+  bool FindAddonAndCheckForUpdate(const std::shared_ptr<IAddon>& addonToCheck,
+                                  const std::map<std::string, std::shared_ptr<IAddon>>& map,
+                                  std::shared_ptr<IAddon>& update) const;
+
+  /*!
+   * \brief Sets up latest version maps from scratch
+   */
+  void SetupLatestVersionMaps();
+
+  /*!
+   * \brief Adds the latest version of an addon to the desired map
+   * \param addonToAdd the addon whose latest version should be added
+   * \param map target map, e.g. latestOfficialVersions or latestPrivateVersions
+   */
+  void AddAddonIfLatest(const std::shared_ptr<IAddon>& addonToAdd,
+                        std::map<std::string, std::shared_ptr<IAddon>>& map) const;
+
+  /*!
+   * \brief Adds the latest version of an addon to the desired map per repository
+   *        used to populate 'latestVersionsByRepo'
+   * \param repoId the repository that addon comes from
+   * \param addonToAdd the addon whose latest version should be added
+   * \param map target map, latestVersionsByRepo
+   */
+  void AddAddonIfLatest(
+      const std::string& repoId,
+      const std::shared_ptr<IAddon>& addonToAdd,
+      std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>>>& map) const;
+
+  const CAddonMgr& m_addonMgr;
+
+  std::vector<std::shared_ptr<IAddon>> m_allAddons;
+
+  std::map<std::string, std::shared_ptr<IAddon>> m_latestOfficialVersions;
+  std::map<std::string, std::shared_ptr<IAddon>> m_latestPrivateVersions;
+  std::map<std::string, std::map<std::string, std::shared_ptr<IAddon>>> m_latestVersionsByRepo;
+  std::map<std::string, std::multimap<std::string, std::shared_ptr<IAddon>>> m_addonsByRepoMap;
+};
+
+}; /* namespace ADDON */

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -25,6 +25,7 @@ struct RepoInfo
 };
 
 class CAddonMgr;
+class CRepository;
 class IAddon;
 
 /**
@@ -96,6 +97,34 @@ public:
    */
   bool GetLatestAddonVersionFromAllRepos(const std::string& addonId,
                                          std::shared_ptr<IAddon>& result) const;
+
+  /*!
+   * \brief Find a dependency to install during an addon install or update
+   *        If the dependency cannot be found in official versions we look in the
+   *        installing/updating addon's (the parent's) origin repository
+   * \param dependsId addon id of the dependency we're looking for
+   * \param parent addon that is the dependee / parent
+   * \param [out] dependencyToInstall pointer to the found dependency, only use
+   *              if function returns true
+   * \param [out] repoForDep the repository that dependency will install from finally
+   * \return true if the dependency was found, false otherwise
+   */
+  bool FindDependency(const std::string& dependsId,
+                      const std::shared_ptr<IAddon>& parent,
+                      std::shared_ptr<IAddon>& dependencyToInstall,
+                      std::shared_ptr<CRepository>& repoForDep) const;
+
+  /*!
+   * \brief Find a dependency addon in the repository of its parent
+   * \param dependsId addon id of the dependency we're looking for
+   * \param parent addon that is the dependee / parent
+   * \param [out] dependencyToInstall pointer to the found dependency, only use
+   *              if function returns true
+   * \return true if the dependency was found, false otherwise
+   */
+  bool FindDependencyByParentRepo(const std::string& dependsId,
+                                  const std::shared_ptr<IAddon>& parent,
+                                  std::shared_ptr<IAddon>& dependencyToInstall) const;
 
 private:
   /*!

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES Addon.cpp
             AddonDatabase.cpp
             AddonInstaller.cpp
             AddonManager.cpp
+            AddonRepos.cpp
             AddonStatusHandler.cpp
             AddonSystemSettings.cpp
             AddonVersion.cpp
@@ -40,6 +41,7 @@ set(HEADERS Addon.h
             AddonInstaller.h
             AddonManager.h
             AddonProvider.h
+            AddonRepos.h
             AddonStatusHandler.h
             AddonSystemSettings.h
             AddonVersion.h

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -13,6 +13,7 @@
 #include "URL.h"
 #include "addons/AddonDatabase.h"
 #include "addons/AddonInstaller.h"
+#include "addons/AddonRepos.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/PluginSource.h"
 #include "addons/RepositoryUpdater.h"
@@ -787,7 +788,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL &path,
     bool installed = CServiceBroker::GetAddonMgr().IsAddonInstalled(addon->ID());
     bool disabled = CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
     bool hasUpdate = outdated.find(addon->ID()) != outdated.end();
-    bool fromOfficialRepo = CServiceBroker::GetAddonMgr().IsFromOfficialRepo(addon);
+    bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon);
 
     pItem->SetProperty("Addon.IsInstalled", installed);
     pItem->SetProperty("Addon.IsEnabled", installed && !disabled);


### PR DESCRIPTION
## Description

1. implementation of class CAddonRepos and refactoring addon maps
2. keep incompatible addons out of maps
3. allow addons to only update from official repos or their own origin

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

--------------------------------------------------------


**any feedback from testers and/or reviewers welcome**

