### PR TITLE
[addons] prevent windows MINMAX macro

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -11,6 +11,10 @@
 #ifndef C_API_ADDON_BASE_H
 #define C_API_ADDON_BASE_H
 
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include "stdbool.h"
 #include "stdint.h"
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/tools/StringUtils.h
@@ -10,6 +10,10 @@
 
 #ifdef __cplusplus
 
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cassert>


### PR DESCRIPTION
## Description

This is in conflict with with e.g. std::min and std::max.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
