### PR TITLE
[skins] load Startup.xml on skin change

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1186,6 +1186,8 @@ void CApplication::ReloadSkin(bool confirm/*=false*/)
         m_confirmSkinChange = false;
         settings->SetString(CSettings::SETTING_LOOKANDFEEL_SKIN, oldSkin);
       }
+      else
+        CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_STARTUP_ANIM);
     }
   }
   else


### PR DESCRIPTION
## Description
several skins use Startup.xml to set up their skin
- they may setting some window properties to their initial values
- they may run skin helper scripts to , for instance, generate the home menu
- they may run an intro video

while this all works fine when it's the default skin that's loaded at kodi startup,
none of this will work if you switch to a different skin while running kodi.
in this case, the code in startup.xml isn't run.

this requires skins that depend on the code in their startup.xml file to implement workarounds to make sure their skin is set-up correctly.

this PR addresses that problem by loading the STARTUP window after switching skins, instead of staying on the settings window.

## Motivation and Context
it's been requested on the forum a few times:
https://forum.kodi.tv/showthread.php?tid=320545
https://forum.kodi.tv/showthread.php?tid=356605

## How Has This Been Tested?
tested this change by switching between various skins.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
