### PR TITLE
[Estuary] [OSD] Adjustments & Fixes following PR18155

### DIFF
--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -55,24 +55,33 @@
 					<onclick>PlayerControl(Rewind)</onclick>
 					<visible>Player.SeekEnabled</visible>
 				</control>
-				<control type="radiobutton" id="602">
-					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/play.png</textureradioonfocus>
-					<textureradioonnofocus>osd/fullscreen/buttons/play.png</textureradioonnofocus>
-					<textureradioofffocus colordiffuse="white">osd/fullscreen/buttons/pause.png</textureradioofffocus>
-					<textureradiooffnofocus>osd/fullscreen/buttons/pause.png</textureradiooffnofocus>
-					<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
+				<control type="group" id="698">
 					<width>76</width>
-					<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back">Focus</animation>
 					<height>76</height>
-					<radiowidth>74</radiowidth>
-					<radioheight>74</radioheight>
-					<font></font>
-					<texturenofocus />
-					<radioposx>1</radioposx>
-					<radioposy>0</radioposy>
-					<selected>Player.Paused</selected>
-					<onclick>PlayerControl(Play)</onclick>
 					<visible>Player.PauseEnabled</visible>
+					<control type="button" id="602">
+						<left>0</left>
+						<top>0</top>
+						<width>74</width>
+						<height>74</height>
+						<label></label>
+						<font></font>
+						<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
+						<texturenofocus />
+						<onleft>601</onleft>
+						<onright>603</onright>
+						<onup>87</onup>
+						<ondown>noop</ondown>
+						<onclick>PlayerControl(Play)</onclick>
+					</control>
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>74</width>
+						<height>74</height>
+						<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(602)">Conditional</animation>
+						<texture colordiffuse="white">$VAR[PlayerControlsPlayImageVar]</texture>
+					</control>
 				</control>
 				<control type="radiobutton" id="603">
 					<include content="OSDButton">
@@ -190,7 +199,7 @@
 						<top>0</top>
 						<width>74</width>
 						<height>74</height>
-						<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(704)">Conditional</animation>
+						<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(70053)">Conditional</animation>
 						<texture colordiffuse="white">$VAR[PlayerControlsRepeatImageVar]</texture>
 					</control>
 				</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -238,6 +238,8 @@
 	<variable name="OSDHelpTextVar">
 		<value condition="Control.HasFocus(87) + !Player.Paused">$LOCALIZE[31054]</value>
 		<value condition="Control.HasFocus(87) + [Player.Paused + Window.IsVisible(videoosd)]">$LOCALIZE[31055]</value>
+		<value condition="Control.HasFocus(608)+ PVR.IsRecordingPlayingChannel">$LOCALIZE[19059]</value>
+		<value condition="Control.HasFocus(608)">$LOCALIZE[264]</value>
 		<value condition="Control.HasFocus(70040)">$LOCALIZE[19019]</value>
 		<value condition="Control.HasFocus(70041)">$LOCALIZE[19069]</value>
 		<value condition="Control.HasFocus(70042)">$LOCALIZE[31065]</value>
@@ -426,6 +428,10 @@
 		<value condition="Control.HasFocus(103)">$LOCALIZE[19040]</value>
 		<value condition="Control.HasFocus(104)">$LOCALIZE[19138]</value>
 		<value condition="Control.HasFocus(105)">$LOCALIZE[137]</value>
+	</variable>
+	<variable name="PlayerControlsPlayImageVar">
+		<value condition="Player.Playing">osd/fullscreen/buttons/pause.png</value>
+		<value>osd/fullscreen/buttons/play.png</value>
 	</variable>
 	<variable name="PlayerControlsRepeatImageVar">
 		<value condition="Playlist.IsRepeatOne">osd/fullscreen/buttons/repeat-one.png</value>

--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -58,26 +58,35 @@
 							<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 						</include>
 						<onclick>PlayerControl(Rewind)</onclick>
-						<visible>Player.SeekEnabled</visible>
+						<visible>Player.SeekEnabled + !VideoPlayer.Content(livetv)</visible>
 					</control>
-					<control type="radiobutton" id="602">
-						<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/play.png</textureradioonfocus>
-						<textureradioonnofocus>osd/fullscreen/buttons/play.png</textureradioonnofocus>
-						<textureradioofffocus colordiffuse="white">osd/fullscreen/buttons/pause.png</textureradioofffocus>
-						<textureradiooffnofocus>osd/fullscreen/buttons/pause.png</textureradiooffnofocus>
-						<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
+					<control type="group" id="698">
 						<width>76</width>
-						<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back">Focus</animation>
 						<height>76</height>
-						<radiowidth>74</radiowidth>
-						<radioheight>74</radioheight>
-						<font></font>
-						<texturenofocus />
-						<radioposx>1</radioposx>
-						<radioposy>0</radioposy>
-						<selected>Player.Paused</selected>
-						<onclick>PlayerControl(Play)</onclick>
 						<visible>Player.PauseEnabled</visible>
+						<control type="button" id="602">
+							<left>0</left>
+							<top>0</top>
+							<width>74</width>
+							<height>74</height>
+							<label></label>
+							<font></font>
+							<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
+							<texturenofocus />
+							<onleft>601</onleft>
+							<onright>603</onright>
+							<onup>87</onup>
+							<ondown>noop</ondown>
+							<onclick>PlayerControl(Play)</onclick>
+						</control>
+						<control type="image">
+							<left>0</left>
+							<top>0</top>
+							<width>74</width>
+							<height>74</height>
+							<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(602)">Conditional</animation>
+							<texture colordiffuse="white">$VAR[PlayerControlsPlayImageVar]</texture>
+						</control>
 					</control>
 					<control type="radiobutton" id="603">
 						<include content="OSDButton">
@@ -90,14 +99,14 @@
 							<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 						</include>
 						<onclick>PlayerControl(Forward)</onclick>
-						<visible>Player.SeekEnabled</visible>
+						<visible>Player.SeekEnabled + !VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="radiobutton" id="607">
 						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 						</include>
 						<onclick>PlayerControl(Next)</onclick>
-						<visible>Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | [VideoPlayer.Content(LiveTV) + Player.SeekEnabled]</visible>
+						<visible>Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1) | PVR.IsTimeShift</visible>
 					</control>
 					<control type="radiobutton" id="608">
 						<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>


### PR DESCRIPTION
Follow up to https://github.com/xbmc/xbmc/pull/18155

### CHANGE - Disable REW/FF for Live TV

There's been some debate on Slack about the usefulness for REW/FF for Live TV following PR18155. The main problem raised by @phunkyfish is that REW/FF became enabled for IPTV streams where it may not be possible to smoothly REW/FF. As we have no way to distinguish between streams from a local network PVR server or a IPTV service over internet, I therefore decided to disable these controls for Live TV. I considered adding a GUI skin setting to enable/disable these buttons but decided to keep it simple, it's a easy skin edit to remove the ` !VideoPlayer.Content(livetv)` if anyone wants them.

### CHANGE - Simplified visible condition for PlayerControl(Next)

Replace the [VideoPlayer.Content(LiveTV) + Player.SeekEnabled] with the simpler `PVR.IsTimeShift` as `PlayerControl(Next)` only works in Live TV when time shifting.

### FIX - Labels of record button were accidentally removed in PR18155

As seen below I experimented with creating new icons for Record so the labels wouldn't be needed (as none of the other player control buttons have labels). In the end came to the conclusion that the simplest thing would be to keep the existing button images and re-introduce the labels that had accidentally been removed.

### FIX - Pause image shown for Play/Pause button when rewinding/forwarding

New to this update of PR. It was noticed that when REW/FF the Play/Pause button displays the Pause image however the action when pressing the button would be Play so when REW/FF the Play image should be shown.

**Before - Pause image shown when forwarding, does not match action**
![image](https://user-images.githubusercontent.com/5781142/90956486-ef4c7900-e47e-11ea-8b3d-e52511e33ac3.png)

**After - Play image shown when forwarding to match action**
![image](https://user-images.githubusercontent.com/5781142/90956510-215ddb00-e47f-11ea-9beb-f802571d5bbc.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

