### PR TITLE
Fix JSON ButtonEvent

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -33,6 +33,7 @@ xbmc/guilib                                     guilib
 xbmc/guilib/guiinfo                             guilib_guiinfo
 xbmc/input                                      input
 xbmc/input/actions                              input/actions
+xbmc/input/button                               input/button
 xbmc/input/joysticks                            input/joysticks
 xbmc/input/joysticks/dialogs                    input/joysticks/dialogs
 xbmc/input/joysticks/generic                    input/joysticks/generic

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -438,8 +438,8 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
     } // case
     case XBMC_BUTTON:
     {
-      CKey key(newEvent.keybutton.button, newEvent.keybutton.holdtime);
-      HandleKey(key);
+      HandleKey(
+          m_buttonStat.TranslateKey(CKey(newEvent.keybutton.button, newEvent.keybutton.holdtime)));
       break;
     }
   } // switch

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -439,7 +439,7 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
     case XBMC_BUTTON:
     {
       CKey key(newEvent.keybutton.button, newEvent.keybutton.holdtime);
-      OnKey(key);
+      HandleKey(key);
       break;
     }
   } // switch

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -10,6 +10,7 @@
 
 #include "input/KeyboardStat.h"
 #include "input/actions/Action.h"
+#include "input/button/ButtonStat.h"
 #include "input/mouse/MouseStat.h"
 #include "input/mouse/interfaces/IMouseInputProvider.h"
 #include "interfaces/IActionListener.h"
@@ -279,6 +280,7 @@ private:
   void ProcessQueuedActions();
 
   CKeyboardStat m_Keyboard;
+  KODI::INPUT::CButtonStat m_buttonStat;
   CMouseStat m_Mouse;
   CKey m_LastKey;
 

--- a/xbmc/input/InputTypes.h
+++ b/xbmc/input/InputTypes.h
@@ -39,5 +39,8 @@ enum class INTERCARDINAL_DIRECTION
   LEFTUP = LEFT | UP,
   LEFTDOWN = LEFT | DOWN,
 };
+
+const unsigned int HOLD_TRESHOLD = 250;
+
 } // namespace INPUT
 } // namespace KODI

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -14,6 +14,7 @@
 #include "KeyboardStat.h"
 
 #include "ServiceBroker.h"
+#include "input/InputTypes.h"
 #include "input/XBMC_keytable.h"
 #include "input/XBMC_vkeys.h"
 #include "peripherals/Peripherals.h"
@@ -22,7 +23,8 @@
 #include "utils/log.h"
 #include "windowing/XBMC_events.h"
 
-#define HOLD_THRESHOLD 250
+using namespace KODI;
+using namespace INPUT;
 
 bool operator==(const XBMC_keysym& lhs, const XBMC_keysym& rhs)
 {
@@ -167,7 +169,7 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
   if (keysym == m_lastKeysym)
   {
     held = XbmcThreads::SystemClockMillis() - m_lastKeyTime;
-    if (held > HOLD_THRESHOLD)
+    if (held > HOLD_TRESHOLD)
       modifiers |= CKey::MODIFIER_LONG;
   }
 

--- a/xbmc/input/button/ButtonStat.cpp
+++ b/xbmc/input/button/ButtonStat.cpp
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+#include "ButtonStat.h"
+
+#include "xbmc/input/InputTypes.h"
+
+using namespace KODI;
+using namespace INPUT;
+
+CButtonStat::CButtonStat() = default;
+CButtonStat::~CButtonStat() = default;
+
+CKey CButtonStat::TranslateKey(CKey key) const
+{
+  uint32_t buttonCode = key.GetButtonCode();
+  if (key.GetHeld() > HOLD_TRESHOLD)
+    buttonCode |= CKey::MODIFIER_LONG;
+
+  CKey translatedKey(buttonCode, key.GetHeld());
+  return translatedKey;
+}

--- a/xbmc/input/button/ButtonStat.h
+++ b/xbmc/input/button/ButtonStat.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "input/Key.h"
+#include "input/XBMC_keyboard.h"
+
+#include <string>
+
+namespace KODI
+{
+namespace INPUT
+{
+
+class CButtonStat
+{
+public:
+  CButtonStat();
+  ~CButtonStat();
+
+  CKey TranslateKey(CKey key) const;
+};
+} // namespace INPUT
+} // namespace KODI

--- a/xbmc/input/button/CMakeLists.txt
+++ b/xbmc/input/button/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES ButtonStat.cpp)
+
+set(HEADERS ButtonStat.h)
+
+core_add_library(input_button)


### PR DESCRIPTION
# RFC
This is an RFC on how to fix the issue.
I see multiple ways to do it, for example:
The CKey constructor could use holdtime and check if it exceeds
the treshold and apply the modifier by itself.
I'm not sure where the longpress translation belongs to from an
architectural pov.

## Description
The current ButtonEvent implementation has 2 problems:
* If any key has a longpress mapping it isn't handled at all
* No matter what holdtime you set, it's not respected

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
