### PR TITLE
Read music info tags from files served over http but not from streams

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1175,10 +1175,6 @@ void CTagLoaderTagLib::AddArtistInstrument(CMusicInfoTag &tag, const std::vector
 
 bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, const std::string& fallbackFileExtension, EmbeddedArt *art /* = NULL */)
 {
-  // Dont try to read the tags for streams & shoutcast
-  if (URIUtils::IsInternetStream(strFileName))
-    return false;
-
   std::string strExtension = URIUtils::GetExtension(strFileName);
   StringUtils::TrimLeft(strExtension, ".");
 
@@ -1195,6 +1191,14 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
   {
     CLog::Log(LOGERROR, "could not create TagLib VFS stream for: %s", strFileName.c_str());
     return false;
+  }
+
+  long file_length = stream->length();
+
+  if (file_length == 0) // a stream returns zero as the length
+  {
+    delete stream; // scrap this instance
+    return false; // and quit without attempting to read non-existent tags
   }
 
   TagLib::File*              file = nullptr;


### PR DESCRIPTION
## Description
This allows Kodi to read tags from files served over http but still excludes trying to read tags from shoutcast etc streams.

## Motivation and Context
This change means that Kodi will not attempt to read any tags from streams but will read tags from files served over http providing the files are of a finite length.
fixes https://github.com/xbmc/xbmc/issues/18110

## How Has This Been Tested?
Tested by playing various radio streams (no tag reading happened) and scanning in an album served by an http server (tags read correctly).  

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
