### PR TITLE
[vfs][addons][audiodecoder] continue addon search if open of extension failed

### DIFF
--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -20,20 +20,21 @@
 #if defined(TARGET_ANDROID)
 #include "platform/android/filesystem/APKDirectory.h"
 #endif
-#include "XbtDirectory.h"
-#include "ZipDirectory.h"
-#include "SmartPlaylistDirectory.h"
-#include "playlists/SmartPlayList.h"
-#include "PlaylistFileDirectory.h"
-#include "playlists/PlayListFactory.h"
+#include "AudioBookFileDirectory.h"
 #include "Directory.h"
 #include "FileItem.h"
-#include "utils/StringUtils.h"
-#include "URL.h"
+#include "PlaylistFileDirectory.h"
 #include "ServiceBroker.h"
+#include "SmartPlaylistDirectory.h"
+#include "URL.h"
+#include "XbtDirectory.h"
+#include "ZipDirectory.h"
 #include "addons/AudioDecoder.h"
 #include "addons/VFSEntry.h"
-#include "AudioBookFileDirectory.h"
+#include "playlists/PlayListFactory.h"
+#include "playlists/SmartPlayList.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
 
 using namespace ADDON;
 using namespace XFILE;
@@ -66,7 +67,11 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
           if (!result->CreateDecoder() || !result->ContainsFiles(url))
           {
             delete result;
-            return nullptr;
+            CLog::Log(LOGINFO,
+                      "CFileDirectoryFactory::{}: Addon '{}' support extension '{}' but creation "
+                      "failed (seems not supported), trying other addons and Kodi",
+                      __func__, addonInfo->ID(), strExtension);
+            continue;
           }
           return result;
         }


### PR DESCRIPTION
## Description
This thought for the case that a addon tried with a extension where can also be on other types.

Before has it exited the function and no further search to find process part.

The error and fix specially visible by *.iso's and use of audiodecoder.sacd with vfs.libarchive (where iso support added).

Before has it called the audiodecoder where fails on a normal file ISO and returned the scan function as unsupported.
With this change here is the search continued and try then also with other addons and with Kodi's own VFS support.

## User related:
- If the audio decoder start fails, try to find its supported file extensions on other addons or Kodi.
  - Previously the search for audio decoders was interrupted if it supported the ending but failed to open.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
Related to request here on vfs.libarchive: https://github.com/xbmc/vfs.libarchive/pull/40

Before with vfs.sacd was it not so easy (but maybe also possible :thinking:), but with audiodecoder.sacd them are a bit independent and then allow with here to play a SACD iso and also to open a normal files ISO.

ping @zach-morris think we can become your request in :smile: 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
With audiodecoder.sacd and vfs.libarchive and open of several ISO's.

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
