### PR TITLE
[cmake] support libplist version 2.2.0

### DIFF
--- a/cmake/modules/FindPlist.cmake
+++ b/cmake/modules/FindPlist.cmake
@@ -15,7 +15,7 @@
 #   Plist::Plist   - The Plist library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_PLIST libplist QUIET)
+  pkg_search_module(PC_PLIST libplist-2.0 libplist QUIET)
 endif()
 
 find_path(PLIST_INCLUDE_DIR plist/plist.h
@@ -23,7 +23,7 @@ find_path(PLIST_INCLUDE_DIR plist/plist.h
 
 set(PLIST_VERSION ${PC_PLIST_VERSION})
 
-find_library(PLIST_LIBRARY NAMES plist libplist
+find_library(PLIST_LIBRARY NAMES plist-2.0 plist libplist-2.0 libplist
                                  PATHS ${PC_PLIST_LIBDIR})
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
## Description
libplist 2.2.0 changed the pkgconfig and library names from
libplist(++) to libplist(++)-2.0. Add these names to cmake pkgconfig
and library lists so cmake can pick up external 2.2 versions as well.

## Motivation and Context
internal libplist had been bumped to 2.2.0 in #18234 but building with external libplist 2.2.0 doesn't work

## How Has This Been Tested?
build tested on LibreELEC master with external libplist 2.2.0 and 2.0.0 - cmake was able to pick up both the old and the new version with this change.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
