### PR TITLE
[Python] Move xbmc.translatePath to xbmcvfs module

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -22,7 +22,7 @@
 #include "aojsonrpc.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "filesystem/File.h"
-#include "filesystem/SpecialProtocol.h"
+#include "filesystem/SpecialProtocol.h" //! @todo remove me when dropping translatePath from this file
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -380,6 +380,8 @@ namespace XBMCAddon
     String translatePath(const String& path)
     {
       XBMC_TRACE;
+      CLog::Log(LOGWARNING, "xbmc.translatePath is deprecated and might be removed in future kodi "
+                            "versions. Please use xbmcvfs.translatePath instead.");
       return CSpecialProtocol::TranslatePath(path);
     }
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -625,6 +625,7 @@ namespace XBMCAddon
     ///
     ///
     /// ------------------------------------------------------------------------
+    /// @python_v19 Deprecated **xbmc.translatePath**. Moved to **xbmcvfs.translatePath**
     ///
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -13,6 +13,7 @@
 #include "Util.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 
@@ -55,6 +56,13 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       return CUtil::MakeLegalPath(filename);
+    }
+
+    // translate path
+    String translatePath(const String& path)
+    {
+      XBMC_TRACE;
+      return CSpecialProtocol::TranslatePath(path);
     }
 
     // validate path

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.h
@@ -170,6 +170,35 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmcvfs
+    /// @brief \python_func{ xbmcvfs.translatePath(path)  }
+    /// Returns the translated path.
+    ///
+    /// @param path string - Path to format
+    /// @return Translated path
+    ///
+    /// @note Only useful if you are coding for both Linux and Windows.
+    ///       e.g. Converts 'special://home' -> '/home/[username]/.kodi'
+    ///       on Linux.
+    ///
+    ///
+    /// ------------------------------------------------------------------------
+    /// @python_v19 New function added (replaces old **xbmc.translatePath**)
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// fpath = xbmcvfs.translatePath('special://home')
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    translatePath(...);
+#else
+    String translatePath(const String& path);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcvfs
     /// @brief \python_func{ xbmcvfs.validatePath(path) }
     /// Returns the validated path.
     ///


### PR DESCRIPTION
## Description
Similar to previous PR's and to ensure consistency with the binary addon API, this moves python's `xbmc.translatePath` to `xbmcvfs.translatePath` since it is a VFS method.

Unlike the other 2 methods I moved, I didn't remove `xbmc.translatePath` completely this time. `xbmc.translatePath` method is used by a lot of addons so, we just log a warning if `xbmc.translatePath` is used informing users that they should move to xbmcvfs instead. Plan is to completely remove the old method by v20, while ensuring devs will adapt their addons in subsequent updates or new submissions to matrix branch.

## Motivation and Context
Cleaner python API

## How Has This Been Tested?
Using a simple python script:

```python
import xbmc
import xbmcvfs
xbmc.log("NEW")
xbmc.log(xbmcvfs.translatePath('special://home'))
xbmc.log("OLD")
xbmc.log(xbmc.translatePath('special://home'))
```

Log:

```
2020-08-29 10:24:28.766 T:3501458   DEBUG <general>: NEW                                           
│2020-08-29 10:24:28.770 T:3501458   DEBUG <general>: /Users/enen/Library/Application Support/Kodi/                                                                                    
│2020-08-29 10:24:28.771 T:3501458   DEBUG <general>: OLD                                           
│2020-08-29 10:24:28.771 T:3501458 WARNING <general>: xbmc.translatePath is deprecated and might be 
removed in future kodi versions. Please use xbmcvfs.translatePath instead.                          │
│2020-08-29 10:24:28.773 T:3501458   DEBUG <general>: /Users/enen/Library/Application Support/Kodi/
```


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
