### PR TITLE
[cmake] allow ffmpeg and libdvd to build in parallel when using ninja

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -96,6 +96,16 @@ else()
     set(LIBDVD_ADDITIONAL_ARGS "-DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}" "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}")
   endif()
 
+  set(MAKE_COMMAND $(MAKE))
+  if(CMAKE_GENERATOR STREQUAL Ninja)
+    set(MAKE_COMMAND make)
+    include(ProcessorCount)
+    ProcessorCount(N)
+    if(NOT N EQUAL 0)
+      set(MAKE_COMMAND make -j${N})
+    endif()
+  endif()
+
   if(ENABLE_DVDCSS)
     if(NOT CORE_SYSTEM_NAME MATCHES windows)
       set(DVDCSS_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdcss.a)
@@ -115,6 +125,7 @@ else()
                                                     "CC=${CMAKE_C_COMPILER}"
                                                     "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
                                                     "LDFLAGS=${CMAKE_LD_FLAGS}"
+                                  BUILD_COMMAND ${MAKE_COMMAND}
                                   BUILD_BYPRODUCTS ${DVDCSS_LIBRARY})
       ExternalProject_Add_Step(dvdcss autoreconf
                                       DEPENDEES download update patch
@@ -156,7 +167,8 @@ else()
                                                   "CC=${CMAKE_C_COMPILER}"
                                                   "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
                                                   "LDFLAGS=${CMAKE_LD_FLAGS}"
-                              BUILD_BYPRODUCTS ${DVDREAD_LIBRARY})
+                                BUILD_COMMAND ${MAKE_COMMAND}
+                                BUILD_BYPRODUCTS ${DVDREAD_LIBRARY})
     ExternalProject_Add_Step(dvdread autoreconf
                                       DEPENDEES download update patch
                                       DEPENDERS configure
@@ -203,6 +215,7 @@ else()
                                                   "DVDREAD_CFLAGS=${DVDREAD_CFLAGS}"
                                                   "DVDREAD_LIBS=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.la"
                                                   "LIBS=${DVDNAV_LIBS}"
+                                BUILD_COMMAND ${MAKE_COMMAND}
                                 BUILD_BYPRODUCTS ${DVDNAV_LIBRARY})
     ExternalProject_Add_Step(dvdnav autoreconf
                                     DEPENDEES download update patch

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -99,6 +99,16 @@ endif()
 
 message(STATUS "FFMPEG_CONF: ${ffmpeg_conf}")
 
+set(MAKE_COMMAND $(MAKE))
+if(CMAKE_GENERATOR STREQUAL Ninja)
+  set(MAKE_COMMAND make)
+  include(ProcessorCount)
+  ProcessorCount(N)
+  if(NOT N EQUAL 0)
+    set(MAKE_COMMAND make -j${N})
+  endif()
+endif()
+
 include(ExternalProject)
 externalproject_add(ffmpeg
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
@@ -124,7 +134,8 @@ externalproject_add(ffmpeg
                       --enable-protocol=http
                       --enable-encoder=png
                       --enable-encoder=mjpeg
-                      ${ffmpeg_conf})
+                      ${ffmpeg_conf}
+                    BUILD_COMMAND ${MAKE_COMMAND})
 
 install(CODE "Message(Done)")
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
allows ffmpeg and libdvd to use parallel build jobs under ninja

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
shorter build time with ninja

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
