### PR TITLE
[addons][audiodecoder] change API to match "C", code improvement, interface doxygen doc fix and improvement

### DIFF
--- a/xbmc/addons/AddonBindings.cmake
+++ b/xbmc/addons/AddonBindings.cmake
@@ -4,7 +4,6 @@
 
 # Keep this in alphabetical order
 set(CORE_ADDON_BINDINGS_FILES
-    ${CORE_SOURCE_DIR}/xbmc/cores/AudioEngine/Utils/AEChannelData.h
     ${CORE_SOURCE_DIR}/xbmc/input/actions/ActionIDs.h
     ${CORE_SOURCE_DIR}/xbmc/input/XBMC_vkeys.h
 )

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -116,8 +116,8 @@ bool CAudioDecoder::Load(const std::string& fileName,
   if (!m_struct.toAddon->read_tag)
     return false;
 
-  char title[256] = { 0 };
-  char artist[256] = { 0 };
+  char title[256] = {0};
+  char artist[256] = {0};
   int length;
   if (m_struct.toAddon->read_tag(&m_struct, fileName.c_str(), title, artist, &length))
   {
@@ -152,5 +152,4 @@ int CAudioDecoder::GetTrackCount(const std::string& strPath)
   return result;
 }
 
-
-} /*namespace ADDON*/
+} /* namespace ADDON */

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -116,14 +116,12 @@ bool CAudioDecoder::Load(const std::string& fileName,
   if (!m_struct.toAddon->read_tag)
     return false;
 
-  char title[256] = {0};
-  char artist[256] = {0};
-  int length;
-  if (m_struct.toAddon->read_tag(&m_struct, fileName.c_str(), title, artist, &length))
+  AUDIO_DECODER_INFO_TAG cTag;
+  if (m_struct.toAddon->read_tag(&m_struct, fileName.c_str(), &cTag))
   {
-    tag.SetTitle(title);
-    tag.SetArtist(artist);
-    tag.SetDuration(length);
+    tag.SetTitle(cTag.title);
+    tag.SetArtist(cTag.artist);
+    tag.SetDuration(cTag.length);
     return true;
   }
 

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -116,16 +116,32 @@ bool CAudioDecoder::Load(const std::string& fileName,
   if (!m_struct.toAddon->read_tag)
     return false;
 
-  AUDIO_DECODER_INFO_TAG cTag;
-  if (m_struct.toAddon->read_tag(&m_struct, fileName.c_str(), &cTag))
+  AUDIO_DECODER_INFO_TAG* cTag = new AUDIO_DECODER_INFO_TAG(); // allocate by his size
+  bool ret = m_struct.toAddon->read_tag(&m_struct, fileName.c_str(), cTag);
+  if (ret)
   {
-    tag.SetTitle(cTag.title);
-    tag.SetArtist(cTag.artist);
-    tag.SetDuration(cTag.length);
-    return true;
+    tag.SetTitle(cTag->title);
+    tag.SetArtist(cTag->artist);
+    tag.SetAlbum(cTag->album);
+    tag.SetAlbumArtist(cTag->album_artist);
+    tag.SetType(cTag->media_type);
+    tag.SetGenre(cTag->genre);
+    tag.SetDuration(cTag->duration);
+    tag.SetTrackNumber(cTag->track);
+    tag.SetDiscNumber(cTag->disc);
+    tag.SetDiscSubtitle(cTag->disc_subtitle);
+    tag.SetTotalDiscs(cTag->disc_total);
+    tag.SetReleaseDate(cTag->release_date);
+    tag.SetLyrics(cTag->lyrics);
+    tag.SetSampleRate(cTag->samplerate);
+    tag.SetNoOfChannels(cTag->channels);
+    tag.SetBitRate(cTag->bitrate);
+    tag.SetComment(cTag->comment);
   }
 
-  return false;
+  delete cTag;
+
+  return ret;
 }
 
 int CAudioDecoder::GetTrackCount(const std::string& strPath)

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -63,7 +63,7 @@ namespace ADDON
     }
 
   private:
-    const AEChannel* m_channel;
+    const AudioEngineChannel* m_channel;
     AddonInstance_AudioDecoder m_struct;
     bool m_hasTags;
   };

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -15,57 +15,57 @@
 
 namespace MUSIC_INFO
 {
-  class CMusicInfoTag;
-  class EmbeddedArt;
+class CMusicInfoTag;
+class EmbeddedArt;
 }
 
 namespace ADDON
 {
 
-  class CAudioDecoder : public IAddonInstanceHandler,
-                        public ICodec,
-                        public MUSIC_INFO::IMusicInfoTagLoader,
-                        public XFILE::CMusicFileDirectory
+class CAudioDecoder : public IAddonInstanceHandler,
+                      public ICodec,
+                      public MUSIC_INFO::IMusicInfoTagLoader,
+                      public XFILE::CMusicFileDirectory
+{
+public:
+  explicit CAudioDecoder(const AddonInfoPtr& addonInfo);
+  ~CAudioDecoder() override;
+
+  // Things that MUST be supplied by the child classes
+  bool CreateDecoder();
+  bool Init(const CFileItem& file, unsigned int filecache) override;
+  int ReadPCM(uint8_t* buffer, int size, int* actualsize) override;
+  bool Seek(int64_t time) override;
+  bool CanInit() override { return true; }
+  bool Load(const std::string& strFileName,
+            MUSIC_INFO::CMusicInfoTag& tag,
+            EmbeddedArt* art = nullptr) override;
+  int GetTrackCount(const std::string& strPath) override;
+
+  static inline std::string GetExtensions(const AddonInfoPtr& addonInfo)
   {
-  public:
-    explicit CAudioDecoder(const AddonInfoPtr& addonInfo);
-    ~CAudioDecoder() override;
+    return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@extension").asString();
+  }
 
-    // Things that MUST be supplied by the child classes
-    bool CreateDecoder();
-    bool Init(const CFileItem& file, unsigned int filecache) override;
-    int ReadPCM(uint8_t* buffer, int size, int* actualsize) override;
-    bool Seek(int64_t time) override;
-    bool CanInit() override { return true; }
-    bool Load(const std::string& strFileName,
-                      MUSIC_INFO::CMusicInfoTag& tag,
-                      EmbeddedArt *art = nullptr) override;
-    int GetTrackCount(const std::string& strPath) override;
+  static inline std::string GetMimetypes(const AddonInfoPtr& addonInfo)
+  {
+    return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@mimetype").asString();
+  }
 
-    static inline std::string GetExtensions(const AddonInfoPtr& addonInfo)
-    {
-      return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@extension").asString();
-    }
+  static inline bool HasTags(const AddonInfoPtr& addonInfo)
+  {
+    return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@tags").asBoolean();
+  }
 
-    static inline std::string GetMimetypes(const AddonInfoPtr& addonInfo)
-    {
-      return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@mimetype").asString();
-    }
+  static inline bool HasTracks(const AddonInfoPtr& addonInfo)
+  {
+    return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@tracks").asBoolean();
+  }
 
-    static inline bool HasTags(const AddonInfoPtr& addonInfo)
-    {
-      return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@tags").asBoolean();
-    }
-
-    static inline bool HasTracks(const AddonInfoPtr& addonInfo)
-    {
-      return addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@tracks").asBoolean();
-    }
-
-  private:
-    const AudioEngineChannel* m_channel;
-    AddonInstance_AudioDecoder m_struct;
-    bool m_hasTags;
-  };
+private:
+  const AudioEngineChannel* m_channel;
+  AddonInstance_AudioDecoder m_struct;
+  bool m_hasTags;
+};
 
 } /*namespace ADDON*/

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AudioEngine.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AudioEngine.h
@@ -98,7 +98,7 @@ namespace audioengine
 /// With the help of this format information, Kodi adjusts its processing
 /// accordingly.
 ///
-//@{
+///@{
 class ATTRIBUTE_HIDDEN AudioEngineFormat
   : public addon::CStructHdl<AudioEngineFormat, AUDIO_ENGINE_FORMAT>
 {
@@ -139,7 +139,7 @@ public:
 
   /// @addtogroup cpp_kodi_audioengine_Defs_AudioEngineFormat
   /// @copydetails cpp_kodi_audioengine_Defs_AudioEngineFormat_Help
-  //@{
+  ///@{
 
   /// @brief The stream's data format (eg, AUDIOENGINE_FMT_S16LE)
   void SetDataFormat(enum AudioEngineDataFormat format) { m_cStructure->m_dataFormat = format; }
@@ -228,8 +228,9 @@ public:
 
     return true;
   }
+  ///@}
 };
-//@}
+///@}
 //----------------------------------------------------------------------------
 
 //}}}

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -20,6 +20,20 @@ namespace addon
 
 class CInstanceAudioDecoder;
 
+//==============================================================================
+/// @defgroup cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag class AudioDecoderInfoTag
+/// @ingroup cpp_kodi_addon_audiodecoder_Defs
+/// @brief **Info tag data structure**\n
+/// Representation of available information of processed audio file.
+///
+/// This is used to store all the necessary data of audio stream and to have on
+/// e.g. GUI for information.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag_Help
+///
+///@{
 class AudioDecoderInfoTag : public CStructHdl<AudioDecoderInfoTag, AUDIO_DECODER_INFO_TAG>
 {
   /*! \cond PRIVATE */
@@ -32,111 +46,198 @@ public:
   AudioDecoderInfoTag(const AudioDecoderInfoTag& tag) : CStructHdl(tag) {}
   /*! \endcond */
 
+  /// @defgroup cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag_Help Value Help
+  /// @ingroup cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag :</b>
+  /// | Name | Type | Set call | Get call
+  /// |------|------|----------|----------
+  /// | **Title** | `std::string` | @ref AudioDecoderInfoTag::SetTitle "SetTitle" | @ref AudioDecoderInfoTag::GetTitle "GetTitle"
+  /// | **Artist** | `std::string` | @ref AudioDecoderInfoTag::SetArtist "SetArtist" | @ref AudioDecoderInfoTag::GetArtist "GetArtist"
+  /// | **Album** | `std::string` | @ref AudioDecoderInfoTag::SetAlbum "SetAlbum" | @ref AudioDecoderInfoTag::GetAlbum "GetAlbum"
+  /// | **Album artist** | `std::string` | @ref AudioDecoderInfoTag::SetAlbumArtist "SetAlbumArtist" | @ref AudioDecoderInfoTag::GetAlbumArtist "GetAlbumArtist"
+  /// | **Media type** | `std::string` | @ref AudioDecoderInfoTag::SetMediaType "SetMediaType" | @ref AudioDecoderInfoTag::GetMediaType "GetMediaType"
+  /// | **Genre** | `std::string` | @ref AudioDecoderInfoTag::SetGenre "SetGenre" | @ref AudioDecoderInfoTag::GetGenre "GetGenre"
+  /// | **Duration** | `int` | @ref AudioDecoderInfoTag::SetDuration "SetDuration" | @ref AudioDecoderInfoTag::GetDuration "GetDuration"
+  /// | **Track number** | `int` | @ref AudioDecoderInfoTag::SetTrack "SetTrack" | @ref AudioDecoderInfoTag::GetTrack "GetTrack"
+  /// | **Disc number** | `int` | @ref AudioDecoderInfoTag::SetDisc "SetDisc" | @ref AudioDecoderInfoTag::GetDisc "GetDisc"
+  /// | **Disc subtitle name** | `std::string` | @ref AudioDecoderInfoTag::SetDiscSubtitle "SetDiscSubtitle" | @ref AudioDecoderInfoTag::GetDiscSubtitle "GetDiscSubtitle"
+  /// | **Disc total amount** | `int` | @ref AudioDecoderInfoTag::SetDiscTotal "SetDiscTotal" | @ref AudioDecoderInfoTag::GetDiscTotal "GetDiscTotal"
+  /// | **Release date** | `std::string` | @ref AudioDecoderInfoTag::SetReleaseDate "SetReleaseDate" | @ref AudioDecoderInfoTag::GetReleaseDate "GetReleaseDate"
+  /// | **Lyrics** | `std::string` | @ref AudioDecoderInfoTag::SetLyrics "SetLyrics" | @ref AudioDecoderInfoTag::GetLyrics "GetLyrics"
+  /// | **Samplerate** | `int` | @ref AudioDecoderInfoTag::SetSamplerate "SetSamplerate" | @ref AudioDecoderInfoTag::GetSamplerate "GetSamplerate"
+  /// | **Channels amount** | `int` | @ref AudioDecoderInfoTag::SetChannels "SetChannels" | @ref AudioDecoderInfoTag::GetChannels "GetChannels"
+  /// | **Bitrate** | `int` | @ref AudioDecoderInfoTag::SetBitrate "SetBitrate" | @ref AudioDecoderInfoTag::GetBitrate "GetBitrate"
+  /// | **Comment text** | `std::string` | @ref AudioDecoderInfoTag::SetComment "SetComment" | @ref AudioDecoderInfoTag::GetComment "GetComment"
+  ///
+
+  /// @addtogroup cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag
+  ///@{
+
+  /// @brief Set the title from music as string on info tag.
   void SetTitle(const std::string& title)
   {
     strncpy(m_cStructure->title, title.c_str(), sizeof(m_cStructure->title) - 1);
   }
 
+  /// @brief Get title name
   std::string GetTitle() const { return m_cStructure->title; }
 
+  /// @brief Set artist name
   void SetArtist(const std::string& artist)
   {
     strncpy(m_cStructure->artist, artist.c_str(), sizeof(m_cStructure->artist) - 1);
   }
 
+  /// @brief Get artist name
   std::string GetArtist() const { return m_cStructure->artist; }
 
+  /// @brief Set album name
   void SetAlbum(const std::string& album)
   {
     strncpy(m_cStructure->album, album.c_str(), sizeof(m_cStructure->album) - 1);
   }
 
+  /// @brief Set album name
   std::string GetAlbum() const { return m_cStructure->album; }
 
+  /// @brief Set album artist name
   void SetAlbumArtist(const std::string& albumArtist)
   {
     strncpy(m_cStructure->album_artist, albumArtist.c_str(),
             sizeof(m_cStructure->album_artist) - 1);
   }
 
+  /// @brief Get album artist name
   std::string GetAlbumArtist() const { return m_cStructure->album_artist; }
 
+  /// @brief Set the media type of the music item.
+  ///
+  /// Available strings about media type for music:
+  /// | String         | Description                                       |
+  /// |---------------:|:--------------------------------------------------|
+  /// | artist         | If it is defined as an artist
+  /// | album          | If it is defined as an album
+  /// | music          | If it is defined as an music
+  /// | song           | If it is defined as a song
+  ///
   void SetMediaType(const std::string& mediaType)
   {
     strncpy(m_cStructure->media_type, mediaType.c_str(), sizeof(m_cStructure->media_type) - 1);
   }
 
+  /// @brief Get the media type of the music item.
   std::string GetMediaType() const { return m_cStructure->media_type; }
 
+  /// @brief Set genre name from music as string if present.
   void SetGenre(const std::string& genre)
   {
     strncpy(m_cStructure->genre, genre.c_str(), sizeof(m_cStructure->genre) - 1);
   }
 
+  /// @brief Get genre name from music as string if present.
   std::string GetGenre() const { return m_cStructure->genre; }
 
+  /// @brief Set the duration of music as integer from info.
   void SetDuration(int duration) { m_cStructure->duration = duration; }
 
+  /// @brief Get the duration of music as integer from info.
   int GetDuration() const { return m_cStructure->duration; }
 
+  /// @brief Set track number (if present) from music info as integer.
   void SetTrack(int track) { m_cStructure->track = track; }
 
+  /// @brief Get track number (if present).
   int GetTrack() const { return m_cStructure->track; }
 
+  /// @brief Set disk number (if present) from music info as integer.
   void SetDisc(int disc) { m_cStructure->disc = disc; }
 
+  /// @brief Get disk number (if present)
   int GetDisc() const { return m_cStructure->disc; }
 
+  /// @brief Set disk subtitle name (if present) from music info.
   void SetDiscSubtitle(const std::string& discSubtitle)
   {
     strncpy(m_cStructure->disc_subtitle, discSubtitle.c_str(),
             sizeof(m_cStructure->disc_subtitle) - 1);
   }
 
+  /// @brief Get disk subtitle name (if present) from music info.
   std::string GetDiscSubtitle() const { return m_cStructure->disc_subtitle; }
 
+  /// @brief Set disks amount quantity (if present) from music info as integer.
   void SetDiscTotal(int discTotal) { m_cStructure->disc_total = discTotal; }
 
+  /// @brief Get disks amount quantity (if present)
   int GetDiscTotal() const { return m_cStructure->disc_total; }
 
+  /// @brief Set release date as string from music info (if present).\n
+  /// [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date YYYY, YYYY-MM or YYYY-MM-DD
   void SetReleaseDate(const std::string& releaseDate)
   {
     strncpy(m_cStructure->release_date, releaseDate.c_str(),
             sizeof(m_cStructure->release_date) - 1);
   }
 
+  /// @brief Get release date as string from music info (if present).
   std::string GetReleaseDate() const { return m_cStructure->release_date; }
 
+  /// @brief Set string from lyrics.
   void SetLyrics(const std::string& lyrics)
   {
     strncpy(m_cStructure->lyrics, lyrics.c_str(), sizeof(m_cStructure->lyrics) - 1);
   }
 
+  /// @brief Get string from lyrics.
   std::string GetLyrics() const { return m_cStructure->lyrics; }
 
+  /// @brief Set related stream samplerate.
   void SetSamplerate(int samplerate) { m_cStructure->samplerate = samplerate; }
 
+  /// @brief Get related stream samplerate.
   int GetSamplerate() const { return m_cStructure->samplerate; }
 
+  /// @brief Set related stream channels amount.
   void SetChannels(int channels) { m_cStructure->channels = channels; }
 
+  /// @brief Get related stream channels amount.
   int GetChannels() const { return m_cStructure->channels; }
 
+  /// @brief Set related stream bitrate.
   void SetBitrate(int bitrate) { m_cStructure->bitrate = bitrate; }
 
+  /// @brief Get related stream bitrate.
   int GetBitrate() const { return m_cStructure->bitrate; }
 
+  /// @brief Set additional information comment (if present).
   void SetComment(const std::string& comment)
   {
     strncpy(m_cStructure->comment, comment.c_str(), sizeof(m_cStructure->comment) - 1);
   }
 
+  /// @brief Get additional information comment (if present).
   std::string GetComment() const { return m_cStructure->comment; }
+
+  ///@}
 
 private:
   AudioDecoderInfoTag(const AUDIO_DECODER_INFO_TAG* tag) : CStructHdl(tag) {}
   AudioDecoderInfoTag(AUDIO_DECODER_INFO_TAG* tag) : CStructHdl(tag) {}
 };
+///@}
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_audiodecoder_Defs Definitions, structures and enumerators
+/// @ingroup cpp_kodi_addon_audiodecoder
+/// @brief **Audio decoder add-on instance definition values**\n
+/// All audio decoder functions associated data structures.
+///
+/// Used to exchange the available options between Kodi and addon.\n
+/// The groups described here correspond to the groups of functions on audio
+/// decoder instance class.
+///
 
 //==============================================================================
 ///
@@ -162,12 +263,25 @@ private:
 ///
 /// **Here's an example on addon.xml:**
 /// ~~~~~~~~~~~~~{.xml}
+/// <?xml version="1.0" encoding="UTF-8"?>
+/// <addon
+///   id="audiodecoder.myspecialnamefor"
+///   version="1.0.0"
+///   name="My special audio decoder addon"
+///   provider-name="Your Name">
+///   <requires>@ADDON_DEPENDS@</requires>
 ///   <extension
 ///     point="kodi.audiodecoder"
 ///     name="2sf"
 ///     extension=".2sf|.mini2sf"
 ///     tags="true"
 ///     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
+///   <extension point="xbmc.addon.metadata">
+///     <summary lang="en_GB">My audio decoder addon addon</summary>
+///     <description lang="en_GB">My audio decoder addon description</description>
+///     <platform>@PLATFORM@</platform>
+///   </extension>
+/// </addon>
 /// ~~~~~~~~~~~~~
 ///
 /// Description to audio decoder related addon.xml values:
@@ -186,21 +300,21 @@ private:
 /// ~~~~~~~~~~~~~{.cpp}
 /// #include <kodi/addon-instance/AudioDecoder.h>
 ///
-/// class CMyAudioDecoder : public ::kodi::addon::CInstanceAudioDecoder
+/// class CMyAudioDecoder : public kodi::addon::CInstanceAudioDecoder
 /// {
 /// public:
-///   CMyAudioDecoder(KODI_HANDLE instance);
+///   CMyAudioDecoder(KODI_HANDLE instance, const std::string& version);
 ///
 ///   bool Init(const std::string& filename, unsigned int filecache,
 ///             int& channels, int& samplerate,
 ///             int& bitspersample, int64_t& totaltime,
-///             int& bitrate, AEDataFormat& format,
-///             std::vector<AEChannel>& channellist) override;
+///             int& bitrate, AudioEngineDataFormat& format,
+///             std::vector<AudioEngineChannel>& channellist) override;
 ///   int ReadPCM(uint8_t* buffer, int size, int& actualsize) override;
 /// };
 ///
-/// CMyAudioDecoder::CMyAudioDecoder(KODI_HANDLE instance)
-///   : CInstanceAudioDecoder(instance)
+/// CMyAudioDecoder::CMyAudioDecoder(KODI_HANDLE instance, const std::string& version)
+///   : kodi::addon::CInstanceAudioDecoder(instance, version)
 /// {
 ///   ...
 /// }
@@ -208,8 +322,8 @@ private:
 /// bool CMyAudioDecoder::Init(const std::string& filename, unsigned int filecache,
 ///                            int& channels, int& samplerate,
 ///                            int& bitspersample, int64_t& totaltime,
-///                            int& bitrate, AEDataFormat& format,
-///                            std::vector<AEChannel>& channellist)
+///                            int& bitrate, AudioEngineDataFormat& format,
+///                            std::vector<AudioEngineChannel>& channellist)
 /// {
 ///   ...
 ///   return true;
@@ -222,29 +336,31 @@ private:
 /// }
 ///
 ///
-/// /*----------------------------------------------------------------------*/
+/// //----------------------------------------------------------------------
 ///
-/// class CMyAddon : public ::kodi::addon::CAddonBase
+/// class CMyAddon : public kodi::addon::CAddonBase
 /// {
 /// public:
 ///   CMyAddon() { }
 ///   ADDON_STATUS CreateInstance(int instanceType,
-///                               std::string instanceID,
+///                               const std::string& instanceID,
 ///                               KODI_HANDLE instance,
+///                               const std::string& version,
 ///                               KODI_HANDLE& addonInstance) override;
 /// };
 ///
-/// /* If you use only one instance in your add-on, can be instanceType and
-///  * instanceID ignored */
+/// // If you use only one instance in your add-on, can be instanceType and
+/// // instanceID ignored
 /// ADDON_STATUS CMyAddon::CreateInstance(int instanceType,
-///                                       std::string instanceID,
+///                                       const std::string& instanceID,
 ///                                       KODI_HANDLE instance,
+///                                       const std::string& version,
 ///                                       KODI_HANDLE& addonInstance)
 /// {
 ///   if (instanceType == ADDON_INSTANCE_AUDIODECODER)
 ///   {
 ///     kodi::Log(ADDON_LOG_NOTICE, "Creating my audio decoder");
-///     addonInstance = new CMyAudioDecoder(instance);
+///     addonInstance = new CMyAudioDecoder(instance, version);
 ///     return ADDON_STATUS_OK;
 ///   }
 ///   else if (...)
@@ -265,13 +381,44 @@ class ATTRIBUTE_HIDDEN CInstanceAudioDecoder : public IAddonInstance
 public:
   //==========================================================================
   /// @ingroup cpp_kodi_addon_audiodecoder
-  /// @brief Class constructor
+  /// @brief Audio decoder class constructor used to support multiple instance
+  /// types.
   ///
-  /// @param[in] instance The addon instance class handler given by Kodi
-  ///                     at \ref kodi::addon::CAddonBase::CreateInstance(...)
+  /// @param[in] instance The instance value given to
+  ///                     <b>`kodi::addon::CAddonBase::CreateInstance(...)`</b>.
   /// @param[in] kodiVersion [opt] Version used in Kodi for this instance, to
   ///                        allow compatibility to older Kodi versions.
-  ///                        @note Recommended to set.
+  ///
+  /// @note Recommended to set <b>`kodiVersion`</b>.
+  ///
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// **Here's example about the use of this:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// class CMyAudioDecoder : public kodi::addon::CInstanceAudioDecoder
+  /// {
+  /// public:
+  ///   CMyAudioDecoder(KODI_HANDLE instance, const std::string& kodiVersion)
+  ///     : kodi::addon::CInstanceAudioDecoder(instance, kodiVersion)
+  ///   {
+  ///      ...
+  ///   }
+  ///
+  ///   ...
+  /// };
+  ///
+  /// ADDON_STATUS CMyAddon::CreateInstance(int instanceType,
+  ///                                       const std::string& instanceID,
+  ///                                       KODI_HANDLE instance,
+  ///                                       const std::string& version,
+  ///                                       KODI_HANDLE& addonInstance)
+  /// {
+  ///   kodi::Log(ADDON_LOG_NOTICE, "Creating my audio decoder");
+  ///   addonInstance = new CMyAudioDecoder(instance, version);
+  ///   return ADDON_STATUS_OK;
+  /// }
+  /// ~~~~~~~~~~~~~
   ///
   explicit CInstanceAudioDecoder(KODI_HANDLE instance, const std::string& kodiVersion = "")
     : IAddonInstance(ADDON_INSTANCE_AUDIODECODER,
@@ -287,19 +434,22 @@ public:
 
   //==========================================================================
   /// @ingroup cpp_kodi_addon_audiodecoder
-  /// @brief Initialize a decoder
+  /// @brief Initialize a decoder.
   ///
-  /// @param[in] filename             The file to read
-  /// @param[in] filecache            The file cache size
-  /// @param[out] channels            Number of channels in output stream
-  /// @param[out] samplerate          Samplerate of output stream
-  /// @param[out] bitspersample       Bits per sample in output stream
-  /// @param[out] totaltime           Total time for stream
-  /// @param[out] bitrate             Average bitrate of input stream
-  /// @param[out] format              Data format for output stream
-  /// @param[out] channellist         Channel mapping for output stream
-  /// @return                         true if successfully done, otherwise
-  ///                                 false
+  /// @param[in] filename The file to read
+  /// @param[in] filecache The file cache size
+  /// @param[out] channels Number of channels in output stream
+  /// @param[out] samplerate Samplerate of output stream
+  /// @param[out] bitspersample Bits per sample in output stream
+  /// @param[out] totaltime Total time for stream
+  /// @param[out] bitrate Average bitrate of input stream
+  /// @param[out] format Data format for output stream, see
+  ///                    @ref cpp_kodi_audioengine_Defs_AudioEngineFormat for
+  ///                    available values
+  /// @param[out] channellist Channel mapping for output streamm, see
+  ///                         @ref cpp_kodi_audioengine_Defs_AudioEngineChannel
+  ///                         for available values
+  /// @return true if successfully done, otherwise false
   ///
   virtual bool Init(const std::string& filename,
                     unsigned int filecache,
@@ -314,38 +464,42 @@ public:
 
   //==========================================================================
   /// @ingroup cpp_kodi_addon_audiodecoder
-  /// @brief Produce some noise
+  /// @brief Produce some noise.
   ///
-  /// @param[in] buffer               Output buffer
-  /// @param[in] size                 Size of output buffer
-  /// @param[out] actualsize          Actual number of bytes written to output buffer
-  /// @return                         Return with following possible values:
-  ///                                 | Value | Description                  |
-  ///                                 |:-----:|:-----------------------------|
-  ///                                 |   0   | on success
-  ///                                 |  -1   | on end of stream
-  ///                                 |   1   | on failure
+  /// @param[in] buffer Output buffer
+  /// @param[in] size Size of output buffer
+  /// @param[out] actualsize Actual number of bytes written to output buffer
+  /// @return Return with following possible values:
+  /// | Value | Description
+  /// |:-----:|:------------
+  /// |   0   | on success
+  /// |  -1   | on end of stream
+  /// |   1   | on failure
   ///
   virtual int ReadPCM(uint8_t* buffer, int size, int& actualsize) = 0;
   //--------------------------------------------------------------------------
 
   //==========================================================================
   /// @ingroup cpp_kodi_addon_audiodecoder
-  /// @brief Seek in output stream
+  /// @brief Seek in output stream.
   ///
-  /// @param[in] time                 Time position to seek to in milliseconds
-  /// @return                         Time position seek ended up on
+  /// @param[in] time Time position to seek to in milliseconds
+  /// @return Time position seek ended up on
   ///
   virtual int64_t Seek(int64_t time) { return time; }
   //--------------------------------------------------------------------------
 
   //==========================================================================
   /// @ingroup cpp_kodi_addon_audiodecoder
-  /// @brief Read tag of a file
+  /// @brief Read tag of a file.
   ///
-  /// @param[in] file                 File to read tag for
-  /// @param[out] tag                 Information tag about
-  /// @return                         True on success, false on failure
+  /// @param[in] file File to read tag for
+  /// @param[out] tag Information tag about
+  /// @return True on success, false on failure
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_audiodecoder_Defs_AudioDecoderInfoTag_Help
   ///
   virtual bool ReadTag(const std::string& file, kodi::addon::AudioDecoderInfoTag& tag)
   {
@@ -355,10 +509,10 @@ public:
 
   //==========================================================================
   /// @ingroup cpp_kodi_addon_audiodecoder
-  /// @brief Get number of tracks in a file
+  /// @brief Get number of tracks in a file.
   ///
-  /// @param[in] file                 File to read tag for
-  /// @return                         Number of tracks in file
+  /// @param[in] file File to read tag for
+  /// @return Number of tracks in file
   ///
   virtual int TrackCount(const std::string& file) { return 1; }
   //--------------------------------------------------------------------------

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -9,11 +9,8 @@
 #pragma once
 
 #include "../AddonBase.h"
-#ifdef BUILD_KODI_ADDON
-#include "../AEChannelData.h"
-#else
-#include "cores/AudioEngine/Utils/AEChannelData.h"
-#endif
+#include "../AudioEngine.h"
+
 #include <stdint.h>
 
 extern "C"
@@ -33,12 +30,16 @@ struct AddonInstance_AudioDecoder;
 typedef struct KodiToAddonFuncTable_AudioDecoder
 {
   KODI_HANDLE addonInstance;
-  bool (__cdecl* init)(const AddonInstance_AudioDecoder* instance,
-                       const char* file, unsigned int filecache,
-                       int* channels, int* samplerate,
-                       int* bitspersample, int64_t* totaltime,
-                       int* bitrate, AEDataFormat* format,
-                       const AEChannel** info);
+  bool(__cdecl* init)(const AddonInstance_AudioDecoder* instance,
+                      const char* file,
+                      unsigned int filecache,
+                      int* channels,
+                      int* samplerate,
+                      int* bitspersample,
+                      int64_t* totaltime,
+                      int* bitrate,
+                      enum AudioEngineDataFormat* format,
+                      const enum AudioEngineChannel** info);
   int  (__cdecl* read_pcm)(const AddonInstance_AudioDecoder* instance, uint8_t* buffer, int size, int* actualsize);
   int64_t  (__cdecl* seek)(const AddonInstance_AudioDecoder* instance, int64_t time);
   bool (__cdecl* read_tag)(const AddonInstance_AudioDecoder* instance,
@@ -224,11 +225,15 @@ public:
   /// @return                         true if successfully done, otherwise
   ///                                 false
   ///
-  virtual bool Init(const std::string& filename, unsigned int filecache,
-                    int& channels, int& samplerate,
-                    int& bitspersample, int64_t& totaltime,
-                    int& bitrate, AEDataFormat& format,
-                    std::vector<AEChannel>& channellist) = 0;
+  virtual bool Init(const std::string& filename,
+                    unsigned int filecache,
+                    int& channels,
+                    int& samplerate,
+                    int& bitspersample,
+                    int64_t& totaltime,
+                    int& bitrate,
+                    AudioEngineDataFormat& format,
+                    std::vector<AudioEngineChannel>& channellist) = 0;
   //--------------------------------------------------------------------------
 
   //==========================================================================
@@ -297,11 +302,16 @@ private:
     m_instanceData->toAddon->track_count = ADDON_TrackCount;
   }
 
-  inline static bool ADDON_Init(const AddonInstance_AudioDecoder* instance, const char* file, unsigned int filecache,
-                                int* channels, int* samplerate,
-                                int* bitspersample, int64_t* totaltime,
-                                int* bitrate, AEDataFormat* format,
-                                const AEChannel** info)
+  inline static bool ADDON_Init(const AddonInstance_AudioDecoder* instance,
+                                const char* file,
+                                unsigned int filecache,
+                                int* channels,
+                                int* samplerate,
+                                int* bitspersample,
+                                int64_t* totaltime,
+                                int* bitrate,
+                                AudioEngineDataFormat* format,
+                                const AudioEngineChannel** info)
   {
     CInstanceAudioDecoder* thisClass =
         static_cast<CInstanceAudioDecoder*>(instance->toAddon->addonInstance);
@@ -311,8 +321,8 @@ private:
                                *bitrate, *format, thisClass->m_channelList);
     if (!thisClass->m_channelList.empty())
     {
-      if (thisClass->m_channelList.back() != AE_CH_NULL)
-        thisClass->m_channelList.push_back(AE_CH_NULL);
+      if (thisClass->m_channelList.back() != AUDIOENGINE_CH_NULL)
+        thisClass->m_channelList.push_back(AUDIOENGINE_CH_NULL);
       *info = thisClass->m_channelList.data();
     }
     else
@@ -350,7 +360,7 @@ private:
     return static_cast<CInstanceAudioDecoder*>(instance->toAddon->addonInstance)->TrackCount(file);
   }
 
-  std::vector<AEChannel> m_channelList;
+  std::vector<AudioEngineChannel> m_channelList;
   AddonInstance_AudioDecoder* m_instanceData;
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -46,9 +46,92 @@ public:
 
   std::string GetArtist() const { return m_cStructure->artist; }
 
-  void SetLength(int length) { m_cStructure->length = length; }
+  void SetAlbum(const std::string& album)
+  {
+    strncpy(m_cStructure->album, album.c_str(), sizeof(m_cStructure->album) - 1);
+  }
 
-  int GetLength() const { return m_cStructure->length; }
+  std::string GetAlbum() const { return m_cStructure->album; }
+
+  void SetAlbumArtist(const std::string& albumArtist)
+  {
+    strncpy(m_cStructure->album_artist, albumArtist.c_str(),
+            sizeof(m_cStructure->album_artist) - 1);
+  }
+
+  std::string GetAlbumArtist() const { return m_cStructure->album_artist; }
+
+  void SetMediaType(const std::string& mediaType)
+  {
+    strncpy(m_cStructure->media_type, mediaType.c_str(), sizeof(m_cStructure->media_type) - 1);
+  }
+
+  std::string GetMediaType() const { return m_cStructure->media_type; }
+
+  void SetGenre(const std::string& genre)
+  {
+    strncpy(m_cStructure->genre, genre.c_str(), sizeof(m_cStructure->genre) - 1);
+  }
+
+  std::string GetGenre() const { return m_cStructure->genre; }
+
+  void SetDuration(int duration) { m_cStructure->duration = duration; }
+
+  int GetDuration() const { return m_cStructure->duration; }
+
+  void SetTrack(int track) { m_cStructure->track = track; }
+
+  int GetTrack() const { return m_cStructure->track; }
+
+  void SetDisc(int disc) { m_cStructure->disc = disc; }
+
+  int GetDisc() const { return m_cStructure->disc; }
+
+  void SetDiscSubtitle(const std::string& discSubtitle)
+  {
+    strncpy(m_cStructure->disc_subtitle, discSubtitle.c_str(),
+            sizeof(m_cStructure->disc_subtitle) - 1);
+  }
+
+  std::string GetDiscSubtitle() const { return m_cStructure->disc_subtitle; }
+
+  void SetDiscTotal(int discTotal) { m_cStructure->disc_total = discTotal; }
+
+  int GetDiscTotal() const { return m_cStructure->disc_total; }
+
+  void SetReleaseDate(const std::string& releaseDate)
+  {
+    strncpy(m_cStructure->release_date, releaseDate.c_str(),
+            sizeof(m_cStructure->release_date) - 1);
+  }
+
+  std::string GetReleaseDate() const { return m_cStructure->release_date; }
+
+  void SetLyrics(const std::string& lyrics)
+  {
+    strncpy(m_cStructure->lyrics, lyrics.c_str(), sizeof(m_cStructure->lyrics) - 1);
+  }
+
+  std::string GetLyrics() const { return m_cStructure->lyrics; }
+
+  void SetSamplerate(int samplerate) { m_cStructure->samplerate = samplerate; }
+
+  int GetSamplerate() const { return m_cStructure->samplerate; }
+
+  void SetChannels(int channels) { m_cStructure->channels = channels; }
+
+  int GetChannels() const { return m_cStructure->channels; }
+
+  void SetBitrate(int bitrate) { m_cStructure->bitrate = bitrate; }
+
+  int GetBitrate() const { return m_cStructure->bitrate; }
+
+  void SetComment(const std::string& comment)
+  {
+    strncpy(m_cStructure->comment, comment.c_str(), sizeof(m_cStructure->comment) - 1);
+  }
+
+  std::string GetComment() const { return m_cStructure->comment; }
 
 private:
   AudioDecoderInfoTag(const AUDIO_DECODER_INFO_TAG* tag) : CStructHdl(tag) {}

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -10,53 +10,9 @@
 
 #include "../AddonBase.h"
 #include "../AudioEngine.h"
+#include "../c-api/addon-instance/audio_decoder.h"
 
-#include <stdint.h>
-
-extern "C"
-{
-
-typedef struct AddonProps_AudioDecoder
-{
-  int dummy;
-} AddonProps_AudioDecoder;
-
-typedef struct AddonToKodiFuncTable_AudioDecoder
-{
-  KODI_HANDLE kodiInstance;
-} AddonToKodiFuncTable_AudioDecoder;
-
-struct AddonInstance_AudioDecoder;
-typedef struct KodiToAddonFuncTable_AudioDecoder
-{
-  KODI_HANDLE addonInstance;
-  bool(__cdecl* init)(const AddonInstance_AudioDecoder* instance,
-                      const char* file,
-                      unsigned int filecache,
-                      int* channels,
-                      int* samplerate,
-                      int* bitspersample,
-                      int64_t* totaltime,
-                      int* bitrate,
-                      enum AudioEngineDataFormat* format,
-                      const enum AudioEngineChannel** info);
-  int  (__cdecl* read_pcm)(const AddonInstance_AudioDecoder* instance, uint8_t* buffer, int size, int* actualsize);
-  int64_t  (__cdecl* seek)(const AddonInstance_AudioDecoder* instance, int64_t time);
-  bool (__cdecl* read_tag)(const AddonInstance_AudioDecoder* instance,
-                           const char* file, char* title,
-                           char* artist, int* length);
-  int  (__cdecl* track_count)(const AddonInstance_AudioDecoder* instance, const char* file);
-} KodiToAddonFuncTable_AudioDecoder;
-
-typedef struct AddonInstance_AudioDecoder
-{
-  struct AddonProps_AudioDecoder* props;
-  struct AddonToKodiFuncTable_AudioDecoder* toKodi;
-  struct KodiToAddonFuncTable_AudioDecoder* toAddon;
-} AddonInstance_AudioDecoder;
-
-} /* extern "C" */
-
+#ifdef __cplusplus
 namespace kodi
 {
 namespace addon
@@ -366,3 +322,4 @@ private:
 
 } /* namespace addon */
 } /* namespace kodi */
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -57,9 +57,9 @@ typedef struct KodiToAddonFuncTable_AudioDecoder
 
 typedef struct AddonInstance_AudioDecoder
 {
-  AddonProps_AudioDecoder props;
-  AddonToKodiFuncTable_AudioDecoder toKodi;
-  KodiToAddonFuncTable_AudioDecoder toAddon;
+  struct AddonProps_AudioDecoder* props;
+  struct AddonToKodiFuncTable_AudioDecoder* toKodi;
+  struct KodiToAddonFuncTable_AudioDecoder* toAddon;
 } AddonInstance_AudioDecoder;
 
 } /* extern "C" */
@@ -297,12 +297,12 @@ private:
 
     m_instanceData = static_cast<AddonInstance_AudioDecoder*>(instance);
 
-    m_instanceData->toAddon.addonInstance = this;
-    m_instanceData->toAddon.init = ADDON_Init;
-    m_instanceData->toAddon.read_pcm = ADDON_ReadPCM;
-    m_instanceData->toAddon.seek = ADDON_Seek;
-    m_instanceData->toAddon.read_tag = ADDON_ReadTag;
-    m_instanceData->toAddon.track_count = ADDON_TrackCount;
+    m_instanceData->toAddon->addonInstance = this;
+    m_instanceData->toAddon->init = ADDON_Init;
+    m_instanceData->toAddon->read_pcm = ADDON_ReadPCM;
+    m_instanceData->toAddon->seek = ADDON_Seek;
+    m_instanceData->toAddon->read_tag = ADDON_ReadTag;
+    m_instanceData->toAddon->track_count = ADDON_TrackCount;
   }
 
   inline static bool ADDON_Init(const AddonInstance_AudioDecoder* instance, const char* file, unsigned int filecache,
@@ -311,16 +311,16 @@ private:
                                 int* bitrate, AEDataFormat* format,
                                 const AEChannel** info)
   {
-    instance->toAddon.addonInstance->m_channelList.clear();
-    bool ret = instance->toAddon.addonInstance->Init(file, filecache, *channels,
+    instance->toAddon->addonInstance->m_channelList.clear();
+    bool ret = instance->toAddon->addonInstance->Init(file, filecache, *channels,
                                                           *samplerate, *bitspersample,
                                                           *totaltime, *bitrate, *format,
-                                                          instance->toAddon.addonInstance->m_channelList);
-    if (!instance->toAddon.addonInstance->m_channelList.empty())
+                                                          instance->toAddon->addonInstance->m_channelList);
+    if (!instance->toAddon->addonInstance->m_channelList.empty())
     {
-      if (instance->toAddon.addonInstance->m_channelList.back() != AE_CH_NULL)
-        instance->toAddon.addonInstance->m_channelList.push_back(AE_CH_NULL);
-      *info = instance->toAddon.addonInstance->m_channelList.data();
+      if (instance->toAddon->addonInstance->m_channelList.back() != AE_CH_NULL)
+        instance->toAddon->addonInstance->m_channelList.push_back(AE_CH_NULL);
+      *info = instance->toAddon->addonInstance->m_channelList.data();
     }
     else
       *info = nullptr;
@@ -329,19 +329,19 @@ private:
 
   inline static int ADDON_ReadPCM(const AddonInstance_AudioDecoder* instance, uint8_t* buffer, int size, int* actualsize)
   {
-    return instance->toAddon.addonInstance->ReadPCM(buffer, size, *actualsize);
+    return instance->toAddon->addonInstance->ReadPCM(buffer, size, *actualsize);
   }
 
   inline static int64_t ADDON_Seek(const AddonInstance_AudioDecoder* instance, int64_t time)
   {
-    return instance->toAddon.addonInstance->Seek(time);
+    return instance->toAddon->addonInstance->Seek(time);
   }
 
   inline static bool ADDON_ReadTag(const AddonInstance_AudioDecoder* instance, const char* file, char* title, char* artist, int* length)
   {
     std::string intTitle;
     std::string intArtist;
-    bool ret = instance->toAddon.addonInstance->ReadTag(file, intTitle, intArtist, *length);
+    bool ret = instance->toAddon->addonInstance->ReadTag(file, intTitle, intArtist, *length);
     if (ret)
     {
       strncpy(title, intTitle.c_str(), ADDON_STANDARD_STRING_LENGTH_SMALL-1);
@@ -352,7 +352,7 @@ private:
 
   inline static int ADDON_TrackCount(const AddonInstance_AudioDecoder* instance, const char* file)
   {
-    return instance->toAddon.addonInstance->TrackCount(file);
+    return instance->toAddon->addonInstance->TrackCount(file);
   }
 
   std::vector<AEChannel> m_channelList;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS audio_encoder.h
+set(HEADERS audio_decoder.h
+            audio_encoder.h
             image_decoder.h
             pvr.h)
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
@@ -16,6 +16,13 @@ extern "C"
 {
 #endif /* __cplusplus */
 
+  struct AUDIO_DECODER_INFO_TAG
+  {
+    char title[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    char artist[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    int length;
+  };
+
   typedef struct AddonProps_AudioDecoder
   {
     int dummy;
@@ -47,9 +54,7 @@ extern "C"
     int64_t(__cdecl* seek)(const struct AddonInstance_AudioDecoder* instance, int64_t time);
     bool(__cdecl* read_tag)(const struct AddonInstance_AudioDecoder* instance,
                             const char* file,
-                            char* title,
-                            char* artist,
-                            int* length);
+                            struct AUDIO_DECODER_INFO_TAG* tag);
     int(__cdecl* track_count)(const struct AddonInstance_AudioDecoder* instance, const char* file);
   } KodiToAddonFuncTable_AudioDecoder;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
@@ -11,16 +11,33 @@
 #include "../addon_base.h"
 #include "../audio_engine.h"
 
+#define AUDIO_DECODER_LYRICS_SIZE 65535
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif /* __cplusplus */
 
+  // WARNING About size use malloc/new!
   struct AUDIO_DECODER_INFO_TAG
   {
     char title[ADDON_STANDARD_STRING_LENGTH_SMALL];
     char artist[ADDON_STANDARD_STRING_LENGTH_SMALL];
-    int length;
+    char album[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    char album_artist[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    char media_type[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    char genre[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    int duration;
+    int track;
+    int disc;
+    char disc_subtitle[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    int disc_total;
+    char release_date[ADDON_STANDARD_STRING_LENGTH_SMALL];
+    char lyrics[AUDIO_DECODER_LYRICS_SIZE];
+    int samplerate;
+    int channels;
+    int bitrate;
+    char comment[ADDON_STANDARD_STRING_LENGTH];
   };
 
   typedef struct AddonProps_AudioDecoder

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../addon_base.h"
+#include "../audio_engine.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+  typedef struct AddonProps_AudioDecoder
+  {
+    int dummy;
+  } AddonProps_AudioDecoder;
+
+  typedef struct AddonToKodiFuncTable_AudioDecoder
+  {
+    KODI_HANDLE kodiInstance;
+  } AddonToKodiFuncTable_AudioDecoder;
+
+  struct AddonInstance_AudioDecoder;
+  typedef struct KodiToAddonFuncTable_AudioDecoder
+  {
+    KODI_HANDLE addonInstance;
+    bool(__cdecl* init)(const struct AddonInstance_AudioDecoder* instance,
+                        const char* file,
+                        unsigned int filecache,
+                        int* channels,
+                        int* samplerate,
+                        int* bitspersample,
+                        int64_t* totaltime,
+                        int* bitrate,
+                        enum AudioEngineDataFormat* format,
+                        const enum AudioEngineChannel** info);
+    int(__cdecl* read_pcm)(const struct AddonInstance_AudioDecoder* instance,
+                           uint8_t* buffer,
+                           int size,
+                           int* actualsize);
+    int64_t(__cdecl* seek)(const struct AddonInstance_AudioDecoder* instance, int64_t time);
+    bool(__cdecl* read_tag)(const struct AddonInstance_AudioDecoder* instance,
+                            const char* file,
+                            char* title,
+                            char* artist,
+                            int* length);
+    int(__cdecl* track_count)(const struct AddonInstance_AudioDecoder* instance, const char* file);
+  } KodiToAddonFuncTable_AudioDecoder;
+
+  typedef struct AddonInstance_AudioDecoder
+  {
+    struct AddonProps_AudioDecoder* props;
+    struct AddonToKodiFuncTable_AudioDecoder* toKodi;
+    struct KodiToAddonFuncTable_AudioDecoder* toAddon;
+  } AddonInstance_AudioDecoder;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/audio_engine.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/audio_engine.h
@@ -35,7 +35,7 @@ extern "C"
   /// m_audioengine = new kodi::audioengine::CAEStream(format, AUDIO_STREAM_FORCE_RESAMPLE | AUDIO_STREAM_AUTOSTART);
   /// ~~~~~~~~~~~~~
   ///
-  //@{
+  ///@{
   typedef enum AudioEngineStreamOptions
   {
     /// force resample even if rates match
@@ -45,7 +45,7 @@ extern "C"
     /// autostart the stream when enough data is buffered
     AUDIO_STREAM_AUTOSTART = 1 << 2,
   } AudioEngineStreamOptions;
-  //@}
+  ///@}
   //----------------------------------------------------------------------------
 
   //============================================================================
@@ -63,7 +63,7 @@ extern "C"
   /// format.SetChannelLayout(std::vector<AudioEngineChannel>(AUDIOENGINE_CH_FL, AUDIOENGINE_CH_FR));
   /// ~~~~~~~~~~~~~
   ///
-  //@{
+  ///@{
   enum AudioEngineChannel
   {
     /// Used inside to indicate the end of a list and not for addon use directly.
@@ -113,7 +113,7 @@ extern "C"
     /// Maximum possible value, to use e.g. as size inside list
     AUDIOENGINE_CH_MAX
   };
-  //@}
+  ///@}
   //----------------------------------------------------------------------------
 
   //============================================================================
@@ -141,7 +141,7 @@ extern "C"
   /// format.SetDataFormat(AUDIOENGINE_FMT_FLOATP);
   /// ~~~~~~~~~~~~~
   ///
-  //@{
+  ///@{
   enum AudioEngineDataFormat
   {
     /// To define format as invalid
@@ -217,7 +217,7 @@ extern "C"
     /// Amount of sample formats.
     AUDIOENGINE_FMT_MAX
   };
-  //@}
+  ///@}
   //----------------------------------------------------------------------------
 
   /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -77,10 +77,11 @@
 #define ADDON_GLOBAL_VERSION_TOOLS_XML_ID             "kodi.binary.global.tools"
 #define ADDON_GLOBAL_VERSION_TOOLS_DEPENDS            "tools/DllHelper.h"
 
-#define ADDON_INSTANCE_VERSION_AUDIODECODER           "2.0.2"
-#define ADDON_INSTANCE_VERSION_AUDIODECODER_MIN       "2.0.1"
+#define ADDON_INSTANCE_VERSION_AUDIODECODER           "3.0.0"
+#define ADDON_INSTANCE_VERSION_AUDIODECODER_MIN       "3.0.0"
 #define ADDON_INSTANCE_VERSION_AUDIODECODER_XML_ID    "kodi.binary.instance.audiodecoder"
-#define ADDON_INSTANCE_VERSION_AUDIODECODER_DEPENDS   "addon-instance/AudioDecoder.h"
+#define ADDON_INSTANCE_VERSION_AUDIODECODER_DEPENDS   "c-api/addon-instance/audio_decoder.h" \
+                                                      "addon-instance/AudioDecoder.h"
 
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER           "2.1.0"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_MIN       "2.1.0"


### PR DESCRIPTION
## Description

This request is intended to bring the audio decoder interface to the new style, as with PVR. Hence 100% "C" ABI based there between Kodi and addon.

In addition, the info given by the addon is very improved and not only title, artist and length available (see screenshots)

## User related:
- Feature: Audio decoder addons can now pass more information on Kodi (album, year, notes ...) 
  - Before was only the title, artist and duration possible to give Kodi

Only for all binary addon system requests may be for the user:
- Binary addon system revised to ensure higher security in its data exchange between addon and Kodi
- Revised binary addon system documentation for outside developers

Commit 1:
---------------------------------
**[addons][audiodecoder] make all "C" interface structures to own memory**

This done to prevent API backward problems if something becomes replaced e.g. on props or to kodi calls.

Commit 2:
---------------------------------
**[addons][audiodecoder] don't use C++ class in C**

Before was the C++ class pointer exchanged between Addon and Kodi, it was not used in Kodi but it breaks the ABI and can't compiled in "C" only.

Commit 3:
---------------------------------
**[addons][audiodecoder] remove use of AEChannelData.h and use AudioEngine.h**

Before was Kodi's own audio engine header AEChannelData.h used. Them breaks "C" ABI as there C++ parts inside. Further ist it more critical about changes and addon code overseen.

With this becomes the already present "AudioEngine.h" header used for.
This becomes translated between Kodi and addon and have in case of Kodi changes still correct on addon.

Commit 4:
---------------------------------
**[addons][audiodecoder] improve error handling about CAudioDecoder::Init**

Before was addon after his init call not checked.
In case it has returned false was  still Kodi's side of data set. But this then not always good, as we not know what it brings.

Further was "int channels" and "int sampleRate" not set before where breaks e.g. coverity scan.

This change does this:
- Make translate of addon to Kodi only if addon returned true
- Set "int channels" and "int sampleRate" to -1
- In case addon returned true and wanted values are not set, becomes a error reported and Kodi's function returns false

Commit 5:
---------------------------------
**[addons][audiodecoder] separate "C" to own file**

This to hold "C++" and "C" independent and allow for other languages.

Commit 6:
---------------------------------
**[addons][audioedecoder] clang cleanup about AudioDecoder.[cpp|.h]**

This have them correct about wanted code styles.

Commit 7:
---------------------------------
**[addons][audiodecoder] use "C" structure and "C++" class to read music tag from addon**

There becomes about "C" the structure AUDIO_DECODER_INFO_TAG added where gives available tag data from addon to Kodi.
Further is within C++ the kodi::addon::AudioDecoderInfoTag added where then used on addon to set his available infos.

Before was there on function a value about every part, this has made it heavier for changes (by add of new parts) also was a bit more to set them from addon.

Now with the C++ wrapper (since PVR API changes) is it available for addon by C++ class where he can set his infos.

Commit 8:
---------------------------------
**[addons][audiodecoder] add some new info parts to info tag**

There becomes on AUDIO_DECODER_INFO_TAG/kodi::addon::AudioDecoderInfoTag some new parts added to allow addon the set of available infos.

Maybe also other parts needed and then need add in future?

The documentation becomes on following changes added.

Commit 9:
---------------------------------
**[addons][audiodecoder] update and cleanup interface docs**

There becomes the documentation updated to have correct with newest doxygen, some parts changed and on new parts documentation added.

Further are few doxygen fixes on audio engine.

Commit 10:
---------------------------------
**[addons][audiodecoder] increase API version to 3.0.0**

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
With related addons.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

Here how now more info is shown about:
![Bildschirmfoto von 2020-07-28 19-07-03](https://user-images.githubusercontent.com/6879739/88700575-2e4e0f80-d109-11ea-8b7d-33ff57c8d4cc.png)
![Bildschirmfoto von 2020-07-28 19-07-13](https://user-images.githubusercontent.com/6879739/88700591-33ab5a00-d109-11ea-94d5-13bd2b4a96b9.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed