### PR TITLE
[addons] fix system add-ons changing origin

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -305,16 +305,16 @@ void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids,
     for (const auto& id : system)
     {
       m_pDS->exec(PrepareSQL("UPDATE installed SET enabled=1 WHERE addonID='%s'", id.c_str()));
-      // Set origin *only* for addons that do not have one yet as it may have been changed by an update.
-      m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s' AND origin=''",
-          ORIGIN_SYSTEM, id.c_str()));
+      // Make sure system addons always have ORIGIN_SYSTEM origin
+      m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s'", ORIGIN_SYSTEM,
+                             id.c_str()));
     }
 
     for (const auto& id : optional)
     {
-      // Set origin for optional system addons that do not have one yet too.
-      m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s' AND origin=''",
-                             ORIGIN_SYSTEM, id.c_str()));
+      // Make sure optional system addons always have ORIGIN_SYSTEM origin
+      m_pDS->exec(PrepareSQL("UPDATE installed SET origin='%s' WHERE addonID='%s'", ORIGIN_SYSTEM,
+                             id.c_str()));
     }
 
     CommitTransaction();

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -654,16 +654,20 @@ bool CAddonInstallJob::DoWork()
   // Needed to set origin correctly for new installed addons.
 
   std::string origin;
-  if (m_addon->HasType(ADDON_REPOSITORY))
+  if (m_addon->Origin() == ORIGIN_SYSTEM)
   {
-    origin = m_addon->ID(); // always set repos origin to itself
+    origin = ORIGIN_SYSTEM; // keep system add-on origin as ORIGIN_SYSTEM
+  }
+  else if (m_addon->HasType(ADDON_REPOSITORY))
+  {
+    origin = m_addon->ID(); // use own id as origin if repository
     if (m_isUpdate)
       CServiceBroker::GetRepositoryUpdater().CheckForUpdates(
           std::static_pointer_cast<CRepository>(m_addon), false);
   }
   else if (m_repo)
   {
-    origin = m_repo->ID();  // else use addons repo as origin
+    origin = m_repo->ID(); // use repo id as origin
   }
 
   CServiceBroker::GetAddonMgr().SetAddonOrigin(m_addon->ID(), origin, m_isUpdate);


### PR DESCRIPTION
## Description
Issue 1: If a system add-on (any add-on with origin of ORIGIN_SYSTEM) gets updated it's origin is set to the repo it was updated from. This is not good, as non-system add-ons can get updates from 3rd party repos if that setting is enabled. Also that system add-on will be "stickied" to that official repo and won't get auto updates from other system repos.
Fix: Keep origin as ORIGIN_SYSTEM if it's current origin is ORIGIN_SYSTEM

Issue 2: If a system add-on is in db without ORIGIN_SYSTEM, it won't be switched back and have same as issue 1.
Fix: Always set system add-ons to have their origin as ORIGIN_SYSTEM on boot (SyncInstalled)

## How Has This Been Tested?
Confirmed fix 1 by updating a system add-on and noting it's Repo changes from "Sytem" to "Kodi Repository"
Also confirmed the origin in db is changed.
Confirmed fix by observing system add-on remain system after update and db value reamain as ORIGIN_SYSTEM.

Confirmed fix 2 by changing system add-on origin in db then restarting kodi and note origin is then ORIGIN_SYSTEM.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
