### PR TITLE
remove ListItem.Property(Addon.OriginType) infolabel as it's a duplicate of ListItem.AddonOrigin

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15853,7 +15853,13 @@ msgctxt "#25013"
 msgid "Auto-skip on"
 msgstr ""
 
-#empty strings from id 25014 to 29800
+#. Used to tell addon origin type
+#. xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+msgctxt "#25014"
+msgid "Manual"
+msgstr ""
+
+#empty strings from id 25015 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15853,29 +15853,7 @@ msgctxt "#25013"
 msgid "Auto-skip on"
 msgstr ""
 
-#. Used for skins to tell addon origin type
-#. xbmc/filesystem/AddonsDirectory.cpp
-#: addons/skin.estuary/xml/DialogAddonInfo.xml
-msgctxt "#25014"
-msgid "system"
-msgstr ""
-
-#. Used for skins to tell addon origin type
-#. xbmc/filesystem/AddonsDirectory.cpp
-#: addons/skin.estuary/xml/AddonBrowser.xml
-msgctxt "#25015"
-msgid "repository"
-msgstr ""
-
-#. Used for skins to tell addon origin type
-#. xbmc/filesystem/AddonsDirectory.cpp
-#: addons/skin.estuary/xml/AddonBrowser.xml
-#: addons/skin.estuary/xml/DialogAddonInfo.xml
-msgctxt "#25016"
-msgid "manual"
-msgstr ""
-
-#empty strings from id 25017 to 29800
+#empty strings from id 25014 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -683,7 +683,7 @@ msgstr ""
 
 #: /xml/DialogAddonInfo.xml
 msgctxt "#31150"
-msgid "Repository"
+msgid "Origin"
 msgstr ""
 
 #: /xml/Home.xml

--- a/addons/skin.estuary/xml/DialogAddonInfo.xml
+++ b/addons/skin.estuary/xml/DialogAddonInfo.xml
@@ -247,14 +247,14 @@
 					<control type="label">
 						<width>470</width>
 						<height>40</height>
-						<label>$INFO[ListItem.AddonSize,[COLOR button_focus]$LOCALIZE[22031]:[/COLOR] ,[CR]]</label>
-						<visible>!String.IsEmpty(ListItem.AddonSize)</visible>
+						<label>$INFO[ListItem.AddonOrigin,[COLOR button_focus]$LOCALIZE[31150]:[/COLOR] ]</label>
+						<visible>!String.IsEmpty(ListItem.AddonOrigin)</visible>
 					</control>
 					<control type="label">
 						<width>470</width>
 						<height>40</height>
-						<label>$INFO[ListItem.AddonOrigin,[COLOR button_focus]$LOCALIZE[31150]:[/COLOR] ]</label>
-						<visible>!String.IsEmpty(ListItem.AddonOrigin) + ListItem.Property(addon.isinstalled)</visible>
+						<label>$INFO[ListItem.AddonSize,[COLOR button_focus]$LOCALIZE[22031]:[/COLOR] ,[CR]]</label>
+						<visible>!String.IsEmpty(ListItem.AddonSize)</visible>
 					</control>
 				</control>
 			</control>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4389,14 +4389,6 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @skinning_v19 **[New Boolean Condition]** \link ListItem_Property_AddonIsBinary `ListItem.Property(Addon.IsBinary)`\endlink
 ///     <p>
 ///   }
-///   \table_row3{   <b>`ListItem.Property(Addon.OriginType)`</b>,
-///                  \anchor ListItem_Property_AddonOriginType
-///                  _string_,
-///     @return A string representing the origin type. One of system\, repository or manual.
-///     <p><hr>
-///     @skinning_v19 **[New String Value]** \link ListItem_Property_AddonOriginType `ListItem.Property(Addon.OriginType)`\endlink
-///     <p>
-///   }
 ///   \table_row3{   <b>`ListItem.Label`</b>,
 ///                  \anchor ListItem_Label
 ///                  _string_,

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -788,29 +788,12 @@ void CAddonsDirectory::GenerateAddonListing(const CURL &path,
     bool disabled = CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
     bool hasUpdate = outdated.find(addon->ID()) != outdated.end();
     bool fromOfficialRepo = CServiceBroker::GetAddonMgr().IsFromOfficialRepo(addon);
-    AddonOriginType addonOriginType = CServiceBroker::GetAddonMgr().GetAddonOriginType(addon);
 
     pItem->SetProperty("Addon.IsInstalled", installed);
     pItem->SetProperty("Addon.IsEnabled", installed && !disabled);
     pItem->SetProperty("Addon.HasUpdate", hasUpdate);
     pItem->SetProperty("Addon.IsFromOfficialRepo", fromOfficialRepo);
     pItem->SetProperty("Addon.IsBinary", addon->IsBinary());
-
-    std::string addonOriginTypeProperty;
-    switch (addonOriginType)
-    {
-      case AddonOriginType::SYSTEM:
-        addonOriginTypeProperty = g_localizeStrings.Get(25014); // system
-        break;
-      case AddonOriginType::REPOSITORY:
-        addonOriginTypeProperty = g_localizeStrings.Get(25015); // repository
-        break;
-      case AddonOriginType::MANUAL:
-      default:
-        addonOriginTypeProperty = g_localizeStrings.Get(25016); // manual
-        break;
-    }
-    pItem->SetProperty("Addon.OriginType", addonOriginTypeProperty);
 
     if (installed)
       pItem->SetProperty("Addon.Status", g_localizeStrings.Get(305));

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -91,7 +91,12 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
           value = origin->Name();
           return true;
         }
-        value = g_localizeStrings.Get(13205);
+        else if (!item->GetAddonInfo()->Origin().empty())
+        {
+          value = item->GetAddonInfo()->Origin();
+          return true;
+        }
+        value = g_localizeStrings.Get(25014);
         return true;
       }
       case LISTITEM_ADDON_SIZE:


### PR DESCRIPTION
## Description
in https://github.com/xbmc/xbmc/pull/18181 @phunkyfish added a new infolabel `ListItem.Property(Addon.OriginType)` which allow skins to display where a certain addon was installed from.
however, we already had an infolabel (ListItem.AddonOrigin) which provides nearly the exact same functionality.

- this PR removes the `ListItem.Property(Addon.OriginType)` infolabel.
- manually installed addons are now listed as 'Manual' instead of 'Unknown'
- in the estuary skin, use 'origin' as a prefix for the addon origin

@ProfYaffle are you keeping up so far?

## Motivation and Context
there is no need to add duplicate code.

## How Has This Been Tested?
i've tested it using the estuary skin, by opening the addon info dialog on various addons.
included in the test are addons that were:
- installed through a zipfile
- installed from the kodi addon repository
- shipped with kodi

## Screenshots (if appropriate):
before:
![old](https://user-images.githubusercontent.com/687265/89745170-3d8e6f00-dab2-11ea-8e21-6b34afda5597.jpg)

after:
![repository](https://user-images.githubusercontent.com/687265/89745175-441ce680-dab2-11ea-8714-16890d5764ed.jpg)
![manual](https://user-images.githubusercontent.com/687265/89745178-48e19a80-dab2-11ea-9e4d-c8d9918db681.jpg)
![system](https://user-images.githubusercontent.com/687265/89745179-4b43f480-dab2-11ea-8ca5-59687e100531.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
