### PR TITLE
[filesystem] Don't overwrite station name with track metadata for shoutcast streams if icy-name header set

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.h
+++ b/xbmc/filesystem/ShoutcastFile.h
@@ -48,6 +48,7 @@ protected:
   int m_discarded; // data used for tags
   int m_currint;
   char* m_buffer; // buffer used for tags
+  bool m_titleFromHeader;
   MUSIC_INFO::CMusicInfoTag m_tag;
 
   CFileCache* m_cacheReader;


### PR DESCRIPTION
## Description
Current core code extracts the icy-name header if it's set but then overwrites it later with the stream title info.  This means that although station names are extracted correctly for those streaming radio stations that set the header, it gets overwritten by the artist and track info and never displayed.

This PR adds a flag that is set if the icy-name header is not empty and uses that to put any artist and track data into the artist infolabel rather than the title so avoiding overwriting the station name.

## Motivation and Context
It's always bugged me that station names were not displayed for streaming stations when other software seemed perfectly capable of doing so.  It was pointed out recently on the forum that the names were not displayed and raised as an issue.  As such, this fixes https://github.com/xbmc/xbmc/issues/18332


## How Has This Been Tested?
Tested by playing multiple streams from some urls I already use daily plus several using the rad.io addon. 
This change only affects shoutcast/icecast radio streams.

## Screenshots (if appropriate):

Before change
<a href="https://ibb.co/Cv6BXBh"><img src="https://i.ibb.co/1KMZpZ8/screenshot044.png" alt="screenshot044" border="0"></a>

After change
<a href="https://ibb.co/rpHhmL2"><img src="https://i.ibb.co/xg6bDcq/screenshot010.png" alt="screenshot010" border="0"></a>

## User related:

Display the name of a streaming radio station as well as the artist and track information if the station name is available.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
