### PR TITLE
Fix enum formatting for libfmt 6 [backport]

### DIFF
--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -11,6 +11,32 @@
 
 #include "gtest/gtest.h"
 
+enum class ECG
+{
+  A,
+  B
+};
+
+enum EG
+{
+  C,
+  D
+};
+
+namespace test_enum
+{
+enum class ECN
+{
+  A = 1,
+  B
+};
+enum EN
+{
+  C = 1,
+  D
+};
+}
+
 TEST(TestStringUtils, Format)
 {
   std::string refstr = "test 25 2.7 ff FF";
@@ -20,6 +46,35 @@ TEST(TestStringUtils, Format)
 
   varstr = StringUtils::Format("", "test", 25, 2.743f, 0x00ff, 0x00ff);
   EXPECT_STREQ("", varstr.c_str());
+}
+
+TEST(TestStringUtils, FormatEnum)
+{
+  const char* zero = "0";
+  const char* one = "1";
+
+  std::string varstr = StringUtils::Format("{}", ECG::A);
+  EXPECT_STREQ(zero, varstr.c_str());
+
+  varstr = StringUtils::Format("{}", EG::C);
+  EXPECT_STREQ(zero, varstr.c_str());
+
+  varstr = StringUtils::Format("{}", test_enum::ECN::A);
+  EXPECT_STREQ(one, varstr.c_str());
+
+  varstr = StringUtils::Format("{}", test_enum::EN::C);
+  EXPECT_STREQ(one, varstr.c_str());
+}
+
+TEST(TestStringUtils, FormatEnumWidth)
+{
+  const char* one = "01";
+
+  std::string varstr = StringUtils::Format("{:02d}", ECG::B);
+  EXPECT_STREQ(one, varstr.c_str());
+
+  varstr = StringUtils::Format("%02d", EG::D);
+  EXPECT_STREQ(one, varstr.c_str());
 }
 
 TEST(TestStringUtils, ToUpper)


### PR DESCRIPTION
Backport of #17351
This attempt removes the enums from fmt altogether, fmt never sees an enum,
only ints.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Unit tests pass

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
