### PR TITLE
[strings] restore "Set GUI resolution limit" strings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20342,7 +20342,14 @@ msgctxt "#36546"
 msgid "Sets the visual depth of subtitles for stereoscopic 3D videos. The higher the value, the closer the subtitles will appear to the viewer."
 msgstr ""
 
-#empty strings from id 36547 to 36548
+#empty string with id 36547
+
+#. Description of setting with label #37021 "Set GUI resolution limit"
+#: system/settings/android.xml
+#: system/settings/gbm.xml
+msgctxt "#36548"
+msgid "Limits resolution of GUI to save memory. Does not affect video playback. Requires restart."
+msgstr ""
 
 #. Description of setting with label #1268 "iOS 8 compatibility mode"
 #: system/settings/settings.xml
@@ -20975,7 +20982,13 @@ msgctxt "#37016"
 msgid "Select this option if your receiver is capable of decoding Dolby Digital Plus (E-AC3) streams."
 msgstr ""
 
-#empty strings from id 37017 to 37021
+#empty strings from id 37017 to 37020
+
+#: system/settings/android.xml
+#: system/settings/gbm.xml
+msgctxt "#37021"
+msgid "Set GUI resolution limit"
+msgstr ""
 
 #: xbmc/network/upnp/UPnPPlayer.cpp
 msgctxt "#37022"


### PR DESCRIPTION
## Description
The strings were accidentally dropped in the RPi removal PR #16321 but they are still referenced in android.xml and gbm.xml
https://github.com/xbmc/xbmc/blob/master/system/settings/android.xml#L15
https://github.com/xbmc/xbmc/blob/master/system/settings/gbm.xml#L50

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
