### PR TITLE
Gets Windows 10 version name from Windows Registry

### DIFF
--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -20,6 +20,8 @@
 
 #define MAX_KNOWN_ATTRIBUTES  46
 
+#define REG_CURRENT_VERSION L"Software\\Microsoft\\Windows NT\\CurrentVersion"
+
 
 class CSysData
 {
@@ -80,6 +82,7 @@ public:
     WindowsVersionWin10_1903,   // Windows 10 1903
     WindowsVersionWin10_1909,   // Windows 10 1909
     WindowsVersionWin10_2004,   // Windows 10 2004
+    WindowsVersionWin10_Future, // Windows 10 future build
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
   };


### PR DESCRIPTION
## Description
Gets Windows 10 version name from Windows Registry

## Motivation and Context
The PR https://github.com/xbmc/xbmc/pull/18214 adds version information for recent versions (already known) of Windows 10 but has the downside that the code would need maintenance to add future versions.

This PR solves this so that for future Windows 10 versions this information is obtained from the Windows registry.

For example for Windows 10 20H2 (build 19042) it will now show: "Windows 10 20H2"

and when it is launched it will show: "Windows 10 2009" (assuming that is the final name).

Currently (without this PR) all future versions of Windows are shown as "Windows 10 2004" since it is the last hardcoded in Kodi

Despite this, it is still useful to follow the enumeration system and add the new Windows versions as new enum elements but only when is need to use a Windows feature not present in the previous versions and is need to check at runtime.

## How Has This Been Tested?
Tested with several Windows versions: 1607, 2004 and 20H2 (insider)

## Screenshots (if appropriate):
Windows 10 1607:
![Anotación 2020-08-24 182647](https://user-images.githubusercontent.com/58434170/91072597-08e5f000-e63a-11ea-98da-48f156aa8304.png)

Windows 10 2004:
![Anotación 2020-08-24 183420](https://user-images.githubusercontent.com/58434170/91072666-2024dd80-e63a-11ea-8e8c-aa107d98c142.png)

Windows 10 20H2:
![Anotación 2020-08-24 182931](https://user-images.githubusercontent.com/58434170/91072739-3a5ebb80-e63a-11ea-85c4-3f2626a0d848.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
