### PR TITLE
[addons] fix: allow system dependencies for repositories

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -737,12 +737,19 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
 
   if (!deps.empty() && m_addon->HasType(ADDON_REPOSITORY))
   {
-    CLog::Log(
-        LOGERROR,
-        "CAddonInstallJob::{}: failed to install repository [{}]. It has dependencies defined",
-        __func__, m_addon->ID());
-    ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24088));
-    return false;
+    bool notSystemAddon = std::none_of(deps.begin(), deps.end(), [](const DependencyInfo& dep) {
+      return CServiceBroker::GetAddonMgr().IsSystemAddon(dep.id);
+    });
+
+    if (notSystemAddon)
+    {
+      CLog::Log(
+          LOGERROR,
+          "CAddonInstallJob::{}: failed to install repository [{}]. It has dependencies defined",
+          __func__, m_addon->ID());
+      ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24088));
+      return false;
+    }
   }
 
   SetText(g_localizeStrings.Get(24079));


### PR DESCRIPTION
## Description
preventing installation of addon-repositories with any dependency defined is way too restrictive.
this pr allows system-addons defined in addon-manifest.xml as dependencies for repositories.

refs:
PR  #18341
https://forum.kodi.tv/showthread.php?tid=356844

## How Has This Been Tested?
local installation @pkscout 's Addon Beta-Channel repo which imports "xbmc.python"

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
