### PR TITLE
EventScanner: Fix threadname not applied

### DIFF
--- a/xbmc/peripherals/EventScanner.cpp
+++ b/xbmc/peripherals/EventScanner.cpp
@@ -26,7 +26,7 @@ using namespace XbmcThreads;
 #define WATCHDOG_TIMEOUT_MS 80
 
 CEventScanner::CEventScanner(IEventScannerCallback& callback)
-  : CThread("PeripEventScanner"), m_callback(callback)
+  : CThread("PeripEventScan"), m_callback(callback)
 {
 }
 


### PR DESCRIPTION
Threadnames are limited to 16 chars
including the terminating null byte
according to:
https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html

This fixes the display of the threads name in debuggers.
Instead of the appname now the threadname is correctly shown.

## Motivation and Context
Bugged me :D

## How Has This Been Tested?
Linux X11 using vscode as IDE.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
