### PR TITLE
[Filesystem][smartplaylists] Don't sort grouped items by label if random order specified in xsp

### DIFF
--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -282,9 +282,23 @@ namespace XFILE
       items.SetProperty(PROPERTY_GROUP_MIXED, playlist.IsGroupMixed());
     }
 
-    // sort grouped list by label
+    // sort grouped list by label unless random was specified for musicvideo artists
     if (items.Size() > 1 && !group.empty())
-      items.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+    {
+      if (playlist.GetOrder() == SortByRandom && group == "actors" &&
+          playlist.GetType() == "musicvideos")
+        items.Sort(SortByRandom, SortOrderAscending,
+                   CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                       CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                       ? SortAttributeIgnoreArticle
+                       : SortAttributeNone);
+      else
+        items.Sort(SortByLabel, SortOrderAscending,
+                   CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                       CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                       ? SortAttributeIgnoreArticle
+                       : SortAttributeNone);
+    }
 
     // go through and set the playlist order
     for (int i = 0; i < items.Size(); i++)


### PR DESCRIPTION
## Description
Allow smartplaylists that contain a group tag to be sorted in random order if that is specified in the xsp.

## Motivation and Context

While looking at improving the music video navigation, I noticed that the random artists for music videos that are shown in the right hand pane of Estuary were not random at all but in alphabetical order.  This list is generated from a simple smart playlist included with the skin.
```
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<smartplaylist type="musicvideos">
    <name></name>
    <match>all</match>
    <group>artists</group>
    <order direction="ascending">random</order>
</smartplaylist>
```

 However, because the current code always sorts grouped items by label, the artists are always shown in alphabetical order.  This PR checks to see if a random order was specified and adjusts the sort accordingly in that case.

## How Has This Been Tested?
Tested by mapping a key to reload the skin and verifying that the artist order is indeed different each time.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
