### PR TITLE
[addons] add maxversion to <dir>for repos

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -111,7 +111,8 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo)
   for (auto element : Type(ADDON_REPOSITORY)->GetElements("dir"))
   {
     DirInfo dir = ParseDirConfiguration(element.second);
-    if (dir.version <= version)
+    if ((dir.minversion.empty() || version >= dir.minversion) &&
+        (dir.maxversion.empty() || version <= dir.maxversion))
       m_dirs.push_back(std::move(dir));
   }
   if (!Type(ADDON_REPOSITORY)->GetValue("info").empty())
@@ -300,7 +301,9 @@ CRepository::DirInfo CRepository::ParseDirConfiguration(const CAddonExtensions& 
     }
   }
 
-  dir.version = AddonVersion{configuration.GetValue("@minversion").asString()};
+  dir.minversion = AddonVersion{configuration.GetValue("@minversion").asString()};
+  dir.maxversion = AddonVersion{configuration.GetValue("@maxversion").asString()};
+
   return dir;
 }
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -23,7 +23,8 @@ namespace ADDON
   public:
     struct DirInfo
     {
-      AddonVersion version{""};
+      AddonVersion minversion{""};
+      AddonVersion maxversion{""};
       std::string info;
       std::string checksum;
       KODI::UTILITY::CDigest::Type checksumType{KODI::UTILITY::CDigest::Type::INVALID};


### PR DESCRIPTION
## Description
This allows setting a maxversion on dir to stop Matrix and above pulling their repo files.

**Default minversion = 0
Default maxversion = Unlimited (999.9.9 in code)
minversion is >= (X.X.X and up)  (same as currently)
maxversion is <=  (X.X.X or below)**

This is backwards compatible and still allows Leia and below that only support minversion to work as they do now.

```
  <extension point="xbmc.addon.repository" name="Inputstream Adaptive Testing Repository">
    <dir maxversion="18.9.0">
      <info compressed="false">https://k.slyguy.xyz/.ia-testing/leia/addons.xml</info>
      <checksum>https://k.slyguy.xyz/.ia-testing/leia/addons.xml.md5</checksum>
      <datadir zip="true">https://k.slyguy.xyz/.ia-testing/leia/</datadir>
      <hashes>false</hashes>
    </dir>
    <dir minversion="19.0.0">
      <info compressed="false">https://k.slyguy.xyz/.ia-testing/matrix/addons.xml</info>
      <checksum>https://k.slyguy.xyz/.ia-testing/matrix/addons.xml.md5</checksum>
      <datadir zip="true">https://k.slyguy.xyz/.ia-testing/matrix/</datadir>
      <hashes>false</hashes>
    </dir>
  </extension>
```
with the above:

Leia and below will only get the leia/addons.xml
- Leia only knows about minversion, so works as normal. Skips the matrix dir as its minversion is higher than itself.

Matrix will only get matrix/addons.xml
- currently it get both, but with this PR, it will ignore Leia as it's maxversion is below itself

thanks to @glennguy for the idea!

## Motivation and Context
Currently, Kodi will download all dir files with a minversion below its version (xbmc.addon version actually).
This may not be wanted.
eg. for a Repository with Matrix and Leia.
Matrix will download both Matrix and Leia addons.xml

## How Has This Been Tested?
editing an addon.xml of a repo, then restarting kodi.
then checking for update.
Making sure it only downloads the correct files.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
