### PR TITLE
Allow scanning of album art served over http

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1066,6 +1066,13 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const std::string &p
   if (albums.size() == 1)
   {
     CFileItem album(path, true);
+    /* If we are scanning a directory served over http(s) the root directory for an album will set
+     * IsInternetStream to true which prevents scanning it for art.  As we can't reach this point
+     * without having read some tags (and tags are not read from streams) we can safely check for
+     * that case and set the IsHTTPDirectory property to enable scanning for art.
+     */
+    if (StringUtils::StartsWithNoCase(path, "http") && StringUtils::EndsWith(path, "/"))
+      album.SetProperty("IsHTTPDirectory", true);
     albumArt = album.GetUserMusicThumb(true);
     if (!albumArt.empty())
       albums[0].art["thumb"] = albumArt;


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/xbmc/xbmc/pull/18218 . That PR allowed reading of tags from files served over http however it transpired that thumbnails were never assigned to the albums.  This PR corrects that.

## Motivation and Context
As explained above, Kodi was unable to read the album art thumbnail from an http directory.  This is because HTTPDirectory.cpp doesn't set the required property.  Kodi then thinks the directory is an internet stream and skips trying to load art from it.  This hasn't yet been raised as an issue but the previous fix didn't feel complete as the art didn't load.

## How Has This Been Tested?
Tested by scanning in multiple albums and associated art from a local Apache2 http server. 

## Screenshots (if appropriate):

## User related
Kodi will correctly load album thumbnails when scanning music files served over http.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
