### PR TITLE
[Windows] Get size of system RAM installed

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -495,6 +495,8 @@ bool CApplication::Create(const CAppParamParser &params)
 
     //! @todo - move to CPlatformXXX ???
 #if defined(TARGET_WINDOWS)
+  CLog::Log(LOGINFO, "System has {:.1f} GB of RAM installed",
+            CWIN32Util::GetSystemMemorySize() / static_cast<double>(MB));
   CLog::Log(LOGINFO, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGINFO, "Running with %s rights",
             (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator"

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -312,6 +312,20 @@ int CWIN32Util::GetDesktopColorDepth()
 #endif
 }
 
+size_t CWIN32Util::GetSystemMemorySize()
+{
+#ifdef TARGET_WINDOWS_STORE
+  MEMORYSTATUSEX statex = {};
+  statex.dwLength = sizeof(statex);
+  GlobalMemoryStatusEx(&statex);
+  return static_cast<size_t>(statex.ullTotalPhys / KB);
+#else
+  ULONGLONG ramSize = 0;
+  GetPhysicallyInstalledSystemMemory(&ramSize);
+  return static_cast<size_t>(ramSize);
+#endif
+}
+
 #ifdef TARGET_WINDOWS_DESKTOP
 std::string CWIN32Util::GetSpecialFolder(int csidl)
 {
@@ -957,7 +971,7 @@ extern "C" {
       const char * const *n2, int c)
   {
     int i;
-    unsigned int len;
+    size_t len;
 
     /* check full name - then abbreviated ones */
     for (; n1 != NULL; n1 = n2, n2 = NULL) {

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -32,6 +32,7 @@ public:
   static bool XBMCShellExecute(const std::string &strPath, bool bWaitForScriptExit=false);
   static std::string GetResInfoString();
   static int GetDesktopColorDepth();
+  static size_t GetSystemMemorySize();
 
   static std::string GetSystemPath();
   static std::string GetProfilePath();


### PR DESCRIPTION
## Description
Add in the log the size of the RAM memory installed in the system.

Before:
```
2020-08-09 19:34:12.984 T:10360    INFO <general>: Host CPU: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz, 8 cores available
2020-08-09 19:34:12.984 T:10360    INFO <general>: Desktop Resolution: 1920x1200 32Bit at 59Hz
```

After:
```
2020-08-09 19:14:05.311 T:14256    INFO <general>: Host CPU: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz, 8 cores available
2020-08-09 19:14:05.311 T:14256    INFO <general>: System has 16.0 GB of RAM installed
2020-08-09 19:14:05.311 T:14256    INFO <general>: Desktop Resolution: 1920x1200 32Bit at 59Hz
```

## Motivation and Context
Some system without graphics dedicated video memory uses Windows system memory as shared video memory. For 4K DXVA2 decoding is need ~3GB of video memory (in total, not only for decoding). 

Windows only can use 1/2 of total system memory as shared video memory, so in a system with 4GB of  RAM only is available 2GB of shared video memory that is insufficient.

Here it is only shown RAM installed for informational purposes and help to troubleshooting. In another PR is checked at runtime, in more precise manner, video memory available to avoid crash due 4K DXVA2 decoding on low memory systems.

## How Has This Been Tested?
Run Kodi on system with 16 GB of RAM installed and capture log.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
