### PR TITLE
WIP: Include LFE mixing setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17699,8 +17699,39 @@ msgctxt "#34113"
 msgid "To keep certain AVRs powered we send an inaudible random noise signal. You can disable this setting if you are using headphone or analog output."
 msgstr ""
 
+#. Indicates if Audio Engine should include lfe when downmixing
+#: system/settings/settings.xml
+msgctxt "#34114"
+msgid "Include LFE when downmixing"
+msgstr ""
+
+#. Description of setting with label #34114 "Include LFE when downmixing"
+#: system/settings/settings.xml
+msgctxt "#34115"
+msgid "If enabled, this setting will include lfe channel into the mixing when there is no dedicated LFE output channel available. This only makes sense for full range speakers."
+msgstr ""
+
+#. Description of setting with label #34114 "Include LFE when downmixing"
+#: system/settings/settings.xml
+msgctxt "#34116"
+msgid "Off"
+msgstr ""
+
+#. Description of setting with label #34114 "Include LFE when downmixing"
+#: system/settings/settings.xml
+msgctxt "#34117"
+msgid "50%"
+msgstr ""
+
+#. Description of setting with label #34114 "Include LFE when downmixing"
+#: system/settings/settings.xml
+msgctxt "#34118"
+msgid "100%"
+msgstr ""
+
+
 #empty strings from id 34114 to 34119
-#34114-34119 reserved for future use
+#34119 reserved for future use
 
 #: system/settings/settings.xml
 msgctxt "#34120"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3233,6 +3233,18 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="audiooutput.mixsublevel" type="integer" label="34114" help="34115">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="34116">0</option>
+              <option label="34117">50</option>
+              <option label="34118">100</option>
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
       </group>
       <group id="2" label="15108">
         <setting id="audiooutput.guisoundmode" type="integer" label="34120" help="36373">

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -593,6 +593,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
                                               &m_settings.silenceTimeoutMinutes, sizeof(int));
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETMIXSUBLEVEL,
                                               &m_settings.mixSubLevel, sizeof(float));
+          CLog::LogF(LOGWARNING, "Mixing Level: {}", mixSubLevel);
           ChangeResamplers();
           if (!NeedReconfigureBuffers() && !NeedReconfigureSink())
             return;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -593,7 +593,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
                                               &m_settings.silenceTimeoutMinutes, sizeof(int));
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETMIXSUBLEVEL,
                                               &m_settings.mixSubLevel, sizeof(float));
-          CLog::LogF(LOGWARNING, "Mixing Level: {}", mixSubLevel);
+          CLog::LogF(LOGWARNING, "Mixing Level: {}", m_settings.mixSubLevel);
           ChangeResamplers();
           if (!NeedReconfigureBuffers() && !NeedReconfigureSink())
             return;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -63,6 +63,7 @@ struct AudioSettings
   double atempoThreshold;
   bool streamNoise;
   int silenceTimeoutMinutes;
+  float mixSubLevel;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -152,6 +152,7 @@ bool CActiveAEBufferPoolResample::Create(
   m_remap = remap;
   m_stereoUpmix = upmix;
   m_mixSubLevel = mixSubLevel * M_SQRT1_2;
+  CLog::LogF(LOGWARNING, "Mixing Level: {}", mixSubLevel);
 
   m_normalize = true;
   if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count() && !normalize))

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -144,12 +144,14 @@ CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
   Flush();
 }
 
-bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, bool upmix, bool normalize)
+bool CActiveAEBufferPoolResample::Create(
+    unsigned int totaltime, bool remap, bool upmix, bool normalize, float mixSubLevel)
 {
   CActiveAEBufferPool::Create(totaltime);
 
   m_remap = remap;
   m_stereoUpmix = upmix;
+  m_mixSubLevel = mixSubLevel * M_SQRT1_2;
 
   m_normalize = true;
   if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count() && !normalize))
@@ -184,13 +186,9 @@ void CActiveAEBufferPoolResample::ChangeResampler()
   srcConfig.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_inputFormat.m_dataFormat);
   srcConfig.dither_bits = CAEUtil::DataFormatToDitherBits(m_inputFormat.m_dataFormat);
 
-  m_resampler->Init(dstConfig, srcConfig,
-                    m_stereoUpmix,
-                    m_normalize,
-                    m_centerMixLevel,
-                    m_remap ? &m_format.m_channelLayout : nullptr,
-                    m_resampleQuality,
-                    m_forceResampler);
+  m_resampler->Init(dstConfig, srcConfig, m_stereoUpmix, m_normalize, m_centerMixLevel,
+                    m_remap ? &m_format.m_channelLayout : nullptr, m_resampleQuality,
+                    m_forceResampler, m_mixSubLevel);
 
   m_changeResampler = false;
 }
@@ -350,7 +348,10 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
   return busy;
 }
 
-void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality)
+void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels,
+                                                     bool stereoupmix,
+                                                     AEQuality quality,
+                                                     float mixSubLevel)
 {
   bool normalize = true;
   if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count()) && !normalizelevels)
@@ -358,13 +359,14 @@ void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool 
     normalize = false;
   }
 
-  if (m_normalize != normalize || m_resampleQuality != quality)
+  if (m_normalize != normalize || m_resampleQuality != quality || m_mixSubLevel != mixSubLevel)
   {
     m_changeResampler = true;
   }
 
   m_resampleQuality = quality;
   m_normalize = normalize;
+  m_mixSubLevel = mixSubLevel;
 }
 
 float CActiveAEBufferPoolResample::GetDelay()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -151,7 +151,7 @@ bool CActiveAEBufferPoolResample::Create(
 
   m_remap = remap;
   m_stereoUpmix = upmix;
-  m_mixSubLevel = mixSubLevel * M_SQRT1_2;
+  m_mixSubLevel = mixSubLevel * static_cast<float>(M_SQRT1_2);
   CLog::LogF(LOGWARNING, "Mixing Level: {}", mixSubLevel);
 
   m_normalize = true;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -78,9 +78,16 @@ public:
   CActiveAEBufferPoolResample(const AEAudioFormat& inputFormat, const AEAudioFormat& outputFormat, AEQuality quality);
   ~CActiveAEBufferPoolResample() override;
   using CActiveAEBufferPool::Create;
-  bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true);
+  bool Create(unsigned int totaltime,
+              bool remap,
+              bool upmix,
+              bool normalize = true,
+              float mixSubLevel = 0.0f);
   bool ResampleBuffers(int64_t timestamp = 0);
-  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality);
+  void ConfigureResampler(bool normalizelevels,
+                          bool stereoupmix,
+                          AEQuality quality,
+                          float mixSubLevel);
   float GetDelay();
   void Flush();
   void SetDrain(bool drain);
@@ -107,6 +114,7 @@ protected:
   double m_centerMixLevel = M_SQRT1_2;
   bool m_fillPackets = false;
   bool m_normalize = true;
+  float m_mixSubLevel = 0.0f;
   bool m_changeResampler = false;
   bool m_forceResampler = false;
   AEQuality m_resampleQuality;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
@@ -85,6 +85,8 @@ bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig,
     return false;
   }
 
+  CLog::LogF(LOGWARNING, "Mixing Level: {}", mixSubLevel);
+
   if (mixSubLevel > 0.0f)
     av_opt_set_double(m_pContext, "lfe_mix_level", mixSubLevel, 0);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
@@ -29,8 +29,15 @@ CActiveAEResampleFFMPEG::~CActiveAEResampleFFMPEG()
   swr_free(&m_pContext);
 }
 
-bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig, SampleConfig srcConfig, bool upmix, bool normalize, double centerMix,
-                                   CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample)
+bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig,
+                                   SampleConfig srcConfig,
+                                   bool upmix,
+                                   bool normalize,
+                                   double centerMix,
+                                   CAEChannelInfo* remapLayout,
+                                   AEQuality quality,
+                                   bool force_resample,
+                                   float mixSubLevel)
 {
   m_dst_chan_layout = dstConfig.channel_layout;
   m_dst_channels = dstConfig.channels;
@@ -77,6 +84,9 @@ bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig, SampleConfig srcConfi
     CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - create context failed");
     return false;
   }
+
+  if (mixSubLevel > 0.0f)
+    av_opt_set_double(m_pContext, "lfe_mix_level", mixSubLevel, 0);
 
   if(quality == AE_QUALITY_HIGH)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
@@ -27,8 +27,15 @@ public:
   const char *GetName() override { return "ActiveAEResampleFFMPEG"; }
   CActiveAEResampleFFMPEG();
   ~CActiveAEResampleFFMPEG() override;
-  bool Init(SampleConfig dstConfig, SampleConfig srcConfig, bool upmix, bool normalize, double centerMix,
-            CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample) override;
+  bool Init(SampleConfig dstConfig,
+            SampleConfig srcConfig,
+            bool upmix,
+            bool normalize,
+            double centerMix,
+            CAEChannelInfo* remapLayout,
+            AEQuality quality,
+            bool force_resample,
+            float mixSubLevel) override;
   int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio) override;
   int64_t GetDelay(int64_t base) override;
   int GetBufferedSamples() override;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -52,6 +52,7 @@ CActiveAESettings::CActiveAESettings(CActiveAE &ae) : m_audioEngine(ae)
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MIXSUBLEVEL);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DTSHDCOREFALLBACK);
   settings->GetSettingsManager()->RegisterCallback(this, settingSet);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -36,6 +36,7 @@ CActiveAESink::CActiveAESink(CEvent* inMsgEvent)
   m_stats = nullptr;
   m_volume = 0.0;
   m_streamNoise = true;
+  m_mixSubLevel = 0.0f;
 }
 
 CActiveAESink::~CActiveAESink() = default;
@@ -326,6 +327,10 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
 
         case CSinkControlProtocol::SETNOISETYPE:
           m_streamNoise = *(bool*)msg->data;
+          return;
+
+        case CSinkControlProtocol::SETMIXSUBLEVEL:
+          m_mixSubLevel = *(float*)msg->data;
           return;
 
         default:
@@ -1192,8 +1197,8 @@ void CActiveAESink::GenerateNoise()
   srcConfig.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_sinkFormat.m_dataFormat);
   srcConfig.dither_bits = CAEUtil::DataFormatToDitherBits(m_sinkFormat.m_dataFormat);
 
-  resampler->Init(dstConfig, srcConfig,
-                  false, false, M_SQRT1_2, nullptr, AE_QUALITY_UNKNOWN, false);
+  resampler->Init(dstConfig, srcConfig, false, false, M_SQRT1_2, nullptr, AE_QUALITY_UNKNOWN, false,
+                  0.0f);
 
   resampler->Resample(m_sampleOfSilence.pkt->data, m_sampleOfSilence.pkt->max_nb_samples,
                      (uint8_t**)&noise, m_sampleOfSilence.pkt->max_nb_samples, 1.0);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -61,6 +61,7 @@ public:
     TIMEOUT,
     SETSILENCETIMEOUT,
     SETNOISETYPE,
+    SETMIXSUBLEVEL,
   };
   enum InSignal
   {
@@ -155,6 +156,7 @@ protected:
   std::unique_ptr<CAEBitstreamPacker> m_packer;
   bool m_needIecPack{false};
   bool m_streamNoise;
+  float m_mixSubLevel;
 };
 
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -143,13 +143,9 @@ void CActiveAEStream::InitRemapper()
     srcConfig.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_format.m_dataFormat);
     srcConfig.dither_bits = CAEUtil::DataFormatToDitherBits(m_format.m_dataFormat);
 
-    m_remapper->Init(dstConfig, srcConfig,
-                     false,
-                     false,
-                     M_SQRT1_2,
-                     &remapLayout,
+    m_remapper->Init(dstConfig, srcConfig, false, false, M_SQRT1_2, &remapLayout,
                      AE_QUALITY_LOW, // not used for remapping
-                     false);
+                     false, 0.0f);
 
     // extra sound packet, we can't resample to the same buffer
     m_remapBuffer =
@@ -654,9 +650,12 @@ bool CActiveAEStreamBuffers::ProcessBuffers()
   return busy;
 }
 
-void CActiveAEStreamBuffers::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality)
+void CActiveAEStreamBuffers::ConfigureResampler(bool normalizelevels,
+                                                bool stereoupmix,
+                                                AEQuality quality,
+                                                float mixSubLevel)
 {
-  m_resampleBuffers->ConfigureResampler(normalizelevels, stereoupmix, quality);
+  m_resampleBuffers->ConfigureResampler(normalizelevels, stereoupmix, quality, mixSubLevel);
 }
 
 float CActiveAEStreamBuffers::GetDelay()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -99,7 +99,10 @@ public:
   bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true);
   void SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
   bool ProcessBuffers();
-  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality);
+  void ConfigureResampler(bool normalizelevels,
+                          bool stereoupmix,
+                          AEQuality quality,
+                          float mixSubLevel);
   bool HasInputLevel(int level);
   float GetDelay();
   void Flush();

--- a/xbmc/cores/AudioEngine/Interfaces/AEResample.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEResample.h
@@ -20,8 +20,15 @@ public:
   virtual const char *GetName() = 0;
   IAEResample() = default;
   virtual ~IAEResample() = default;
-  virtual bool Init(SampleConfig dstConfig, SampleConfig srcConfig, bool upmix, bool normalize, double centerMix,
-                    CAEChannelInfo *remapLayout, AEQuality quality, bool force_resample) = 0;
+  virtual bool Init(SampleConfig dstConfig,
+                    SampleConfig srcConfig,
+                    bool upmix,
+                    bool normalize,
+                    double centerMix,
+                    CAEChannelInfo* remapLayout,
+                    AEQuality quality,
+                    bool force_resample,
+                    float mixSubLevel) = 0;
   virtual int Resample(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, double ratio) = 0;
   virtual int64_t GetDelay(int64_t base) = 0;
   virtual int GetBufferedSamples() = 0;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -253,13 +253,8 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     srcConfig.bits_per_sample = CAEUtil::DataFormatToUsedBits(m_srcFormat.m_dataFormat);
     srcConfig.dither_bits = CAEUtil::DataFormatToDitherBits(m_srcFormat.m_dataFormat);
 
-    m_pResampler->Init(dstConfig, srcConfig,
-                       false,
-                       false,
-                       M_SQRT1_2,
-                       NULL,
-                       AE_QUALITY_UNKNOWN,
-                       false);
+    m_pResampler->Init(dstConfig, srcConfig, false, false, M_SQRT1_2, NULL, AE_QUALITY_UNKNOWN,
+                       false, 0.0f);
 
     m_planes = AE_IS_PLANAR(m_srcFormat.m_dataFormat) ? m_channels : 1;
     m_format = m_srcFormat;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -394,6 +394,7 @@ public:
   static constexpr auto SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD = "audiooutput.atempothreshold";
   static constexpr auto SETTING_AUDIOOUTPUT_STREAMSILENCE = "audiooutput.streamsilence";
   static constexpr auto SETTING_AUDIOOUTPUT_STREAMNOISE = "audiooutput.streamnoise";
+  static constexpr auto SETTING_AUDIOOUTPUT_MIXSUBLEVEL = "audiooutput.mixsublevel";
   static constexpr auto SETTING_AUDIOOUTPUT_GUISOUNDMODE = "audiooutput.guisoundmode";
   static constexpr auto SETTING_AUDIOOUTPUT_GUISOUNDVOLUME = "audiooutput.guisoundvolume";
   static constexpr auto SETTING_AUDIOOUTPUT_PASSTHROUGH = "audiooutput.passthrough";


### PR DESCRIPTION
There are some setups out there, that consist of e.g. 5.0 speakers or 2.0 speakers which have both Full Range L and R speakers. Currently AE does not include lfe channel when downmixing, which is good practice and recommended by several dolby formats.

Never the less, some people requested to be able to include the lfe channel when downmixing.

I currently don't have much time to work on this feature at once, therefore I post it early, but don't yet intend to merge it. Testers are obviously welcome.