### PR TITLE
[filesystem] Disregard Apple Resource Fork data

### DIFF
--- a/xbmc/filesystem/Directorization.h
+++ b/xbmc/filesystem/Directorization.h
@@ -77,6 +77,11 @@ namespace XFILE
       if (entryFileName == filePath)
         continue;
 
+      // Disregard Apple Resource Fork data
+      std::size_t found = entryPath.find("__MACOSX");
+      if (found != std::string::npos)
+        continue;
+
       std::vector<std::string> pathTokens;
       StringUtils::Tokenize(entryFileName, pathTokens, "/");
 


### PR DESCRIPTION
## Description
Apple adds additional resource data when creating zip archives and its stored in a folder __MACOSX
We want to disregard any files/folders inside these __MACOSX folders as they provide nothing of value
to Kodi

## Motivation and Context
Short version:
Allow CAddonInstall to install Finder created zip files. closes #18125 

Long Version:
Currently we have a set limit of a single folder in a zip archive, otherwise CAddonInstaller::InstallFromZip will fail https://github.com/xbmc/xbmc/blob/77fbffd29f0b8a91716028e2e1cf683d9465a69c/xbmc/addons/AddonInstaller.cpp#L263-L264

Apple creates a hidden resource data folder when an archive is created via Finder, therefore the size count is now 2, and the above failure occurs.

I see 2 options to resolve the issue. The first is what is PR'd here. We just skip any paths/files that have __MACOSX in them when we Directorize a CURL url. I see this as the least disruptive, as the __MACOSX resource data is of no value to kodi.

The second option would effectively remove the single folder limit on zip files. This brings a considerable amout of potential issues/regressions, but would allow the ability for a zip to include multiple folders (ie addons) in a single zip. A considerable amount of work would be required to handle dependency ordering inside an archive, that im not willing to do. If anyone ever wants to look into that, give me a yell, happy to pass on notes.

## How Has This Been Tested?
Locally on osx

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
