### PR TITLE
tools/depends: fix linux add-on build

### DIFF
--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -6,6 +6,11 @@ export PKG_CONFIG_LIBDIR = $(ADDON_DEPS_DIR)/lib/pkgconfig
 ifeq ($(CROSS_COMPILING),yes)
   DEPS = $(TOOLCHAIN_FILE) $(abs_top_srcdir)/target/config-binaddons.site $(abs_top_srcdir)/target/Toolchain_binaddons.cmake $(CONFIG_SUB) $(CONFIG_GUESS)
   TOOLCHAIN = -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)
+  ifeq ($(OS),linux)
+    ifneq ($(TARGET_PLATFORM),gbm)
+      DEPS += linux-system-libs
+    endif
+  endif
 endif
 
 ifeq ($(PLATFORM),)


### PR DESCRIPTION
Overlooked in #16321 this shouldn't have been removed.

GBM will have to be updated as we build the GL library for that instead of using the system libs. I'll do that shortly.