### PR TITLE
Fix CSettingControlList regression after adding user values option

### DIFF
--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -402,7 +402,7 @@ public:
 
   virtual bool AllowEmpty() const { return m_allowEmpty; }
   void SetAllowEmpty(bool allowEmpty) { m_allowEmpty = allowEmpty; }
-  bool AllowNewOption() const { return m_allowNewOption; }
+  virtual bool AllowNewOption() const { return m_allowNewOption; }
   void SetAllowNewOption(bool allowNewOption) { m_allowNewOption = allowNewOption; }
 
   SettingOptionsType GetOptionsType() const;


### PR DESCRIPTION
Follow up to https://github.com/xbmc/xbmc/pull/18236 CSettingControlList  - the addition of option to allow users to enter new values not on the preset list, which caused a regression in some types of selection list setting controls. Reported here https://github.com/xbmc/xbmc/pull/18236#issuecomment-671101025

The problem was casting setting as `CSettingString` to get property, without conditional checks for other list element types, and using `GetDefinition()`

@ksooo thanks for picking up on this so quickly