### PR TITLE
[playlists] Fix XSPF path canonicalization

### DIFF
--- a/xbmc/playlists/PlayListXSPF.cpp
+++ b/xbmc/playlists/PlayListXSPF.cpp
@@ -103,12 +103,12 @@ bool CPlayListXSPF::Load(const std::string& strFileName)
 
       if (!localpath.empty())
       {
+        // We don't use URIUtils::CanonicalizePath because m_strBasePath may be a
+        // protocol e.g. smb
 #ifdef TARGET_WINDOWS
         StringUtils::Replace(localpath, "/", "\\");
-        localpath = URIUtils::CanonicalizePath(localpath, '\\');
-#else
-        localpath = URIUtils::CanonicalizePath(localpath, '/');
 #endif
+        localpath = URIUtils::GetRealPath(localpath);
 
         newItem->SetPath(localpath);
       }


### PR DESCRIPTION
## Description
The path of the playlist file may contain a protocol, so with relative
locations, we can't use URIUtils::CanonicalizePath. It destroys the protocol of
the URI.

## Motivation and Context
Relative locations in XSPF files with URI protocols (e.g. smb://nas/playlist/playlist.xspf) have been broken since they were first added. The problem comes from URIUtils::CanonicalizePath, which has a warning about not being used in this case.

## How Has This Been Tested?
I tested this with a playlist that wouldn't play on Coreelec with my home nas. I verified that it also didn't play with latest head on my laptop. With the change the playlist now plays. I looked at adding code to the existing XSPF test, but that loads a local file, and I didn't see any straightforward way of lying to it about where the file was located.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
       TestWebServer.CanHeadFile fails both at master and with my change.