### PR TITLE
[depends] add linux-arm-gbm build

### DIFF
--- a/tools/buildsteps/linux-arm-gbm/configure-depends
+++ b/tools/buildsteps/linux-arm-gbm/configure-depends
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  cd $WORKSPACE/tools/depends;./configure \
+    --with-toolchain=/usr --prefix=$XBMC_DEPENDS_ROOT --host=arm-linux-gnueabihf --with-platform=gbm --with-tarballs=$TARBALLS $DEBUG_SWITCH
+fi

--- a/tools/buildsteps/linux-arm-gbm/configure-xbmc
+++ b/tools/buildsteps/linux-arm-gbm/configure-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+make -C $WORKSPACE/tools/depends/target/cmakebuildsys

--- a/tools/buildsteps/linux-arm-gbm/make-binary-addons
+++ b/tools/buildsteps/linux-arm-gbm/make-binary-addons
@@ -1,0 +1,28 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+. $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
+
+#clear the build failed file
+rm -f $WORKSPACE/cmake/$FAILED_BUILD_FILENAME
+
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons when requested by env/jenkins
+if [ "$BUILD_BINARY_ADDONS" == "true" ]
+then
+  for addon in $BINARY_ADDONS
+  do
+    echo "building $addon"
+    git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
+    cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS V=99 VERBOSE=1  || ALL_BINARY_ADDONS_BUILT="0"
+  done
+fi
+
+if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
+then
+  tagSuccessFulBuild $WORKSPACE/cmake
+else
+  #mark the build failure in the filesystem but leave jenkins running
+  tagFailedBuild $WORKSPACE/cmake
+fi

--- a/tools/buildsteps/linux-arm-gbm/make-depends
+++ b/tools/buildsteps/linux-arm-gbm/make-depends
@@ -1,0 +1,8 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS || make && tagSuccessFulBuild $WORKSPACE/tools/depends
+fi

--- a/tools/buildsteps/linux-arm-gbm/make-native-depends
+++ b/tools/buildsteps/linux-arm-gbm/make-native-depends
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
+then
+  git clean -xffd $WORKSPACE/tools/depends/native
+  cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends
+fi

--- a/tools/buildsteps/linux-arm-gbm/make-xbmc
+++ b/tools/buildsteps/linux-arm-gbm/make-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE/build;make -j$BUILDTHREADS || make

--- a/tools/buildsteps/linux-arm-gbm/package
+++ b/tools/buildsteps/linux-arm-gbm/package
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#nothing for linux atm

--- a/tools/buildsteps/linux-arm-gbm/prepare-depends
+++ b/tools/buildsteps/linux-arm-gbm/prepare-depends
@@ -1,0 +1,15 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#clean without depends for skipping depends build if possible
+#also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
+cd $WORKSPACE;git clean -xfd -e "cmake/.last_success_revision" -e "tools/depends" ${DEPLOYED_BINARY_ADDONS}
+
+# if depends path has changed - cleanout everything and do a full rebuild
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  #clean up the rest too
+  cd $WORKSPACE;git clean -xffd
+  cd $WORKSPACE/tools/depends/;./bootstrap
+fi

--- a/tools/buildsteps/linux-arm-gbm/prepare-xbmc
+++ b/tools/buildsteps/linux-arm-gbm/prepare-xbmc
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
+. $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/linux-arm-gbm/run-tests
+++ b/tools/buildsteps/linux-arm-gbm/run-tests
@@ -1,0 +1,14 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux-arm-gbm
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE/build;make -j$BUILDTHREADS kodi-test
+if [ "$Configuration" != "Coverage" ]; then
+  cd $WORKSPACE;build/kodi-test --gtest_output=xml:gtestresults.xml
+else
+  cd $WORKSPACE/build;GTEST_OUTPUT="xml:$WORKSPACE/gtestresults.xml" make coverage
+fi
+
+awk '{ if ($1 == "<testcase" && match($0, "notrun")) print substr($0,0,length($0)-2) "><skipped/></testcase>"; else print $0;}' gtestresults.xml > gtestresults-skipped.xml
+rm gtestresults.xml
+mv gtestresults-skipped.xml gtestresults.xml

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -23,6 +23,10 @@ ifeq ($(TARGET_PLATFORM),wayland)
   EXPAT = expat
 endif
 
+ifeq ($(TARGET_PLATFORM),gbm)
+  NATIVE += MarkupSafe Mako
+endif
+
 .PHONY: $(NATIVE) native
 
 all: native
@@ -46,6 +50,8 @@ python3: $(EXPAT) libffi pkg-config zlib
 setuptools: python3
 wayland-scanner: expat
 waylandpp-scanner: cmake
+MarkupSafe: python3 setuptools
+Mako: MarkupSafe
 
 #liblzo2 has stale packaged automake files that cause borked host/build detection
 liblzo2: automake

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -42,7 +42,7 @@ libtool: automake
 libjpeg-turbo: cmake yasm
 libpng: zlib
 meson: python3 setuptools
-ninja: python3
+ninja: meson
 swig: pcre
 distutilscross: python3
 tar: xz automake
@@ -50,7 +50,11 @@ python3: $(EXPAT) libffi pkg-config zlib
 setuptools: python3
 wayland-scanner: expat
 waylandpp-scanner: cmake
-MarkupSafe: python3 setuptools
+
+# python installs are not thread safe when using easy_install method.
+# MarkupSafe doesn't really depend on ninja but we need to make the
+# build sequential
+MarkupSafe: ninja
 Mako: MarkupSafe
 
 #liblzo2 has stale packaged automake files that cause borked host/build detection

--- a/tools/depends/native/Mako/Makefile
+++ b/tools/depends/native/Mako/Makefile
@@ -1,0 +1,29 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=Mako
+VERSION=1.1.3
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+	cd $(TARBALLS_LOCATION); chmod +x $(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+.installed-$(PLATFORM): $(PLATFORM)
+	cd $(PLATFORM); $(PREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
+	touch $@
+
+clean:
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/native/MarkupSafe/Makefile
+++ b/tools/depends/native/MarkupSafe/Makefile
@@ -1,0 +1,29 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=MarkupSafe
+VERSION=1.1.1
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+	cd $(TARBALLS_LOCATION); chmod +x $(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+.installed-$(PLATFORM): $(PLATFORM)
+	cd $(PLATFORM); $(PREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
+	touch $@
+
+clean:
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/native/meson/Makefile
+++ b/tools/depends/native/meson/Makefile
@@ -4,7 +4,7 @@ DEPS=../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=meson
-VERSION=0.51.0
+VERSION=0.55.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -62,8 +62,8 @@ WAYLANDPP_DEPS=
 ALSA_LIB=
 ifeq ($(OS),linux)
   DEPENDS += dbus libuuid
-  #not for raspberry pi
-  ifneq ($(TARGET_PLATFORM),raspberry-pi)
+  # not for raspberry pi or gbm
+  ifeq (,$(filter $(TARGET_PLATFORM),raspberry-pi gbm))
     DEPENDS += linux-system-libs
     WAYLANDPP_DEPS += linux-system-libs
   endif

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -75,6 +75,10 @@ ifeq ($(OS),linux)
   endif
   ifeq ($(TARGET_PLATFORM),gbm)
     DEPENDS += libdrm mesa
+    ifeq ($(CPU),x86_64)
+      DEPENDS += libva
+      LIBVA = libva
+    endif
   endif
 endif
 
@@ -107,7 +111,7 @@ pythonmodule-pycryptodome: $(PYMODULE_DEPS) python3 pythonmodule-setuptools
 pythonmodule-pil: bzip2 $(PYMODULE_DEPS) $(ZLIB) libjpeg-turbo libpng freetype2 python3 pythonmodule-setuptools
 pythonmodule-setuptools: $(PYMODULE_DEPS) python3
 libxslt: libgcrypt libxml2
-ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d
+ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)
 libcec: p8-platform
 crossguid: $(LIBUUID)
 libdvdnav: libdvdread
@@ -124,6 +128,7 @@ fribidi: meson-cross-file
 libspdlog: libfmt
 libdrm: meson-cross-file
 mesa: libdrm meson-cross-file
+libva: libdrm
 
 .installed-$(PLATFORM): $(DEPENDS)
 	touch $@

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -73,6 +73,9 @@ ifeq ($(OS),linux)
   ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),raspberry-pi gbm))
     DEPENDS += libxkbcommon libinput libudev libevdev mtdev
   endif
+  ifeq ($(TARGET_PLATFORM),gbm)
+    DEPENDS += libdrm mesa
+  endif
 endif
 
 ifeq ($(TARGET_PLATFORM),wayland)
@@ -119,6 +122,8 @@ taglib: $(ZLIB)
 dav1d: meson-cross-file
 fribidi: meson-cross-file
 libspdlog: libfmt
+libdrm: meson-cross-file
+mesa: libdrm meson-cross-file
 
 .installed-$(PLATFORM): $(DEPENDS)
 	touch $@

--- a/tools/depends/target/libdrm/Makefile
+++ b/tools/depends/target/libdrm/Makefile
@@ -1,0 +1,76 @@
+include ../../Makefile.include
+DEPS=../../Makefile.include Makefile
+
+LIBNAME=libdrm
+VERSION=2.4.102
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.xz
+
+MESON_BUILD_TYPE=release
+
+ifeq ($(DEBUG_BUILD), yes)
+  MESON_BUILD_TYPE=debug
+endif
+
+# configuration settings
+CONFIGURE = $(NATIVEPREFIX)/bin/python3 $(NATIVEPREFIX)/bin/meson \
+	--prefix=$(PREFIX) \
+	--libdir=lib \
+	--buildtype=$(MESON_BUILD_TYPE) \
+	-Dlibkms=false \
+	-Dnouveau=false \
+	-Domap=false \
+	-Dexynos=false \
+	-Dtegra=false \
+	-Dintel=false \
+	-Dradeon=false \
+	-Damdgpu=false \
+	-Dvmwgfx=false \
+	-Dvc4=false \
+	-Dfreedreno=false \
+	-Detnaviv=false \
+	-Dcairo-tests=false \
+	-Dman-pages=false \
+	-Dvalgrind=false \
+	-Dfreedreno-kgsl=false \
+	-Dinstall-test-programs=false \
+	-Dudev=false
+
+ifeq ($(CROSS_COMPILING), yes)
+CONFIGURE += --cross-file $(PREFIX)/share/cross-file.meson
+export CC=$(CC_FOR_BUILD)
+export CXX=$(CXX_FOR_BUILD)
+export CFLAGS=$(CFLAGS_FOR_BUILD)
+export CXXFLAGS=$(CXXFLAGS_FOR_BUILD)
+else
+export CC CXX CFLAGS CXXFLAGS
+endif
+export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
+
+LIBDYLIB=$(PLATFORM)/build/$(LIBNAME).so
+
+all: .installed-$(PLATFORM)
+
+download: $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); rm -rf build; mkdir -p build
+	cd $(PLATFORM); $(CONFIGURE) . build
+
+$(LIBDYLIB): $(PLATFORM)
+	cd $(PLATFORM)/build; $(NATIVEPREFIX)/bin/ninja -v
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	cd $(PLATFORM)/build; $(NATIVEPREFIX)/bin/ninja -v install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/libva/Makefile
+++ b/tools/depends/target/libva/Makefile
@@ -1,0 +1,64 @@
+include ../../Makefile.include
+DEPS=../../Makefile.include Makefile
+
+LIBNAME=libva
+VERSION=2.8.0
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.bz2
+
+MESON_BUILD_TYPE=release
+
+ifeq ($(DEBUG_BUILD), yes)
+  MESON_BUILD_TYPE=debug
+endif
+
+# configuration settings
+CONFIGURE = $(NATIVEPREFIX)/bin/python3 $(NATIVEPREFIX)/bin/meson \
+	--prefix=$(PREFIX) \
+  --libdir=lib \
+	--buildtype=$(MESON_BUILD_TYPE) \
+	-Ddisable_drm=false \
+	-Denable_docs=false \
+	-Denable_va_messaging=true \
+	-Dwith_x11=no \
+	-Dwith_glx=no \
+	-Dwith_wayland=no
+
+ifeq ($(CROSS_COMPILING), yes)
+CONFIGURE += --cross-file $(PREFIX)/share/cross-file.meson
+export CC=$(CC_FOR_BUILD)
+export CXX=$(CXX_FOR_BUILD)
+export CFLAGS=$(CFLAGS_FOR_BUILD)
+export CXXFLAGS=$(CXXFLAGS_FOR_BUILD)
+else
+export CC CXX CFLAGS CXXFLAGS
+endif
+export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
+
+LIBDYLIB=$(PLATFORM)/build/$(LIBNAME).so
+
+all: .installed-$(PLATFORM)
+
+download: $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); rm -rf build; mkdir -p build
+	cd $(PLATFORM); $(CONFIGURE) . build
+
+$(LIBDYLIB): $(PLATFORM)
+	cd $(PLATFORM)/build; $(NATIVEPREFIX)/bin/ninja -v
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	cd $(PLATFORM)/build; $(NATIVEPREFIX)/bin/ninja -v install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/mesa/Makefile
+++ b/tools/depends/target/mesa/Makefile
@@ -1,0 +1,93 @@
+include ../../Makefile.include
+DEPS=../../Makefile.include Makefile
+
+LIBNAME=mesa
+VERSION=20.1.7
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.xz
+
+MESON_BUILD_TYPE=release
+
+ifeq ($(DEBUG_BUILD), yes)
+  MESON_BUILD_TYPE=debug
+endif
+
+ifeq ($(CPU), x86_64)
+  MESA_GALLIUM_DRIVERS=iris
+else ifeq ($(CPU), arm)
+  MESA_GALLIUM_DRIVERS=kmsro,vc4
+endif
+
+# configuration settings
+CONFIGURE = $(NATIVEPREFIX)/bin/python3 $(NATIVEPREFIX)/bin/meson \
+	--prefix=$(PREFIX) \
+	--libdir=lib \
+	--buildtype=$(MESON_BUILD_TYPE) \
+	-Ddri-drivers= \
+	-Dgallium-drivers="$(MESA_GALLIUM_DRIVERS)" \
+	-Dgallium-extra-hud=false \
+	-Dgallium-xvmc=false \
+	-Dgallium-omx=disabled \
+	-Dgallium-nine=false \
+	-Dgallium-opencl=disabled \
+	-Dvulkan-drivers= \
+	-Dshader-cache=true \
+	-Dshared-glapi=true \
+	-Dopengl=true \
+	-Dgbm=true \
+	-Degl=true \
+	-Dvalgrind=false \
+	-Dlibunwind=false \
+	-Dlmsensors=false \
+	-Dbuild-tests=false \
+	-Dselinux=false \
+	-Dosmesa=none \
+	-Dplatforms="drm" \
+	-Ddri3=false \
+	-Dglx=disabled \
+	-Dglvnd=false \
+	-Dllvm=false \
+	-Dgallium-vdpau=false \
+	-Dgallium-va=false \
+	-Dgallium-xa=false \
+	-Dgles1=false \
+	-Dgles2=true
+
+ifeq ($(CROSS_COMPILING), yes)
+CONFIGURE += --cross-file $(PREFIX)/share/cross-file.meson
+export CC=$(CC_FOR_BUILD)
+export CXX=$(CXX_FOR_BUILD)
+export CFLAGS=$(CFLAGS_FOR_BUILD)
+export CXXFLAGS=$(CXXFLAGS_FOR_BUILD)
+else
+export CC CXX CFLAGS CXXFLAGS
+endif
+export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
+
+LIBDYLIB=$(PLATFORM)/build/src/egl/libEGL.so
+
+all: .installed-$(PLATFORM)
+
+download: $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); rm -rf build; mkdir -p build
+	cd $(PLATFORM); $(CONFIGURE) . build
+
+$(LIBDYLIB): $(PLATFORM)
+	cd $(PLATFORM)/build; $(NATIVEPREFIX)/bin/ninja -v
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	cd $(PLATFORM)/build; $(NATIVEPREFIX)/bin/ninja -v install
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/meson-cross-setup.sh
+++ b/tools/depends/target/meson-cross-setup.sh
@@ -15,9 +15,9 @@ cpu = '$CPU'
 endian = 'little'
 
 [properties]
-$($NATIVEPREFIX/bin/python3 -c "print('c_args = {}'.format([x for x in '$CFLAGS'.split()]))")
+$($NATIVEPREFIX/bin/python3 -c "print('c_args = {}'.format([x for x in '$CFLAGS'.split() if x not in ['-g', '-gdwarf-2']]))")
 $($NATIVEPREFIX/bin/python3 -c "print('c_link_args = {}'.format([x for x in '$LDFLAGS'.split()]))")
-$($NATIVEPREFIX/bin/python3 -c "print('cpp_args = {}'.format([x for x in '$CXXFLAGS'.split()]))")
+$($NATIVEPREFIX/bin/python3 -c "print('cpp_args = {}'.format([x for x in '$CXXFLAGS'.split() if x not in ['-g', '-gdwarf-2']]))")
 $($NATIVEPREFIX/bin/python3 -c "print('cpp_link_args = {}'.format([x for x in '$LDFLAGS'.split()]))")
 
 [paths]


### PR DESCRIPTION
This PR adds a linux-arm-gbm build target to be used by jenkins. The motivation for this is to eventually remove the raspberry pi build. This will also be a test bed for any other arm platforms.

This adds a few new dependencies because we need to cross compile libdrm, libGLESv2 and libEGL.
 - MarkupSafe
 - Mako
 - libdrm
 - mesa

I have also removed the linux-system-libs target for gbm builds. This will make it so we can use the compiled GLES library. In doing this I have also added libva as a dependency for the x86_64 gbm build.

I have also updated meson to the latest version available.

I have already created the project in jenkins and have run a test build for the linux-arm-gbm project. The linux-64-gbm project will need to be tested by jenkins.

The successful cross build is here https://jenkins.kodi.tv/view/Linux/job/LINUX-arm-GBM/lastSuccessfulBuild/

