### PR TITLE
[addons][vfs] fix addon version update and not allow disable, uninstall and update in case of use 

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -610,8 +610,18 @@ bool CAddonMgr::UnloadAddon(const std::string& addonId)
   if (!IsAddonInstalled(addonId))
     return true;
 
+  AddonPtr localAddon;
+  // can't unload an binary addon that is in use
+  if (GetAddon(addonId, localAddon, ADDON_UNKNOWN, false) && localAddon->IsBinary() &&
+      localAddon->IsInUse())
+  {
+    CLog::Log(LOGERROR, "CAddonMgr::{}: could not unload binary add-on {}, as is in use", __func__,
+              addonId);
+    return false;
+  }
+
   m_installedAddons.erase(addonId);
-  CLog::Log(LOGDEBUG, "CAddonMgr: %s unloaded", addonId.c_str());
+  CLog::Log(LOGDEBUG, "CAddonMgr::{}: {} unloaded", __func__, addonId);
 
   lock.Leave();
   AddonEvents::Unload event(addonId);

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -25,7 +25,19 @@ CVFSAddonCache::~CVFSAddonCache()
 void CVFSAddonCache::Init()
 {
   CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CVFSAddonCache::OnEvent);
-  Update();
+
+  // Load all available VFS addons during Kodi start
+  std::vector<AddonInfoPtr> addonInfos;
+  CServiceBroker::GetAddonMgr().GetAddonInfos(addonInfos, true, ADDON_VFS);
+
+  CSingleLock lock(m_critSection);
+  for (const auto& addonInfo : addonInfos)
+  {
+    VFSEntryPtr vfs = std::make_shared<CVFSEntry>(addonInfo);
+    m_addonsInstances.emplace_back(vfs);
+    if (!vfs->GetZeroconfType().empty())
+      CZeroconfBrowser::GetInstance()->AddServiceType(vfs->GetZeroconfType());
+  }
 }
 
 void CVFSAddonCache::Deinit()
@@ -73,31 +85,43 @@ void CVFSAddonCache::OnEvent(const AddonEvent& event)
       typeid(event) == typeid(AddonEvents::ReInstalled))
   {
     if (CServiceBroker::GetAddonMgr().HasType(event.id, ADDON_VFS))
-      Update();
+      Update(event.id);
   }
   else if (typeid(event) == typeid(AddonEvents::UnInstalled))
   {
-    Update();
+    Update(event.id);
   }
 }
 
-void CVFSAddonCache::Update()
+void CVFSAddonCache::Update(const std::string& id)
 {
   std::vector<VFSEntryPtr> addonmap;
 
-  std::vector<AddonInfoPtr> addonInfos;
-  CServiceBroker::GetAddonMgr().GetAddonInfos(addonInfos, true, ADDON_VFS);
-  for (const auto& addonInfo : addonInfos)
-  {
-    VFSEntryPtr vfs = std::make_shared<CVFSEntry>(addonInfo);
-    addonmap.push_back(vfs);
-    if (!vfs->GetZeroconfType().empty())
-      CZeroconfBrowser::GetInstance()->AddServiceType(vfs->GetZeroconfType());
-  }
-
+  // Stop used instance if present, otherwise the new becomes created on already created addon base one.
   {
     CSingleLock lock(m_critSection);
-    m_addonsInstances = std::move(addonmap);
+
+    const auto& itAddon =
+        std::find_if(m_addonsInstances.begin(), m_addonsInstances.end(),
+                     [&id](const VFSEntryPtr& addon) { return addon->ID() == id; });
+
+    if (itAddon != m_addonsInstances.end())
+    {
+      m_addonsInstances.erase(itAddon);
+    }
+  }
+
+  // Create and init the new VFS addon instance
+  AddonInfoPtr addonInfo = CServiceBroker::GetAddonMgr().GetAddonInfo(id, ADDON_VFS);
+  if (addonInfo && !CServiceBroker::GetAddonMgr().IsAddonDisabled(id))
+  {
+    VFSEntryPtr vfs = std::make_shared<CVFSEntry>(addonInfo);
+
+    if (!vfs->GetZeroconfType().empty())
+      CZeroconfBrowser::GetInstance()->AddServiceType(vfs->GetZeroconfType());
+
+    CSingleLock lock(m_critSection);
+    m_addonsInstances.emplace_back(vfs);
   }
 }
 

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -19,7 +19,7 @@ namespace ADDON
   class CVFSEntry;
   typedef std::shared_ptr<CVFSEntry> VFSEntryPtr;
 
-  class CVFSAddonCache
+  class CVFSAddonCache : public CAddonDllInformer
   {
   public:
     virtual ~CVFSAddonCache();
@@ -31,6 +31,7 @@ namespace ADDON
   protected:
     void Update(const std::string& id);
     void OnEvent(const AddonEvent& event);
+    bool IsInUse(const std::string& id) override;
 
     CCriticalSection m_critSection;
     std::vector<VFSEntryPtr> m_addonsInstances;

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -29,7 +29,7 @@ namespace ADDON
     VFSEntryPtr GetAddonInstance(const std::string& strId);
 
   protected:
-    void Update();
+    void Update(const std::string& id);
     void OnEvent(const AddonEvent& event);
 
     CCriticalSection m_critSection;

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -267,6 +267,18 @@ void CAddonDll::DestroyInstance(ADDON_INSTANCE_HANDLER instanceClass)
     Destroy();
 }
 
+bool CAddonDll::IsInUse() const
+{
+  if (m_informer)
+    return m_informer->IsInUse(ID());
+  return false;
+}
+
+void CAddonDll::RegisterInformer(CAddonDllInformer* informer)
+{
+  m_informer = informer;
+}
+
 AddonPtr CAddonDll::GetRunningInstance() const
 {
   if (CServiceBroker::IsBinaryAddonCacheUp())

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -30,6 +30,18 @@ namespace ADDON
  */
 using ADDON_INSTANCE_HANDLER = const void*;
 
+/*!
+ * @brief Information class for use on addon type managers.
+ *
+ * This to query via @ref CAddonDll the manager so that work can be performed.
+ * If there are multiple instances it be harder to be informed about any changes.
+ */
+class CAddonDllInformer
+{
+public:
+  virtual bool IsInUse(const std::string& id) = 0;
+};
+
 class CAddonDll : public CAddon
 {
 public:
@@ -96,6 +108,8 @@ public:
    */
   void DestroyInstance(ADDON_INSTANCE_HANDLER instanceClass);
 
+  bool IsInUse() const override;
+  void RegisterInformer(CAddonDllInformer* informer);
   AddonPtr GetRunningInstance() const override;
 
   void OnPreInstall() override;
@@ -141,6 +155,7 @@ private:
   bool m_initialized = false;
   bool LoadDll();
   std::map<ADDON_INSTANCE_HANDLER, std::pair<ADDON_TYPE, KODI_HANDLE>> m_usedInstances;
+  CAddonDllInformer* m_informer = nullptr;
 
   virtual ADDON_STATUS TransferSettings();
 


### PR DESCRIPTION
## Description
Commit 1:
-------------------
**[addons][vfs] fix addon version update**

Before was by a VFS addon update still the old version shown and the new visible after Kodi restart.

This was coming with the binary addon instance handling and here where the new was created before the old was destroyed, in this case does the system create a new instance on already opened addon (which in this case the old version).

This change unload now before the VFS addon (if not used somewhere else) and create the new after them, with this the correct CAddonDll with new version becomes created.

Further is the way improved and only the changed addon restarted, all others stays untouched. Before was by update of one addon all VFS addons restarted.

Commit 2:
-------------------
**[addons][vfs] not allow disable, uninstall and update in case of use**

Before was there easily possible to uninstall the addon if it was in use.
There becomes a check added and the CVFSAddonCache asked about usage of addon, if yes the parts becomes prevented.

To make this, is a helper class added where register on CAddonDll. As the binary addons use instance handlers, becomes it hard to make another way.
A instance class is for started place, mostly independent from CAddon and as there can be not easy to maintain.

By VFS is a bit different instance use, there is always only one, where handle itself open of different parts at same time.
This checks now how much his shared_ptr is in use, if higher as 1 report that addon class outside used.

But the added CAddonDll parts can be also used for multiple instances of other types within addon, only need then his related manager arranged to them.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## User related:

- Prevent VFS addon changes (update, disable and uninstall) if in use
- Fix VFS addon problem, where Kodi has needed restart before to show new installed version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
With vfs.rar and vfs.sacd, about vfs.rar it can takes longer, until addon allowed to change, as there can be much work,

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
Picture of Dialog without active playback
![Bildschirmfoto von 2020-08-15 03-32-33](https://user-images.githubusercontent.com/6879739/90302691-4e6f2400-dea8-11ea-8a47-bc7cb21106ed.png)

The same during playback via addon:
![Bildschirmfoto von 2020-08-15 03-33-14](https://user-images.githubusercontent.com/6879739/90302703-6181f400-dea8-11ea-8529-c75f0b052fc2.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
