### PR TITLE
[videolib]Setting Art level none means no art at all

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -879,11 +879,6 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="myvideos.extractthumb" type="boolean" label="38190" help="36180">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
         <setting id="myvideos.extractchapterthumbs" type="boolean" label="37044" help="37045">
           <level>2</level>
           <default>true</default>
@@ -983,11 +978,6 @@
             <dependency type="enable" setting="videolibrary.tvshowsselectfirstunwatcheditem" operator="!is">0</dependency> <!-- Never -->
           </dependencies>
           <control type="list" format="string" />
-        </setting>
-        <setting id="videolibrary.actorthumbs" type="boolean" label="20402" help="36143">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
         </setting>
         <setting id="videolibrary.moviesetsfolder" type="path" label="20226" help="36300">
           <level>1</level>
@@ -1105,6 +1095,22 @@
             <multiselect>true</multiselect>
             <addbuttonlabel>13516</addbuttonlabel>
           </control>
+        </setting>
+        <setting id="videolibrary.actorthumbs" type="boolean" label="20402" help="36143">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="visible" setting="videolibrary.artworklevel" operator="!is">3</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="myvideos.extractthumb" type="boolean" label="38190" help="36180">
+          <level>1</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="visible" setting="videolibrary.artworklevel" operator="!is">3</dependency>
+          </dependencies>
+          <control type="toggle" />
         </setting>
       </group>
     </category>

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1512,6 +1512,11 @@ namespace VIDEO
 
   void CVideoInfoScanner::GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir, bool useLocal, const std::string &actorArtPath)
   {
+    int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
+    if (artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_NONE)
+      return;
+
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
     movieDetails.m_fanart.Unpack();
     movieDetails.m_strPictureURL.Parse();
@@ -1529,8 +1534,6 @@ namespace VIDEO
       for (std::string artType : movieSetArtTypes)
         artTypes.push_back("set." + artType);
     }
-    int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->
-      GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
     bool addAll = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_ALL;
     bool exactName = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_BASIC;
     // find local art

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -482,7 +482,9 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
         }
       }
       else if (settings->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTTHUMB) &&
-               settings->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
+               settings->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS) &&
+               settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL) !=
+                   CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_NONE)
       {
         CFileItem item(*pItem);
         std::string path(item.GetPath());

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -362,13 +362,20 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       CFileItemPtr item(new CFileItem(it->strName));
       if (!it->thumb.empty())
         item->SetArt("thumb", it->thumb);
-      else if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOLIBRARY_ACTORTHUMBS))
-      { // backward compatibility
-        std::string thumb = CScraperUrl::GetThumbUrl(it->thumbUrl.GetFirstUrlByType());
-        if (!thumb.empty())
-        {
-          item->SetArt("thumb", thumb);
-          CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+      else
+      {
+        const std::shared_ptr<CSettings> settings =
+            CServiceBroker::GetSettingsComponent()->GetSettings();
+        if (settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL) !=
+                CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_NONE &&
+            settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_ACTORTHUMBS))
+        { // backward compatibility
+          std::string thumb = CScraperUrl::GetThumbUrl(it->thumbUrl.GetFirstUrlByType());
+          if (!thumb.empty())
+          {
+            item->SetArt("thumb", thumb);
+            CTextureCache::GetInstance().BackgroundCacheImage(thumb);
+          }
         }
       }
       item->SetArt("icon", "DefaultActor.png");


### PR DESCRIPTION
## Description
Ensure art level none is applied to actors thumbs and thumbnails extracted from video files too. Ensure that hitting refresh from info dialog does not cause art to be added. 
Make this aspect of controlling artwork more obvious for the user by moving the settings for both under Artwork section.

## Motivation and Context
https://github.com/xbmc/xbmc/pull/18072 added an art level setting, including level = none for those users that wanted to be able to turn artwork off. However this left actors thumbs and the thumbnails extracted from video files still appearing.

Settings when art level is "maximum" - actors thumbs and thumbnails optional
![art level = max](https://i.imgur.com/MdEOuQ2.jpg)

Settings when art level is "none"
![art level = none](https://i.imgur.com/l17jSSK.jpg)

@rmrector this is my attempt at turnng off all video related art, which is what I beleive "none" should do.  Your thoughts?