### PR TITLE
[Python][xbmcgui] Allow to set the ControlTextBox text before the con…

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -138,12 +138,16 @@ namespace XBMCAddon
         // send message
         CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
       }
+      else
+      {
+        m_label = text;
+      }
     }
 
     String ControlTextBox::getText()
     {
-      if (!pGUIControl)
-        return nullptr;
+      if (pGUIControl == nullptr)
+        return m_label;
 
       XBMCAddonUtils::GuiLock lock(languageHook, false);
       return static_cast<CGUITextBox*>(pGUIControl)->GetDescription();
@@ -157,6 +161,7 @@ namespace XBMCAddon
         CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
         CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
       }
+      m_label.clear();
     }
 
     void ControlTextBox::scroll(long position)
@@ -182,8 +187,9 @@ namespace XBMCAddon
            (float)dwPosX, (float)dwPosY, (float)dwWidth, (float)dwHeight,
            label);
 
-      // reset textbox
-      CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
+      // set label
+      CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
+      msg.SetLabel(m_label);
       pGUIControl->OnMessage(msg);
 
       return pGUIControl;

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -604,6 +604,7 @@ namespace XBMCAddon
       int iControlDown = 0;
       int iControlLeft = 0;
       int iControlRight = 0;
+      std::string m_label{};
       CGUIControl* pGUIControl = nullptr;
 #endif
 
@@ -1826,9 +1827,9 @@ namespace XBMCAddon
       ///
       /// @param text                 string  - text string.
       ///
-      /// @note setText only has effect after the control is added to a window
-      ///
-      ///--------------------------------------------------------------------------
+      ///-----------------------------------------------------------------------
+      /// @python_v19 setText can now be used before adding the control to the window (the defined
+      /// value is taken into consideration when the control is created)
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1852,11 +1853,8 @@ namespace XBMCAddon
       ///
       /// @return                       To get text from box
       ///
-      /// @note getText only works after you add the control to a window
-      /// and set the control text (using \ref python_xbmcgui_control_textbox_settext
-      /// "setText").
-      ///
       ///-----------------------------------------------------------------------
+      /// @python_v19 getText() can now be used before adding the control to the window
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -1878,9 +1876,8 @@ namespace XBMCAddon
       /// @brief \python_func{ reset() }
       /// Clear's this textbox.
       ///
-      /// @note reset only works after you add the control to a window.
-      ///
       ///-----------------------------------------------------------------------
+      /// @python_v19 reset() will reset any text defined for this control even before you add the control to the window
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}


### PR DESCRIPTION
…trol is added to the window

## Description
Improvement over https://github.com/xbmc/xbmc/pull/17747, this PR allows the text on a controltextbox to be set before the control is added to the window. Before you had to actually create the control, add it to the window, and set the text/label afterwards.

## Motivation and Context
Make GUI programming from python more flexible. Due to code style/code organization reasons you usually want to create controls, define their labels, and only add them to the window upon some event.

## How Has This Been Tested?
Using the following snippet:

```python
import xbmcgui, xbmc
windowID = xbmcgui.getCurrentWindowId()
window = xbmcgui.Window(windowID)
textbox = xbmcgui.ControlTextBox(900,600,200,200)
textbox.setText("MY STRING A")
print("My string:" + textbox.getText())
window.addControl(textbox)
xbmc.sleep(3000)
textbox.setText("MY STRING B")
xbmc.sleep(3000)
window.removeControl(textbox)
```

Before only "MY STRING B" would be shown. After the change, "MY STRING A" shows and is replaced afterwards by "MY STRING B"

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
