### PR TITLE
[GBM] rework gbm interface

### DIFF
--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -28,7 +28,8 @@ void CGBMBufferObject::Register()
 
 CGBMBufferObject::CGBMBufferObject()
 {
-  m_device = static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetGBMDevice();
+  m_device =
+      static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetGBMDevice()->Get();
 }
 
 CGBMBufferObject::~CGBMBufferObject()

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -24,7 +24,8 @@ bool CGBMUtils::CreateDevice(int fd)
   auto device = gbm_create_device(fd);
   if (!device)
   {
-    CLog::Log(LOGERROR, "CGBMUtils::%s - failed to create device", __FUNCTION__);
+    CLog::Log(LOGERROR, "CGBMUtils::{} - failed to create device: {}", __FUNCTION__,
+              strerror(errno));
     return false;
   }
 
@@ -53,13 +54,13 @@ bool CGBMUtils::CGBMDevice::CreateSurface(
 
   if (!surface)
   {
-    CLog::Log(LOGERROR, "CGBMUtils::%s - failed to create surface", __FUNCTION__);
+    CLog::Log(LOGERROR, "CGBMUtils::{} - failed to create surface: {}", __FUNCTION__,
+              strerror(errno));
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "CGBMUtils::%s - created surface with size %dx%d", __FUNCTION__,
-                                                                         width,
-                                                                         height);
+  CLog::Log(LOGDEBUG, "CGBMUtils::{} - created surface with size {}x{}", __FUNCTION__, width,
+            height);
 
   m_surface.reset(new CGBMSurface(surface));
 

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <queue>
+
 #include <gbm.h>
 
 namespace KODI
@@ -27,7 +29,6 @@ public:
   bool CreateSurface(int width, int height, uint32_t format, const uint64_t *modifiers, const int modifiers_count);
   void DestroySurface();
   struct gbm_bo *LockFrontBuffer();
-  void ReleaseBuffer();
 
   struct gbm_device* GetDevice() const { return m_device; }
   struct gbm_surface* GetSurface() const { return m_surface; }
@@ -35,8 +36,8 @@ public:
 protected:
   struct gbm_device *m_device = nullptr;
   struct gbm_surface *m_surface = nullptr;
-  struct gbm_bo *m_bo = nullptr;
-  struct gbm_bo *m_next_bo = nullptr;
+
+  std::queue<gbm_bo*> m_buffers;
 };
 
 }

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -20,6 +20,10 @@ namespace WINDOWING
 namespace GBM
 {
 
+/**
+ * @brief A wrapper for gbm c classes to allow OOP and RAII.
+ *
+ */
 class CGBMUtils
 {
 public:
@@ -27,8 +31,20 @@ public:
   CGBMUtils& operator=(const CGBMUtils&) = delete;
   CGBMUtils() = default;
   ~CGBMUtils() = default;
+
+  /**
+   * @brief Create a gbm device for allocating buffers
+   *
+   * @param fd The file descriptor for a backend device
+   * @return true The device creation succeeded
+   * @return false The device creation failed
+   */
   bool CreateDevice(int fd);
 
+  /**
+   * @brief A wrapper for gbm_device to allow OOP and RAII
+   *
+   */
   class CGBMDevice
   {
   public:
@@ -37,14 +53,34 @@ public:
     explicit CGBMDevice(gbm_device* device);
     ~CGBMDevice() = default;
 
+    /**
+     * @brief Create a gbm surface
+     *
+     * @param width The width to use for the surface
+     * @param height The height to use for the surface
+     * @param format The format to use for the surface
+     * @param modifiers The modifiers to use for the surface
+     * @param modifiers_count The amount of modifiers in the modifiers param
+     * @return true The surface creation succeeded
+     * @return false The surface creation failed
+     */
     bool CreateSurface(int width,
                        int height,
                        uint32_t format,
                        const uint64_t* modifiers,
                        const int modifiers_count);
 
+    /**
+     * @brief Get the underlying gbm_device
+     *
+     * @return gbm_device* A pointer to the underlying gbm_device
+     */
     gbm_device* Get() const { return m_device; }
 
+    /**
+     * @brief A wrapper for gbm_surface to allow OOP and RAII
+     *
+     */
     class CGBMSurface
     {
     public:
@@ -53,8 +89,17 @@ public:
       explicit CGBMSurface(gbm_surface* surface);
       ~CGBMSurface() = default;
 
+      /**
+       * @brief Get the underlying gbm_surface
+       *
+       * @return gbm_surface* A pointer to the underlying gbm_surface
+       */
       gbm_surface* Get() const { return m_surface; }
 
+      /**
+       * @brief A wrapper for gbm_bo to allow OOP and RAII
+       *
+       */
       class CGBMSurfaceBuffer
       {
       public:
@@ -63,6 +108,11 @@ public:
         explicit CGBMSurfaceBuffer(gbm_surface* surface);
         ~CGBMSurfaceBuffer();
 
+        /**
+         * @brief Get the underlying gbm_bo
+         *
+         * @return gbm_bo* A pointer to the underlying gbm_bo
+         */
         gbm_bo* Get() const { return m_buffer; }
 
       private:
@@ -70,6 +120,11 @@ public:
         gbm_bo* m_buffer{nullptr};
       };
 
+      /**
+       * @brief Lock the surface's current front buffer.
+       *
+       * @return CGBMSurfaceBuffer* A pointer to a CGBMSurfaceBuffer object
+       */
       CGBMSurfaceBuffer* LockFrontBuffer();
 
     private:
@@ -77,6 +132,11 @@ public:
       std::queue<std::unique_ptr<CGBMSurfaceBuffer>> m_buffers;
     };
 
+    /**
+     * @brief Get the CGBMSurface object
+     *
+     * @return CGBMSurface* A pointer to the CGBMSurface object
+     */
     CGBMDevice::CGBMSurface* GetSurface() const { return m_surface.get(); }
 
   private:
@@ -93,6 +153,11 @@ public:
     std::unique_ptr<CGBMSurface, CGBMSurfaceDeleter> m_surface;
   };
 
+  /**
+   * @brief Get the CGBMDevice object
+   *
+   * @return CGBMDevice* A pointer to the CGBMDevice object
+   */
   CGBMUtils::CGBMDevice* GetDevice() const { return m_device.get(); }
 
 private:

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <memory>
 #include <queue>
 
 #include <gbm.h>
@@ -22,22 +23,88 @@ namespace GBM
 class CGBMUtils
 {
 public:
+  CGBMUtils(const CGBMUtils&) = delete;
+  CGBMUtils& operator=(const CGBMUtils&) = delete;
   CGBMUtils() = default;
   ~CGBMUtils() = default;
   bool CreateDevice(int fd);
-  void DestroyDevice();
-  bool CreateSurface(int width, int height, uint32_t format, const uint64_t *modifiers, const int modifiers_count);
-  void DestroySurface();
-  struct gbm_bo *LockFrontBuffer();
 
-  struct gbm_device* GetDevice() const { return m_device; }
-  struct gbm_surface* GetSurface() const { return m_surface; }
+  class CGBMDevice
+  {
+  public:
+    CGBMDevice(const CGBMDevice&) = delete;
+    CGBMDevice& operator=(const CGBMDevice&) = delete;
+    explicit CGBMDevice(gbm_device* device);
+    ~CGBMDevice() = default;
 
-protected:
-  struct gbm_device *m_device = nullptr;
-  struct gbm_surface *m_surface = nullptr;
+    bool CreateSurface(int width,
+                       int height,
+                       uint32_t format,
+                       const uint64_t* modifiers,
+                       const int modifiers_count);
 
-  std::queue<gbm_bo*> m_buffers;
+    gbm_device* Get() const { return m_device; }
+
+    class CGBMSurface
+    {
+    public:
+      CGBMSurface(const CGBMSurface&) = delete;
+      CGBMSurface& operator=(const CGBMSurface&) = delete;
+      explicit CGBMSurface(gbm_surface* surface);
+      ~CGBMSurface() = default;
+
+      gbm_surface* Get() const { return m_surface; }
+
+      class CGBMSurfaceBuffer
+      {
+      public:
+        CGBMSurfaceBuffer(const CGBMSurfaceBuffer&) = delete;
+        CGBMSurfaceBuffer& operator=(const CGBMSurfaceBuffer&) = delete;
+        explicit CGBMSurfaceBuffer(gbm_surface* surface);
+        ~CGBMSurfaceBuffer();
+
+        gbm_bo* Get() const { return m_buffer; }
+
+      private:
+        gbm_surface* m_surface{nullptr};
+        gbm_bo* m_buffer{nullptr};
+      };
+
+      CGBMSurfaceBuffer* LockFrontBuffer();
+
+    private:
+      gbm_surface* m_surface{nullptr};
+      std::queue<std::unique_ptr<CGBMSurfaceBuffer>> m_buffers;
+    };
+
+    CGBMDevice::CGBMSurface* GetSurface() const { return m_surface.get(); }
+
+  private:
+    gbm_device* m_device{nullptr};
+
+    struct CGBMSurfaceDeleter
+    {
+      void operator()(CGBMSurface* p) const
+      {
+        if (p)
+          gbm_surface_destroy(p->Get());
+      }
+    };
+    std::unique_ptr<CGBMSurface, CGBMSurfaceDeleter> m_surface;
+  };
+
+  CGBMUtils::CGBMDevice* GetDevice() const { return m_device.get(); }
+
+private:
+  struct CGBMDeviceDeleter
+  {
+    void operator()(CGBMDevice* p) const
+    {
+      if (p)
+        gbm_device_destroy(p->Get());
+    }
+  };
+  std::unique_ptr<CGBMDevice, CGBMDeviceDeleter> m_device;
 };
 
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -189,11 +189,6 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   auto result = m_DRM->SetVideoMode(res, bo);
 
-  if (!std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
-  {
-    m_GBM->ReleaseBuffer();
-  }
-
   int delay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.delayrefreshchange");
   if (delay > 0)
     m_dispResetTimer.Set(delay * 100);
@@ -217,11 +212,6 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
   }
 
   m_DRM->FlipPage(bo, rendered, videoLayer);
-
-  if (rendered)
-  {
-    m_GBM->ReleaseBuffer();
-  }
 
   if (m_videoLayerBridge && !videoLayer)
   {

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -118,8 +118,6 @@ bool CWinSystemGbm::InitWindowSystem()
 
 bool CWinSystemGbm::DestroyWindowSystem()
 {
-  m_GBM->DestroyDevice();
-
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - deinitialized DRM", __FUNCTION__);
 
   m_libinput.reset();
@@ -184,7 +182,7 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   if (!std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
   {
-    bo = m_GBM->LockFrontBuffer();
+    bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
   }
 
   auto result = m_DRM->SetVideoMode(res, bo);
@@ -208,7 +206,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 
   if (rendered)
   {
-    bo = m_GBM->LockFrontBuffer();
+    bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
   }
 
   m_DRM->FlipPage(bo, rendered, videoLayer);

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -56,7 +56,7 @@ public:
   std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; };
   void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge) { m_videoLayerBridge = bridge; };
 
-  struct gbm_device *GetGBMDevice() const { return m_GBM->GetDevice(); }
+  CGBMUtils::CGBMDevice* GetGBMDevice() const { return m_GBM->GetDevice(); }
   std::shared_ptr<CDRMUtils> GetDrm() const { return m_DRM; }
 
 protected:

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -23,7 +23,7 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
-  if (!m_eglContext.CreatePlatformDisplay(m_GBM->GetDevice(), m_GBM->GetDevice()))
+  if (!m_eglContext.CreatePlatformDisplay(m_GBM->GetDevice()->Get(), m_GBM->GetDevice()->Get()))
   {
     return false;
   }
@@ -69,7 +69,8 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   uint32_t format = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
   std::vector<uint64_t> *modifiers = m_DRM->GetGuiPlaneModifiersForFormat(format);
 
-  if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(), modifiers->size()))
+  if (!m_GBM->GetDevice()->CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(),
+                                         modifiers->size()))
   {
     CLog::Log(LOGERROR, "CWinSystemGbmEGLContext::{} - failed to initialize GBM", __FUNCTION__);
     return false;
@@ -78,7 +79,9 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   // This check + the reinterpret cast is for security reason, if the user has outdated platform header files which often is the case
   static_assert(sizeof(EGLNativeWindowType) == sizeof(gbm_surface*), "Declaration specifier differs in size");
 
-  if (!m_eglContext.CreatePlatformSurface(m_GBM->GetSurface(), reinterpret_cast<EGLNativeWindowType>(m_GBM->GetSurface())))
+  if (!m_eglContext.CreatePlatformSurface(
+          m_GBM->GetDevice()->GetSurface()->Get(),
+          reinterpret_cast<EGLNativeWindowType>(m_GBM->GetDevice()->GetSurface()->Get())))
   {
     return false;
   }
@@ -100,7 +103,6 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
 bool CWinSystemGbmEGLContext::DestroyWindow()
 {
   m_eglContext.DestroySurface();
-  m_GBM->DestroySurface();
 
   CLog::Log(LOGDEBUG, "CWinSystemGbmEGLContext::{} - deinitialized GBM", __FUNCTION__);
   return true;


### PR DESCRIPTION
This PR improves a few things but is functionally the same

 - implement a queue to allow getting as many buffers as the gbm surface allows (this likely won't provide any performance improvement as long as we are blocking on vsync. Future changes to come).
 - change `CGBMUtils` to use OOP and RAII. Now if you destroy the begining of the chain the rest will come along in the reverse order that it was initialized.
 - change the logging to use the new style format
 - add doxygen (not really needed but I wanted to add it).