### PR TITLE
[cmake] fix build by remove quotation marks on ExternalProject values

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -185,7 +185,7 @@ function(add_addon_depends addon searchpath)
         set(EXTERNALPROJECT_SETUP PREFIX ${BUILD_DIR}/${id}
                                   CMAKE_ARGS ${extraflags} ${BUILD_ARGS}
                                   PATCH_COMMAND ${PATCH_COMMAND}
-                                  "${INSTALL_COMMAND}")
+                                  ${INSTALL_COMMAND})
 
         if(CMAKE_VERSION VERSION_GREATER 3.5.9)
           list(APPEND EXTERNALPROJECT_SETUP GIT_SHALLOW 1)
@@ -201,7 +201,7 @@ function(add_addon_depends addon searchpath)
             externalproject_add(${id}
                                 GIT_REPOSITORY ${url}
                                 GIT_TAG ${revision}
-                                "${EXTERNALPROJECT_SETUP}")
+                                ${EXTERNALPROJECT_SETUP})
 
             # For patchfiles to work, disable (users globally set) autocrlf=true
             if(CMAKE_MINIMUM_REQUIRED_VERSION VERSION_GREATER 3.7)
@@ -249,12 +249,12 @@ function(add_addon_depends addon searchpath)
                                 "${URL_HASH_COMMAND}"
                                 DOWNLOAD_DIR ${DOWNLOAD_DIR}
                                 CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
-                                "${EXTERNALPROJECT_SETUP}")
+                                ${EXTERNALPROJECT_SETUP})
           endif()
         else()
           externalproject_add(${id}
                               SOURCE_DIR ${dir}
-                              "${EXTERNALPROJECT_SETUP}")
+                              ${EXTERNALPROJECT_SETUP})
         endif()
 
         if(deps)


### PR DESCRIPTION
## Description
Before was about externalproject_add and related values, quotation marks used.
This breaks since cmake 3.18.0 his use (3.17.4 ok about).

There it reports this by project related "PATCH_COMMAND ${PATCH_COMMAND}" as there a "" behind and seems to take this instead of patch path.

Produced error message:
```
patching file ''
Hunk #1 FAILED at 16.
1 out of 1 hunk FAILED -- saving rejects to file .rej
/usr/bin/patch: **** Can't reopen file '' : No such file or directory
```

This 2 values has used the quotation marks:
- INSTALL_COMMAND
- EXTERNALPROJECT_SETUP

This remove them to have working again and fix e.g. Azure build system where takes this new version.

## User related:
Not user relevant

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
