### PR TITLE
[PVR] PVR Recording Year update

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -581,6 +581,16 @@ CDateTime CPVRRecording::FirstAired() const
   return m_firstAired;
 }
 
+int CPVRRecording::GetYear() const
+{
+  return m_premiered.GetYear();
+}
+
+bool CPVRRecording::HasYear() const
+{
+  return m_premiered.IsValid();
+}
+
 bool CPVRRecording::IsNew() const
 {
   return (m_iFlags & PVR_RECORDING_FLAG_IS_NEW) > 0;

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -334,6 +334,18 @@ namespace PVR
    CDateTime FirstAired() const;
 
    /*!
+    * @brief Get the premiere year of this event.
+    * @return The premiere year
+    */
+   int GetYear() const override;
+
+   /*!
+    * @brief Check if the premiere year of this event is valid
+    * @return True if the event has as valid premiere date, false otherwise
+    */
+   bool HasYear() const override;
+
+   /*!
     * @brief Check whether this recording will be flagged as new.
     * @return True if this recording will be flagged as new, false otherwise
     */

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -80,8 +80,8 @@ public:
   const std::map<std::string, std::string>& GetUniqueIDs() const;
   const std::string& GetDefaultUniqueID() const;
   bool HasUniqueID() const;
-  bool HasYear() const;
-  int GetYear() const;
+  virtual bool HasYear() const;
+  virtual int GetYear() const;
   bool HasPremiered() const;
   const CDateTime& GetPremiered() const;
   const CDateTime& GetFirstAired() const;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

PVR recordings are are mix of videos including movies, TV shows, sports and news. Video library separates movies and TV however they share code for displaying the recording year. This PR is designed to separate PVR recording display logic from the library display logic

Specifically the goal is to only display a recording year when SetYear() is used by the addon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

The change is motivated bY the following

- display the same look and feel as the EPG which only show the year when it is set by the PVR addon.
- dispaly the same look and feel as the TV Libarary which does not have a year on most TV shows
- Avoid confusion of adding a year to a TV show that a users is not expecting one

Optionally the same logic could be applied to the first air date since since most commercial movies with a premier date do not actually air in that first year but there is not as much confusion there

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

It has been tested on Windows Matrix current nightlies, Estuary skin when the year is set or not se

Because the recording tag for VIDEOPLAYER_YEAR and LISTITEM_YEAR will now be handled solely by PVRGUIInfo.cpp it will no longer is impacted by how VideoGUIInfo.cpp logic would process them

## Screenshots (if appropriate):

This is a video of the current view https://youtu.be/oJZJ97WIhco and this is after the proposed change https://youtu.be/lF8j6XgxVMEIt

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
