### PR TITLE
[addons][gui] behavior changes to DialogAddonInfo buttons

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15584,7 +15584,11 @@ msgctxt "#24137"
 msgid "Install auto updates only"
 msgstr ""
 
-#empty strings from id 24138 to 24138
+#. Button caption in DialogAddoninfo
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#24138"
+msgid "Update"
+msgstr ""
 
 #. Label for the action provided by addon management events to jump to a specific Add-on
 #: xbmc/events/AddonManagementEvent.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13646,7 +13646,7 @@ msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 msgctxt "#21342"
-msgid "There are currently no updates available for this add-on."
+msgid "There are currently no versions available for this add-on."
 msgstr ""
 
 #: system/settings.xml
@@ -15224,7 +15224,7 @@ msgid "Update available"
 msgstr ""
 
 msgctxt "#24069"
-msgid "Update"
+msgid "Versions"
 msgstr ""
 
 msgctxt "#24070"

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -887,6 +887,12 @@ bool CAddonMgr::IsAddonInstalled(const std::string& ID)
   return GetAddon(ID, tmp, ADDON_UNKNOWN, false);
 }
 
+bool CAddonMgr::IsAddonInstalled(const std::string& ID, const std::string& origin) const
+{
+  AddonPtr tmp;
+  return (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp && tmp->Origin() == origin);
+}
+
 bool CAddonMgr::IsAddonInstalled(const std::string& ID,
                                  const std::string& origin,
                                  const AddonVersion& version)
@@ -894,12 +900,6 @@ bool CAddonMgr::IsAddonInstalled(const std::string& ID,
   AddonPtr tmp;
   return (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp && tmp->Origin() == origin &&
           tmp->Version() == version);
-}
-
-bool CAddonMgr::IsAddonInstalled(const std::string& ID, const std::string& origin) const
-{
-  AddonPtr tmp;
-  return (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp && tmp->Origin() == origin);
 }
 
 bool CAddonMgr::CanAddonBeInstalled(const AddonPtr& addon)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -241,6 +241,13 @@ namespace ADDON
     bool IsAddonInstalled(const std::string& ID);
 
     /* \brief Checks whether an addon is installed from a
+     *        particular origin repo
+     * \param ID id of the addon
+     * \param origin origin repository id
+     */
+    bool IsAddonInstalled(const std::string& ID, const std::string& origin) const;
+
+    /* \brief Checks whether an addon is installed from a
      *        particular origin repo and version
      * \param ID id of the addon
      * \param origin origin repository id
@@ -249,13 +256,6 @@ namespace ADDON
     bool IsAddonInstalled(const std::string& ID,
                           const std::string& origin,
                           const AddonVersion& version);
-
-    /* \brief Checks whether an addon is installed from a
-     *        particular origin repo
-     * \param ID id of the addon
-     * \param origin origin repository id
-     */
-    bool IsAddonInstalled(const std::string& ID, const std::string& origin) const;
 
     /* \brief Checks whether an addon can be installed. Broken addons can't be installed.
     \param addon addon to be checked

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -32,15 +32,11 @@ static std::vector<RepoInfo> officialRepoInfos = CCompileInfo::LoadOfficialRepoI
  *
  */
 
-bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon)
-{
-  return IsFromOfficialRepo(addon, false);
-}
-
-bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon, bool bCheckAddonPath)
+bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon,
+                                     CheckAddonPath checkAddonPath)
 {
   auto comparator = [&](const RepoInfo& officialRepo) {
-    if (bCheckAddonPath)
+    if (checkAddonPath == CheckAddonPath::YES)
     {
       return (addon->Origin() == officialRepo.m_repoId &&
               StringUtils::StartsWithNoCase(addon->Path(), officialRepo.m_origin));
@@ -133,7 +129,7 @@ void CAddonRepos::SetupLatestVersionMaps()
     {
       const auto& addonToAdd = addonMapEntry.second;
 
-      if (IsFromOfficialRepo(addonToAdd, true))
+      if (IsFromOfficialRepo(addonToAdd, CheckAddonPath::YES))
       {
         AddAddonIfLatest(addonToAdd, m_latestOfficialVersions);
       }
@@ -246,7 +242,7 @@ bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
     if (ORIGIN_SYSTEM != addon->Origin() && !hasOfficialUpdate) // not a system addon
     {
       // If we didn't find an official update
-      if (IsFromOfficialRepo(addon, true)) // is an official addon
+      if (IsFromOfficialRepo(addon, CheckAddonPath::YES)) // is an official addon
       {
         if (updateMode == AddonRepoUpdateMode::ANY_REPOSITORY)
         {

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -22,6 +22,12 @@ class CAddonMgr;
 class CRepository;
 class IAddon;
 
+enum class CheckAddonPath
+{
+  YES,
+  NO,
+};
+
 /**
  * Struct - CAddonWithUpdate
  */
@@ -97,21 +103,15 @@ public:
 
   /*!
    * \brief Checks if the origin-repository of a given addon is defined as official repo
-   *        but does not check the origin path (e.g. https://mirrors.kodi.tv ...)
+   *        and can also verify if the origin-path (e.g. https://mirrors.kodi.tv ...)
+   *        is matching
    * \param addon pointer to addon to be checked
-   * \return true if the repository id of a given addon is defined as official
-   */
-  static bool IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon);
-
-  /*!
-   * \brief Checks if the origin-repository of a given addon is defined as official repo
-   *        and verify if the origin-path is also defined and matching
-   * \param addon pointer to addon to be checked
-   * \param bCheckAddonPath also check origin path
+   * \param checkAddonPath also check origin path
    * \return true if the repository id of a given addon is defined as official
    *         and the addons origin matches the defined official origin of the repo id
    */
-  static bool IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon, bool bCheckAddonPath);
+  static bool IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon,
+                                 CheckAddonPath checkAddonPath);
 
   /*!
    * \brief Check if an update is available for a single addon

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -153,8 +153,8 @@ bool CGUIDialogAddonInfo::OnAction(const CAction& action)
 
 void CGUIDialogAddonInfo::OnInitWindow()
 {
-  UpdateControls();
   CGUIDialog::OnInitWindow();
+  UpdateControls();
 }
 
 void CGUIDialogAddonInfo::UpdateControls()
@@ -201,6 +201,10 @@ void CGUIDialogAddonInfo::UpdateControls()
   SET_CONTROL_LABEL(CONTROL_BTN_SELECT, CanUse() ? 21480 : (CanOpen() ? 21478 : 21479));
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_SETTINGS, isInstalled && m_localAddon->HasSettings());
+  if (isInstalled && m_localAddon->HasSettings())
+  {
+    SET_CONTROL_FOCUS(CONTROL_BTN_SETTINGS, 0);
+  }
 
   auto deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(m_item->GetAddonInfo()->ID());
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_DEPENDENCIES, !deps.empty());

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -169,12 +169,34 @@ void CGUIDialogAddonInfo::UpdateControls()
       m_localAddon && !CServiceBroker::GetAddonMgr().IsAddonDisabled(m_localAddon->ID());
   bool canDisable =
       isInstalled && CServiceBroker::GetAddonMgr().CanAddonBeDisabled(m_localAddon->ID());
-  bool canInstall =
-      !isInstalled && m_item->GetAddonInfo()->LifecycleState() != AddonLifecycleState::BROKEN;
+  bool canInstall = !isInstalled && itemAddonInfo->LifecycleState() != AddonLifecycleState::BROKEN;
   bool canUninstall = m_localAddon && CServiceBroker::GetAddonMgr().CanUninstall(m_localAddon);
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canInstall || canUninstall);
-  SET_CONTROL_LABEL(CONTROL_BTN_INSTALL, isInstalled ? 24037 : 24038);
+  bool isUpdate = (!isInstalled && CServiceBroker::GetAddonMgr().IsAddonInstalled(
+                                       itemAddonInfo->ID(), itemAddonInfo->Origin()));
+
+  if (isInstalled)
+  {
+    SET_CONTROL_LABEL(CONTROL_BTN_INSTALL, 24037); // uninstall
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canUninstall);
+  }
+  else
+  {
+    if (isUpdate)
+    {
+      SET_CONTROL_LABEL(CONTROL_BTN_INSTALL, 24138); // update
+    }
+    else
+    {
+      SET_CONTROL_LABEL(CONTROL_BTN_INSTALL, 24038); // install
+    }
+
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canInstall);
+    if (canInstall)
+    {
+      SET_CONTROL_FOCUS(CONTROL_BTN_INSTALL, 0);
+    }
+  }
 
   if (m_addonEnabled)
   {

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -230,8 +230,6 @@ int CGUIDialogAddonInfo::AskForVersion(std::vector<std::pair<AddonVersion, std::
   dialog->SetHeading(CVariant{21338});
   dialog->SetUseDetails(true);
 
-  std::sort(versions.begin(), versions.end(), std::greater<std::pair<AddonVersion, std::string>>());
-
   for (const auto& versionInfo : versions)
   {
     CFileItem item(StringUtils::Format(g_localizeStrings.Get(21339).c_str(),

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -826,7 +826,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     bool isUpdate = CheckOutdatedOrUpdate(false); // check if it's an available update
     bool hasUpdate = CheckOutdatedOrUpdate(true); // check if it's an outdated addon
 
-    bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon);
+    bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon, CheckAddonPath::NO);
 
     pItem->SetProperty("Addon.IsInstalled", installed);
     pItem->SetProperty("Addon.IsEnabled", installed && !disabled);


### PR DESCRIPTION
## Description
### Commit 1:
refactoring but no logical changes

### Commit 2:
sort order in the versions/updates select-dialog is changed to:
1. versions from official repos (latest first, descending)
2. versions from private repos (latest first, descending)

### Commit 3:
caption of the update-button is renamed to "versions"

### Commit 4:
allows new installation of an addon from version-select dialog. (not only upgrading or downgrading to a different version/origin)

### Commit 5:
settings button is focused by default if the addon has configurable settings

### Commit 6:
Install/Uninstall (and now Update) - button changes its caption accordingly and is focused when available

## How Has This Been Tested?
local installation on debian.
i tried to cover all possible cases, but strongly suggest to runtime test it and play through scenarios

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
