### PR TITLE
Expose listitem filename and path from xbmcgui.ListItem.getVideoInfoTag

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -109,6 +109,11 @@ namespace XBMCAddon
       return infoTag->m_strPath;
     }
 
+    String InfoTagVideo::getFilenameAndPath()
+    {
+      return infoTag->m_strFileNameAndPath;
+    }
+
     String InfoTagVideo::getIMDBNumber()
     {
       return infoTag->GetUniqueID();

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -323,6 +323,23 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getFilenameAndPath() }
+      /// To get the full path with filename where the video is stored.
+      ///
+      /// @return [string] File name and Path
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v19 New function added.
+      ///
+      getFilenameAndPath();
+#else
+      String getFilenameAndPath();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
       /// @brief \python_func{ getIMDBNumber() }
       /// To get the [IMDb](https://en.wikipedia.org/wiki/Internet_Movie_Database)
       /// number of the video (if present).


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Expose listitem filename and path from xbmcgui.ListItem.getVideoInfoTag().getFilenameAndPath() to return the same as the ListItem.FileNameAndPath infoLabel

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When working on a context menu I found this missing, and had to resort to the info label. The issue is the info label could be different than sys.listitem due to mouse movement for example. This is also the only way I'm aware of to get the query string for a plugin url in this case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested, printed debug strings below

```
DEBUG <general>: getInfoLabel(ListItem.FileName): ""
DEBUG <general>: getInfoLabel(ListItem.Path): "plugin://plugin.video.composite_for_plex/library/movies/"
DEBUG <general>: getInfoLabel(ListItem.FileNameAndPath): "plugin://plugin.video.composite_for_plex/library/movies/?url=http%3A//192.168.1.10%3A32400/library/metadata/7439&mode=5"

DEBUG <general>: getVideoInfoTag().getFile(): ""
DEBUG <general>: getVideoInfoTag().getPath(): "plugin://plugin.video.composite_for_plex/library/movies/"
DEBUG <general>: getVideoInfoTag().getFilenameAndPath(): "plugin://plugin.video.composite_for_plex/library/movies/?url=http%3A//192.168.1.10%3A32400/library/metadata/7439&mode=5"
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
