### PR TITLE
[subtitles][ass] Fix completely overlapping subtitle overlays

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -24,6 +24,8 @@ void CDVDOverlayContainer::Add(CDVDOverlay* pOverlay)
 
   CSingleLock lock(*this);
 
+  bool addToOverlays = true;
+
   // markup any non ending overlays, to finish
   // when this new one starts, there can be
   // multiple overlays queued at same start
@@ -39,12 +41,24 @@ void CDVDOverlayContainer::Add(CDVDOverlay* pOverlay)
       if(m_overlays[i]->iPTSStopTime <= pOverlay->iPTSStartTime)
         break;
     }
-    if(m_overlays[i]->iPTSStartTime != pOverlay->iPTSStartTime)
+
+    // ASS type overlays that completely overlap any previously added one shouldn't be enqueued.
+    // The timeframe is already contained within the previous overlay.
+    if (pOverlay->IsOverlayType(DVDOVERLAY_TYPE_SSA) &&
+        pOverlay->iPTSStartTime >= m_overlays[i]->iPTSStartTime &&
+        pOverlay->iPTSStopTime <= m_overlays[i]->iPTSStopTime)
+    {
+      pOverlay->Release();
+      addToOverlays = false;
+      break;
+    }
+
+    else if (m_overlays[i]->iPTSStartTime != pOverlay->iPTSStartTime)
       m_overlays[i]->iPTSStopTime = pOverlay->iPTSStartTime;
   }
 
-  m_overlays.push_back(pOverlay);
-
+  if (addToOverlays)
+    m_overlays.push_back(pOverlay);
 }
 
 VecOverlays* CDVDOverlayContainer::GetOverlays()

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -18,7 +18,7 @@ CDVDOverlayContainer::~CDVDOverlayContainer()
   Clear();
 }
 
-void CDVDOverlayContainer::Add(CDVDOverlay* pOverlay)
+void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(CDVDOverlay* pOverlay)
 {
   pOverlay->Acquire();
 

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
@@ -22,7 +22,19 @@ public:
   CDVDOverlayContainer();
   virtual ~CDVDOverlayContainer();
 
-  void Add(CDVDOverlay* pPicture); // add a overlay to the fifo
+  /*!
+  * \brief Adds an overlay into the container by processing the existing overlay collection first
+  *
+  * \details Processes the overlay collection whenever a new overlay is added. Usefull to change
+  * the overlay's PTS values of previously added overlays if the collection itself is sequential. This
+  * is, for example, the case of ASS subtitles in which a single call to ass_render_frame generates all
+  * the subtitle images on a single call even if two subtitles exist at the same time frame. Other cases
+  * might exist where an overlay shouldn't be added to the collection if completely contained in another
+  * overlay.
+  *
+  * \param pPicture pointer to the overlay to be evaluated and possibly added to the collection
+  */
+  void ProcessAndAddOverlayIfValid(CDVDOverlay* pPicture);
 
   VecOverlays* GetOverlays(); // get the first overlay in this fifo
   bool ContainsOverlayType(DVDOverlayType type);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3843,7 +3843,7 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
     switch (iMessage)
     {
     case BD_EVENT_MENU_OVERLAY:
-      m_overlayContainer.Add(static_cast<CDVDOverlay*>(pData));
+      m_overlayContainer.ProcessAndAddOverlayIfValid(static_cast<CDVDOverlay*>(pData));
       break;
     case BD_EVENT_PLAYLIST_STOP:
       m_messenger.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH));

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -61,7 +61,7 @@ void CVideoPlayerSubtitle::SendMessage(CDVDMsg* pMsg, int priority)
 
         while((overlay = m_pOverlayCodec->GetOverlay()) != NULL)
         {
-          m_pOverlayContainer->Add(overlay);
+          m_pOverlayContainer->ProcessAndAddOverlayIfValid(overlay);
           overlay->Release();
         }
       }
@@ -72,7 +72,7 @@ void CVideoPlayerSubtitle::SendMessage(CDVDMsg* pMsg, int priority)
       if (pSPUInfo)
       {
         CLog::Log(LOGDEBUG, "CVideoPlayer::ProcessSubData: Got complete SPU packet");
-        m_pOverlayContainer->Add(pSPUInfo);
+        m_pOverlayContainer->ProcessAndAddOverlayIfValid(pSPUInfo);
         pSPUInfo->Release();
       }
     }
@@ -204,7 +204,7 @@ void CVideoPlayerSubtitle::Process(double pts, double offset)
       if(pOverlay->iPTSStopTime != 0.0)
         pOverlay->iPTSStopTime -= offset;
 
-      m_pOverlayContainer->Add(pOverlay);
+      m_pOverlayContainer->ProcessAndAddOverlayIfValid(pOverlay);
       pOverlay->Release();
       pOverlay = m_pSubtitleFileParser->Parse(pts);
     }


### PR DESCRIPTION
Superseeds https://github.com/xbmc/xbmc/pull/18330

## Description
When libass is asked to render subtitles, it does it sequentially. It means that if two subtitles/ass events belonging to the same ass track (kodi transforms them into 2 overlays) are contained within the same timeframe, a single call to libass render_images will render both overlay pictures. To accomplish this while avoiding multiple repetitions of the same images on screen, kodi turns the subtitle stream sequential, by modifying the previous added overlay stop PTS with the new overlay start PTS. All works well unless the added overlay is **completely** contained within a previous overlay (thus startPTS > oldOne but stopPTS < oldOne). In that case we should not add the overlay since the timeframe is already contained by old event.

The following example illustrates the problem:

```
Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,{\be3}Should show/hide every 2s
Dialogue: 0,0:00:01.00,0:00:09.00,TOP,,0,0,0,,{\be3\blur3\fad(200,200)}Should be on screen from 1s to 9s
Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,{\be3}Should show/hide every 2s

```

After kodi processes the overlay collection this becomes

```
Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,{\be3}Should show/hide every 2s
Dialogue: 0,0:00:01.00,0:00:06.00,TOP,,0,0,0,,{\be3\blur3\fad(200,200)}Should be on screen from 1s to 9s
Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,{\be3}Should show/hide every 2s
```

The top subtitle that should have been displayed on screen from 1 to 9s is marked to end up at 6 seconds. Thus from 6 to "whatever new subtitle entry" timestamp, no other overlay will appear on screen.

Regarding the implementation:
~Note that the only way an overlay can have the "replace" property set to `true` and without the `stopPTS = 0` is exactly any ASS overlay. Thus, this fix should be well contained and should not introduce any regressions.~

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18298

## How Has This Been Tested?
With the subtitle file provided in the issue report by @Doraemoe. I tested this subtitle added externally (used to be broken) or muxed into a mkv container (where the issue did not reflect previously). Both display correctly now.
Also tested other subtitled media (srt and pgs) and didn't spot any regressions.

@Doraemoe can I ask you to re-test again? This time should be the last :)

## Screenshots (if appropriate):

**Master:**
![MASTER](https://i.imgur.com/lwS9R3e.png "MASTER")

**PR:**
![PR](https://i.imgur.com/kbFxYuD.png "PR")

Note the top overlay showing as supposed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
