### PR TITLE
[Android] Fix MediaCodec OES/EGL rendering

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -156,7 +156,6 @@ protected:
   int m_state;
 
   std::shared_ptr<CJNIXBMCVideoView> m_jnivideoview;
-  CJNISurface* m_jnisurface;
   CJNISurface m_jnivideosurface;
   unsigned int m_textureId;
   std::shared_ptr<CJNIMediaCodec> m_codec;


### PR DESCRIPTION
## Description
[Android] Fix MediaCodec OES/EGL rendering by using the correct render surface

## Motivation and Context
Without this PR rendering MediaCodec OES/EGL does only show a black screen.
Reason is that the current code doesn't select the correct render surface when configuring MediaCodec decoder.

This PR fixes this by passing the correct surface when configuring MediaCodec.

## How Has This Been Tested?
- Disable MediaCodec (Surface) in settings::player::Video settings
- Playback any movie.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
