### PR TITLE
Fix compilation errors on targets Windows UWP-ARM and UWP-Win32

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -166,13 +166,13 @@ void CAEBitstreamPacker::PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size
 
   int maxSize = TRUEHD_FRAME_OFFSET;
   if (m_trueHDPos == 0)
-    maxSize -= sizeof(mat_start_code) + BURST_HEADER_SIZE;
+    maxSize -= static_cast<int>(sizeof(mat_start_code)) + BURST_HEADER_SIZE;
   else if (m_trueHDPos == 11)
     maxSize -= -MAT_MIDDLE_CODE_OFFSET;
   else if (m_trueHDPos == 12)
-    maxSize -= sizeof(mat_middle_code) + MAT_MIDDLE_CODE_OFFSET;
+    maxSize -= static_cast<int>(sizeof(mat_middle_code)) + MAT_MIDDLE_CODE_OFFSET;
   else if (m_trueHDPos == 23)
-    maxSize -= sizeof(mat_end_code) + (24 * TRUEHD_FRAME_OFFSET - MAT_FRAME_SIZE);
+    maxSize -= static_cast<int>(sizeof(mat_end_code)) + (24 * TRUEHD_FRAME_OFFSET - MAT_FRAME_SIZE);
 
   if (size > maxSize)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -11,7 +11,9 @@
 #include "DVDCodecs/Video/DXVA.h"
 #include "rendering/dx/RenderContext.h"
 #include "utils/CPUInfo.h"
-#include "utils/gpu_memcpy_sse4.h"
+#ifndef _M_ARM
+  #include "utils/gpu_memcpy_sse4.h"
+#endif
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 

--- a/xbmc/platform/win10/CPUInfoWin10.cpp
+++ b/xbmc/platform/win10/CPUInfoWin10.cpp
@@ -37,8 +37,9 @@ CCPUInfoWin10::CCPUInfoWin10()
   m_cpuCount = siSysInfo.dwNumberOfProcessors;
   m_cpuModel = "Unknown";
 
-  int CPUInfo[4]; // receives EAX, EBX, ECD and EDX in that order
+  int CPUInfo[4] = {}; // receives EAX, EBX, ECD and EDX in that order
 
+#ifndef _M_ARM
   __cpuid(CPUInfo, 0);
   int MaxStdInfoType = CPUInfo[0];
 
@@ -77,6 +78,7 @@ CCPUInfoWin10::CCPUInfoWin10()
     if (CPUInfo[CPUINFO_EDX] & CPUID_80000001_EDX_3DNOWEXT)
       m_cpuFeatures |= CPU_FEATURE_3DNOWEXT;
   }
+#endif
 
   // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
   if (m_cpuFeatures & CPU_FEATURE_SSE)

--- a/xbmc/platform/win32/CPUInfoWin32.cpp
+++ b/xbmc/platform/win32/CPUInfoWin32.cpp
@@ -124,7 +124,7 @@ CCPUInfoWin32::CCPUInfoWin32()
   else
     m_cpuQueryLoad = nullptr;
 
-  int CPUInfo[4]; // receives EAX, EBX, ECD and EDX in that order
+  int CPUInfo[4] = {}; // receives EAX, EBX, ECD and EDX in that order
 
   __cpuid(CPUInfo, 0);
   int MaxStdInfoType = CPUInfo[0];
@@ -227,7 +227,7 @@ int CCPUInfoWin32::GetUsedPercentage()
     {
       PDH_RAW_COUNTER cnt;
       DWORD cntType;
-      PDH_HCOUNTER coreCounter;
+      PDH_HCOUNTER coreCounter = nullptr;
       if (i < m_coreCounters.size())
         coreCounter = m_coreCounters[i];
       if (coreCounter && PdhGetRawCounterValue(coreCounter, &cntType, &cnt) == ERROR_SUCCESS &&

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -77,13 +77,15 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
 
+  HMODULE hDbgHelpDll = nullptr;
+
   if (hDumpFile == INVALID_HANDLE_VALUE)
   {
     goto cleanup;
   }
 
   // Load the DBGHELP DLL
-  HMODULE hDbgHelpDll = ::LoadLibrary(L"DBGHELP.DLL");
+  hDbgHelpDll = ::LoadLibrary(L"DBGHELP.DLL");
   if (!hDbgHelpDll)
   {
     goto cleanup;


### PR DESCRIPTION
## Description
Fix compilation errors on targets Windows UWP-ARM and UWP-Win32

## Motivation and Context
Jenkins builds for UWP-ARM and UWP-Win32 are currently disabled because not needed and compilation errors are not catched out.

## How Has This Been Tested?
Build UWP-ARM and UWP-Win32 using Visual Studio 2017 with normal BulidSetup scripts

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
