### PR TITLE
Added correct NEON detection for aarch64 compilers

### DIFF
--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -257,6 +257,11 @@ CCPUInfoLinux::CCPUInfoLinux()
     m_cpuFeatures |= CPU_FEATURE_NEON;
 #endif
 
+#if defined(HAS_NEON) && defined(__aarch64__)
+  if (getauxval(AT_HWCAP) & HWCAP_ASIMD)
+    m_cpuFeatures |= CPU_FEATURE_NEON;
+#endif
+
   // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
   if (m_cpuFeatures & CPU_FEATURE_SSE)
     m_cpuFeatures |= CPU_FEATURE_MMX2;


### PR DESCRIPTION
## Description
Added the correct check for NEON detection for aarch64 compilers

## Motivation and Context
NEON is not enabled if compiled on aarch64 architecture (aarch64 compilers)

## How Has This Been Tested?
Compiled the whole Kodi on aarch64 board (Odroid-C2) and now kodi.log correctly shows the NEON enabled string (and Kodi runs like a charm...)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
