### PR TITLE
[Estaury] music - fix player.showinfo animation

### DIFF
--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -40,6 +40,7 @@
 			<visible>[Player.ShowInfo | Window.IsActive(musicosd)] + !MusicPlayer.Content(livetv)</visible>
 			<height>460</height>
 			<include>OpenClose_Left</include>
+			<include>Visible_Left</include>
 			<bottom>0</bottom>
 			<control type="image">
 				<left>0</left>


### PR DESCRIPTION
## Description


as reported by @ksooo :
```
I just spotted a visual glitch with the music OSD:
- Select a song in one of the music media windows
- switch to full schreen  (key “tab”)
- => OSD opens, cover image and meta data (track number, title etc) area smoothly slide in from left. Nice.
- hide the OSD (key ‘i’)
- show the OSD (key ‘i’ again)
- => cover and meta data area show up without any animation. Ugly.
```

this fixes the issue by adding a visible animation to the related code.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
