### PR TITLE
[PVR] Remove "Rename" from recordings and timers context menu

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9370,13 +9370,7 @@ msgctxt "#19040"
 msgid "Timers"
 msgstr ""
 
-#empty string with id 19041
-
-#. label for "rename timer" confirmation input dialog
-#: xbmc/pvr/PVRGUIActions.cpp
-msgctxt "#19042"
-msgid "Are you sure you want to rename this timer?"
-msgstr ""
+#empty strings from id 19041 to 19042
 
 #. pvr settings "recording" category label
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9370,11 +9370,7 @@ msgctxt "#19040"
 msgid "Timers"
 msgstr ""
 
-#. label for "rename recording" confirmation input dialog
-#: xbmc/pvr/PVRGUIActions.cpp
-msgctxt "#19041"
-msgid "Are you sure you want to rename this recording?"
-msgstr ""
+#empty string with id 19041
 
 #. label for "rename timer" confirmation input dialog
 #: xbmc/pvr/PVRGUIActions.cpp

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -64,7 +64,6 @@ namespace PVR
     DECL_CONTEXTMENUITEM(EditTimer);
     DECL_CONTEXTMENUITEM(DeleteTimer);
     DECL_STATICCONTEXTMENUITEM(EditRecording);
-    DECL_STATICCONTEXTMENUITEM(RenameRecording);
     DECL_CONTEXTMENUITEM(DeleteRecording);
     DECL_STATICCONTEXTMENUITEM(UndeleteRecording);
     DECL_STATICCONTEXTMENUITEM(DeleteWatchedRecordings);
@@ -331,27 +330,6 @@ namespace PVR
     bool EditRecording::Execute(const CFileItemPtr& item) const
     {
       return CServiceBroker::GetPVRManager().GUIActions()->EditRecording(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Rename recording
-
-    bool RenameRecording::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRRecording> recording = item.GetPVRRecordingInfoTag();
-      if (recording &&
-          !recording->IsDeleted() &&
-          !recording->IsInProgress())
-      {
-        const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(recording->ClientID());
-        return client && client->GetClientCapabilities().SupportsRecordingsRename();
-      }
-      return false;
-    }
-
-    bool RenameRecording::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().GUIActions()->RenameRecording(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -712,7 +690,6 @@ namespace PVR
         std::make_shared<CONTEXTMENUITEM::StartRecording>(264), /* Record */
         std::make_shared<CONTEXTMENUITEM::StopRecording>(19059), /* Stop recording */
         std::make_shared<CONTEXTMENUITEM::EditRecording>(21450), /* Edit */
-        std::make_shared<CONTEXTMENUITEM::RenameRecording>(118), /* Rename */
         std::make_shared<CONTEXTMENUITEM::DeleteRecording>(),
         std::make_shared<CONTEXTMENUITEM::UndeleteRecording>(19290), /* Undelete */
         std::make_shared<CONTEXTMENUITEM::DeleteWatchedRecordings>(19327), /* Delete watched */

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -68,7 +68,6 @@ namespace PVR
     DECL_STATICCONTEXTMENUITEM(UndeleteRecording);
     DECL_STATICCONTEXTMENUITEM(DeleteWatchedRecordings);
     DECL_CONTEXTMENUITEM(ToggleTimerState);
-    DECL_STATICCONTEXTMENUITEM(RenameTimer);
     DECL_STATICCONTEXTMENUITEM(AddReminder);
 
     class PVRClientMenuHook : public IContextMenuItem
@@ -559,31 +558,6 @@ namespace PVR
     }
 
     ///////////////////////////////////////////////////////////////////////////////
-    // Rename timer
-
-    bool RenameTimer::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
-      if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return false;
-
-      // As epg-based timers will get it's title from the epg tag, they should not be renamable.
-      if (timer->IsManual())
-      {
-        const std::shared_ptr<CPVRTimerType> timerType(timer->GetTimerType());
-        if (!timerType->IsReadOnly())
-          return true;
-      }
-
-      return false;
-    }
-
-    bool RenameTimer::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().GUIActions()->RenameTimer(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
     // Delete timer
 
     std::string DeleteTimer::GetLabel(const CFileItem& item) const
@@ -685,7 +659,6 @@ namespace PVR
         std::make_shared<CONTEXTMENUITEM::EditTimerRule>(),
         std::make_shared<CONTEXTMENUITEM::DeleteTimerRule>(19295), /* Delete timer rule */
         std::make_shared<CONTEXTMENUITEM::EditTimer>(),
-        std::make_shared<CONTEXTMENUITEM::RenameTimer>(118), /* Rename */
         std::make_shared<CONTEXTMENUITEM::DeleteTimer>(),
         std::make_shared<CONTEXTMENUITEM::StartRecording>(264), /* Record */
         std::make_shared<CONTEXTMENUITEM::StopRecording>(19059), /* Stop recording */

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -131,7 +131,7 @@ bool CGUIDialogPVRRecordingSettings::OnSettingChanging(std::shared_ptr<const CSe
     if (m_recording->WillBeExpiredWithNewLifetime(iNewLifetime))
     {
       if (HELPERS::ShowYesNoDialogText(CVariant{19068}, // "Recording settings"
-                                       StringUtils::Format(g_localizeStrings.Get(19147).c_str(), iNewLifetime)) // "Setting the lieftime..."
+                                       StringUtils::Format(g_localizeStrings.Get(19147).c_str(), iNewLifetime)) // "Setting the lifetime..."
           != HELPERS::DialogResponse::YES)
         return false;
     }

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -1080,25 +1080,6 @@ namespace PVR
     return CGUIDialogPVRRecordingSettings::CanEditRecording(item);
   }
 
-  bool CPVRGUIActions::RenameRecording(const CFileItemPtr& item) const
-  {
-    const std::shared_ptr<CPVRRecording> recording(item->GetPVRRecordingInfoTag());
-    if (!recording)
-      return false;
-
-    std::string strNewName(recording->m_strTitle);
-    if (!CGUIKeyboardFactory::ShowAndGetInput(strNewName, CVariant{g_localizeStrings.Get(19041)}, false))
-      return false;
-
-    if (!AsyncRenameRecording(strNewName).Execute(item))
-    {
-      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
-      return false;
-    }
-
-    return true;
-  }
-
   bool CPVRGUIActions::DeleteRecording(const CFileItemPtr& item) const
   {
     if ((!item->IsPVRRecording() && !item->m_bIsFolder) || item->IsParentFolder())

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -867,34 +867,6 @@ namespace PVR
     return {};
   }
 
-  bool CPVRGUIActions::RenameTimer(const CFileItemPtr& item) const
-  {
-    if (!item->HasPVRTimerInfoTag())
-      return false;
-
-    const std::shared_ptr<CPVRTimerInfoTag> timer(item->GetPVRTimerInfoTag());
-
-    std::string strNewName(timer->m_strTitle);
-    if (CGUIKeyboardFactory::ShowAndGetInput(strNewName,
-                                             CVariant{g_localizeStrings.Get(19042)}, // "Are you sure you want to rename this timer?"
-                                             false))
-    {
-      if (CServiceBroker::GetPVRManager().Timers()->RenameTimer(timer, strNewName))
-        return true;
-
-      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19263}); // "Error", "Could not update the timer. Check the log for more information about this message."
-      return false;
-    }
-
-    CGUIWindowPVRBase* pvrWindow = dynamic_cast<CGUIWindowPVRBase*>(CServiceBroker::GetGUI()->GetWindowManager().GetWindow(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow()));
-    if (pvrWindow)
-      pvrWindow->DoRefresh();
-    else
-      CLog::LogF(LOGERROR, "Called on non-pvr window. No refresh possible.");
-
-    return true;
-  }
-
   bool CPVRGUIActions::DeleteTimer(const CFileItemPtr& item) const
   {
     return DeleteTimer(item, false, false);

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -218,13 +218,6 @@ namespace PVR
     bool CanEditRecording(const CFileItem& item) const;
 
     /*!
-     * @brief Rename a recording, showing a text input dialog.
-     * @param item containing a recording to rename.
-     * @return true, if the recording was renamed successfully, false otherwise.
-     */
-    bool RenameRecording(const std::shared_ptr<CFileItem>& item) const;
-
-    /*!
      * @brief Delete a recording, always showing a confirmation dialog.
      * @param item containing a recording to delete.
      * @return true, if the recording was deleted successfully, false otherwise.

--- a/xbmc/pvr/guilib/PVRGUIActions.h
+++ b/xbmc/pvr/guilib/PVRGUIActions.h
@@ -155,13 +155,6 @@ namespace PVR
     std::shared_ptr<CFileItem> GetTimerRule(const std::shared_ptr<CFileItem>& item) const;
 
     /*!
-     * @brief Rename a timer, showing a text input dialog.
-     * @param item containing a timer to rename.
-     * @return true, if the timer was renamed successfully, false otherwise.
-     */
-    bool RenameTimer(const std::shared_ptr<CFileItem>& item) const;
-
-    /*!
      * @brief Delete a timer, always showing a confirmation dialog.
      * @param item containing a timer to delete. item must be a timer, an epg tag or a channel.
      * @return true, if the timer was deleted successfully, false otherwise.

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -531,18 +531,6 @@ TimerOperationResult CPVRTimerInfoTag::DeleteFromClient(bool bForce /* = false *
   return (error == PVR_ERROR_NO_ERROR) ? TimerOperationResult::OK : TimerOperationResult::FAILED;
 }
 
-bool CPVRTimerInfoTag::RenameOnClient(const std::string& strNewName)
-{
-  {
-    // set the new timer title locally
-    CSingleLock lock(m_critSection);
-    m_strTitle = strNewName;
-  }
-
-  // update timer data in the backend
-  return UpdateOnClient();
-}
-
 bool CPVRTimerInfoTag::Persist()
 {
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -276,13 +276,6 @@ namespace PVR
     TimerOperationResult DeleteFromClient(bool bForce = false) const;
 
     /*!
-     * @brief Rename this timer on the backend, transferring all local data of this timer to the backend.
-     * @param strNewName The new name.
-     * @return True on success, false otherwise.
-     */
-    bool RenameOnClient(const std::string& strNewName);
-
-    /*!
      * @brief Update this timer on the backend, transferring all local data of this timer to the backend.
      * @return True on success, false otherwise.
      */

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -963,20 +963,6 @@ TimerOperationResult CPVRTimers::DeleteTimer(const std::shared_ptr<CPVRTimerInfo
   return ret;
 }
 
-bool CPVRTimers::RenameTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, const std::string& strNewName)
-{
-  bool bReturn = false;
-  if (tag->IsOwnedByClient())
-  {
-    bReturn = tag->RenameOnClient(strNewName);
-  }
-  else
-  {
-    bReturn = RenameLocalTimer(tag, strNewName);
-  }
-  return bReturn;
-}
-
 bool CPVRTimers::UpdateTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag)
 {
   bool bReturn = false;
@@ -1080,21 +1066,6 @@ bool CPVRTimers::DeleteLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, 
     lock.Leave();
     NotifyTimersEvent();
   }
-
-  return bReturn;
-}
-
-bool CPVRTimers::RenameLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, const std::string& strNewName)
-{
-  {
-    CSingleLock lock(m_critSection);
-    tag->m_strTitle = strNewName;
-  }
-  // no need to re-create timer and children. changed timer title does not invalidate any children.
-  bool bReturn = !!PersistAndUpdateLocalTimer(tag, nullptr);
-
-  if (bReturn)
-    NotifyTimersEvent();
 
   return bReturn;
 }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -218,13 +218,6 @@ namespace PVR
     TimerOperationResult DeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bForce = false, bool bDeleteRule = false);
 
     /*!
-     * @brief Rename a timer on the client. Doesn't update the timer in the container. The backend will do this.
-     * @param tag The timer to rename.
-     * @return True if timer rename request was sent correctly, false if not.
-     */
-    bool RenameTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, const std::string& strNewName);
-
-    /*!
      * @brief Update the timer on the client. Doesn't update the timer in the container. The backend will do this.
      * @param tag The timer to update.
      * @return True if timer update request was sent correctly, false if not.
@@ -273,7 +266,6 @@ namespace PVR
 
     bool AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify);
     bool DeleteLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify);
-    bool RenameLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, const std::string& strNewName);
     bool UpdateLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag);
     std::shared_ptr<CPVRTimerInfoTag> PersistAndUpdateLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer,
                                                                  const std::shared_ptr<CPVRTimerInfoTag>& parentTimer);


### PR DESCRIPTION
Remove "Rename" from recordings and timers context menu as this functionality is also available in the respective settings dialog. Reason: safe some space, we have already to much ctx menu item, imo.

@phunkyfish when you find some time for a review...