### PR TITLE
 [tvOS] Fix TopShelf for jailbroken devices

### DIFF
--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -71,7 +71,15 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& items, TVOSTopShelfItemsCate
     // Shared dicts  (if we are sandboxed we use sharedDefaults, else we use sharedJailbreak)
     auto sharedDefaults =
         isSandboxed ? [[NSUserDefaults alloc] initWithSuiteName:[tvosShared getSharedID]] : nil;
-    auto sharedJailbreak = isSandboxed ? nil : [[NSMutableDictionary alloc] initWithCapacity:2];
+    const auto sharedJailbreakUrl = [storeUrl URLByAppendingPathComponent:@"shared.dict"];
+    NSMutableDictionary* sharedJailbreak = nil;
+    if (!isSandboxed)
+    {
+      if ([[NSFileManager defaultManager] fileExistsAtPath:sharedJailbreakUrl.path])
+        sharedJailbreak = [NSMutableDictionary dictionaryWithContentsOfURL:sharedJailbreakUrl];
+      else
+        sharedJailbreak = [[NSMutableDictionary alloc] initWithCapacity:2];
+    }
 
     // Function used to add category items in TopShelf shared dict
     CVideoThumbLoader thumbLoader;
@@ -177,8 +185,7 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& items, TVOSTopShelfItemsCate
 
     // Synchronize shared dict
     [sharedDefaults synchronize];
-    [sharedJailbreak writeToURL:[storeUrl URLByAppendingPathComponent:@"shared.dict"]
-                     atomically:YES];
+    [sharedJailbreak writeToURL:sharedJailbreakUrl atomically:YES];
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

This PR only concerns Apple TV where Kodi was installed with `dpkg -i` or by NitoTV (jailbroken devices).

This PR fix an issue where Kodi TopShelf only contains items from the last category that called `CTVOSTopShelf::SetTopShelfItems` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently the shared dictionary that hold top shelf items is cleared on each `CTVOSTopShelf::SetTopShelfItems` call.
Instead, we need to use the existing dictionary if this one already exists.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On checkra1n jailbroken Apple TV 4K.

## User impact

Jailbroken Apple TV users will be able to have two or more categories working on their Kodi TopShelf.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
