### PR TITLE
[addons] fix: insert addon into db after installation

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -1284,3 +1284,28 @@ void CAddonDatabase::GetInstallData(const AddonInfoPtr& addon)
     CLog::Log(LOGERROR, "CAddonDatabase::{}: failed", __FUNCTION__);
   }
 }
+
+bool CAddonDatabase::AddInstalledAddon(const std::shared_ptr<CAddonInfo>& addon,
+                                       const std::string& origin)
+{
+  try
+  {
+    if (!m_pDB)
+      return false;
+    if (!m_pDS)
+      return false;
+
+    std::string now = CDateTime::GetCurrentDateTime().GetAsDBDateTime();
+
+    m_pDS->exec(PrepareSQL("INSERT INTO installed(addonID, enabled, installDate, origin) "
+                           "VALUES('%s', 1, '%s', '%s')",
+                           addon->ID().c_str(), now.c_str(), origin.c_str()));
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -214,6 +214,13 @@ public:
 
   void GetInstallData(const ADDON::AddonInfoPtr& addon);
 
+  /*! \brief Add dataset for a new installed addon to the database
+   *  \param addon the addon to insert
+   *  \param origin the origin it was installed from
+   *  \return true on success, false otherwise
+   */
+  bool AddInstalledAddon(const std::shared_ptr<CAddonInfo>& addon, const std::string& origin);
+
 protected:
   void CreateTables() override;
   void CreateAnalytics() override;

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -656,7 +656,8 @@ bool CAddonInstallJob::DoWork()
     return false;
 
   // Load new installed and if successed replace defined m_addon here with new one
-  if (!CServiceBroker::GetAddonMgr().LoadAddon(m_addon->ID(), m_addon->Version()) ||
+  if (!CServiceBroker::GetAddonMgr().LoadAddon(m_addon->ID(), m_addon->Origin(),
+                                               m_addon->Version()) ||
       !CServiceBroker::GetAddonMgr().GetAddon(m_addon->ID(), m_addon))
   {
     CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to reload addon", m_addon->ID().c_str());

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -590,9 +590,11 @@ bool CAddonMgr::HasType(const std::string &id, const TYPE &type)
   return GetAddon(id, addon, type, false);
 }
 
-bool CAddonMgr::FindAddon(const std::string& addonId, const AddonVersion& addonVersion)
+bool CAddonMgr::FindAddon(const std::string& addonId,
+                          const std::string& origin,
+                          const AddonVersion& addonVersion)
 {
-  ADDON_INFO_LIST installedAddons;
+  std::map<std::string, std::shared_ptr<CAddonInfo>> installedAddons;
 
   FindAddons(installedAddons, "special://xbmcbin/addons");
   FindAddons(installedAddons, "special://xbmc/addons");
@@ -607,6 +609,11 @@ bool CAddonMgr::FindAddon(const std::string& addonId, const AddonVersion& addonV
   m_database.GetInstallData(it->second);
   CLog::Log(LOGINFO, "CAddonMgr::{}: {} v{} installed", __FUNCTION__, addonId,
             addonVersion.asString());
+
+  if (!IsAddonInstalled(addonId))
+  {
+    m_database.AddInstalledAddon(it->second, origin);
+  }
 
   m_installedAddons[addonId] = it->second; // insert/replace entry
 
@@ -680,7 +687,9 @@ bool CAddonMgr::UnloadAddon(const std::string& addonId)
   return true;
 }
 
-bool CAddonMgr::LoadAddon(const std::string& addonId, const AddonVersion& addonVersion)
+bool CAddonMgr::LoadAddon(const std::string& addonId,
+                          const std::string& origin,
+                          const AddonVersion& addonVersion)
 {
   CSingleLock lock(m_critSection);
 
@@ -690,7 +699,7 @@ bool CAddonMgr::LoadAddon(const std::string& addonId, const AddonVersion& addonV
     return true;
   }
 
-  if (!FindAddon(addonId, addonVersion))
+  if (!FindAddon(addonId, origin, addonVersion))
   {
     CLog::Log(LOGERROR, "CAddonMgr: could not reload add-on %s. FindAddon failed.", addonId.c_str());
     return false;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -139,12 +139,15 @@ namespace ADDON
      */
     bool FindAddons();
 
-    /*! \brief Checks whether given addon with given version is installed
+    /*! \brief Checks whether given addon with given origin/version is installed
      * \param addonId addon to check
+     * \param origin origin to check
      * \param addonVersion version to check
      * \return True if installed, false otherwise
      */
-    bool FindAddon(const std::string& addonId, const AddonVersion& addonVersion);
+    bool FindAddon(const std::string& addonId,
+                   const std::string& origin,
+                   const AddonVersion& addonVersion);
 
     /*!
      * @brief Fills the the provided vector with the list of incompatible
@@ -190,7 +193,9 @@ namespace ADDON
      *
      * Returns true if the addon was successfully loaded and enabled; otherwise false.
      */
-    bool LoadAddon(const std::string& addonId, const AddonVersion& addonVersion);
+    bool LoadAddon(const std::string& addonId,
+                   const std::string& origin,
+                   const AddonVersion& addonVersion);
 
     /*! @note: should only be called by AddonInstaller
      *


### PR DESCRIPTION
## Description
follow up to pullrequest #18499

addons were not written to the `installed` table after update/new install due to missing synchronization.
this pr fixes the issue.

## How Has This Been Tested?
installed new addon from repo and verified the db entry.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
