### PR TITLE
[addons] fix database column select and table field order

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -166,7 +166,7 @@ void CAddonDatabase::CreateTables()
   CLog::Log(LOGINFO, "create installed table");
   m_pDS->exec("CREATE TABLE installed (id INTEGER PRIMARY KEY, addonID TEXT UNIQUE, "
               "enabled BOOLEAN, installDate TEXT, lastUpdated TEXT, lastUsed TEXT, "
-              "disabledReason INTEGER NOT NULL DEFAULT 0, origin TEXT NOT NULL DEFAULT '') \n");
+              "origin TEXT NOT NULL DEFAULT '', disabledReason INTEGER NOT NULL DEFAULT 0) \n");
 }
 
 void CAddonDatabase::CreateAnalytics()

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -1066,14 +1066,16 @@ void CAddonDatabase::GetInstallData(const AddonInfoPtr& addon)
     if (!m_pDS)
       return;
 
-    m_pDS->query(PrepareSQL("SELECT * FROM installed WHERE addonID='%s'", addon->ID().c_str()));
+    m_pDS->query(PrepareSQL("SELECT addonID, installDate, lastUpdated, lastUsed, "
+                            "origin FROM installed WHERE addonID='%s'",
+                            addon->ID().c_str()));
     if (!m_pDS->eof())
     {
-      CAddonInfoBuilder::SetInstallData(addon,
-                                        CDateTime::FromDBDateTime(m_pDS->fv(3).get_asString()),
-                                        CDateTime::FromDBDateTime(m_pDS->fv(4).get_asString()),
-                                        CDateTime::FromDBDateTime(m_pDS->fv(5).get_asString()),
-                                        m_pDS->fv(6).get_asString());
+      CAddonInfoBuilder::SetInstallData(
+          addon, CDateTime::FromDBDateTime(m_pDS->fv("installDate").get_asString()),
+          CDateTime::FromDBDateTime(m_pDS->fv("lastUpdated").get_asString()),
+          CDateTime::FromDBDateTime(m_pDS->fv("lastUsed").get_asString()),
+          m_pDS->fv("origin").get_asString());
     }
     m_pDS->close();
   }


### PR DESCRIPTION
## Description
Explicitly select columns in addon database query to ensure the correct fields are retrieved and passed through.
Fixes an issue reported in #18181

on creation of addons-table "installed" column `disabledReason` is appended to existing cols

## How Has This Been Tested?
local installation on debian

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@ronie and @phunkyfish 