### PR TITLE
[addons][inputstream][videocodec] API improvement

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -28,6 +28,11 @@
 //Increment this level always if you add features which can lead to compile failures in the addon
 #define INPUTSTREAM_VERSION_LEVEL 2
 
+#define INPUTSTREAM_MAX_STREAM_COUNT 256
+#define INPUTSTREAM_MAX_STRING_NAME_SIZE 256
+#define INPUTSTREAM_MAX_STRING_CODEC_SIZE 32
+#define INPUTSTREAM_MAX_STRING_LANGUAGE_SIZE 64
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -90,9 +95,8 @@ extern "C"
    */
   struct INPUTSTREAM_IDS
   {
-    static const unsigned int MAX_STREAM_COUNT = 256;
     unsigned int m_streamCount;
-    unsigned int m_streamIds[MAX_STREAM_COUNT];
+    unsigned int m_streamIds[INPUTSTREAM_MAX_STREAM_COUNT];
   };
 
   /*!
@@ -238,45 +242,90 @@ extern "C"
 
     uint32_t m_flags;
 
-    char m_name[256]; /*!< @brief (optinal) name of the stream, \0 for default handling */
-    char m_codecName[32]; /*!< @brief (required) name of codec according to ffmpeg */
-    char m_codecInternalName
-        [32]; /*!< @brief (optional) internal name of codec (selectionstream info) */
-    STREAMCODEC_PROFILE m_codecProfile; /*!< @brief (optional) the profile of the codec */
-    unsigned int m_pID; /*!< @brief (required) physical index */
+    //! @brief (optional) name of the stream, \0 for default handling
+    char m_name[INPUTSTREAM_MAX_STRING_NAME_SIZE];
+
+    //! @brief (required) name of codec according to ffmpeg
+    char m_codecName[INPUTSTREAM_MAX_STRING_CODEC_SIZE];
+
+    //! @brief (optional) internal name of codec (selectionstream info)
+    char m_codecInternalName[INPUTSTREAM_MAX_STRING_CODEC_SIZE];
+
+    //! @brief (optional) the profile of the codec
+    STREAMCODEC_PROFILE m_codecProfile;
+
+    //! @brief (required) physical index
+    unsigned int m_pID;
 
     const uint8_t* m_ExtraData;
     unsigned int m_ExtraSize;
 
-    char m_language[64]; /*!< @brief RFC 5646 language code (empty string if undefined) */
+    //! @brief RFC 5646 language code (empty string if undefined)
+    char m_language[INPUTSTREAM_MAX_STRING_LANGUAGE_SIZE];
 
-    unsigned int
-        m_FpsScale; /*!< @brief Scale of 1000 and a rate of 29970 will result in 29.97 fps */
+    //! Video stream related data
+    //@{
+
+    //! @brief Scale of 1000 and a rate of 29970 will result in 29.97 fps
+    unsigned int m_FpsScale;
+
     unsigned int m_FpsRate;
-    unsigned int m_Height; /*!< @brief height of the stream reported by the demuxer */
-    unsigned int m_Width; /*!< @brief width of the stream reported by the demuxer */
-    float m_Aspect; /*!< @brief display aspect of stream */
 
+    //! @brief height of the stream reported by the demuxer
+    unsigned int m_Height;
 
-    unsigned int m_Channels; /*!< @brief (required) amount of channels */
-    unsigned int m_SampleRate; /*!< @brief (required) sample rate */
-    unsigned int m_BitRate; /*!< @brief (required) bit rate */
-    unsigned int m_BitsPerSample; /*!< @brief (required) bits per sample */
+    //! @brief width of the stream reported by the demuxer
+    unsigned int m_Width;
+
+    //! @brief display aspect of stream
+    float m_Aspect;
+
+    //@}
+
+    //! Audio stream related data
+    //@{
+
+    //! @brief (required) amount of channels
+    unsigned int m_Channels;
+
+    //! @brief (required) sample rate
+    unsigned int m_SampleRate;
+
+    //! @brief (required) bit rate
+    unsigned int m_BitRate;
+
+    //! @brief (required) bits per sample
+    unsigned int m_BitsPerSample;
+
     unsigned int m_BlockAlign;
+
+    //@}
 
     CRYPTO_INFO m_cryptoInfo;
 
     // new in API version 2.0.8
-    unsigned int m_codecFourCC; /*!< @brief Codec If available, the fourcc code codec */
-    COLORSPACE m_colorSpace; /*!< @brief definition of colorspace */
-    COLORRANGE m_colorRange; /*!< @brief color range if available */
+    //@{
+    //! @brief Codec If available, the fourcc code codec
+    unsigned int m_codecFourCC;
+
+    //! @brief definition of colorspace
+    COLORSPACE m_colorSpace;
+
+    //! @brief color range if available
+    COLORRANGE m_colorRange;
+    //@}
 
     //new in API 2.0.9 / INPUTSTREAM_VERSION_LEVEL 1
+    //@{
     COLORPRIMARIES m_colorPrimaries;
     COLORTRC m_colorTransferCharacteristic;
-    INPUTSTREAM_MASTERING_METADATA* m_masteringMetadata; /*!< @brief mastering static Metadata */
-    INPUTSTREAM_CONTENTLIGHT_METADATA*
-        m_contentLightMetadata; /*!< @brief content light static Metadata */
+    //@}
+
+    //! @brief mastering static Metadata
+    INPUTSTREAM_MASTERING_METADATA* m_masteringMetadata;
+
+    //! @brief content light static Metadata
+    INPUTSTREAM_CONTENTLIGHT_METADATA* m_contentLightMetadata;
   };
 
   struct INPUTSTREAM_TIMES

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -372,9 +372,9 @@ extern "C"
 
   typedef struct AddonInstance_InputStream /* internal */
   {
-    AddonProps_InputStream props;
-    AddonToKodiFuncTable_InputStream toKodi;
-    KodiToAddonFuncTable_InputStream toAddon;
+    AddonProps_InputStream* props;
+    AddonToKodiFuncTable_InputStream* toKodi;
+    KodiToAddonFuncTable_InputStream* toAddon;
   } AddonInstance_InputStream;
 
 #ifdef __cplusplus
@@ -612,8 +612,8 @@ public:
      */
   DemuxPacket* AllocateDemuxPacket(int dataSize)
   {
-    return m_instanceData->toKodi.allocate_demux_packet(m_instanceData->toKodi.kodiInstance,
-                                                        dataSize);
+    return m_instanceData->toKodi->allocate_demux_packet(m_instanceData->toKodi->kodiInstance,
+                                                         dataSize);
   }
 
   /*!
@@ -623,8 +623,8 @@ public:
      */
   DemuxPacket* AllocateEncryptedDemuxPacket(int dataSize, unsigned int encryptedSubsampleCount)
   {
-    return m_instanceData->toKodi.allocate_encrypted_demux_packet(
-        m_instanceData->toKodi.kodiInstance, dataSize, encryptedSubsampleCount);
+    return m_instanceData->toKodi->allocate_encrypted_demux_packet(
+        m_instanceData->toKodi->kodiInstance, dataSize, encryptedSubsampleCount);
   }
 
   /*!
@@ -633,7 +633,7 @@ public:
      */
   void FreeDemuxPacket(DemuxPacket* packet)
   {
-    return m_instanceData->toKodi.free_demux_packet(m_instanceData->toKodi.kodiInstance, packet);
+    return m_instanceData->toKodi->free_demux_packet(m_instanceData->toKodi->kodiInstance, packet);
   }
 
 private:
@@ -654,66 +654,69 @@ private:
     sscanf(kodiVersion.c_str(), "%d.%d.%d", &api[0], &api[1], &api[2]);
 
     m_instanceData = static_cast<AddonInstance_InputStream*>(instance);
-    m_instanceData->toAddon.addonInstance = this;
-    m_instanceData->toAddon.open = ADDON_Open;
-    m_instanceData->toAddon.close = ADDON_Close;
-    m_instanceData->toAddon.get_capabilities = ADDON_GetCapabilities;
+    m_instanceData->toAddon->addonInstance = this;
+    m_instanceData->toAddon->open = ADDON_Open;
+    m_instanceData->toAddon->close = ADDON_Close;
+    m_instanceData->toAddon->get_capabilities = ADDON_GetCapabilities;
 
-    m_instanceData->toAddon.get_stream_ids = ADDON_GetStreamIds;
-    m_instanceData->toAddon.get_stream = ADDON_GetStream;
-    m_instanceData->toAddon.enable_stream = ADDON_EnableStream;
-    m_instanceData->toAddon.open_stream = ADDON_OpenStream;
-    m_instanceData->toAddon.demux_reset = ADDON_DemuxReset;
-    m_instanceData->toAddon.demux_abort = ADDON_DemuxAbort;
-    m_instanceData->toAddon.demux_flush = ADDON_DemuxFlush;
-    m_instanceData->toAddon.demux_read = ADDON_DemuxRead;
-    m_instanceData->toAddon.demux_seek_time = ADDON_DemuxSeekTime;
-    m_instanceData->toAddon.demux_set_speed = ADDON_DemuxSetSpeed;
-    m_instanceData->toAddon.set_video_resolution = ADDON_SetVideoResolution;
+    m_instanceData->toAddon->get_stream_ids = ADDON_GetStreamIds;
+    m_instanceData->toAddon->get_stream = ADDON_GetStream;
+    m_instanceData->toAddon->enable_stream = ADDON_EnableStream;
+    m_instanceData->toAddon->open_stream = ADDON_OpenStream;
+    m_instanceData->toAddon->demux_reset = ADDON_DemuxReset;
+    m_instanceData->toAddon->demux_abort = ADDON_DemuxAbort;
+    m_instanceData->toAddon->demux_flush = ADDON_DemuxFlush;
+    m_instanceData->toAddon->demux_read = ADDON_DemuxRead;
+    m_instanceData->toAddon->demux_seek_time = ADDON_DemuxSeekTime;
+    m_instanceData->toAddon->demux_set_speed = ADDON_DemuxSetSpeed;
+    m_instanceData->toAddon->set_video_resolution = ADDON_SetVideoResolution;
 
-    m_instanceData->toAddon.get_total_time = ADDON_GetTotalTime;
-    m_instanceData->toAddon.get_time = ADDON_GetTime;
+    m_instanceData->toAddon->get_total_time = ADDON_GetTotalTime;
+    m_instanceData->toAddon->get_time = ADDON_GetTime;
 
-    m_instanceData->toAddon.get_times = ADDON_GetTimes;
-    m_instanceData->toAddon.pos_time = ADDON_PosTime;
+    m_instanceData->toAddon->get_times = ADDON_GetTimes;
+    m_instanceData->toAddon->pos_time = ADDON_PosTime;
 
-    m_instanceData->toAddon.read_stream = ADDON_ReadStream;
-    m_instanceData->toAddon.seek_stream = ADDON_SeekStream;
-    m_instanceData->toAddon.position_stream = ADDON_PositionStream;
-    m_instanceData->toAddon.length_stream = ADDON_LengthStream;
-    m_instanceData->toAddon.is_real_time_stream = ADDON_IsRealTimeStream;
+    m_instanceData->toAddon->read_stream = ADDON_ReadStream;
+    m_instanceData->toAddon->seek_stream = ADDON_SeekStream;
+    m_instanceData->toAddon->position_stream = ADDON_PositionStream;
+    m_instanceData->toAddon->length_stream = ADDON_LengthStream;
+    m_instanceData->toAddon->is_real_time_stream = ADDON_IsRealTimeStream;
 
-    int minChapterVersion[3] = { 2, 0, 10 };
-    if (compareVersion(api, minChapterVersion) >= 0)
+    // Added on 2.0.10
+    m_instanceData->toAddon->get_chapter = ADDON_GetChapter;
+    m_instanceData->toAddon->get_chapter_count = ADDON_GetChapterCount;
+    m_instanceData->toAddon->get_chapter_name = ADDON_GetChapterName;
+    m_instanceData->toAddon->get_chapter_pos = ADDON_GetChapterPos;
+    m_instanceData->toAddon->seek_chapter = ADDON_SeekChapter;
+
+    // Added on 2.0.12
+    m_instanceData->toAddon->block_size_stream = ADDON_GetBlockSize;
+
+    /*
+    // Way to include part on new API version
+    int minPartVersion[3] = { 3, 0, 0 };
+    if (compareVersion(api, minPartVersion) >= 0)
     {
-      m_instanceData->toAddon.get_chapter = ADDON_GetChapter;
-      m_instanceData->toAddon.get_chapter_count = ADDON_GetChapterCount;
-      m_instanceData->toAddon.get_chapter_name = ADDON_GetChapterName;
-      m_instanceData->toAddon.get_chapter_pos = ADDON_GetChapterPos;
-      m_instanceData->toAddon.seek_chapter = ADDON_SeekChapter;
-    }
 
-    int minBlockSizeVersion[3] = {2, 0, 12};
-    if (compareVersion(api, minBlockSizeVersion) >= 0)
-    {
-      m_instanceData->toAddon.block_size_stream = ADDON_GetBlockSize;
     }
+    */
   }
 
   inline static bool ADDON_Open(const AddonInstance_InputStream* instance, INPUTSTREAM* props)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->Open(*props);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->Open(*props);
   }
 
   inline static void ADDON_Close(const AddonInstance_InputStream* instance)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->Close();
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->Close();
   }
 
   inline static void ADDON_GetCapabilities(const AddonInstance_InputStream* instance,
                                            INPUTSTREAM_CAPABILITIES* capabilities)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->GetCapabilities(*capabilities);
   }
 
@@ -721,47 +724,48 @@ private:
   // IDemux
   inline static struct INPUTSTREAM_IDS ADDON_GetStreamIds(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetStreamIds();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetStreamIds();
   }
 
   inline static struct INPUTSTREAM_INFO ADDON_GetStream(const AddonInstance_InputStream* instance,
                                                         int streamid)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetStream(streamid);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
+        ->GetStream(streamid);
   }
 
   inline static void ADDON_EnableStream(const AddonInstance_InputStream* instance,
                                         int streamid,
                                         bool enable)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->EnableStream(streamid, enable);
   }
 
   inline static bool ADDON_OpenStream(const AddonInstance_InputStream* instance, int streamid)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->OpenStream(streamid);
   }
 
   inline static void ADDON_DemuxReset(const AddonInstance_InputStream* instance)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxReset();
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->DemuxReset();
   }
 
   inline static void ADDON_DemuxAbort(const AddonInstance_InputStream* instance)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxAbort();
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->DemuxAbort();
   }
 
   inline static void ADDON_DemuxFlush(const AddonInstance_InputStream* instance)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxFlush();
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->DemuxFlush();
   }
 
   inline static DemuxPacket* ADDON_DemuxRead(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxRead();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->DemuxRead();
   }
 
   inline static bool ADDON_DemuxSeekTime(const AddonInstance_InputStream* instance,
@@ -769,20 +773,20 @@ private:
                                          bool backwards,
                                          double* startpts)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->DemuxSeekTime(time, backwards, *startpts);
   }
 
   inline static void ADDON_DemuxSetSpeed(const AddonInstance_InputStream* instance, int speed)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->DemuxSetSpeed(speed);
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->DemuxSetSpeed(speed);
   }
 
   inline static void ADDON_SetVideoResolution(const AddonInstance_InputStream* instance,
                                               int width,
                                               int height)
   {
-    static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->SetVideoResolution(width, height);
   }
 
@@ -790,57 +794,57 @@ private:
   // IDisplayTime
   inline static int ADDON_GetTotalTime(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetTotalTime();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetTotalTime();
   }
 
   inline static int ADDON_GetTime(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetTime();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetTime();
   }
 
   // ITime
   inline static bool ADDON_GetTimes(const AddonInstance_InputStream* instance,
                                     INPUTSTREAM_TIMES* times)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetTimes(*times);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetTimes(*times);
   }
 
   // IPosTime
   inline static bool ADDON_PosTime(const AddonInstance_InputStream* instance, int ms)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->PosTime(ms);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->PosTime(ms);
   }
 
   inline static int ADDON_GetChapter(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapter();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetChapter();
   }
 
   inline static int ADDON_GetChapterCount(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapterCount();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetChapterCount();
   }
 
   inline static const char* ADDON_GetChapterName(const AddonInstance_InputStream* instance, int ch)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapterName(ch);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetChapterName(ch);
   }
 
   inline static int64_t ADDON_GetChapterPos(const AddonInstance_InputStream* instance, int ch)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetChapterPos(ch);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetChapterPos(ch);
   }
 
   inline static bool ADDON_SeekChapter(const AddonInstance_InputStream* instance, int ch)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->SeekChapter(ch);
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->SeekChapter(ch);
   }
 
   inline static int ADDON_ReadStream(const AddonInstance_InputStream* instance,
                                      uint8_t* buffer,
                                      unsigned int bufferSize)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->ReadStream(buffer, bufferSize);
   }
 
@@ -848,28 +852,28 @@ private:
                                          int64_t position,
                                          int whence)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)
         ->SeekStream(position, whence);
   }
 
   inline static int64_t ADDON_PositionStream(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->PositionStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->PositionStream();
   }
 
   inline static int64_t ADDON_LengthStream(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->LengthStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->LengthStream();
   }
 
   inline static int ADDON_GetBlockSize(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->GetBlockSize();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->GetBlockSize();
   }
 
   inline static bool ADDON_IsRealTimeStream(const AddonInstance_InputStream* instance)
   {
-    return static_cast<CInstanceInputStream*>(instance->toAddon.addonInstance)->IsRealTimeStream();
+    return static_cast<CInstanceInputStream*>(instance->toAddon->addonInstance)->IsRealTimeStream();
   }
 
   AddonInstance_InputStream* m_instanceData;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -132,9 +132,9 @@ extern "C"
 
   typedef struct AddonInstance_VideoCodec
   {
-    AddonProps_VideoCodec props;
-    AddonToKodiFuncTable_VideoCodec toKodi;
-    KodiToAddonFuncTable_VideoCodec toAddon;
+    AddonProps_VideoCodec* props;
+    AddonToKodiFuncTable_VideoCodec* toKodi;
+    KodiToAddonFuncTable_VideoCodec* toAddon;
   } AddonInstance_VideoCodec;
 }
 
@@ -184,13 +184,15 @@ namespace kodi
       //! \copydoc CInstanceVideoCodec::GetFrameBuffer
       bool GetFrameBuffer(VIDEOCODEC_PICTURE &picture)
       {
-        return m_instanceData->toKodi.get_frame_buffer(m_instanceData->toKodi.kodiInstance, &picture);
+        return m_instanceData->toKodi->get_frame_buffer(m_instanceData->toKodi->kodiInstance,
+                                                        &picture);
       }
 
       //! \copydoc CInstanceVideoCodec::ReleaseFrameBuffer
       void ReleaseFrameBuffer(void *buffer)
       {
-        return m_instanceData->toKodi.release_frame_buffer(m_instanceData->toKodi.kodiInstance, buffer);
+        return m_instanceData->toKodi->release_frame_buffer(m_instanceData->toKodi->kodiInstance,
+                                                            buffer);
       }
 
     private:
@@ -201,43 +203,43 @@ namespace kodi
 
         m_instanceData = static_cast<AddonInstance_VideoCodec*>(instance);
 
-        m_instanceData->toAddon.addonInstance = this;
-        m_instanceData->toAddon.open = ADDON_Open;
-        m_instanceData->toAddon.reconfigure = ADDON_Reconfigure;
-        m_instanceData->toAddon.add_data = ADDON_AddData;
-        m_instanceData->toAddon.get_picture = ADDON_GetPicture;
-        m_instanceData->toAddon.get_name = ADDON_GetName;
-        m_instanceData->toAddon.reset = ADDON_Reset;
+        m_instanceData->toAddon->addonInstance = this;
+        m_instanceData->toAddon->open = ADDON_Open;
+        m_instanceData->toAddon->reconfigure = ADDON_Reconfigure;
+        m_instanceData->toAddon->add_data = ADDON_AddData;
+        m_instanceData->toAddon->get_picture = ADDON_GetPicture;
+        m_instanceData->toAddon->get_name = ADDON_GetName;
+        m_instanceData->toAddon->reset = ADDON_Reset;
       }
 
       inline static bool ADDON_Open(const AddonInstance_VideoCodec* instance, VIDEOCODEC_INITDATA *initData)
       {
-        return instance->toAddon.addonInstance->Open(*initData);
+        return instance->toAddon->addonInstance->Open(*initData);
       }
 
       inline static bool ADDON_Reconfigure(const AddonInstance_VideoCodec* instance, VIDEOCODEC_INITDATA *initData)
       {
-        return instance->toAddon.addonInstance->Reconfigure(*initData);
+        return instance->toAddon->addonInstance->Reconfigure(*initData);
       }
 
       inline static bool ADDON_AddData(const AddonInstance_VideoCodec* instance, const DemuxPacket *packet)
       {
-        return instance->toAddon.addonInstance->AddData(*packet);
+        return instance->toAddon->addonInstance->AddData(*packet);
       }
 
       inline static VIDEOCODEC_RETVAL ADDON_GetPicture(const AddonInstance_VideoCodec* instance, VIDEOCODEC_PICTURE *picture)
       {
-        return instance->toAddon.addonInstance->GetPicture(*picture);
+        return instance->toAddon->addonInstance->GetPicture(*picture);
       }
 
       inline static const char *ADDON_GetName(const AddonInstance_VideoCodec* instance)
       {
-        return instance->toAddon.addonInstance->GetName();
+        return instance->toAddon->addonInstance->GetName();
       }
 
       inline static void ADDON_Reset(const AddonInstance_VideoCodec* instance)
       {
-        return instance->toAddon.addonInstance->Reset();
+        return instance->toAddon->addonInstance->Reset();
       }
 
       AddonInstance_VideoCodec* m_instanceData;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -18,8 +18,6 @@
 #include "cores/VideoPlayer/Interface/Addon/DemuxPacket.h"
 #endif
 
-namespace kodi { namespace addon { class CInstanceVideoCodec; } }
-
 extern "C"
 {
   enum VIDEOCODEC_FORMAT
@@ -102,7 +100,7 @@ extern "C"
   struct AddonInstance_VideoCodec;
   typedef struct KodiToAddonFuncTable_VideoCodec
   {
-    kodi::addon::CInstanceVideoCodec* addonInstance;
+    KODI_HANDLE addonInstance;
 
     //! \brief Opens a codec
     bool (__cdecl* open) (const AddonInstance_VideoCodec* instance, VIDEOCODEC_INITDATA *initData);
@@ -214,32 +212,35 @@ namespace kodi
 
       inline static bool ADDON_Open(const AddonInstance_VideoCodec* instance, VIDEOCODEC_INITDATA *initData)
       {
-        return instance->toAddon->addonInstance->Open(*initData);
+        return static_cast<CInstanceVideoCodec*>(instance->toAddon->addonInstance)->Open(*initData);
       }
 
       inline static bool ADDON_Reconfigure(const AddonInstance_VideoCodec* instance, VIDEOCODEC_INITDATA *initData)
       {
-        return instance->toAddon->addonInstance->Reconfigure(*initData);
+        return static_cast<CInstanceVideoCodec*>(instance->toAddon->addonInstance)
+            ->Reconfigure(*initData);
       }
 
       inline static bool ADDON_AddData(const AddonInstance_VideoCodec* instance, const DemuxPacket *packet)
       {
-        return instance->toAddon->addonInstance->AddData(*packet);
+        return static_cast<CInstanceVideoCodec*>(instance->toAddon->addonInstance)
+            ->AddData(*packet);
       }
 
       inline static VIDEOCODEC_RETVAL ADDON_GetPicture(const AddonInstance_VideoCodec* instance, VIDEOCODEC_PICTURE *picture)
       {
-        return instance->toAddon->addonInstance->GetPicture(*picture);
+        return static_cast<CInstanceVideoCodec*>(instance->toAddon->addonInstance)
+            ->GetPicture(*picture);
       }
 
       inline static const char *ADDON_GetName(const AddonInstance_VideoCodec* instance)
       {
-        return instance->toAddon->addonInstance->GetName();
+        return static_cast<CInstanceVideoCodec*>(instance->toAddon->addonInstance)->GetName();
       }
 
       inline static void ADDON_Reset(const AddonInstance_VideoCodec* instance)
       {
-        return instance->toAddon->addonInstance->Reset();
+        return static_cast<CInstanceVideoCodec*>(instance->toAddon->addonInstance)->Reset();
       }
 
       AddonInstance_VideoCodec* m_instanceData;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -80,7 +80,7 @@ extern "C"
 
     int64_t pts;
 
-    KODI_HANDLE buffer; //< will be passed in release_frame_buffer
+    KODI_HANDLE videoBufferHandle; //< will be passed in release_frame_buffer
   };
 
   enum VIDEOCODEC_RETVAL

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -104,8 +104,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.3.3"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.3.1"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.3.4"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.3.4"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 
@@ -158,8 +158,8 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h" \
                                                       "c-api/addon-instance/visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "1.0.3"
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "1.0.2"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "1.0.4"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "1.0.4"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "addon-instance/VideoCodec.h" \
                                                       "StreamCodec.h" \

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -237,7 +237,7 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
     if (pVideoPicture->videoBuffer)
       pVideoPicture->videoBuffer->Release();
 
-    pVideoPicture->videoBuffer = static_cast<CVideoBuffer*>(picture.buffer);
+    pVideoPicture->videoBuffer = static_cast<CVideoBuffer*>(picture.videoBufferHandle);
 
     int strides[YuvImage::MAX_PLANES], planeOffsets[YuvImage::MAX_PLANES];
     for (int i = 0; i<YuvImage::MAX_PLANES; ++i)
@@ -306,7 +306,7 @@ void CAddonVideoCodec::Reset()
   {
     if (ret == VIDEOCODEC_RETVAL::VC_PICTURE)
     {
-      videoBuffer = static_cast<CVideoBuffer*>(picture.buffer);
+      videoBuffer = static_cast<CVideoBuffer*>(picture.videoBufferHandle);
       if (videoBuffer)
         videoBuffer->Release();
     }
@@ -324,7 +324,7 @@ bool CAddonVideoCodec::GetFrameBuffer(VIDEOCODEC_PICTURE &picture)
     return false;
   }
   picture.decodedData = videoBuffer->GetMemPtr();
-  picture.buffer = videoBuffer;
+  picture.videoBufferHandle = videoBuffer;
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -15,8 +15,6 @@
 #include "cores/VideoPlayer/Interface/Addon/TimingConstants.h"
 #include "utils/log.h"
 
-using namespace kodi::addon;
-
 CAddonVideoCodec::CAddonVideoCodec(CProcessInfo& processInfo,
                                    ADDON::AddonInfoPtr& addonInfo,
                                    KODI_HANDLE parentInstance)
@@ -25,11 +23,14 @@ CAddonVideoCodec::CAddonVideoCodec(CProcessInfo& processInfo,
     m_codecFlags(0),
     m_displayAspect(0.0f)
 {
-  m_struct = { { 0 } };
-  m_struct.toKodi.kodiInstance = this;
-  m_struct.toKodi.get_frame_buffer = get_frame_buffer;
-  m_struct.toKodi.release_frame_buffer = release_frame_buffer;
-  if (CreateInstance(&m_struct) != ADDON_STATUS_OK || !m_struct.toAddon.open)
+  m_struct.props = new AddonProps_VideoCodec();
+  m_struct.toAddon = new KodiToAddonFuncTable_VideoCodec();
+  m_struct.toKodi = new AddonToKodiFuncTable_VideoCodec();
+
+  m_struct.toKodi->kodiInstance = this;
+  m_struct.toKodi->get_frame_buffer = get_frame_buffer;
+  m_struct.toKodi->release_frame_buffer = release_frame_buffer;
+  if (CreateInstance(&m_struct) != ADDON_STATUS_OK || !m_struct.toAddon->open)
   {
     CLog::Log(LOGERROR, "CInputStreamAddon: Failed to create add-on instance for '%s'", addonInfo->ID().c_str());
     return;
@@ -42,6 +43,11 @@ CAddonVideoCodec::~CAddonVideoCodec()
   Reset();
 
   DestroyInstance();
+
+  // Delete "C" interface structures
+  delete m_struct.toAddon;
+  delete m_struct.toKodi;
+  delete m_struct.props;
 }
 
 bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamInfo &hints)
@@ -155,7 +161,7 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
 
 bool CAddonVideoCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
-  if (!m_struct.toAddon.open)
+  if (!m_struct.toAddon->open)
     return false;
 
   unsigned int nformats(0);
@@ -166,7 +172,7 @@ bool CAddonVideoCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   if (!CopyToInitData(initData, hints))
     return false;
 
-  bool ret = m_struct.toAddon.open(&m_struct, &initData);
+  bool ret = m_struct.toAddon->open(&m_struct, &initData);
   m_processInfo.SetVideoDecoderName(GetName(), false);
 
   return ret;
@@ -174,33 +180,33 @@ bool CAddonVideoCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 
 bool CAddonVideoCodec::Reconfigure(CDVDStreamInfo &hints)
 {
-  if (!m_struct.toAddon.reconfigure)
+  if (!m_struct.toAddon->reconfigure)
     return false;
 
   VIDEOCODEC_INITDATA initData;
   if (!CopyToInitData(initData, hints))
     return false;
 
-  return m_struct.toAddon.reconfigure(&m_struct, &initData);
+  return m_struct.toAddon->reconfigure(&m_struct, &initData);
 }
 
 bool CAddonVideoCodec::AddData(const DemuxPacket &packet)
 {
-  if (!m_struct.toAddon.add_data)
+  if (!m_struct.toAddon->add_data)
     return false;
 
-  return m_struct.toAddon.add_data(&m_struct, &packet);
+  return m_struct.toAddon->add_data(&m_struct, &packet);
 }
 
 CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPicture)
 {
-  if (!m_struct.toAddon.get_picture)
+  if (!m_struct.toAddon->get_picture)
     return CDVDVideoCodec::VC_ERROR;
 
   VIDEOCODEC_PICTURE picture;
   picture.flags = (m_codecFlags & DVD_CODEC_CTRL_DRAIN) ? VIDEOCODEC_PICTURE::FLAG_DRAIN : 0;
 
-  switch (m_struct.toAddon.get_picture(&m_struct, &picture))
+  switch (m_struct.toAddon->get_picture(&m_struct, &picture))
   {
   case VIDEOCODEC_RETVAL::VC_NONE:
     return CDVDVideoCodec::VC_NONE;
@@ -286,8 +292,8 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
 
 const char* CAddonVideoCodec::GetName()
 {
-  if (m_struct.toAddon.get_name)
-    return m_struct.toAddon.get_name(&m_struct);
+  if (m_struct.toAddon->get_name)
+    return m_struct.toAddon->get_name(&m_struct);
   return "";
 }
 
@@ -302,7 +308,7 @@ void CAddonVideoCodec::Reset()
   picture.flags = VIDEOCODEC_PICTURE::FLAG_DRAIN;
 
   VIDEOCODEC_RETVAL ret;
-  while ((ret = m_struct.toAddon.get_picture(&m_struct, &picture)) != VIDEOCODEC_RETVAL::VC_EOF)
+  while ((ret = m_struct.toAddon->get_picture(&m_struct, &picture)) != VIDEOCODEC_RETVAL::VC_EOF)
   {
     if (ret == VIDEOCODEC_RETVAL::VC_PICTURE)
     {
@@ -311,8 +317,8 @@ void CAddonVideoCodec::Reset()
         videoBuffer->Release();
     }
   }
-  if (m_struct.toAddon.reset)
-    m_struct.toAddon.reset(&m_struct);
+  if (m_struct.toAddon->reset)
+    m_struct.toAddon->reset(&m_struct);
 }
 
 bool CAddonVideoCodec::GetFrameBuffer(VIDEOCODEC_PICTURE &picture)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -29,6 +29,8 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
       avPkt.side_data_elems = pPacket->iSideDataElems;
       av_packet_free_side_data(&avPkt);
     }
+    if (pPacket->cryptoInfo)
+      delete pPacket->cryptoInfo;
     delete pPacket;
   }
 }
@@ -66,7 +68,7 @@ DemuxPacket* CDVDDemuxUtils::AllocateDemuxPacket(unsigned int iDataSize, unsigne
 {
   DemuxPacket *ret(AllocateDemuxPacket(iDataSize));
   if (ret && encryptedSubsampleCount > 0)
-    ret->cryptoInfo = std::shared_ptr<DemuxCryptoInfo>(new DemuxCryptoInfo(encryptedSubsampleCount));
+    ret->cryptoInfo = new DemuxCryptoInfo(encryptedSubsampleCount);
   return ret;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -354,7 +354,7 @@ std::vector<CDemuxStream*> CInputStreamAddon::GetStreams() const
   std::vector<CDemuxStream*> streams;
 
   INPUTSTREAM_IDS streamIDs = m_struct.toAddon->get_stream_ids(&m_struct);
-  if (streamIDs.m_streamCount > INPUTSTREAM_IDS::MAX_STREAM_COUNT)
+  if (streamIDs.m_streamCount > INPUTSTREAM_MAX_STREAM_COUNT)
     return streams;
 
   for (unsigned int i = 0; i < streamIDs.m_streamCount; ++i)

--- a/xbmc/cores/VideoPlayer/Interface/Addon/DemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/Interface/Addon/DemuxPacket.h
@@ -43,7 +43,7 @@ extern "C"
     int dispTime = 0;
     bool recoveryPoint = false;
 
-    std::shared_ptr<DemuxCryptoInfo> cryptoInfo;
+    struct DemuxCryptoInfo* cryptoInfo = nullptr;
   } DemuxPacket;
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description

This changes are taken from https://github.com/xbmc/xbmc/pull/17438 and to bring the more less critical changes on another request and have to other smaller and more clean.

## User related:

Not user relevant

Only for all binary addon system requests may be for the user:
- Binary addon system revised to ensure higher security in its data exchange between addon and Kodi

Commit 1:
--------------------
**[addons][inputstream] make all "C" interface structures to own memory**

This done to prevent API backward problems if something becomes replaced e.g. on props or to kodi calls.

Commit 2:
--------------------
**[addons][inputstream] use "C" defines about array sizes**

There was before this values set direct by number and by MAX_STREAM_COUNT as static const value within structure.

Here becomes changed to use them as "C" defines, this needed to have a safe interface between Kodi and addon. Also to allow "C" only for other languages.

Commit 3:
--------------------
**[addons][codec] rename buffer to videoBufferHandle on VIDEOCODEC_PICTURE**

Before with named "buffer" was for me on begin confusing and thought first
about data buffer used on addons itself. This was only a pointer to a
class in Kodi itself and not handled by addons.

Commit 4:
--------------------
**[addons][codec] use every addon functions structure in own mem**

Before was them all together in one memory where makes it with API harder if something was added.

Commit 5:
--------------------
**[addons][codec] don't use C++ class pointer within "C" structure**

This makes it hard to use the header for "C" only (e.g. base for other languages).

Commit 6:
--------------------
**[addons][inputstream] don't use C++ shared_ptr within "C" interface**

There was a shared_ptr used on DemuxPacket where can be critical if addon and Kodi was compiled with different versions.

On following changes are the DemuxPacket and DemuxCryptoInfo also cleaned to match "C".

Commit 7:
--------------------
**[addons][binary] increase inputstream and videocodec API version**

About inputstream becomes increased to 2.3.4
About videocodec becomes increased to 1.0.4

Increase related to last changes where addons need a recompile.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
