### PR TITLE
[addons] fix: update-icon in addon browser

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -887,6 +887,12 @@ bool CAddonMgr::IsAddonInstalled(const std::string& ID,
           tmp->Version() == version);
 }
 
+bool CAddonMgr::IsAddonInstalled(const std::string& ID, const std::string& origin) const
+{
+  AddonPtr tmp;
+  return (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp && tmp->Origin() == origin);
+}
+
 bool CAddonMgr::CanAddonBeInstalled(const AddonPtr& addon)
 {
   return addon != nullptr && addon->LifecycleState() != AddonLifecycleState::BROKEN &&

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -245,6 +245,13 @@ namespace ADDON
                           const std::string& origin,
                           const AddonVersion& version);
 
+    /* \brief Checks whether an addon is installed from a
+     *        particular origin repo
+     * \param ID id of the addon
+     * \param origin origin repository id
+     */
+    bool IsAddonInstalled(const std::string& ID, const std::string& origin) const;
+
     /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
     \param addon addon to be checked
     */

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -213,7 +213,19 @@ bool CAddonsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = true;
       const CFileItem* item = static_cast<const CFileItem*>(gitem);
       if (item->GetAddonInfo())
-        value = CServiceBroker::GetAddonMgr().IsAutoUpdateable(item->GetAddonInfo()->ID());
+        value = CServiceBroker::GetAddonMgr().IsAutoUpdateable(item->GetAddonInfo()->ID()) ||
+                !CServiceBroker::GetAddonMgr().IsAddonInstalled(item->GetAddonInfo()->ID(),
+                                                                item->GetAddonInfo()->Origin());
+
+      //! @Todo: store origin of not-autoupdateable installed addons in table 'update_rules'
+      //         of the addon database. this is needed to pin ambiguous addon-id's that are
+      //         available from multiple origins accordingly.
+      //
+      //         after this is done the above call should be changed to
+      //
+      //         value = CServiceBroker::GetAddonMgr().IsAutoUpdateable(item->GetAddonInfo()->ID(),
+      //                                                                item->GetAddonInfo()->Origin());
+
       return true;
     }
   }


### PR DESCRIPTION
## Description
follow up to #18514
corrects display behavior of the pin-icon in AddonBrowser

only the addon-id is stored in the `update_rules` table, thus equal addon id's from different origins available in repos were marked as _not AutoUpdateble (pinned)_. (see screenshot 1)

this is resolved by verifying if the particular addon is effectively installed from this origin when setting the gui infolabel.

(overload of `CAddonMgr::IsAddonInstalled()` is needed anyway for following gui changes)

## How Has This Been Tested?
debian stretch local

## Screenshots (if appropriate):

**before:**

![95016343-b6ddb480-0652-11eb-89d2-84aabe7701b6](https://user-images.githubusercontent.com/58829855/95092093-8a479c80-0727-11eb-8776-4375ea3d882d.png)

**after:**

![fixed](https://user-images.githubusercontent.com/58829855/95092116-916eaa80-0727-11eb-89e0-f82bc6706a81.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
