### PR TITLE
[addons] refactoring/improvement of  pin logic and 'vectors<->map'

### DIFF
--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -74,7 +74,9 @@ public:
   bool InstallFromZip(const std::string &path);
 
    /*! Install an addon with a specific version and repository */
-  void Install(const std::string& addonId, const ADDON::AddonVersion& version, const std::string& repoId);
+  bool Install(const std::string& addonId,
+               const ADDON::AddonVersion& version,
+               const std::string& repoId);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
   Iterates through the addon's dependencies, checking they're installed or installable.
@@ -126,11 +128,15 @@ private:
   /*! \brief Install an addon from a repository or zip
    \param addon the AddonPtr describing the addon
    \param repo the repository to install addon from
-   \param background whether to install in the background or not. Defaults to true.
+   \param background whether to install in the background or not.
    \return true on successful install, false on failure.
    */
-  bool DoInstall(const ADDON::AddonPtr &addon, const ADDON::RepositoryPtr &repo,
-      bool background = true, bool modal = false, bool autoUpdate = false);
+  bool DoInstall(const ADDON::AddonPtr& addon,
+                 const ADDON::RepositoryPtr& repo,
+                 bool background,
+                 bool modal,
+                 bool autoUpdate,
+                 bool dependsInstall);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -23,6 +23,36 @@ namespace ADDON
 
 class CAddonDatabase;
 
+enum class BackgroundJob
+{
+  YES,
+  NO,
+};
+
+enum class ModalJob
+{
+  YES,
+  NO,
+};
+
+enum class AutoUpdateJob
+{
+  YES,
+  NO,
+};
+
+enum class DependencyJob
+{
+  YES,
+  NO,
+};
+
+enum class InstallModalPrompt
+{
+  PROMPT,
+  NO_PROMPT,
+};
+
 class CAddonInstaller : public IJobCallback
 {
 public:
@@ -40,16 +70,18 @@ public:
    \return true on successful install, false otherwise.
    \sa Install
    */
-  bool InstallModal(const std::string &addonID, ADDON::AddonPtr &addon, bool promptForInstall = true);
+  bool InstallModal(const std::string& addonID,
+                    ADDON::AddonPtr& addon,
+                    InstallModalPrompt promptForInstall);
 
   /*! \brief Install an addon if it is available in a repository
    \param addonID the addon ID of the item to install
-   \param background whether to install in the background or not. Defaults to true.
+   \param background whether to install in the background or not.
    \param modal whether to show a modal dialog when not installing in background
    \return true on successful install, false on failure.
    \sa DoInstall
    */
-  bool InstallOrUpdate(const std::string &addonID, bool background = true, bool modal = false);
+  bool InstallOrUpdate(const std::string& addonID, BackgroundJob background, ModalJob modal);
 
   /*! \brief Install a dependency from a specific repository
    \param dependsId the dependency to install
@@ -134,10 +166,10 @@ private:
    */
   bool DoInstall(const ADDON::AddonPtr& addon,
                  const ADDON::RepositoryPtr& repo,
-                 bool background,
-                 bool modal,
-                 bool autoUpdate,
-                 bool dependsInstall);
+                 BackgroundJob background,
+                 ModalJob modal,
+                 AutoUpdateJob autoUpdate,
+                 DependencyJob dependsInstall);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -161,7 +193,9 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr& addon, const ADDON::RepositoryPtr& repo, bool isAutoUpdate);
+  CAddonInstallJob(const ADDON::AddonPtr& addon,
+                   const ADDON::RepositoryPtr& repo,
+                   AutoUpdateJob isAutoUpdate);
 
   bool DoWork() override;
 
@@ -183,8 +217,7 @@ public:
    */
   static bool GetAddon(const std::string& addonID, ADDON::RepositoryPtr& repo, ADDON::AddonPtr& addon);
 
-  /*! Setter for m_dependsInstall */
-  void SetDependsInstall(bool dependsInstall) { m_dependsInstall = dependsInstall; };
+  void SetDependsInstall(DependencyJob dependsInstall) { m_dependsInstall = dependsInstall; };
 
 private:
   void OnPreInstall();
@@ -204,8 +237,8 @@ private:
   ADDON::AddonPtr m_addon;
   ADDON::RepositoryPtr m_repo;
   bool m_isUpdate;
-  bool m_isAutoUpdate;
-  bool m_dependsInstall = false;
+  AutoUpdateJob m_isAutoUpdate;
+  DependencyJob m_dependsInstall = DependencyJob::NO;
   const char* m_currentType = TYPE_DOWNLOAD;
 };
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -51,13 +51,14 @@ public:
    */
   bool InstallOrUpdate(const std::string &addonID, bool background = true, bool modal = false);
 
-  /*! \brief Install an addon from a specific repository
-   \param addon the addon to install
+  /*! \brief Install a dependency from a specific repository
+   \param dependsId the dependency to install
    \param repo the repository to install the addon from
    \return true on successful install, false on failure.
    \sa DoInstall
    */
-  bool InstallOrUpdate(const ADDON::AddonPtr& addon, const ADDON::RepositoryPtr& repo);
+  bool InstallOrUpdateDependency(const ADDON::AddonPtr& dependsId,
+                                 const ADDON::RepositoryPtr& repo);
 
   /*! \brief Installs a vector of addons
    \param addons the list of addons to install
@@ -182,6 +183,9 @@ public:
    */
   static bool GetAddon(const std::string& addonID, ADDON::RepositoryPtr& repo, ADDON::AddonPtr& addon);
 
+  /*! Setter for m_dependsInstall */
+  void SetDependsInstall(bool dependsInstall) { m_dependsInstall = dependsInstall; };
+
 private:
   void OnPreInstall();
   void OnPostInstall();
@@ -201,6 +205,7 @@ private:
   ADDON::RepositoryPtr m_repo;
   bool m_isUpdate;
   bool m_isAutoUpdate;
+  bool m_dependsInstall = false;
   const char* m_currentType = TYPE_DOWNLOAD;
 };
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -247,9 +247,8 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
   return result;
 }
 
-bool CAddonMgr::GetAvailableUpdatesAndOutdatedAddons(
-    std::vector<std::shared_ptr<IAddon>>& outdated,
-    std::vector<std::shared_ptr<IAddon>>& updates) const
+bool CAddonMgr::GetAddonsWithAvailableUpdate(
+    std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const
 {
   CSingleLock lock(m_critSection);
   auto start = XbmcThreads::SystemClockMillis();
@@ -258,12 +257,10 @@ bool CAddonMgr::GetAvailableUpdatesAndOutdatedAddons(
   CAddonRepos addonRepos(*this);
 
   addonRepos.LoadAddonsFromDatabase(m_database);
-
   GetAddonsForUpdate(installed);
+  addonRepos.BuildAddonsWithUpdateList(installed, addonsWithUpdate);
 
-  addonRepos.BuildUpdateAndOutdatedList(installed, updates, outdated);
-
-  CLog::Log(LOGDEBUG, "CAddonMgr::GetAvailableUpdatesAndOutdatedAddons took %i ms",
+  CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__,
             XbmcThreads::SystemClockMillis() - start);
 
   return true;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -266,6 +266,22 @@ bool CAddonMgr::GetAddonsWithAvailableUpdate(
   return true;
 }
 
+bool CAddonMgr::GetCompatibleVersions(
+    const std::string& addonId, std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const
+{
+  CSingleLock lock(m_critSection);
+  auto start = XbmcThreads::SystemClockMillis();
+
+  CAddonRepos addonRepos(*this);
+  addonRepos.LoadAddonsFromDatabase(m_database, addonId);
+  addonRepos.BuildCompatibleVersionsList(compatibleVersions);
+
+  CLog::Log(LOGDEBUG, "CAddonMgr::{} took {} ms", __func__,
+            XbmcThreads::SystemClockMillis() - start);
+
+  return true;
+}
+
 bool CAddonMgr::HasAvailableUpdates()
 {
   return !GetAvailableUpdates().empty();

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -26,6 +26,8 @@ namespace ADDON
 
   const std::string ADDON_PYTHON_EXT           = "*.py";
 
+  struct CAddonWithUpdate;
+
   /**
   * Class - IAddonMgrCallback
   * This callback should be inherited by any class which manages
@@ -448,14 +450,13 @@ namespace ADDON
     /*@}}}*/
 
     /*!
-     * \brief Fetches list of outdated addons as well as available updates and
-     *        stores them into separate vectors.
-     * \param[out] outdated target vector of outdated addons (that have updates available)
-     * \param[out] updates target vector of available updates (determined for installed add-ons)
+     * \brief Retrieves list of outdated addons as well as their related
+     *        available updates and stores them into map.
+     * \param[out] addonsWithUpdate target map
      * \return true or false
      */
-    bool GetAvailableUpdatesAndOutdatedAddons(std::vector<std::shared_ptr<IAddon>>& outdated,
-                                              std::vector<std::shared_ptr<IAddon>>& updates) const;
+    bool GetAddonsWithAvailableUpdate(
+        std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const;
 
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -458,6 +458,15 @@ namespace ADDON
     bool GetAddonsWithAvailableUpdate(
         std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const;
 
+    /*!
+     * \brief Retrieves list of compatible addon versions of all origins
+     * \param[in] addonId addon to look up
+     * \param[out] compatibleVersions target vector to be filled
+     * \return true or false
+     */
+    bool GetCompatibleVersions(const std::string& addonId,
+                               std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const;
+
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;
 

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -493,3 +493,13 @@ bool CAddonRepos::FindDependencyByParentRepo(const std::string& dependsId,
 
   return false;
 }
+
+void CAddonRepos::BuildCompatibleVersionsList(
+    std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const
+{
+  for (const auto& addon : m_allAddons)
+  {
+    if (m_addonMgr.IsCompatible(*addon))
+      compatibleVersions.emplace_back(addon);
+  }
+}

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -208,20 +208,21 @@ void CAddonRepos::BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IA
   }
 }
 
-void CAddonRepos::BuildUpdateAndOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                                             std::vector<std::shared_ptr<IAddon>>& updates,
-                                             std::vector<std::shared_ptr<IAddon>>& outdated) const
+void CAddonRepos::BuildAddonsWithUpdateList(
+    const std::vector<std::shared_ptr<IAddon>>& installed,
+    std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const
 {
   std::shared_ptr<IAddon> update;
 
-  CLog::Log(LOGDEBUG, "CAddonRepos::{}: Building combined list from installed add-ons", __func__);
+  CLog::Log(LOGDEBUG,
+            "CAddonRepos::{}: Building combined addons-with-update map from installed add-ons",
+            __func__);
 
   for (const auto& addon : installed)
   {
     if (DoAddonUpdateCheck(addon, update))
     {
-      updates.emplace_back(update);
-      outdated.emplace_back(addon);
+      addonsWithUpdate.insert({addon->ID(), {addon, update}});
     }
   }
 }

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -16,6 +16,7 @@
 namespace ADDON
 {
 
+class AddonVersion;
 class CAddonDatabase;
 class CAddonMgr;
 class CRepository;
@@ -174,6 +175,13 @@ public:
   bool FindDependencyByParentRepo(const std::string& dependsId,
                                   const std::string& parentRepoId,
                                   std::shared_ptr<IAddon>& dependencyToInstall) const;
+
+  /*!
+   * \brief Build compatible versions list based on the contents of m_allAddons
+   * \note content of m_allAddons depends on the preceding call to @ref LoadAddonsFromDatabase()
+   * \param[out] compatibleVersions target vector to be filled
+   */
+  void BuildCompatibleVersionsList(std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const;
 
 private:
   /*!

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -22,6 +22,15 @@ class CRepository;
 class IAddon;
 
 /**
+ * Struct - CAddonWithUpdate
+ */
+struct CAddonWithUpdate
+{
+  std::shared_ptr<IAddon> m_installed;
+  std::shared_ptr<IAddon> m_update;
+};
+
+/**
  * Class - CAddonRepos
  * Reads information about installed official/third party repos and their contained add-ons from the database.
  * Used to check for updates for installed add-ons and dependencies while obeying permission rules.
@@ -77,16 +86,13 @@ public:
                          std::vector<std::shared_ptr<IAddon>>& outdated) const;
 
   /*!
-   * \brief Build the list of available updates as well as outdated addons.
-   *        Stored into two separate vectors
+   * \brief Build the list of outdated addons and their available updates.
    * \param installed vector of all addons installed on the system that are
    *        checked for an update
-   * \param[out] updates list of addon versions that have an update available
-   * \param[out] outdated list of addons that are outdated
+   * \param[out] addonsWithUpdate target map
    */
-  void BuildUpdateAndOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                                  std::vector<std::shared_ptr<IAddon>>& updates,
-                                  std::vector<std::shared_ptr<IAddon>>& outdated) const;
+  void BuildAddonsWithUpdateList(const std::vector<std::shared_ptr<IAddon>>& installed,
+                                 std::map<std::string, CAddonWithUpdate>& addonsWithUpdate) const;
 
   /*!
    * \brief Checks if the origin-repository of a given addon is defined as official repo

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -161,7 +161,7 @@ class UpdateAddons : public IRunnable
   void Run() override
   {
     for (const auto& addon : CServiceBroker::GetAddonMgr().GetAvailableUpdates())
-      CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID());
+      CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), BackgroundJob::YES, ModalJob::NO);
   }
 };
 
@@ -171,7 +171,8 @@ class UpdateAllowedAddons : public IRunnable
   {
     for (const auto& addon : CServiceBroker::GetAddonMgr().GetAvailableUpdates())
       if (CServiceBroker::GetAddonMgr().IsAutoUpdateable(addon->ID()))
-        CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID());
+        CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), BackgroundJob::YES,
+                                                       ModalJob::NO);
   }
 };
 
@@ -607,7 +608,8 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE>& types,
         if (!CServiceBroker::GetAddonMgr().IsAddonInstalled(addon->ID()))
         {
           AddonPtr installedAddon;
-          if (!CAddonInstaller::GetInstance().InstallModal(addon->ID(), installedAddon, false))
+          if (!CAddonInstaller::GetInstance().InstallModal(addon->ID(), installedAddon,
+                                                           InstallModalPrompt::NO_PROMPT))
             continue;
         }
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -116,7 +116,8 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   // try the plugin type first, and if not found, try an unknown type
   if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN) &&
       !CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), m_addon, ADDON_UNKNOWN) &&
-      !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), m_addon))
+      !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), m_addon,
+                                                   InstallModalPrompt::PROMPT))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;
@@ -457,7 +458,9 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
     return false;
 
   AddonPtr addon;
-  if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) && !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) &&
+      !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon,
+                                                   InstallModalPrompt::PROMPT))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;

--- a/xbmc/games/controllers/windows/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/windows/ControllerInstaller.cpp
@@ -107,7 +107,8 @@ void CControllerInstaller::Process()
         100 * (installedCount + 1) / static_cast<unsigned int>(installableAddons.size());
     pProgressDialog->SetPercentage(percentage);
 
-    if (!ADDON::CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID(), false, false))
+    if (!ADDON::CAddonInstaller::GetInstance().InstallOrUpdate(
+            addon->ID(), ADDON::BackgroundJob::NO, ADDON::ModalJob::NO))
     {
       CLog::Log(LOGERROR, "Controller installer: Failed to install %s", addon->ID().c_str());
       // "Error"

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -133,8 +133,8 @@ bool CGUIDialogSelectGameClient::Install(const std::string& gameClient)
   if (!bInstalled)
   {
     ADDON::AddonPtr installedAddon;
-    bInstalled =
-        ADDON::CAddonInstaller::GetInstance().InstallModal(gameClient, installedAddon, false);
+    bInstalled = ADDON::CAddonInstaller::GetInstance().InstallModal(
+        gameClient, installedAddon, ADDON::InstallModalPrompt::NO_PROMPT);
     if (!bInstalled)
     {
       CLog::Log(LOGERROR, "Select game client dialog: Failed to install %s", gameClient.c_str());

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -53,7 +53,7 @@ static int InstallAddon(const std::vector<std::string>& params)
   const std::string& addonid = params[0];
 
   AddonPtr addon;
-  CAddonInstaller::GetInstance().InstallModal(addonid, addon);
+  CAddonInstaller::GetInstance().InstallModal(addonid, addon, InstallModalPrompt::PROMPT);
 
   return 0;
 }

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -67,7 +67,8 @@ void CRssManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
     ADDON::AddonPtr addon;
     if (!CServiceBroker::GetAddonMgr().GetAddon("script.rss.editor", addon))
     {
-      if (!ADDON::CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon))
+      if (!ADDON::CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon,
+                                                              ADDON::InstallModalPrompt::PROMPT))
         return;
     }
     CBuiltins::GetInstance().Execute("RunScript(script.rss.editor)");


### PR DESCRIPTION
## Description
### Commit 1:
replace two vectors with a single map for building list of outdated addons and their available updates

### Commit 2:
let function `CAddonInstaller::Install()` return a bool for success/failure
turned arguments of `CAddonInstaller::DoInstall()` into non-optionals and changed calls accordingly

### Commit 3:
changes the pin/unpin logic as a whole
top-level addons (but not their dependencies on installation or update) are unpinned only if the latest version within their origin has been installed - pinned on a lower version install
only compatible addon versions are now offered by the select-dialog in `DialogAddoninfo`

### Commit 4:
finally turn bool arguments to enum classes and change optional arguments

## How Has This Been Tested?
manually tested on local installation.
have not seen regressions with the recent gui-update changes (#18454)
commit 1 has been running on my live-branch for about two weeks.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@phunkyfish & @AlwinEsch 
could you please have a look on this?