### PR TITLE
[docs][python] document xbmcgui.ListItem().setProperty() properties t…

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -868,6 +868,17 @@ namespace XBMCAddon
       /// the offset in seconds at which to start playback of an item.  Others may be used in the skin
       /// to add extra information, such as 'WatchedCount' for tvshow items
       ///
+      /// - **Internal Properties**
+      /// | Key           | Description                                     |
+      /// |--------------:|:------------------------------------------------|
+      /// | inputstream   | string (inputstream.adaptive) - Set the inputstream add-on that will be used to play the item
+      /// | IsPlayable    | string - "true", "false" - Mark the item as playable, **mandatory for playable items**
+      /// | MimeType      | string (application/x-mpegURL) - Set the MimeType of the item before playback
+      /// | ResumeTime    | float (1962.0) - Set the resume point of the item in seconds
+      /// | SpecialSort   | string - "top", "bottom" - The item will remain at the top or bottom of the current list
+      /// | StartOffset   | float (60.0) - Set the offset in seconds at which to start playback of the item
+      /// | StartPercent  | float (15.0) - Set the percentage at which to start playback of the item
+      /// | TotalTime     | float (7848.0) - Set the total time of the item in seconds
       ///
       ///-----------------------------------------------------------------------
       ///


### PR DESCRIPTION
…hat are handled internally

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Document listitem properties that are handled internally

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I've only seen references to these properties in the forum and didn't see them documented any where

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Ran doxygen, see screenshot below

## Screenshots (if appropriate):
![screenshot](https://snipboard.io/7eucak.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
