### PR TITLE
Raise limit of screenshots

### DIFF
--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -102,7 +102,7 @@ void CScreenShot::TakeScreenshot()
 
   if (!strDir.empty())
   {
-    std::string file = CUtil::GetNextFilename(URIUtils::AddFileToFolder(strDir, "screenshot%03d.png"), 999);
+    std::string file = CUtil::GetNextFilename(URIUtils::AddFileToFolder(strDir, "screenshot%05d.png"), 65535);
 
     if (!file.empty())
     {


### PR DESCRIPTION
..from 999 to 65535, which is the maximum number of files in a FAT32 folder. Still pretty low, but more reasonable and does not break compatibility.

## Screenshots (if appropriate):
Couldn't take screenshot. Limit exceeded. ;-)
