### PR TITLE
Simplify TexturePacker

### DIFF
--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -33,6 +33,8 @@ bool GIFDecoder::CanDecode(const std::string &filename)
 bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
 {
   int n = 0;
+  bool result = false;
+
   GifHelper *gifImage = new GifHelper();
   if (gifImage->LoadGif(filename.c_str()))
   {
@@ -55,33 +57,20 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
         frame.rgbaImage.bbp = 32;
         frame.rgbaImage.pitch = pitch;
         frame.delay = extractedFrames[i]->m_delay;
+        frame.decoder = this;
 
         frames.frameList.push_back(frame);
       }
     }
-    frames.user = gifImage;
-    frames.destroyFN = &gifDestroyFN;
-    return true;
+    result = true;
   }
-  else
-  {
-    delete gifImage;
-    return false;
-  }
+  delete gifImage;
+  return result;
 }
 
-void GIFDecoder::FreeDecodedFrames(DecodedFrames &frames)
+void GIFDecoder::FreeDecodedFrame(DecodedFrame &frame)
 {
-  for (unsigned int i = 0; i < frames.frameList.size(); i++)
-  {
-    delete [] frames.frameList[i].rgbaImage.pixels;
-  }
-  delete (GifHelper *)frames.user;
-  frames.clear();
-}
-void GIFDecoder::gifDestroyFN(void* user)
-{
-  delete (GifHelper *)user;
+  delete [] frame.rgbaImage.pixels;
 }
 
 void GIFDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
@@ -28,11 +28,9 @@ class GIFDecoder : public IDecoder
     ~GIFDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string &filename, DecodedFrames &frames) override;
-    void FreeDecodedFrames(DecodedFrames &frames) override;
+    void FreeDecodedFrame(DecodedFrame &frame) override;
     const char* GetImageFormatName() override { return "GIF"; }
     const char* GetDecoderName() override { return "libgif"; }
   protected:
     void FillSupportedExtensions() override;
-  private:
-    static void gifDestroyFN(void* user);
 };

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -23,6 +23,34 @@
 #include <string>
 #include <vector>
 
+/* forward declarations */
+
+class DecodedFrame;
+class DecodedFrames;
+
+class IDecoder
+{
+  public:
+    virtual ~IDecoder() = default;
+    virtual bool CanDecode(const std::string &filename) = 0;
+    virtual bool LoadFile(const std::string &filename, DecodedFrames &frames) = 0;
+    virtual void FreeDecodedFrame(DecodedFrame &frame) = 0;
+    virtual const char* GetImageFormatName() = 0;
+    virtual const char* GetDecoderName() = 0;
+
+    const std::vector<std::string>& GetSupportedExtensions()
+    {
+      m_supportedExtensions.clear();
+      FillSupportedExtensions();
+      return m_supportedExtensions;
+    }
+
+  protected:
+    virtual void FillSupportedExtensions() = 0;
+    //fill this with extensions in FillSupportedExtensions like ".png"
+    std::vector<std::string> m_supportedExtensions;
+};
+
 class RGBAImage
 {
 public:
@@ -41,6 +69,7 @@ public:
   DecodedFrame() = default;
   RGBAImage rgbaImage; /* rgbaimage for this frame */
   int delay = 0; /* Frame delay in ms */
+  IDecoder* decoder = nullptr; /* Pointer to decoder */
 };
 
 class DecodedFrames
@@ -48,43 +77,22 @@ class DecodedFrames
   public:
     DecodedFrames() = default;
     std::vector<DecodedFrame> frameList;
-    void* user = nullptr; /* used internally*/
-    void (*destroyFN)(void*) = nullptr;
 
     void clear()
     {
       for (auto f : frameList)
       {
-        delete[] f.rgbaImage.pixels;
-      }
-      if (destroyFN)
-      {
-        destroyFN(user);
+        if (f.decoder != NULL)
+        {
+          f.decoder->FreeDecodedFrame(f);
+        }
+        else
+        {
+          fprintf(stderr,
+            "ERROR: %s - can not determine decoder type for frame!\n",
+            __FUNCTION__);
+        }
       }
       frameList.clear();
-      user = NULL;
     }
-};
-
-class IDecoder
-{
-  public:
-    virtual ~IDecoder() = default;
-    virtual bool CanDecode(const std::string &filename) = 0;
-    virtual bool LoadFile(const std::string &filename, DecodedFrames &frames) = 0;
-    virtual void FreeDecodedFrames(DecodedFrames &frames) = 0;
-    virtual const char* GetImageFormatName() = 0;
-    virtual const char* GetDecoderName() = 0;
-
-    const std::vector<std::string>& GetSupportedExtensions()
-    {
-      m_supportedExtensions.clear();
-      FillSupportedExtensions();
-      return m_supportedExtensions;
-    }
-
-  protected:
-    virtual void FillSupportedExtensions() = 0;
-    //fill this with extensions in FillSupportedExtensions like ".png"
-    std::vector<std::string> m_supportedExtensions;
 };

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
@@ -86,7 +86,6 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   // Image Size is calculated as (width * height * bytes per pixel = 4
   ImageSize = cinfo.image_width * cinfo.image_height * 4;
 
-  frames.user = NULL;
   DecodedFrame frame;
 
   frame.rgbaImage.pixels = (char *)new char[ImageSize];
@@ -117,20 +116,18 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frame.rgbaImage.width = cinfo.image_width;
   frame.rgbaImage.bbp = 32;
   frame.rgbaImage.pitch = 4 * cinfo.image_width;
+
+  frame.decoder = this;
+
   frames.frameList.push_back(frame);
 
   delete arq;
   return true;
 }
 
-void JPGDecoder::FreeDecodedFrames(DecodedFrames &frames)
+void JPGDecoder::FreeDecodedFrame(DecodedFrame &frame)
 {
-  for (unsigned int i = 0; i < frames.frameList.size(); i++)
-  {
-    delete [] frames.frameList[i].rgbaImage.pixels;
-  }
-
-  frames.clear();
+  delete [] frame.rgbaImage.pixels;
 }
 
 void JPGDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.h
@@ -28,7 +28,7 @@ class JPGDecoder : public IDecoder
     ~JPGDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string &filename, DecodedFrames &frames) override;
-    void FreeDecodedFrames(DecodedFrames &frames) override;
+    void FreeDecodedFrame(DecodedFrame &frame) override;
     const char* GetImageFormatName() override { return "JPG"; }
     const char* GetDecoderName() override { return "libjpeg"; }
   protected:

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
@@ -216,7 +216,6 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   // read the png into image_data through row_pointers
   png_read_image(png_ptr, row_pointers);
 
-  frames.user = NULL;
   DecodedFrame frame;
 
   frame.rgbaImage.pixels = (char *)image_data;
@@ -224,6 +223,9 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frame.rgbaImage.width = temp_width;
   frame.rgbaImage.bbp = 32;
   frame.rgbaImage.pitch = 4 * temp_width;
+
+  frame.decoder = this;
+
   frames.frameList.push_back(frame);
   // clean up
   png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
@@ -231,14 +233,9 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   return true;
 }
 
-void PNGDecoder::FreeDecodedFrames(DecodedFrames &frames)
+void PNGDecoder::FreeDecodedFrame(DecodedFrame &frame)
 {
-  for (unsigned int i = 0; i < frames.frameList.size(); i++)
-  {
-    delete [] frames.frameList[i].rgbaImage.pixels;
-  }
-
-  frames.clear();
+  delete [] frame.rgbaImage.pixels;
 }
 
 void PNGDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.h
@@ -28,7 +28,7 @@ class PNGDecoder : public IDecoder
     ~PNGDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string &filename, DecodedFrames &frames) override;
-    void FreeDecodedFrames(DecodedFrames &frames) override;
+    void FreeDecodedFrame(DecodedFrame &frame) override;
     const char* GetImageFormatName() override { return "PNG"; }
     const char* GetDecoderName() override { return "libpng"; }
   protected:


### PR DESCRIPTION
## Description

Simplify TexturePacker logic and prevent memory leaks in 18.8

## Motivation and Context

Building Kodi 18.8 in Debian with asan+lsan+ubsan breaks with the following error:

=================================================================
==241706==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 69370335 byte(s) in 661 object(s) allocated from:
    #0 0x7fb290a737a7 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.6+0xab7a7)
    #1 0x563e2bed8b09 in PNGDecoder::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, DecodedFrames&) (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x17cb09)
    #2 0x563e2be71392 in DecoderManager::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, DecodedFrames&) (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x115392)
    #3 0x563e2be7d1bf in createBundle(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double, unsigned int, bool) (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x1211bf)
    #4 0x563e2be69990 in main (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x10d990)
    #5 0x7fb28fbc7cc9 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: 69370335 byte(s) leaked in 661 allocation(s).

The root cause of the leak is decoder's FreeDecodedFrames never called.

In 19.0 the leak was fixed but the new version removes unnecessary fields
like frames.user and destroyFN.

## How Has This Been Tested?

Built 18.8 with sanitizers, forward-ported to 19.0 without building (yet)

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed