### PR TITLE
Fix compiler warnings: 'Loop variable creates copy. Use reference typ…

### DIFF
--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -76,10 +76,10 @@ void CContextMenuAddon::ParseMenu(
 
   m_items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, ID()));
 
-  for (const auto subMenu : elem->GetElements("menu"))
+  for (const auto& subMenu : elem->GetElements("menu"))
     ParseMenu(&subMenu.second, menuId, anonGroupCount);
 
-  for (const auto element : elem->GetElements("item"))
+  for (const auto& element : elem->GetElements("item"))
   {
     std::string visCondition = element.second.GetValue("visible").asString();
     std::string library = element.second.GetValue("@library").asString();

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -250,7 +250,7 @@ namespace MUSIC_UTILS
 
     db.Close();
 
-    for (const auto type : artTypes)
+    for (const auto& type : artTypes)
     {
       CFileItemPtr artitem(new CFileItem(type, false));
       // Localise the names of common types of art

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -932,7 +932,7 @@ void CGUIDialogMusicInfo::OnGetArt()
 
     // Update local item and art list with current art
     m_item->SetArt(type, newArt);
-    for (const auto artitem : m_artTypeList)
+    for (const auto& artitem : m_artTypeList)
     {
       if (artitem->GetProperty("artType") == type)
       {

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -453,7 +453,7 @@ void CGUIDialogSongInfo::OnGetArt()
     // Show any fallback art when song art removed
     if (newArt.empty() && m_song->HasArt(type))
       newArt = m_song->GetArt(type);
-    for (const auto artitem : m_artTypeList)
+    for (const auto& artitem : m_artTypeList)
     {
       if (artitem->GetProperty("artType") == type)
       {

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1385,13 +1385,13 @@ void CWebServer::LogRequest(const HTTPRequest& request) const
   if (!getValues.empty())
   {
     std::vector<std::string> values;
-    for (const auto get : getValues)
+    for (const auto& get : getValues)
       values.push_back(get.first + " = " + get.second);
 
     m_logger->debug(" [IN] Query arguments: {}", StringUtils::Join(values, "; "));
   }
 
-  for (const auto header : headerValues)
+  for (const auto& header : headerValues)
     m_logger->debug(" [IN] {}: {}", header.first, header.second);
 }
 
@@ -1406,7 +1406,7 @@ void CWebServer::LogResponse(const HTTPRequest& request, int responseStatus) con
 
   m_logger->debug("[OUT] {} {} {}", request.version, responseStatus, request.pathUrlFull);
 
-  for (const auto header : headerValues)
+  for (const auto& header : headerValues)
     m_logger->debug("[OUT] {}: {}", header.first, header.second);
 }
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -320,7 +320,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
 
   pSlideShow->Reset();
   bool bShowVideos = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PICTURES_SHOWVIDEOS);
-  for (const auto pItem : *m_vecItems)
+  for (const auto& pItem : *m_vecItems)
   {
     if (!pItem->m_bIsFolder &&
         !(URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())) &&

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -895,7 +895,7 @@ bool CGUIControlButtonSetting::OnClick()
         std::shared_ptr<CSettingList> settingList =
             std::static_pointer_cast<CSettingList>(m_pSetting);
         setting = std::static_pointer_cast<CSettingAddon>(settingList->GetDefinition());
-        for (const SettingPtr addon : settingList->GetValue())
+        for (const SettingPtr& addon : settingList->GetValue())
           addonIDs.push_back(std::static_pointer_cast<CSettingAddon>(addon)->GetValue());
       }
       else
@@ -1021,7 +1021,7 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
               addonIDs.push_back(std::static_pointer_cast<CSettingString>(setting)->GetValue());
 
             std::vector<std::string> addonNames;
-            for (const auto addonID : addonIDs)
+            for (const auto& addonID : addonIDs)
             {
               ADDON::AddonPtr addon;
               if (CServiceBroker::GetAddonMgr().GetAddon(addonID, addon))


### PR DESCRIPTION
Fix compiler warnings: 'Loop variable creates copy. Use reference type to prevent copying'

Xcode 12 moans about this.

@phunkyfish @fuzzard  maybe you can have a look at the (trivial) changes.