### PR TITLE
Allow default subtitle  settings for closed captioning

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -137,6 +137,9 @@ public:
     if ((ss.flags & StreamFlags::FLAG_FORCED) && (ss.flags & StreamFlags::FLAG_DEFAULT))
       return false;
 
+    if (ss.language == "cc" && ss.flags & StreamFlags::FLAG_HEARING_IMPAIRED)
+      return false;
+
     if(!original)
     {
       std::string subtitle_language = g_langInfo.GetSubtitleLanguage();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Default playback of files and streams with subtitles embedded in the video stream, the standard in North America and
commonly known as closed captioning, do not respect the user global or file table based settings for default
on or off.  They stay off.

The reason for this is Kodi hardcodes the language of thses captions with a "cc" magic value which doesn't match other language options in current subtitle handling.

This PR add these "cc" files to the list of supported subtitles which do have proper defaults

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Currently the issue impacts changing channels, playing recordings and notably when a NextPVR skips a stream the stream could close and reopen and the subtitles would be off after the skip

It allows a user with closed captioning to use the default subtitle options available for other file types.

It partially addresses https://github.com/xbmc/xbmc/issues/16434 tagged for Leia which needs updating to Matrix.
The reason I write "partially" as there is a class of files with closed captionning that Kodi doesn't properly identify.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

It has been tested on Windows Matrix current nightlies, Estuary skin with live TV, recordings and file samples.

A user who requested this feature also tested the change and it addressed his issues.

Because the change is specific to "cc" language and StreamFlags::FLAG_HEARING_IMPAIRED settings the impact on other areas of code is minimized.

A good source of samples would be here https://www.ccextractor.org/public:general:tvsamples   

## Screenshots (if appropriate):

This is a video of the current view https://youtu.be/oJZJ97WIhco and this is after the proposed change https://youtu.be/lF8j6XgxVMEIt

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
