### PR TITLE
update addon listing after changing auto-update status

### DIFF
--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -81,5 +81,13 @@ namespace ADDON
     {
       explicit Unload(std::string id) : AddonEvent(std::move(id)) {}
     };
+
+    /**
+     * Emitted after the auto-update rules of the add-on has been changed.
+     */
+    struct UpdateRuleModified : AddonEvent
+    {
+      explicit UpdateRuleModified(std::string id) : AddonEvent(std::move(id)) {}
+    };
   }
 }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -879,11 +879,13 @@ bool CAddonMgr::LoadAddonDescription(const std::string &directory, AddonPtr &add
 
 bool CAddonMgr::AddUpdateRuleToList(const std::string& id, AddonUpdateRule updateRule)
 {
+  m_events.Publish(AddonEvents::UpdateRuleModified(id));
   return m_updateRules.AddUpdateRuleToList(m_database, id, updateRule);
 }
 
 bool CAddonMgr::RemoveAllUpdateRulesFromList(const std::string& id)
 {
+  m_events.Publish(AddonEvents::UpdateRuleModified(id));
   return m_updateRules.RemoveAllUpdateRulesFromList(m_database, id);
 }
 

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -289,7 +289,8 @@ void CDirectoryProvider::OnAddonEvent(const ADDON::AddonEvent& event)
         typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
         typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
         typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged))
+        typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged) ||
+        typeid(event) == typeid(ADDON::AddonEvents::UpdateRuleModified))
       m_updateState = INVALIDATED;
   }
 }


### PR DESCRIPTION
## Description
the addon listing in the addonbrowser wasn't updated after toggling the auto-update button in the addon dialog.
this resulted in incorrect icons being displayed in the addon browser.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
