### PR TITLE
[python] remove autoexec.py

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4136,19 +4136,6 @@ void CApplication::Process()
   // (this can only be done after CServiceBroker::GetGUI()->GetWindowManager().Render())
   CApplicationMessenger::GetInstance().ProcessWindowMessages();
 
-  if (m_autoExecScriptExecuted)
-  {
-    m_autoExecScriptExecuted = false;
-
-    // autoexec.py - profile
-    std::string strAutoExecPy = CSpecialProtocol::TranslatePath("special://profile/autoexec.py");
-
-    if (XFILE::CFile::Exists(strAutoExecPy))
-      CScriptInvocationManager::GetInstance().ExecuteAsync(strAutoExecPy);
-    else
-      CLog::Log(LOGDEBUG, "no profile autoexec.py (%s) found, skipping", strAutoExecPy.c_str());
-  }
-
   // handle any active scripts
 
   {
@@ -4933,9 +4920,6 @@ void CApplication::SetLoggingIn(bool switchingProfiles)
   // would therefore write the previous skin's settings into the new profile
   // instead of into the previous one
   m_saveSkinOnUnloading = !switchingProfiles;
-
-  // make sure that the autoexec.py script is executed after logging in
-  m_autoExecScriptExecuted = true;
 }
 
 void CApplication::CloseNetworkShares()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -391,7 +391,6 @@ protected:
   bool m_ignoreSkinSettingChanges = false;
 
   bool m_saveSkinOnUnloading = true;
-  bool m_autoExecScriptExecuted = false;
 
 #if defined(TARGET_DARWIN_IOS)
   friend class CWinEventsIOS;

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -672,8 +672,6 @@ void CPythonInvoker::onError(const std::string &exceptionType /* = "" */, const 
     std::string message;
     if (m_addon && !m_addon->Name().empty())
       message = StringUtils::Format(g_localizeStrings.Get(2102).c_str(), m_addon->Name().c_str());
-    else if (m_sourceFile == CSpecialProtocol::TranslatePath("special://profile/autoexec.py"))
-      message = StringUtils::Format(g_localizeStrings.Get(2102).c_str(), "autoexec.py");
     else
        message = g_localizeStrings.Get(2103);
     pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, message, g_localizeStrings.Get(2104));


### PR DESCRIPTION
## Description
Removes automatic script execution for autoexec.py script

## Motivation and Context
Was discussion about past plans to remove autoexec.py usage. Change seemed simple enough, but figure we'll start this PR purely to get the discussion rolling about pros/cons

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
