### PR TITLE
WASAPI: fix crash due incorrect AE format requested in some circumstances

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -692,6 +692,17 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
     CAESinkFactoryWin::BuildWaveFormatExtensible(format, wfxex);
   }
 
+  // Prevents NULL speaker mask. To do: debug exact cause.
+  // When this happens requested AE format is AE_FMT_FLOAT + channel layout
+  // RAW, RAW, RAW... (6 channels). Only happens at end of playback PT
+  // stream, force to defaults does not affect functionality or user
+  // experience. Only avoids crash.
+  if (!wfxex.dwChannelMask && format.m_dataFormat <= AE_FMT_FLOAT)
+  {
+    CLog::LogF(LOGWARNING, "NULL Channel Mask detected. Default values are enforced.");
+    format.m_sampleRate = 0; // force defaults in following code
+  }
+
   /* Test for incomplete format and provide defaults */
   if (format.m_sampleRate == 0 ||
       format.m_channelLayout == CAEChannelInfo(nullptr) ||


### PR DESCRIPTION
## Description
Fixes https://github.com/xbmc/xbmc/issues/18453

## Motivation and Context
Try to fix a crash when VideoPlayer finishes playing (end of stream). See issue #18453 for more details. The solution is not perfect because it does not eliminate the primary root cause but I believe that it is sufficiently effective, simple and innocuous to be merged.

It is a simple additional verification that the requested AE audio format is valid. If the issue does not happen, the code does nothing and if it happens, avoids hard crash.

## How Has This Been Tested?
No more Kodi crashes in a week

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
