### PR TITLE
[PythonInvoker] Remove deprecated python c api calls, clang-format

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -6,9 +6,10 @@
  *  See LICENSES/README.md for more information.
  */
 
+// clang-format off
 // python.h should always be included first before any other includes
 #include <Python.h>
-#include <iterator>
+// clang-format on
 
 #include "Application.h"
 #include "PythonInvoker.h"
@@ -40,9 +41,10 @@
 // clang-format on
 
 #include <cassert>
+#include <iterator>
 
 #ifdef TARGET_WINDOWS
-extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);
+extern "C" FILE* fopen_utf8(const char* _Filename, const char* _Mode);
 #else
 #define fopen_utf8 fopen
 #endif
@@ -63,7 +65,8 @@ using namespace KODI::MESSAGING;
 
 CCriticalSection CPythonInvoker::s_critical;
 
-static const std::string getListOfAddonClassesAsString(XBMCAddon::AddonClass::Ref<XBMCAddon::Python::PythonLanguageHook>& languageHook)
+static const std::string getListOfAddonClassesAsString(
+    XBMCAddon::AddonClass::Ref<XBMCAddon::Python::PythonLanguageHook>& languageHook)
 {
   std::string message;
   CSingleLock l(*(languageHook.get()));
@@ -81,11 +84,13 @@ static const std::string getListOfAddonClassesAsString(XBMCAddon::AddonClass::Re
   return message;
 }
 
-static std::vector<std::vector<wchar_t>> storeArgumentsCCompatible(std::vector<std::wstring> const& input)
+static std::vector<std::vector<wchar_t>> storeArgumentsCCompatible(
+    std::vector<std::wstring> const& input)
 {
   std::vector<std::vector<wchar_t>> output;
-  std::transform(input.begin(), input.end(), std::back_inserter(output),
-                 [](std::wstring const& i) { return std::vector<wchar_t>(i.c_str(), i.c_str() + i.length() + 1); });
+  std::transform(input.begin(), input.end(), std::back_inserter(output), [](std::wstring const& i) {
+    return std::vector<wchar_t>(i.c_str(), i.c_str() + i.length() + 1);
+  });
 
   if (output.empty())
     output.emplace_back(1u, '\0');
@@ -101,10 +106,10 @@ static std::vector<wchar_t*> getCPointersToArguments(std::vector<std::vector<wch
   return output;
 }
 
-CPythonInvoker::CPythonInvoker(ILanguageInvocationHandler *invocationHandler)
-  : ILanguageInvoker(invocationHandler),
-    m_threadState(NULL), m_stop(false)
-{ }
+CPythonInvoker::CPythonInvoker(ILanguageInvocationHandler* invocationHandler)
+  : ILanguageInvoker(invocationHandler), m_threadState(NULL), m_stop(false)
+{
+}
 
 CPythonInvoker::~CPythonInvoker()
 {
@@ -114,22 +119,25 @@ CPythonInvoker::~CPythonInvoker()
     return;
 
   if (GetState() < InvokerStateExecutionDone)
-    CLog::Log(LOGDEBUG, "CPythonInvoker(%d): waiting for python thread \"%s\" to stop",
-      GetId(), (!m_sourceFile.empty() ? m_sourceFile.c_str() : "unknown script"));
+    CLog::Log(LOGDEBUG, "CPythonInvoker(%d): waiting for python thread \"%s\" to stop", GetId(),
+              (!m_sourceFile.empty() ? m_sourceFile.c_str() : "unknown script"));
   Stop(true);
   pulseGlobalEvent();
 
   onExecutionFinalized();
 }
 
-bool CPythonInvoker::Execute(const std::string &script, const std::vector<std::string> &arguments /* = std::vector<std::string>() */)
+bool CPythonInvoker::Execute(
+    const std::string& script,
+    const std::vector<std::string>& arguments /* = std::vector<std::string>() */)
 {
   if (script.empty())
     return false;
 
   if (!CFile::Exists(script))
   {
-    CLog::Log(LOGERROR, "CPythonInvoker(%d): python script \"%s\" does not exist", GetId(), CSpecialProtocol::TranslatePath(script).c_str());
+    CLog::Log(LOGERROR, "CPythonInvoker(%d): python script \"%s\" does not exist", GetId(),
+              CSpecialProtocol::TranslatePath(script).c_str());
     return false;
   }
 
@@ -139,7 +147,7 @@ bool CPythonInvoker::Execute(const std::string &script, const std::vector<std::s
   return ILanguageInvoker::Execute(script, arguments);
 }
 
-bool CPythonInvoker::execute(const std::string &script, const std::vector<std::string> &arguments)
+bool CPythonInvoker::execute(const std::string& script, const std::vector<std::string>& arguments)
 {
   std::vector<std::wstring> w_arguments;
   for (auto argument : arguments)
@@ -284,7 +292,8 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
   // set current directory and python's path.
   PySys_SetArgv(argc, &argv[0]);
 
-  CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): entering source directory %s", GetId(), m_sourceFile.c_str(), scriptDir.c_str());
+  CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): entering source directory %s", GetId(),
+            m_sourceFile.c_str(), scriptDir.c_str());
   PyObject* module = PyImport_AddModule("__main__");
   PyObject* moduleDict = PyModule_GetDict(module);
 
@@ -309,7 +318,9 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
 #ifdef TARGET_WINDOWS
       if (!g_charsetConverter.utf8ToSystem(nativeFilename, true))
       {
-        CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): can't convert filename \"%s\" to system encoding", GetId(), m_sourceFile.c_str(), realFilename.c_str());
+        CLog::Log(LOGERROR,
+                  "CPythonInvoker(%d, %s): can't convert filename \"%s\" to system encoding",
+                  GetId(), m_sourceFile.c_str(), realFilename.c_str());
         return false;
       }
 #endif
@@ -324,11 +335,13 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
 
         Py_DECREF(f);
         setState(InvokerStateRunning);
-        XBMCAddon::Python::PyContext pycontext; // this is a guard class that marks this callstack as being in a python context
+        XBMCAddon::Python::PyContext
+            pycontext; // this is a guard class that marks this callstack as being in a python context
         executeScript(fp, realFilename, moduleDict);
       }
       else
-        CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): %s not found!", GetId(), m_sourceFile.c_str(), m_sourceFile.c_str());
+        CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): %s not found!", GetId(), m_sourceFile.c_str(),
+                  m_sourceFile.c_str());
     }
     catch (const XbmcCommons::Exception& e)
     {
@@ -339,7 +352,8 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
     catch (...)
     {
       setState(InvokerStateFailed);
-      CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): failure in script", GetId(), m_sourceFile.c_str());
+      CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): failure in script", GetId(),
+                m_sourceFile.c_str());
       failed = true;
     }
   }
@@ -348,7 +362,8 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
   InvokerState stateToSet;
   if (!failed && !PyErr_Occurred())
   {
-    CLog::Log(LOGINFO, "CPythonInvoker(%d, %s): script successfully run", GetId(), m_sourceFile.c_str());
+    CLog::Log(LOGINFO, "CPythonInvoker(%d, %s): script successfully run", GetId(),
+              m_sourceFile.c_str());
     stateToSet = InvokerStateScriptDone;
     onSuccess();
   }
@@ -366,9 +381,11 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
     // if it failed with an exception we already logged the details
     if (!failed)
     {
-      PythonBindings::PythonToCppException *e = NULL;
-      if (PythonBindings::PythonToCppException::ParsePythonException(exceptionType, exceptionValue, exceptionTraceback))
-        e = new PythonBindings::PythonToCppException(exceptionType, exceptionValue, exceptionTraceback);
+      PythonBindings::PythonToCppException* e = NULL;
+      if (PythonBindings::PythonToCppException::ParsePythonException(exceptionType, exceptionValue,
+                                                                     exceptionTraceback))
+        e = new PythonBindings::PythonToCppException(exceptionType, exceptionValue,
+                                                     exceptionTraceback);
       else
         e = new PythonBindings::PythonToCppException();
 
@@ -491,7 +508,9 @@ bool CPythonInvoker::stop(bool abort)
     {
       if (timeout.IsTimePast())
       {
-        CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): script didn't stop in %d seconds - let's kill it", GetId(), m_sourceFile.c_str(), PYTHON_SCRIPT_TIMEOUT / 1000);
+        CLog::Log(LOGERROR,
+                  "CPythonInvoker(%d, %s): script didn't stop in %d seconds - let's kill it",
+                  GetId(), m_sourceFile.c_str(), PYTHON_SCRIPT_TIMEOUT / 1000);
         break;
       }
 
@@ -510,7 +529,8 @@ bool CPythonInvoker::stop(bool abort)
 
     // Useful for add-on performance metrics
     if (!timeout.IsTimePast())
-      CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): script termination took %dms", GetId(), m_sourceFile.c_str(), PYTHON_SCRIPT_TIMEOUT - timeout.MillisLeft());
+      CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): script termination took %dms", GetId(),
+                m_sourceFile.c_str(), PYTHON_SCRIPT_TIMEOUT - timeout.MillisLeft());
 
     // Since we released the m_critical it's possible that the state is cleaned up
     // so we need to recheck for m_threadState == NULL
@@ -606,7 +626,8 @@ void CPythonInvoker::onExecutionFailed()
   PyEval_SaveThread();
 
   setState(InvokerStateFailed);
-  CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): abnormally terminating python thread", GetId(), m_sourceFile.c_str());
+  CLog::Log(LOGERROR, "CPythonInvoker(%d, %s): abnormally terminating python thread", GetId(),
+            m_sourceFile.c_str());
 
   CSingleLock lock(m_critical);
   m_threadState = NULL;
@@ -624,11 +645,12 @@ void CPythonInvoker::onInitialization()
 
   // get a possible initialization script
   const char* runscript = getInitializationScript();
-  if (runscript!= NULL && strlen(runscript) > 0)
+  if (runscript != NULL && strlen(runscript) > 0)
   {
     // redirecting default output to debug console
     if (PyRun_SimpleString(runscript) == -1)
-      CLog::Log(LOGFATAL, "CPythonInvoker(%d, %s): initialize error", GetId(), m_sourceFile.c_str());
+      CLog::Log(LOGFATAL, "CPythonInvoker(%d, %s): initialize error", GetId(),
+                m_sourceFile.c_str());
   }
 }
 
@@ -637,7 +659,7 @@ void CPythonInvoker::onPythonModuleInitialization(void* moduleDict)
   if (m_addon.get() == NULL || moduleDict == NULL)
     return;
 
-  PyObject *moduleDictionary = (PyObject *)moduleDict;
+  PyObject* moduleDictionary = (PyObject*)moduleDict;
 
   PyObject* pyaddonid = PyUnicode_FromString(m_addon->ID().c_str());
   PyDict_SetItemString(moduleDictionary, "__xbmcaddonid__", pyaddonid);
@@ -646,10 +668,12 @@ void CPythonInvoker::onPythonModuleInitialization(void* moduleDict)
   PyObject* pyxbmcapiversion = PyUnicode_FromString(version.asString().c_str());
   PyDict_SetItemString(moduleDictionary, "__xbmcapiversion__", pyxbmcapiversion);
 
-  PyObject *pyinvokerid = PyLong_FromLong(GetId());
+  PyObject* pyinvokerid = PyLong_FromLong(GetId());
   PyDict_SetItemString(moduleDictionary, "__xbmcinvokerid__", pyinvokerid);
 
-  CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): instantiating addon using automatically obtained id of \"%s\" dependent on version %s of the xbmc.python api",
+  CLog::Log(LOGDEBUG,
+            "CPythonInvoker(%d, %s): instantiating addon using automatically obtained id of \"%s\" "
+            "dependent on version %s of the xbmc.python api",
             GetId(), m_sourceFile.c_str(), m_addon->ID().c_str(), version.asString().c_str());
 }
 
@@ -658,12 +682,16 @@ void CPythonInvoker::onDeinitialization()
   XBMC_TRACE;
 }
 
-void CPythonInvoker::onError(const std::string &exceptionType /* = "" */, const std::string &exceptionValue /* = "" */, const std::string &exceptionTraceback /* = "" */)
+void CPythonInvoker::onError(const std::string& exceptionType /* = "" */,
+                             const std::string& exceptionValue /* = "" */,
+                             const std::string& exceptionTraceback /* = "" */)
 {
   CPyThreadState releaseGil;
   CSingleLock gc(CServiceBroker::GetWinSystem()->GetGfxContext());
 
-  CGUIDialogKaiToast *pDlgToast = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(WINDOW_DIALOG_KAI_TOAST);
+  CGUIDialogKaiToast* pDlgToast =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogKaiToast>(
+          WINDOW_DIALOG_KAI_TOAST);
   if (pDlgToast != NULL)
   {
     std::string message;
@@ -672,12 +700,13 @@ void CPythonInvoker::onError(const std::string &exceptionType /* = "" */, const 
     else if (m_sourceFile == CSpecialProtocol::TranslatePath("special://profile/autoexec.py"))
       message = StringUtils::Format(g_localizeStrings.Get(2102).c_str(), "autoexec.py");
     else
-       message = g_localizeStrings.Get(2103);
+      message = g_localizeStrings.Get(2103);
     pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, message, g_localizeStrings.Get(2104));
   }
 }
 
-void CPythonInvoker::initializeModules(const std::map<std::string, PythonModuleInitialization> &modules)
+void CPythonInvoker::initializeModules(
+    const std::map<std::string, PythonModuleInitialization>& modules)
 {
   for (const auto& module : modules)
   {

--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -23,10 +23,11 @@ typedef struct _object PyObject;
 class CPythonInvoker : public ILanguageInvoker
 {
 public:
-  explicit CPythonInvoker(ILanguageInvocationHandler *invocationHandler);
+  explicit CPythonInvoker(ILanguageInvocationHandler* invocationHandler);
   ~CPythonInvoker() override;
 
-  bool Execute(const std::string &script, const std::vector<std::string> &arguments = std::vector<std::string>()) override;
+  bool Execute(const std::string& script,
+               const std::vector<std::string>& arguments = std::vector<std::string>()) override;
 
   bool IsStopping() const override { return m_stop || ILanguageInvoker::IsStopping(); }
 
@@ -34,7 +35,7 @@ public:
 
 protected:
   // implementation of ILanguageInvoker
-  bool execute(const std::string &script, const std::vector<std::string> &arguments) override;
+  bool execute(const std::string& script, const std::vector<std::string>& arguments) override;
   virtual void executeScript(FILE* fp, const std::string& script, PyObject* moduleDict);
   bool stop(bool abort) override;
   void onExecutionDone() override;
@@ -48,15 +49,17 @@ protected:
   virtual void onPythonModuleInitialization(void* moduleDict);
   virtual void onDeinitialization();
 
-  virtual void onSuccess() { }
-  virtual void onAbort() { }
-  virtual void onError(const std::string &exceptionType = "", const std::string &exceptionValue = "", const std::string &exceptionTraceback = "");
+  virtual void onSuccess() {}
+  virtual void onAbort() {}
+  virtual void onError(const std::string& exceptionType = "",
+                       const std::string& exceptionValue = "",
+                       const std::string& exceptionTraceback = "");
 
   std::string m_sourceFile;
   CCriticalSection m_critical;
 
 private:
-  void initializeModules(const std::map<std::string, PythonModuleInitialization> &modules);
+  void initializeModules(const std::map<std::string, PythonModuleInitialization>& modules);
   bool initializeModule(PythonModuleInitialization module);
   void addPath(const std::string& path); // add path in UTF-8 encoding
   void getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<std::string>& paths);

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -417,49 +417,6 @@ void XBPython::OnNotification(const std::string& sender,
   }
 }
 
-void XBPython::RegisterExtensionLib(LibraryLoader* pLib)
-{
-  if (!pLib)
-    return;
-
-  CSingleLock lock(m_critSection);
-
-  CLog::Log(LOGDEBUG, "%s, adding %s (%p)", __FUNCTION__, pLib->GetName(), (void*)pLib);
-  m_extensions.push_back(pLib);
-}
-
-void XBPython::UnregisterExtensionLib(LibraryLoader* pLib)
-{
-  if (!pLib)
-    return;
-
-  CSingleLock lock(m_critSection);
-  CLog::Log(LOGDEBUG, "%s, removing %s (0x%p)", __FUNCTION__, pLib->GetName(), (void*)pLib);
-  PythonExtensionLibraries::iterator iter = m_extensions.begin();
-  while (iter != m_extensions.end())
-  {
-    if (*iter == pLib)
-    {
-      m_extensions.erase(iter);
-      break;
-    }
-    ++iter;
-  }
-}
-
-void XBPython::UnloadExtensionLibs()
-{
-  CLog::Log(LOGDEBUG, "%s, clearing python extension libraries", __FUNCTION__);
-  CSingleLock lock(m_critSection);
-  PythonExtensionLibraries::iterator iter = m_extensions.begin();
-  while (iter != m_extensions.end())
-  {
-    DllLoaderContainer::ReleaseModule(*iter);
-    ++iter;
-  }
-  m_extensions.clear();
-}
-
 void XBPython::Uninitialize()
 {
   // don't handle any more announcements as most scripts are probably already

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -6,38 +6,40 @@
  *  See LICENSES/README.md for more information.
  */
 
+// clang-format off
 // python.h should always be included first before any other includes
 #include <Python.h>
+// clang-format on
 
-#include <algorithm>
-
-#include "cores/DllLoader/DllLoaderContainer.h"
 #include "XBPython.h"
+
+#include "ServiceBroker.h"
+#include "Util.h"
+#include "cores/DllLoader/DllLoaderContainer.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
+#include "interfaces/AnnouncementManager.h"
+#include "interfaces/legacy/AddonUtils.h"
+#include "interfaces/legacy/Monitor.h"
+#include "interfaces/python/AddonPythonInvoker.h"
+#include "interfaces/python/PythonInvoker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/JSONVariantWriter.h"
-#include "utils/log.h"
 #include "utils/Variant.h"
-#include "Util.h"
+#include "utils/log.h"
+
 #ifdef TARGET_WINDOWS
 #include "platform/Environment.h"
 #include "utils/SystemInfo.h"
 #endif
-#include "settings/AdvancedSettings.h"
-#include "settings/SettingsComponent.h"
 
-#include "interfaces/AnnouncementManager.h"
-
-#include "interfaces/legacy/Monitor.h"
-#include "interfaces/legacy/AddonUtils.h"
-#include "interfaces/python/AddonPythonInvoker.h"
-#include "interfaces/python/PythonInvoker.h"
-#include "ServiceBroker.h"
+#include <algorithm>
 
 XBPython::XBPython()
 {
-  m_bInitialized      = false;
-  m_mainThreadState   = NULL;
+  m_bInitialized = false;
+  m_mainThreadState = NULL;
   m_iDllScriptCounter = 0;
   m_vecPlayerCallbackList.clear();
   m_vecMonitorCallbackList.clear();
@@ -52,61 +54,70 @@ XBPython::~XBPython()
 }
 
 #define LOCK_AND_COPY(type, dest, src) \
-  if (!m_bInitialized) return; \
+  if (!m_bInitialized) \
+    return; \
   CSingleLock lock(src); \
   src.hadSomethingRemoved = false; \
   type dest; \
   dest = src
 
-#define CHECK_FOR_ENTRY(l,v) \
-  (l.hadSomethingRemoved ? (std::find(l.begin(),l.end(),v) != l.end()) : true)
+#define CHECK_FOR_ENTRY(l, v) \
+  (l.hadSomethingRemoved ? (std::find(l.begin(), l.end(), v) != l.end()) : true)
 
-void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+void XBPython::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                        const char* sender,
+                        const char* message,
+                        const CVariant& data)
 {
   if (flag & ANNOUNCEMENT::VideoLibrary)
   {
-   if (strcmp(message, "OnScanFinished") == 0)
-     OnScanFinished("video");
-   else if (strcmp(message, "OnScanStarted") == 0)
-     OnScanStarted("video");
-   else if (strcmp(message, "OnCleanStarted") == 0)
-     OnCleanStarted("video");
-   else if (strcmp(message, "OnCleanFinished") == 0)
-     OnCleanFinished("video");
+    if (strcmp(message, "OnScanFinished") == 0)
+      OnScanFinished("video");
+    else if (strcmp(message, "OnScanStarted") == 0)
+      OnScanStarted("video");
+    else if (strcmp(message, "OnCleanStarted") == 0)
+      OnCleanStarted("video");
+    else if (strcmp(message, "OnCleanFinished") == 0)
+      OnCleanFinished("video");
   }
   else if (flag & ANNOUNCEMENT::AudioLibrary)
   {
-   if (strcmp(message, "OnScanFinished") == 0)
-     OnScanFinished("music");
-   else if (strcmp(message, "OnScanStarted") == 0)
-     OnScanStarted("music");
-   else if (strcmp(message, "OnCleanStarted") == 0)
-     OnCleanStarted("music");
-   else if (strcmp(message, "OnCleanFinished") == 0)
-     OnCleanFinished("music");
+    if (strcmp(message, "OnScanFinished") == 0)
+      OnScanFinished("music");
+    else if (strcmp(message, "OnScanStarted") == 0)
+      OnScanStarted("music");
+    else if (strcmp(message, "OnCleanStarted") == 0)
+      OnCleanStarted("music");
+    else if (strcmp(message, "OnCleanFinished") == 0)
+      OnCleanFinished("music");
   }
   else if (flag & ANNOUNCEMENT::GUI)
   {
-   if (strcmp(message, "OnScreensaverDeactivated") == 0)
-     OnScreensaverDeactivated();
-   else if (strcmp(message, "OnScreensaverActivated") == 0)
-     OnScreensaverActivated();
-   else if (strcmp(message, "OnDPMSDeactivated") == 0)
-     OnDPMSDeactivated();
-   else if (strcmp(message, "OnDPMSActivated") == 0)
-     OnDPMSActivated();
+    if (strcmp(message, "OnScreensaverDeactivated") == 0)
+      OnScreensaverDeactivated();
+    else if (strcmp(message, "OnScreensaverActivated") == 0)
+      OnScreensaverActivated();
+    else if (strcmp(message, "OnDPMSDeactivated") == 0)
+      OnDPMSDeactivated();
+    else if (strcmp(message, "OnDPMSActivated") == 0)
+      OnDPMSActivated();
   }
 
   std::string jsonData;
-  if (CJSONVariantWriter::Write(data, jsonData, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_jsonOutputCompact))
-    OnNotification(sender, std::string(ANNOUNCEMENT::AnnouncementFlagToString(flag)) + "." + std::string(message), jsonData);
+  if (CJSONVariantWriter::Write(
+          data, jsonData,
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_jsonOutputCompact))
+    OnNotification(sender,
+                   std::string(ANNOUNCEMENT::AnnouncementFlagToString(flag)) + "." +
+                       std::string(message),
+                   jsonData);
 }
 
 // message all registered callbacks that we started playing
-void XBPython::OnPlayBackStarted(const CFileItem &file)
+void XBPython::OnPlayBackStarted(const CFileItem& file)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -115,7 +126,7 @@ void XBPython::OnPlayBackStarted(const CFileItem &file)
 }
 
 // message all registered callbacks that we changed stream
-void XBPython::OnAVStarted(const CFileItem &file)
+void XBPython::OnAVStarted(const CFileItem& file)
 {
   XBMC_TRACE;
   LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
@@ -142,7 +153,7 @@ void XBPython::OnAVChange()
 void XBPython::OnPlayBackPaused()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -154,7 +165,7 @@ void XBPython::OnPlayBackPaused()
 void XBPython::OnPlayBackResumed()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -166,7 +177,7 @@ void XBPython::OnPlayBackResumed()
 void XBPython::OnPlayBackEnded()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -178,7 +189,7 @@ void XBPython::OnPlayBackEnded()
 void XBPython::OnPlayBackStopped()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -190,7 +201,7 @@ void XBPython::OnPlayBackStopped()
 void XBPython::OnPlayBackError()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -202,7 +213,7 @@ void XBPython::OnPlayBackError()
 void XBPython::OnPlayBackSpeedChanged(int iSpeed)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -214,7 +225,7 @@ void XBPython::OnPlayBackSpeedChanged(int iSpeed)
 void XBPython::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -226,7 +237,7 @@ void XBPython::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
 void XBPython::OnPlayBackSeekChapter(int iChapter)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -238,7 +249,7 @@ void XBPython::OnPlayBackSeekChapter(int iChapter)
 void XBPython::OnQueueNextItem()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<void*>,tmp,m_vecPlayerCallbackList);
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, it))
@@ -294,10 +305,10 @@ void XBPython::UnregisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallba
   }
 }
 
-void XBPython::OnSettingsChanged(const std::string &ID)
+void XBPython::OnSettingsChanged(const std::string& ID)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it) && (it->GetId() == ID))
@@ -308,7 +319,7 @@ void XBPython::OnSettingsChanged(const std::string &ID)
 void XBPython::OnScreensaverActivated()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -319,7 +330,7 @@ void XBPython::OnScreensaverActivated()
 void XBPython::OnScreensaverDeactivated()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -330,7 +341,7 @@ void XBPython::OnScreensaverDeactivated()
 void XBPython::OnDPMSActivated()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -341,7 +352,7 @@ void XBPython::OnDPMSActivated()
 void XBPython::OnDPMSDeactivated()
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -349,10 +360,10 @@ void XBPython::OnDPMSDeactivated()
   }
 }
 
-void XBPython::OnScanStarted(const std::string &library)
+void XBPython::OnScanStarted(const std::string& library)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -360,10 +371,10 @@ void XBPython::OnScanStarted(const std::string &library)
   }
 }
 
-void XBPython::OnScanFinished(const std::string &library)
+void XBPython::OnScanFinished(const std::string& library)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -371,10 +382,10 @@ void XBPython::OnScanFinished(const std::string &library)
   }
 }
 
-void XBPython::OnCleanStarted(const std::string &library)
+void XBPython::OnCleanStarted(const std::string& library)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -382,10 +393,10 @@ void XBPython::OnCleanStarted(const std::string &library)
   }
 }
 
-void XBPython::OnCleanFinished(const std::string &library)
+void XBPython::OnCleanFinished(const std::string& library)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -393,10 +404,12 @@ void XBPython::OnCleanFinished(const std::string &library)
   }
 }
 
-void XBPython::OnNotification(const std::string &sender, const std::string &method, const std::string &data)
+void XBPython::OnNotification(const std::string& sender,
+                              const std::string& method,
+                              const std::string& data)
 {
   XBMC_TRACE;
-  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>,tmp,m_vecMonitorCallbackList);
+  LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (auto& it : tmp)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, it))
@@ -404,7 +417,7 @@ void XBPython::OnNotification(const std::string &sender, const std::string &meth
   }
 }
 
-void XBPython::RegisterExtensionLib(LibraryLoader *pLib)
+void XBPython::RegisterExtensionLib(LibraryLoader* pLib)
 {
   if (!pLib)
     return;
@@ -415,13 +428,13 @@ void XBPython::RegisterExtensionLib(LibraryLoader *pLib)
   m_extensions.push_back(pLib);
 }
 
-void XBPython::UnregisterExtensionLib(LibraryLoader *pLib)
+void XBPython::UnregisterExtensionLib(LibraryLoader* pLib)
 {
   if (!pLib)
     return;
 
   CSingleLock lock(m_critSection);
-  CLog::Log(LOGDEBUG, "%s, removing %s (0x%p)", __FUNCTION__, pLib->GetName(), (void *)pLib);
+  CLog::Log(LOGDEBUG, "%s, removing %s (0x%p)", __FUNCTION__, pLib->GetName(), (void*)pLib);
   PythonExtensionLibraries::iterator iter = m_extensions.begin();
   while (iter != m_extensions.end())
   {
@@ -441,8 +454,8 @@ void XBPython::UnloadExtensionLibs()
   PythonExtensionLibraries::iterator iter = m_extensions.begin();
   while (iter != m_extensions.end())
   {
-      DllLoaderContainer::ReleaseModule(*iter);
-      ++iter;
+    DllLoaderContainer::ReleaseModule(*iter);
+    ++iter;
   }
   m_extensions.clear();
 }
@@ -454,7 +467,7 @@ void XBPython::Uninitialize()
   // would lead to a crash
   CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
 
-  LOCK_AND_COPY(std::vector<PyElem>,tmpvec,m_vecPyList);
+  LOCK_AND_COPY(std::vector<PyElem>, tmpvec, m_vecPyList);
   m_vecPyList.clear();
   m_vecPyList.hadSomethingRemoved = true;
 
@@ -488,7 +501,7 @@ void XBPython::Process()
   }
 }
 
-bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
+bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
 {
   if (invoker == NULL)
     return false;
@@ -515,8 +528,10 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
       // so point it to frameworks which is where python3.8 is located
       setenv("PYTHONHOME", CSpecialProtocol::TranslatePath("special://frameworks").c_str(), 1);
       setenv("PYTHONPATH", CSpecialProtocol::TranslatePath("special://frameworks").c_str(), 1);
-      CLog::Log(LOGDEBUG, "PYTHONHOME -> %s", CSpecialProtocol::TranslatePath("special://frameworks").c_str());
-      CLog::Log(LOGDEBUG, "PYTHONPATH -> %s", CSpecialProtocol::TranslatePath("special://frameworks").c_str());
+      CLog::Log(LOGDEBUG, "PYTHONHOME -> %s",
+                CSpecialProtocol::TranslatePath("special://frameworks").c_str());
+      CLog::Log(LOGDEBUG, "PYTHONPATH -> %s",
+                CSpecialProtocol::TranslatePath("special://frameworks").c_str());
     }
 #elif defined(TARGET_WINDOWS)
     // because the third party build of python is compiled with vs2008 we need
@@ -540,7 +555,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
 
 #if PY_VERSION_HEX < 0x03070000
     // Python >= 3.7 Py_Initialize implicitly calls PyEval_InitThreads
-    // Python < 3.7 we have to manually call initthreads. 
+    // Python < 3.7 we have to manually call initthreads.
     // PyEval_InitThreads is a no-op on subsequent calls, No need to wrap in
     // PyEval_ThreadsInitialized() check
     PyEval_InitThreads();
@@ -564,7 +579,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker *invoker)
   return m_bInitialized;
 }
 
-void XBPython::OnScriptStarted(ILanguageInvoker *invoker)
+void XBPython::OnScriptStarted(ILanguageInvoker* invoker)
 {
   if (invoker == NULL)
     return;
@@ -573,14 +588,14 @@ void XBPython::OnScriptStarted(ILanguageInvoker *invoker)
     return;
 
   PyElem inf;
-  inf.id        = invoker->GetId();
-  inf.bDone     = false;
-  inf.pyThread  = static_cast<CPythonInvoker*>(invoker);
+  inf.id = invoker->GetId();
+  inf.bDone = false;
+  inf.pyThread = static_cast<CPythonInvoker*>(invoker);
   CSingleLock lock(m_vecPyList);
   m_vecPyList.push_back(inf);
 }
 
-void XBPython::NotifyScriptAborting(ILanguageInvoker *invoker)
+void XBPython::NotifyScriptAborting(ILanguageInvoker* invoker)
 {
   XBMC_TRACE;
 
@@ -617,7 +632,7 @@ void XBPython::OnExecutionEnded(ILanguageInvoker* invoker)
   }
 }
 
-void XBPython::OnScriptFinalized(ILanguageInvoker *invoker)
+void XBPython::OnScriptFinalized(ILanguageInvoker* invoker)
 {
   XBMC_TRACE;
   CSingleLock lock(m_critSection);

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -102,13 +102,7 @@ public:
 
   bool WaitForEvent(CEvent& hEvent, unsigned int milliseconds);
 
-  void RegisterExtensionLib(LibraryLoader* pLib);
-  void UnregisterExtensionLib(LibraryLoader* pLib);
-  void UnloadExtensionLibs();
-
 private:
-  void Finalize();
-
   CCriticalSection m_critSection;
   void* m_mainThreadState;
   bool m_bInitialized;

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -21,41 +21,44 @@
 class CPythonInvoker;
 class CVariant;
 
-typedef struct {
+typedef struct
+{
   int id;
   bool bDone;
   CPythonInvoker* pyThread;
-}PyElem;
+} PyElem;
 
 class LibraryLoader;
 
 namespace XBMCAddon
 {
-  namespace xbmc
-  {
-    class Monitor;
-  }
+namespace xbmc
+{
+class Monitor;
 }
+} // namespace XBMCAddon
 
-template <class T> struct LockableType : public T, public CCriticalSection
-{ bool hadSomethingRemoved; };
+template<class T>
+struct LockableType : public T, public CCriticalSection
+{
+  bool hadSomethingRemoved;
+};
 
-typedef LockableType<std::vector<void*> > PlayerCallbackList;
-typedef LockableType<std::vector<XBMCAddon::xbmc::Monitor*> > MonitorCallbackList;
-typedef LockableType<std::vector<PyElem> > PyList;
+typedef LockableType<std::vector<void*>> PlayerCallbackList;
+typedef LockableType<std::vector<XBMCAddon::xbmc::Monitor*>> MonitorCallbackList;
+typedef LockableType<std::vector<PyElem>> PyList;
 typedef std::vector<LibraryLoader*> PythonExtensionLibraries;
 
-class XBPython :
-  public IPlayerCallback,
-  public ANNOUNCEMENT::IAnnouncer,
-  public ILanguageInvocationHandler
+class XBPython : public IPlayerCallback,
+                 public ANNOUNCEMENT::IAnnouncer,
+                 public ILanguageInvocationHandler
 {
 public:
   XBPython();
   ~XBPython() override;
   void OnPlayBackEnded() override;
-  void OnPlayBackStarted(const CFileItem &file) override;
-  void OnAVStarted(const CFileItem &file) override;
+  void OnPlayBackStarted(const CFileItem& file) override;
+  void OnAVStarted(const CFileItem& file) override;
   void OnAVChange() override;
   void OnPlayBackPaused() override;
   void OnPlayBackResumed() override;
@@ -66,49 +69,54 @@ public:
   void OnPlayBackSeekChapter(int iChapter) override;
   void OnQueueNextItem() override;
 
-  void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const char* sender,
+                const char* message,
+                const CVariant& data) override;
   void RegisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void RegisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback);
   void UnregisterPythonMonitorCallBack(XBMCAddon::xbmc::Monitor* pCallback);
-  void OnSettingsChanged(const std::string &strings);
+  void OnSettingsChanged(const std::string& strings);
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
   void OnDPMSActivated();
   void OnDPMSDeactivated();
-  void OnScanStarted(const std::string &library);
-  void OnScanFinished(const std::string &library);
-  void OnCleanStarted(const std::string &library);
-  void OnCleanFinished(const std::string &library);
-  void OnNotification(const std::string &sender, const std::string &method, const std::string &data);
+  void OnScanStarted(const std::string& library);
+  void OnScanFinished(const std::string& library);
+  void OnCleanStarted(const std::string& library);
+  void OnCleanFinished(const std::string& library);
+  void OnNotification(const std::string& sender,
+                      const std::string& method,
+                      const std::string& data);
 
   void Process() override;
   void PulseGlobalEvent() override;
   void Uninitialize() override;
-  bool OnScriptInitialized(ILanguageInvoker *invoker) override;
-  void OnScriptStarted(ILanguageInvoker *invoker) override;
-  void NotifyScriptAborting(ILanguageInvoker *invoker) override;
+  bool OnScriptInitialized(ILanguageInvoker* invoker) override;
+  void OnScriptStarted(ILanguageInvoker* invoker) override;
+  void NotifyScriptAborting(ILanguageInvoker* invoker) override;
   void OnExecutionEnded(ILanguageInvoker* invoker) override;
-  void OnScriptFinalized(ILanguageInvoker *invoker) override;
+  void OnScriptFinalized(ILanguageInvoker* invoker) override;
   ILanguageInvoker* CreateInvoker() override;
 
   bool WaitForEvent(CEvent& hEvent, unsigned int milliseconds);
 
-  void RegisterExtensionLib(LibraryLoader *pLib);
-  void UnregisterExtensionLib(LibraryLoader *pLib);
+  void RegisterExtensionLib(LibraryLoader* pLib);
+  void UnregisterExtensionLib(LibraryLoader* pLib);
   void UnloadExtensionLibs();
 
 private:
   void Finalize();
 
-  CCriticalSection    m_critSection;
-  void*             m_mainThreadState;
-  bool              m_bInitialized;
-  int               m_iDllScriptCounter; // to keep track of the total scripts running that need the dll
+  CCriticalSection m_critSection;
+  void* m_mainThreadState;
+  bool m_bInitialized;
+  int m_iDllScriptCounter; // to keep track of the total scripts running that need the dll
 
   //Vector with list of threads used for running scripts
-  PyList              m_vecPyList;
-  PlayerCallbackList  m_vecPlayerCallbackList;
+  PyList m_vecPyList;
+  PlayerCallbackList m_vecPlayerCallbackList;
   MonitorCallbackList m_vecMonitorCallbackList;
 
   // any global events that scripts should be using

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -105,13 +105,11 @@ private:
   void*             m_mainThreadState;
   bool              m_bInitialized;
   int               m_iDllScriptCounter; // to keep track of the total scripts running that need the dll
-  unsigned int      m_endtime;
 
   //Vector with list of threads used for running scripts
   PyList              m_vecPyList;
   PlayerCallbackList  m_vecPlayerCallbackList;
   MonitorCallbackList m_vecMonitorCallbackList;
-  LibraryLoader*      m_pDll;
 
   // any global events that scripts should be using
   CEvent m_globalEvent;


### PR DESCRIPTION
## Description
**1st commit:**

- Python 3.9 b1 has introduced a change that has inadvertently caused a deprecated (since 3.2) function (PyEval_ReleaseLock) to cause segfaults.
This update changes to use the non deprecated calls around GIL acquire/release. This prepares us for the planned removal of these deprecated features in Python 4 as well.

- In addition to this change, have gone through and removed some old comments that are no longer current

- XBPython::Finalize() codepath also does not appear to be executed in any way on current master. Have removed this just to clean up the code. My concern here is we no longer execute Py_Finalize, however as far as i can prove so far, we havent done this at least since the py3 change, with no apparent side effects. 
As we have 1 main interpreter that is init on first call of XBPython::OnScriptInitialized, we dont uninit the interpreter at all again as m_iDllScriptCounter never goes to 0 until system shutdown, at which the 10s timer never becomes valid. If anyone can see a requirement for us to call Py_Finalize(), we could look to call it on shutdown somewhere, but wasnt something i could implement without spending more time on it, and im still not even sure what benefit it would bring as all existing threads/scripts are being shutdown/managed already.

**2/3 commits:**

- Just running clang-format

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=356701

## How Has This Been Tested?
OSX Python 3.8.5
@ronie has confirmed Python 3.8 and 3.9RC1, and another confirmation from @asavah 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
