### PR TITLE
[Settings] CSettingControlList - option for user to add value to list

### DIFF
--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -563,6 +563,7 @@ bool CSettingsOperations::SerializeSettingString(std::shared_ptr<const CSettingS
   obj["default"] = setting->GetDefault();
 
   obj["allowempty"] = setting->AllowEmpty();
+  obj["allownewoption"] = setting->AllowNewOption();
 
   switch (setting->GetOptionsType())
   {

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -226,6 +226,7 @@ bool CSettingControlList::Deserialize(const TiXmlNode *node, bool update /* = fa
   XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
   XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_MULTISELECT, m_multiselect);
   XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_HIDEVALUE, m_hideValue);
+  XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_ADDBUTTONLABEL, m_addButtonLabel);
 
   return true;
 }

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -19,6 +19,7 @@
 #define SETTING_XML_ELM_CONTROL_MULTISELECT "multiselect"
 #define SETTING_XML_ELM_CONTROL_POPUP "popup"
 #define SETTING_XML_ELM_CONTROL_FORMATVALUE "value"
+#define SETTING_XML_ELM_CONTROL_ADDBUTTONLABEL "addbuttonlabel"
 #define SETTING_XML_ATTR_SHOW_MORE "more"
 #define SETTING_XML_ATTR_SHOW_DETAILS "details"
 #define SETTING_XML_ATTR_SEPARATOR_POSITION "separatorposition"
@@ -188,6 +189,8 @@ public:
   void SetMultiSelect(bool multiselect) { m_multiselect = multiselect; }
   bool HideValue() const { return m_hideValue; }
   void SetHideValue(bool hideValue) { m_hideValue = hideValue; }
+  int GetAddButtonLabel() const { return m_addButtonLabel; }
+  void SetAddButtonLabel(int label) { m_addButtonLabel = label; }
 
   SettingControlListValueFormatter GetFormatter() const { return m_formatter; }
   void SetFormatter(SettingControlListValueFormatter formatter) { m_formatter = formatter; }
@@ -196,6 +199,7 @@ protected:
   int m_heading = -1;
   bool m_multiselect = false;
   bool m_hideValue = false;
+  int m_addButtonLabel = -1;
   SettingControlListValueFormatter m_formatter = nullptr;
 };
 

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -1353,6 +1353,8 @@ void CSettingString::MergeDetails(const CSetting& other)
     m_value = stringSetting.m_value;
   if (m_allowEmpty == false && stringSetting.m_allowEmpty == true)
     m_allowEmpty = stringSetting.m_allowEmpty;
+  if (m_allowNewOption == false && stringSetting.m_allowNewOption == true)
+    m_allowNewOption = stringSetting.m_allowNewOption;
   if (m_translatableOptions.empty() && !stringSetting.m_translatableOptions.empty())
     m_translatableOptions = stringSetting.m_translatableOptions;
   if (m_options.empty() && !stringSetting.m_options.empty())
@@ -1382,6 +1384,9 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
   {
     // get allowempty (needs to be parsed before parsing the default value)
     XMLUtils::GetBoolean(constraints, SETTING_XML_ELM_ALLOWEMPTY, m_allowEmpty);
+
+    // Values other than those in options contraints allowed to be added
+    XMLUtils::GetBoolean(constraints, SETTING_XML_ELM_ALLOWNEWOPTION, m_allowNewOption);
 
     // get the entries
     auto options = constraints->FirstChildElement(SETTING_XML_ELM_OPTIONS);
@@ -1452,7 +1457,7 @@ bool CSettingString::CheckValidity(const std::string &value) const
     if (!CheckSettingOptionsValidity(value, m_translatableOptions))
       return false;
   }
-  else if (!m_options.empty())
+  else if (!m_options.empty() && !m_allowNewOption)
   {
     if (!CheckSettingOptionsValidity(value, m_options))
       return false;
@@ -1569,6 +1574,7 @@ void CSettingString::copy(const CSettingString &setting)
   m_value = setting.m_value;
   m_default = setting.m_default;
   m_allowEmpty = setting.m_allowEmpty;
+  m_allowNewOption = setting.m_allowNewOption;
   m_translatableOptions = setting.m_translatableOptions;
   m_options = setting.m_options;
   m_optionsFillerName = setting.m_optionsFillerName;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -402,6 +402,8 @@ public:
 
   virtual bool AllowEmpty() const { return m_allowEmpty; }
   void SetAllowEmpty(bool allowEmpty) { m_allowEmpty = allowEmpty; }
+  bool AllowNewOption() const { return m_allowNewOption; }
+  void SetAllowNewOption(bool allowNewOption) { m_allowNewOption = allowNewOption; }
 
   SettingOptionsType GetOptionsType() const;
   const TranslatableStringSettingOptions& GetTranslatableOptions() const { return m_translatableOptions; }
@@ -430,6 +432,7 @@ protected:
   std::string m_value;
   std::string m_default;
   bool m_allowEmpty = false;
+  bool m_allowNewOption = false;
   TranslatableStringSettingOptions m_translatableOptions;
   StringSettingOptions m_options;
   std::string m_optionsFillerName;

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -37,6 +37,7 @@
 #define SETTING_XML_ELM_STEP "step"
 #define SETTING_XML_ELM_MAXIMUM "maximum"
 #define SETTING_XML_ELM_ALLOWEMPTY "allowempty"
+#define SETTING_XML_ELM_ALLOWNEWOPTION "allownewoption"
 #define SETTING_XML_ELM_DEPENDENCIES "dependencies"
 #define SETTING_XML_ELM_DEPENDENCY "dependency"
 #define SETTING_XML_ELM_UPDATES "updates"

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -21,6 +21,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIImage.h"
+#include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUISettingsSliderControl.h"
@@ -585,21 +586,97 @@ bool CGUIControlListSetting::OnClick()
   if (dialog == NULL)
     return false;
 
+  bool bValueAdded = false;
   CFileItemList options;
   std::shared_ptr<const CSettingControlList> control =
       std::static_pointer_cast<const CSettingControlList>(m_pSetting->GetControl());
-  if (!GetItems(m_pSetting, options, false) || options.Size() <= 0 ||
-      (!control->CanMultiSelect() && options.Size() <= 1))
-    return false;
+  bool optionsValid = GetItems(m_pSetting, options, false);
+  std::shared_ptr<const CSettingString> setting =
+    std::static_pointer_cast<const CSettingString>(m_pSetting);
+  if (!setting->AllowNewOption())
+  {
+    // Do not show dialog if
+    // * there are no items to be chosen or
+    // * only one value can be chosen and there are less than two items available
+    if (!optionsValid || options.Size() <= 0 || (!control->CanMultiSelect() && options.Size() <= 1))
+      return false;
 
-  dialog->Reset();
-  dialog->SetHeading(CVariant{Localize(m_pSetting->GetLabel())});
-  dialog->SetItems(options);
-  dialog->SetMultiSelection(control->CanMultiSelect());
-  dialog->Open();
+    dialog->Reset();
+    dialog->SetHeading(CVariant{Localize(m_pSetting->GetLabel())});
+    dialog->SetItems(options);
+    dialog->SetMultiSelection(control->CanMultiSelect());
+    dialog->Open();
 
-  if (!dialog->IsConfirmed())
-    return false;
+    if (!dialog->IsConfirmed())
+      return false;
+  }
+  else
+  {
+    // Possible to add items, as well as select from any options given
+    // Add any current values that are not options as items in list
+    std::vector<CVariant> list =
+      CSettingUtils::GetList(std::static_pointer_cast<const CSettingList>(m_pSetting));
+    for (const auto& value : list)
+    {
+      bool found = std::any_of(options.begin(), options.end(), [&](const auto& p) {
+        return p->GetProperty("value").asString() == value.asString();
+      });
+      if (!found)
+      {
+        CFileItemPtr item(new CFileItem(value.asString()));
+        item->SetProperty("value", value.asString());
+        item->Select(true);
+        options.Add(item);
+      }
+    }
+
+    bool bRepeat = true;
+    while (bRepeat)
+    {
+      std::string strAddButton = Localize(control->GetAddButtonLabel());
+      if (strAddButton.empty())
+        strAddButton = Localize(15019); // "ADD"
+      dialog->Reset(); // Clears AddButtonPressed
+      dialog->SetHeading(CVariant{ Localize(m_pSetting->GetLabel()) });
+      dialog->SetItems(options);
+      dialog->SetMultiSelection(control->CanMultiSelect());
+      dialog->EnableButton2(setting->AllowNewOption(), strAddButton);
+
+      dialog->Open();
+
+      if (!dialog->IsConfirmed())
+        return false;
+
+      if (dialog->IsButton2Pressed())
+      {
+        // Get new list value
+        std::string strLabel;
+        bool bValidType = false;
+        while (!bValidType && CGUIKeyboardFactory::ShowAndGetInput(
+          strLabel, CVariant{ Localize(control->GetAddButtonLabel()) }, false))
+        {
+          // Validate new value is unique and truncate at any comma
+          StringUtils::Trim(strLabel);
+          strLabel = strLabel.substr(0, strLabel.find(','));
+          if (!strLabel.empty())
+          {
+            bValidType = !std::any_of(options.begin(), options.end(), [&](const auto& p) {
+              return p->GetProperty("value").asString() == strLabel;
+            });
+          }
+          if (bValidType)
+          { // Add new value to the list of options
+            CFileItemPtr pItem(new CFileItem(strLabel));
+            pItem->Select(true);
+            pItem->SetProperty("value", strLabel);
+            options.Add(pItem);
+            bValueAdded = true;
+          }
+        }
+      }
+      bRepeat = dialog->IsButton2Pressed();
+    }
+  }
 
   std::vector<CVariant> values;
   for (int i : dialog->GetSelectedItems())
@@ -636,7 +713,7 @@ bool CGUIControlListSetting::OnClick()
   }
 
   if (ret)
-    UpdateFromSetting(true);
+    UpdateFromSetting(!bValueAdded);
   else
     SetValid(false);
 
@@ -654,12 +731,21 @@ void CGUIControlListSetting::Update(bool fromControl, bool updateDisplayOnly)
   std::shared_ptr<const CSettingControlList> control =
       std::static_pointer_cast<const CSettingControlList>(m_pSetting->GetControl());
   bool optionsValid = GetItems(m_pSetting, options, !updateDisplayOnly);
+  std::shared_ptr<const CSettingString> setting =
+    std::static_pointer_cast<const CSettingString>(m_pSetting);
   std::string label2;
   if (optionsValid && !control->HideValue())
   {
     SettingControlListValueFormatter formatter = control->GetFormatter();
     if (formatter)
       label2 = formatter(m_pSetting);
+
+    if (label2.empty() && setting->AllowNewOption())
+    {
+      const std::shared_ptr<const CSettingList> settingList =
+          std::static_pointer_cast<const CSettingList>(m_pSetting);
+      label2 = settingList->ToString();
+    }
 
     if (label2.empty())
     {
@@ -679,10 +765,10 @@ void CGUIControlListSetting::Update(bool fromControl, bool updateDisplayOnly)
 
   if (!updateDisplayOnly)
   {
-    // disable the control if
+    // Disable the control if no items can be added and
     // * there are no items to be chosen
     // * only one value can be chosen and there are less than two items available
-    if (!m_pButton->IsDisabled() &&
+    if (!m_pButton->IsDisabled() && !setting->AllowNewOption() &&
         (options.Size() <= 0 || (!control->CanMultiSelect() && options.Size() <= 1)))
       m_pButton->SetEnabled(false);
   }


### PR DESCRIPTION
Add option to settings selection list controls to allow the user to enter and select values not to the preset list of options.

When this property is enabled on the selection dialog displayed has a 3rd button. Clicking on that button displays the keyboard input dialog where the user can enter the new value.

`CSettingList` setting gains contsraint
-`<allownewoption>`  true when user is allowed to add selected values not in the set options
`CSettingControlList` gains property:
-`<addbuttonlabel>` the label for the both the button shown on the selection dialog and the heading of the subsequent keyboard entry dialog 

~First commit is https://github.com/xbmc/xbmc/pull/18235, **which must be merged first**, only the 2nd commit relates to this PR~.

This is part of a chain of PRs that lead to https://github.com/xbmc/xbmc/pull/18173 that provides GUI settings to control how music artwork is fetched. That PR can be used to test this functionality, and provides the example of why this is needed. Similar will be needed by video library/artwork  settings too.