### PR TITLE
fix binary add-ons build for GLES

### DIFF
--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -7,8 +7,12 @@ ifeq ($(CROSS_COMPILING),yes)
   DEPS = $(TOOLCHAIN_FILE) $(abs_top_srcdir)/target/config-binaddons.site $(abs_top_srcdir)/target/Toolchain_binaddons.cmake $(CONFIG_SUB) $(CONFIG_GUESS)
   TOOLCHAIN = -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)
   ifeq ($(OS),linux)
-    ifneq ($(TARGET_PLATFORM),gbm)
-      DEPS += linux-system-libs
+    DEPS += linux-system-libs linux-system-x11-libs
+
+    ifeq ($(RENDER_SYSTEM),gl)
+      DEPS += linux-system-gl-libs
+    else
+      DEPS += linux-system-gles-libs
     endif
   endif
 endif
@@ -92,22 +96,38 @@ $(TOOLCHAIN_FILE): $(abs_top_srcdir)/target/Toolchain_binaddons.cmake
 	mkdir -p $(ADDON_DEPS_DIR)/share
 	sed "s|@CMAKE_FIND_ROOT_PATH@|$(ADDON_DEPS_DIR)|g" $(abs_top_srcdir)/target/Toolchain_binaddons.cmake > $@
 
+HOST_LIBDIR := $(firstword $(wildcard /usr/lib64 /usr/lib/$(HOST)))
+
 linux-system-libs:
+	mkdir -p $(ADDON_DEPS_DIR)/lib
+	[ -f $(ADDON_DEPS_DIR)/lib/libm.so ] || ln -sf $(HOST_LIBDIR)/libm.so $(ADDON_DEPS_DIR)/lib/
+
+linux-system-x11-libs:
 	mkdir -p $(ADDON_DEPS_DIR)/lib/pkgconfig $(ADDON_DEPS_DIR)/include
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/x11.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
-	[ -f $(ADDON_DEPS_DIR)/lib/libX11.so ] || ln -sf /usr/lib/$(HOST)/libX11.so* $(ADDON_DEPS_DIR)/lib/
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/x11.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
+	[ -f $(ADDON_DEPS_DIR)/lib/libX11.so ] || ln -sf $(HOST_LIBDIR)/libX11.so* $(ADDON_DEPS_DIR)/lib/
 	[ -L $(ADDON_DEPS_DIR)/include/X11 ] || ln -sf /usr/include/X11 $(ADDON_DEPS_DIR)/include/X11
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/xproto.pc ] || ln -sf /usr/share/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/kbproto.pc ] || ln -sf /usr/share/pkgconfig/kbproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/kbproto.pc
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/damageproto.pc ] || ln -sf /usr/share/pkgconfig/damageproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/damageproto.pc
 	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/fixesproto.pc ] || ln -sf /usr/share/pkgconfig/fixesproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/fixesproto.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/pthread-stubs.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/ice.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/sm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/libdrm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/gl.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/glu.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/libGL.so ] || ln -sf /usr/lib/$(HOST)/libGL.so $(ADDON_DEPS_DIR)/lib/libGL.so
-	[ -L $(ADDON_DEPS_DIR)/include/GL ] || ln -sf /usr/include/GL $(ADDON_DEPS_DIR)/include/GL
-	[ -f $(ADDON_DEPS_DIR)/lib/libm.so ] || ln -sf /usr/lib/$(HOST)/libm.so $(ADDON_DEPS_DIR)/lib/
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/pthread-stubs.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/ice.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/sm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/libdrm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc
 
+linux-system-gl-libs:
+	mkdir -p $(ADDON_DEPS_DIR)/lib/pkgconfig $(ADDON_DEPS_DIR)/include
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/gl.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc ] || ln -sf $(HOST_LIBDIR)/pkgconfig/glu.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/libGL.so ] || ln -sf $(HOST_LIBDIR)/libGL.so $(ADDON_DEPS_DIR)/lib/libGL.so
+	[ -L $(ADDON_DEPS_DIR)/include/GL ] || ln -sf /usr/include/GL $(ADDON_DEPS_DIR)/include/GL
+
+linux-system-gles-libs:
+	mkdir -p $(ADDON_DEPS_DIR)/lib/pkgconfig $(ADDON_DEPS_DIR)/include
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glesv2.pc ] || ln -sf $(PREFIX)/lib/pkgconfig/glesv2.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glesv2.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/libGLESv2.so ] || ln -sf $(PREFIX)/lib/libGLESv2.so $(ADDON_DEPS_DIR)/lib/libGLESv2.so
+	[ -L $(ADDON_DEPS_DIR)/include/GLES2 ] || ln -sf $(PREFIX)/include/GLES2 $(ADDON_DEPS_DIR)/include/GLES2
+	[ -L $(ADDON_DEPS_DIR)/include/KHR ] || ln -sf $(PREFIX)/include/KHR $(ADDON_DEPS_DIR)/include/KHR
+	[ -L $(ADDON_DEPS_DIR)/include/EGL ] || ln -sf $(PREFIX)/include/EGL $(ADDON_DEPS_DIR)/include/EGL
+	[ -f $(ADDON_DEPS_DIR)/lib/libEGL.so ] || ln -sf $(PREFIX)/lib/libEGL.so $(ADDON_DEPS_DIR)/lib/libEGL.so


### PR DESCRIPTION
The Toolchain_binaddons.cmake doesn't have a fallback for the render system. So let's just be explicit about it here. We already cover the OpenGL cases so GBM can cover OpenGLES.

We need to build OpenGLES via mesa. So we need to link that to the binary add-ons sysroot.

sample build shown here: https://jenkins.kodi.tv/job/LINUX-64-GBM/9786/