### PR TITLE
Add offset/position support to Player.* infolabels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -469,6 +469,22 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     video.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.offset(number).Title`</b>,
+///                  \anchor Player_Offset_Title
+///                  _string_,
+///     @return The title of audio or video which has an offset `number` with respect to the currently playing item.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Offset_Title `Player.offset(number).Title`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.position(number).Title`</b>,
+///                  \anchor Player_Position_Title
+///                  _string_,
+///     @return The title of the audio or video which has an offset `number` with respect to the start of the playlist.
+///     <p>><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Position_Title `Player.position(number).Title`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`Player.Muted`</b>,
 ///                  \anchor Player_Muted
 ///                  _boolean_,
@@ -553,11 +569,43 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     @return The full path of the currently playing song or movie
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.offset(number).Folderpath`</b>,
+///                  \anchor Player_Offset_Folderpath
+///                  _string_,
+///     @return The full path of the audio or video file which has an offset `number` with respect to the currently playing item.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Offset_Folderpath `Player.offset(number).Folderpath`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.position(number).Folderpath`</b>,
+///                  \anchor Player_Position_Folderpath
+///                  _string_,
+///     @return The full path of the audio or video file which has an offset `number` with respect to the start of the playlist.
+///     <p>><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Position_Folderpath `Player.position(number).Folderpath`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`Player.FilenameAndPath`</b>,
 ///                  \anchor Player_FilenameAndPath
 ///                  _string_,
 ///     @return The full path with filename of the currently
 ///     playing song or movie
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.offset(number).FilenameAndPath`</b>,
+///                  \anchor Player_Offset_FilenameAndPath
+///                  _string_,
+///     @return The full path with filename of audio or video file which has an offset `number` with respect to the currently playing item.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Offset_FilenameAndPath `Player.offset(number).FilenameAndPath`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.position(number).FilenameAndPath`</b>,
+///                  \anchor Player_Position_FilenameAndPath
+///                  _string_,
+///     @return The full path with filename of the audio or video file which has an offset `number` with respect to the start of the playlist.
+///     <p>><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Position_FilenameAndPath `Player.position(number).FilenameAndPath`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.Filename`</b>,
@@ -566,6 +614,22 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     @return The filename of the currently playing media.
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Player_Filename `Player.Filename`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.offset(number).Filename`</b>,
+///                  \anchor Player_Offset_Filename
+///                  _string_,
+///     @return The filename of audio or video file which has an offset `number` with respect to the currently playing item.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Offset_Filename `Player.offset(number).Filename`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.position(number).Filename`</b>,
+///                  \anchor Player_Position_Filename
+///                  _string_,
+///     @return The filename of the audio or video file which has an offset `number` with respect to the start of the playlist.
+///     <p>><hr>
+///     @skinning_v19 **[New Infolabel]** \link Player_Position_Filename `Player.position(number).Filename`\endlink
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.IsInternetStream`</b>,
@@ -9963,6 +10027,21 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         return AddMultiInfo(CGUIInfo(value, 1, position)); // 1 => relative
       }
     }
+    else if (info[0].name == "player")
+    { //! @todo these two don't allow duration(foo) and also don't allow more than this number of levels...
+      if (info[1].name == "position")
+      {
+        int position = atoi(info[1].param().c_str());
+        int value = TranslatePlayerString(info[2].name); // player.position(foo).bar
+        return AddMultiInfo(CGUIInfo(value, 2, position)); // 2 => absolute (0 used for not set)
+      }
+      else if (info[1].name == "offset")
+      {
+        int position = atoi(info[1].param().c_str());
+        int value = TranslatePlayerString(info[2].name); // player.offset(foo).bar
+        return AddMultiInfo(CGUIInfo(value, 1, position)); // 1 => relative
+      }
+    }
     else if (info[0].name == "container")
     {
       if (info[1].name == "listitem" ||
@@ -10072,6 +10151,16 @@ int CGUIInfoManager::TranslateMusicPlayerString(const std::string &info) const
 int CGUIInfoManager::TranslateVideoPlayerString(const std::string& info) const
 {
   for (const infomap& i : videoplayer)
+  {
+    if (info == i.str)
+      return i.val;
+  }
+  return 0;
+}
+
+int CGUIInfoManager::TranslatePlayerString(const std::string& info) const
+{
+  for (const infomap& i : player_labels)
   {
     if (info == i.str)
       return i.val;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -174,6 +174,7 @@ private:
   int TranslateListItem(const Property& cat, const Property& prop, int id, bool container);
   int TranslateMusicPlayerString(const std::string &info) const;
   int TranslateVideoPlayerString(const std::string& info) const;
+  int TranslatePlayerString(const std::string& info) const;
   static TIME_FORMAT TranslateTimeFormat(const std::string &format);
 
   std::string GetMultiInfoLabel(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, std::string *fallback = nullptr) const;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -49,17 +49,17 @@
 #define PLAYER_SUBTITLE_DELAY        42
 #define PLAYER_AUDIO_DELAY           43
 #define PLAYER_PASSTHROUGH           44
-#define PLAYER_PATH                  45
-#define PLAYER_FILEPATH              46
+// unused 45
+// unused 46
 #define PLAYER_SEEKOFFSET            47
 #define PLAYER_PROGRESS_CACHE        48
 #define PLAYER_ITEM_ART              49
 #define PLAYER_CAN_PAUSE             50
 #define PLAYER_CAN_SEEK              51
 #define PLAYER_START_TIME            52
-#define PLAYER_TITLE                 53
+// unused 53
 #define PLAYER_ISINTERNETSTREAM      54
-#define PLAYER_FILENAME              55
+// unused 55
 #define PLAYER_SEEKSTEPSIZE          56
 #define PLAYER_IS_CHANNEL_PREVIEW_ACTIVE  57
 #define PLAYER_SUPPORTS_TEMPO        58
@@ -73,6 +73,15 @@
 #define PLAYER_ICON                  66
 #define PLAYER_CUTLIST               67
 #define PLAYER_CHAPTERS              68
+// Keep player infolabels that work with offset and position together
+#define PLAYER_PATH                  81
+#define PLAYER_FILEPATH              82
+#define PLAYER_TITLE                 83
+#define PLAYER_FILENAME              84
+
+// Range of player infolabels that work with offset and position
+#define PLAYER_OFFSET_POSITION_FIRST PLAYER_PATH
+#define PLAYER_OFFSET_POSITION_LAST PLAYER_FILENAME
 
 #define WEATHER_CONDITIONS_TEXT     100
 #define WEATHER_TEMPERATURE         101

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -77,8 +77,9 @@ bool CMusicGUIInfo::InitCurrentItem(CFileItem *item)
 bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
   // For musicplayer "offset" and "position" info labels check playlist
-  if (info.GetData1() && info.m_info >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
-      info.m_info <= MUSICPLAYER_OFFSET_POSITION_LAST)
+  if (info.GetData1() && ((info.m_info >= MUSICPLAYER_OFFSET_POSITION_FIRST &&
+      info.m_info <= MUSICPLAYER_OFFSET_POSITION_LAST) ||
+      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
     return GetPlaylistInfo(value, info);
 
   const CMusicInfoTag* tag = item->GetMusicInfoTag();

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -87,8 +87,9 @@ bool CVideoGUIInfo::InitCurrentItem(CFileItem *item)
 bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const
 {
   // For videoplayer "offset" and "position" info labels check playlist
-  if (info.GetData1() && info.m_info >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
-      info.m_info <= VIDEOPLAYER_OFFSET_POSITION_LAST)
+  if (info.GetData1() && ((info.m_info >= VIDEOPLAYER_OFFSET_POSITION_FIRST &&
+      info.m_info <= VIDEOPLAYER_OFFSET_POSITION_LAST) ||
+      (info.m_info >= PLAYER_OFFSET_POSITION_FIRST && info.m_info <= PLAYER_OFFSET_POSITION_LAST)))
     return GetPlaylistInfo(value, info);
 
   const CVideoInfoTag* tag = item->GetVideoInfoTag();


### PR DESCRIPTION
## Description
We currently support .offset() and .position() for MuicPlayer and VideoPlayer infolabels.

This PR adds that support to Player infolabels as well.


## How Has This Been Tested?
I've tested the new .offset() and .position() Player labels for both Music and Video, using a modified skin.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
