### PR TITLE
[Builtins][MediaWindow] Propagate window replace intention and set th…

### DIFF
--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -85,6 +85,10 @@ static int ActivateWindow(const std::vector<std::string>& params2)
         bIsSameStartFolder = static_cast<CGUIMediaWindow*>(activeWindow)->IsSameStartFolder(params[0]);
     }
 
+    // let the window know it is being replaced
+    if (Replace)
+      params.emplace_back("replace");
+
     // activate window only if window and path differ from the current active window
     if (iWindow != CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() || !bIsSameStartFolder)
     {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -523,9 +523,13 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     {
       if (m_vecItems->GetPath() == "?")
         m_vecItems->SetPath("");
+
       std::string dir = message.GetStringParam(0);
-      const std::string &ret = message.GetStringParam(1);
-      bool returning = StringUtils::EqualsNoCase(ret, "return");
+      const std::string& ret = message.GetStringParam(1);
+      const std::string& swap = message.GetStringParam(message.GetNumStringParams() - 1);
+      const bool returning = StringUtils::EqualsNoCase(ret, "return");
+      const bool replacing = StringUtils::EqualsNoCase(swap, "replace");
+
       if (!dir.empty())
       {
         // ensure our directory is valid
@@ -561,8 +565,9 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         // if "return" is defined make sure we set the startDirectory to the directory we are
         // moving to (so that we can move back to where we were onBack). If we are activating
         // the same window but with a different path, do nothing - we are simply adding to the
-        // window history.
-        if (message.GetParam1() != message.GetParam2())
+        // window history. Note that if the window is just being replaced, the start directory
+        // also needs to be set as the manager has just popped the previous window.
+        if (message.GetParam1() != message.GetParam2() || replacing)
           m_startDirectory = returning ? dir : GetRootPath();
       }
       if (message.GetParam2() == PLUGIN_REFRESH_DELAY)


### PR DESCRIPTION
…e start directory

## Description
https://github.com/xbmc/xbmc/pull/17893 introduced a regression when using the `ReplaceWindow` builtin. The main issue lies in the fact that the new logic don't set the start directory if we came from the same window as we are just adding a new path to the window history. The problem is that, with replace window, the last window is in fact being popped from the window history by the window manager. This means that if we replace the same window with a different path chances are the window won't move to the new path. 

To fix it, I'm propagating this replace/swapping window intention as a string parameter thus reinstating the previous `ReplaceWindow` behaviour while keeping the same `ActivateWindow` behaviour.

@ronie @roidy can you guys check if you can still reproduce the issue?

The previous PR should have not been backported as I said here (https://github.com/xbmc/xbmc/pull/17893#issuecomment-646017485). As a result we now have the `ReplaceWindow` and a few skins broken in Leia. I'll add a backport label just in case we decide to make yet another final-final-reallyfinal Leia version (@DaveTBlake fyi).

## Motivation and Context
Fix https://github.com/xbmc/xbmc/issues/18239

## How Has This Been Tested?

Using a simple python script:

```python
    xbmc.executebuiltin("ActivateWindow(Videos,videodb://movies/titles/,return)")
    xbmc.sleep(3000)
    xbmc.executebuiltin("ReplaceWindow(Videos,videodb://movies/genres/,return)")
    xbmc.sleep(5000)
    xbmc.executebuiltin("ReplaceWindow(Videos,videodb://movies/titles/,return)")

```

