### PR TITLE
Teach CCueDocument to handle per-track genres and comments

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -193,7 +193,10 @@ void CCueDocument::GetSongs(VECSONGS &songs)
     //Pass album artist to MusicInfoTag object by setting album artist vector.
     aSong.SetAlbumArtist(StringUtils::Split(m_strArtist, advancedSettings->m_musicItemSeparator));
     aSong.strAlbum = m_strAlbum;
-    aSong.genre = StringUtils::Split(m_strGenre, advancedSettings->m_musicItemSeparator);
+    if ((track.strGenre.length() == 0) && (m_strGenre.length() > 0))
+      aSong.genre = StringUtils::Split(m_strGenre, advancedSettings->m_musicItemSeparator);
+    else
+      aSong.genre = StringUtils::Split(track.strGenre, advancedSettings->m_musicItemSeparator);
     aSong.iYear = m_iYear;
     aSong.iTrack = track.iTrackNumber;
     if (m_iDiscNumber > 0)
@@ -367,7 +370,16 @@ bool CCueDocument::Parse(CueReader& reader, const std::string& strFile)
     }
     else if (StringUtils::StartsWithNoCase(strLine, "REM GENRE"))
     {
-      m_strGenre = ExtractInfo(strLine.substr(9));
+      if (totalTracks == -1) // No tracks yet
+      {
+        // Genre applies to whole disc
+        m_strGenre = ExtractInfo(strLine.substr(9));
+      }
+      else
+      {
+        // Genre applies to single track
+        m_tracks[totalTracks].strGenre = ExtractInfo(strLine.substr(9));
+      }
     }
     else if (StringUtils::StartsWithNoCase(strLine, "REM REPLAYGAIN_ALBUM_GAIN"))
       m_albumReplayGain.SetGain(strLine.substr(26));

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -206,6 +206,7 @@ void CCueDocument::GetSongs(VECSONGS &songs)
     else
       aSong.strTitle = track.strTitle;
     aSong.strFileName = track.strFile;
+    aSong.strComment = track.strComment;
     aSong.iStartOffset = track.iStartTime;
     aSong.iEndOffset = track.iEndTime;
     if (aSong.iEndOffset)
@@ -380,6 +381,10 @@ bool CCueDocument::Parse(CueReader& reader, const std::string& strFile)
         // Genre applies to single track
         m_tracks[totalTracks].strGenre = ExtractInfo(strLine.substr(9));
       }
+    }
+    else if (StringUtils::StartsWithNoCase(strLine, "REM COMMENT"))
+    {
+      m_tracks[totalTracks].strComment = ExtractInfo(strLine.substr(11));
     }
     else if (StringUtils::StartsWithNoCase(strLine, "REM REPLAYGAIN_ALBUM_GAIN"))
       m_albumReplayGain.SetGain(strLine.substr(26));

--- a/xbmc/CueDocument.h
+++ b/xbmc/CueDocument.h
@@ -25,6 +25,7 @@ class CCueDocument
     std::string strArtist;
     std::string strTitle;
     std::string strFile;
+    std::string strGenre;
     int iTrackNumber = 0;
     int iStartTime = 0;
     int iEndTime = 0;

--- a/xbmc/CueDocument.h
+++ b/xbmc/CueDocument.h
@@ -26,6 +26,7 @@ class CCueDocument
     std::string strTitle;
     std::string strFile;
     std::string strGenre;
+    std::string strComment;
     int iTrackNumber = 0;
     int iStartTime = 0;
     int iEndTime = 0;


### PR DESCRIPTION
## Description
Hi all.  I've had this branch in my local repo for many years (ouch, Github now informs me since 2011...), but apparently never saw fit to put it up for review.  This change adds support for per-track genres and comments in cue sheets.  Comment support is a little simplistic with the last comment on each track winning, but in my library that was good enough.  It's been long enough since I originally wrote this code I don't remember whether this particular format (per-track genres and comments) matches published standards for cue sheets or not.  This PR is primarily to test the waters and see if there is community interest in this change.  The commit messages have historical details to help me remember the evolving history of these patches, but I'm happy to reword them if the community does want to integrate them.

Note: these patches are currently against Leia, not master, as I prefer to keep my local Kodi build based on stable releases.  I can retarget the commits if master is preferred (I am one of the [potentially cursed] git-ninjas referred to in the contributing guide, so that rebase wouldn't be a problem).

## Motivation and Context
The motivation for the genre change is in my library I have several broad genres like "Instrumental" or "Vocal", and with those broad categories it is common for a single album to have some instrumental tracks and some vocal tracks.  Kodi worked very well with my tagging scheme in FLAC files, but I have two AC3 (Dolby Digital) albums stored as raw bitstreams in WAV files requiring cue sheets, and I found Kodi did not allow me to tag individual track genres.  Unfortunately the actual cue sheets I've been using are apparently locked up on a decomissioned hard drive -- I didn't realize until tonight they didn't survive the most recent NAS migration, but I think I can dig them up if there's interest.

The motivation for the comment change came from [Star Wars: A Musical Journey](https://starwars.fandom.com/wiki/Star_Wars:_A_Musical_Journey), where the disc jacket has a natural Title - Subtitle flow where the subtitle listed the original tracks being mixed in the new recording (the link shows this pretty well), so I used the comment field capture the subtitle.  IIRC at the time the default skin showed the comment field in the track info screen, so it was beneficial to correctly capture the field for each track. 

## How Has This Been Tested?
Only tested locally in my library with the two cue sheets previously mentioned, but tested from Gotham through Jarvis in my primary listening system.  All use would have been on Mac, though I forget the specific OS versions (nothing from the past two years, the Mac Mini cooked itself sometime around late 2017/early 2018).

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project (I think...?)
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
