### PR TITLE
[addons] zip installs, warning and no updates; browsing repos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
 list(APPEND install_data ${ADDON_INSTALL_DATA})
 add_library(compileinfo OBJECT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)
 set_target_properties(compileinfo PROPERTIES FOLDER "Build Utilities")
-target_compile_options(compileinfo PRIVATE "${SYSTEM_DEFINES}")
+target_compile_options(compileinfo PRIVATE "${SYSTEM_DEFINES} ${ARCH_DEFINES}")
 
 # RC File
 if(WIN32)

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20860,7 +20860,13 @@ msgctxt "#36636"
 msgid "You must first enter a password before web server authentication can be enabled."
 msgstr ""
 
-#empty strings from id 36637 to 36898
+#. Text in confirm dialog when installing addon from zip
+#: xbmc/addons/GUIWindowAddonBrowser.cpp
+msgctxt "#36637"
+msgid "Note that add-ons installed from zip (excluding served repositories) will not auto-update and must be manually updated. Would you like to proceed?"
+msgstr ""
+
+#empty strings from id 36638 to 36898
 
 #. Description of setting with label #729 "Enable SSL"
 #: system/settings/settings.xml

--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -7,11 +7,12 @@
  */
 
 #include "CompileInfo.h"
+#include "addons/AddonRepoInfo.h"
+#include "utils/StringUtils.h"
 
 #include <algorithm>
 #include <cstddef>
 #include <string>
-
 
 int CCompileInfo::GetMajor()
 {
@@ -55,11 +56,6 @@ const char* CCompileInfo::GetSCMID()
   return "@APP_SCMID@";
 }
 
-std::string CCompileInfo::GetOfficialAddonRepos()
-{
-  return "@APP_ADDON_REPOS@";
-}
-
 std::string CCompileInfo::GetSharedLibrarySuffix()
 {
   return "@APP_SHARED_LIBRARY_SUFFIX@";
@@ -84,4 +80,23 @@ std::string CCompileInfo::GetBuildDate()
 const char*  CCompileInfo::GetVersionCode()
 {
   return "@APP_VERSION_CODE@";
+}
+
+std::vector<ADDON::RepoInfo> CCompileInfo::LoadOfficialRepoInfos()
+{
+  const std::vector<std::string> officialAddonRepos =
+      StringUtils::Split("@APP_ADDON_REPOS@", ',');
+
+  std::vector<ADDON::RepoInfo> officialRepoInfos;
+  ADDON::RepoInfo newRepoInfo;
+
+  for (const auto& addonRepo : officialAddonRepos)
+  {
+    const std::vector<std::string> tmpRepoInfo = StringUtils::Split(addonRepo, '|');
+    newRepoInfo.m_repoId = tmpRepoInfo.front();
+    newRepoInfo.m_origin = tmpRepoInfo.back();
+    officialRepoInfos.emplace_back(newRepoInfo);
+  }
+
+  return officialRepoInfos;
 }

--- a/xbmc/CompileInfo.h
+++ b/xbmc/CompileInfo.h
@@ -9,6 +9,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
+
+namespace ADDON
+{
+struct RepoInfo;
+}
 
 class CCompileInfo
 {
@@ -20,9 +26,9 @@ public:
   static const char* GetAppName();
   static const char* GetSuffix(); // Git "Tag", e.g. alpha1
   static const char* GetSCMID(); // Git Revision
-  static std::string GetOfficialAddonRepos();
   static std::string GetSharedLibrarySuffix();
   static const char* GetCopyrightYears();
   static std::string GetBuildDate();
   static const char* GetVersionCode();
+  static std::vector<ADDON::RepoInfo> LoadOfficialRepoInfos();
 };

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -26,7 +26,7 @@ CDatabaseManager::CDatabaseManager() :
   m_bIsUpgrading(false)
 {
   // Initialize the addon database (must be before the addon manager is init'd)
-  CAddonDatabase db;
+  ADDON::CAddonDatabase db;
   UpdateDatabase(db);
 }
 
@@ -44,7 +44,10 @@ void CDatabaseManager::Initialize()
 
   // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
   //       before CVideoDatabase.
-  { CAddonDatabase db; UpdateDatabase(db); }
+  {
+    ADDON::CAddonDatabase db;
+    UpdateDatabase(db);
+  }
   { CViewDatabase db; UpdateDatabase(db); }
   { CTextureDatabase db; UpdateDatabase(db); }
   { CMusicDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseMusic); }

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -131,7 +131,7 @@ int CAddonDatabase::GetMinSchemaVersion() const
 
 int CAddonDatabase::GetSchemaVersion() const
 {
-  return 30;
+  return 31;
 }
 
 void CAddonDatabase::CreateTables()
@@ -227,6 +227,11 @@ void CAddonDatabase::UpdateTables(int version)
   if (version < 30)
   {
     m_pDS->exec("ALTER TABLE repo ADD nextcheck TEXT");
+  }
+  if (version < 31)
+  {
+    m_pDS->exec("UPDATE installed SET origin = addonID WHERE (origin='') AND "
+                "EXISTS (SELECT * FROM repo WHERE repo.addonID = installed.addonID)");
   }
 }
 

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -294,6 +294,13 @@ void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids,
           ORIGIN_SYSTEM, id.c_str()));
     }
 
+    for (const auto& id : optional)
+    {
+      // Set origin for optional system addons that do not have one yet too.
+      m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s' AND origin=''",
+                             ORIGIN_SYSTEM, id.c_str()));
+    }
+
     CommitTransaction();
   }
   catch (...)

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -16,6 +16,9 @@
 #include <string>
 #include <vector>
 
+namespace ADDON
+{
+
 class CAddonDatabase : public CDatabase
 {
 public:
@@ -172,3 +175,4 @@ protected:
   int GetRepositoryId(const std::string& addonId);
 };
 
+}; // namespace ADDON

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -651,7 +651,18 @@ bool CAddonInstallJob::DoWork()
 
   // Write origin to database via addon manager, where this information is up-to-date.
   // Needed to set origin correctly for new installed addons.
-  CServiceBroker::GetAddonMgr().SetAddonOrigin(m_addon->ID(), m_repo ? m_repo->ID() : "", m_isUpdate);
+
+  std::string origin;
+  if (m_repo) // if we have an origin use it
+  {
+    origin = m_repo->ID();
+  }
+  else if (m_addon->HasType(ADDON_REPOSITORY))
+  {
+    origin = m_addon->ID(); // set origin to addon-id which is the repo itself
+  }
+
+  CServiceBroker::GetAddonMgr().SetAddonOrigin(m_addon->ID(), origin, m_isUpdate);
 
   bool notify = (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS)
         || !m_isAutoUpdate) && !IsModal();

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -18,6 +18,9 @@
 #include <utility>
 #include <vector>
 
+namespace ADDON
+{
+
 class CAddonDatabase;
 
 class CAddonInstaller : public IJobCallback
@@ -208,3 +211,5 @@ private:
   ADDON::AddonPtr m_addon;
   bool m_removeData;
 };
+
+}; // namespace ADDON

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -108,7 +108,7 @@ bool CAddonMgr::Init()
 {
   CSingleLock lock(m_critSection);
 
-  if (!LoadManifest(m_systemAddons, m_optionalAddons))
+  if (!LoadManifest(m_systemAddons, m_optionalSystemAddons))
   {
     CLog::Log(LOGERROR, "ADDONS: Failed to read manifest");
     return false;
@@ -551,7 +551,7 @@ bool CAddonMgr::FindAddons()
   CSingleLock lock(m_critSection);
 
   // Sync with db
-  m_database.SyncInstalled(installed, m_systemAddons, m_optionalAddons);
+  m_database.SyncInstalled(installed, m_systemAddons, m_optionalSystemAddons);
   for (const auto& addon : installedAddons)
   {
     m_database.GetInstallData(addon.second);

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -283,10 +283,13 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons)
 bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, const TYPE &type)
 {
   CSingleLock lock(m_critSection);
+  CAddonRepos addonRepos(*this);
+
+  if (!addonRepos.LoadAddonsFromDatabase(m_database))
+    return false;
 
   // get all addons
-  if (!m_database.GetRepositoryContent(addons))
-    return false;
+  addonRepos.GetLatestAddonVersions(addons);
 
   // go through all addons and remove all that are already installed
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -434,7 +434,7 @@ namespace ADDON
     CEventSource<AddonEvent> m_events;
     CBlockingEventSource<AddonEvent> m_unloadEvents;
     std::set<std::string> m_systemAddons;
-    std::set<std::string> m_optionalAddons;
+    std::set<std::string> m_optionalSystemAddons;
     ADDON_INFO_LIST m_installedAddons;
 
     // Temporary path given to add-ons, whose content is deleted when Kodi is stopped

--- a/xbmc/addons/AddonRepoInfo.h
+++ b/xbmc/addons/AddonRepoInfo.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace ADDON
+{
+
+/**
+ * Struct - RepoInfo
+ */
+struct RepoInfo
+{
+  std::string m_repoId;
+  std::string m_origin;
+};
+
+}; /* namespace ADDON */

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -11,6 +11,7 @@
 #include "Addon.h"
 #include "AddonDatabase.h"
 #include "AddonManager.h"
+#include "AddonRepoInfo.h"
 #include "AddonSystemSettings.h"
 #include "CompileInfo.h"
 #include "Repository.h"
@@ -24,31 +25,7 @@
 
 using namespace ADDON;
 
-namespace ADDON
-{
-
-std::vector<RepoInfo> LoadOfficialRepoInfos()
-{
-  const std::vector<std::string> officialAddonRepos =
-      StringUtils::Split(CCompileInfo::GetOfficialAddonRepos(), ',');
-
-  std::vector<RepoInfo> officialRepoInfos;
-  RepoInfo newRepoInfo;
-
-  for (const auto& addonRepo : officialAddonRepos)
-  {
-    const std::vector<std::string> tmpRepoInfo = StringUtils::Split(addonRepo, '|');
-    newRepoInfo.m_repoId = tmpRepoInfo.front();
-    newRepoInfo.m_origin = tmpRepoInfo.back();
-    officialRepoInfos.emplace_back(newRepoInfo);
-  }
-
-  return officialRepoInfos;
-}
-
-static std::vector<RepoInfo> officialRepoInfos = LoadOfficialRepoInfos();
-
-} // namespace ADDON
+static std::vector<RepoInfo> officialRepoInfos = CCompileInfo::LoadOfficialRepoInfos();
 
 /**********************************************************
  * CAddonRepos

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -196,22 +196,26 @@ bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
 
   bool hasOfficialUpdate = FindAddonAndCheckForUpdate(addon, m_latestOfficialVersions, update);
 
-  if (ORIGIN_SYSTEM != addon->Origin() && !hasOfficialUpdate) // not a system addon
+  // addons with an empty origin have at least been checked against official repositories
+  if (!addon->Origin().empty())
   {
-    // If we didn't find an official update
-    if (IsFromOfficialRepo(addon, true)) // is an official addon
+    if (ORIGIN_SYSTEM != addon->Origin() && !hasOfficialUpdate) // not a system addon
     {
-      if (updateMode == AddonRepoUpdateMode::ANY_REPOSITORY)
-        if (!FindAddonAndCheckForUpdate(addon, m_latestPrivateVersions, update))
-          return false;
-    }
-    else
-    {
-      // ...we check for updates in the origin repo only
-      const auto& repoEntry = m_latestVersionsByRepo.find(addon->Origin());
-      if (repoEntry != m_latestVersionsByRepo.end())
-        if (!FindAddonAndCheckForUpdate(addon, repoEntry->second, update))
-          return false;
+      // If we didn't find an official update
+      if (IsFromOfficialRepo(addon, true)) // is an official addon
+      {
+        if (updateMode == AddonRepoUpdateMode::ANY_REPOSITORY)
+          if (!FindAddonAndCheckForUpdate(addon, m_latestPrivateVersions, update))
+            return false;
+      }
+      else
+      {
+        // ...we check for updates in the origin repo only
+        const auto& repoEntry = m_latestVersionsByRepo.find(addon->Origin());
+        if (repoEntry != m_latestVersionsByRepo.end())
+          if (!FindAddonAndCheckForUpdate(addon, repoEntry->second, update))
+            return false;
+      }
     }
   }
 

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -8,21 +8,15 @@
 
 #pragma once
 
-#include "AddonDatabase.h"
-
 #include <map>
+#include <memory>
+#include <string>
 #include <vector>
+
+class CAddonDatabase;
 
 namespace ADDON
 {
-/**
- * Struct - RepoInfo
- */
-struct RepoInfo
-{
-  std::string m_repoId;
-  std::string m_origin;
-};
 
 class CAddonMgr;
 class CRepository;
@@ -37,7 +31,7 @@ class IAddon;
 class CAddonRepos
 {
 public:
-  CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr){}; // ctor
+  CAddonRepos(const CAddonMgr& addonMgr) : m_addonMgr(addonMgr){};
 
   /*!
    * \brief Load the map of all available addon versions in any installed repository

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -42,15 +42,27 @@ public:
   /*!
    * \brief Load the map of all available addon versions in any installed repository
    * \param database reference to the database to load addons from
+   * \return true on success, false otherwise
    */
-  void LoadAddonsFromDatabase(const CAddonDatabase& database);
+  bool LoadAddonsFromDatabase(const CAddonDatabase& database);
 
   /*!
    * \brief Load the map of all available versions of an addonId in any installed repository
    * \param database reference to the database to load addons from
    * \param addonId the addon id we want to retrieve versions for
+   * \return true on success, false otherwise
    */
-  void LoadAddonsFromDatabase(const CAddonDatabase& database, const std::string& addonId);
+  bool LoadAddonsFromDatabase(const CAddonDatabase& database, const std::string& addonId);
+
+  /*!
+   * \brief Load the map of all available versions in one installed repository
+   * \param database reference to the database to load addons from
+   * \param repoAddon pointer to the repo we want to retrieve versions from
+   *        note this is of type AddonPtr, not RepositoryPtr
+   * \return true on success, false otherwise
+   */
+  bool LoadAddonsFromDatabase(const CAddonDatabase& database,
+                              const std::shared_ptr<IAddon>& repoAddon);
 
   /*!
    * \brief Build the list of addons to be updated depending on defined rules
@@ -92,11 +104,19 @@ public:
    * \brief Retrieves the latest version of an addon from all installed repositories
    *        follows addon origin restriction rules
    * \param addonId addon id we're looking the latest version for
-   * \param[out] result pointer to the found addon
+   * \param[out] addon pointer to the found addon
    * \return true if a version was found, false otherwise
    */
   bool GetLatestAddonVersionFromAllRepos(const std::string& addonId,
-                                         std::shared_ptr<IAddon>& result) const;
+                                         std::shared_ptr<IAddon>& addon) const;
+
+  /*!
+   * \brief Retrieves the latest official versions of addons to vector.
+   *        Private versions are added obeying the set updateMode.
+   *        (either OFFICIAL_ONLY or ANY_REPOSITORY)
+   * \param[out] addonList retrieved addon list in a vector
+   */
+  void GetLatestAddonVersions(std::vector<std::shared_ptr<IAddon>>& addonList) const;
 
   /*!
    * \brief Find a dependency to install during an addon install or update
@@ -127,6 +147,15 @@ public:
                                   std::shared_ptr<IAddon>& dependencyToInstall) const;
 
 private:
+  /*!
+   * \brief Load the map of addons
+   * \note this function should only by called from publicly exposed wrappers
+   * \return true on success, false otherwise
+   */
+  bool LoadAddonsFromDatabase(const CAddonDatabase& database,
+                              const std::string& addonId,
+                              const std::shared_ptr<IAddon>& repoAddon);
+
   /*!
    * \brief Looks up an addon in a given repository map and
    *        checks if an update is available
@@ -171,12 +200,12 @@ private:
    * \brief Looks up an addon entry in a specific map
    * \param addonId addon we want to retrieve
    * \param map the map we're looking into for the wanted addon
-   * \param[out] result pointer to the found addon, only use when function returns true
+   * \param[out] addon pointer to the found addon, only use when function returns true
    * \return true if the addon was found in the map, false otherwise
    */
   bool GetLatestVersionByMap(const std::string& addonId,
                              const std::map<std::string, std::shared_ptr<IAddon>>& map,
-                             std::shared_ptr<IAddon>& result) const;
+                             std::shared_ptr<IAddon>& addon) const;
 
   const CAddonMgr& m_addonMgr;
 

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -13,11 +13,10 @@
 #include <string>
 #include <vector>
 
-class CAddonDatabase;
-
 namespace ADDON
 {
 
+class CAddonDatabase;
 class CAddonMgr;
 class CRepository;
 class IAddon;

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES Addon.cpp
 set(HEADERS Addon.h
             AddonBuilder.h
             AddonEvents.h
+            AddonRepoInfo.h
             BinaryAddonCache.h
             AddonDatabase.h
             AddonInstaller.h

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -190,14 +190,18 @@ void CGUIWindowAddonBrowser::InstallFromZip()
   }
   else
   {
-    // pop up filebrowser to grab an installed folder
-    VECSOURCES shares = *CMediaSourceSettings::GetInstance().GetSources("files");
-    CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-    CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
-    std::string path;
-    if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
+    if (ShowYesNoDialogText(19098, 36637) == DialogResponse::YES)
     {
-      CAddonInstaller::GetInstance().InstallFromZip(path);
+      // pop up filebrowser to grab an installed folder
+      VECSOURCES shares = *CMediaSourceSettings::GetInstance().GetSources("files");
+      CServiceBroker::GetMediaManager().GetLocalDrives(shares);
+      CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
+      std::string path;
+      if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041),
+                                                path))
+      {
+        CAddonInstaller::GetInstance().InstallFromZip(path);
+      }
     }
   }
 }

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -107,7 +107,7 @@ void CControllerInstaller::Process()
         100 * (installedCount + 1) / static_cast<unsigned int>(installableAddons.size());
     pProgressDialog->SetPercentage(percentage);
 
-    if (!CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), false, false))
+    if (!ADDON::CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), false, false))
     {
       CLog::Log(LOGERROR, "Controller installer: Failed to install %s", addon->ID().c_str());
       // "Error"

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -133,7 +133,8 @@ bool CGUIDialogSelectGameClient::Install(const std::string& gameClient)
   if (!bInstalled)
   {
     ADDON::AddonPtr installedAddon;
-    bInstalled = CAddonInstaller::GetInstance().InstallModal(gameClient, installedAddon, false);
+    bInstalled =
+        ADDON::CAddonInstaller::GetInstance().InstallModal(gameClient, installedAddon, false);
     if (!bInstalled)
     {
       CLog::Log(LOGERROR, "Select game client dialog: Failed to install %s", gameClient.c_str());

--- a/xbmc/interfaces/json-rpc/AddonsOperations.h
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.h
@@ -11,7 +11,11 @@
 #include "JSONRPC.h"
 #include "addons/IAddon.h"
 
+namespace ADDON
+{
 class CAddonDatabase;
+}
+
 class CVariant;
 
 namespace JSONRPC
@@ -26,6 +30,10 @@ namespace JSONRPC
     static JSONRPC_STATUS ExecuteAddon(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
   private:
-    static void FillDetails(ADDON::AddonPtr addon, const CVariant& fields, CVariant &result, CAddonDatabase &addondb, bool append = false);
+    static void FillDetails(ADDON::AddonPtr addon,
+                            const CVariant& fields,
+                            CVariant& result,
+                            ADDON::CAddonDatabase& addondb,
+                            bool append = false);
   };
 }

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -67,7 +67,7 @@ void CRssManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
     ADDON::AddonPtr addon;
     if (!CServiceBroker::GetAddonMgr().GetAddon("script.rss.editor", addon))
     {
-      if (!CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon))
+      if (!ADDON::CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon))
         return;
     }
     CBuiltins::GetInstance().Execute("RunScript(script.rss.editor)");


### PR DESCRIPTION
## Description

### refactoring of the addon system

- always warn when installing addons from zip
- zip installed repos get their origin set to themselves
- if an addon has no repo it will at least update-check official repos
- fixes an issue with filtering addon views that was introduced with #18111
- sets origin for optional system addons (e.g. versioncheck) on sync
- small refactoring of #18207
- move CAddonDatabase/CAddonInstaller into namespace ADDON

## How Has This Been Tested?
local installation on debian

## Screenshots (if appropriate):
zip-install warning dialog:
![screenshot001](https://user-images.githubusercontent.com/58829855/90949651-4421cc80-e44a-11ea-8ce2-a1aa91569f2a.png)

before fixing addon filtering:
![flaw_before](https://user-images.githubusercontent.com/58829855/90876402-ea19fc00-e3a2-11ea-87ae-37cf603bf8a5.png)

after fixing addon filtering:
![flaw_after](https://user-images.githubusercontent.com/58829855/90876440-faca7200-e3a2-11ea-8bb6-850c088f29f4.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@enen92 @phunkyfish 