### PR TITLE
[PythonInvoker] Re-add support for Python 3.5-3.6

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -182,8 +182,15 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
   {
     if (!m_threadState)
     {
+#if PY_VERSION_HEX < 0x03070000
+      // this is a TOTAL hack. We need the GIL but we need to borrow a PyThreadState in order to get it
+      // as of Python 3.2 since PyEval_AcquireLock is deprecated
+      extern PyThreadState* savestate;
+      PyEval_RestoreThread(savestate);
+#else
       PyThreadState* ts = PyThreadState_New(PyInterpreterState_Main());
       PyEval_RestoreThread(ts);
+#endif
       l_threadState = Py_NewInterpreter();
       PyEval_ReleaseThread(l_threadState);
       if (l_threadState == NULL)
@@ -605,8 +612,12 @@ void CPythonInvoker::onExecutionDone()
     // unregister the language hook
     m_languageHook->UnregisterMe();
 
+#if PY_VERSION_HEX < 0x03070000
+    PyEval_ReleaseLock();
+#else
     PyThreadState_Swap(PyInterpreterState_ThreadHead(PyInterpreterState_Main()));
     PyEval_SaveThread();
+#endif
 
     // set stopped event - this allows ::stop to run and kill remaining threads
     // this event has to be fired without holding m_critical

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -36,6 +36,9 @@
 
 #include <algorithm>
 
+// Only required for Py3 < 3.7
+PyThreadState* savestate;
+
 XBPython::XBPython()
 {
   m_bInitialized = false;
@@ -528,7 +531,7 @@ bool XBPython::OnScriptInitialized(ILanguageInvoker* invoker)
 
     if (!(m_mainThreadState = PyThreadState_Get()))
       CLog::Log(LOGERROR, "Python threadstate is NULL.");
-    PyEval_SaveThread();
+    savestate = PyEval_SaveThread();
 
     m_bInitialized = true;
   }


### PR DESCRIPTION
## Description
Restore some of the old "hack" methods to support python < 3.7 on linux platforms

## Motivation and Context
Fails to build against python 3.5/3.6 due to PyInterpreterState_Main only being introduced in 3.7
Therefore we ifdef and restore some of the old "hack" calls whilst we still support python 3.5/3.6

## How Has This Been Tested?
@howie-f - Can you just chime in and confirm if it worked for you

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
