### PR TITLE
[addons] fix: always set a repos origin to itself

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -653,13 +653,13 @@ bool CAddonInstallJob::DoWork()
   // Needed to set origin correctly for new installed addons.
 
   std::string origin;
-  if (m_repo) // if we have an origin use it
+  if (m_addon->HasType(ADDON_REPOSITORY))
   {
-    origin = m_repo->ID();
+    origin = m_addon->ID(); // always set repos origin to itself
   }
-  else if (m_addon->HasType(ADDON_REPOSITORY))
+  else if (m_repo)
   {
-    origin = m_addon->ID(); // set origin to addon-id which is the repo itself
+    origin = m_repo->ID();  // else use addons repo as origin
   }
 
   CServiceBroker::GetAddonMgr().SetAddonOrigin(m_addon->ID(), origin, m_isUpdate);


### PR DESCRIPTION
## Description
@howie-f 
This just flips the origin logic so the check for repo is first.
Therefore, a repo add-on's origin is always set to itself.

## Motivation and Context
Currently installing a repo from another repo - the 2nd repos origin is set to the 1st repo.
This means it can't update itself without a "change of origin" warning.

It also means that 1st repo could "turn bad" and update the 2nd repo to point elsewhere.
That would then make all the add-ons installed from 2nd repo also able to be hijacked.

A repo just always be responsible for updating itself.

## How Has This Been Tested?
Confirmed by installing a repo from a repo.
Noted the 2nd repos origin is set to the 1st repo in addons.db
Also noted it can't update itself.

After this PR, its origin is correctly set to itself.
And it can then update itself freely.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
