### PR TITLE
[python][xbmcgui] Permit visibility definitions before creating controls

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -95,6 +95,7 @@ namespace XBMCAddon
         0,
         true,
         false);
+      pGUIControl->SetVisible(m_visible);
 
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
       pGUIControl->OnMessage(msg);
@@ -186,6 +187,7 @@ namespace XBMCAddon
       pGUIControl = new CGUITextBox(iParentId, iControlId,
            (float)dwPosX, (float)dwPosY, (float)dwWidth, (float)dwHeight,
            label);
+      pGUIControl->SetVisible(m_visible);
 
       // set label
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
@@ -305,6 +307,7 @@ namespace XBMCAddon
         CTextureInfo(strTextureFocus),
         CTextureInfo(strTextureNoFocus),
         label);
+      pGUIControl->SetVisible(m_visible);
 
       CGUIButtonControl* pGuiButtonControl =
         static_cast<CGUIButtonControl*>(pGUIControl);
@@ -359,6 +362,7 @@ namespace XBMCAddon
       pGUIControl = new CGUIImage(iParentId, iControlId,
             (float)dwPosX, (float)dwPosY, (float)dwWidth, (float)dwHeight,
             CTextureInfo(strFileName));
+      pGUIControl->SetVisible(m_visible);
 
       if (pGUIControl && aspectRatio <= CAspectRatio::AR_KEEP)
         static_cast<CGUIImage*>(pGUIControl)->SetAspectRatio((CAspectRatio::ASPECT_RATIO)aspectRatio);
@@ -417,6 +421,7 @@ namespace XBMCAddon
          CTextureInfo(strTextureBg), CTextureInfo(strTextureLeft),
          CTextureInfo(strTextureMid), CTextureInfo(strTextureRight),
          CTextureInfo(strTextureOverlay));
+      pGUIControl->SetVisible(m_visible);
 
       if (pGUIControl && colorDiffuse)
         static_cast<CGUIProgressControl*>(pGUIControl)->SetColorDiffuse(GUILIB::GUIINFO::CGUIInfoColor(colorDiffuse));
@@ -521,6 +526,7 @@ namespace XBMCAddon
                                          (float) dwPosY,
                                          (float) dwWidth,
                                          (float) dwHeight);
+      pGUIControl->SetVisible(m_visible);
       return pGUIControl;
     }
 
@@ -666,6 +672,7 @@ namespace XBMCAddon
         CTextureInfo(strTextureRadioOffNoFocus),
         CTextureInfo(strTextureRadioOnDisabled),
         CTextureInfo(strTextureRadioOffDisabled));
+      pGUIControl->SetVisible(m_visible);
 
       CGUIRadioButtonControl* pGuiButtonControl =
         static_cast<CGUIRadioButtonControl*>(pGUIControl);
@@ -706,8 +713,14 @@ namespace XBMCAddon
     {
       DelayedCallGuard dcguard(languageHook);
       XBMCAddonUtils::GuiLock lock(languageHook, false);
-      if (pGUIControl)
+      if (pGUIControl != nullptr)
+      {
         pGUIControl->SetVisible(visible);
+      }
+      else
+      {
+        m_visible = visible;
+      }
     }
 
     bool Control::isVisible()
@@ -969,6 +982,7 @@ namespace XBMCAddon
         label,
         false,
         bHasPath);
+      pGUIControl->SetVisible(m_visible);
       static_cast<CGUILabelControl*>(pGUIControl)->SetLabel(strText);
       return pGUIControl;
     }
@@ -1035,6 +1049,7 @@ namespace XBMCAddon
         CTextureInfo(strTextureNoFocus),
         label,
         strText);
+      pGUIControl->SetVisible(m_visible);
 
       // set label
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
@@ -1163,7 +1178,7 @@ namespace XBMCAddon
         (float)itemHeight,
         (float)imageWidth, (float)imageHeight,
         (float)space);
-
+      pGUIControl->SetVisible(m_visible);
       return pGUIControl;
     }
 

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -1808,7 +1808,7 @@ namespace XBMCAddon
     /// below shows how a ControlTextBox can be created, added to the current window and
     /// have some of its properties changed.
     ///
-    /// /// **Extended example:**
+    /// **Extended example:**
     /// ~~~~~~~~~~~~~{.py}
     /// ...
     /// textbox = xbmcgui.ControlTextBox(100, 250, 300, 300, textColor='0xFFFFFFFF')
@@ -1837,6 +1837,7 @@ namespace XBMCAddon
       /// @param text                 string  - text string.
       ///
       ///-----------------------------------------------------------------------
+      ///
       /// @python_v19 setText can now be used before adding the control to the window (the defined
       /// value is taken into consideration when the control is created)
       ///
@@ -1863,6 +1864,7 @@ namespace XBMCAddon
       /// @return                       To get text from box
       ///
       ///-----------------------------------------------------------------------
+      ///
       /// @python_v19 getText() can now be used before adding the control to the window
       ///
       /// **Example:**
@@ -1912,6 +1914,7 @@ namespace XBMCAddon
       ///
       /// @note scroll() only works after the control is added to a window.
       ///
+      ///
       ///-----------------------------------------------------------------------
       ///
       /// **Example:**
@@ -1941,6 +1944,7 @@ namespace XBMCAddon
       /// @note autoScroll only works after you add the control to a window.
       ///
       ///-----------------------------------------------------------------------
+      ///
       /// @python_v15 New function added.
       ///
       /// **Example:**

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -239,11 +239,15 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_control
       /// @brief \python_func{ setVisible(visible) }
       /// Set's the control's visible/hidden state.
+      /// \anchor python_xbmcgui_control_setVisible
       ///
       /// @param visible            bool - True=visible / False=hidden.
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v19 You can now define the visible state of a control before it being
+      /// added to a window. This value will be taken into account when the control is later
+      /// added.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -261,7 +265,11 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control
       /// @brief \python_func{ isVisible() }
-      /// Get the control's visible/hidden state.
+      /// Get the control's visible/hidden state with respect to the container/window
+      ///
+      /// @note If a given control is set visible (c.f. \ref python_xbmcgui_control_setVisible "setVisible()"
+      /// but was not yet added to a window, this method will return `False` (the control is not visible yet since
+      /// it was not added to the window).
       ///
       ///-----------------------------------------------------------------------
       /// @python_v18 New function added.
@@ -605,6 +613,7 @@ namespace XBMCAddon
       int iControlLeft = 0;
       int iControlRight = 0;
       std::string m_label{};
+      bool m_visible{true};
       CGUIControl* pGUIControl = nullptr;
 #endif
 


### PR DESCRIPTION
## Description
The last one of the xbmcgui improvements series, this fixes something that has always annoyed me:
When you create a control and add it to a window, the control is always visible (window.addControl(control) will actually **create** the control). You can't simply structure a python class that creates all the controls you want in init (some of them you actually want to have hidden until further processing) and add them all to a given window. You'll actually have to have control addition and visibility always tightly coupled and structured on a per-control basis.
This PR fixes it by allowing the use of `setVisible()` before `window.addControl`. The defined value will be taken into consideration when the control is created.

## Motivation and Context
Make kodi great again.

## How Has This Been Tested?
With the following script:

```python
button = xbmcgui.ControlButton(200, 330, 220, 50, label='BUTTON', alignment=6, font='font13', textColor='0xFFFFFFFF')
button.setVisible(False)
window.addControl(button)
xbmc.sleep(5000)
button.setVisible(True)
xbmc.sleep(3000)
window.removeControl(button)
```

The control should only show after 5 seconds.

Note this is not a breaking change, just a new possibility. A 2nd commit is added to improve doxygen.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
