### PR TITLE
[addons] fixed/reworked serialization way for addon extensions on database

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -26,7 +26,7 @@
 
 using namespace ADDON;
 
-static std::string SerializeMetadata(const CAddonInfo& addon)
+std::string CAddonDatabaseSerializer::SerializeMetadata(const CAddonInfo& addon)
 {
   CVariant variant;
   variant["author"] = addon.Author();
@@ -47,7 +47,7 @@ static std::string SerializeMetadata(const CAddonInfo& addon)
     variant["screenshots"].push_back(item);
 
   variant["extensions"] = CVariant(CVariant::VariantTypeArray);
-  variant["extensions"].push_back(ADDON::CAddonInfo::TranslateType(addon.MainType(), false));
+  variant["extensions"].push_back(SerializeExtensions(*addon.Type(addon.MainType())));
 
   variant["dependencies"] = CVariant(CVariant::VariantTypeArray);
   for (const auto& dep : addon.GetDependencies())
@@ -74,7 +74,42 @@ static std::string SerializeMetadata(const CAddonInfo& addon)
   return json;
 }
 
-static void DeserializeMetadata(const std::string& document, CAddonInfoBuilder::CFromDB& builder)
+CVariant CAddonDatabaseSerializer::SerializeExtensions(const CAddonExtensions& addonType)
+{
+  CVariant variant;
+  variant["type"] = addonType.m_point;
+
+  variant["values"] = CVariant(CVariant::VariantTypeArray);
+  for (const auto& value : addonType.m_values)
+  {
+    CVariant info(CVariant::VariantTypeObject);
+    info["id"] = value.first;
+    info["content"] = CVariant(CVariant::VariantTypeArray);
+    for (const auto& content : value.second)
+    {
+      CVariant contentEntry(CVariant::VariantTypeObject);
+      contentEntry["key"] = content.first;
+      contentEntry["value"] = content.second.str;
+      info["content"].push_back(std::move(contentEntry));
+    }
+
+    variant["values"].push_back(std::move(info));
+  }
+
+  variant["children"] = CVariant(CVariant::VariantTypeArray);
+  for (auto& child : addonType.m_children)
+  {
+    CVariant info(CVariant::VariantTypeObject);
+    info["id"] = child.first;
+    info["child"] = SerializeExtensions(child.second);
+    variant["children"].push_back(std::move(info));
+  }
+
+  return variant;
+}
+
+void CAddonDatabaseSerializer::DeserializeMetadata(const std::string& document,
+                                                   CAddonInfoBuilder::CFromDB& builder)
 {
   CVariant variant;
   if (!CJSONVariantParser::Parse(document, variant))
@@ -103,7 +138,10 @@ static void DeserializeMetadata(const std::string& document, CAddonInfoBuilder::
     screenshots.push_back(it->asString());
   builder.SetScreenshots(std::move(screenshots));
 
-  builder.SetType(CAddonInfo::TranslateType(variant["extensions"][0].asString()));
+  CAddonType addonType;
+  DeserializeExtensions(variant["extensions"][0], addonType);
+  addonType.m_type = CAddonInfo::TranslateType(addonType.m_point);
+  builder.SetExtensions(std::move(addonType));
 
   {
     std::vector<DependencyInfo> deps;
@@ -119,6 +157,37 @@ static void DeserializeMetadata(const std::string& document, CAddonInfoBuilder::
   for (auto it = variant["extrainfo"].begin_array(); it != variant["extrainfo"].end_array(); ++it)
     extraInfo.emplace((*it)["key"].asString(), (*it)["value"].asString());
   builder.SetExtrainfo(std::move(extraInfo));
+}
+
+void CAddonDatabaseSerializer::DeserializeExtensions(const CVariant& variant,
+                                                     CAddonExtensions& addonType)
+{
+  addonType.m_point = variant["type"].asString();
+
+  for (auto value = variant["values"].begin_array(); value != variant["values"].end_array();
+       ++value)
+  {
+    std::string id = (*value)["id"].asString();
+    std::vector<std::pair<std::string, SExtValue>> extValues;
+    for (auto content = (*value)["content"].begin_array();
+         content != (*value)["content"].end_array(); ++content)
+    {
+      extValues.emplace_back((*content)["key"].asString(), (*content)["value"].asString());
+    }
+
+    addonType.m_values.emplace_back(id, extValues);
+  }
+
+  for (auto child = variant["children"].begin_array(); child != variant["children"].end_array();
+       ++child)
+  {
+    CAddonExtensions childExt;
+    DeserializeExtensions((*child)["child"], childExt);
+    std::string id = (*child)["id"].asString();
+    addonType.m_children.emplace_back(id, childExt);
+  }
+
+  return;
 }
 
 CAddonDatabase::CAddonDatabase() = default;
@@ -435,7 +504,7 @@ bool CAddonDatabase::FindByAddonId(const std::string& addonId, ADDON::VECADDONS&
       builder.SetName(m_pDS->fv("name").get_asString());
       builder.SetSummary(m_pDS->fv("summary").get_asString());
       builder.SetDescription(m_pDS->fv("description").get_asString());
-      DeserializeMetadata(m_pDS->fv("metadata").get_asString(), builder);
+      CAddonDatabaseSerializer::DeserializeMetadata(m_pDS->fv("metadata").get_asString(), builder);
       builder.SetChangelog(m_pDS->fv("news").get_asString());
       builder.SetOrigin(m_pDS->fv("repoID").get_asString());
 
@@ -582,7 +651,7 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
     builder.SetName(m_pDS2->fv("name").get_asString());
     builder.SetSummary(m_pDS2->fv("summary").get_asString());
     builder.SetDescription(m_pDS2->fv("description").get_asString());
-    DeserializeMetadata(m_pDS2->fv("metadata").get_asString(), builder);
+    CAddonDatabaseSerializer::DeserializeMetadata(m_pDS2->fv("metadata").get_asString(), builder);
 
     addon = CAddonBuilder::Generate(builder.get(), ADDON_UNKNOWN);
     return addon != nullptr;
@@ -666,7 +735,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
       builder.SetSummary(m_pDS->fv("summary").get_asString());
       builder.SetDescription(m_pDS->fv("description").get_asString());
       builder.SetOrigin(m_pDS->fv("repoID").get_asString());
-      DeserializeMetadata(m_pDS->fv("metadata").get_asString(), builder);
+      CAddonDatabaseSerializer::DeserializeMetadata(m_pDS->fv("metadata").get_asString(), builder);
 
       auto addon = CAddonBuilder::Generate(builder.get(), ADDON_UNKNOWN);
       if (addon)
@@ -774,13 +843,9 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository,
       m_pDS->exec(PrepareSQL(
           "INSERT INTO addons (id, metadata, addonID, version, name, summary, description, news) "
           "VALUES (NULL, '%s', '%s', '%s', '%s','%s', '%s','%s')",
-          SerializeMetadata(*addon).c_str(),
-          addon->ID().c_str(),
-          addon->Version().asString().c_str(),
-          addon->Name().c_str(),
-          addon->Summary().c_str(),
-          addon->Description().c_str(),
-          addon->ChangeLog().c_str()));
+          CAddonDatabaseSerializer::SerializeMetadata(*addon).c_str(), addon->ID().c_str(),
+          addon->Version().asString().c_str(), addon->Name().c_str(), addon->Summary().c_str(),
+          addon->Description().c_str(), addon->ChangeLog().c_str()));
 
       int idAddon = static_cast<int>(m_pDS->lastinsertid());
       if (idAddon <= 0)

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -26,7 +26,7 @@
 
 using namespace ADDON;
 
-static std::string SerializeMetadata(const IAddon& addon)
+static std::string SerializeMetadata(const CAddonInfo& addon)
 {
   CVariant variant;
   variant["author"] = addon.Author();
@@ -47,7 +47,7 @@ static std::string SerializeMetadata(const IAddon& addon)
     variant["screenshots"].push_back(item);
 
   variant["extensions"] = CVariant(CVariant::VariantTypeArray);
-  variant["extensions"].push_back(ADDON::CAddonInfo::TranslateType(addon.Type(), false));
+  variant["extensions"].push_back(ADDON::CAddonInfo::TranslateType(addon.MainType(), false));
 
   variant["dependencies"] = CVariant(CVariant::VariantTypeArray);
   for (const auto& dep : addon.GetDependencies())
@@ -747,8 +747,10 @@ int CAddonDatabase::GetRepositoryId(const std::string& addonId)
   return m_pDS->fv("id").get_asInt();
 }
 
-bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository, const AddonVersion& version,
-    const std::string& checksum, const std::vector<AddonPtr>& addons)
+bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository,
+                                             const AddonVersion& version,
+                                             const std::string& checksum,
+                                             const std::vector<AddonInfoPtr>& addons)
 {
   try
   {

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -11,6 +11,7 @@
 #include "AddonBuilder.h"
 #include "FileItem.h"
 #include "addons/Addon.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
 #include "dbwrappers/Database.h"
 
 #include <string>
@@ -18,6 +19,28 @@
 
 namespace ADDON
 {
+
+/*!
+ * @brief Addon content serializer/deserializer.
+ *
+ * Used to save data from the add-on in the database using json format.
+ * The corresponding field in SQL is "addons" for "metadata".
+ *
+ * @warning Changes in the json format need a way to update the addon database
+ * for users, otherwise problems may occur when reading the old content.
+ */
+class CAddonDatabaseSerializer
+{
+  CAddonDatabaseSerializer() = delete;
+
+public:
+  static std::string SerializeMetadata(const CAddonInfo& addon);
+  static void DeserializeMetadata(const std::string& document, CAddonInfoBuilder::CFromDB& builder);
+
+private:
+  static CVariant SerializeExtensions(const CAddonExtensions& addonType);
+  static void DeserializeExtensions(const CVariant& document, CAddonExtensions& addonType);
+};
 
 class CAddonDatabase : public CDatabase
 {

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -45,8 +45,10 @@ public:
   /*! Returns all addons in the repositories with id `addonId`. */
   bool FindByAddonId(const std::string& addonId, ADDON::VECADDONS& addons) const;
 
-  bool UpdateRepositoryContent(const std::string& repositoryId, const ADDON::AddonVersion& version,
-      const std::string& checksum, const std::vector<ADDON::AddonPtr>& addons);
+  bool UpdateRepositoryContent(const std::string& repositoryId,
+                               const ADDON::AddonVersion& version,
+                               const std::string& checksum,
+                               const std::vector<AddonInfoPtr>& addons);
 
   int GetRepoChecksum(const std::string& id, std::string& checksum);
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -304,15 +304,6 @@ namespace ADDON
      */
     bool LoadAddonDescription(const std::string &path, AddonPtr &addon);
 
-    /*! \brief Parse a repository XML file for addons and load their descriptors
-     A repository XML is essentially a concatenated list of addon descriptors.
-     \param repo The repository info.
-     \param xml The XML document from repository.
-     \param addons [out] returned list of addons.
-     \return true if the repository XML file is parsed, false otherwise.
-     */
-    bool AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::string& xml, VECADDONS& addons);
-
     bool ServicesHasStarted() const;
 
     /*!
@@ -409,9 +400,6 @@ namespace ADDON
      *
      * @warning This should be never used from other places outside of addon
      * system directory.
-     *
-     * Currently listed call sources:
-     * - @ref CAddonInstallJob::DoWork
      */
     /*@{{{*/
 
@@ -429,8 +417,28 @@ namespace ADDON
      * @param[in] isUpdate If call becomes done on already installed addon and
      *                     update only.
      * @return True if successfully done, otherwise false
+     *
+     * Currently listed call sources:
+     * - @ref CAddonInstallJob::DoWork
      */
     bool SetAddonOrigin(const std::string& addonId, const std::string& repoAddonId, bool isUpdate);
+
+    /*!
+     * @brief Parse a repository XML file for addons and load their descriptors.
+     *
+     * A repository XML is essentially a concatenated list of addon descriptors.
+     *
+     * @param[in] repo The repository info.
+     * @param[in] xml The XML document from repository.
+     * @param[out] addons returned list of addons.
+     * @return true if the repository XML file is parsed, false otherwise.
+     *
+     * Currently listed call sources:
+     * - @ref CRepository::FetchIndex
+     */
+    bool AddonsFromRepoXML(const CRepository::DirInfo& repo,
+                           const std::string& xml,
+                           std::vector<AddonInfoPtr>& addons);
 
     /*@}}}*/
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -183,7 +183,9 @@ bool CRepository::FetchChecksum(const std::string& url,
   return true;
 }
 
-bool CRepository::FetchIndex(const DirInfo& repo, std::string const& digest, VECADDONS& addons) noexcept
+bool CRepository::FetchIndex(const DirInfo& repo,
+                             std::string const& digest,
+                             std::vector<AddonInfoPtr>& addons) noexcept
 {
   XFILE::CCurlFile http;
 
@@ -222,7 +224,7 @@ bool CRepository::FetchIndex(const DirInfo& repo, std::string const& digest, VEC
 
 CRepository::FetchStatus CRepository::FetchIfChanged(const std::string& oldChecksum,
                                                      std::string& checksum,
-                                                     VECADDONS& addons,
+                                                     std::vector<AddonInfoPtr>& addons,
                                                      int& recheckAfter) const
 {
   checksum = "";
@@ -260,7 +262,7 @@ CRepository::FetchStatus CRepository::FetchIfChanged(const std::string& oldCheck
 
   for (const auto& dirTuple : dirChecksums)
   {
-    VECADDONS tmp;
+    std::vector<AddonInfoPtr> tmp;
     if (!FetchIndex(std::get<0>(dirTuple), std::get<1>(dirTuple), tmp))
       return STATUS_ERROR;
     addons.insert(addons.end(), tmp.begin(), tmp.end());
@@ -324,7 +326,7 @@ bool CRepositoryUpdateJob::DoWork()
     oldChecksum = "";
 
   std::string newChecksum;
-  VECADDONS addons;
+  std::vector<AddonInfoPtr> addons;
   int recheckAfter;
   auto status = m_repo->FetchIfChanged(oldChecksum, newChecksum, addons, recheckAfter);
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -46,7 +46,7 @@ namespace ADDON
 
     FetchStatus FetchIfChanged(const std::string& oldChecksum,
                                std::string& checksum,
-                               VECADDONS& addons,
+                               std::vector<AddonInfoPtr>& addons,
                                int& recheckAfter) const;
 
     struct ResolveResult
@@ -60,7 +60,9 @@ namespace ADDON
     static bool FetchChecksum(const std::string& url,
                               std::string& checksum,
                               int& recheckAfter) noexcept;
-    static bool FetchIndex(const DirInfo& repo, std::string const& digest, VECADDONS& addons) noexcept;
+    static bool FetchIndex(const DirInfo& repo,
+                           std::string const& digest,
+                           std::vector<AddonInfoPtr>& addons) noexcept;
 
     static DirInfo ParseDirConfiguration(const CAddonExtensions& configuration);
 

--- a/xbmc/addons/addoninfo/AddonExtensions.h
+++ b/xbmc/addons/addoninfo/AddonExtensions.h
@@ -18,6 +18,7 @@ namespace ADDON
 {
 
 class CAddonInfoBuilder;
+class CAddonDatabaseSerializer;
 
 struct SExtValue
 {
@@ -67,6 +68,7 @@ public:
 
 private:
   friend class CAddonInfoBuilder;
+  friend class CAddonDatabaseSerializer;
 
   std::string m_point;
   EXT_VALUES m_values;

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.h
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.h
@@ -57,21 +57,19 @@ public:
     void SetExtrainfo(InfoMap extrainfo)
     {
       m_addonInfo->m_extrainfo = std::move(extrainfo);
-
-      const auto& it = m_addonInfo->m_extrainfo.find("provides");
-      if (it != m_addonInfo->m_extrainfo.end())
-      {
-        CAddonType addonType(m_addonInfo->m_mainType);
-        addonType.SetProvides(it->second);
-        m_addonInfo->m_types.push_back(addonType);
-      }
     }
-    void SetType(TYPE type) { m_addonInfo->m_mainType = type; }
     void SetInstallDate(const CDateTime& installDate) { m_addonInfo->m_installDate = installDate; }
     void SetLastUpdated(const CDateTime& lastUpdated) { m_addonInfo->m_lastUpdated = lastUpdated; }
     void SetLastUsed(const CDateTime& lastUsed) { m_addonInfo->m_lastUsed = lastUsed; }
     void SetOrigin(std::string origin) { m_addonInfo->m_origin = std::move(origin); }
     void SetPackageSize(uint64_t size) { m_addonInfo->m_packageSize = size; }
+    void SetExtensions(CAddonType addonType)
+    {
+      if (!addonType.GetValue("provides").empty())
+        addonType.SetProvides(addonType.GetValue("provides").asString());
+      m_addonInfo->m_types.push_back(std::move(addonType));
+      m_addonInfo->m_mainType = addonType.m_type;
+    }
 
     const AddonInfoPtr& get() { return m_addonInfo; }
 

--- a/xbmc/addons/addoninfo/AddonType.h
+++ b/xbmc/addons/addoninfo/AddonType.h
@@ -72,6 +72,7 @@ typedef enum
 } TYPE;
 
 class CAddonInfoBuilder;
+class CAddonDatabaseSerializer;
 
 class CAddonType : public CAddonExtensions
 {
@@ -108,6 +109,7 @@ public:
 
 private:
   friend class CAddonInfoBuilder;
+  friend class CAddonDatabaseSerializer;
 
   void SetProvides(const std::string& content);
 

--- a/xbmc/addons/test/TestAddonBuilder.cpp
+++ b/xbmc/addons/test/TestAddonBuilder.cpp
@@ -34,7 +34,8 @@ TEST_F(TestAddonBuilder, ShouldBuildDependencyAddons)
   CAddonInfoBuilder::CFromDB builder;
   builder.SetId("aa");
   builder.SetDependencies(deps);
-  builder.SetType(ADDON_UNKNOWN);
+  CAddonType addonType(ADDON_UNKNOWN);
+  builder.SetExtensions(addonType);
   AddonPtr addon = CAddonBuilder::Generate(builder.get(), ADDON_UNKNOWN);
   EXPECT_EQ(deps, addon->GetDependencies());
 }
@@ -43,7 +44,8 @@ TEST_F(TestAddonBuilder, ShouldReturnDerivedType)
 {
   CAddonInfoBuilder::CFromDB builder;
   builder.SetId("aa");
-  builder.SetType(ADDON_RESOURCE_LANGUAGE);
+  CAddonType addonType(ADDON_RESOURCE_LANGUAGE);
+  builder.SetExtensions(addonType);
   auto addon = std::dynamic_pointer_cast<CLanguageResource>(CAddonBuilder::Generate(builder.get(), ADDON_UNKNOWN));
   EXPECT_NE(nullptr, addon);
 }

--- a/xbmc/addons/test/TestAddonDatabase.cpp
+++ b/xbmc/addons/test/TestAddonDatabase.cpp
@@ -35,7 +35,7 @@ protected:
     std::set<std::string> installed{"repository.a", "repository.b"};
     database.SyncInstalled(installed, installed, std::set<std::string>());
 
-    VECADDONS addons;
+    std::vector<AddonInfoPtr> addons;
     CreateAddon(addons, "foo.bar", "1.0.0");
     database.SetRepoUpdateData("repository.a", {});
     database.UpdateRepositoryContent("repository.a", AddonVersion("1.0.0"), "test", addons);
@@ -46,13 +46,12 @@ protected:
     database.UpdateRepositoryContent("repository.b", AddonVersion("1.0.0"), "test", addons);
   }
 
-  void CreateAddon(VECADDONS& addons, std::string id, std::string version)
+  void CreateAddon(std::vector<AddonInfoPtr>& addons, std::string id, std::string version)
   {
     CAddonInfoBuilder::CFromDB builder;
     builder.SetId(id);
     builder.SetVersion(AddonVersion(version));
-    AddonPtr addon = CAddonBuilder::Generate(builder.get(), ADDON_UNKNOWN);
-    addons.push_back(addon);
+    addons.push_back(builder.get());
   }
 
   void TearDown() override

--- a/xbmc/addons/test/TestAddonInfoBuilder.cpp
+++ b/xbmc/addons/test/TestAddonInfoBuilder.cpp
@@ -129,7 +129,9 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_DBEntry)
   CAddonInfoBuilder::CFromDB builder;
   builder.SetId("video.blablabla.org");
   builder.SetVersion(AddonVersion("1.2.3"));
-  builder.SetType(ADDON_PLUGIN);
+  CAddonType addonType(ADDON_PLUGIN);
+  addonType.Insert("provides", "video audio");
+  builder.SetExtensions(addonType);
   builder.SetName("The Bla Bla Bla Addon");
   builder.SetAuthor("Team Kodi");
   builder.SetSummary("Summary bla bla bla");
@@ -141,7 +143,6 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_DBEntry)
   builder.SetEMail("a@a.dummy");
   builder.SetSource("https://github.com/xbmc/xbmc");
   InfoMap extrainfo;
-  extrainfo["provides"] = "video audio";
   extrainfo["language"] = "marsian";
   builder.SetExtrainfo(extrainfo);
 


### PR DESCRIPTION
## Description

This request is related to report from @garbear to me, with game addons the repo does not have the necessary data to identify it correctly.

This adds a way to store the complete content of the master addon type extensions in the database and to have all its content available. As if it were installed.

I'm not sure yet if everything is in the right way and maybe you still have an idea?

## User related

- Improve addon type management in addon database to use the complete content of the addon.
  - Previously, with some add-on types (e.g. game add-ons), some necessary content was not available and could not be correctly identified from the add-on repo.

Commit 1:
------------------------------
**[addons] use CAddonInfo within repo addon content scan**

This changes to the following functions from IAddon to CAddonInfo:
- CAddonManager::AddonsFromRepoXML
- CRepository::FetchIfChanged
- CRepository::FetchIndex
- CAddonDatabase::UpdateRepositoryContent
- SerializeMetadata (AddonDatabase.cpp)

The main reason is to have CAddonInfo available on "SerializeMetadata" and to have all its content available within the database (future changes).

In addition, this also has other advantages:
- The performance is significantly better because the associated addon class does not have to be created for each individual repo addon
- It is a step further to separate add-on management and usage
  - The background is that the CAddon class (and associated child class) should only be created when actually used
- Adjusted the addon manager a little to separate the contained parts into groups
  - The aim is to have a clearer overview in the addon manager which parts are used externally and which parts are only used internally for management

It is easy to contribute to this, since this chain of use is not very cross-branched.

Commit 2:
------------------------------
**[addons] add reworked serialization way for addon extensions on database**

This changes the way the field of the addon.xml of `<extensions point="addon_type_name">...</extension>` is stored in the database.

Previously, only the addon type string was stored as "extension" in json and any sub-data was stored separately under "extrainfo". This makes it difficult to process more complex data.

This introduces a way to save the complete extension's in a json format and when reading all the data of the main addon type is available.

**WARNING:**
A way has to be introduced in order to update the add-on database appropriately, otherwise the content of the previous version is no longer visible in Kodi.
As a temporary test way, the old "Addons32.db" can be deleted so that it is recreated.

Commit 3:
------------------------------
**[addons] update database table to ver. 33 and add update point**

This increases the database version to 33 and adds an update call to change the "metadata" in json format.

The problem with game addons has not yet been resolved directly with this database update, only the old format is converted to the new one (and parts are missing).

Only when the regular update process is carried out will the content be converted to the new type.

Commit 4:
------------------------------
**[addons] fix database wrong handle to change "broken" to new "lifecycledesc"**

Before was there in database the "broken" value from json checked for presence only.
As them sould always present was every addon marked as broken.

This now done by database update and changed to current types.

Also is a fix call added to change previous changed database and have correct again.

This error was brought by me on https://github.com/xbmc/xbmc/pull/18438

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Here example how new stored as json in database (the line with `children` there):
```json
{
  "art":{
    "fanart":"http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/fanart.jpg"
  },
  "author":"SiLVO","broken":"",
  "dependencies":[
    {"addonId":"xbmc.gui","minversion":"5.15.0","optional":false,"version":"5.15.0"},
    {"addonId":"script.skinshortcuts","minversion":"1.0.10","optional":false,"version":"1.0.10"},
    {"addonId":"service.library.data.provider","minversion":"0.0.7","optional":false,"version":"0.0.7"},
    {"addonId":"resource.images.studios.white","minversion":"0.0.1","optional":false,"version":"0.0.1"},
    {"addonId":"resource.images.recordlabels.white","minversion":"0.0.1","optional":false,"version":"0.0.1"}
  ],
  "disclaimer":"",
  "extensions":[
    {
      "children":[
      ],
      "type":"xbmc.gui.skin",
      "values":[
      {
        "content":[
          {"key":"@debugging","value":"false"}
        ],
        "id":""
      },
      {
        "content":[
          {"key":"res@width","value":"1920"},
          {"key":"res@height","value":"1080"},
          {"key":"res@aspect","value":"16:9"},
          {"key":"res@default","value":"true"},
          {"key":"res@folder","value":"16x9"}
        ],
        "id":"res"
      }]
    }
  ],
  "extrainfo":[
  ],
  "icon":"http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/icon.png",
  "path":"https://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/skin.aeon.nox.silvo-7.9.6.zip",
  "screenshots":[
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-01.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-02.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-03.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-04.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-05.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-06.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-07.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-08.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-09.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-10.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-11.jpg",
    "http://mirrors.kodi.tv/addons/matrix/skin.aeon.nox.silvo/resources/screenshots/screenshot-12.jpg"
  ],
  "size":51818074
}
```
It becomes a json part added about.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
