### PR TITLE
[addons] fix: override empty addon origin to find dependencies from parent repo

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -817,7 +817,13 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
           RepositoryPtr repoForDep;
           AddonPtr dependencyToInstall;
 
-          if (!addonRepos.FindDependency(addonID, m_addon, dependencyToInstall, repoForDep))
+          // origin of m_addon is empty at least if an addon is installed for the first time
+          // we need to override "parentRepoId" in this case
+
+          const std::string& parentRepoId =
+              m_addon->Origin().empty() ? repo->ID() : m_addon->Origin();
+
+          if (!addonRepos.FindDependency(addonID, parentRepoId, dependencyToInstall, repoForDep))
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[{}]: failed to find dependency {}", m_addon->ID(),
                       addonID);

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -424,7 +424,7 @@ void CAddonRepos::GetLatestAddonVersionsFromAllRepos(
 }
 
 bool CAddonRepos::FindDependency(const std::string& dependsId,
-                                 const std::shared_ptr<IAddon>& parent,
+                                 const std::string& parentRepoId,
                                  std::shared_ptr<IAddon>& dependencyToInstall,
                                  std::shared_ptr<CRepository>& repoForDep) const
 {
@@ -452,7 +452,7 @@ bool CAddonRepos::FindDependency(const std::string& dependsId,
   {
     // If we didn't find an official version of this dependency
     // ...we check in the origin repo of the parent
-    if (!FindDependencyByParentRepo(dependsId, parent, dependencyToInstall))
+    if (!FindDependencyByParentRepo(dependsId, parentRepoId, dependencyToInstall))
       return false;
   }
 
@@ -464,9 +464,8 @@ bool CAddonRepos::FindDependency(const std::string& dependsId,
 
   repoForDep = std::static_pointer_cast<CRepository>(tmp);
 
-  CLog::Log(LOGDEBUG,
-            "ADDONS: found dependency [{}] for install/update from repo [{}]. dependee is [{}]",
-            dependencyToInstall->ID(), repoForDep->ID(), parent->ID());
+  CLog::Log(LOGDEBUG, "ADDONS: found dependency [{}] for install/update from repo [{}]",
+            dependencyToInstall->ID(), repoForDep->ID());
 
   if (dependencyToInstall->HasType(ADDON_REPOSITORY))
   {
@@ -481,10 +480,10 @@ bool CAddonRepos::FindDependency(const std::string& dependsId,
 }
 
 bool CAddonRepos::FindDependencyByParentRepo(const std::string& dependsId,
-                                             const std::shared_ptr<IAddon>& parent,
+                                             const std::string& parentRepoId,
                                              std::shared_ptr<IAddon>& dependencyToInstall) const
 {
-  const auto& repoEntry = m_latestVersionsByRepo.find(parent->Origin());
+  const auto& repoEntry = m_latestVersionsByRepo.find(parentRepoId);
   if (repoEntry != m_latestVersionsByRepo.end())
   {
     if (GetLatestVersionByMap(dependsId, repoEntry->second, dependencyToInstall))

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -146,27 +146,27 @@ public:
    *        If the dependency cannot be found in official versions we look in the
    *        installing/updating addon's (the parent's) origin repository
    * \param dependsId addon id of the dependency we're looking for
-   * \param parent addon that is the dependee / parent
+   * \param parentRepoId origin repository of the dependee
    * \param [out] dependencyToInstall pointer to the found dependency, only use
    *              if function returns true
    * \param [out] repoForDep the repository that dependency will install from finally
    * \return true if the dependency was found, false otherwise
    */
   bool FindDependency(const std::string& dependsId,
-                      const std::shared_ptr<IAddon>& parent,
+                      const std::string& parentRepoId,
                       std::shared_ptr<IAddon>& dependencyToInstall,
                       std::shared_ptr<CRepository>& repoForDep) const;
 
   /*!
    * \brief Find a dependency addon in the repository of its parent
    * \param dependsId addon id of the dependency we're looking for
-   * \param parent addon that is the dependee / parent
+   * \param parentRepoId origin repository of the dependee
    * \param [out] dependencyToInstall pointer to the found dependency, only use
    *              if function returns true
    * \return true if the dependency was found, false otherwise
    */
   bool FindDependencyByParentRepo(const std::string& dependsId,
-                                  const std::shared_ptr<IAddon>& parent,
+                                  const std::string& parentRepoId,
                                   std::shared_ptr<IAddon>& dependencyToInstall) const;
 
 private:


### PR DESCRIPTION
## Description
Origin property of an addon is empty at least if it is installed for the first time.
Dependencies that live in the same repo cannot be found in this case.
The repository needs to be explicitly set on install.

## How Has This Been Tested?
local installation on debian
installed addon: `plugin.audio.au.radio` of repo: `repository.slyguy` 

the addon installed properly and fetched its dependencies:
```
DEBUG <general>: ADDONS: found dependency [script.module.slyguy] for install/update from repo [repository.slyguy]. dependee is [plugin.audio.au.radio]
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@matthuisman thanks for reporting and maybe you would like to test this