### PR TITLE
[Subtitles][ASS] Make ASS subtitles belonging  to the same ass track …

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.cpp
@@ -119,10 +119,9 @@ int CDVDOverlayCodecSSA::Decode(DemuxPacket *pPacket)
   if(m_pOverlay)
   {
     /* there will only ever be one active, so we
-     * must always make sure any new one overlap
-     * include the full duration of the old one */
-    if(m_pOverlay->iPTSStopTime > pts + duration)
-      duration = m_pOverlay->iPTSStopTime - pts;
+     * must always make sure any new one doesn't overlap
+     * with the previous one */
+    m_pOverlay->iPTSStopTime = pts;
     SAFE_RELEASE(m_pOverlay);
   }
 

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -23,26 +23,6 @@ void CDVDOverlayContainer::Add(CDVDOverlay* pOverlay)
   pOverlay->Acquire();
 
   CSingleLock lock(*this);
-
-  // markup any non ending overlays, to finish
-  // when this new one starts, there can be
-  // multiple overlays queued at same start
-  // point so only stop them when we get a
-  // new startpoint
-  for(int i = m_overlays.size();i>0;)
-  {
-    i--;
-    if(m_overlays[i]->iPTSStopTime)
-    {
-      if(!m_overlays[i]->replace)
-        break;
-      if(m_overlays[i]->iPTSStopTime <= pOverlay->iPTSStartTime)
-        break;
-    }
-    if(m_overlays[i]->iPTSStartTime != pOverlay->iPTSStartTime)
-      m_overlays[i]->iPTSStopTime = pOverlay->iPTSStartTime;
-  }
-
   m_overlays.push_back(pOverlay);
 
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.cpp
@@ -64,6 +64,41 @@ void CDVDSubtitleLineCollection::Sort()
   }
 }
 
+void CDVDSubtitleLineCollection::MakeSequential()
+{
+  if (!m_pHead || !m_pHead->pNext)
+    return;
+
+  ListElement* p1 = m_pHead;
+  ListElement* p2 = m_pHead;
+
+  while (p1->pNext != nullptr)
+  {
+    p2 = p1->pNext;
+
+    if (p2->pOverlay->replace)
+    {
+      // remove overlay if it overlaps with the previous one
+      if (p2->pOverlay->iPTSStartTime > p1->pOverlay->iPTSStartTime &&
+          p2->pOverlay->iPTSStopTime < p1->pOverlay->iPTSStopTime)
+      {
+        if (p2->pNext)
+        {
+          p1->pNext = p2->pNext;
+          delete p2;
+          continue;
+        }
+      }
+      // set previous subtitle stop time to the new one start time
+      else if (p2->pOverlay->iPTSStartTime < p1->pOverlay->iPTSStopTime)
+        p1->pOverlay->iPTSStopTime = p2->pOverlay->iPTSStartTime;
+    }
+
+    // move to next subtitle on the list
+    p1 = p2;
+  }
+}
+
 CDVDOverlay* CDVDSubtitleLineCollection::Get(double iPts)
 {
   CDVDOverlay* pOverlay = NULL;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.h
@@ -29,6 +29,15 @@ public:
   void Add(CDVDOverlay* pSubtitle);
   void Sort();
 
+  /*!
+   * \brief Makes the overlay collection sequential by ensuring only one overlay exists at a given time.
+   * This is done by modifying individual overlay's start and stop pts or by removing any overlapping overlays if another
+   * one exists on the same time frame.
+   * It is useful for cases such as ASS subs in which libass renders all existing overlays provided the player pts, In such cases,
+   * as long as the library is informed that an overlay exists on a specific time frame, all images will  be rendered at a single pass.
+  */
+  void MakeSequential();
+
   CDVDOverlay* Get(double iPts = 0LL); // get the first overlay in this fifo
 
   void Reset();

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -52,6 +52,7 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo &hints)
     }
   }
   m_collection.Sort();
+  m_collection.MakeSequential();
   return true;
 }
 


### PR DESCRIPTION
…sequential

## Description
The subtitle logic is far from easy to follow. At the moment, whenever an overlay is added to an overlay container, the stop PTS of the previous subtitle might be modified if it has a stop time higher than the new overlay start pts.
At first I didn't understand why this logic exists but after a while I got to the conclusion that it exists because of ASS subtitles. Libass generates all images (a new texture) that belong to a given PTS when called with a start and stop PTS. If that logic is removed, and if 2 subtitles entries exist at the same time, we are effectively calling libass to generate images for those 2 time frames. If the 2 time-frames overlap, we might end up with duplicated subtitles. This logic exists to ensure that the subtitle collection is sequential, and that only an "overlay" exists at each moment in time.

Apart from not easy to follow, this also has a bug with overlapping subs. If a subtitle entry exists that starts after the previous one and stops before the previous one, we will set the previous subtitle stop pts to the new stop pts - leading to a possible case where a timeframe exists with no subtitle at all. See the following example:

```
Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,{\be3}Should show/hide every 2s
Dialogue: 0,0:00:01.00,0:00:09.00,TOP,,0,0,0,,{\be3\blur3\fad(200,200)}Should be on screen from 1s to 9s
Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,{\be3}Should show/hide every 2s

```

After passing through the old logic, this becomes:

```
Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,{\be3}Should show/hide every 2s
Dialogue: 0,0:00:01.00,0:00:06.00,TOP,,0,0,0,,{\be3\blur3\fad(200,200)}Should be on screen from 1s to 9s
Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,{\be3}Should show/hide every 2s
```

Which makes the second subtitle not to render until the final 9s.

To solve this issue I moved the logic to a new method in DVDLineCollection (MakeSequential), fixed the said edge case by removing the overlapping sub, improved the docs and made the call only where we need it - in the libass parser.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18298

## How Has This Been Tested?
With the provided sample in the issue report. Tested other overlapping subs (srt), with overlapping start times, overlapping subs and didn't spot any different behaviour. I didn't test other subtitle formats like PGS.

@Doraemoe can you please do a comprehensive test with your media to see if any issue pops up? 

Any help testing this extensively is also appreciated!

## Screenshots (if appropriate):

**Master:**
![MASTER](https://i.imgur.com/lwS9R3e.png "MASTER")

**PR:**
![PR](https://i.imgur.com/kbFxYuD.png "PR")

Note the top overlay showing as supposed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
