### PR TITLE
[pvr]Fix channelgroups table create statement

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -111,8 +111,8 @@ void CPVRDatabase::CreateTables()
               "sName           varchar(64), "
               "iLastWatched    integer, "
               "bIsHidden       bool, "
-              "iPosition       integer"
-              "iLastOpened     integer, "
+              "iPosition       integer, "
+              "iLastOpened     integer"
               ")");
 
   CLog::LogFC(LOGDEBUG, LOGPVR, "Creating table 'map_channelgroups_channels'");


### PR DESCRIPTION
Wrong SQL sytax used in https://github.com/xbmc/xbmc/pull/18520 to create channelgroups table. Means creation of TV37.db fails on new installs

Bump of db version not needed here