### PR TITLE
[depends] meson related fixes

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -262,7 +262,7 @@ case $host in
         if test "x$use_cpu" = "xarm64-v8a"; then
           platform_cflags+=" -march=armv8-a -mtune=cortex-a53"
         fi
-        meson_cpu="arch64"
+        meson_cpu="aarch64"
       ;;
       i*86*-linux-android*|x86_64*-linux-android*)
         if test "x$use_cpu" = "xauto"; then

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -12,7 +12,7 @@ DEPENDS = \
 	libxml2 rapidjson libmicrohttpd mariadb libffi \
 	python3 libshairplay libfmt libspdlog \
 	libplist libcec libbluray tinyxml \
-	taglib libusb libnfs meson-cross-file \
+	taglib libusb libnfs \
 	pythonmodule-pil pythonmodule-pycryptodome pythonmodule-setuptools \
 	libxslt ffmpeg crossguid libudfread \
 	libdvdread libdvdnav libdvdcss p8-platform flatbuffers dav1d
@@ -191,7 +191,7 @@ linux-system-libs: linux-system-libs-egl
 	[ -f $(PREFIX)/lib/pkgconfig/xkbcommon.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/xkbcommon.pc $(PREFIX)/lib/pkgconfig/xkbcommon.pc
 	[ -f $(PREFIX)/lib/pkgconfig/libva.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/libva.pc $(PREFIX)/lib/pkgconfig/libva.pc
 
-meson-cross-file:
+$(PREFIX)/share/cross-file.meson:
 	PREFIX="$(PREFIX)" \
 	NATIVEPREFIX="$(NATIVEPREFIX)" \
 	CC="$(CC)" \
@@ -204,5 +204,7 @@ meson-cross-file:
 	CFLAGS="$(CFLAGS)" \
 	CXXFLAGS="$(CXXFLAGS)" \
 	LDFLAGS="$(LDFLAGS)" \
-	./meson-cross-setup.sh
+	./meson-cross-setup.sh $@
 
+.PHONY: meson-cross-file
+meson-cross-file: $(PREFIX)/share/cross-file.meson

--- a/tools/depends/target/dav1d/Makefile
+++ b/tools/depends/target/dav1d/Makefile
@@ -51,7 +51,7 @@ export CC CXX CFLAGS CXXFLAGS
 endif
 export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
 
-LIBDYLIB=$(PLATFORM)/lib/lib$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/build/src/lib$(LIBNAME).a
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/libinput/Makefile
+++ b/tools/depends/target/libinput/Makefile
@@ -27,7 +27,7 @@ export CC CXX CFLAGS CXXFLAGS
 endif
 export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
 
-LIBDYLIB=$(PLATFORM)/build/libinput.a
+LIBDYLIB=$(PLATFORM)/build/libinput.so
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/meson-cross-setup.sh
+++ b/tools/depends/target/meson-cross-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cat > $PREFIX/share/cross-file.meson << EOF
+cat > $1 << EOF
 [binaries]
 $($NATIVEPREFIX/bin/python3 -c "print('c = {}'.format('$CC'.split()))")
 $($NATIVEPREFIX/bin/python3 -c "print('cpp = {}'.format('$CXX'.split()))")

--- a/tools/depends/target/meson-cross-setup.sh
+++ b/tools/depends/target/meson-cross-setup.sh
@@ -2,8 +2,8 @@
 
 cat > $PREFIX/share/cross-file.meson << EOF
 [binaries]
-$($NATIVEPREFIX/bin/python3 -c "print('c = \'{}\''.format('$CC'.split()[-1]))")
-$($NATIVEPREFIX/bin/python3 -c "print('cpp = \'{}\''.format('$CXX'.split()[-1]))")
+$($NATIVEPREFIX/bin/python3 -c "print('c = {}'.format('$CC'.split()))")
+$($NATIVEPREFIX/bin/python3 -c "print('cpp = {}'.format('$CXX'.split()))")
 ar = '$AR'
 strip = '$STRIP'
 pkgconfig = '$NATIVEPREFIX/bin/pkg-config'


### PR DESCRIPTION
This PR includes some various meson related fixes as explained below:

 - Packages that are built using meson weren't using ccache. This should be corrected by this PR. (I can't remember if in the past this was broken with old versions of meson or something else).

 - `aarch64` cpu target for android-aarch64 was misspelled (not sure if this actually caused problems or if meson was just warning about it).
```
WARNING: Unknown CPU family arch64, please report this at https://github.com/mesonbuild/meson/issues/new
```

 - Fix the dynlib name for dav1d. This was causing the dav1d package to be rebuilt if the target was called again (even though it built fine the first time).

 - Same thing for libinput.

 - The `cross-file.meson` was being generated any time the `meson-cross-file` target was being called. We only need to generate it once.