### PR TITLE
[Music]Fix rescrape of single album or artist

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -340,8 +340,9 @@ void CMusicInfoScanner::FetchAlbumInfo(const std::string& strDirectory,
       CDirectoryNode::GetDatabaseInfo(strDirectory, params);
       if (params.GetAlbumId() != -1)
       {
-        //Add single album as item to scan
+        //Add single album (id and path) as item to scan
         CFileItemPtr item(new CFileItem(strDirectory, false));
+        item->GetMusicInfoTag()->SetDatabaseId(params.GetAlbumId(), MediaTypeAlbum);
         items.Add(item);
       }
       else
@@ -401,8 +402,9 @@ void CMusicInfoScanner::FetchArtistInfo(const std::string& strDirectory,
       CDirectoryNode::GetDatabaseInfo(strDirectory, params);
       if (params.GetArtistId() != -1)
       {
-        //Add single artist as item to scan
+        //Add single artist (id and path) as item to scan
         CFileItemPtr item(new CFileItem(strDirectory, false));
+        item->GetMusicInfoTag()->SetDatabaseId(params.GetAlbumId(), MediaTypeArtist);
         items.Add(item);
       }
       else


### PR DESCRIPTION
Fix rescrape of single album or artist after changing informaton provider (scraper) from context menu

Users can selectively change the scraper (and settings) to use when scraping artists or albums from the context menu on the music nav screens, and are then prompted to rescrape that item or items immediately using those new settings. When only applying settings to a single artist or album this rescrep was not taking place.