### PR TITLE
[Estuary] display AddonLifecycleDesc

### DIFF
--- a/addons/skin.estuary/xml/AddonBrowser.xml
+++ b/addons/skin.estuary/xml/AddonBrowser.xml
@@ -30,14 +30,14 @@
 						<texture colordiffuse="AAFFFFFF">colors/black.png</texture>
 					</control>
 					<control type="textbox">
-						<left>85</left>
+						<left>75</left>
 						<top>110</top>
-						<width>425</width>
+						<width>450</width>
 						<height>470</height>
 						<align>center</align>
 						<aligny>center</aligny>
 						<label>$VAR[AddonLifecycleType]</label>
-						<font>font36_title</font>
+						<font>font32_title</font>
 					</control>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/DialogAddonInfo.xml
+++ b/addons/skin.estuary/xml/DialogAddonInfo.xml
@@ -222,14 +222,14 @@
 						<texture colordiffuse="AAFFFFFF">colors/black.png</texture>
 					</control>
 					<control type="textbox">
-						<left>34</left>
+						<left>25</left>
 						<top>24</top>
-						<width>460</width>
+						<width>478</width>
 						<height>500</height>
 						<align>center</align>
 						<aligny>center</aligny>
 						<label>$VAR[AddonLifecycleType]</label>
-						<font>font36_title</font>
+						<font>font32_title</font>
 					</control>
 				</control>
 				<control type="image">

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -161,8 +161,8 @@
 		<value>$LOCALIZE[16018]</value>
 	</variable>
 	<variable name="AddonLifecycleType">
-		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170])">$LOCALIZE[24049]</value> <!-- Deprecated -->
-		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])">$LOCALIZE[24096]</value> <!-- Broken -->
+		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170])">[COLOR button_focus]$LOCALIZE[24170][/COLOR][CR]$INFO[ListItem.AddonLifecycleDesc]</value> <!-- Deprecated -->
+		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])">[COLOR button_focus]$LOCALIZE[24171][/COLOR][CR]$INFO[ListItem.AddonLifecycleDesc]</value> <!-- Broken -->
 	</variable>
 	<variable name="AddonsListIconVar">
 		<value condition="[String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170]) | String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])] + !ListItem.Property(addon.isenabled)">icons/addonstatus/disable.png</value>


### PR DESCRIPTION
## Description
in https://github.com/xbmc/xbmc/pull/18286, a new infolabel was added `ListItem.AddonLifecycleDesc`
this infolabel wasn't used in Estuary, so users were not informed of the reason why an addon is broken or deprecated.


## Motivation and Context
as requested by @AlwinEsch 

## How Has This Been Tested?
tested in Estuary, by adding `<lifecyclestate type="deprecated">Some Text about why this addon is no longer needed</lifecyclestate>` to the addon.xml file of a test addon.

## Screenshots (if appropriate):

before:
![before](https://user-images.githubusercontent.com/687265/93465141-a3a8b600-f8ea-11ea-9593-7d646aeede1a.jpg)

after:
![after](https://user-images.githubusercontent.com/687265/93465161-ab685a80-f8ea-11ea-894b-0468e2f48bc6.jpg)

after (addoninfo dialog):
![after-info](https://user-images.githubusercontent.com/687265/93465189-b58a5900-f8ea-11ea-9479-47800db54021.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
