### PR TITLE
Fix double defined number within ActionIDs.h

### DIFF
--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -55,7 +55,6 @@
   25 //!< turn subtitles on/off. Can b used in videoFullScreen.xml window id=2005
 #define ACTION_NEXT_SUBTITLE \
   26 //!< switch to next subtitle of movie. Can b used in videoFullScreen.xml window id=2005
-#define ACTION_BROWSE_SUBTITLE 247 //!< Browse for subtitle. Can be used in videofullscreen
 #define ACTION_PLAYER_DEBUG 27 //!< show debug info for VideoPlayer
 #define ACTION_NEXT_PICTURE \
   28 //!< show next picture of slideshow. Can b used in slideshow.xml window id=2007
@@ -327,7 +326,7 @@
 #define ACTION_VOLUME_SET 245
 #define ACTION_TOGGLE_COMMSKIP 246
 
-#define ACTION_HDR_TOGGLE 247 //!< Toggle display HDR on/off
+#define ACTION_BROWSE_SUBTITLE 247 //!< Browse for subtitle. Can be used in videofullscreen
 
 #define ACTION_PLAYER_RESET 248 //!< Send a reset command to the active game
 
@@ -335,6 +334,8 @@
 
 #define ACTION_VIDEO_NEXT_STREAM 250 //!< Cycle video streams. Used in videofullscreen.
 #define ACTION_QUEUE_ITEM_NEXT 251 //!< used to queue an item to the next position in the playlist
+
+#define ACTION_HDR_TOGGLE 260 //!< Toggle display HDR on/off
 
 // Voice actions
 #define ACTION_VOICE_RECOGNIZE 300


### PR DESCRIPTION
## Description
Closes https://github.com/xbmc/xbmc/issues/18400

## Motivation and Context
I inadvertently duplicate it on Windows HDR commit. As the 247 was not in order, I thought it was not used.... Since they are used in different contexts, coincidentally, it seems that it has not caused issues but it is "dangerous" while it is like this.

To prevent it from happening again, it is good practice to keep the list of defines in numerical order.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
