### PR TITLE
[video][pvr] Remove context menu items from recordings window's '..' entries

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -410,7 +410,7 @@ namespace PVR
     bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
     {
       // recordings folder?
-      if (item.m_bIsFolder)
+      if (item.m_bIsFolder && !item.IsParentFolder())
         return CPVRRecordingsPath(item.GetPath()).IsValid();
 
       return false;

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -71,7 +71,7 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
-      return URIUtils::IsPVRRecordingFileOrFolder(item.GetPath());
+      return !item.IsParentFolder() && URIUtils::IsPVRRecordingFileOrFolder(item.GetPath());
   }
   else if (!item.HasVideoInfoTag())
     return false;
@@ -97,7 +97,7 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
-      return URIUtils::IsPVRRecordingFileOrFolder(item.GetPath());
+      return !item.IsParentFolder() && URIUtils::IsPVRRecordingFileOrFolder(item.GetPath());
   }
   else if (!item.HasVideoInfoTag())
     return false;
@@ -234,7 +234,8 @@ void PlayAndQueueRecordings(const std::shared_ptr<CFileItem>& item, int windowId
 
 bool IsActiveRecordingsFolder(const CFileItem& item)
 {
-  if (item.m_bIsFolder && StringUtils::StartsWith(item.GetPath(), "pvr://recordings/"))
+  if (item.m_bIsFolder && !item.IsParentFolder() &&
+      URIUtils::IsPVRRecordingFileOrFolder(item.GetPath()))
   {
     // Note: Recordings contained in the folder must be sorted properly, thus this
     //       item is only available if one of the recordings windows is active.


### PR DESCRIPTION
Parent folder entries ('..') should not have "delete watched", "mark watched" and "mark unwatched" context menu items.

@phunkyfish if you find so time for a review...