### PR TITLE
EPG: speed up CPVREpgContainer::PersistAll() using transactions

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -227,6 +227,7 @@ CDatabase::CDatabase() :
   m_sqlite = true;
   m_bMultiWrite = false;
   m_multipleExecute = false;
+  m_transactionCount = 0;
 }
 
 CDatabase::~CDatabase(void)
@@ -348,6 +349,8 @@ bool CDatabase::ExecuteQuery(const std::string &strQuery)
       return bReturn;
     m_pDS->exec(strQuery);
     bReturn = true;
+    if (InTransaction())
+      ++m_transactionCount;
   }
   catch (...)
   {
@@ -607,6 +610,7 @@ void CDatabase::Close()
 
   m_openCount = 0;
   m_multipleExecute = false;
+  m_transactionCount = 0;
 
   if (nullptr == m_pDB)
     return;
@@ -667,6 +671,7 @@ void CDatabase::BeginTransaction()
   {
     if (nullptr != m_pDB)
       m_pDB->start_transaction();
+    m_transactionCount = 0;
   }
   catch (...)
   {
@@ -707,6 +712,11 @@ bool CDatabase::InTransaction()
   if (nullptr == m_pDB.get())
     return false;
   return m_pDB->in_transaction();
+}
+
+int CDatabase::TransactionCount()
+{
+  return m_transactionCount;
 }
 
 bool CDatabase::CreateDatabase()

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -702,6 +702,12 @@ void CDatabase::RollbackTransaction()
   }
 }
 
+bool CDatabase::InTransaction()
+{
+  if (NULL != m_pDB.get()) return false;
+  return m_pDB->in_transaction();
+}
+
 bool CDatabase::CreateDatabase()
 {
   BeginTransaction();

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -704,7 +704,8 @@ void CDatabase::RollbackTransaction()
 
 bool CDatabase::InTransaction()
 {
-  if (NULL != m_pDB.get()) return false;
+  if (nullptr == m_pDB.get())
+    return false;
   return m_pDB->in_transaction();
 }
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -105,6 +105,7 @@ public:
   void BeginTransaction();
   virtual bool CommitTransaction();
   void RollbackTransaction();
+  bool InTransaction();
   void CopyDB(const std::string& latestDb);
   void DropAnalytics();
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -106,6 +106,7 @@ public:
   virtual bool CommitTransaction();
   void RollbackTransaction();
   bool InTransaction();
+  int TransactionCount();
   void CopyDB(const std::string& latestDb);
   void DropAnalytics();
 
@@ -255,4 +256,6 @@ private:
 
   bool m_multipleExecute;
   std::vector<std::string> m_multipleQueries;
+
+  int m_transactionCount; /*!< Number of transactions since BeginTransaction() */
 };

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -291,7 +291,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpg::GetTags() const
   return m_tags.GetAllTags();
 }
 
-bool CPVREpg::Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bQueueWrite)
+bool CPVREpg::Persist(const std::shared_ptr<CPVREpgDatabase>& database)
 {
   // Note: It is guaranteed that both this EPG instance and database instance are already
   //       locked when this method gets called! No additional locking is needed here!
@@ -304,7 +304,7 @@ bool CPVREpg::Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bQu
 
   if (m_iEpgID <= 0 || m_bChanged)
   {
-    const int iId = database->Persist(*this, m_iEpgID > 0);
+    const int iId = database->Persist(*this);
     if (iId > 0 && m_iEpgID != iId)
     {
       m_iEpgID = iId;
@@ -313,15 +313,15 @@ bool CPVREpg::Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bQu
   }
 
   if (m_tags.NeedsSave())
-    m_tags.Persist(!bQueueWrite);
+    m_tags.Persist();
 
   if (m_bUpdateLastScanTime)
-    database->PersistLastEpgScanTime(m_iEpgID, m_lastScanTime, bQueueWrite);
+    database->PersistLastEpgScanTime(m_iEpgID, m_lastScanTime);
 
   m_bChanged = false;
   m_bUpdateLastScanTime = false;
 
-  return bQueueWrite || database->CommitInsertQueries();
+  return true;
 }
 
 bool CPVREpg::Delete(const std::shared_ptr<CPVREpgDatabase>& database)

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -205,10 +205,9 @@ namespace PVR
     /*!
      * @brief Persist this table in the given database
      * @param database The database.
-     * @param bQueueWrite Don't execute the query immediately but queue it if true.
      * @return True if the table was persisted, false otherwise.
      */
-    bool Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bQueueWrite);
+    bool Persist(const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
      * @brief Delete this table from the given database

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -303,6 +303,7 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
   {
     // Note: We must lock the db the whole time, otherwise races may occure.
     database->Lock();
+    database->BeginTransaction();
 
     XbmcThreads::EndTime processTimeslice(iMaxTimeslice);
     for (const auto& epg : changedEpgs)
@@ -312,18 +313,18 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
         CLog::Log(LOGDEBUG, "EPG Container: Persisting events for channel '%s'...",
                   epg->GetChannelData()->ChannelName().c_str());
 
-        bReturn &= epg->Persist(database, true);
+        bReturn &= epg->Persist(database);
       }
 
       epg->Unlock();
     }
 
-    if (bReturn)
-      database->CommitInsertQueries();
-
+    CLog::Log(LOGDEBUG, "EPG Container: committing {} queries.", database->TransactionCount());
+    database->CommitTransaction();
     database->Unlock();
   }
 
+  CLog::Log(LOGDEBUG, "EPG Container: Persist completed.");
   return bReturn;
 }
 

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -310,7 +310,7 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
     {
       if (!processTimeslice.IsTimePast())
       {
-        CLog::Log(LOGDEBUG, "EPG Container: Persisting events for channel '%s'...",
+        CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: Persisting events for channel '%s'...",
                   epg->GetChannelData()->ChannelName().c_str());
 
         bReturn &= epg->Persist(database);
@@ -319,12 +319,13 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
       epg->Unlock();
     }
 
-    CLog::Log(LOGDEBUG, "EPG Container: committing {} queries.", database->TransactionCount());
+    CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: committing {} queries.",
+              database->TransactionCount());
     database->CommitTransaction();
     database->Unlock();
   }
 
-  CLog::Log(LOGDEBUG, "EPG Container: Persist completed.");
+  CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: Persist completed.");
   return bReturn;
 }
 
@@ -599,7 +600,7 @@ bool CPVREpgContainer::RemoveOldEntries()
     database->BeginTransaction();
   }
 
-  CLog::Log(LOGDEBUG, "EPG Container: Removing old entries...");
+  CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: Removing old entries...");
 
   /* call Cleanup() on all known EPG tables */
   for (const auto& epgEntry : m_epgIdToEpgMap)
@@ -607,13 +608,13 @@ bool CPVREpgContainer::RemoveOldEntries()
 
   if (database)
   {
-    CLog::Log(LOGDEBUG, "EPG Container: Committing removed old entries ({} queries)...",
+    CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: Committing removed old entries ({} queries)...",
               database->TransactionCount());
     database->CommitTransaction();
     database->Unlock();
   }
 
-  CLog::Log(LOGDEBUG, "EPG Container: Old entries removed");
+  CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: Old entries removed");
 
   CSingleLock lock(m_critSection);
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iLastEpgCleanup);

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -314,6 +314,13 @@ bool CPVREpgContainer::PersistAll(unsigned int iMaxTimeslice) const
                   epg->GetChannelData()->ChannelName().c_str());
 
         bReturn &= epg->Persist(database);
+        if (database->TransactionCount() > 10000)
+        {
+          CLog::Log(LOGDEBUG, LOGEPG, "EPG Container: committing {} queries in loop.",
+                    database->TransactionCount());
+          database->CommitTransaction();
+          database->BeginTransaction();
+        }
       }
 
       epg->Unlock();

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -221,18 +221,16 @@ namespace PVR
      * @brief Update the last scan time.
      * @param iEpgId The table to update the time for.
      * @param lastScanTime The time to write to the database.
-     * @param bQueueWrite Don't execute the query immediately but queue it if true.
      * @return True if it was updated successfully, false otherwise.
      */
-    bool PersistLastEpgScanTime(int iEpgId, const CDateTime& lastScanTime, bool bQueueWrite);
+    bool PersistLastEpgScanTime(int iEpgId, const CDateTime& lastScanTime);
 
     /*!
      * @brief Persist an EPG table. It's entries are not persisted.
      * @param epg The table to persist.
-     * @param bQueueWrite Don't execute the query immediately but queue it if true.
      * @return The database ID of this entry or 0 if bSingleUpdate is false and the query was queued.
      */
-    int Persist(const CPVREpg& epg, bool bQueueWrite);
+    int Persist(const CPVREpg& epg);
 
     /*!
      * @brief Erase all EPG tags with the given epg ID and an end time less than the given time.
@@ -252,10 +250,9 @@ namespace PVR
     /*!
      * @brief Persist an infotag.
      * @param tag The tag to persist.
-     * @param bSingleUpdate If true, this is a single update and the query will be executed immediately.
      * @return The database ID of this entry or 0 if bSingleUpdate is false and the query was queued.
      */
-    int Persist(const CPVREpgInfoTag& tag, bool bSingleUpdate = true);
+    int Persist(const CPVREpgInfoTag& tag);
 
     /*!
      * @return Last EPG id in the database

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -550,7 +550,7 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId /
   return bChanged;
 }
 
-bool CPVREpgInfoTag::Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bSingleUpdate /* = true */)
+bool CPVREpgInfoTag::Persist(const std::shared_ptr<CPVREpgDatabase>& database)
 {
   bool bReturn = false;
 
@@ -560,7 +560,7 @@ bool CPVREpgInfoTag::Persist(const std::shared_ptr<CPVREpgDatabase>& database, b
     return bReturn;
   }
 
-  int iId = database->Persist(*this, bSingleUpdate);
+  int iId = database->Persist(*this);
   if (iId >= 0)
   {
     bReturn = true;

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -344,10 +344,9 @@ namespace PVR
     /*!
      * @brief Persist this tag in the given database.
      * @param database The database.
-     * @param bSingleUpdate True if this is a single update, false if more updates will follow.
      * @return True if the tag was persisted correctly, false otherwise.
      */
-    bool Persist(const std::shared_ptr<CPVREpgDatabase>& database, bool bSingleUpdate = true);
+    bool Persist(const std::shared_ptr<CPVREpgDatabase>& database);
 
     /*!
      * @brief Update the information in this tag with the info in the given tag.

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -572,7 +572,7 @@ bool CPVREpgTagsContainer::NeedsSave() const
   return !m_changedTags.empty() || !m_deletedTags.empty();
 }
 
-void CPVREpgTagsContainer::Persist(bool bCommit)
+void CPVREpgTagsContainer::Persist()
 {
   if (m_database)
   {
@@ -592,13 +592,10 @@ void CPVREpgTagsContainer::Persist(bool bCommit)
       m_database->DeleteEpgTagsByMinEndMaxStartTime(m_iEpgID, tag.second->StartAsUTC() + ONE_SECOND,
                                                     tag.second->EndAsUTC() - ONE_SECOND);
 
-      tag.second->Persist(m_database, false);
+      tag.second->Persist(m_database);
     }
 
     m_changedTags.clear();
-
-    if (bCommit)
-      m_database->CommitInsertQueries();
 
     m_database->Unlock();
   }

--- a/xbmc/pvr/epg/EpgTagsContainer.cpp
+++ b/xbmc/pvr/epg/EpgTagsContainer.cpp
@@ -578,7 +578,7 @@ void CPVREpgTagsContainer::Persist()
   {
     m_database->Lock();
 
-    CLog::Log(LOGDEBUG, "EPG Tags Container: Updating %d, deleting %d events...",
+    CLog::Log(LOGDEBUG, LOGEPG, "EPG Tags Container: Updating %d, deleting %d events...",
               m_changedTags.size(), m_deletedTags.size());
 
     for (const auto& tag : m_deletedTags)

--- a/xbmc/pvr/epg/EpgTagsContainer.h
+++ b/xbmc/pvr/epg/EpgTagsContainer.h
@@ -160,9 +160,8 @@ public:
 
   /*!
    * @brief Persist this container in its database.
-   * @param bCommit Whether to commit the data.
    */
-  void Persist(bool bCommit);
+  void Persist();
 
   /*!
    * @brief Delete this container from its database.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Speed up EPG database updates in CPVREpgContainer::PersistAll() using a SQL transaction. Do the same for CPVREpgContainer::RemoveOldEntries().

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
While testing Matrix on my Linux desktop with HDD I've noticed long exit times due to PVR database updates. 

The issue can be triggered by changing the VDR server in VNSI client and exit kodi. In this [debug log](http://ix.io/2rq2) it takes 1:58 minutes for ~150 channels.

```
2020-07-11 19:46:40.067 T:15948    INFO <general>: EPG Container: Persisting unsaved events...
2020-07-11 19:48:38.729 T:15948    INFO <general>: EPG Container: Persisting events done
```

There is already some discussion and tests related to this PR in Issue #17800.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Build the PR with recent master for Linux x86_64. When testing using the trigger kodi does exit in only few seconds (see [debug log](http://ix.io/2vMZ)):

```
2020-08-30 19:18:31.230 T:31950    INFO <general>: EPG Container: Persisting unsaved events...
2020-08-30 19:18:32.278 T:31950    INFO <general>: EPG Container: Persisting events done
```



## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
