### PR TITLE
fix crash introduced by pr18186

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -249,9 +249,13 @@ void CGUIDialogVideoInfo::OnInitWindow()
 
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH,
-      (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) &&
-      !StringUtils::StartsWithNoCase(m_movieItem->GetProperty("xxuniqueid").c_str(), "xx"));
+  const std::string uniqueId = m_movieItem->GetProperty("xxuniqueid").asString();
+  if (uniqueId.empty() || !StringUtils::StartsWithNoCase(uniqueId.c_str(), "xx"))
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH,
+        (profileManager->GetCurrentProfile().canWriteDatabases() ||
+        g_passwordManager.bMasterUser));
+  else
+    CONTROL_DISABLE(CONTROL_BTN_REFRESH);
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
       (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) &&
       !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->


### PR DESCRIPTION
## Description
Due to a regression introduced by https://github.com/xbmc/xbmc/pull/18186, kodi currently crashes when opening the video info dialog for all library items (non-plugin provided content). 

This fixes the crash by first doing an empty() check before doing the StartsWithNoCase() comparison.

thanx @MediaBrasil / @fuzzard for the heads-up!
https://github.com/xbmc/xbmc/commit/1abba0563fb0c4c1bb8fce10584319b6a743dc83#commitcomment-41577537


## How Has This Been Tested?
tested by opening the video info dialog for movies / tv shows / episodes / musicvideos, both from the libray listing, as well s from the home screen widgets.



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
