### PR TITLE
[addons] fixes: disable pinning for system addons / gui usability improvements

### DIFF
--- a/addons/skin.estuary/xml/DialogAddonInfo.xml
+++ b/addons/skin.estuary/xml/DialogAddonInfo.xml
@@ -217,7 +217,7 @@
 								</item>
 								<item>
 									<label>$LOCALIZE[126]:</label>
-									<label2>$INFO[ListItem.Property(Addon.Status)]</label2>
+									<label2>$INFO[ListItem.Property(Addon.Status)]$INFO[ListItem.Property(Addon.ValidUpdateVersion),[CR]($LOCALIZE[19114]: ,)]</label2>
 									<visible>!String.IsEmpty(ListItem.Property(Addon.Status))</visible>
 								</item>
 								<item>
@@ -251,11 +251,6 @@
 						<param name="icon" value="icons/infodialogs/configure.png" />
 						<param name="label" value="$LOCALIZE[24020]" />
 					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="8" />
-						<param name="icon" value="icons/infodialogs/update.png" />
-						<param name="label" value="$LOCALIZE[24069]" />
-					</include>
 					<control type="radiobutton" id="13">
 						<width>262</width>
 						<height>140</height>
@@ -280,6 +275,16 @@
 						<param name="icon_off" value="icons/infodialogs/enabled.png" />
 						<param name="selected" value="!String.StartsWith(Control.GetLabel(7),$LOCALIZE[24022]) | !Window.IsActive(addonbrowser)" />
 						<param name="label" value="" />
+					</include>
+					<include content="InfoDialogButton">
+						<param name="id" value="8" />
+						<param name="icon" value="icons/infodialogs/install.png" />
+						<param name="label" value="$LOCALIZE[24138]" />
+					</include>
+					<include content="InfoDialogButton">
+						<param name="id" value="14" />
+						<param name="icon" value="icons/infodialogs/update.png" />
+						<param name="label" value="$LOCALIZE[24069]" />
 					</include>
 					<include content="InfoDialogToggleButton">
 						<param name="id" value="6" />

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -13,17 +13,8 @@
 		<value></value>
 	</variable>
 	<variable name="AddonCountLabel">
-		<value condition="Integer.IsGreater(Container(8000).NumItems,10)">&gt;9</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,9)">9</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,8)">8</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,7)">7</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,6)">6</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,5)">5</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,4)">4</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,3)">3</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,2)">2</value>
-		<value condition="Integer.IsGreater(Container(8000).NumItems,0)">1</value>
-		<value>[COLOR grey]0[/COLOR]</value>
+		<value condition="Integer.IsGreater(System.AddonUpdateCount,0)">$INFO[System.AddonUpdateCount]</value>
+		<value>$INFO[System.AddonUpdateCount,[COLOR grey],[/COLOR]]</value>
 	</variable>
 	<variable name="MusicInfoTextboxVar">
 		<value condition="String.IsEqual(ListItem.DbType,song)">$INFO[ListItem.Comment,[B]$LOCALIZE[569][/B][CR][COLOR=white],[/COLOR]]</value>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4497,6 +4497,14 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @skinning_v19 **[New Boolean Condition]** \link ListItem_Property_AddonIsUpdate `ListItem.Property(Addon.IsUpdate)`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.Property(Addon.ValidUpdateVersion)`</b>,
+///                  \anchor ListItem_Property_ValidUpdateVersion
+///                  _string_,
+///     @return The version string of a valid update for the addon. Empty string if there is no valid update available.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link ListItem_Property_ValidUpdateVersion `ListItem.Property(Addon.ValidUpdateVersion)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.Label`</b>,
 ///                  \anchor ListItem_Label
 ///                  _string_,

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1697,6 +1697,14 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///     @param id - the addon id
 ///     <p>
 ///   }
+///   \table_row3{   <b>`System.AddonUpdateCount`</b>,
+///                  \anchor System_AddonUpdateCount
+///                  _string_,
+///     @return The number of available addon updates.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link  System_AddonUpdateCount `
+///     System.AddonUpdateCount`\endlink <p>
+///   }
 ///   \table_row3{   <b>`System.IdleTime(time)`</b>,
 ///                  \anchor System_IdleTime
 ///                  _boolean_,
@@ -1790,6 +1798,7 @@ const infomap system_labels[] = {{"hasnetwork", SYSTEM_ETHERNET_LINK_ACTIVE},
                                  {"hascms", SYSTEM_HAS_CMS},
                                  {"privacypolicy", SYSTEM_PRIVACY_POLICY},
                                  {"haspvraddon", SYSTEM_HAS_PVR_ADDON},
+                                 {"addonupdatecount", SYSTEM_ADDON_UPDATE_COUNT},
                                  {"supportscpuusage", SYSTEM_SUPPORTS_CPU_USAGE}};
 
 /// \page modules__infolabels_boolean_conditions

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -698,7 +698,8 @@ bool CAddonInstallJob::DoWork()
   }
   else
   {
-    if (!m_addon->Origin().empty()) // we only do pinning/unpinning for non-zip installs
+    // we only do pinning/unpinning for non-zip installs and not system origin
+    if (!m_addon->Origin().empty() && m_addon->Origin() != ORIGIN_SYSTEM)
     {
       std::vector<std::shared_ptr<IAddon>> compatibleVersions;
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -41,6 +41,7 @@ private:
   void UpdateControls();
 
   void OnUpdate();
+  void OnSelectVersion();
   void OnInstall();
   void OnUninstall();
   void OnEnableDisable();

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -811,7 +811,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     bool disabled = CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
 
     std::function<bool(bool)> CheckOutdatedOrUpdate = [&](bool checkOutdated) -> bool {
-      const auto& mapEntry = addonsWithUpdate.find(addon->ID());
+      auto mapEntry = addonsWithUpdate.find(addon->ID());
       if (mapEntry != addonsWithUpdate.end())
       {
         const std::shared_ptr<IAddon>& checkedObject =
@@ -826,12 +826,20 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     bool isUpdate = CheckOutdatedOrUpdate(false); // check if it's an available update
     bool hasUpdate = CheckOutdatedOrUpdate(true); // check if it's an outdated addon
 
+    std::string validUpdateVersion;
+    if (hasUpdate)
+    {
+      auto mapEntry = addonsWithUpdate.find(addon->ID());
+      validUpdateVersion = mapEntry->second.m_update->Version().asString();
+    }
+
     bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon, CheckAddonPath::NO);
 
     pItem->SetProperty("Addon.IsInstalled", installed);
     pItem->SetProperty("Addon.IsEnabled", installed && !disabled);
     pItem->SetProperty("Addon.HasUpdate", hasUpdate);
     pItem->SetProperty("Addon.IsUpdate", isUpdate);
+    pItem->SetProperty("Addon.ValidUpdateVersion", validUpdateVersion);
     pItem->SetProperty("Addon.IsFromOfficialRepo", fromOfficialRepo);
     pItem->SetProperty("Addon.IsBinary", addon->IsBinary());
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -398,6 +398,7 @@
 #define SKIN_ASPECT_RATIO           607
 #define SKIN_FONT                   608
 
+#define SYSTEM_ADDON_UPDATE_COUNT   642
 #define SYSTEM_PRIVACY_POLICY       643
 #define SYSTEM_TOTAL_MEMORY         644
 #define SYSTEM_CPU_USAGE            645

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -305,6 +305,10 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case SYSTEM_RENDER_VERSION:
       value = CServiceBroker::GetRenderSystem()->GetRenderVersionString();
       return true;
+    case SYSTEM_ADDON_UPDATE_COUNT:
+      value =
+          StringUtils::Format("{0}", CServiceBroker::GetAddonMgr().GetAvailableUpdates().size());
+      return true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // NETWORK_*


### PR DESCRIPTION
## Description
### Commit 1:
system addons, for instance `service.xbmc.versioncheck`, `metadata.themoviedb.org` should not be auto pinned on an update

### Commit 2:
corrects the number of available addon-updates displayed on the home-screen by introducing infolabel `AddonUpdateCount`
(thx @ronie)

### Commit 3:
`DialogAddonInfo`: improve usability. the `Versions` button moves to the right and turns into an `Update` button, if an update is available `AND` the local outdated addon has `Auto-updates` enabled aka is not pinned.
The available Update-Version is also displayed in the dialog now.

![screenshot00001](https://user-images.githubusercontent.com/58829855/95728023-47337f00-0c7b-11eb-8eed-826ec5fda7ff.png)

![screenshot00003](https://user-images.githubusercontent.com/58829855/95728041-4e5a8d00-0c7b-11eb-83d1-aae37dbc88a5.png)

## How Has This Been Tested?
debian stretch local

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
