### PR TITLE
[Estuary] add seek slider to the new seekbar

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -66,6 +66,17 @@
 				<midtexture colordiffuse="button_focus">colors/white.png</midtexture>
 				<visible>!VideoPlayer.Content(LiveTV)</visible>
 			</control>
+			<control type="slider">
+				<left>0</left>
+				<top>50</top>
+				<width>100%</width>
+				<height>26</height>
+				<texturesliderbar colordiffuse="00FFFFFF">osd/progress/nub_bar.png</texturesliderbar>
+				<textureslidernib colordiffuse="button_focus">osd/progress/nub_bar.png</textureslidernib>
+				<textureslidernibfocus colordiffuse="button_focus">colors/white.png</textureslidernibfocus>
+				<info>Player.Seekbar</info>
+				<visible>!VideoPlayer.Content(LiveTV) + [Player.Seeking | Player.DisplayAfterSeek]</visible>
+			</control>
 			<control type="group">
 				<visible>VideoPlayer.Content(LiveTV)</visible>
 				<control type="group">
@@ -91,6 +102,17 @@
 						<param name="epg_bar_height" value="16"/>
 					</include>
 				</control>
+			</control>
+			<control type="slider">
+				<left>0</left>
+				<top>50</top>
+				<width>100%</width>
+				<height>26</height>
+				<texturesliderbar colordiffuse="00FFFFFF">osd/progress/nub_bar.png</texturesliderbar>
+				<textureslidernib colordiffuse="button_focus">osd/progress/nub_bar.png</textureslidernib>
+				<textureslidernibfocus colordiffuse="button_focus">colors/white.png</textureslidernibfocus>
+				<info>PVR.TimeShiftSeekbar</info>
+				<visible>[Player.Seeking | Player.DisplayAfterSeek] + !Player.ChannelPreviewActive</visible>
 			</control>
 		</control>
 		<control type="group">


### PR DESCRIPTION
## Description
on the new (minimal) seekbar, the seek slider nib was missing during a seek operation.

@enen92 

## Screenshots (if appropriate):
before:
![before](https://user-images.githubusercontent.com/687265/95273060-54e3a180-0842-11eb-9fda-51c583fa4924.jpg)

after:
![after](https://user-images.githubusercontent.com/687265/95273071-5745fb80-0842-11eb-94b9-ca48c74427fe.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
