### PR TITLE
[addons] repository dependency restrictions, install from all repos and install dialog changes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15336,7 +15336,11 @@ msgctxt "#24087"
 msgid "All repositories"
 msgstr ""
 
-#empty string with id 24088
+#. Used as a text in the progress dialog when install of a repo fails
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24088"
+msgid "Failed to install repository"
+msgstr ""
 
 msgctxt "#24089"
 msgid "Add-on restarts"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22011,7 +22011,13 @@ msgctxt "#39027"
 msgid "Sortname"
 msgstr ""
 
-#empty strings from id 39028 to 39029
+#. Text for yes/no dialog when silently uninstalling an addon
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#39028"
+msgid "Addon \"{0:s}\"[CR]Origin \"{1:s}\"[CR]Version \"{2:s}\"[CR]- will uninstall and be replaced. Would you like to proceed?"
+msgstr ""
+
+#empty string id 39029
 
 #. Media source, a filter and smart playlist rule option
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -147,6 +147,7 @@
 	<variable name="AddonsLabel2Var">
 		<value condition="ListItem.Property(addon.downloading)">$INFO[ListItem.Property(addon.status)]</value>
 		<value condition="!Container.SortMethod(1)">$INFO[ListItem.Label2]</value>
+		<value condition="String.IsEqual(ListItem.Path,addons://all/)">$INFO[ListItem.AddonOrigin,, - ]$INFO[ListItem.AddonVersion]</value>
 		<value>$INFO[ListItem.AddonCreator,, - ]$INFO[ListItem.AddonVersion]</value>
 	</variable>
 	<variable name="RatingSettingLabel2Var">

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -733,9 +733,19 @@ bool CAddonInstallJob::DoFileOperation(FileAction action, CFileItemList &items, 
 
 bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryPtr& repo)
 {
-  SetText(g_localizeStrings.Get(24079));
-  auto deps = m_addon->GetDependencies();
+  const auto& deps = m_addon->GetDependencies();
 
+  if (!deps.empty() && m_addon->HasType(ADDON_REPOSITORY))
+  {
+    CLog::Log(
+        LOGERROR,
+        "CAddonInstallJob::{}: failed to install repository [{}]. It has dependencies defined",
+        __func__, m_addon->ID());
+    ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24088));
+    return false;
+  }
+
+  SetText(g_localizeStrings.Get(24079));
   unsigned int totalSteps = static_cast<unsigned int>(deps.size()) + 1;
   if (ShouldCancel(0, totalSteps))
     return false;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -123,7 +123,10 @@ namespace ADDON
     bool ReloadSettings(const std::string &id);
 
     /*! Get addons with available updates */
-    VECADDONS GetAvailableUpdates() const;
+    std::vector<std::shared_ptr<IAddon>> GetAvailableUpdates() const;
+
+    /*! Get addons that are outdated */
+    std::vector<std::shared_ptr<IAddon>> GetOutdatedAddons() const;
 
     /*! Returns true if there is any addon with available updates, otherwise false */
     bool HasAvailableUpdates();
@@ -221,6 +224,16 @@ namespace ADDON
      \param ID id of the addon
     */
     bool IsAddonInstalled(const std::string& ID);
+
+    /* \brief Checks whether an addon is installed from a
+     *        particular origin repo and version
+     * \param ID id of the addon
+     * \param origin origin repository id
+     * \param version the version of the addon
+     */
+    bool IsAddonInstalled(const std::string& ID,
+                          const std::string& origin,
+                          const AddonVersion& version);
 
     /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
     \param addon addon to be checked
@@ -380,10 +393,21 @@ namespace ADDON
 
     VECADDONS m_updateableAddons;
 
+    /*!
+     * \brief returns a vector with either available updates or outdated addons.
+     *        usually called by its wrappers GetAvailableUpdates() or
+     *        GetOutdatedAddons()
+     * \param[in] true to return outdated addons, false to return available updates
+     * \return vector filled with either available updates or outdated addons
+     */
+    std::vector<std::shared_ptr<IAddon>> GetAvailableUpdatesOrOutdatedAddons(
+        bool returnOutdatedAddons) const;
+
     bool GetAddonsInternal(const TYPE& type,
                            VECADDONS& addons,
                            bool enabledOnly,
                            bool checkIncompatible = false) const;
+
     bool EnableSingle(const std::string& id);
 
     void FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path);

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -393,6 +393,15 @@ bool CAddonRepos::FindDependency(const std::string& dependsId,
             "ADDONS: found dependency [{}] for install/update from repo [{}]. dependee is [{}]",
             dependencyToInstall->ID(), repoForDep->ID(), parent->ID());
 
+  if (dependencyToInstall->HasType(ADDON_REPOSITORY))
+  {
+    CLog::Log(LOGDEBUG,
+              "ADDONS: dependency with id [{}] has type ADDON_REPOSITORY and will not install!",
+              dependencyToInstall->ID());
+
+    return false;
+  }
+
   return true;
 }
 

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -67,6 +67,16 @@ public:
                        std::vector<std::shared_ptr<IAddon>>& updates) const;
 
   /*!
+   * \brief Build the list of addons that are outdated and have an update
+   *        available depending on defined rules
+   * \param installed vector of all addons installed on the system that are
+   *        checked for an update
+   * \param[out] outdated list of addon versions that have an update available
+   */
+  void BuildOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
+                         std::vector<std::shared_ptr<IAddon>>& outdated) const;
+
+  /*!
    * \brief Checks if the origin-repository of a given addon is defined as official repo
    *        but does not check the origin path (e.g. https://mirrors.kodi.tv ...)
    * \param addon pointer to addon to be checked
@@ -105,11 +115,19 @@ public:
 
   /*!
    * \brief Retrieves the latest official versions of addons to vector.
-   *        Private versions are added obeying the set updateMode.
+   *        Private versions are added obeying updateMode.
    *        (either OFFICIAL_ONLY or ANY_REPOSITORY)
    * \param[out] addonList retrieved addon list in a vector
    */
   void GetLatestAddonVersions(std::vector<std::shared_ptr<IAddon>>& addonList) const;
+
+  /*!
+   * \brief Retrieves the latest official versions of addons to vector.
+   *        Private versions (latest per repository) are added obeying updateMode.
+   *        (either OFFICIAL_ONLY or ANY_REPOSITORY)
+   * \param[out] addonList retrieved addon list in a vector
+   */
+  void GetLatestAddonVersionsFromAllRepos(std::vector<std::shared_ptr<IAddon>>& addonList) const;
 
   /*!
    * \brief Find a dependency to install during an addon install or update
@@ -140,6 +158,14 @@ public:
                                   std::shared_ptr<IAddon>& dependencyToInstall) const;
 
 private:
+  /*!
+   * \brief Executor for BuildUpdateList() and BuildOutdatedList()
+   * \sa BuildUpdateList() BuildOutdatedList()
+   */
+  void BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
+                                 std::vector<std::shared_ptr<IAddon>>& result,
+                                 bool returnOutdatedAddons) const;
+
   /*!
    * \brief Load the map of addons
    * \note this function should only by called from publicly exposed wrappers

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -79,13 +79,16 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
       }
       if (iControl == CONTROL_BTN_INSTALL)
       {
-        if (!m_localAddon)
+        const auto& itemAddonInfo = m_item->GetAddonInfo();
+        if (!CServiceBroker::GetAddonMgr().IsAddonInstalled(
+                itemAddonInfo->ID(), itemAddonInfo->Origin(), itemAddonInfo->Version()))
         {
           OnInstall();
           return true;
         }
         else
         {
+          m_silentUninstall = false;
           OnUninstall();
           return true;
         }
@@ -158,7 +161,9 @@ void CGUIDialogAddonInfo::UpdateControls()
   if (!m_item)
     return;
 
-  bool isInstalled = NULL != m_localAddon.get();
+  const auto& itemAddonInfo = m_item->GetAddonInfo();
+  bool isInstalled = CServiceBroker::GetAddonMgr().IsAddonInstalled(
+      itemAddonInfo->ID(), itemAddonInfo->Origin(), itemAddonInfo->Version());
   m_addonEnabled =
       m_localAddon && !CServiceBroker::GetAddonMgr().IsAddonDisabled(m_localAddon->ID());
   bool canDisable =
@@ -329,8 +334,26 @@ void CGUIDialogAddonInfo::OnInstall()
   if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))
     return;
 
-  if (m_localAddon || !m_item->HasAddonInfo())
+  if (!m_item->HasAddonInfo())
     return;
+
+  if (m_localAddon)
+  {
+    const std::string& header = g_localizeStrings.Get(19098); // Warning!
+    const std::string text =
+        StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->ID(),
+                            m_localAddon->Origin(), m_localAddon->Version().asString());
+
+    if (CGUIDialogYesNo::ShowAndGetInput(header, text))
+    {
+      m_silentUninstall = true;
+      OnUninstall();
+    }
+    else
+    {
+      return;
+    }
+  }
 
   const auto& itemAddonInfo = m_item->GetAddonInfo();
 
@@ -429,7 +452,7 @@ void CGUIDialogAddonInfo::OnUninstall()
     return;
 
   // prompt user to be sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24037}, CVariant{750}))
+  if (!m_silentUninstall && !CGUIDialogYesNo::ShowAndGetInput(CVariant{24037}, CVariant{750}))
     return;
 
   bool removeData = false;

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -86,4 +86,10 @@ private:
   CFileItemPtr m_item;
   ADDON::AddonPtr m_localAddon;
   bool m_addonEnabled = false;
+
+  /*!< a switch to force @ref OnUninstall() to proceed without user interaction.
+   *   useful for cases like where another repo’s version of an addon must
+   *   be removed before installing a new version.
+   */
+  bool m_silentUninstall = false;
 };

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -46,6 +46,10 @@ namespace XFILE
     static bool GetScriptsAndPlugins(const std::string &content, CFileItemList &items);
 
     static void GenerateAddonListing(const CURL &path, const ADDON::VECADDONS& addons, CFileItemList &items, const std::string label);
+    static void GenerateAddonListingUpdates(const CURL& path,
+                                            const ADDON::VECADDONS& addons,
+                                            CFileItemList& items,
+                                            const std::string label);
     static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false);
 
     /*! \brief Returns true if `path` is a path or subpath of the repository directory, otherwise false */
@@ -53,5 +57,10 @@ namespace XFILE
 
   private:
     bool GetSearchResults(const CURL& path, CFileItemList &items);
+    static void GenerateAddonListing(const CURL& path,
+                                     const ADDON::VECADDONS& addons,
+                                     CFileItemList& items,
+                                     const std::string label,
+                                     bool alwaysShowUpdateIcon);
   };
 }


### PR DESCRIPTION
## Description

### refactoring of the addon system

- repository add-ons cannot have any dependencies, deny installation of those
- an add-on cannot have a dependency that is a repository
- do not show the select version dialog when installing from the addon-info dialog
- show the latest version of each add-on from any repository when "install from all repos"
- show a warning dialog when the same addon-id is installed from a different origin
- skin estuary now displays infolabel `AddonOrigin` instead of `AddonCreator`

## How Has This Been Tested?
local installation on debian
**testing is greatly appreciated**
have not discovered any functional flaws so far

## Screenshots:
will follow (with comments)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@phunkyfish 
@enen92 
@AlwinEsch 