### PR TITLE
CEC: Don't resume playback on tv standby.

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -623,7 +623,7 @@ void CPeripheralCecAdapter::OnTvStandby(void)
       KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
       break;
     case LOCALISED_ID_PAUSE:
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PAUSE);
+      KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PAUSE_IF_PLAYING);
       break;
     case LOCALISED_ID_STOP:
       KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_STOP);


### PR DESCRIPTION

## Description
Don't resume playback on tv standby, if "when the TV is switched off": "Pause Playback" option is selected.

## Motivation and Context
Currently if CEC on TV is used to control Kodi and "when the TV is switched off": "Pause Playback" option is selected in CEC adapter settings.
1. Run a video.
2. Pause playback.
3. Switch off the TV.
Actual: It resume playback and video is playing when TV is switched off(which is useless).
Expected: Video stay paused.

## How Has This Been Tested?
I'm using Kodi on Raspberry Pi 3B and CEC on TV as input.
With original Kodi.
1. Run a video.
2. Pause playback.(remember playback time)
3. Switch off the TV.
4. Wait 20 seconds.
5. Switch on the TV.
Video is playing and 20 seconds were passed.

Applied the patch and compiled and run Kodi.
1. Run a video.
2. Pause playback.(remember playback time)
3. Switch off the TV.
4. Wait 20 seconds.
5. Switch on the TV.
Video is paused and display the same playback time.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
