### PR TITLE
[addons] fix: add missing nullptr check in installer

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -818,10 +818,10 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
           AddonPtr dependencyToInstall;
 
           // origin of m_addon is empty at least if an addon is installed for the first time
-          // we need to override "parentRepoId" in this case
+          // we need to override "parentRepoId" if the passed in repo is valid.
 
           const std::string& parentRepoId =
-              m_addon->Origin().empty() ? repo->ID() : m_addon->Origin();
+              m_addon->Origin().empty() && repo ? repo->ID() : m_addon->Origin();
 
           if (!addonRepos.FindDependency(addonID, parentRepoId, dependencyToInstall, repoForDep))
           {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

PR 18439 https://github.com/xbmc/xbmc/pull/18439 introduced a crash on install when and addon is being installed from a zip file with dependencies that are found on a repo that also need to be installed.

This change adds a test to only use a repo value when the source is a repo

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Kodi should not crash installing addons from zip files

This was discussed with @howie-f on the Kodi Forum https://forum.kodi.tv/showthread.php?tid=357269&action=lastpost

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested using a zipped addon which worked prior to PR 18349 and doesn't crash with the fix

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
