### PR TITLE
Add poster-option for recently-added movies

### DIFF
--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -75,6 +75,7 @@ bool CRecentlyAddedJob::UpdateVideo()
 
       home->SetProperty("LatestMovie." + value + ".Thumb"       , item->GetArt("thumb"));
       home->SetProperty("LatestMovie." + value + ".Fanart"      , item->GetArt("fanart"));
+      home->SetProperty("LatestMovie." + value + ".Poster"      , item->GetArt("poster"));
     }
   }
   for (; i < NUM_ITEMS; ++i)
@@ -89,6 +90,7 @@ bool CRecentlyAddedJob::UpdateVideo()
     home->SetProperty("LatestMovie." + value + ".Path"        , "");
     home->SetProperty("LatestMovie." + value + ".Trailer"     , "");
     home->SetProperty("LatestMovie." + value + ".Fanart"      , "");
+    home->SetProperty("LatestMovie." + value + ".Poster"      , "");
   }
 
   i = 0;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This change gives the option to use "Poster" as possible artwork for the `Window(Home).Property(key)`-infolabel

I might have set the wrong labels. Please correct them if needed. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Skin Confluence currently has the problem that it uses for example: 
`<thumb>$INFO[Window.Property(LatestMovie.7.Thumb)]</thumb>`
to refer to the movie artwork at the "Recently added movies"-section. With the current code it's not possible to show movie posters, only thumbs. As there's no option to use "Poster" instead of "Thumb" and fixing that would require a bunch of skin confluence re-writing, I would love to have this option available and probably other skinners can make use of it as well

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested of Fedora with current Kodi master and an additional change at Confluence itseld. Please see:
https://github.com/xbmc/skin.confluence/pull/82

## Screenshots (if appropriate):
Before this change here and the change a Confluence, please see this forum thread: 
https://forum.kodi.tv/showthread.php?tid=356715

After the core and Confluence change:
![image](https://user-images.githubusercontent.com/7235787/91621815-c05d6800-e994-11ea-9608-413b238c9e84.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
