### PR TITLE
[gbm] Fix check for supported broadcom modifiers

### DIFF
--- a/cmake/modules/FindLibDRM.cmake
+++ b/cmake/modules/FindLibDRM.cmake
@@ -15,7 +15,7 @@
 #   LibDRM::LibDRM   - The LibDRM library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBDRM libdrm>=2.4.82 QUIET)
+  pkg_check_modules(PC_LIBDRM libdrm>=2.4.95 QUIET)
 endif()
 
 find_path(LIBDRM_INCLUDE_DIR NAMES drm.h

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -946,6 +946,13 @@ bool plane::SupportsFormat(uint32_t format)
 
 bool plane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
 {
+  /*
+   * Some broadcom modifiers have parameters encoded which need to be
+   * masked out before comparing with reported modifiers.
+   */
+  if (modifier >> 56 == DRM_FORMAT_MOD_VENDOR_BROADCOM)
+    modifier = fourcc_mod_broadcom_mod(modifier);
+
   if (modifier == DRM_FORMAT_MOD_LINEAR)
   {
     if (!SupportsFormat(format))


### PR DESCRIPTION
## Description
The check for supported plane modifiers which was added in #17710 didn't take into account that some of the broadcom modifiers have parameters included but the driver reports allowed modifiers with those parameter bits set to zero.

eg driver reports SAND128 modifier as 0x700000000000004 (DRM_FORMAT_MOD_BROADCOM_SAND128) but the requested modifier includes the column height (eg 0x7000000000ca804 - DRM_FORMAT_MOD_BROADCOM_SAND128_COL_HEIGHT(..))

The strict comparison made the check fail and lead to non-working HEVC playback on RPi4 (as EGL import of this format isn't supported yet).

The fix is quite simple: mask out the parameter bits of broadcom modifiers before performing the comparison.

Note: this PR also includes a libdrm bump to 2.4.95 (from Oct 2018) as this adds the definitions and helper functions for broadcom SAND modifiers required by the fix.

## Motivation and Context
Make hardware decoded HEVC playback working again on RPi4.

## How Has This Been Tested?
Runtime tested on RPi4 running LibreELEC master with kodi master cdfe287bb58dfb75de8cbce591824d449dcee0c5 - both 8bit and 10bit HEVC playback worked again.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
