### PR TITLE
[python] Stop any running scripts on shutdown

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2679,6 +2679,9 @@ void CApplication::Stop(int exitCode)
     // Stop services before unloading Python
     CServiceBroker::GetServiceAddons().Stop();
 
+    // Stop any other python scripts that may be looping waiting for monitor.abortRequested()
+    CScriptInvocationManager::GetInstance().StopRunningScripts();
+
     // unregister action listeners
     UnregisterActionListener(&m_appPlayer.GetSeekHandler());
     UnregisterActionListener(&CPlayerController::GetInstance());

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -359,6 +359,15 @@ bool CScriptInvocationManager::Stop(int scriptId, bool wait /* = false */)
   return invokerThread->Stop(wait);
 }
 
+void CScriptInvocationManager::StopRunningScripts(bool wait /* = false */)
+{
+  for (auto& it : m_scripts)
+  {
+    if (!it.second.done)
+      Stop(it.second.script, wait);
+  }
+}
+
 bool CScriptInvocationManager::Stop(const std::string &scriptPath, bool wait /* = false */)
 {
   if (scriptPath.empty())

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -115,6 +115,12 @@ public:
   bool Stop(int scriptId, bool wait = false);
   bool Stop(const std::string &scriptPath, bool wait = false);
 
+  /*!
+   *\brief Stop all running scripts
+   *\param wait if kodi should wait for each script to finish (default false)
+  */
+  void StopRunningScripts(bool wait = false);
+
   bool IsRunning(int scriptId) const;
   bool IsRunning(const std::string& scriptPath) const;
 


### PR DESCRIPTION
## Description
On shutdown, kodi only stops or sends the abort intention to all python services that are running. If some other script happens to have a long running loop waiting for the abortRequest in xbmc.Monitor, kodi will not flag the request. This creates a memory leak and can lead to kodi hanging/freezing on shutdown.

This PR adds a new method to `CScriptInvocationManager` to ensure we are able to stop any scripts that may still be running after shutting down the python services.

@jimfcarroll can you please review if you find a bit of time?

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18191


## How Has This Been Tested?
With the provided script by @CastagnaIT in the issue report.

