### PR TITLE
Add version info for recent Windows 10 versions

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -652,11 +652,25 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
         osNameVer.append("Server 2012 R2");
       break;
     case WindowsVersionWin10:
-    case WindowsVersionWin10_FCU:
-      if (osvi.wProductType == VER_NT_WORKSTATION)
-        osNameVer.append("10");
-      else
-        osNameVer.append("Unknown future server version");
+      osNameVer.append("10");
+      break;
+    case WindowsVersionWin10_1709:
+      osNameVer.append("10 1709");
+      break;
+    case WindowsVersionWin10_1803:
+      osNameVer.append("10 1803");
+      break;
+    case WindowsVersionWin10_1809:
+      osNameVer.append("10 1809");
+      break;
+    case WindowsVersionWin10_1903:
+      osNameVer.append("10 1903");
+      break;
+    case WindowsVersionWin10_1909:
+      osNameVer.append("10 1909");
+      break;
+    case WindowsVersionWin10_2004:
+      osNameVer.append("10 2004");
       break;
     case WindowsVersionFuture:
       osNameVer.append("Unknown future version");
@@ -818,8 +832,18 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin8_1;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber < 16299)
         m_WinVer = WindowsVersionWin10;
-      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 16299)
-        m_WinVer = WindowsVersionWin10_FCU;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 16299)
+        m_WinVer = WindowsVersionWin10_1709;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 17134)
+        m_WinVer = WindowsVersionWin10_1803;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 17763)
+        m_WinVer = WindowsVersionWin10_1809;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 18362)
+        m_WinVer = WindowsVersionWin10_1903;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 18363)
+        m_WinVer = WindowsVersionWin10_1909;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 19041)
+        m_WinVer = WindowsVersionWin10_2004;
       /* Insert checks for new Windows versions here */
       else if ( (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 3) || osvi.dwMajorVersion > 10)
         m_WinVer = WindowsVersionFuture;

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -74,7 +74,12 @@ public:
     WindowsVersionWin8,         // Windows 8, Windows Server 2012
     WindowsVersionWin8_1,       // Windows 8.1
     WindowsVersionWin10,        // Windows 10
-    WindowsVersionWin10_FCU,    // Windows 10 Fall Creators Update
+    WindowsVersionWin10_1709,   // Windows 10 1709 (FCU)
+    WindowsVersionWin10_1803,   // Windows 10 1803
+    WindowsVersionWin10_1809,   // Windows 10 1809
+    WindowsVersionWin10_1903,   // Windows 10 1903
+    WindowsVersionWin10_1909,   // Windows 10 1909
+    WindowsVersionWin10_2004,   // Windows 10 2004
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
   };

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -144,7 +144,7 @@ void CWinSystemWin32DX::OnMove(int x, int y)
 bool CWinSystemWin32DX::DPIChanged(WORD dpi, RECT windowRect) const
 {
   // on Win10 FCU the OS keeps window size exactly the same size as it was
-  if (CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10_FCU))
+  if (CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10_1709))
     return true;
 
   m_deviceResources->SetDpi(dpi);


### PR DESCRIPTION
## Description
Add version info for recent Windows 10 versions

## Motivation and Context
It makes it easier to identify specific Windows 10 version when viewing Kodi logs. 
It also improves the information of the system in GUI / System Info.
Can be used new definitions in code to differentiate Windows 10 builds at runtime.

## How Has This Been Tested?
Run Kodi on Windows 10 2004

```
2020-07-26 12:21:39.916 T:3760     INFO <general>: -----------------------------------------------------------------------
2020-07-26 12:21:39.916 T:3760     INFO <general>: Starting Kodi (19.0-ALPHA1 (18.9.701) Git:20200723-25af320809). Platform: Windows NT x86 64-bit
2020-07-26 12:21:39.916 T:3760     INFO <general>: Using Debug Kodi x64 build
2020-07-26 12:21:39.917 T:3760     INFO <general>: Kodi compiled 2020-07-26 by MSVC 191627042 for Windows NT x86 64-bit version 10.0 (0x0A000008)
2020-07-26 12:21:39.917 T:3760     INFO <general>: Running on Windows 10 2004, kernel: Windows NT x86 64-bit version 10.0.19041
2020-07-26 12:21:39.917 T:3760     INFO <general>: FFmpeg version/source: 4.3.1-Kodi
2020-07-26 12:21:39.917 T:3760     INFO <general>: Host CPU: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz, 8 cores available
2020-07-26 12:21:39.918 T:3760     INFO <general>: Desktop Resolution: 1920x1200 32Bit at 59Hz
```

## Screenshots (if appropriate):
Before:
![Anotación 2020-07-26 122055](https://user-images.githubusercontent.com/58434170/88477002-c945be80-cf3c-11ea-90fe-0e3890e9dc1c.png)

After:
![Anotación 2020-07-26 122341](https://user-images.githubusercontent.com/58434170/88477007-cea30900-cf3c-11ea-9550-467e4759831c.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
