### PR TITLE
[PVR] Fix grid container model access with invalid index in CGUIEPGGridContainer::GetDescription().

### DIFF
--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1651,10 +1651,15 @@ std::string CGUIEPGGridContainer::GetDescription() const
 {
   CSingleLock lock(m_critSection);
 
-  const std::shared_ptr<CFileItem> item =
-      m_gridModel->GetGridItem(m_channelCursor + m_channelOffset, m_blockCursor + m_blockOffset);
-  if (item)
-    return item->GetLabel();
+  const int channelIndex = m_channelCursor + m_channelOffset;
+  const int blockIndex = m_blockCursor + m_blockOffset;
+
+  if (channelIndex < m_gridModel->ChannelItemsSize() && blockIndex < m_gridModel->GridItemsSize())
+  {
+    const std::shared_ptr<CFileItem> item = m_gridModel->GetGridItem(channelIndex, blockIndex);
+    if (item)
+      return item->GetLabel();
+  }
 
   return {};
 }


### PR DESCRIPTION
Fixes #18256 

Runtime tested on macOS, latest Kodi master + pvr.demo.

@phunkyfish mind looking at the code change?

@ronie , @howie-f fyi