### PR TITLE
[addons][visualization] fix stuttering on high sample streams and fix missing data

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1382,6 +1382,9 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         vizFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
         vizFormat.m_dataFormat = AE_FMT_FLOAT;
         vizFormat.m_sampleRate = 44100;
+        vizFormat.m_frames =
+            m_internalFormat.m_frames *
+            (static_cast<float>(vizFormat.m_sampleRate) / m_internalFormat.m_sampleRate);
 
         // input buffers
         m_vizBuffersInput = new CActiveAEBufferPool(m_internalFormat);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2241,7 +2241,8 @@ bool CActiveAE::RunStages()
                 break;
               else
               {
-                unsigned int samples = static_cast<unsigned int>(buf->pkt->nb_samples);
+                unsigned int samples = static_cast<unsigned int>(buf->pkt->nb_samples) *
+                                       buf->pkt->config.channels / buf->pkt->planes;
                 for (auto& it : m_audioCallback)
                   it->OnAudioData((float*)(buf->pkt->data[0]), samples);
                 buf->Return();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -310,7 +310,8 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
         }
 
         // pts of last sample we added to the buffer
-        m_lastSamplePts += (in->pkt->nb_samples-in->pkt_start_offset) * 1000 / m_format.m_sampleRate;
+        m_lastSamplePts +=
+            (in->pkt->nb_samples - in->pkt_start_offset) * 1000 / in->pkt->config.sample_rate;
       }
 
       // calculate pts for last sample in m_procSample


### PR DESCRIPTION
## Description

Before was on streams with very high samplerate e.g. 352800 together with high CPU consumption a very big continues stuttering on visualization show.

Commit 1:
----------------------
**[audioengine][viz] fix visualization frames amount**

It has used to big frame size from e.g. 384000 Hz to 44100 Hz
and the small Samplerate used the bigger frames amount from high rate.

Commit 2:
----------------------
**[audioengine][viz] fix visualization audio data size**

When copying the stream for visualization, its entire content was never used and only the number of samples was given and not multiplied by the required number of channel

Commit 3:
----------------------
**[audioengine] fix wrong PTS calc on resampler**

It has used by PTS correction, the sample amount of input where was related to e.g. 384000Hz sample rate but in resampler it has used the sample rate of output where e.g. 44100Hz to calculate and produce a much to high value.

## User related

- Fix: GUI visualization stuttering on high samplerate streams

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context

This fix also this issue here https://github.com/xbmc/visualization.waveform/issues/17
Ans seen the bug also by new addon visualization.matrix.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?

Was with visualization.wav and visualization.matrix on several highlevel streams and see videos below.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

Video with fix:
https://youtu.be/7QWBZ72TdZg

Video without fix:
https://youtu.be/fv4ZiYFs2hA


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
