### PR TITLE
[VideoPlayer] Application crash/exit when changing streams with RDS stream present

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -522,22 +522,21 @@ bool CDVDRadioRDSData::CheckStream(CDVDStreamInfo &hints)
 
 bool CDVDRadioRDSData::OpenStream(CDVDStreamInfo hints)
 {
+  CloseStream(true);
+
   m_messageQueue.Init();
   if (hints.type == STREAM_RADIO_RDS)
   {
     Flush();
     CLog::Log(LOGINFO, "Creating UECP (RDS) data thread");
     Create();
+    return true;
   }
-  return true;
+  return false;
 }
 
 void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 {
-  // wait until buffers are empty
-  if (bWaitForBuffers)
-    m_messageQueue.WaitUntilEmpty();
-
   m_messageQueue.Abort();
 
   // wait for decode_video thread to end
@@ -547,7 +546,8 @@ void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 
   m_messageQueue.End();
   m_currentInfoTag.reset();
-  m_currentChannel->SetRadioRDSInfoTag(m_currentInfoTag);
+  if (m_currentChannel)
+    m_currentChannel->SetRadioRDSInfoTag(m_currentInfoTag);
   m_currentChannel.reset();
 }
 


### PR DESCRIPTION
## Description
VideoPlayer will crash by attempting to terminate the process via exit() if a stream/channel change occurs while the current stream/channel has an RDS stream present.

## Motivation and Context
Working with a a Radio PVR that supports RDS the problem was noted trying to change channels.  I used a similar change made to the Teletext stream years ago, where OpenStream() will implicitly call CloseStream(), and then made any necessary adjustments so that wouldn't blow up either, again based on other stream types like Teletext as reference points.

This problem exists in Leia as well, if PR accepted I would like to issue a backport and try to get that into 18.8.

## How Has This Been Tested?
Tested on Windows x64, debug build of 2020.07.22 nightly Matrix build.  No specific issues were encountered.  After the change set was in place, the call to exit() would no longer occur and channel changes worked fine.  RDS data was cleared between channel changes as expected.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
