### PR TITLE
[filesystem][music] fix music tag set if file contains several streams

### DIFF
--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -50,7 +50,9 @@ bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)
   if (!m_struct.toAddon->init)
     return false;
 
-  // for replaygain
+  /// for replaygain
+  /// @todo About audio decoder in most cases Kodi's one not work, add fallback
+  /// to use addon if this fails. Need API change about addons music info tag!
   CTagLoaderTagLib tag;
   tag.Load(file.GetDynPath(), XFILE::CMusicFileDirectory::m_tag, NULL);
 

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -51,7 +51,12 @@ bool CMusicFileDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     else if (m_tag.Loaded())
       *pItem->GetMusicInfoTag() = m_tag;
 
-    pItem->GetMusicInfoTag()->SetTrackNumber(i+1);
+    /*
+     * Check track number not set and take stream entry number about.
+     * NOTE: Audio decoder addons can also give a own track number.
+     */
+    if (pItem->GetMusicInfoTag()->GetTrackNumber() == 0)
+      pItem->GetMusicInfoTag()->SetTrackNumber(i+1);
     items.Add(pItem);
   }
 

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -40,7 +40,15 @@ bool CMusicFileDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     strLabel = StringUtils::Format("%s%s-%i.%s", strPath.c_str(), strFileName.c_str(), i+1, m_strExt.c_str());
     pItem->SetPath(strLabel);
 
-    if (m_tag.Loaded())
+    /*
+     * Try fist to load tag about related stream track. If them fails or not
+     * available, take base tag for all streams (in this case the item names
+     * are all the same).
+     */
+    MUSIC_INFO::CMusicInfoTag tag;
+    if (Load(strLabel, tag, nullptr))
+      *pItem->GetMusicInfoTag() = tag;
+    else if (m_tag.Loaded())
       *pItem->GetMusicInfoTag() = m_tag;
 
     pItem->GetMusicInfoTag()->SetTrackNumber(i+1);

--- a/xbmc/filesystem/MusicFileDirectory.h
+++ b/xbmc/filesystem/MusicFileDirectory.h
@@ -23,6 +23,9 @@ namespace XFILE
       bool ContainsFiles(const CURL& url) override;
       bool AllowAll() const override { return true; }
     protected:
+      virtual bool Load(const std::string& strFileName,
+                        MUSIC_INFO::CMusicInfoTag& tag,
+                        EmbeddedArt* art = nullptr) { return false; }
       virtual int GetTrackCount(const std::string& strPath) = 0;
       std::string m_strExt;
       MUSIC_INFO::CMusicInfoTag m_tag;


### PR DESCRIPTION
## Description

This solves problems with files that contain multiple streams.

Occurs primarily with some audio decoder add-ons and especially with SACD streams (which can be used for popular music and contains large tag data which must be given to Kodi).

Before the "tag" of the basic source (e.g. SACD ISO itself) was used and all things contained therein were given, so the necessary names of the respective content were missing.

On second commit becomes checked that track number is set by e.g. audiodecoder addon, if 0 fallback to old where the list number is taken.
 
## User related:
- Fixed list view of music files which contain multiple streams and are used as folders.
  - Previously, the necessary information was not set in its content and e.g. artist and title name not available.
   >This primarily refers to files which are processed by audiodecoder addons.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?

With several audiodecoder addons.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

View before:
![Bildschirmfoto von 2020-08-11 10-13-16](https://user-images.githubusercontent.com/6879739/89873840-520a5e80-dbbb-11ea-9e50-f5435db2e6e8.png)

With fix:
![Bildschirmfoto von 2020-08-11 10-01-48](https://user-images.githubusercontent.com/6879739/89873056-25a21280-dbba-11ea-9a2c-7b6a1796f6d7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
