### PR TITLE
fix warning

### DIFF
--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -495,7 +495,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         const CGUIViewState *viewState = window->GetViewState();
         if (viewState)
         {
-          value = (static_cast<unsigned int>(viewState->GetSortMethod().sortBy) == info.GetData2());
+          value = (static_cast<int>(viewState->GetSortMethod().sortBy) == info.GetData2());
           return true;
         }
       }

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -509,7 +509,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
         const CGUIViewState *viewState = window->GetViewState();
         if (viewState)
         {
-          value = (static_cast<int>(viewState->GetSortOrder()) == info.GetData1());
+          value = (static_cast<unsigned int>(viewState->GetSortOrder()) == info.GetData1());
           return true;
         }
       }


### PR DESCRIPTION
## Description
i noticed that pr #18388 seems to fix a warning on a different line than in the description, so i took the liberty to fix the described one:

```
GUIControlsGUIInfo.cpp:498:81: 
warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
 value = (static_cast<unsigned int>(viewState->GetSortMethod().sortBy) == info.GetData2());
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

