### PR TITLE
[VideoPlayer] Don't pause audio stream when video stream is reporting a stillframe state

### DIFF
--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -95,6 +95,7 @@ public:
   virtual int GetVideoBitrate() = 0;
   virtual void SetSpeed(int iSpeed) = 0;
   virtual bool IsEOS() { return false; };
+  virtual bool IsStillFrame() const { return false; }
 };
 
 class CDVDAudioCodec;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1830,9 +1830,10 @@ void CVideoPlayer::HandlePlaySpeed()
   {
     if (m_playSpeed == DVD_PLAYSPEED_NORMAL && !isInMenu)
     {
-      // take action is audio or video stream is stalled
+      // take action if audio stream is stalled or video stream is stalled (other than a stillframe condition)
       if (((m_VideoPlayerAudio->IsStalled() && m_CurrentAudio.inited) ||
-           (m_VideoPlayerVideo->IsStalled() && m_CurrentVideo.inited)) &&
+           (m_VideoPlayerVideo->IsStalled() && !m_VideoPlayerVideo->IsStillFrame() &&
+            m_CurrentVideo.inited)) &&
           m_syncTimer.IsTimePast())
       {
         if (m_pInputStream->IsRealtime())

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -61,6 +61,7 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
 
   m_bRenderSubs = false;
   m_stalled = false;
+  m_stillframe = false;
   m_paused = false;
   m_syncState = IDVDStreamPlayer::SYNC_STARTING;
   m_iSubtitleDelay = 0;
@@ -381,6 +382,7 @@ void CVideoPlayerVideo::Process()
 
         CLog::Log(LOGINFO, "CVideoPlayerVideo - Stillframe detected, switching to forced %f fps", m_fFrameRate);
         m_stalled = true;
+        m_stillframe = true;
         pts += frametime * 4;
       }
 
@@ -520,10 +522,11 @@ void CVideoPlayerVideo::Process()
       DemuxPacket* pPacket = static_cast<CDVDMsgDemuxerPacket*>(pMsg)->GetPacket();
       bool bPacketDrop = static_cast<CDVDMsgDemuxerPacket*>(pMsg)->GetPacketDrop();
 
-      if (m_stalled)
+      if (m_stalled && m_stillframe)
       {
         CLog::Log(LOGINFO, "CVideoPlayerVideo - Stillframe left, switching to normal playback");
         m_stalled = false;
+        m_stillframe = false;
       }
 
       bRequestDrop = false;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -72,6 +72,7 @@ public:
   std::string GetPlayerInfo() override;
   int GetVideoBitrate() override;
   void SetSpeed(int iSpeed) override;
+  bool IsStillFrame() const override { return m_stillframe; }
 
   // classes
   CDVDOverlayContainer* m_pOverlayContainer;
@@ -121,6 +122,7 @@ protected:
   float m_fForcedAspectRatio;
   int m_speed;
   std::atomic_bool m_stalled;
+  std::atomic_bool m_stillframe;
   std::atomic_bool m_rewindStalled;
   bool m_paused;
   IDVDStreamPlayer::ESyncState m_syncState;


### PR DESCRIPTION
## Description
This PR represents a _partial_ fix for Issues [18389](https://github.com/xbmc/xbmc/issues/18389) and [17041](https://github.com/xbmc/xbmc/issues/17041).

The Issues note that playback of MPEG-TS streams like "MusicChoice" become problematic due to the video stream consisting of nothing but still frames that are refreshed at a time period longer than Kodi is willing to tolerate, causing the audio stream to pause/unpause at regular intervals.

I believe that there are two concerns in play here.  The constant and periodic pause/resume of audio and the initial time it takes to open these streams for playback and a one-time pause in audio after the stream starts playback and needs to be tested differently.

Based on commentary in Issue [18389](https://github.com/xbmc/xbmc/issues/18389), this PR attempts to resolve the former problem -- the constant and periodic pause in the audio stream.  It does not attempt to resolve the stream startup concerns as I feel that any proposed changes there will have significantly different side-effects to general playback.

## Motivation and Context
Motivation is to partially fix these Issues without breaking anything else and get channels like MusicChoice mostly functional.  As noted above, I think the secondary Issue of stream playback start time and an initial pause event in audio playback should be treated as separate concern(s) since that will be caused by different code paths.

 Issues [18389](https://github.com/xbmc/xbmc/issues/18389) and [17041](https://github.com/xbmc/xbmc/issues/17041)

## How Has This Been Tested?
Proposed change set has been tested on Windows x64 and Linux x32 systems.  If the understanding that the possibility for slow stream playback startup as well as one initial audio pause are agreed to be unrelated, my tests have otherwise passed.  The Kodi log will still show a great deal of "Timeout waiting for buffer" messages, but playback itself will continue normally -- feedback/suggestions as to how to squelch that message would be greatly appreciated.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
