### PR TITLE
potential read access violation with an addon path setting

### DIFF
--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -65,9 +65,13 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
       auto source = sources->FirstChild("source");
       while (source != nullptr)
       {
-        std::string strSource = source->FirstChild()->ValueStr();
-        if (!strSource.empty())
-          m_sources.push_back(strSource);
+        auto child = source->FirstChild();
+        if (child != nullptr)
+        {
+          std::string strSource = child->ValueStr();
+          if (!strSource.empty())
+            m_sources.push_back(strSource);
+        }
 
         source = source->NextSibling("source");
       }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This fixes a potential read access violation when an add-on path setting source is empty.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Converted settings to new format and ran into this reproducible crash.
Settings similar to below would cause Kodi to crash on access, due to the empty `<source/>`
```
<?xml version="1.0" ?>
<settings version="1">
    <category help="" id="export" label="30001">
        <group id="1">
            <setting help="" id="export_path" label="30001" type="path">
                <level>0</level>
                <default/>
                <constraints>
                    <sources>
                        <source/>
                    </sources>
                    <allowempty>true</allowempty>
                </constraints>
                <control format="path" type="button">
                    <heading>30001</heading>
                </control>
            </setting>
        </group>
    </category>
</settings>

```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime, no longer crashes

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
