### PR TITLE
Video-RefClock: Fix computation

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -248,8 +248,8 @@ int CDVDClock::UpdateFramerate(double fps, double* interval /*= NULL*/)
   //set the speed of the videoreferenceclock based on fps, refreshrate and maximum speed adjust set by user
   if (m_maxspeedadjust > 0.05)
   {
-    if (weight / MathUtils::round_int(weight) < 1.0 + m_maxspeedadjust / 200.0
-    &&  weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 200.0)
+    if (weight / MathUtils::round_int(weight) < 1.0 + m_maxspeedadjust / 100.0 &&
+      weight / MathUtils::round_int(weight) > 1.0 - m_maxspeedadjust / 100.0)
       weight = MathUtils::round_int(weight);
   }
   double speed = (rate * 2.0 ) / (fps * weight);


### PR DESCRIPTION
The given computation of the speed up results in 1.0 when speed up would be larger or  equal than 2.5 %.
This broke especially playback of 23.976 fps content at 25 / 50 hz. Allow that again.