### PR TITLE
[addons] Fix available update list not empty although all updates wer…

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -656,7 +656,7 @@ bool CAddonInstallJob::DoWork()
     return false;
 
   // Load new installed and if successed replace defined m_addon here with new one
-  if (!CServiceBroker::GetAddonMgr().LoadAddon(m_addon->ID()) ||
+  if (!CServiceBroker::GetAddonMgr().LoadAddon(m_addon->ID(), m_addon->Version()) ||
       !CServiceBroker::GetAddonMgr().GetAddon(m_addon->ID(), m_addon))
   {
     CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to reload addon", m_addon->ID().c_str());

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -139,6 +139,13 @@ namespace ADDON
      */
     bool FindAddons();
 
+    /*! \brief Checks whether given addon with given version is installed
+     * \param addonId addon to check
+     * \param addonVersion version to check
+     * \return True if installed, false otherwise
+     */
+    bool FindAddon(const std::string& addonId, const AddonVersion& addonVersion);
+
     /*!
      * @brief Fills the the provided vector with the list of incompatible
      * enabled addons and returns if there's any.
@@ -183,7 +190,7 @@ namespace ADDON
      *
      * Returns true if the addon was successfully loaded and enabled; otherwise false.
      */
-    bool LoadAddon(const std::string& addonId);
+    bool LoadAddon(const std::string& addonId, const AddonVersion& addonVersion);
 
     /*! @note: should only be called by AddonInstaller
      *


### PR DESCRIPTION
Fix available update list not empty although all updates were successfully installed.

Ever encountered the situation that you had a list of available addon updates with more than one addon to update and that after hitting 'install all updates', after installing all updates without errors, the list was not empty? Hitting "install all updates" one or several more times fixed it, right?

![screenshot001](https://user-images.githubusercontent.com/3226626/94965419-c26a9780-04fb-11eb-89d5-27712b1367bd.png)
(The list item stays there until you restart Kodi or hit 'install all updates' one more time.)


Reason is a race in the addon install logic that only can occur when multiple updates are installed simultaneously. This PR fixes that race.

@phunkyfish maybe you can have a look at the code changes.