### PR TITLE
GUIDialogSelect - add optional 3rd button

### DIFF
--- a/addons/skin.estouchy/xml/DialogSelect.xml
+++ b/addons/skin.estouchy/xml/DialogSelect.xml
@@ -226,6 +226,12 @@
 				<include>ButtonInfoDialogsCommonValues</include>
 				<label>186</label>
 			</control>
+			<control type="button" id="8">
+				<description>Add button</description>
+				<width>200</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+				<label></label>
+			</control>
 			<control type="button" id="7">
 				<description>Cancel button</description>
 				<width>200</width>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -142,6 +142,10 @@
 					<param name="label" value="" />
 				</include>
 				<include content="DefaultDialogButton">
+					<param name="id" value="8" />
+					<param name="label" value="" />
+				</include>
+				<include content="DefaultDialogButton">
 					<param name="id" value="7" />
 					<param name="label" value="$LOCALIZE[222]" />
 				</include>

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -19,6 +19,7 @@
 #define CONTROL_SIMPLE_LIST     3
 #define CONTROL_DETAILED_LIST   6
 #define CONTROL_EXTRA_BUTTON    5
+#define CONTROL_EXTRA_BUTTON2 8
 #define CONTROL_CANCEL_BUTTON   7
 
 CGUIDialogSelect::CGUIDialogSelect() : CGUIDialogSelect(WINDOW_DIALOG_SELECT) {}
@@ -26,8 +27,9 @@ CGUIDialogSelect::CGUIDialogSelect() : CGUIDialogSelect(WINDOW_DIALOG_SELECT) {}
 CGUIDialogSelect::CGUIDialogSelect(int windowId)
     : CGUIDialogBoxBase(windowId, "DialogSelect.xml"),
     m_bButtonEnabled(false),
+    m_bButton2Enabled(false),
     m_bButtonPressed(false),
-    m_buttonLabel(-1),
+    m_bButton2Pressed(false),
     m_selectedItem(nullptr),
     m_useDetails(false),
     m_multiSelection(false),
@@ -49,6 +51,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       CGUIDialogBoxBase::OnMessage(message);
 
       m_bButtonEnabled = false;
+      m_bButton2Enabled = false;
       m_useDetails = false;
       m_multiSelection = false;
 
@@ -73,6 +76,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       m_bButtonPressed = false;
+      m_bButton2Pressed = false;
       m_bConfirmed = false;
       CGUIDialogBoxBase::OnMessage(message);
       return true;
@@ -103,6 +107,13 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
             }
           }
         }
+      }
+      if (iControl == CONTROL_EXTRA_BUTTON2)
+      {
+        m_bButton2Pressed = true;
+        if (m_multiSelection)
+          m_bConfirmed = true;
+        Close();
       }
       if (iControl == CONTROL_EXTRA_BUTTON)
       {
@@ -166,6 +177,9 @@ void CGUIDialogSelect::Reset()
 {
   m_bButtonEnabled = false;
   m_bButtonPressed = false;
+  m_bButton2Enabled = false;
+  m_bButton2Pressed = false;
+
   m_useDetails = false;
   m_multiSelection = false;
   m_focusToButton = false;
@@ -216,12 +230,35 @@ const std::vector<int>& CGUIDialogSelect::GetSelectedItems() const
 void CGUIDialogSelect::EnableButton(bool enable, int label)
 {
   m_bButtonEnabled = enable;
+  m_buttonLabel = g_localizeStrings.Get(label);
+}
+
+void CGUIDialogSelect::EnableButton(bool enable, const std::string& label)
+{
+  m_bButtonEnabled = enable;
   m_buttonLabel = label;
+}
+
+void CGUIDialogSelect::EnableButton2(bool enable, int label)
+{
+  m_bButton2Enabled = enable;
+  m_button2Label = g_localizeStrings.Get(label);
+}
+
+void CGUIDialogSelect::EnableButton2(bool enable, const std::string& label)
+{
+  m_bButton2Enabled = enable;
+  m_button2Label = label;
 }
 
 bool CGUIDialogSelect::IsButtonPressed()
 {
   return m_bButtonPressed;
+}
+
+bool CGUIDialogSelect::IsButton2Pressed()
+{
+  return m_bButton2Pressed;
 }
 
 void CGUIDialogSelect::Sort(bool bSortOrder /*=true*/)
@@ -325,11 +362,19 @@ void CGUIDialogSelect::OnInitWindow()
 
   if (m_bButtonEnabled)
   {
-    SET_CONTROL_LABEL(CONTROL_EXTRA_BUTTON, g_localizeStrings.Get(m_buttonLabel));
+    SET_CONTROL_LABEL(CONTROL_EXTRA_BUTTON, m_buttonLabel);
     SET_CONTROL_VISIBLE(CONTROL_EXTRA_BUTTON);
   }
   else
     SET_CONTROL_HIDDEN(CONTROL_EXTRA_BUTTON);
+
+  if (m_bButton2Enabled)
+  {
+    SET_CONTROL_LABEL(CONTROL_EXTRA_BUTTON2, m_button2Label);
+    SET_CONTROL_VISIBLE(CONTROL_EXTRA_BUTTON2);
+  }
+  else
+    SET_CONTROL_HIDDEN(CONTROL_EXTRA_BUTTON2);
 
   SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
 

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -33,7 +33,11 @@ public:
   int GetSelectedItem() const;
   const std::vector<int>& GetSelectedItems() const;
   void EnableButton(bool enable, int label);
+  void EnableButton(bool enable, const std::string& label);
+  void EnableButton2(bool enable, int label);
+  void EnableButton2(bool enable, const std::string& label);
   bool IsButtonPressed();
+  bool IsButton2Pressed();
   void Sort(bool bSortOrder = true);
   void SetSelected(int iSelected);
   void SetSelected(const std::string &strSelectedLabel);
@@ -55,8 +59,11 @@ protected:
 
 private:
   bool m_bButtonEnabled;
+  bool m_bButton2Enabled;
   bool m_bButtonPressed;
-  int m_buttonLabel;
+  bool m_bButton2Pressed;
+  std::string m_buttonLabel;
+  std::string m_button2Label;
   CFileItemPtr m_selectedItem;
   bool m_useDetails;
   bool m_multiSelection;


### PR DESCRIPTION
Add an optional 3rd button to the standard select dialog GUIDialogSelect
Update Estuary and Estouchy skins to be able to show this button (id=8)

An example use is in UI for entering multi-value settings where the user can either pick from a default list or add a new value, but other uses may arise in future. 

![GUIDialogSelect with 3 buttons](https://i.imgur.com/Gg9lO3r.jpg?2)
See https://github.com/xbmc/xbmc/pull/18173 where it will be used for the artist and album art whitelist settings that offer multiple selection of art types, enabling the user to add own new art types. Similar applies to video art.

Other skins will need to be modified similarly, not sure where that needs to be documented or how best to notify skinners. @ronie perhaps you can advise.