### PR TITLE
[filesystem] Shoutcast: HTML decode response headers.

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.h
+++ b/xbmc/filesystem/ShoutcastFile.h
@@ -51,7 +51,7 @@ protected:
   void ReadTruncated(char* buf2, int size);
 
 private:
-  std::string ToUTF8(const std::string& str);
+  std::string DecodeToUTF8(const std::string& str);
 
   CCurlFile m_file;
   std::string m_fileCharset;


### PR DESCRIPTION
Before:
<img width="1680" alt="Screenshot 2020-09-29 at 19 24 13" src="https://user-images.githubusercontent.com/3226626/94956807-0dc97980-04ed-11eb-8e1c-676dc151d508.png">

After:
<img width="1680" alt="Screenshot 2020-09-29 at 19 30 57" src="https://user-images.githubusercontent.com/3226626/94956792-0904c580-04ed-11eb-9cb8-f7f06c0512d6.png">

@emveepee if you find so time for a runtime test...
@DaveTBlake could you take a look at the code change?