### PR TITLE
[Windows] Improves 'F11' key behaviour (manual HDR toggle)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1667,6 +1667,12 @@ bool CApplication::OnAction(const CAction &action)
   // Display HDR : toggle HDR on/off
   if (action.GetID() == ACTION_HDR_TOGGLE)
   {
+    // Only enables manual HDR toggle if no video is playing or auto HDR switch is disabled
+    if (m_appPlayer.IsPlayingVideo() &&
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CServiceBroker::GetWinSystem()->SETTING_WINSYSTEM_IS_HDR_DISPLAY))
+      return true;
+
     HDR_STATUS hdrStatus = CServiceBroker::GetWinSystem()->ToggleHDR();
 
     if (hdrStatus == HDR_STATUS::HDR_OFF)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -518,7 +518,13 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
   }
 
   if (!DX::Windowing()->IsHDROutput())
+  {
+    if (m_lastHdr10.RedPrimary[0] != 0)
+      m_lastHdr10 = {};
+    if (m_HdrType != HDR_TYPE::HDR_NONE_SDR)
+      m_HdrType = HDR_TYPE::HDR_NONE_SDR;
     return;
+  }
 
   // HDR10
   if (rb->color_transfer == AVCOL_TRC_SMPTE2084 && rb->primaries == AVCOL_PRI_BT2020)
@@ -579,6 +585,7 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
         DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
         m_HdrType = HDR_TYPE::HDR_NONE_SDR;
         m_iCntMetaData = 0;
+        m_lastHdr10 = {};
         if (m_AutoSwitchHDR)
           DX::Windowing()->ToggleHDR(); // Toggle display HDR OFF
       }


### PR DESCRIPTION
## Description
Improves 'F11' key behaviour (manual HDR toggle):
* In auto HDR mode (default), F11 key is disabled while a video is playing (can still be used from kodi GUI).
* In manual HDR mode is now possible toggle HDR on the fly while HDR video is playing (toggles between HDR passthrough or HDR tonemapped).

## Motivation and Context
Following PR https://github.com/xbmc/xbmc/pull/18406 indirectly has enabled option to use F11 key / `ACTION_HDR_TOGGLE` while video is playing. Previously it was not possible because `ACTION_BROWSE_SUBTITLE` intercepted the call during full screen video playback. Before, F11 key could only be used from the Kodi GUI to toggle Windows HDR switch.

Due to this limitation, it has never been used in this way and now the operation is erratic in some cases.

Now the functionality is fixed/extended so that it can be used while the video is playing (and works as expected). It only makes sense in manual mode since with auto HDR switch mode enabled it is already enabled/disabled when starting/stopping the video and e.g. manual disable would cause it to automatically re-enable.

## How Has This Been Tested?
**Auto HDR ON - Settings/Player/Use display HDR capabilities = ON  (default)**
F11 key is disabled while video is playing   (before dialog browse subtitle appears due double defined action id)
F11 key toggles Windows HDR switch from Kodi GUI    (same as before)

**Auto HDR OFF - Settings/Player/Use display HDR capabilities = OFF**
F11 key toggles between HDR passthrough or HDR tonemapped (internal Kodi processing) while video is playing  (before dialog browse subtitle appears due double defined action id)
F11 key toggles Windows HDR switch from Kodi GUI    (same as before)

The average user probably does not know (nor does he need to know) that the F11 key exists, but manual mode can be useful as a troubleshooting or to quick compare video difference between HDR passthrough / tonemapped. 

I also know that some users use F11 from the Kodi GUI just before exit Kodi because they are going to launch a game or other program that needs Windows HDR ON. It's easier to hit F11 key than to have to go into Windows display settings and change the setting there :)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
