### PR TITLE
Fix how limits applied when limitStart is greater/equal the number of items

### DIFF
--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -965,6 +965,11 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
     items.erase(items.begin(), items.begin() + limitStart);
     limitEnd -= limitStart;
   }
+  else if (limitStart > 0)
+  {
+    items.erase(items.begin(), items.end());
+    limitEnd = 0;
+  }
   if (limitEnd > 0 && (size_t)limitEnd < items.size())
     items.erase(items.begin() + limitEnd, items.end());
 }
@@ -1003,6 +1008,11 @@ void SortUtils::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute attribute
   {
     items.erase(items.begin(), items.begin() + limitStart);
     limitEnd -= limitStart;
+  }
+  else if (limitStart > 0)
+  {
+    items.erase(items.begin(), items.end());
+    limitEnd = 0;
   }
   if (limitEnd > 0 && (size_t)limitEnd < items.size())
     items.erase(items.begin() + limitEnd, items.end());


### PR DESCRIPTION
If limitStart is greater/equal the number of items, queries should return empty results

## Description
Right now, if limitStart is >= the number of items in the results it's ignored entirely.  This is incorrect behavior: if only 10 items match a query, and a request comes in for the 11-20th items, the result should be empty.

## Motivation and Context
I ran across this when implementing paginated results for a Web interface that uses the Kodi API

## How Has This Been Tested?
Tested with both empty and non-empty limits, and limits above and below number of results.  This is a localized change that should not impact other code.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

I cannot check the final box because TestWebServer.CanHeadFile is failing for me.  It fails with or without this change, and appears to be completely unrelated.  All other tests passed.