### PR TITLE
[macOS][jenkins] fail only release build on notarization failure

### DIFF
--- a/tools/darwin/packaging/osx/mkdmg-osx.sh.in
+++ b/tools/darwin/packaging/osx/mkdmg-osx.sh.in
@@ -11,6 +11,7 @@ if [ ${SWITCH:-""} = "debug" ]; then
 elif [ ${SWITCH:-""} = "release" ]; then
   echo "Packaging Release target for OSX"
   APP="$DIRNAME/../../../../build/Release/@APP_NAME@.app"
+  isReleaseBuild=1
 else
   echo "You need to specify the build target"
   exit 1
@@ -65,5 +66,8 @@ echo "done"
 # codesign and notarize dmg
 if [ "$EXPANDED_CODE_SIGN_IDENTITY_NAME" ]; then
   codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" "$dmgPath"
-  ./notarize.sh "$dmgPath" "$APP/Contents/Info.plist"
+  if ! ./notarize.sh "$dmgPath" "$APP/Contents/Info.plist" && [[ $isReleaseBuild == 1 ]]; then
+    exit 1
+  fi
 fi
+exit 0


### PR DESCRIPTION
## Description
Ensures that packaging script doesn't return error if notarization script returns fails.

## Motivation and Context
Solves jenkins build failures like https://jenkins.kodi.tv/job/OSX-64/19284/

## How Has This Been Tested?
Made a build in cloned job with notarization script forced to return error: https://jenkins.kodi.tv/view/All/job/OSX-64-codesign-test/26/

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
