### PR TITLE
[addons] fix: show warning only when changing origin

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -337,7 +337,12 @@ void CGUIDialogAddonInfo::OnInstall()
   if (!m_item->HasAddonInfo())
     return;
 
-  if (m_localAddon)
+  const auto& itemAddonInfo = m_item->GetAddonInfo();
+  const std::string& origin = itemAddonInfo->Origin();
+
+  if (m_localAddon && (m_localAddon->Origin() != origin) &&
+      (CAddonSystemSettings::GetInstance().GetAddonRepoUpdateMode() !=
+       AddonRepoUpdateMode::ANY_REPOSITORY))
   {
     const std::string& header = g_localizeStrings.Get(19098); // Warning!
     const std::string text =
@@ -355,10 +360,7 @@ void CGUIDialogAddonInfo::OnInstall()
     }
   }
 
-  const auto& itemAddonInfo = m_item->GetAddonInfo();
-
   const std::string& addonId = itemAddonInfo->ID();
-  const std::string& origin = itemAddonInfo->Origin();
   const AddonVersion& version = itemAddonInfo->Version();
 
   Close();


### PR DESCRIPTION
## Description
PR #18341 claims to show a warning dialog when the same addon-id is installed from a different origin.
this was not the case when installing an announced addon-update manually.
warning messages are now also ommitted when updates from `Any repositories` are permitted.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
