### PR TITLE
[addons] cleanup: remove 'alwaysShowUpdateIcon' - workaround

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -172,7 +172,7 @@
 		<value condition="ListItem.Property(addon.orphaned)">icons/addonstatus/orphan.png</value>
 		<value condition="ListItem.Property(addon.downloading)">icons/addonstatus/install.png</value>
 		<value condition="ListItem.Property(addon.isinstalled) + !ListItem.Property(addon.isenabled) + Window.IsActive(addonbrowser)">icons/addonstatus/disable.png</value>
-		<value condition="ListItem.Property(addon.hasupdate)">icons/addonstatus/update.png</value>
+		<value condition="ListItem.Property(addon.hasupdate) | ListItem.Property(addon.isupdate)">icons/addonstatus/update.png</value>
 		<value condition="ListItem.Property(addon.isenabled) + String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24169])">icons/addonstatus/enabled-normal.png</value>
 		<value condition="ListItem.Property(addon.isenabled) + String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170])">icons/addonstatus/enabled-deprecated.png</value>
 		<value condition="ListItem.Property(addon.isenabled) + String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])">icons/addonstatus/enabled-broken.png</value>

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -499,7 +499,7 @@ static void DependencyAddons(const CURL& path, CFileItemList &items)
 static void OutdatedAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons = CServiceBroker::GetAddonMgr().GetAvailableUpdates();
-  CAddonsDirectory::GenerateAddonListingUpdates(path, addons, items, g_localizeStrings.Get(24043));
+  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24043));
 
   if (!items.IsEmpty())
   {
@@ -788,25 +788,10 @@ bool CAddonsDirectory::IsRepoDirectory(const CURL& url)
       || CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), tmp, ADDON_REPOSITORY);
 }
 
-void CAddonsDirectory::GenerateAddonListing(const CURL &path,
-    const VECADDONS& addons, CFileItemList &items, const std::string label)
-{
-  GenerateAddonListing(path, addons, items, label, false);
-}
-
-void CAddonsDirectory::GenerateAddonListingUpdates(const CURL& path,
-                                                   const VECADDONS& addons,
-                                                   CFileItemList& items,
-                                                   const std::string label)
-{
-  GenerateAddonListing(path, addons, items, label, true);
-}
-
 void CAddonsDirectory::GenerateAddonListing(const CURL& path,
                                             const VECADDONS& addons,
                                             CFileItemList& items,
-                                            const std::string label,
-                                            bool alwaysShowUpdateIcon)
+                                            const std::string label)
 {
   std::map<std::string, CAddonWithUpdate> addonsWithUpdate;
 
@@ -839,8 +824,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     };
 
     bool isUpdate = CheckOutdatedOrUpdate(false); // check if it's an available update
-    bool hasUpdate =
-        alwaysShowUpdateIcon || CheckOutdatedOrUpdate(true); // check if it's an outdated addon
+    bool hasUpdate = CheckOutdatedOrUpdate(true); // check if it's an outdated addon
 
     bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon);
 

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -46,10 +46,6 @@ namespace XFILE
     static bool GetScriptsAndPlugins(const std::string &content, CFileItemList &items);
 
     static void GenerateAddonListing(const CURL &path, const ADDON::VECADDONS& addons, CFileItemList &items, const std::string label);
-    static void GenerateAddonListingUpdates(const CURL& path,
-                                            const ADDON::VECADDONS& addons,
-                                            CFileItemList& items,
-                                            const std::string label);
     static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false);
 
     /*! \brief Returns true if `path` is a path or subpath of the repository directory, otherwise false */
@@ -57,10 +53,5 @@ namespace XFILE
 
   private:
     bool GetSearchResults(const CURL& path, CFileItemList &items);
-    static void GenerateAddonListing(const CURL& path,
-                                     const ADDON::VECADDONS& addons,
-                                     CFileItemList& items,
-                                     const std::string label,
-                                     bool alwaysShowUpdateIcon);
   };
 }


### PR DESCRIPTION
## Description
PR #18341 needed to introduce a workaround in order to show the update-icon properly in the gui.
with the new addon-property `isUpdate` this workaround is now obsolete and removed.

this pr also fixes a small inconsistency not showing the update-icon in `AddonBrowser / Install addons`

## Screenshots (if appropriate):
**before:**

![before](https://user-images.githubusercontent.com/58829855/95016329-a6c5d500-0652-11eb-92ac-57609acaa8a9.png)

**after:**

![after](https://user-images.githubusercontent.com/58829855/95016343-b6ddb480-0652-11eb-89d2-84aabe7701b6.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

This is definitely not a "must have" for Alpha 2, so feel free to bump it.
