### PR TITLE
[depends/target] fix runtime failure Pillow 7.1.2

### DIFF
--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -14,6 +14,13 @@ PYTHONPATH=$(PREFIX)/lib/python3.7/site-packages/
 PILPATH=$(PYTHONPATH)
 LDSHARED=$(CC) -shared
 
+# Clear pkg-config data, as it will pull from Native pkg-config incorrectly
+ifeq ($(CROSS_COMPILING), yes)
+export PKG_CONFIG_PATH=
+export PKG_CONFIG_LIBDIR=${PREFIX}/lib/pkgconfig
+export PKG_CONFIG_SYSROOT_DIR=${SDKROOT}
+endif
+
 ifeq ($(OS),android)
 PILPATH=$(PREFIX)/share/$(APP_NAME)/addons/script.module.pil
 PILPATHLIB=$(PILPATH)/lib
@@ -28,10 +35,11 @@ endif
 ifeq (darwin, $(findstring darwin, $(HOST)))
 #ensure that only our target ldflags are passed to the python build
 LDSHARED=$(CC) -bundle -undefined dynamic_lookup
+ZLIB_ROOT=ZLIB_ROOT="$(SDKROOT)/usr"
 endif
 
 BUILD_OPTS=--plat-name $(OS)-$(CPU) --disable-jpeg2000 --disable-webp --disable-imagequant --disable-tiff --disable-webp --disable-webpmux --disable-xcb --disable-lcms --disable-platform-guessing
-CROSSFLAGS=PYTHONXCPREFIX="$(PREFIX)" CC="$(CC) $(CFLAGS)" LDSHARED="$(LDSHARED)" LDFLAGS="$(LDFLAGS) $(EXTRALDFLAGS)" PYTHONPATH="$(PYTHONPATH)"
+CROSSFLAGS=$(ZLIB_ROOT) PYTHONXCPREFIX="$(PREFIX)" CC="$(CC) $(CFLAGS)" LDSHARED="$(LDSHARED)" LDFLAGS="$(LDFLAGS) $(EXTRALDFLAGS)" PYTHONPATH="$(PYTHONPATH)"
 
 all: .installed-$(PLATFORM)
 


### PR DESCRIPTION
## Description
Pillow is incorrectly linking native dependencies for zlib due to pkg-config using native pc data.
For Darwin systems, correctly set and use SDKROOT for zlib, as we dont build zlib for target platforms.

TLDR: Fix pillow running on osx from jenkins built binaries

## Motivation and Context
User posted on forums about failure to use Pillow library on osx https://forum.kodi.tv/showthread.php?tid=356325

## How Has This Been Tested?
otool -L of the _imaging.cpython-37-darwin.so correctly links against sysroot zlib

Before:
```
macosx10.15_x86_64-target-debug/build/lib.macosx-10.15-x86_64-3.7/PIL/_imaging.cpython-37-darwin.so:
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/Users/Shared/xbmc-depends/x86_64-darwin19.5.0-native/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
```

After:
```
macosx10.15_x86_64-target-debug/build/lib.macosx-10.15-x86_64-3.7/PIL/_imaging.cpython-37-darwin.so:
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
