### PR TITLE
[SlideShow] handle PlayPause action

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1635,7 +1635,10 @@ bool CApplication::OnAction(const CAction &action)
   // playing or ACTION_PLAYER_PLAY if we are seeking (FF/RW) or not playing.
   if (action.GetID() == ACTION_PLAYER_PLAYPAUSE)
   {
-    if (m_appPlayer.IsPlaying() && m_appPlayer.GetPlaySpeed() == 1)
+    CGUIWindowSlideShow* pSlideShow = CServiceBroker::GetGUI()->
+                         GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
+    if ((m_appPlayer.IsPlaying() && m_appPlayer.GetPlaySpeed() == 1) ||
+         (pSlideShow && pSlideShow->InSlideShow() && !pSlideShow->IsPaused()))
       return OnAction(CAction(ACTION_PAUSE));
     else
       return OnAction(CAction(ACTION_PLAYER_PLAY));


### PR DESCRIPTION
## Description
it's currently not possible to pause the picture slideshow using a keyboard/remote button that's mapped to the PlayPause action.
(PlayPause works fine for other media, like videos or music)

the root cause of it is that PlayPause is not mapped to either Play or Pause in Apllication.cpp for the picture slideshow.
at the moment it only takes video and music playback into account, resulting in PlayPause to be always mapped to Play in case the picture slideshow is running.

## Motivation and Context
fixes https://github.com/xbmc/xbmc/issues/18328

## How Has This Been Tested?
tested using a custom keymap where i've mapped the PlayPause action to a button
`<f11>PlayPause</f11>`
started a picture slideshow and confirmed both pause & play work correctly using this button.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
