### PR TITLE
[tools/depends] bump samba-gplv3 4.11.13

### DIFF
--- a/tools/depends/target/samba-gplv3/02-cross_compile.patch
+++ b/tools/depends/target/samba-gplv3/02-cross_compile.patch
@@ -87,7 +87,7 @@
      conf.CHECK_HEADERS('libaio.h locale.h ndir.h pwd.h')
      conf.CHECK_HEADERS('shadow.h sys/acl.h')
      conf.CHECK_HEADERS('sys/attributes.h attr/attributes.h sys/capability.h sys/dir.h sys/epoll.h')
-@@ -679,7 +680,7 @@
+@@ -680,7 +680,7 @@
      conf.CHECK_CODE('''#define LIBREPLACE_CONFIGURE_TEST_STRPTIME
                         #include "tests/strptime.c"''',
                         define='HAVE_WORKING_STRPTIME',
@@ -96,7 +96,7 @@
                         addmain=False,
                         msg='Checking for working strptime')
  
-@@ -694,7 +695,7 @@
+@@ -695,7 +695,7 @@
  
      conf.CHECK_CODE('#include "tests/snprintf.c"',
                      define="HAVE_C99_VSNPRINTF",
@@ -105,7 +105,7 @@
                      addmain=False,
                      msg="Checking for C99 vsnprintf")
  
-@@ -791,7 +792,7 @@
+@@ -792,7 +792,7 @@
                      exit(0);
                      ''',
                      define='HAVE_SECURE_MKSTEMP',
@@ -114,7 +114,7 @@
                      mandatory=True) # lets see if we get a mandatory failure for this one
  
      # look for a method of finding the list of network interfaces
-@@ -803,6 +804,7 @@
+@@ -804,6 +804,7 @@
                             #define %s 1
                             #define NO_CONFIG_H 1
                             #define AUTOCONF_TEST 1
@@ -122,7 +122,7 @@
                             #include "replace.c"
                             #include "inet_ntop.c"
                             #include "snprintf.c"
-@@ -813,7 +815,7 @@
+@@ -814,7 +815,7 @@
                             method,
                             lib='nsl socket' + bsd_for_strlcpy,
                             addmain=False,

--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile 01-fix-dependencies.patch 02-cross_compile
 
 # lib name, version
 LIBNAME=samba
-VERSION=4.11.6
+VERSION=4.11.13
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
## Description
bump samba to 4.11.13

## Motivation and Context
Have been told about issues with Catalina+ and smb access. Did a test mockup bumping to 4.12, but that didnt fix the issue at hand, so just doing the minor bump here instead.

As samba 4.12 has some new requirements (zlib, Perl module Parse::Yapp::Driver), this is probably the safer bet for v19 for now.

## How Has This Been Tested?
Built on apple platforms, runtime tested ok on ios/tvos

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
