### PR TITLE
[addons] Allow repo server to dictate update interval

### DIFF
--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -57,19 +57,41 @@ public:
   /*! Get addons across all repositories */
   bool GetRepositoryContent(ADDON::VECADDONS& addons) const;
 
-  /*!
-   \brief Set repo last checked date, and create the repo if needed
-   \param id id of the repository
-   \returns id of the repository, or -1 on error.
-   */
-  int SetLastChecked(const std::string& id, const ADDON::AddonVersion& version, const std::string& timestamp);
+  struct RepoUpdateData
+  {
+    /*! \brief last time the repo was checked, or invalid CDateTime if never checked */
+    CDateTime lastCheckedAt;
+    /*! \brief last version of the repo add-on that was checked, or empty if never checked */
+    ADDON::AddonVersion lastCheckedVersion{""};
+    /*! \brief next time the repo should be checked, or invalid CDateTime if unknown */
+    CDateTime nextCheckAt;
+
+    RepoUpdateData() = default;
+
+    RepoUpdateData(CDateTime lastCheckedAt,
+                   ADDON::AddonVersion lastCheckedVersion,
+                   CDateTime nextCheckAt)
+      : lastCheckedAt{lastCheckedAt},
+        lastCheckedVersion{lastCheckedVersion},
+        nextCheckAt{nextCheckAt}
+    {
+    }
+  };
 
   /*!
-   \brief Retrieve the time a repository was last checked and the version it was for
-   \param id id of the repo
-   \return last time the repo was checked, or invalid CDateTime if never checked
+   \brief Set data concerning repository update (last/next date etc.), and create the repo if needed
+   \param id add-on id of the repository
+   \param updateData update data to set
+   \returns id of the repository, or -1 on error.
    */
-  std::pair<CDateTime, ADDON::AddonVersion> LastChecked(const std::string& id);
+  int SetRepoUpdateData(const std::string& id, const RepoUpdateData& updateData);
+
+  /*!
+   \brief Retrieve repository update data (last/next date etc.)
+   \param id add-on id of the repo
+   \return update data of the repository
+   */
+  RepoUpdateData GetRepoUpdateData(const std::string& id);
 
   bool Search(const std::string& search, ADDON::VECADDONS& items);
 
@@ -146,5 +168,7 @@ protected:
 
   bool GetAddon(int id, ADDON::AddonPtr& addon);
   void DeleteRepository(const std::string& id);
+  void DeleteRepositoryContents(const std::string& id);
+  int GetRepositoryId(const std::string& addonId);
 };
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -28,6 +28,7 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <iterator>
 #include <tuple>
 #include <utility>
@@ -79,8 +80,9 @@ CRepository::ResolveResult CRepository::ResolvePathAndHash(const AddonPtr& addon
 
   if (hash.Empty())
   {
+    int tmp;
     // Expected hash, but none found -> fall back to old method
-    if (!FetchChecksum(path + "." + hashTypeStr, hash.value) || hash.Empty())
+    if (!FetchChecksum(path + "." + hashTypeStr, hash.value, tmp) || hash.Empty())
     {
       CLog::Log(LOGERROR, "Failed to find hash for {} from HTTP header and in separate file", path);
       return {};
@@ -131,7 +133,9 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo)
   }
 }
 
-bool CRepository::FetchChecksum(const std::string& url, std::string& checksum) noexcept
+bool CRepository::FetchChecksum(const std::string& url,
+                                std::string& checksum,
+                                int& recheckAfter) noexcept
 {
   CFile file;
   if (!file.Open(url))
@@ -152,6 +156,29 @@ bool CRepository::FetchChecksum(const std::string& url, std::string& checksum) n
   {
     checksum = checksum.substr(0, pos);
   }
+
+  // Determine update interval from (potential) HTTP response
+  // Default: 24 h
+  recheckAfter = 24 * 60 * 60;
+  // This special header is set by the Kodi mirror redirector to control client update frequency
+  // depending on the load on the mirrors
+  const std::string recheckAfterHeader{
+      file.GetProperty(FILE_PROPERTY_RESPONSE_HEADER, "X-Kodi-Recheck-After")};
+  if (!recheckAfterHeader.empty())
+  {
+    try
+    {
+      // Limit value range to sensible values (1 hour to 1 week)
+      recheckAfter =
+          std::max(std::min(std::stoi(recheckAfterHeader), 24 * 7 * 60 * 60), 1 * 60 * 60);
+    }
+    catch (...)
+    {
+      CLog::Log(LOGWARNING, "Could not parse X-Kodi-Recheck-After header value '{}' from {}",
+                recheckAfterHeader, url);
+    }
+  }
+
   return true;
 }
 
@@ -193,27 +220,42 @@ bool CRepository::FetchIndex(const DirInfo& repo, std::string const& digest, VEC
 }
 
 CRepository::FetchStatus CRepository::FetchIfChanged(const std::string& oldChecksum,
-    std::string& checksum, VECADDONS& addons) const
+                                                     std::string& checksum,
+                                                     VECADDONS& addons,
+                                                     int& recheckAfter) const
 {
   checksum = "";
   std::vector<std::tuple<DirInfo const&, std::string>> dirChecksums;
+  std::vector<int> recheckAfterTimes;
+
   for (const auto& dir : m_dirs)
   {
     if (!dir.checksum.empty())
     {
       std::string part;
-      if (!FetchChecksum(dir.checksum, part))
+      int recheckAfterThisDir;
+      if (!FetchChecksum(dir.checksum, part, recheckAfterThisDir))
       {
         CLog::Log(LOGERROR, "CRepository: failed read '%s'", dir.checksum.c_str());
         return STATUS_ERROR;
       }
       dirChecksums.emplace_back(dir, part);
+      recheckAfterTimes.push_back(recheckAfterThisDir);
       checksum += part;
     }
   }
 
-  if (oldChecksum == checksum && !oldChecksum.empty())
-    return STATUS_NOT_MODIFIED;
+  // Default interval: 24 h
+  recheckAfter = 24 * 60 * 60;
+  if (dirChecksums.size() == m_dirs.size() && !dirChecksums.empty())
+  {
+    // Use smallest update interval out of all received (individual intervals per directory are
+    // not possible)
+    recheckAfter = *std::min_element(recheckAfterTimes.begin(), recheckAfterTimes.end());
+    // If all directories have checksums and they match the last one, nothing has changed
+    if (dirChecksums.size() == m_dirs.size() && oldChecksum == checksum)
+      return STATUS_NOT_MODIFIED;
+  }
 
   for (const auto& dirTuple : dirChecksums)
   {
@@ -274,16 +316,19 @@ bool CRepositoryUpdateJob::DoWork()
   if (database.GetRepoChecksum(m_repo->ID(), oldChecksum) == -1)
     oldChecksum = "";
 
-  std::pair<CDateTime, ADDON::AddonVersion> lastCheck = database.LastChecked(m_repo->ID());
-  if (lastCheck.second != m_repo->Version())
+  const CAddonDatabase::RepoUpdateData updateData{database.GetRepoUpdateData(m_repo->ID())};
+  if (updateData.lastCheckedVersion != m_repo->Version())
     oldChecksum = "";
 
   std::string newChecksum;
   VECADDONS addons;
-  auto status = m_repo->FetchIfChanged(oldChecksum, newChecksum, addons);
+  int recheckAfter;
+  auto status = m_repo->FetchIfChanged(oldChecksum, newChecksum, addons, recheckAfter);
 
-  database.SetLastChecked(m_repo->ID(), m_repo->Version(),
-      CDateTime::GetCurrentDateTime().GetAsDBDateTime());
+  database.SetRepoUpdateData(
+      m_repo->ID(), CAddonDatabase::RepoUpdateData(
+                        CDateTime::GetCurrentDateTime(), m_repo->Version(),
+                        CDateTime::GetCurrentDateTime() + CDateTimeSpan(0, 0, 0, recheckAfter)));
 
   MarkFinished();
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -43,7 +43,10 @@ namespace ADDON
       STATUS_ERROR
     };
 
-    FetchStatus FetchIfChanged(const std::string& oldChecksum, std::string& checksum, VECADDONS& addons) const;
+    FetchStatus FetchIfChanged(const std::string& oldChecksum,
+                               std::string& checksum,
+                               VECADDONS& addons,
+                               int& recheckAfter) const;
 
     struct ResolveResult
     {
@@ -53,7 +56,9 @@ namespace ADDON
     ResolveResult ResolvePathAndHash(AddonPtr const& addon) const;
 
   private:
-    static bool FetchChecksum(const std::string& url, std::string& checksum) noexcept;
+    static bool FetchChecksum(const std::string& url,
+                              std::string& checksum,
+                              int& recheckAfter) noexcept;
     static bool FetchIndex(const DirInfo& repo, std::string const& digest, VECADDONS& addons) noexcept;
 
     static DirInfo ParseDirConfiguration(const CAddonExtensions& configuration);

--- a/xbmc/addons/RepositoryUpdater.h
+++ b/xbmc/addons/RepositoryUpdater.h
@@ -75,6 +75,8 @@ private:
 
   void OnEvent(const ADDON::AddonEvent& event);
 
+  CDateTime ClosestNextCheck() const;
+
   CCriticalSection m_criticalSection;
   CTimer m_timer;
   CEvent m_doneEvent;

--- a/xbmc/addons/test/TestAddonDatabase.cpp
+++ b/xbmc/addons/test/TestAddonDatabase.cpp
@@ -37,10 +37,12 @@ protected:
 
     VECADDONS addons;
     CreateAddon(addons, "foo.bar", "1.0.0");
+    database.SetRepoUpdateData("repository.a", {});
     database.UpdateRepositoryContent("repository.a", AddonVersion("1.0.0"), "test", addons);
 
     addons.clear();
     CreateAddon(addons, "foo.baz", "1.1.0");
+    database.SetRepoUpdateData("repository.b", {});
     database.UpdateRepositoryContent("repository.b", AddonVersion("1.0.0"), "test", addons);
   }
 


### PR DESCRIPTION
## Description
Add support for `X-Kodi-Recheck-After` header on repo update.

The header is live on mirrors.kodi.tv, so it can already be tested.

## Motivation and Context
We currently have no possibility to update the repository update
interval; it is fixed at 24 h. It is desirable to control this value
from the server side so we are more flexible and can, e.g., offer faster
updates if server load allows it.

This commit adds client-side support for the `X-Kodi-Recheck-After`
response header to the checksum HTTP request. It specifies how many
seconds to wait until the repo is checked for updates the next time.
The server is free to set this value as it sees fit. If the header is
not included in the response, a default value of 24 h is used.

The header is only supported in repositories that have checksums enabled
for all directories.

## How Has This Been Tested?
On Linux with kodi official repo

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
