### PR TITLE
[addons] Always check repo for add-on updates after updating repo add-on

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -11,6 +11,7 @@
 #include "FilesystemInstaller.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h" // for callback
+#include "RepositoryUpdater.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
@@ -656,6 +657,9 @@ bool CAddonInstallJob::DoWork()
   if (m_addon->HasType(ADDON_REPOSITORY))
   {
     origin = m_addon->ID(); // always set repos origin to itself
+    if (m_isUpdate)
+      CServiceBroker::GetRepositoryUpdater().CheckForUpdates(
+          std::static_pointer_cast<CRepository>(m_addon), false);
   }
   else if (m_repo)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Upon updating a repository add-on Kodi will now always check for any changes to the repo's addons.xml

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When a repository add-on updates there is a good chance that among the changes will be a change in the location of addons.xml
Eg. I'm currently about to restructure my 3rd party repo to have different folders in <dir> tags 
(for Leia, Matrix etc.) and this will involve moving most add-on zips, creating new/modifying existing addons.xml
Only the repository add-on is left in the root folder with the according addons.xml to continue to allow users to update in the future.
i.e

```
│   addons.xml
│   addons.xml.md5
│───plugin.video.example
│───plugin.video.example2   
└───repository.example
```
now becomes
```
│   addons.xml
│   addons.xml.md5
├───leia
│   │   addons.xml
│   │   addons.xml.md5
│   ├───plugin.video.example
│   ├───plugin.video.example2
│   └───repository.example
├───matrix
│   │   addons.xml
│   │   addons.xml.md5
│   ├───plugin.video.example
│   ├───plugin.video.example2
│   └───repository.example
└───repository.example
```

Currently the workflow is this:
* 6 hours pass since the last check of addons.xml
* Repository add-on is now updated to the latest version, user can now only see repository add-on in repo
* Another 6 hours pass, addons.xml is updated and user can now see full contents of repo.

After the changes in this PR the new repo contents will be available to the user straight after repository add-on update.

Many 3rd party repository maintainers will be needing to make similar updates in the coming months if they wish to have a unified repo that supports Matrix and older versions simultaneously due to the breaking xbmc.python dependency requirements. This PR will aid in the transition and make for an improved user experience. I can't think of a reason why a change to a repo's addon.xml shouldn't always trigger an update check.

One side effect of this is it will not be possible to 'downgrade' a repository add-on if it is self hosted and automatic updates are enabled as it gets updated to latest within seconds. I can't see a big use case for needing to do this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on Win10 x64.
* Install repository from zip and observe addons.xml downloaded
* Test update both ways:
  * Reinstall repository add-on from zip 
  * View repository add-on information - > Update -> select current version and install
* addons.xml.md5 is checked and addons.xml downloaded/processed

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
