### PR TITLE
[win10] Bump SDK to v10.0.18362.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ CMakeSettings.json
 
 # Windows specific generated files
 *.appx
+*.appxsym
+*.msix
 *.cer
 *.exp
 *.ilk

--- a/docs/README.Windows.md
+++ b/docs/README.Windows.md
@@ -176,7 +176,7 @@ BuildSetup.bat
 
 *Normal* 32bit and 64bit builds generate an `exe` file ready to run, located at `%userprofile%\kodi\kodi-build\Debug` or `%userprofile%\kodi\kodi-build\Release`, depending on the build config. An installer `exe` file, located at `%userprofile%\kodi\project\Win32BuildSetup`, is also generated.
 
-UWP builds generate `appx`, `appxsym` and `cer` files, located at `%userprofile%\kodi\`. You can install them following this **[guide](https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Universal_Windows_Platform)**.
+UWP builds generate `msix`, `appxsym` and `cer` files, located at `%userprofile%\kodi\project\UWPBuildSetup`. You can install them following this **[guide](https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Universal_Windows_Platform)**.
 
 **[back to top](#table-of-contents)**
 
@@ -235,7 +235,7 @@ cmake --build . --config "Release"
 ```
 
 *Normal* 32bit and 64bit builds generate an `exe` file ready to run, located at `%userprofile%\kodi-build\Debug` or `%userprofile%\kodi-build\Release`, depending on the build config.
-UWP builds generate `appx`, `appxsym` and `cer` files, located inside directories at `%userprofile%\kodi-build\AppPackages\kodi\`. You can install them following this **[guide](https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Universal_Windows_Platform)**.
+UWP builds generate `msix`, `appxsym` and `cer` files, located inside directories at `%userprofile%\kodi-build\AppPackages\kodi\`. You can install them following this **[guide](https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Universal_Windows_Platform)**.
 
 
 **[back to top](#table-of-contents)** | **[back to section top](#6-build-kodi-manually)**

--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -266,38 +266,47 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
 
 :MAKE_APPX
   set app_ext=msix
+  set app_path=%base_dir%\project\UWPBuildSetup
+  if not exist "%app_path%" mkdir %app_path%
   call %base_dir%\project\Win32BuildSetup\extract_git_rev.bat > NUL
   for /F %%a IN ('dir /B /S %WORKSPACE%\AppPackages ^| findstr /I /R "%APP_NAME%_.*_%TARGET_ARCHITECTURE%_%buildconfig%\.%app_ext%$"') DO (
-    copy /Y %%a %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
-    copy /Y %%~dpna.cer %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
-    copy /Y %%~dpna.appxsym %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
-    goto END
+    copy /Y %%a %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
+    copy /Y %%~dpna.cer %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
+    copy /Y %%~dpna.appxsym %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
+    goto END_APPX
   )
   rem Release builds don't have Release in it's name
   for /F %%a IN ('dir /B /S %WORKSPACE%\AppPackages ^| findstr /I /R "%APP_NAME%_.*_%TARGET_ARCHITECTURE%\.%app_ext%$"') DO (
-    copy /Y %%a %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
-    copy /Y %%~dpna.cer %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
-    copy /Y %%~dpna.appxsym %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
-    goto END
+    copy /Y %%a %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
+    copy /Y %%~dpna.cer %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
+    copy /Y %%~dpna.appxsym %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
+    goto END_APPX
   )
 
   rem apxx file has win32 instead of x86 in it's name
   if %TARGET_ARCHITECTURE%==x86 (
     for /F %%a IN ('dir /B /S %WORKSPACE%\AppPackages ^| findstr /I /R "%APP_NAME%_.*_win32_%buildconfig%\.%app_ext%$"') DO (
-      copy /Y %%a %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
-      copy /Y %%~dpna.cer %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
-      copy /Y %%~dpna.appxsym %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
-      goto END
+      copy /Y %%a %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
+      copy /Y %%~dpna.cer %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
+      copy /Y %%~dpna.appxsym %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
+      goto END_APPX
     )
 
     rem Release builds don't have Release in it's name
     for /F %%a IN ('dir /B /S %WORKSPACE%\AppPackages ^| findstr /I /R "%APP_NAME%_.*_win32\.%app_ext%$"') DO (
-      copy /Y %%a %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
-      copy /Y %%~dpna.cer %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
-      copy /Y %%~dpna.appxsym %base_dir%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
-      goto END
+      copy /Y %%a %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.%app_ext%
+      copy /Y %%~dpna.cer %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.cer
+      copy /Y %%~dpna.appxsym %app_path%\%APP_NAME%-%GIT_REV%-%BRANCH%-%TARGET_ARCHITECTURE%.appxsym
+      goto END_APPX
     )
   )
+
+:END_APPX
+  ECHO ------------------------------------------------------------
+  ECHO Done!
+  ECHO Setup is located at %app_path%
+  ECHO ------------------------------------------------------------
+  GOTO END
 
 :DIE
   ECHO ------------------------------------------------------------

--- a/tools/buildsteps/windows/vswhere.bat
+++ b/tools/buildsteps/windows/vswhere.bat
@@ -38,7 +38,7 @@ IF "%arch%"=="x86" (
 )
 
 IF "%vcstore%"=="store" (
-  SET sdkver=10.0.17763.0
+  SET sdkver=10.0.18362.0
   SET toolsdir="win10-%toolsdir%"
 )
 


### PR DESCRIPTION
## Description
* Bump UWP SKD to v10.0.18362.0
* Add extensions .appxsym and .msix to gitignore file
* Move generated installers to 'project/UWPBuildSetup' folder (before are generated at root of repository)

## Motivation and Context
Trying to generate UWP build I have come across some (minor) issues:

* The SDK that currently is required (10.0.17763.0) I no longer had it installed since it is quite old.
* The installation packages are generated in the root folder of repository and gets tracked by Git as new file is generated.

I think that generating the installers in 'project\UWPBuildSetup' is more logical and similar to how it is for Win32. Although I am aware that changing this can break some scripts (I ask for feedback).

As a related topic: currently the UWP-64 nightlies are not being generated (http://mirrors.kodi.tv/nightlies/windows/uwp64/master/) only the .cer is copied and I think it is because in the last update of the SDK installers extension .appx was changed to .msix and it probably this has broke the uploading the files to server.

See changes in https://github.com/xbmc/xbmc/pull/15924/files

So this change will probably not break anything new and it is a good time to do it and then adapt the upload scripts according.

## How Has This Been Tested?
Build UWP-64 using Visual Studio 2107 from Windows 10 2004

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
