### PR TITLE
[pvr] remember last opened TV/Radio group across restarts

### DIFF
--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -49,7 +49,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 36; }
+    int GetSchemaVersion() const override { return 37; }
 
     /*!
      * @brief Get the default sqlite database filename.
@@ -212,6 +212,14 @@ namespace PVR
      * @return whether the update was successful
      */
     bool UpdateLastWatched(const CPVRChannelGroup& group);
+    //@}
+
+    /*!
+     * @brief Updates the last opened timestamp for the channel group
+     * @param group the group
+     * @return whether the update was successful
+     */
+    bool UpdateLastOpened(const CPVRChannelGroup& group);
     //@}
 
   private:

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1065,6 +1065,30 @@ bool CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
   return false;
 }
 
+uint64_t CPVRChannelGroup::LastOpened() const
+{
+  CSingleLock lock(m_critSection);
+  return m_iLastOpened;
+}
+
+bool CPVRChannelGroup::SetLastOpened(uint64_t iLastOpened)
+{
+  const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
+
+  CSingleLock lock(m_critSection);
+
+  if (m_iLastOpened != iLastOpened)
+  {
+    m_iLastOpened = iLastOpened;
+
+    /* update the database immediately */
+    if (database)
+      return database->UpdateLastOpened(*this);
+  }
+
+  return false;
+}
+
 bool CPVRChannelGroup::PreventSortAndRenumber() const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -245,6 +245,18 @@ namespace PVR
     bool SetLastWatched(time_t iLastWatched);
 
     /*!
+     * @return Time in milliseconds from epoch this group was last opened.
+     */
+    uint64_t LastOpened() const;
+
+    /*!
+     * @brief Set the time in milliseconds from epoch this group was last opened.
+     * @param iLastOpened The new value.
+     * @return True if something changed, false otherwise.
+     */
+    bool SetLastOpened(uint64_t iLastOpened);
+
+    /*!
      * @brief Set if sorting and renumbering should happen after adding/updating channels to group.
      * @param bPreventSortAndRenumber The new sorting and renumbering prevention value for this group.
      */
@@ -559,6 +571,7 @@ namespace PVR
     bool m_bUsingBackendChannelNumbers = false; /*!< true to use the channel numbers from 1 backend, false otherwise */
     bool m_bPreventSortAndRenumber = false; /*!< true when sorting and renumbering should not be done after adding/updating channels to the group */
     time_t m_iLastWatched = 0; /*!< last time group has been watched */
+    uint64_t m_iLastOpened = 0; /*!< time in milliseconds from epoch this group was last opened */
     bool m_bHidden = false; /*!< true if this group is hidden, false otherwise */
     int m_iPosition = 0; /*!< the position of this group within the group list */
     std::vector<std::shared_ptr<PVRChannelGroupMember>> m_sortedMembers; /*!< members sorted by channel number */

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -22,6 +22,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -92,6 +93,7 @@ bool CPVRChannelGroups::Update(const CPVRChannelGroup& group, bool bUpdateFromCl
     {
       updateGroup->SetLastWatched(group.LastWatched());
       updateGroup->SetHidden(group.IsHidden());
+      updateGroup->SetLastOpened(group.LastOpened());
     }
   }
 
@@ -355,9 +357,9 @@ bool CPVRChannelGroups::Load()
     return false;
   }
 
-  // set the last played group as selected group at startup
-  std::shared_ptr<CPVRChannelGroup> lastPlayedGroup = GetLastPlayedGroup();
-  SetSelectedGroup(lastPlayedGroup ? lastPlayedGroup : internalGroup);
+  // set the last opened group as selected group at startup
+  std::shared_ptr<CPVRChannelGroup> lastOpenedGroup = GetLastOpenedGroup();
+  SetSelectedGroup(lastOpenedGroup ? lastOpenedGroup : internalGroup);
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "{} {} channel groups loaded", m_groups.size(),
               m_bRadio ? "radio" : "TV");
@@ -409,6 +411,21 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastPlayedGroup(int iCha
   }
 
   return group;
+}
+
+std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::GetLastOpenedGroup() const
+{
+  std::shared_ptr<CPVRChannelGroup> lastOpenedGroup;
+
+  CSingleLock lock(m_critSection);
+  for (const auto& group : m_groups)
+  {
+    if (group->LastOpened() > 0 &&
+        (!lastOpenedGroup || group->LastOpened() > lastOpenedGroup->LastOpened()))
+      lastOpenedGroup = group;
+  }
+
+  return lastOpenedGroup;
 }
 
 std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroups::GetMembers(bool bExcludeHidden /* = false */) const
@@ -497,6 +514,10 @@ void CPVRChannelGroups::SetSelectedGroup(const std::shared_ptr<CPVRChannelGroup>
 
   for (auto& group : m_groups)
     group->SetSelectedGroup(group == m_selectedGroup);
+
+  auto duration = std::chrono::system_clock::now().time_since_epoch();
+  uint64_t tsMillis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+  m_selectedGroup->SetLastOpened(tsMillis);
 }
 
 void CPVRChannelGroups::UpdateSelectedGroup()

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -123,6 +123,11 @@ namespace PVR
     std::shared_ptr<CPVRChannelGroup> GetLastPlayedGroup(int iChannelID = -1) const;
 
     /*!
+     * @return The last opened group.
+     */
+    std::shared_ptr<CPVRChannelGroup> GetLastOpenedGroup() const;
+
+    /*!
      * @brief Get the list of groups.
      * @param groups The list to store the results in.
      * @param bExcludeHidden Whenever to exclude hidden channel groups.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Remember the last opened group across restarts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Currently only the last played group is remembered. This can be a bit unintuitive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

On OSX

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
