### PR TITLE
[Music][guiinfo] Add new MusicPlayer infolabel and boolean

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2593,6 +2593,22 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     @skinning_v19 **[New Infolabel]** \link MusicPlayer_BPM `MusicPlayer.BPM`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`MusicPlayer.IsMultiDisc`</b>,
+///                  \anchor MusicPlayer_IsMultiDisc
+///                  _boolean_,
+///     @return Returns **true** if the album currently playing has more than one disc.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link MusicPlayer_IsMultiDisc `MusicPlayer.IsMultiDisc`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`MusicPlayer.TotalDiscs`</b>,
+///                  \anchor MusicPlayer_TotalDiscs
+///                  _string_,
+///     @return The number of discs associated with the currently playing album.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link MusicPlayer_TotalDiscs `MusicPlayer.TotalDiscs`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
@@ -2636,7 +2652,9 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
                                   { "property",         MUSICPLAYER_PROPERTY },
                                   { "releasedate",      MUSICPLAYER_RELEASEDATE },
                                   { "originaldate",     MUSICPLAYER_ORIGINALDATE },
-                                  { "bpm",              MUSICPLAYER_BPM }
+                                  { "bpm",              MUSICPLAYER_BPM },
+                                  { "ismultidisc",      MUSICPLAYER_ISMULTIDISC },
+                                  { "totaldiscs",       MUSICPLAYER_TOTALDISCS }
 };
 
 /// \page modules__infolabels_boolean_conditions

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -198,12 +198,14 @@
 #define MUSICPLAYER_CHANNEL_NAME    237
 #define MUSICPLAYER_CHANNEL_GROUP   238
 #define MUSICPLAYER_CHANNEL_NUMBER  239
+#define MUSICPLAYER_TOTALDISCS      240
 // Musicplayer infobools
-#define MUSICPLAYER_HASPREVIOUS     240
-#define MUSICPLAYER_HASNEXT         241
-#define MUSICPLAYER_EXISTS          242
-#define MUSICPLAYER_PLAYLISTPLAYING 243
-#define MUSICPLAYER_CONTENT         244
+#define MUSICPLAYER_HASPREVIOUS     241
+#define MUSICPLAYER_HASNEXT         242
+#define MUSICPLAYER_EXISTS          243
+#define MUSICPLAYER_PLAYLISTPLAYING 244
+#define MUSICPLAYER_CONTENT         245
+#define MUSICPLAYER_ISMULTIDISC     246
 
 // Keep videoplayer infolabels that work with offset and position together
 #define VIDEOPLAYER_TITLE             250

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -145,6 +145,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
           return true;
         }
         break;
+      case MUSICPLAYER_TOTALDISCS:
       case LISTITEM_TOTALDISCS:
         value = StringUtils::Format("%i", tag->GetTotalDiscs());
         return true;
@@ -573,6 +574,9 @@ bool CMusicGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
 
 bool CMusicGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const
 {
+  const CFileItem* item = static_cast<const CFileItem*>(gitem);
+  const CMusicInfoTag* tag = item->GetMusicInfoTag();
+
   switch (info.m_info)
   {
     ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -619,7 +623,13 @@ bool CMusicGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
       value = (index >= 0 && index < CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC).size());
       return true;
     }
-
+    case MUSICPLAYER_ISMULTIDISC:
+      if (tag)
+      {
+        value = (item->GetMusicInfoTag()->GetTotalDiscs() > 1);
+        return true;
+      }
+      break;
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // MUSICPM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -631,8 +641,6 @@ bool CMusicGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
     // LISTITEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case LISTITEM_IS_BOXSET:
-      const CFileItem* item = static_cast<const CFileItem*>(gitem);
-      const CMusicInfoTag* tag = item->GetMusicInfoTag();
       if (tag)
       {
         value = item->GetMusicInfoTag()->GetBoxset() == true;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -445,6 +445,7 @@ void CMusicDatabase::CreateViews()
               "        iSampleRate, "
               "        iChannels, "
               "        album.iAlbumDuration AS iAlbumDuration, "
+              "        album.iDiscTotal as iDiscTotal, "
               "        song.dateAdded as dateAdded, "
               "        song.dateNew AS dateNew, "
               "        song.dateModified AS dateModified "
@@ -2832,6 +2833,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   ReplayGain replaygain;
   replaygain.Set(record->at(song_strReplayGain).get_asString());
   item->GetMusicInfoTag()->SetReplayGain(replaygain);
+  item->GetMusicInfoTag()->SetTotalDiscs(record->at(song_iDiscTotal).get_asInt());
 
   item->GetMusicInfoTag()->SetLoaded(true);
   // Get filename with full path
@@ -8598,7 +8600,7 @@ void CMusicDatabase::UpdateTables(int version)
 
 int CMusicDatabase::GetSchemaVersion() const
 {
-  return 80;
+  return 81; // Bump version to add iDisctotal to songview for MusicPlayer infolabel and boolean
 }
 
 int CMusicDatabase::GetMusicNeedsTagScan()

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -831,6 +831,7 @@ private:
     song_iSampleRate,
     song_iChannels,
     song_iAlbumDuration,
+    song_iDiscTotal,
     song_dateAdded,
     song_dateNew,
     song_dateModified,


### PR DESCRIPTION
## Description
Add new `MusicPlayer.IsMultiDisc` boolean and `MusicPlayer.TotalDiscs` infolabel as discussed on slack.

Music db version bumped as songview view modified

## Motivation and Context
Provides a method for skinners to hide the disc number in the musicvisualisation window if the album only consists of a single disc.  Can also be used to display f.e `Disc 3 of 5`

## How Has This Been Tested?
Tested with a modified skin to display the number of discs belonging to an album if `MusicPlayer.IsMultiDisc` was true, else to just display the text `Single disc album`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
