### PR TITLE
[backport][video] fix video scan of some archive packages

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3252,9 +3252,12 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     URIUtils::GetParentPath(name2,strMovieName);
     if (URIUtils::IsInArchive(m_strPath))
     {
-      std::string strArchivePath;
-      URIUtils::GetParentPath(strMovieName, strArchivePath);
-      strMovieName = strArchivePath;
+      // Try to get archive itself, if empty take path before
+      name2 = CURL(m_strPath).GetHostName();
+      if (name2.empty())
+        name2 = strMovieName;
+
+      URIUtils::GetParentPath(name2, strMovieName);
     }
   }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -219,6 +219,17 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
       CFileItemList items;
       CDirectory::GetDirectory(item.GetPath(), items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
                                DIR_FLAG_DEFAULTS);
+
+      // Check for cases 1_dir/1_dir/.../file (e.g. by packages where have a extra folder)
+      while (items.Size() == 1 && items[0]->m_bIsFolder)
+      {
+        const std::string path = items[0]->GetPath();
+        items.Clear();
+        CDirectory::GetDirectory(path, items,
+                                 CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
+                                 DIR_FLAG_DEFAULTS);
+      }
+
       items.Stack();
 
       // check for media files


### PR DESCRIPTION
## Description

**Not sure if makes sense to create now a request for Leia and maybe a 18.9 comes?** If nothing anymore this can be closed.

Commit 1:
-----------------------------------
**[video] fix content scan about videos inside archive with folder**

Related to scan movies by directory name.

There some packages (ZIP, RAR) where the video is in own folder.
Before was the check inside CFileItem (about archive) by go one path up and to get dir name where archive is stored.

The problem is that sometimes the video is stored in another folder and the name used often does not correspond to the required one.

---------------------------------------------------------

e.g. this has worked before:
- rar://some_path_to_archive/the_movie_name/the_archive.rar/the_movie_name.avi

As normal way (no archives) it was gone to get dir of file:
- rar://some_path_to_archive/the_movie_name/the_archive.rar/

There it then for archives has get the parent of them:
- rar://some_path_to_archive/the_movie_name/
And "the_movie_name" was used for check.

---------------------------------------------------------

e.g. this has not worked before:
- rar://some_path_to_archive/the_movie_name/the_archive.rar/some_unusable_or_usable_name/the_movie_name.avi

There was then come by "CFileItem::GetBaseMoviePath":
- rar://some_path_to_archive/the_movie_name/the_archive.rar/
and the wanted "the_movie_name" not available.

As fix it now use "CURL(m_strPath).GetHostName()" to get the path of archive itself and then from them the parent. In case it gives empty string it fallback to old way.

Commit 2:
-----------------------------------

**[video] fix "Scan for new content" calls about archives**

Before it has not worked as it expected a video file in given directory.
By archives was there the archive name instead of video files.

This checks now the used folder about entries, if now only **1** and them a **directory only** becomes it opened and checked again. This done so long until a path is found where have more as 1 entry or no more is a directory.

E.g. this has brought problems:
- rar://some_path_to_archive/the_movie_name/the_archive.rar/the_movie_name.avi
where scan is started on
- file://some_path_to_archive/the_movie_name
The name there was needed to have for search

e.g there the "the_archive.rar" is only one entry, seen as directory and why added the check about.

This then also work with:
- rar://some_path_to_archive/the_movie_name/the_archive.rar/some_unusable_or_usable_name/the_movie_name.avi

It goes so long up until video file is found.

Here how shown before:
![Bildschirmfoto von 2020-07-24 18-04-09](https://user-images.githubusercontent.com/6879739/88411441-37bd3c00-cdd8-11ea-9bfe-e79a8fe84bdf.png)

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

About first commit fix
---------------------

Scan without fix:
![Bildschirmfoto von 2020-07-24 18-07-13](https://user-images.githubusercontent.com/6879739/88412143-65ef4b80-cdd9-11ea-95ec-de34a5a26c77.png)

Scan with fix:
![Bildschirmfoto von 2020-07-24 18-08-21](https://user-images.githubusercontent.com/6879739/88412175-70a9e080-cdd9-11ea-86b0-52fe454ad516.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
