### PR TITLE
[addons][cmake][binary] add test about "C" ABI

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+project(kodi-dev-kit)
+
+include(cmake/test/abi-interface-test.cmake)

--- a/xbmc/addons/kodi-addon-dev-kit/cmake/test/abi-interface-test.cmake
+++ b/xbmc/addons/kodi-addon-dev-kit/cmake/test/abi-interface-test.cmake
@@ -1,0 +1,181 @@
+option(DEVKIT_TEST "To test dev-kit" TRUE)
+option(DEVKIT_TEST_CPP "To test dev-kit headers correct in \"C++\" compile" FALSE)
+option(DEVKIT_TEST_STOP_ON_ERROR "To stop build if during \"C\" ABI test an error was found" FALSE)
+
+if(NOT DEVKIT_TEST)
+  return()
+endif()
+
+include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
+
+list(APPEND CMAKE_REQUIRED_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/include/kodi
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+
+message(STATUS "################################################################################")
+message(STATUS "# Run test about dev-kit headers for correct style")
+message(STATUS "#")
+
+# Set minimal required defines
+if(CORE_SYSTEM_NAME STREQUAL android)
+  set(DEVKIT_TEST_DEFINES "\
+#define HAS_GLES 3
+#define TARGET_POSIX
+#define TARGET_LINUX
+#define TARGET_ANDROID
+")
+elseif(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
+  set(DEVKIT_TEST_DEFINES "\
+#define HAS_GLES 2
+#define TARGET_POSIX
+#define TARGET_DARWIN
+#define TARGET_DARWIN_EMBEDDED
+")
+elseif(CORE_SYSTEM_NAME STREQUAL osx)
+  set(DEVKIT_TEST_DEFINES "\
+#define HAS_GL 1
+#define TARGET_DARWIN
+#define TARGET_DARWIN_OSX
+")
+elseif(CORE_SYSTEM_NAME STREQUAL windows)
+  set(DEVKIT_TEST_DEFINES "\
+#define HAS_DX 1
+#define WIN32
+#define TARGET_WINDOWS
+#define TARGET_WINDOWS_DESKTOP
+")
+elseif(CORE_SYSTEM_NAME STREQUAL linux)
+  set(DEVKIT_TEST_DEFINES "\
+#define HAS_GL 1
+#define TARGET_POSIX
+#define TARGET_LINUX
+")
+else()
+  set(DEVKIT_TEST_DEFINES "\
+#define HAS_GL 1
+#define TARGET_POSIX
+#define TARGET_FREEBSD
+")
+endif()
+
+# Read list of all available headers
+file(GLOB_RECURSE DEVKIT_HEADERS
+  include/kodi/*.h
+)
+
+##
+# Check the "C" headers itself with compile in "C"
+#
+
+message(STATUS "")
+message(STATUS "================================================================================")
+message(STATUS "Run \"C\" headers:")
+
+set(DEVKIT_HEADER_NO 0)
+foreach(DEVKIT_HEADER ${DEVKIT_HEADERS})
+  if(NOT DEVKIT_HEADER MATCHES "c-api")
+    continue()
+  endif()
+
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/include/" "" DEVKIT_HEADER_NAME ${DEVKIT_HEADER})
+
+  message(STATUS "--------------------------------------------------------------------------------")
+  message(STATUS "Checking \"C\" ABI about \"#include <${DEVKIT_HEADER_NAME}>\":")
+
+  math(EXPR DEVKIT_HEADER_NO "${DEVKIT_HEADER_NO}+1")
+  set(DEVKIT_TEST_NAME "C_TEST_BUILD_A_${DEVKIT_HEADER_NO}")
+
+  check_c_source_compiles("\
+${DEVKIT_TEST_DEFINES}
+#include \"${DEVKIT_HEADER}\"
+int main()
+{
+  return 0;
+}" ${DEVKIT_TEST_NAME})
+
+  if (NOT ${DEVKIT_TEST_NAME} EQUAL 1)
+    if(${DEVKIT_TEST_STOP_ON_ERROR})
+      message(FATAL_ERROR " - Header not match needed \"C\" ABI: \"#include <${DEVKIT_HEADER_NAME}>\" (see CMakeError.log)")
+    else()
+      message(STATUS " - WARNING: Header not match needed \"C\" ABI: \"#include <${DEVKIT_HEADER_NAME}>\" (see CMakeError.log)")
+    endif()
+  endif()
+endforeach()
+
+##
+# Check the "C++" headers itself with compile in "C"
+#
+message(STATUS "")
+message(STATUS "================================================================================")
+message(STATUS "Run \"C++\" headers (to confirm there a safe within \"C\"):")
+
+set(DEVKIT_HEADER_NO 0)
+foreach(DEVKIT_HEADER ${DEVKIT_HEADERS})
+  if(DEVKIT_HEADER MATCHES "c-api")
+    continue()
+  endif()
+
+  string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/include/" "" DEVKIT_HEADER_NAME ${DEVKIT_HEADER})
+
+  message(STATUS "--------------------------------------------------------------------------------")
+  message(STATUS "Checking \"C\" ABI about \"#include <${DEVKIT_HEADER_NAME}>\":")
+
+  math(EXPR DEVKIT_HEADER_NO "${DEVKIT_HEADER_NO}+1")
+  set(DEVKIT_TEST_NAME "C_TEST_BUILD_B_${DEVKIT_HEADER_NO}")
+
+  check_c_source_compiles("\
+${DEVKIT_TEST_DEFINES}
+#include \"${DEVKIT_HEADER}\"
+int main()
+{
+  return 0;
+}" ${DEVKIT_TEST_NAME})
+
+  if (NOT ${DEVKIT_TEST_NAME} EQUAL 1)
+    if(${DEVKIT_TEST_STOP_ON_ERROR})
+      message(FATAL_ERROR " - \"C++\" header not safe about \"C\" ABI: \"#include <${DEVKIT_HEADER_NAME}>\" (see CMakeError.log)")
+    else()
+      message(STATUS " - WARNING: \"C++\" header not safe about \"C\" ABI: \"#include <${DEVKIT_HEADER_NAME}>\" (see CMakeError.log)")
+    endif()
+  endif()
+endforeach()
+
+##
+# Check the "C++" headers itself with compile in "C++"
+#
+if(DEVKIT_TEST_CPP)
+  message(STATUS "")
+  message(STATUS "================================================================================")
+  message(STATUS "Run \"C++\" headers (to confirm there a correct within \"C++\"):")
+
+  set(DEVKIT_HEADER_NO 0)
+  foreach(DEVKIT_HEADER ${DEVKIT_HEADERS})
+    if(DEVKIT_HEADER MATCHES "c-api")
+      continue()
+    endif()
+
+    string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/include/" "" DEVKIT_HEADER_NAME ${DEVKIT_HEADER})
+
+    message(STATUS "--------------------------------------------------------------------------------")
+    message(STATUS "Checking \"C++\" about \"#include <${DEVKIT_HEADER_NAME}>\":")
+
+    math(EXPR DEVKIT_HEADER_NO "${DEVKIT_HEADER_NO}+1")
+    set(DEVKIT_TEST_NAME "CPP_TEST_BUILD_${DEVKIT_HEADER_NO}")
+
+    check_cxx_source_compiles("\
+${DEVKIT_TEST_DEFINES}
+#include \"${DEVKIT_HEADER}\"
+int main()
+{
+  return 0;
+}" ${DEVKIT_TEST_NAME})
+
+    if (NOT ${DEVKIT_TEST_NAME} EQUAL 1)
+      if(${DEVKIT_TEST_STOP_ON_ERROR})
+        message(FATAL_ERROR " - \"C++\" header failed to build: \"#include <${DEVKIT_HEADER_NAME}>\" (see CMakeError.log)")
+      else()
+        message(STATUS " - \"C++\" header failed to build: \"#include <${DEVKIT_HEADER_NAME}>\" (see CMakeError.log)")
+      endif()
+    endif()
+  endforeach()
+endif()


### PR DESCRIPTION
## Description
This introduces cmake-based test system to the addon headers.
The background to this is to have the header contained therein in the correct "C" ABI.
This is not yet called up by Kodi's creation itself, as there are still many errors in it.

The background is easy to check whether it is correct and if everything has been reworked to be carried out during Kodi's creation to avoid new mistakes.

Why this cmake is in this folder has another background, regarding trademark policy history it could come that the dev-kit folder is independent and not directly in Kodi.
In addition, you have a better overview of what the new "abi-interface-test.cmake" belongs to and is not mixed with Kodi's other cmake stuff.

Why the header must be so explicit in "C" has the following reasons:
- As a basis for other languages
- With more security if Kodi and Addon were created by different compilers and versions

Here his pasted output:
https://paste.ubuntu.com/p/7wBvm7WpZ2/

## User related
Purely for the development side and uninteresting for users.

Only for all binary addon system requests may be for the user:
- Binary addon system revised to ensure higher security in its data exchange between addon and Kodi
- Revised binary addon system documentation for outside developers

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
```sh
mkdir xbmc/addons/kodi-addon-dev-kit/build
cd xbmc/addons/kodi-addon-dev-kit/build
cmake .. -DDEVKIT_TEST_STOP_ON_ERROR=FALSE -DDEVKIT_TEST_CPP=true
```

Temporary also added in Kodi's build to see what jenkins say.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
