### PR TITLE
[estouchy] replace AddonBroken with AddonLifecycleType(Desc) infolabels

### DIFF
--- a/addons/skin.estouchy/xml/DialogAddonInfo.xml
+++ b/addons/skin.estouchy/xml/DialogAddonInfo.xml
@@ -193,7 +193,7 @@
 					<aligny>center</aligny>
 					<font>font20_title</font>
 					<textcolor>selected</textcolor>
-					<visible>String.IsEmpty(ListItem.AddonBroken)</visible>
+					<visible>String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24169])</visible>
 				</control>
 				<control type="textbox">
 					<description>Disclaimer</description>
@@ -205,7 +205,7 @@
 					<label fallback="231">$INFO[ListItem.AddonDisclaimer]</label>
 					<textcolor>selected</textcolor>
 					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
-					<visible>String.IsEmpty(ListItem.AddonBroken)</visible>
+					<visible>String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24169])</visible>
 				</control>
 				<control type="label">
 					<description>Broken label</description>
@@ -214,11 +214,24 @@
 					<width>200</width>
 					<height>25</height>
 					<font>font20_title</font>
-					<label>$LOCALIZE[24098]:</label>
+					<label>$LOCALIZE[24171]:</label>
 					<align>right</align>
 					<aligny>center</aligny>
 					<textcolor>selected</textcolor>
-					<visible>!String.IsEmpty(ListItem.AddonBroken)</visible>
+					<visible>String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])</visible>
+				</control>
+				<control type="label">
+					<description>Deprecated label</description>
+					<posx>200</posx>
+					<posy>120</posy>
+					<width>200</width>
+					<height>25</height>
+					<font>font20_title</font>
+					<label>$LOCALIZE[24170]:</label>
+					<align>right</align>
+					<aligny>center</aligny>
+					<textcolor>selected</textcolor>
+					<visible>String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170])</visible>
 				</control>
 				<control type="textbox">
 					<description>Reason label</description>
@@ -227,12 +240,11 @@
 					<width>730</width>
 					<height>50</height>
 					<font>font20</font>
-					<label>$INFO[ListItem.Addonbroken]</label>
+					<label>$INFO[ListItem.AddonLifecycleDesc]</label>
 					<align>left</align>
-					<aligny>center</aligny>
 					<textcolor>selected</textcolor>
 					<autoscroll time="2000" delay="3000" repeat="5000">true</autoscroll>
-					<visible>!String.IsEmpty(ListItem.AddonBroken)</visible>
+					<visible>String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170]) | String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])</visible>
 				</control>
 			</control>
 		</control>
@@ -275,6 +287,7 @@
 				<align>left</align>
 				<include>ButtonInfoDialogsCommonValues</include>
 				<label>21340</label>
+				<textwidth>150</textwidth>
 			</control>
 			<control type="button" id="12">
 				<description>Changelog button</description>

--- a/addons/skin.estouchy/xml/ViewsWide.xml
+++ b/addons/skin.estouchy/xml/ViewsWide.xml
@@ -730,7 +730,7 @@
 					<posy>45</posy>
 					<width>840</width>
 					<height>20</height>
-					<font>font20</font>
+					<font>font24</font>
 					<selectedcolor>selected</selectedcolor>
 					<align>left</align>
 					<aligny>center</aligny>
@@ -741,18 +741,11 @@
 					<posy>7</posy>
 					<width>870</width>
 					<height>30</height>
-					<font>font20</font>
+					<font>font24</font>
 					<selectedcolor>selected</selectedcolor>
 					<align>right</align>
 					<aligny>center</aligny>
 					<label>$INFO[ListItem.AddonVersion]$INFO[ListItem.Property(Addon.Status), - ]</label>
-				</control>
-				<control type="image">
-					<posx>40r</posx>
-					<posy>20</posy>
-					<width>30</width>
-					<height>30</height>
-					<texture>$INFO[ListItem.Overlay]</texture>
 				</control>
 				<control type="textbox">
 					<posx>250</posx>
@@ -761,7 +754,7 @@
 					<height>145</height>
 					<font>font25</font>
 					<align>justify</align>
-					<label>$INFO[ListItem.AddonBroken,[COLOR=blue][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDisclaimer,[COLOR=blue][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDescription]</label>
+					<label>$INFO[ListItem.AddonLifecycleDesc,[COLOR=selected][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDisclaimer,[COLOR=blue][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDescription]</label>
 				</control>
 			</itemlayout>
 			<focusedlayout condition="Container.Content(Addons)" height="240" width="$PARAM[panel-width]">
@@ -796,7 +789,7 @@
 					<posy>45</posy>
 					<width>840</width>
 					<height>20</height>
-					<font>font20</font>
+					<font>font24</font>
 					<selectedcolor>selected</selectedcolor>
 					<align>left</align>
 					<aligny>center</aligny>
@@ -807,18 +800,11 @@
 					<posy>7</posy>
 					<width>870</width>
 					<height>30</height>
-					<font>font20</font>
+					<font>font24</font>
 					<selectedcolor>selected</selectedcolor>
 					<align>right</align>
 					<aligny>center</aligny>
 					<label>$INFO[ListItem.AddonVersion]$INFO[ListItem.Property(Addon.Status), - ]</label>
-				</control>
-				<control type="image">
-					<posx>40r</posx>
-					<posy>20</posy>
-					<width>30</width>
-					<height>30</height>
-					<texture>$INFO[ListItem.Overlay]</texture>
 				</control>
 				<control type="textbox">
 					<posx>250</posx>
@@ -827,7 +813,7 @@
 					<height>145</height>
 					<font>font25</font>
 					<align>justify</align>
-					<label>$INFO[ListItem.AddonBroken,[COLOR=blue][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDisclaimer,[COLOR=blue][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDescription]</label>
+					<label>$INFO[ListItem.AddonLifecycleDesc,[COLOR=selected][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDisclaimer,[COLOR=blue][B],[/B][/COLOR][CR]]$INFO[ListItem.AddonDescription]</label>
 					<autoscroll delay="2000" time="2000" repeat="2000">True</autoscroll>
 				</control>
 			</focusedlayout>


### PR DESCRIPTION
## Description
in https://github.com/xbmc/xbmc/pull/18286 two new infolabels (ListItem.AddonLifecycleType / ListItem.AddonLifecycleDesc) were added that replace the ListItem.AddonBroken infolabel.

this updates the Estouchy skin for that change.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
