### PR TITLE
GUIComponent: Remove register of stereoscopic manager

### DIFF
--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -41,9 +41,6 @@ void CGUIComponent::Init()
   m_stereoscopicsManager->Initialize();
   m_guiInfoManager->Initialize();
 
-  //! @todo This is something we need to change
-  m_pWindowManager->AddMsgTarget(m_stereoscopicsManager.get());
-
   CServiceBroker::RegisterGUI(this);
 }
 


### PR DESCRIPTION
The stereoscopic manager is registered in 2 places.
Once in GUICompontent's init and another time in load
skin where all other AddMsgTarget calls take place.

During startup of the application following sequence happens:
* GuiCompontent init
* Skin unload
* Skin load

When we unload the skin all message targets are removed and
they are readded in skin load.
Hence the registration of stereoscopig manager in GUIComponent isn't necessary.

## Motivation and Context
Found during debugging.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

