### PR TITLE
[Estuary] larger menu on settings windows

### DIFF
--- a/addons/skin.estuary/xml/SettingsCategory.xml
+++ b/addons/skin.estuary/xml/SettingsCategory.xml
@@ -19,7 +19,7 @@
 			<include>OpenClose_Right</include>
 			<control type="grouplist" id="5">
 				<description>control area</description>
-				<top>163</top>
+				<top>133</top>
 				<left>470</left>
 				<pagecontrol>60</pagecontrol>
 				<right>0</right>
@@ -31,7 +31,7 @@
 			</control>
 			<control type="image">
 				<left>470</left>
-				<top>160</top>
+				<top>130</top>
 				<right>0</right>
 				<height>2</height>
 				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
@@ -89,9 +89,9 @@
 			<control type="grouplist" id="3">
 				<description>button area</description>
 				<left>0</left>
-				<top>160</top>
+				<top>130</top>
 				<width>470</width>
-				<height>720</height>
+				<height>810</height>
 				<usecontrolcoords>true</usecontrolcoords>
 				<onleft>5</onleft>
 				<onright>5</onright>
@@ -101,7 +101,7 @@
 			<control type="button" id="10">
 				<description>Default Category Button</description>
 				<left>0</left>
-				<height>90</height>
+				<height>85</height>
 				<width>470</width>
 				<textoffsetx>40</textoffsetx>
 				<aligny>center</aligny>
@@ -109,34 +109,10 @@
 				<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
 				<texturenofocus />
 			</control>
-			<control type="radiobutton" id="20">
-				<width>470</width>
-				<left>0</left>
-				<bottom>110</bottom>
-				<height>90</height>
-				<aligny>center</aligny>
-				<onclick>SettingsLevelChange</onclick>
-				<textoffsetx>100</textoffsetx>
-				<textoffsety>0</textoffsety>
-				<texturefocus colordiffuse="button_focus">colors/white.png</texturefocus>
-				<texturenofocus />
-				<radioposx>40</radioposx>
-				<radioposy>0</radioposy>
-				<radiowidth>40</radiowidth>
-				<radioheight>40</radioheight>
-				<onleft>5</onleft>
-				<onright>5</onright>
-				<onup>3</onup>
-				<ondown>3</ondown>
-				<textureradioonfocus>icons/settings.png</textureradioonfocus>
-				<textureradioonnofocus>icons/settings.png</textureradioonnofocus>
-				<textureradioofffocus>icons/settings.png</textureradioofffocus>
-				<textureradiooffnofocus>icons/settings.png</textureradiooffnofocus>
-			</control>
 		</control>
 		<control type="group">
 			<right>0</right>
-			<top>163</top>
+			<top>133</top>
 			<bottom>137</bottom>
 			<width>60</width>
 			<control type="scrollbar" id="60">
@@ -160,6 +136,34 @@
 			<param name="breadcrumbs_label" value="$LOCALIZE[5]$INFO[Control.GetLabel(2), / ]" />
 		</include>
 		<include>BottomBar</include>
+		<control type="group">
+			<depth>DepthContentPanel</depth>
+			<include>OpenClose_Left</include>
+			<control type="radiobutton" id="20">
+				<width>470</width>
+				<left>0</left>
+				<bottom>70</bottom>
+				<height>90</height>
+				<aligny>center</aligny>
+				<onclick>SettingsLevelChange</onclick>
+				<textoffsetx>100</textoffsetx>
+				<textoffsety>0</textoffsety>
+				<texturefocus colordiffuse="button_focus">colors/white.png</texturefocus>
+				<texturenofocus />
+				<radioposx>40</radioposx>
+				<radioposy>0</radioposy>
+				<radiowidth>40</radiowidth>
+				<radioheight>40</radioheight>
+				<onleft>5</onleft>
+				<onright>5</onright>
+				<onup>3</onup>
+				<ondown>3</ondown>
+				<textureradioonfocus>icons/settings.png</textureradioonfocus>
+				<textureradioonnofocus>icons/settings.png</textureradioonnofocus>
+				<textureradioofffocus>icons/settings.png</textureradioofffocus>
+				<textureradiooffnofocus>icons/settings.png</textureradiooffnofocus>
+			</control>
+		</control>
 		<control type="group">
 			<include>OpenClose_Right</include>
 			<control type="textbox" id="6">

--- a/addons/skin.estuary/xml/SettingsProfile.xml
+++ b/addons/skin.estuary/xml/SettingsProfile.xml
@@ -20,7 +20,7 @@
 			<include>OpenClose_Right</include>
 			<left>472</left>
 			<control type="image">
-				<top>160</top>
+				<top>130</top>
 				<right>0</right>
 				<height>3</height>
 				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
@@ -32,7 +32,7 @@
 				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
 			</control>
 			<control type="panel" id="2">
-				<top>163</top>
+				<top>148</top>
 				<left>30</left>
 				<visible>Container(9000).Hasfocus(2)</visible>
 				<right>0</right>
@@ -182,7 +182,7 @@
 			</include>
 			<control type="list" id="9000">
 				<left>0</left>
-				<top>160</top>
+				<top>130</top>
 				<width>470</width>
 				<height>567</height>
 				<onleft>9100</onleft>
@@ -190,7 +190,7 @@
 				<onup>9000</onup>
 				<ondown>9000</ondown>
 				<scrolltime>300</scrolltime>
-				<itemlayout height="90" width="470">
+				<itemlayout height="85" width="470">
 					<control type="label">
 						<left>30</left>
 						<right>30</right>
@@ -200,7 +200,7 @@
 						<aligny>center</aligny>
 					</control>
 				</itemlayout>
-				<focusedlayout height="90" width="470">
+				<focusedlayout height="85" width="470">
 					<control type="image">
 						<right>0</right>
 						<bottom>0</bottom>

--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -17,11 +17,11 @@
 		</control>
 		<control type="group">
 			<left>40</left>
-			<top>70</top>
+			<top>133</top>
 			<include>OpenClose_Right</include>
 			<control type="grouplist">
 				<left>420</left>
-				<top>105</top>
+				<top>30</top>
 				<height>550</height>
 				<orientation>vertical</orientation>
 				<control type="label" id="2">
@@ -83,14 +83,14 @@
 			<control type="textbox" id="30">
 				<left>420</left>
 				<right>50</right>
-				<top>100</top>
+				<top>30</top>
 				<bottom>347</bottom>
 				<pagecontrol>60</pagecontrol>
 				<autoscroll delay="5000" repeat="7500" time="5000">!Control.HasFocus(60)</autoscroll>
 			</control>
 			<control type="scrollbar" id="60">
 				<right>0</right>
-				<top>93</top>
+				<top>0</top>
 				<width>12</width>
 				<bottom>340</bottom>
 				<orientation>vertical</orientation>
@@ -106,7 +106,7 @@
 			</control>
 			<control type="image">
 				<left>380</left>
-				<top>90</top>
+				<top>-3</top>
 				<right>0</right>
 				<height>3</height>
 				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
@@ -122,7 +122,7 @@
 			</include>
 			<control type="grouplist" id="9000">
 				<left>0</left>
-				<top>160</top>
+				<top>130</top>
 				<width>420</width>
 				<height>100%</height>
 				<onup>9000</onup>
@@ -131,7 +131,7 @@
 				<control type="button" id="95">
 					<description>Button Summary Values</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[20037]</label>
@@ -139,7 +139,7 @@
 				<control type="button" id="94">
 					<description>Button Storage</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[13277]</label>
@@ -147,7 +147,7 @@
 				<control type="button" id="96">
 					<description>Button Network</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[13279]</label>
@@ -155,7 +155,7 @@
 				<control type="button" id="97">
 					<description>Button Video</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[13280]</label>
@@ -163,7 +163,7 @@
 				<control type="button" id="98">
 					<description>Button Hardware</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[13281]</label>
@@ -171,7 +171,7 @@
 				<control type="button" id="99">
 					<description>Button PVR</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[19191]</label>
@@ -179,7 +179,7 @@
 				<control type="button" id="100">
 					<description>Button Privacy policy</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="85" />
 					</include>
 					<width>420</width>
 					<label>$LOCALIZE[12389]</label>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -21,7 +21,7 @@
 			<left>470</left>
 			<include>OpenClose_Right</include>
 			<control type="grouplist" id="700">
-				<top>160</top>
+				<top>133</top>
 				<left>0</left>
 				<right>0</right>
 				<bottom>140</bottom>
@@ -75,7 +75,7 @@
 				</control>
 			</control>
 			<control type="grouplist" id="600">
-				<top>160</top>
+				<top>133</top>
 				<left>0</left>
 				<right>0</right>
 				<bottom>140</bottom>
@@ -131,7 +131,7 @@
 				</control>
 			</control>
 			<control type="grouplist" id="610">
-				<top>160</top>
+				<top>133</top>
 				<left>0</left>
 				<right>0</right>
 				<bottom>140</bottom>
@@ -248,7 +248,7 @@
 			<control type="image">
 				<description>Dialog Header image</description>
 				<left>0</left>
-				<top>160</top>
+				<top>130</top>
 				<right>0</right>
 				<height>3</height>
 				<texture colordiffuse="button_focus" border="2">dialogs/separator-grey.png</texture>
@@ -272,34 +272,34 @@
 			<control type="list" id="9000">
 				<description>button area</description>
 				<left>0</left>
-				<top>160</top>
+				<top>130</top>
 				<width>470</width>
 				<height>700</height>
 				<onleft>10000</onleft>
 				<onright>10000</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
-				<itemlayout height="90" width="470">
+				<itemlayout height="85" width="470">
 					<control type="label">
 						<textoffsetx>30</textoffsetx>
 						<width>470</width>
-						<height>90</height>
+						<height>85</height>
 						<label>$INFO[ListItem.Label]</label>
 						<font>font37</font>
 						<aligny>center</aligny>
 					</control>
 				</itemlayout>
-				<focusedlayout height="90" width="470">
+				<focusedlayout height="85" width="470">
 					<control type="image">
 						<width>470</width>
-						<height>90</height>
+						<height>85</height>
 						<texture colordiffuse="button_focus">lists/focus.png</texture>
 						<animation effect="fade" start="100" end="50" time="40" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
 						<textoffsetx>30</textoffsetx>
 						<width>470</width>
-						<height>90</height>
+						<height>85</height>
 						<font>font37</font>
 						<aligny>center</aligny>
 						<label>$INFO[ListItem.Label]</label>
@@ -323,7 +323,7 @@
 		</control>
 		<control type="group">
 			<right>0</right>
-			<top>163</top>
+			<top>133</top>
 			<bottom>137</bottom>
 			<width>60</width>
 			<control type="scrollbar" id="60">


### PR DESCRIPTION
## Description
recently, a 9th category button was added to the PVR settings section.
due to the limited height of the button menu area in Estuary, not all category buttons would be visible anymore.

these changes are based on https://github.com/xbmc/xbmc/pull/18350 (thanx @emveepee / @jjd-uk)
with the following additional tweaks:
- slightly reduce the height of the category buttons (in order to have a small gap between the category buttons and the settings level button)
- put the settings level button on top of the bottom shadow (looks odd if the button was partly covered by it)
- adjust the other similar windows as well, to keep a unified layout (SettingsProfile.xml, SettingsSystemInfo.xml, SkinSettings.xml)

## Motivation and Context
a typical user might not instantly know that there are more categories available, since they aren't all visible on screen.
there's no indicator either (or scrollbar) in that area that would provide a clue to scroll further down the list.

## How Has This Been Tested?
see screenshots below.

## Screenshots (if appropriate):
before:
![before](https://user-images.githubusercontent.com/687265/91671377-6ee4e280-eb26-11ea-985f-bb813fb9bfda.jpg)

after:
![after](https://user-images.githubusercontent.com/687265/91671387-802def00-eb26-11ea-9be7-e8c6a8eae24e.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
