### PR TITLE
[python][xbmcgui] Do not return null to python addons

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -261,7 +261,8 @@ namespace XBMCAddon
 
     String ControlButton::getLabel()
     {
-      if (!pGUIControl) return NULL;
+      if (pGUIControl == nullptr)
+        return strText;
 
       XBMCAddonUtils::GuiLock lock(languageHook, false);
       return static_cast<CGUIButtonControl*>(pGUIControl)->GetLabel();
@@ -269,7 +270,8 @@ namespace XBMCAddon
 
     String ControlButton::getLabel2()
     {
-      if (!pGUIControl) return NULL;
+      if (pGUIControl == nullptr)
+        return strText2;
 
       XBMCAddonUtils::GuiLock lock(languageHook, false);
       return static_cast<CGUIButtonControl*>(pGUIControl)->GetLabel2();
@@ -978,8 +980,6 @@ namespace XBMCAddon
 
     String ControlLabel::getLabel()
     {
-      if (!pGUIControl)
-        return NULL;
       return strText;
     }
     // ============================================================
@@ -1002,6 +1002,10 @@ namespace XBMCAddon
       strTextureNoFocus = noFocusTexture ? noFocusTexture :
         XBMCAddonUtils::getDefaultImage("edit", "texturenofocus");
 
+      if (!label.empty())
+      {
+        strText = label;
+      }
       if (font) strFont = font;
       if (_textColor) sscanf( _textColor, "%x", &textColor );
       if (_disabledColor) sscanf( _disabledColor, "%x", &disabledColor );
@@ -1026,6 +1030,11 @@ namespace XBMCAddon
         label,
         strText);
 
+      // set label
+      CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
+      msg.SetLabel(strText);
+      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, iParentId);
+
       return pGUIControl;
     }
 
@@ -1042,8 +1051,6 @@ namespace XBMCAddon
 
     String ControlEdit::getLabel()
     {
-      if (!pGUIControl)
-        return NULL;
       return strText;
     }
 


### PR DESCRIPTION
## Description
At the moment python addons can crash Kodi fairly easy just by invoking any `xbmcgui` method that returns `NULL`. Examples are `getLabel()` for controls not yet added to any container/window. This PR covers them all apart from `ControlTextBox` which was luckily covered by https://github.com/xbmc/xbmc/pull/18504

Since those values are created on each control constructor (or are empty strings), just return them instead of null.

## Motivation and Context
Kodi shouldn't crash

## How Has This Been Tested?
With the following script:

```python
import xbmcgui
button = xbmcgui.ControlButton(100, 330, 220, 50, label=u'mybutton', alignment=6, font='font13', textColor='0xFFFFFFFF')
print("my button label:" + button.getLabel())
control = xbmcgui.ControlEdit(0, 0, 0, 0, label="myedit")
print("my edit label:" + control.getLabel())
```

This script will result in a crash in current master. PR log shows this instead:

```
│2020-10-03 23:16:12.442 T:47264   DEBUG <general>: my button label:mybutton
│2020-10-03 23:16:12.444 T:47264   DEBUG <general>: my edit label:myedit
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
