### PR TITLE
[addons][filesystem] fix windows build about his RemoveDirectory macro

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -28,6 +28,9 @@ typedef intptr_t ssize_t;
 #ifdef DeleteFile
 #undef DeleteFile
 #endif // DeleteFile
+#ifdef RemoveDirectory
+#undef RemoveDirectory
+#endif // RemoveDirectory
 #endif // _WIN32
 
 #ifdef TARGET_POSIX // Linux, Mac, FreeBSD

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -59,7 +59,7 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h" \
                                                       "c-api/audio_engine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.5"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.1.6"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.1.0"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h" \


### PR DESCRIPTION
## Description

As there is a API function about "RemoveDirectory" becomes it in conflict with Windows if used.

This error then come:
```
error C2039: 'RemoveDirectoryW': is not a member of 'kodi::vfs'
```

This add like for the others a `#undef`macro to prevent this.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
