### PR TITLE
[addons][language] fix crash if selected language addon no more present 

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -668,7 +668,7 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   if (!addonMgr.GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, true))
   {
     if (!addonMgr.IsAddonInstalled(language) ||
-        (addonMgr.IsAddonDisabled(addon->ID()) && !addonMgr.EnableAddon(addon->ID())))
+        (addonMgr.IsAddonDisabled(language) && !addonMgr.EnableAddon(language)))
     {
       CLog::Log(LOGWARNING,
                 "CLangInfo::{}: could not find or enable language add-on '{}', loading default...",

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -667,7 +667,8 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   // Find the chosen language add-on if it's enabled
   if (!addonMgr.GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, true))
   {
-    if (addonMgr.IsAddonDisabled(addon->ID()) && !addonMgr.EnableAddon(addon->ID()))
+    if (!addonMgr.IsAddonInstalled(language) ||
+        (addonMgr.IsAddonDisabled(addon->ID()) && !addonMgr.EnableAddon(addon->ID())))
     {
       CLog::Log(LOGWARNING,
                 "CLangInfo::{}: could not find or enable language add-on '{}', loading default...",


### PR DESCRIPTION
## Description

Found the crash while playing with addons and occurred after I deleted `~/.kodi/addons/resource.language.de_de`.

This fixes the problem.

Commit 1:
------------------------------
**[addons][language] fix crash if selected language addon no more present**

Previously, if the language addon was deleted for any reason, Kodi crashed on startup.

This adds a check that the add-on is actually there.

Here the backtrace about crash before:
```
#0  CLangInfo::SetLanguage (this=0x55555ad37eb0, language="resource.language.de_de", reloadServices=false) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/LangInfo.cpp:670
#1  0x0000555557ad51eb in CApplication::LoadLanguage (this=0x55555ad34c20, reload=false) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/Application.cpp:4915
#2  0x0000555557abdbd0 in CApplication::Initialize (this=0x55555ad34c20) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/Application.cpp:737
#3  0x0000555557635500 in XBMC_Run (renderGUI=true, params=...) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/platform/xbmc.cpp:46
#4  0x0000555556e0b08c in main (argc=1, argv=0x7fffffffdf38) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/platform/posix/main.cpp:77
```

Commit 2:
------------------------------
**[addons][language] don't use CAddon class if GetAddon returned false**

Before has it after failed `GetAddon` call used the `CAddon` class to get his ID and to use on other calls.

As we never know exact why `GetAddon` failed can we never sure that related class is really created.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
