### PR TITLE
[addons][install] fix origin view direct after install of addon

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -640,13 +640,9 @@ bool CAddonInstallJob::DoWork()
 
   ADDON::OnPostInstall(m_addon, m_isUpdate, IsModal());
 
-  {
-    CAddonDatabase database;
-    database.Open();
-    database.SetOrigin(m_addon->ID(), m_repo ? m_repo->ID() : "");
-    if (m_isUpdate)
-      database.SetLastUpdated(m_addon->ID(), CDateTime::GetCurrentDateTime());
-  }
+  // Write origin to database via addon manager, where this information is up-to-date.
+  // Needed to set origin correctly for new installed addons.
+  CServiceBroker::GetAddonMgr().SetAddonOrigin(m_addon->ID(), m_repo ? m_repo->ID() : "", m_isUpdate);
 
   bool notify = (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS)
         || !m_isAutoUpdate) && !IsModal();

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -1124,4 +1124,26 @@ bool CAddonMgr::FindAddonAndCheckForUpdate(const AddonPtr& addonToCheck,
   return false;
 }
 
+/*!
+ * @brief Addon update and install management.
+ */
+/*@{{{*/
+
+bool CAddonMgr::SetAddonOrigin(const std::string& addonId, const std::string& repoAddonId, bool isUpdate)
+{
+  CSingleLock lock(m_critSection);
+
+  m_database.SetOrigin(addonId, repoAddonId);
+  if (isUpdate)
+    m_database.SetLastUpdated(addonId, CDateTime::GetCurrentDateTime());
+
+  // If available in manager update
+  const AddonInfoPtr info = GetAddonInfo(addonId);
+  if (info)
+    m_database.GetInstallData(info);
+  return true;
+}
+
+/*@}}}*/
+
 } /* namespace ADDON */

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -331,6 +331,38 @@ namespace ADDON
 
     AddonOriginType GetAddonOriginType(const AddonPtr& addon) const;
 
+    /*!
+     * @brief Addon update and install management.
+     *
+     * Parts inside here are used for changes about addon system.
+     *
+     * @warning This should be never used from other places outside of addon
+     * system directory.
+     *
+     * Currently listed call sources:
+     * - @ref CAddonInstallJob::DoWork
+     */
+    /*@{{{*/
+
+    /*!
+     * @brief Update addon origin data.
+     *
+     * This becomes called from @ref CAddonInstallJob to set the source repo and
+     * if update, to set also the date.
+     *
+     * @note This must be called after the addon manager has inserted a new addon
+     * with @ref FindAddons() into database.
+     *
+     * @param[in] addonId Identifier of addon
+     * @param[in] repoAddonId Identifier of related repository addon
+     * @param[in] isUpdate If call becomes done on already installed addon and
+     *                     update only.
+     * @return True if successfully done, otherwise false
+     */
+    bool SetAddonOrigin(const std::string& addonId, const std::string& repoAddonId, bool isUpdate);
+
+    /*@}}}*/
+
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;
 


### PR DESCRIPTION
## Description

Before was if a new addon was installed and shown via "User installed add-ons" the origin (Repository) not known and shown as "Unknown", after a Kodi restart it was then available.

There was before after the install by CAddonInstallJob the manager called to add the new, but after the new was added there, the installer set the origin in database where was before not available in manager.
With this the database was correct and on next Kodi start used.

This change move the database update to the manager so that it also direct update the origin within his listed addons.

Ping @howie-f that's the fix about.

## User related

- Fix Repository show of new installed addon on his information dialog of "My add-ons", where was before shown as "Unknown" and after a Kodi restart available and correct.

> About Leia to Matrix no differences (as this fault was introduced in Matrix)

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

**Text and images copied from https://github.com/xbmc/xbmc/pull/18181#issuecomment-671361033**

think i have come across another issue...

tested with a fresh install of kodi with https://github.com/xbmc/xbmc/pull/18181 applied:
1) start kodi and install the Southpark addon from our repo
2) next, go to `My Addons > Video addons > Southpark`
the origin is not shown correctly
![sp1](https://user-images.githubusercontent.com/687265/89786855-e2de2d00-db1c-11ea-83e1-f2d0660e3789.jpg)

3) restart Kodi and go to `My Addons > Video addons > Southpark` again
the origin is now shown correctly
![sp2](https://user-images.githubusercontent.com/687265/89786862-e5408700-db1c-11ea-98c7-1f108a07a54b.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
