### PR TITLE
Fix crash when VideoPlayer ends playback related to audio passthrough (WASAPI)

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1127,11 +1127,11 @@ AEAudioFormat CActiveAE::GetInputFormat(AEAudioFormat *desiredFmt)
 
   if (m_streams.empty())
   {
-    inputFormat.m_dataFormat    = AE_FMT_FLOAT;
-    inputFormat.m_sampleRate    = 44100;
-    inputFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
-    inputFormat.m_frames        = 0;
-    inputFormat.m_frameSize     = 0;
+    inputFormat.m_dataFormat = AE_FMT_FLOAT;
+    inputFormat.m_sampleRate = m_settings.passthrough ? 48000 : 44100;
+    inputFormat.m_channelLayout = static_cast<enum AEStdChLayout>(m_settings.channels);
+    inputFormat.m_frames = 0;
+    inputFormat.m_frameSize = 0;
   }
   // force input format after unpausing slave
   else if (desiredFmt != NULL)


### PR DESCRIPTION
## Description
Fixes https://github.com/xbmc/xbmc/issues/18453

## Motivation and Context
I have been testing various solutions for some time (some more elaborate), finally I think that this one, despite being very simple, is effective in solving the issue.

In Windows I don't think it can cause any problems and I'm already testing it myself but I would like someone else to try it on other platforms/systems. I'm not sure why 44100 / 2 channels is used as a fixed default value to initialize the audio. On Windows I think that 48000 could always be used by default (on other systems I don't know).

## How Has This Been Tested?
**Before - crash:**

```
2020-09-24 10:00:22.468 T:8572     INFO <general>: CVideoPlayer::OnExit()
2020-09-24 10:00:22.469 T:8572     INFO <general>: VideoPlayer: eof, waiting for queues to empty
2020-09-24 10:00:22.469 T:8572     INFO <general>: Closing stream player 1
2020-09-24 10:00:22.469 T:8572     INFO <general>: CDVDMessageQueue(audio)::WaitUntilEmpty
2020-09-24 10:00:22.469 T:8572     INFO <general>: Waiting for audio thread to exit
2020-09-24 10:00:22.470 T:2500    ERROR <general>: Got MSGQ_ABORT or MSGO_IS_ERROR return true
2020-09-24 10:00:22.470 T:2500     INFO <general>: thread end: CVideoPlayerAudio::OnExit()
2020-09-24 10:00:22.470 T:8572     INFO <general>: Closing audio device
2020-09-24 10:00:22.598 T:8572     INFO <general>: Deleting audio codec
2020-09-24 10:00:22.598 T:8572     INFO <general>: Closing stream player 2
2020-09-24 10:00:22.598 T:8572     INFO <general>: CDVDMessageQueue(video)::WaitUntilEmpty
2020-09-24 10:00:22.598 T:8572     INFO <general>: waiting for video thread to exit
2020-09-24 10:00:22.598 T:1956    ERROR <general>: Got MSGQ_ABORT or MSGO_IS_ERROR return true
2020-09-24 10:00:22.599 T:1956     INFO <general>: thread end: video_thread
2020-09-24 10:00:22.599 T:8572     INFO <general>: deleting video codec
2020-09-24 10:00:22.605 T:8572     INFO <general>: Closing stream player 3
2020-09-24 10:00:22.609 T:9152     INFO <general>: Deleting settings information for files smb://DISKSTATION/NAS/MKV/Pitch Black (2000).mkv
2020-09-24 10:00:22.634 T:2312     INFO <general>: CVideoPlayer::CloseFile()
2020-09-24 10:00:22.635 T:2312     INFO <general>: DXVA::CDecoder::Close: closing decoder.
2020-09-24 10:00:22.636 T:2312     INFO <general>: DXVA: closing decoder context.
2020-09-24 10:00:22.642 T:2312     INFO <general>: VideoPlayer: waiting for threads to exit
2020-09-24 10:00:22.642 T:2312     INFO <general>: VideoPlayer: finished waiting
2020-09-24 10:00:22.642 T:2312     INFO <general>: CVideoPlayer::CloseFile()
2020-09-24 10:00:22.642 T:2312     INFO <general>: VideoPlayer: waiting for threads to exit
2020-09-24 10:00:22.642 T:2312     INFO <general>: VideoPlayer: finished waiting
2020-09-24 10:00:23.847 T:7376    ERROR <general>: CAESinkWASAPI::AddPackets: Endpoint Buffer timed out
2020-09-24 10:00:23.847 T:7376    ERROR <general>: CActiveAESink::OutputSamples - sink returned error
2020-09-24 10:00:23.868 T:7808    ERROR <general>: CAESinkDirectSound::GetDefaultDevice: Retrival of audio endpoint enumeration failed. - HRESULT = -2147023728 ErrorMessage = (null)
2020-09-24 10:00:23.869 T:7808     INFO <general>: No Devices found - retry: 4
2020-09-24 10:00:25.380 T:7808     INFO <general>: Found 2 Lists of Devices
2020-09-24 10:00:25.380 T:7808     INFO <general>: Enumerated DIRECTSOUND devices:
2020-09-24 10:00:25.380 T:7808     INFO <general>:     Device 1
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_deviceName      : {DA00317E-AC5A-47B7-8A1C-282431E17DCB}
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_displayName     : HDMI - DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_displayNameExtra: DIRECTSOUND: DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_channels        : FL, FR, FC, BL, BR, LFE
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_sampleRates     : 48000
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2020-09-24 10:00:25.380 T:7808     INFO <general>:     Device 2
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_deviceName      : default
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_displayName     : default
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_displayNameExtra: 
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_channels        : FL, FR, FC, BL, BR, LFE
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_sampleRates     : 48000
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2020-09-24 10:00:25.380 T:7808     INFO <general>: Enumerated WASAPI devices:
2020-09-24 10:00:25.380 T:7808     INFO <general>:     Device 1
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_deviceName      : {DA00317E-AC5A-47B7-8A1C-282431E17DCB}
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_displayName     : HDMI - DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_displayNameExtra: WASAPI: DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:00:25.380 T:7808     INFO <general>:         m_channels        : FL, FR, FC, LFE, SL, SR
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2020-09-24 10:00:25.381 T:7808     INFO <general>:     Device 2
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_deviceName      : default
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_displayName     : default
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_displayNameExtra: 
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_channels        : FL, FR, FC, LFE, SL, SR
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2020-09-24 10:00:25.381 T:7808     INFO <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2020-09-24 10:00:25.381 T:7376     INFO <general>: CActiveAESink::OpenSink - initialize sink
2020-09-24 10:00:25.417 T:7376     INFO <general>: CAESinkWASAPI::InitializeExclusive: WASAPI Exclusive Mode Sink Initialized using: AE_FMT_S24NE4MSB, 44100, 6
2020-09-24 10:00:25.417 T:7376    ERROR <general>: CActiveAEResampleFFMPEG::Init - init resampler failed
2020-09-24 10:00:25.417 T:7376    ERROR <general>: CActiveAEResampleFFMPEG::Resample - resample failed
2020-09-24 10:00:25.418 T:7808    ERROR <general>: CActiveAEResampleFFMPEG::Init - init resampler failed
****************************************** CRASH HERE ****************************************************************
```



**After - no crash:**

```
2020-09-24 10:05:54.517 T:1956     INFO <general>: CVideoPlayer::OnExit()
2020-09-24 10:05:54.517 T:1956     INFO <general>: VideoPlayer: eof, waiting for queues to empty
2020-09-24 10:05:54.517 T:1956     INFO <general>: Closing stream player 1
2020-09-24 10:05:54.517 T:1956     INFO <general>: CDVDMessageQueue(audio)::WaitUntilEmpty
2020-09-24 10:05:54.518 T:1956     INFO <general>: Waiting for audio thread to exit
2020-09-24 10:05:54.518 T:6964    ERROR <general>: Got MSGQ_ABORT or MSGO_IS_ERROR return true
2020-09-24 10:05:54.518 T:6964     INFO <general>: thread end: CVideoPlayerAudio::OnExit()
2020-09-24 10:05:54.518 T:1956     INFO <general>: Closing audio device
2020-09-24 10:05:54.597 T:1956     INFO <general>: Deleting audio codec
2020-09-24 10:05:54.597 T:1956     INFO <general>: Closing stream player 2
2020-09-24 10:05:54.597 T:1956     INFO <general>: CDVDMessageQueue(video)::WaitUntilEmpty
2020-09-24 10:05:54.597 T:1956     INFO <general>: waiting for video thread to exit
2020-09-24 10:05:54.597 T:4244    ERROR <general>: Got MSGQ_ABORT or MSGO_IS_ERROR return true
2020-09-24 10:05:54.598 T:4244     INFO <general>: thread end: video_thread
2020-09-24 10:05:54.598 T:1956     INFO <general>: deleting video codec
2020-09-24 10:05:54.604 T:1956     INFO <general>: Closing stream player 3
2020-09-24 10:05:54.607 T:5316     INFO <general>: Deleting settings information for files smb://DISKSTATION/NAS/MKV/Pitch Black (2000).mkv
2020-09-24 10:05:54.620 T:5556     INFO <general>: CVideoPlayer::CloseFile()
2020-09-24 10:05:54.621 T:5556     INFO <general>: DXVA::CDecoder::Close: closing decoder.
2020-09-24 10:05:54.621 T:5556     INFO <general>: DXVA: closing decoder context.
2020-09-24 10:05:54.627 T:5556     INFO <general>: VideoPlayer: waiting for threads to exit
2020-09-24 10:05:54.628 T:5556     INFO <general>: VideoPlayer: finished waiting
2020-09-24 10:05:54.628 T:5556     INFO <general>: CVideoPlayer::CloseFile()
2020-09-24 10:05:54.628 T:5556     INFO <general>: VideoPlayer: waiting for threads to exit
2020-09-24 10:05:54.628 T:5556     INFO <general>: VideoPlayer: finished waiting
2020-09-24 10:05:55.795 T:7508    ERROR <general>: CAESinkWASAPI::AddPackets: Endpoint Buffer timed out
2020-09-24 10:05:55.795 T:7508    ERROR <general>: CActiveAESink::OutputSamples - sink returned error
2020-09-24 10:05:55.826 T:7928    ERROR <general>: CAESinkDirectSound::GetDefaultDevice: Retrival of audio endpoint enumeration failed. - HRESULT = -2147023728 ErrorMessage = (null)
2020-09-24 10:05:55.827 T:7928     INFO <general>: No Devices found - retry: 4
2020-09-24 10:05:57.338 T:7928     INFO <general>: Found 2 Lists of Devices
2020-09-24 10:05:57.338 T:7928     INFO <general>: Enumerated DIRECTSOUND devices:
2020-09-24 10:05:57.338 T:7928     INFO <general>:     Device 1
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceName      : {DA00317E-AC5A-47B7-8A1C-282431E17DCB}
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayName     : HDMI - DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayNameExtra: DIRECTSOUND: DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_channels        : FL, FR, FC, BL, BR, LFE
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_sampleRates     : 48000
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2020-09-24 10:05:57.338 T:7928     INFO <general>:     Device 2
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceName      : default
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayName     : default
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayNameExtra: 
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_channels        : FL, FR, FC, BL, BR, LFE
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_sampleRates     : 48000
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2020-09-24 10:05:57.338 T:7928     INFO <general>: Enumerated WASAPI devices:
2020-09-24 10:05:57.338 T:7928     INFO <general>:     Device 1
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceName      : {DA00317E-AC5A-47B7-8A1C-282431E17DCB}
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayName     : HDMI - DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayNameExtra: WASAPI: DENON-AVR (2- Sonido Intel(R) para pantallas)
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_channels        : FL, FR, FC, LFE, SL, SR
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2020-09-24 10:05:57.338 T:7928     INFO <general>:     Device 2
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceName      : default
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayName     : default
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_displayNameExtra: 
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_channels        : FL, FR, FC, LFE, SL, SR
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2020-09-24 10:05:57.338 T:7928     INFO <general>:         m_streamTypes     : STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2020-09-24 10:05:57.339 T:7508     INFO <general>: CActiveAESink::OpenSink - initialize sink
2020-09-24 10:05:57.360 T:7508     INFO <general>: CAESinkWASAPI::InitializeExclusive: WASAPI Exclusive Mode Sink Initialized using: AE_FMT_S24NE4MSB, 48000, 6
2020-09-24 10:05:59.448 T:7508     INFO <general>: CActiveAESink::OpenSink - initialize sink
2020-09-24 10:05:59.462 T:7508     INFO <general>: CAESinkWASAPI::InitializeExclusive: WASAPI Exclusive Mode Sink Initialized using: AE_FMT_S24NE4MSB, 48000, 6
2020-09-24 10:06:19.493 T:5556     INFO <general>: Loading skin file: DialogButtonMenu.xml, load type: KEEP_IN_MEMORY
2020-09-24 10:06:21.219 T:5556     INFO <general>: Stopping player
2020-09-24 10:06:21.219 T:5556     INFO <general>: Storing total System Uptime
2020-09-24 10:06:21.220 T:5556     INFO <general>: Saving settings
2020-09-24 10:06:21.235 T:5556     INFO <general>: Saving skin settings
2020-09-24 10:06:21.240 T:5556     INFO <general>: Stopping all
2020-09-24 10:06:21.240 T:5556     INFO <general>: CServiceAddonManager: failed to stop service.xbmc.versioncheck (may have ended)
2020-09-24 10:06:21.317 T:5556     INFO <general>: Application stopped
2020-09-24 10:06:21.518 T:5556     INFO <general>: XBApplicationEx: destroying...
2020-09-24 10:06:21.849 T:5556     INFO <general>: unload skin
.
.
.
**************************************** NO CRASH *******************************************************************
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
