### PR TITLE
[addons] fix crash by missing list end define

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -441,7 +441,7 @@ static void UserInstalledAddons(const CURL& path, CFileItemList &items)
   VECADDONS addons;
   CServiceBroker::GetAddonMgr().GetInstalledAddons(addons);
   addons.erase(std::remove_if(addons.begin(), addons.end(),
-                              [](const AddonPtr& addon) { return !IsUserInstalled(addon); }));
+                              [](const AddonPtr& addon) { return !IsUserInstalled(addon); }), addons.end());
 
   if (addons.empty())
     return;


### PR DESCRIPTION
## Description

On CAddonDirectory was by mistake for cleanup a required part removed where makes a crash during addon directory scan.

Here his backtrace about:
```
Thread 31 "waiting" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff5d7fb700 (LWP 277889)]
0x0000555558168415 in XFILE::GenerateTypeListing (path=..., types=Python Exception <class 'AttributeError'> 'NoneType' object has no attribute 'pointer': 
std::set with 19 elements, addons=std::vector of length 123, capacity 128 = {...}, items=...)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/AddonsDirectory.cpp:170
170       if (addon->HasType(type))
(gdb) bt
#0  0x0000555558168415 in XFILE::GenerateTypeListing (path=..., types=Python Exception <class 'AttributeError'> 'NoneType' object has no attribute 'pointer': 
std::set with 19 elements, addons=std::vector of length 123, capacity 128 = {...}, items=...)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/AddonsDirectory.cpp:170
#1  0x000055555816a939 in XFILE::GenerateMainCategoryListing (path=..., addons=std::vector of length 123, capacity 128 = {...}, items=...)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/AddonsDirectory.cpp:346
#2  0x000055555816c343 in XFILE::UserInstalledAddons (path=..., items=...) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/AddonsDirectory.cpp:452
#3  0x000055555816f66f in XFILE::CAddonsDirectory::GetDirectory (this=0x7fff48000c90, url=..., items=...) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/AddonsDirectory.cpp:698
#4  0x0000555558195947 in XFILE::CDirectory::GetDirectory (url=..., pDirectory=std::shared_ptr<XFILE::IDirectory> (use count 3, weak count 0) = {...}, items=..., hints=...)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/Directory.cpp:191
#5  0x0000555558195370 in XFILE::CDirectory::GetDirectory (strPath="addons://user/", pDirectory=std::shared_ptr<XFILE::IDirectory> (use count 3, weak count 0) = {...}, items=..., strMask="", flags=6)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/Directory.cpp:134
#6  0x00005555581f2ae9 in XFILE::CVirtualDirectory::GetDirectory (this=0x55555ba4b7a8, url=..., items=..., bUseFileDirectories=false, keepImpl=true)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/filesystem/VirtualDirectory.cpp:70
#7  0x00005555573e5813 in (anonymous namespace)::CGetDirectoryItems::Run (this=0x7fffffffa7c0) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/windows/GUIMediaWindow.cpp:92
#8  0x000055555757bb5d in CThread::Process (this=0x7fffffffa4c0) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/threads/Thread.cpp:213
#9  0x00005555577c06d4 in CBusyWaiter::Process (this=0x7fffffffa4c0) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/dialogs/GUIDialogBusy.cpp:52
#10 0x000055555757be09 in CThread::Action (this=0x7fffffffa4c0) at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/threads/Thread.cpp:282
#11 0x000055555757b3ff in CThread::<lambda(CThread*, std::promise<bool>)>::operator()(CThread *, std::promise<bool>) const (__closure=0x55555d0d0368, pThread=0x7fffffffa4c0, promise=...)
    at /home/alwin/Development/Kodi/kodi-Matrix/xbmc/threads/Thread.cpp:140
#12 0x000055555757c89f in std::__invoke_impl<void, CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> >(std::__invoke_other, CThread::<lambda(CThread*, std::promise<bool>)> &&) (__f=...) at /usr/include/c++/9/bits/invoke.h:60
#13 0x000055555757c7ca in std::__invoke<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> >(CThread::<lambda(CThread*, std::promise<bool>)> &&) (__fn=...)
    at /usr/include/c++/9/bits/invoke.h:95
#14 0x000055555757c6fd in std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > >::_M_invoke<0, 1, 2>(std::_Index_tuple<0, 1, 2>)
    (this=0x55555d0d0368) at /usr/include/c++/9/thread:244
#15 0x000055555757c69c in std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > >::operator()(void) (this=0x55555d0d0368)
    at /usr/include/c++/9/thread:251
#16 0x000055555757c680 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > > >::_M_run(void) (
    this=0x55555d0d0360) at /usr/include/c++/9/thread:195
#17 0x00007ffff56aecb4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#18 0x00007ffff7f83609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#19 0x00007ffff5c3c103 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
