### PR TITLE
Detect Display Resolution change

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -165,12 +165,8 @@ bool CInputStreamAddon::Open()
   props.m_libFolder = libFolder.c_str();
   props.m_profileFolder = profileFolder.c_str();
 
-  unsigned int videoWidth = 1280;
-  unsigned int videoHeight = 720;
-  if (m_player)
-    m_player->GetVideoResolution(videoWidth, videoHeight);
-  SetVideoResolution(videoWidth, videoHeight);
-
+  DetectDisplayResolution();
+  
   bool ret = m_struct.toAddon.open(&m_struct, &props);
   if (ret)
   {
@@ -182,7 +178,21 @@ bool CInputStreamAddon::Open()
   }
   return ret;
 }
-
+void CInputStreamAddon::DetectDisplayResolution()
+{
+  unsigned int videoWidth = 1280;
+  unsigned int videoHeight = 720;
+  if (m_player)
+    m_player->GetVideoResolution(videoWidth, videoHeight);
+  if(videoWidth_!=videoWidth || videoHeight_!=videoHeight)
+    {
+    SetVideoResolution(videoWidth, videoHeight);
+    CLog::Log(LOGINFO,"Display Resolution Change Detected, Previous: (%u x %u), Current: (%u x %u)",
+                                                            videoWidth_,videoHeight_,videoWidth,videoHeight);
+      videoWidth_=videoWidth;
+      videoHeight_=videoHeight; 
+    }
+}
 void CInputStreamAddon::Close()
 {
   if (m_struct.toAddon.close)
@@ -266,6 +276,8 @@ int CInputStreamAddon::GetTime()
 // ITime
 CDVDInputStream::ITimes* CInputStreamAddon::GetITimes()
 {
+    DetectDisplayResolution();
+
   if ((m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTS_ITIME) == 0)
     return nullptr;
 
@@ -663,3 +675,4 @@ void CInputStreamAddon::cb_free_demux_packet(void* kodiInstance, DemuxPacket* pa
 }
 
 //@}
+

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -106,6 +106,10 @@ protected:
   IVideoPlayer* m_player;
 
 private:
+  void DetectDisplayResolution();
+  unsigned int videoWidth_ = 0;
+  unsigned int videoHeight_ = 0;
+
   std::vector<std::string> m_fileItemProps;
   INPUTSTREAM_CAPABILITIES m_caps;
 
@@ -143,3 +147,4 @@ private:
   static void cb_free_demux_packet(void* kodiInstance, DemuxPacket* pPacket);
   //@}
 };
+


### PR DESCRIPTION
## Description
Will trigger new resolution in Inputstream.Adaptive.
Tweaked the callback to periodically check, and then call is made to IA API for updating the new display resolution

## Motivation and Context
The purpose of it is to update the new display resolution when Kodi is in windowed mode

## How Has This Been Tested?
Checked it manually and logging

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ X] **Improvement** (non-breaking change which improves existing functionality)
- [ X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
