### PR TITLE
[GBM] rework drm init with drmGetDevices2

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -849,11 +849,8 @@ void CDRMUtils::DestroyDrm()
 {
   RestoreOriginalMode();
 
-  auto ret = drmDropMaster(m_fd);
-  if (ret < 0)
-  {
-    CLog::Log(LOGDEBUG, "CDRMUtils::%s - failed to drop drm master: %s", __FUNCTION__, strerror(errno));
-  }
+  if (drmAuthMagic(m_fd, 0) == EINVAL)
+    drmDropMaster(m_fd);
 
   close(m_renderFd);
   close(m_fd);

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -11,8 +11,6 @@
 #include "GBMUtils.h"
 #include "windowing/Resolution.h"
 
-#include "platform/posix/utils/FileHandle.h"
-
 #include <map>
 #include <vector>
 
@@ -92,7 +90,6 @@ public:
   virtual bool InitDrm();
   virtual void DestroyDrm();
 
-  std::string GetModule() const { return m_module; }
   int GetFileDescriptor() const { return m_fd; }
   int GetRenderNodeFileDescriptor() const { return m_renderFd; }
   struct plane* GetVideoPlane() const { return m_video_plane; }
@@ -122,7 +119,7 @@ protected:
   static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object);
   static void FreeProperties(struct drm_object *object);
 
-  KODI::UTILS::POSIX::CFileHandle m_fd;
+  int m_fd;
   struct connector *m_connector = nullptr;
   struct encoder *m_encoder = nullptr;
   struct crtc *m_crtc = nullptr;
@@ -149,9 +146,9 @@ private:
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
   RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
   bool CheckConnector(int connectorId);
+  void PrintDrmDeviceInfo(drmDevicePtr device);
 
-  KODI::UTILS::POSIX::CFileHandle m_renderFd;
-  std::string m_module;
+  int m_renderFd;
 
   drmModeResPtr m_drm_resources = nullptr;
 

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -56,7 +56,6 @@ public:
   std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; };
   void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge) { m_videoLayerBridge = bridge; };
 
-  std::string GetModule() const { return m_DRM->GetModule(); }
   struct gbm_device *GetGBMDevice() const { return m_GBM->GetDevice(); }
   std::shared_ptr<CDRMUtils> GetDrm() const { return m_DRM; }
 


### PR DESCRIPTION
This PR does a couple things and cleans up some code:
 - Change to use drmGetDevices2 instead of using a modules list with drmOpenWithType
 - Logs the drm device information
 - Drops use of CFileHandle as it's just not needed for this application
 - Cleans up some logging
 - Better logging for drmSetMaster/drmDropMaster

Using drmGetDevices2 allows us to not have to maintain a list of drm kernel modules anymore. We can query all the drm devices available and choose which one we use through our normal selection process.
