### PR TITLE
[addons][screensaver] cleanup API, improve "C" interface, not use void* direct as value 

### DIFF
--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -23,18 +23,21 @@ CScreenSaver::CScreenSaver(const AddonInfoPtr& addonInfo)
   m_presets = CSpecialProtocol::TranslatePath(Path());
   m_profile = CSpecialProtocol::TranslatePath(Profile());
 
-  m_struct = {{0}};
-  m_struct.props.x = 0;
-  m_struct.props.y = 0;
-  m_struct.props.device = CServiceBroker::GetWinSystem()->GetHWContext();
-  m_struct.props.width = CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth();
-  m_struct.props.height = CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight();
-  m_struct.props.pixelRatio = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().fPixelRatio;
-  m_struct.props.name = m_name.c_str();
-  m_struct.props.presets = m_presets.c_str();
-  m_struct.props.profile = m_profile.c_str();
+  m_struct.props = new AddonProps_Screensaver();
+  m_struct.props->x = 0;
+  m_struct.props->y = 0;
+  m_struct.props->device = CServiceBroker::GetWinSystem()->GetHWContext();
+  m_struct.props->width = CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth();
+  m_struct.props->height = CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight();
+  m_struct.props->pixelRatio = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo().fPixelRatio;
+  m_struct.props->name = m_name.c_str();
+  m_struct.props->presets = m_presets.c_str();
+  m_struct.props->profile = m_profile.c_str();
 
-  m_struct.toKodi.kodiInstance = this;
+  m_struct.toKodi = new AddonToKodiFuncTable_Screensaver();
+  m_struct.toKodi->kodiInstance = this;
+
+  m_struct.toAddon = new KodiToAddonFuncTable_Screensaver();
 
   /* Open the class "kodi::addon::CInstanceScreensaver" on add-on side */
   if (CreateInstance(&m_struct) != ADDON_STATUS_OK)
@@ -45,25 +48,29 @@ CScreenSaver::~CScreenSaver()
 {
   /* Destroy the class "kodi::addon::CInstanceScreensaver" on add-on side */
   DestroyInstance();
+
+  delete m_struct.toAddon;
+  delete m_struct.toKodi;
+  delete m_struct.props;
 }
 
 bool CScreenSaver::Start()
 {
-  if (m_struct.toAddon.Start)
-    return m_struct.toAddon.Start(&m_struct);
+  if (m_struct.toAddon->Start)
+    return m_struct.toAddon->Start(&m_struct);
   return false;
 }
 
 void CScreenSaver::Stop()
 {
-  if (m_struct.toAddon.Stop)
-    m_struct.toAddon.Stop(&m_struct);
+  if (m_struct.toAddon->Stop)
+    m_struct.toAddon->Stop(&m_struct);
 }
 
 void CScreenSaver::Render()
 {
-  if (m_struct.toAddon.Render)
-    m_struct.toAddon.Render(&m_struct);
+  if (m_struct.toAddon->Render)
+    m_struct.toAddon->Render(&m_struct);
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -11,8 +11,6 @@
 #include "../AddonBase.h"
 #include "../gui/renderHelper.h"
 
-namespace kodi { namespace addon { class CInstanceScreensaver; }}
-
 extern "C"
 {
 
@@ -53,7 +51,7 @@ typedef struct AddonToKodiFuncTable_Screensaver
  */
 typedef struct KodiToAddonFuncTable_Screensaver
 {
-  kodi::addon::CInstanceScreensaver* addonInstance;
+  KODI_HANDLE addonInstance;
   bool (__cdecl* Start) (AddonInstance_Screensaver* instance);
   void (__cdecl* Stop) (AddonInstance_Screensaver* instance);
   void (__cdecl* Render) (AddonInstance_Screensaver* instance);
@@ -424,23 +422,30 @@ namespace addon
 
     inline static bool ADDON_Start(AddonInstance_Screensaver* instance)
     {
-      instance->toAddon.addonInstance->m_renderHelper = kodi::gui::GetRenderHelper();
-      return instance->toAddon.addonInstance->Start();
+      CInstanceScreensaver* thisClass =
+          static_cast<CInstanceScreensaver*>(instance->toAddon.addonInstance);
+      thisClass->m_renderHelper = kodi::gui::GetRenderHelper();
+      return thisClass->Start();
     }
 
     inline static void ADDON_Stop(AddonInstance_Screensaver* instance)
     {
-      instance->toAddon.addonInstance->Stop();
-      instance->toAddon.addonInstance->m_renderHelper = nullptr;
+      CInstanceScreensaver* thisClass =
+          static_cast<CInstanceScreensaver*>(instance->toAddon.addonInstance);
+      thisClass->Stop();
+      thisClass->m_renderHelper = nullptr;
     }
 
     inline static void ADDON_Render(AddonInstance_Screensaver* instance)
     {
-      if (!instance->toAddon.addonInstance->m_renderHelper)
+      CInstanceScreensaver* thisClass =
+          static_cast<CInstanceScreensaver*>(instance->toAddon.addonInstance);
+
+      if (!thisClass->m_renderHelper)
         return;
-      instance->toAddon.addonInstance->m_renderHelper->Begin();
-      instance->toAddon.addonInstance->Render();
-      instance->toAddon.addonInstance->m_renderHelper->End();
+      thisClass->m_renderHelper->Begin();
+      thisClass->Render();
+      thisClass->m_renderHelper->End();
     }
 
     /*

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -18,379 +18,382 @@ namespace kodi
 namespace addon
 {
 
-  //============================================================================
+//============================================================================
+///
+/// \addtogroup cpp_kodi_addon_screensaver
+/// @brief \cpp_class{ kodi::addon::CInstanceScreensaver }
+/// **Screensaver add-on instance**
+///
+/// A screensaver is a Kodi addon that fills the screen with moving images or
+/// patterns when the computer is not in use. Initially designed to prevent
+/// phosphor burn-in on CRT and plasma computer monitors (hence the name),
+/// screensavers are now used primarily for entertainment, security or to
+/// display system status information.
+///
+/// Include the header \ref ScreenSaver.h "#include <kodi/addon-instance/ScreenSaver.h>"
+/// to use this class.
+///
+/// This interface allows the creating of screensavers for Kodi, based upon
+/// **DirectX** or/and **OpenGL** rendering with `C++` code.
+///
+/// The interface is small and easy usable. It has three functions:
+///
+/// * <b><c>Start()</c></b> - Called on creation
+/// * <b><c>Render()</c></b> - Called at render time
+/// * <b><c>Stop()</c></b> - Called when the screensaver has no work
+///
+/// Additionally, there are several \ref cpp_kodi_addon_screensaver_CB "other functions"
+/// available in which the child class can ask about the current hardware,
+/// including the device, display and several other parts.
+///
+///
+/// --------------------------------------------------------------------------
+///
+///
+/// **Here is an example of the minimum required code to start a screensaver:**
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/addon-instance/Screensaver.h>
+///
+/// class CMyScreenSaver : public kodi::addon::CAddonBase,
+///                        public kodi::addon::CInstanceScreensaver
+/// {
+/// public:
+///   CMyScreenSaver();
+///
+///   bool Start() override;
+///   void Render() override;
+/// };
+///
+/// CMyScreenSaver::CMyScreenSaver()
+/// {
+///   ...
+/// }
+///
+/// bool CMyScreenSaver::Start()
+/// {
+///   ...
+///   return true;
+/// }
+///
+/// void CMyScreenSaver::Render()
+/// {
+///   ...
+/// }
+///
+/// ADDONCREATOR(CMyScreenSaver)
+/// ~~~~~~~~~~~~~
+///
+///
+/// --------------------------------------------------------------------------
+///
+///
+/// **Here is another example where the screensaver is used together with
+/// other instance types:**
+///
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/addon-instance/Screensaver.h>
+///
+/// class CMyScreenSaver : public ::kodi::addon::CInstanceScreensaver
+/// {
+/// public:
+///   CMyScreenSaver(KODI_HANDLE instance);
+///
+///   bool Start() override;
+///   void Render() override;
+/// };
+///
+/// CMyScreenSaver::CMyScreenSaver(KODI_HANDLE instance)
+///   : CInstanceScreensaver(instance)
+/// {
+///   ...
+/// }
+///
+/// bool CMyScreenSaver::Start()
+/// {
+///   ...
+///   return true;
+/// }
+///
+/// void CMyScreenSaver::Render()
+/// {
+///   ...
+/// }
+///
+///
+/// /*----------------------------------------------------------------------*/
+///
+/// class CMyAddon : public ::kodi::addon::CAddonBase
+/// {
+/// public:
+///   CMyAddon() { }
+///   ADDON_STATUS CreateInstance(int instanceType,
+///                               std::string instanceID,
+///                               KODI_HANDLE instance,
+///                               KODI_HANDLE& addonInstance) override;
+/// };
+///
+/// /* If you use only one instance in your add-on, can be instanceType and
+///  * instanceID ignored */
+/// ADDON_STATUS CMyAddon::CreateInstance(int instanceType,
+///                                       std::string instanceID,
+///                                       KODI_HANDLE instance,
+///                                       KODI_HANDLE& addonInstance)
+/// {
+///   if (instanceType == ADDON_INSTANCE_SCREENSAVER)
+///   {
+///     kodi::Log(ADDON_LOG_NOTICE, "Creating my Screensaver");
+///     addonInstance = new CMyScreenSaver(instance);
+///     return ADDON_STATUS_OK;
+///   }
+///   else if (...)
+///   {
+///     ...
+///   }
+///   return ADDON_STATUS_UNKNOWN;
+/// }
+///
+/// ADDONCREATOR(CMyAddon)
+/// ~~~~~~~~~~~~~
+///
+/// The destruction of the example class `CMyScreenSaver` is called from
+/// Kodi's header. Manually deleting the add-on instance is not required.
+///
+//----------------------------------------------------------------------------
+class ATTRIBUTE_HIDDEN CInstanceScreensaver : public IAddonInstance
+{
+public:
+  //==========================================================================
   ///
-  /// \addtogroup cpp_kodi_addon_screensaver
-  /// @brief \cpp_class{ kodi::addon::CInstanceScreensaver }
-  /// **Screensaver add-on instance**
+  /// @ingroup cpp_kodi_addon_screensaver
+  /// @brief Screensaver class constructor
   ///
-  /// A screensaver is a Kodi addon that fills the screen with moving images or
-  /// patterns when the computer is not in use. Initially designed to prevent
-  /// phosphor burn-in on CRT and plasma computer monitors (hence the name),
-  /// screensavers are now used primarily for entertainment, security or to
-  /// display system status information.
+  /// Used by an add-on that only supports screensavers.
   ///
-  /// Include the header \ref ScreenSaver.h "#include <kodi/addon-instance/ScreenSaver.h>"
-  /// to use this class.
-  ///
-  /// This interface allows the creating of screensavers for Kodi, based upon
-  /// **DirectX** or/and **OpenGL** rendering with `C++` code.
-  ///
-  /// The interface is small and easy usable. It has three functions:
-  ///
-  /// * <b><c>Start()</c></b> - Called on creation
-  /// * <b><c>Render()</c></b> - Called at render time
-  /// * <b><c>Stop()</c></b> - Called when the screensaver has no work
-  ///
-  /// Additionally, there are several \ref cpp_kodi_addon_screensaver_CB "other functions"
-  /// available in which the child class can ask about the current hardware,
-  /// including the device, display and several other parts.
-  ///
-  ///
-  /// --------------------------------------------------------------------------
-  ///
-  ///
-  /// **Here is an example of the minimum required code to start a screensaver:**
-  /// ~~~~~~~~~~~~~{.cpp}
-  /// #include <kodi/addon-instance/Screensaver.h>
-  ///
-  /// class CMyScreenSaver : public kodi::addon::CAddonBase,
-  ///                        public kodi::addon::CInstanceScreensaver
-  /// {
-  /// public:
-  ///   CMyScreenSaver();
-  ///
-  ///   bool Start() override;
-  ///   void Render() override;
-  /// };
-  ///
-  /// CMyScreenSaver::CMyScreenSaver()
-  /// {
-  ///   ...
-  /// }
-  ///
-  /// bool CMyScreenSaver::Start()
-  /// {
-  ///   ...
-  ///   return true;
-  /// }
-  ///
-  /// void CMyScreenSaver::Render()
-  /// {
-  ///   ...
-  /// }
-  ///
-  /// ADDONCREATOR(CMyScreenSaver)
-  /// ~~~~~~~~~~~~~
-  ///
-  ///
-  /// --------------------------------------------------------------------------
-  ///
-  ///
-  /// **Here is another example where the screensaver is used together with
-  /// other instance types:**
-  ///
-  /// ~~~~~~~~~~~~~{.cpp}
-  /// #include <kodi/addon-instance/Screensaver.h>
-  ///
-  /// class CMyScreenSaver : public ::kodi::addon::CInstanceScreensaver
-  /// {
-  /// public:
-  ///   CMyScreenSaver(KODI_HANDLE instance);
-  ///
-  ///   bool Start() override;
-  ///   void Render() override;
-  /// };
-  ///
-  /// CMyScreenSaver::CMyScreenSaver(KODI_HANDLE instance)
-  ///   : CInstanceScreensaver(instance)
-  /// {
-  ///   ...
-  /// }
-  ///
-  /// bool CMyScreenSaver::Start()
-  /// {
-  ///   ...
-  ///   return true;
-  /// }
-  ///
-  /// void CMyScreenSaver::Render()
-  /// {
-  ///   ...
-  /// }
-  ///
-  ///
-  /// /*----------------------------------------------------------------------*/
-  ///
-  /// class CMyAddon : public ::kodi::addon::CAddonBase
-  /// {
-  /// public:
-  ///   CMyAddon() { }
-  ///   ADDON_STATUS CreateInstance(int instanceType,
-  ///                               std::string instanceID,
-  ///                               KODI_HANDLE instance,
-  ///                               KODI_HANDLE& addonInstance) override;
-  /// };
-  ///
-  /// /* If you use only one instance in your add-on, can be instanceType and
-  ///  * instanceID ignored */
-  /// ADDON_STATUS CMyAddon::CreateInstance(int instanceType,
-  ///                                       std::string instanceID,
-  ///                                       KODI_HANDLE instance,
-  ///                                       KODI_HANDLE& addonInstance)
-  /// {
-  ///   if (instanceType == ADDON_INSTANCE_SCREENSAVER)
-  ///   {
-  ///     kodi::Log(ADDON_LOG_NOTICE, "Creating my Screensaver");
-  ///     addonInstance = new CMyScreenSaver(instance);
-  ///     return ADDON_STATUS_OK;
-  ///   }
-  ///   else if (...)
-  ///   {
-  ///     ...
-  ///   }
-  ///   return ADDON_STATUS_UNKNOWN;
-  /// }
-  ///
-  /// ADDONCREATOR(CMyAddon)
-  /// ~~~~~~~~~~~~~
-  ///
-  /// The destruction of the example class `CMyScreenSaver` is called from
-  /// Kodi's header. Manually deleting the add-on instance is not required.
-  ///
-  //----------------------------------------------------------------------------
-  class ATTRIBUTE_HIDDEN CInstanceScreensaver : public IAddonInstance
+  CInstanceScreensaver()
+    : IAddonInstance(ADDON_INSTANCE_SCREENSAVER, GetKodiTypeVersion(ADDON_INSTANCE_SCREENSAVER))
   {
-  public:
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver
-    /// @brief Screensaver class constructor
-    ///
-    /// Used by an add-on that only supports screensavers.
-    ///
-    CInstanceScreensaver()
-      : IAddonInstance(ADDON_INSTANCE_SCREENSAVER, GetKodiTypeVersion(ADDON_INSTANCE_SCREENSAVER))
-    {
-      if (CAddonBase::m_interface->globalSingleInstance != nullptr)
-        throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation of more as one in single instance way is not allowed!");
+    if (CAddonBase::m_interface->globalSingleInstance != nullptr)
+      throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation of more as one in single "
+                             "instance way is not allowed!");
 
-      SetAddonStruct(CAddonBase::m_interface->firstKodiInstance);
-      CAddonBase::m_interface->globalSingleInstance = this;
-    }
-    //--------------------------------------------------------------------------
+    SetAddonStruct(CAddonBase::m_interface->firstKodiInstance);
+    CAddonBase::m_interface->globalSingleInstance = this;
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver
-    /// @brief Screensaver class constructor used to support multiple instance
-    /// types
-    ///
-    /// @param[in] instance               The instance value given to
-    ///                                   <b>`kodi::addon::CAddonBase::CreateInstance(...)`</b>.
-    /// @param[in] kodiVersion [opt] Version used in Kodi for this instance, to
-    ///                        allow compatibility to older Kodi versions.
-    ///                        @note Recommended to set.
-    ///
-    /// @warning Only use `instance` from the CreateInstance call
-    ///
-    explicit CInstanceScreensaver(KODI_HANDLE instance, const std::string& kodiVersion = "")
-      : IAddonInstance(ADDON_INSTANCE_SCREENSAVER,
-                       !kodiVersion.empty() ? kodiVersion
-                                            : GetKodiTypeVersion(ADDON_INSTANCE_SCREENSAVER))
-    {
-      if (CAddonBase::m_interface->globalSingleInstance != nullptr)
-        throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation of multiple together with single instance way is not allowed!");
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver
+  /// @brief Screensaver class constructor used to support multiple instance
+  /// types
+  ///
+  /// @param[in] instance               The instance value given to
+  ///                                   <b>`kodi::addon::CAddonBase::CreateInstance(...)`</b>.
+  /// @param[in] kodiVersion [opt] Version used in Kodi for this instance, to
+  ///                        allow compatibility to older Kodi versions.
+  ///                        @note Recommended to set.
+  ///
+  /// @warning Only use `instance` from the CreateInstance call
+  ///
+  explicit CInstanceScreensaver(KODI_HANDLE instance, const std::string& kodiVersion = "")
+    : IAddonInstance(ADDON_INSTANCE_SCREENSAVER,
+                     !kodiVersion.empty() ? kodiVersion
+                                          : GetKodiTypeVersion(ADDON_INSTANCE_SCREENSAVER))
+  {
+    if (CAddonBase::m_interface->globalSingleInstance != nullptr)
+      throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation of multiple together "
+                             "with single instance way is not allowed!");
 
-      SetAddonStruct(instance);
-    }
-    //--------------------------------------------------------------------------
+    SetAddonStruct(instance);
+  }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver
-    /// @brief Destructor
-    ///
-    ~CInstanceScreensaver() override = default;
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver
+  /// @brief Destructor
+  ///
+  ~CInstanceScreensaver() override = default;
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver
-    /// @brief Used to notify the screensaver that it has been started
-    ///
-    /// @return                         true if the screensaver was started
-    ///                                 successfully, false otherwise
-    ///
-    virtual bool Start() { return true; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver
+  /// @brief Used to notify the screensaver that it has been started
+  ///
+  /// @return                         true if the screensaver was started
+  ///                                 successfully, false otherwise
+  ///
+  virtual bool Start() { return true; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver
-    /// @brief Used to inform the screensaver that the rendering control was
-    /// stopped
-    ///
-    virtual void Stop() {}
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver
+  /// @brief Used to inform the screensaver that the rendering control was
+  /// stopped
+  ///
+  virtual void Stop() {}
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver
-    /// @brief Used to indicate when the add-on should render
-    ///
-    virtual void Render() {}
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver
+  /// @brief Used to indicate when the add-on should render
+  ///
+  virtual void Render() {}
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// \defgroup cpp_kodi_addon_screensaver_CB Information functions
-    /// \ingroup cpp_kodi_addon_screensaver
-    /// @brief **To get info about the device, display and several other parts**
-    ///
-    //@{
+  //==========================================================================
+  ///
+  /// \defgroup cpp_kodi_addon_screensaver_CB Information functions
+  /// \ingroup cpp_kodi_addon_screensaver
+  /// @brief **To get info about the device, display and several other parts**
+  ///
+  //@{
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Device that represents the display adapter
-    ///
-    /// @return A pointer to the device
-    ///
-    /// @note This is only available on **DirectX**, It us unused (`nullptr`) on
-    /// **OpenGL**
-    ///
-    inline void* Device() { return m_instanceData->props->device; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Device that represents the display adapter
+  ///
+  /// @return A pointer to the device
+  ///
+  /// @note This is only available on **DirectX**, It us unused (`nullptr`) on
+  /// **OpenGL**
+  ///
+  inline void* Device() { return m_instanceData->props->device; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Returns the X position of the rendering window
-    ///
-    /// @return The X position, in pixels
-    ///
-    inline int X() { return m_instanceData->props->x; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Returns the X position of the rendering window
+  ///
+  /// @return The X position, in pixels
+  ///
+  inline int X() { return m_instanceData->props->x; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Returns the Y position of the rendering window
-    ///
-    /// @return The Y position, in pixels
-    ///
-    inline int Y() { return m_instanceData->props->y; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Returns the Y position of the rendering window
+  ///
+  /// @return The Y position, in pixels
+  ///
+  inline int Y() { return m_instanceData->props->y; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Returns the width of the rendering window
-    ///
-    /// @return The width, in pixels
-    ///
-    inline int Width() { return m_instanceData->props->width; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Returns the width of the rendering window
+  ///
+  /// @return The width, in pixels
+  ///
+  inline int Width() { return m_instanceData->props->width; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Returns the height of the rendering window
-    ///
-    /// @return The height, in pixels
-    ///
-    inline int Height() { return m_instanceData->props->height; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Returns the height of the rendering window
+  ///
+  /// @return The height, in pixels
+  ///
+  inline int Height() { return m_instanceData->props->height; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Pixel aspect ratio (often abbreviated PAR) is a ratio that
-    /// describes how the width of a pixel compares to the height of that pixel.
-    ///
-    /// @return The pixel aspect ratio used by the display
-    ///
-    inline float PixelRatio() { return m_instanceData->props->pixelRatio; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Pixel aspect ratio (often abbreviated PAR) is a ratio that
+  /// describes how the width of a pixel compares to the height of that pixel.
+  ///
+  /// @return The pixel aspect ratio used by the display
+  ///
+  inline float PixelRatio() { return m_instanceData->props->pixelRatio; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Used to get the name of the add-on defined in `addon.xml`
-    ///
-    /// @return The add-on name
-    ///
-    inline std::string Name() { return m_instanceData->props->name; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Used to get the name of the add-on defined in `addon.xml`
+  ///
+  /// @return The add-on name
+  ///
+  inline std::string Name() { return m_instanceData->props->name; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Used to get the full path where the add-on is installed
-    ///
-    /// @return The add-on installation path
-    ///
-    inline std::string Presets() { return m_instanceData->props->presets; }
-    //--------------------------------------------------------------------------
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Used to get the full path where the add-on is installed
+  ///
+  /// @return The add-on installation path
+  ///
+  inline std::string Presets() { return m_instanceData->props->presets; }
+  //--------------------------------------------------------------------------
 
-    //==========================================================================
-    ///
-    /// @ingroup cpp_kodi_addon_screensaver_CB
-    /// @brief Used to get the full path to the add-on's user profile
-    ///
-    /// @note The trailing folder (consisting of the add-on's ID) is not created
-    /// by default. If it is needed, you must call kodi::vfs::CreateDirectory()
-    /// to create the folder.
-    ///
-    /// @return Path to the user profile
-    ///
-    inline std::string Profile() { return m_instanceData->props->profile; }
-    //--------------------------------------------------------------------------
-    //@}
+  //==========================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_screensaver_CB
+  /// @brief Used to get the full path to the add-on's user profile
+  ///
+  /// @note The trailing folder (consisting of the add-on's ID) is not created
+  /// by default. If it is needed, you must call kodi::vfs::CreateDirectory()
+  /// to create the folder.
+  ///
+  /// @return Path to the user profile
+  ///
+  inline std::string Profile() { return m_instanceData->props->profile; }
+  //--------------------------------------------------------------------------
+  //@}
 
-  private:
-    void SetAddonStruct(KODI_HANDLE instance)
-    {
-      if (instance == nullptr)
-        throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation with empty addon structure not allowed, table must be given from Kodi!");
+private:
+  void SetAddonStruct(KODI_HANDLE instance)
+  {
+    if (instance == nullptr)
+      throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation with empty addon "
+                             "structure not allowed, table must be given from Kodi!");
 
-      m_instanceData = static_cast<AddonInstance_Screensaver*>(instance);
-      m_instanceData->toAddon->addonInstance = this;
-      m_instanceData->toAddon->Start = ADDON_Start;
-      m_instanceData->toAddon->Stop = ADDON_Stop;
-      m_instanceData->toAddon->Render = ADDON_Render;
-    }
+    m_instanceData = static_cast<AddonInstance_Screensaver*>(instance);
+    m_instanceData->toAddon->addonInstance = this;
+    m_instanceData->toAddon->Start = ADDON_Start;
+    m_instanceData->toAddon->Stop = ADDON_Stop;
+    m_instanceData->toAddon->Render = ADDON_Render;
+  }
 
-    inline static bool ADDON_Start(AddonInstance_Screensaver* instance)
-    {
-      CInstanceScreensaver* thisClass =
-          static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
-      thisClass->m_renderHelper = kodi::gui::GetRenderHelper();
-      return thisClass->Start();
-    }
+  inline static bool ADDON_Start(AddonInstance_Screensaver* instance)
+  {
+    CInstanceScreensaver* thisClass =
+        static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
+    thisClass->m_renderHelper = kodi::gui::GetRenderHelper();
+    return thisClass->Start();
+  }
 
-    inline static void ADDON_Stop(AddonInstance_Screensaver* instance)
-    {
-      CInstanceScreensaver* thisClass =
-          static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
-      thisClass->Stop();
-      thisClass->m_renderHelper = nullptr;
-    }
+  inline static void ADDON_Stop(AddonInstance_Screensaver* instance)
+  {
+    CInstanceScreensaver* thisClass =
+        static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
+    thisClass->Stop();
+    thisClass->m_renderHelper = nullptr;
+  }
 
-    inline static void ADDON_Render(AddonInstance_Screensaver* instance)
-    {
-      CInstanceScreensaver* thisClass =
-          static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
+  inline static void ADDON_Render(AddonInstance_Screensaver* instance)
+  {
+    CInstanceScreensaver* thisClass =
+        static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
 
-      if (!thisClass->m_renderHelper)
-        return;
-      thisClass->m_renderHelper->Begin();
-      thisClass->Render();
-      thisClass->m_renderHelper->End();
-    }
+    if (!thisClass->m_renderHelper)
+      return;
+    thisClass->m_renderHelper->Begin();
+    thisClass->Render();
+    thisClass->m_renderHelper->End();
+  }
 
-    /*
+  /*
      * Background render helper holds here and in addon base.
      * In addon base also to have for the others, and stored here for the worst
      * case where this class is independent from base and base becomes closed
@@ -399,9 +402,9 @@ namespace addon
      * This is on Kodi with GL unused and the calls to there are empty (no work)
      * On Kodi with Direct X where angle is present becomes this used.
      */
-    std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
-    AddonInstance_Screensaver* m_instanceData;
-  };
+  std::shared_ptr<kodi::gui::IRenderHelper> m_renderHelper;
+  AddonInstance_Screensaver* m_instanceData;
+};
 
 } /* namespace addon */
 } /* namespace kodi */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -9,68 +9,10 @@
 #pragma once
 
 #include "../AddonBase.h"
+#include "../c-api/addon-instance/screensaver.h"
 #include "../gui/renderHelper.h"
 
-extern "C"
-{
-
-struct AddonInstance_Screensaver;
-
-/*!
- * @brief Screensaver properties
- *
- * Not to be used outside this header.
- */
-typedef struct AddonProps_Screensaver
-{
-  void *device;
-  int x;
-  int y;
-  int width;
-  int height;
-  float pixelRatio;
-  const char *name;
-  const char *presets;
-  const char *profile;
-} AddonProps_Screensaver;
-
-/*!
- * @brief Screensaver callbacks
- *
- * Not to be used outside this header.
- */
-typedef struct AddonToKodiFuncTable_Screensaver
-{
-  KODI_HANDLE kodiInstance;
-} AddonToKodiFuncTable_Screensaver;
-
-/*!
- * @brief Screensaver function hooks
- *
- * Not to be used outside this header.
- */
-typedef struct KodiToAddonFuncTable_Screensaver
-{
-  KODI_HANDLE addonInstance;
-  bool (__cdecl* Start) (AddonInstance_Screensaver* instance);
-  void (__cdecl* Stop) (AddonInstance_Screensaver* instance);
-  void (__cdecl* Render) (AddonInstance_Screensaver* instance);
-} KodiToAddonFuncTable_Screensaver;
-
-/*!
- * @brief Screensaver instance
- *
- * Not to be used outside this header.
- */
-typedef struct AddonInstance_Screensaver
-{
-  AddonProps_Screensaver* props;
-  AddonToKodiFuncTable_Screensaver* toKodi;
-  KodiToAddonFuncTable_Screensaver* toAddon;
-} AddonInstance_Screensaver;
-
-} /* extern "C" */
-
+#ifdef __cplusplus
 namespace kodi
 {
 namespace addon
@@ -463,3 +405,4 @@ namespace addon
 
 } /* namespace addon */
 } /* namespace kodi */
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -64,9 +64,9 @@ typedef struct KodiToAddonFuncTable_Screensaver
  */
 typedef struct AddonInstance_Screensaver
 {
-  AddonProps_Screensaver props;
-  AddonToKodiFuncTable_Screensaver toKodi;
-  KodiToAddonFuncTable_Screensaver toAddon;
+  AddonProps_Screensaver* props;
+  AddonToKodiFuncTable_Screensaver* toKodi;
+  KodiToAddonFuncTable_Screensaver* toAddon;
 } AddonInstance_Screensaver;
 
 } /* extern "C" */
@@ -318,7 +318,7 @@ namespace addon
     /// @note This is only available on **DirectX**, It us unused (`nullptr`) on
     /// **OpenGL**
     ///
-    inline void* Device() { return m_instanceData->props.device; }
+    inline void* Device() { return m_instanceData->props->device; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -328,7 +328,7 @@ namespace addon
     ///
     /// @return The X position, in pixels
     ///
-    inline int X() { return m_instanceData->props.x; }
+    inline int X() { return m_instanceData->props->x; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -338,7 +338,7 @@ namespace addon
     ///
     /// @return The Y position, in pixels
     ///
-    inline int Y() { return m_instanceData->props.y; }
+    inline int Y() { return m_instanceData->props->y; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -348,7 +348,7 @@ namespace addon
     ///
     /// @return The width, in pixels
     ///
-    inline int Width() { return m_instanceData->props.width; }
+    inline int Width() { return m_instanceData->props->width; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -358,7 +358,7 @@ namespace addon
     ///
     /// @return The height, in pixels
     ///
-    inline int Height() { return m_instanceData->props.height; }
+    inline int Height() { return m_instanceData->props->height; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -369,7 +369,7 @@ namespace addon
     ///
     /// @return The pixel aspect ratio used by the display
     ///
-    inline float PixelRatio() { return m_instanceData->props.pixelRatio; }
+    inline float PixelRatio() { return m_instanceData->props->pixelRatio; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -379,7 +379,7 @@ namespace addon
     ///
     /// @return The add-on name
     ///
-    inline std::string Name() { return m_instanceData->props.name; }
+    inline std::string Name() { return m_instanceData->props->name; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -389,7 +389,7 @@ namespace addon
     ///
     /// @return The add-on installation path
     ///
-    inline std::string Presets() { return m_instanceData->props.presets; }
+    inline std::string Presets() { return m_instanceData->props->presets; }
     //--------------------------------------------------------------------------
 
     //==========================================================================
@@ -403,7 +403,7 @@ namespace addon
     ///
     /// @return Path to the user profile
     ///
-    inline std::string Profile() { return m_instanceData->props.profile; }
+    inline std::string Profile() { return m_instanceData->props->profile; }
     //--------------------------------------------------------------------------
     //@}
 
@@ -414,16 +414,16 @@ namespace addon
         throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation with empty addon structure not allowed, table must be given from Kodi!");
 
       m_instanceData = static_cast<AddonInstance_Screensaver*>(instance);
-      m_instanceData->toAddon.addonInstance = this;
-      m_instanceData->toAddon.Start = ADDON_Start;
-      m_instanceData->toAddon.Stop = ADDON_Stop;
-      m_instanceData->toAddon.Render = ADDON_Render;
+      m_instanceData->toAddon->addonInstance = this;
+      m_instanceData->toAddon->Start = ADDON_Start;
+      m_instanceData->toAddon->Stop = ADDON_Stop;
+      m_instanceData->toAddon->Render = ADDON_Render;
     }
 
     inline static bool ADDON_Start(AddonInstance_Screensaver* instance)
     {
       CInstanceScreensaver* thisClass =
-          static_cast<CInstanceScreensaver*>(instance->toAddon.addonInstance);
+          static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
       thisClass->m_renderHelper = kodi::gui::GetRenderHelper();
       return thisClass->Start();
     }
@@ -431,7 +431,7 @@ namespace addon
     inline static void ADDON_Stop(AddonInstance_Screensaver* instance)
     {
       CInstanceScreensaver* thisClass =
-          static_cast<CInstanceScreensaver*>(instance->toAddon.addonInstance);
+          static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
       thisClass->Stop();
       thisClass->m_renderHelper = nullptr;
     }
@@ -439,7 +439,7 @@ namespace addon
     inline static void ADDON_Render(AddonInstance_Screensaver* instance)
     {
       CInstanceScreensaver* thisClass =
-          static_cast<CInstanceScreensaver*>(instance->toAddon.addonInstance);
+          static_cast<CInstanceScreensaver*>(instance->toAddon->addonInstance);
 
       if (!thisClass->m_renderHelper)
         return;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -262,7 +262,7 @@ public:
   /// @note This is only available on **DirectX**, It us unused (`nullptr`) on
   /// **OpenGL**
   ///
-  inline void* Device() { return m_instanceData->props->device; }
+  inline kodi::HardwareContext Device() { return m_instanceData->props->device; }
   //--------------------------------------------------------------------------
 
   //==========================================================================

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/CMakeLists.txt
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/CMakeLists.txt
@@ -2,6 +2,7 @@ set(HEADERS audio_decoder.h
             audio_encoder.h
             image_decoder.h
             pvr.h
+            screensaver.h
             visualization.h)
 
 if(NOT ENABLE_STATIC_LIBS)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../addon_base.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+  struct AddonInstance_Screensaver;
+
+  /*!
+   * @brief Screensaver properties
+   *
+   * Not to be used outside this header.
+   */
+  typedef struct AddonProps_Screensaver
+  {
+    void* device;
+    int x;
+    int y;
+    int width;
+    int height;
+    float pixelRatio;
+    const char* name;
+    const char* presets;
+    const char* profile;
+  } AddonProps_Screensaver;
+
+  /*!
+   * @brief Screensaver callbacks
+   *
+   * Not to be used outside this header.
+   */
+  typedef struct AddonToKodiFuncTable_Screensaver
+  {
+    KODI_HANDLE kodiInstance;
+  } AddonToKodiFuncTable_Screensaver;
+
+  /*!
+   * @brief Screensaver function hooks
+   *
+   * Not to be used outside this header.
+   */
+  typedef struct KodiToAddonFuncTable_Screensaver
+  {
+    KODI_HANDLE addonInstance;
+    bool(__cdecl* Start)(struct AddonInstance_Screensaver* instance);
+    void(__cdecl* Stop)(struct AddonInstance_Screensaver* instance);
+    void(__cdecl* Render)(struct AddonInstance_Screensaver* instance);
+  } KodiToAddonFuncTable_Screensaver;
+
+  /*!
+   * @brief Screensaver instance
+   *
+   * Not to be used outside this header.
+   */
+  typedef struct AddonInstance_Screensaver
+  {
+    struct AddonProps_Screensaver* props;
+    struct AddonToKodiFuncTable_Screensaver* toKodi;
+    struct KodiToAddonFuncTable_Screensaver* toAddon;
+  } AddonInstance_Screensaver;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
@@ -24,7 +24,7 @@ extern "C"
    */
   typedef struct AddonProps_Screensaver
   {
-    void* device;
+    ADDON_HARDWARE_CONTEXT device;
     int x;
     int y;
     int width;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -135,10 +135,11 @@
                                                       "addon-instance/pvr/Stream.h" \
                                                       "addon-instance/pvr/Timers.h"
 
-#define ADDON_INSTANCE_VERSION_SCREENSAVER            "2.0.2"
-#define ADDON_INSTANCE_VERSION_SCREENSAVER_MIN        "2.0.1"
+#define ADDON_INSTANCE_VERSION_SCREENSAVER            "2.1.0"
+#define ADDON_INSTANCE_VERSION_SCREENSAVER_MIN        "2.1.0"
 #define ADDON_INSTANCE_VERSION_SCREENSAVER_XML_ID     "kodi.binary.instance.screensaver"
-#define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "addon-instance/Screensaver.h"
+#define ADDON_INSTANCE_VERSION_SCREENSAVER_DEPENDS    "c-api/addon-instance/screensaver.h" \
+                                                      "addon-instance/Screensaver.h"
 
 #define ADDON_INSTANCE_VERSION_VFS                    "2.3.2"
 #define ADDON_INSTANCE_VERSION_VFS_MIN                "2.3.1"


### PR DESCRIPTION
## Description
This thought to make **Screensaver** in way equal to PVR API, so to have the "C" in separate header and helper class.

Need version increase on all screensaver addons, but no code changes for here.

## User related:

Not user relevant

Only for all binary addon system requests may be for the user:
- Binary addon system revised to ensure higher security in its data exchange between addon and Kodi
- Revised binary addon system documentation for outside developers

Commit 1:
-----------------------------
**[addons][screensaver] don't use C++ class in C**

Before was the C++ class pointer exchanged between Addon and Kodi, it was not used in Kodi but it breaks the ABI and can't compiled in "C" only.

Commit 2:
-----------------------------
**[addons][screensaver] make all "C" interface structures to own memory**

This done to prevent API backward problems if something becomes replaced
e.g. on props or to kodi calls.

Commit 3:
-----------------------------
**[addons][screensaver] separate "C" to own file**

This to hold "C++" and "C" independent and allow for other languages.

Commit 4:
-----------------------------
**[addons][screensaver] clang cleanup about header**

That the "kodi/addon-instance/Screensaver.h" header match the clang style.

Commit 5:
-----------------------------
**[addons][screensaver] use ADDON_HARDWARE_CONTEXT and kodi::HardwareContext for `void*`**

There becomes on HardwareContext related calls (e.g. to get ID3D11DeviceContext* on Windows)
within visualization the ADDON_HARDWARE_CONTEXT about "C" and the kodi::HardwareContext about "C++"
used, instead of void* before.

The value itself still void*, only named to related type. This done to prevent inside
Kodi's API, the use of void* on addon as much as possible.

All places where the addon must use them should be with a name to have more clean.
This then also better if this parts used for other languages.


Commit 6:
-----------------------------
**[addons][screensaver] cleanup doxygen docs**

This cleanup, fix (newer doxygen versions) and extend the screensaver docs.

Commit 7:
-----------------------------
**[addons][screensaver] increase API version to 2.1.0**

Also the min is increased and all screensaver addons need a new release.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
