### PR TITLE
[Music]Handle artist fanart same as other types of art

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3419,7 +3419,7 @@ std::string CFileItem::GetLocalFanart() const
     items.Append(moreItems);
   }
 
-  std::vector<std::string> fanarts = StringUtils::Split(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fanartImages, "|");
+  std::vector<std::string> fanarts = { "fanart" };
 
   strFile = URIUtils::ReplaceExtension(strFile, "-fanart");
   fanarts.insert(m_bIsFolder ? fanarts.end() : fanarts.begin(), URIUtils::GetFileName(strFile));

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -820,9 +820,16 @@ void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
   int nThumbs = item.GetProperty("artist.thumbs").asInteger32();
   ParseThumbs(artist.thumbURL, item, nThumbs, "artist.thumb");
 
+  // Support deprecated fanarts property, add to artist.thumbURL
   int nFanart = item.GetProperty("artist.fanarts").asInteger32();
-  artist.fanart.m_xml = ParseFanart(item, nFanart, "artist.fanart");
-  artist.fanart.Unpack();
+  if (nFanart > 0)
+  {
+    CFanart fanart;
+    fanart.m_xml = ParseFanart(item, nFanart, "artist.fanart");
+    fanart.Unpack();
+    for (unsigned int i = 0; i < fanart.GetNumFanarts(); i++)
+      artist.thumbURL.AddParsedUrl(fanart.GetImageURL(i), "fanart", fanart.GetPreviewURL(i));
+  }
 }
 
 template<>

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "XBDateTime.h"
-#include "utils/Fanart.h"
 #include "utils/ScraperUrl.h"
 #include "utils/StringUtils.h"
 
@@ -110,8 +109,7 @@ public:
   std::string strDisbanded;
   std::vector<std::string> yearsActive;
   std::string strPath;
-  CScraperUrl thumbURL; // Data for available thumbs
-  CFanart fanart;  // Data for available fanart, urls etc.
+  CScraperUrl thumbURL; // Data for available remote art
   std::map<std::string, std::string> art;  // Current artwork - thumb, fanart etc.
   std::vector<CDiscoAlbum> discography;
   CDateTime dateAdded; // From related file creation or modification times, or when (re-)scanned

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -125,7 +125,7 @@ void CMusicDatabase::CreateTables()
               " strBorn text, strFormed text, strGenres text, strMoods text, "
               " strStyles text, strInstruments text, strBiography text, "
               " strDied text, strDisbanded text, strYearsActive text, "
-              " strImage text, strFanart text, "
+              " strImage text, "
               " lastScraped varchar(20) default NULL, "
               " bScrapedMBID INTEGER NOT NULL DEFAULT 0, "
               " idInfoSetting INTEGER NOT NULL DEFAULT 0, "
@@ -498,7 +498,7 @@ void CMusicDatabase::CreateViews()
               "  strBorn, strFormed, strGenres,"
               "  strMoods, strStyles, strInstruments, "
               "  strBiography, strDied, strDisbanded, "
-              "  strYearsActive, strImage, strFanart, "
+              "  strYearsActive, strImage, "
               "  bScrapedMBID, lastScraped, "
               "  dateAdded, dateNew, dateModified "
               "FROM artist");
@@ -1614,8 +1614,7 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
                artist.strBiography, artist.strDied,
                artist.strDisbanded,
                StringUtils::Join(artist.yearsActive, itemSeparator).c_str(),
-               artist.thumbURL.GetData(),
-               artist.fanart.m_xml.c_str());
+               artist.thumbURL.GetData());
 
   DeleteArtistDiscography(artist.idArtist);
   for (const auto &disc : artist.discography)
@@ -1790,10 +1789,8 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                                   const std::string& strStyles, const std::string& strInstruments,
                                   const std::string& strBiography, const std::string& strDied,
                                   const std::string& strDisbanded, const std::string& strYearsActive,
-                                  const std::string& strImage, const std::string& strFanart)
+                                  const std::string& strImage)
 {
-  CScraperUrl thumbURL;
-  CFanart fanart;
   if (idArtist < 0)
     return -1;
 
@@ -1818,7 +1815,7 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       " strBorn = '%s', strFormed = '%s', strGenres = '%s', "
                       " strMoods = '%s', strStyles = '%s', strInstruments = '%s', "
                       " strBiography = '%s', strDied = '%s', strDisbanded = '%s', "
-                      " strYearsActive = '%s', strImage = '%s', strFanart = '%s', "
+                      " strYearsActive = '%s', strImage = '%s', "
                       " lastScraped = '%s', bScrapedMBID = %i",
                       strArtist.c_str(),
                       /* strSortName.c_str(),*/
@@ -1827,7 +1824,7 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       strBorn.c_str(), strFormed.c_str(), strGenres.c_str(),
                       strMoods.c_str(), strStyles.c_str(), strInstruments.c_str(),
                       strBiography.c_str(), strDied.c_str(), strDisbanded.c_str(),
-                      strYearsActive.c_str(), strImage.c_str(), strFanart.c_str(),
+                      strYearsActive.c_str(), strImage.c_str(),
                       CDateTime::GetUTCDateTime().GetAsDBDateTime().c_str(), isScrapedMBID);
   if (useMBIDNull)
     strSQL += PrepareSQL(", strMusicBrainzArtistID = NULL");
@@ -2989,8 +2986,6 @@ CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const re
 
   if (needThumb)
   {
-    artist.fanart.m_xml = record->at(artist_strFanart).get_asString();
-    artist.fanart.Unpack();
     artist.thumbURL.ParseFromData(record->at(artist_strImage).get_asString());
   }
 
@@ -8579,7 +8574,55 @@ void CMusicDatabase::UpdateTables(int version)
                 "WHERE song.idAlbum = album.idAlbum) "
                 "WHERE EXISTS (SELECT 1 FROM song WHERE song.idAlbum = album.idAlbum)");
   }
-
+  if (version < 82)
+  {
+    // Update artist table combining fanart URL data into strImage field
+    // Clear empty URL data <fanart /> and <thumb />
+    m_pDS->exec("UPDATE artist SET strFanart = '' WHERE strFanart = '<fanart />'");
+    m_pDS->exec("UPDATE artist SET strImage = '' WHERE strImage = '<thumb />'");
+    //Prepare strFanart - strip <fanart>...</fanart>, add aspect to the URLs
+    m_pDS->exec("UPDATE artist SET strFanart = REPLACE(strFanart, '<fanart>', '')");
+    m_pDS->exec("UPDATE artist SET strFanart = REPLACE(strFanart, '</fanart>', '')");
+    m_pDS->exec("UPDATE artist SET strFanart = REPLACE(strFanart, 'thumb preview', 'thumb "
+                "aspect=\"fanart\" preview')");
+    // Remove strFanart column from artist table
+    m_pDS->exec("CREATE TABLE artist_new (idArtist INTEGER PRIMARY KEY, "
+                "strArtist varchar(256), strMusicBrainzArtistID text, "
+                "strSortName text, "
+                "strType text, strGender text, strDisambiguation text, "
+                "strBorn text, strFormed text, strGenres text, strMoods text, "
+                "strStyles text, strInstruments text, strBiography text, "
+                "strDied text, strDisbanded text, strYearsActive text, "
+                "strImage text, "
+                "lastScraped varchar(20) default NULL, "
+                "bScrapedMBID INTEGER NOT NULL DEFAULT 0, "
+                "idInfoSetting INTEGER NOT NULL DEFAULT 0, "
+                "dateAdded TEXT, dateNew TEXT, dateModified TEXT)");
+    // Concatentate fanart URLs into strImage field
+    // Prepare SQL to convert CONCAT to || in SQLite
+    m_pDS->exec(PrepareSQL("INSERT INTO artist_new "
+                           "(idArtist, strArtist, strMusicBrainzArtistID, "
+                           "strSortName, strType, strGender, strDisambiguation, "
+                           "strBorn, strFormed, strGenres, strMoods, "
+                           "strStyles , strInstruments , strBiography , "
+                           "strDied, strDisbanded, strYearsActive, "
+                           "strImage, "
+                           "lastScraped, bScrapedMBID, idInfoSetting, "
+                           "dateAdded, dateNew, dateModified) "
+                           "SELECT "
+                           "artist.idArtist, "
+                           "strArtist, strMusicBrainzArtistID, "
+                           "strSortName, strType, strGender, strDisambiguation, "
+                           "strBorn, strFormed, strGenres, strMoods, "
+                           "strStyles, strInstruments, strBiography, "
+                           "strDied, strDisbanded, strYearsActive, "
+                           "CONCAT(strImage, strFanart), "
+                           "lastScraped, bScrapedMBID, idInfoSetting, "
+                           "dateAdded, dateNew, dateModified "
+                           "FROM artist"));
+    m_pDS->exec("DROP TABLE artist");
+    m_pDS->exec("ALTER TABLE artist_new RENAME TO artist");
+  }
   // Set the verion of tag scanning required.
   // Not every schema change requires the tags to be rescanned, set to the highest schema version
   // that needs this. Forced rescanning (of music files that have not changed since they were
@@ -8600,7 +8643,7 @@ void CMusicDatabase::UpdateTables(int version)
 
 int CMusicDatabase::GetSchemaVersion() const
 {
-  return 81; // Bump version to add iDisctotal to songview for MusicPlayer infolabel and boolean
+  return 82;
 }
 
 int CMusicDatabase::GetMusicNeedsTagScan()
@@ -12006,11 +12049,6 @@ std::vector<std::string> CMusicDatabase::GetAvailableArtTypesForItem(int mediaId
     CArtist artist;
     if (GetArtist(mediaId, artist))
     {
-      //! @todo artwork: fanart stored separately, doesn't need to be
-      if (artist.fanart.GetNumFanarts())
-        result.emplace_back("fanart");
-
-      // all other images
       for (const auto& urlEntry : artist.thumbURL.GetUrls())
       {
         std::string artType = urlEntry.m_aspect;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -338,7 +338,7 @@ public:
                     const std::string& strStyles, const std::string& strInstruments,
                     const std::string& strBiography, const std::string& strDied,
                     const std::string& strDisbanded, const std::string& strYearsActive,
-                    const std::string& strImage, const std::string& strFanart);
+                    const std::string& strImage);
   bool UpdateArtistScrapedMBID(int idArtist, const std::string& strMusicBrainzArtistID);
   bool GetTranslateBlankArtist() { return m_translateBlankArtist; }
   void SetTranslateBlankArtist(bool translate) { m_translateBlankArtist = translate; }
@@ -915,7 +915,6 @@ private:
     artist_strDisbanded,
     artist_strYearsActive,
     artist_strImage,
-    artist_strFanart,
     artist_bScrapedMBID,
     artist_lastScraped,
     artist_dateAdded,

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -145,6 +145,14 @@ protected:
    */
   INFO_RET DownloadArtistInfo(const CArtist& artist, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, bool bUseScrapedMBID, CGUIDialogProgress* pDialog = NULL);
 
+  /*! \brief Get the types of art for an artist or album that are to be
+  automatically fetched from local files during scanning
+  \param mediaType [in] artist or album
+  \param iArtLevel [in] art level
+  \return vector of art types that are to be fetched during scanning
+  */
+  std::vector<CVariant> GetArtWhitelist(const MediaType& mediaType, int iArtLevel);
+
   /*! \brief Add extra local artwork for albums and artists
   This common utility scans the given folder for local (non-thumb) art.
   The art types checked are determined by whitelist and usealllocalart settings.

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -268,7 +268,6 @@ void CAdvancedSettings::Initialize()
   m_bShoutcastArt = true;
 
   m_musicThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG";
-  m_fanartImages = "fanart.jpg|fanart.png";
   m_musicArtistExtraArt = { };
   m_musicAlbumExtraArt = {};
 
@@ -1042,12 +1041,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   // show art for shoutcast v2 streams (set to false for devices with limited storage)
   XMLUtils::GetBoolean(pRootElement, "shoutcastart", m_bShoutcastArt);
-
-  // movie fanarts
-  TiXmlElement* pFanart = pRootElement->FirstChildElement("fanart");
-  if (pFanart)
-    GetCustomExtensions(pFanart,m_fanartImages);
-
   // music filename->tag filters
   TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");
   if (filters)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -230,7 +230,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bShoutcastArt;
 
     std::string m_musicThumbs;
-    std::string m_fanartImages;
     std::vector<std::string> m_musicArtistExtraArt;
     std::vector<std::string> m_musicAlbumExtraArt;
 


### PR DESCRIPTION
There is no longer any reason why fanart should be treated differently from any other possible type of art, so this moves handling of artist fanart into processing common to all art. This is a change to  internal implementation, it will not impact on skins or anything accessing the art for an artist.

It entails:
- Storing URLs for fanart  available from remote site in the same field in artist table as URLs for other art types.
- Deprecating <fanart> in advancedsettings.xml (the optional fanart image filenames)
- Supporting input of fanart URL separately by old scrapers and from old NFO files

The music database is bumped to v82, migration converts any fanart URLs and appends them to the other remote art URLs for the artist. 

The option to configure the filenames used for fanart in advancedsettings.xml was dropped for video some time ago, and hence neglected by users for music too, so there is no issue in removing it completely.

In future artist scrapers can simply return the available art URLs for fanart with the rest of the scraped art,  setting `aspect="fanart"`

@rmrector as we first discussed doing long ago, will you be able to look at similar for the video library?

@ronie this is the change that needs to merge before the scraper change of https://github.com/xbmc/xbmc/pull/18511