### PR TITLE
[Estuary] fix scrolling of addon-version label

### DIFF
--- a/addons/skin.estuary/xml/View_55_WideList.xml
+++ b/addons/skin.estuary/xml/View_55_WideList.xml
@@ -280,6 +280,7 @@
 				<aligny>center</aligny>
 				<font>font27</font>
 				<label>$VAR[AddonsLabel2Var]</label>
+				<scroll>true</scroll>
 			</control>
 			<control type="image">
 				<right>40</right>
@@ -303,7 +304,6 @@
 				<height>80</height>
 				<right>40</right>
 				<aligny>center</aligny>
-				<scroll>true</scroll>
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="label">


### PR DESCRIPTION
## Description
in the addons listing, the label on the right-hand side did not scroll,
making it impossible to see the version number.

## Screenshots (if appropriate):
![scroll](https://user-images.githubusercontent.com/687265/95658716-ceb6ac00-0b1c-11eb-845a-cf27dea0c184.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
