### PR TITLE
[PVR] Fixed deadlock on PVR startup (connection state change vs. epg …

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -294,7 +294,7 @@ std::shared_ptr<CPVRGUIActions> CPVRManager::GUIActions() const
 
 std::shared_ptr<CPVRPlaybackState> CPVRManager::PlaybackState() const
 {
-  CSingleLock lock(m_critSection);
+  // note: m_playbackState is const (only set/reset in ctor/dtor). no need for a lock here.
   return m_playbackState;
 }
 
@@ -306,6 +306,7 @@ CPVREpgContainer& CPVRManager::EpgContainer()
 
 void CPVRManager::Clear()
 {
+  m_playbackState->Clear();
   m_pendingUpdates->Clear();
   m_epgContainer.Clear();
 
@@ -316,7 +317,6 @@ void CPVRManager::Clear()
   m_recordings.reset();
   m_channelGroups.reset();
   m_parentalTimer.reset();
-  m_playbackState.reset();
   m_database.reset();
 
   m_bEpgsCreated = false;
@@ -333,7 +333,6 @@ void CPVRManager::ResetProperties()
   m_timers.reset(new CPVRTimers);
   m_guiInfo.reset(new CPVRGUIInfo);
   m_parentalTimer.reset(new CStopWatch);
-  m_playbackState.reset(new CPVRPlaybackState);
 }
 
 void CPVRManager::Init()

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -433,7 +433,7 @@ namespace PVR
 
     CEventSource<PVREvent> m_events;
 
-    std::shared_ptr<CPVRPlaybackState> m_playbackState;
+    const std::shared_ptr<CPVRPlaybackState> m_playbackState;
 
     CPVRGUIActionListener m_actionListener;
     CPVRSettings m_settings;

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -59,8 +59,23 @@ CPVRPlaybackState::CPVRPlaybackState() = default;
 
 CPVRPlaybackState::~CPVRPlaybackState() = default;
 
+void CPVRPlaybackState::Clear()
+{
+  CSingleLock lock(m_critSection);
+
+  m_playingChannel.reset();
+  m_playingRecording.reset();
+  m_playingEpgTag.reset();
+  m_playingClientId = -1;
+  m_playingChannelUniqueId = -1;
+  m_strPlayingClientName.clear();
+  m_lastWatchedUpdateTimer.reset();
+}
+
 void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem> item)
 {
+  CSingleLock lock(m_critSection);
+
   m_playingChannel.reset();
   m_playingRecording.reset();
   m_playingEpgTag.reset();
@@ -116,6 +131,8 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem> item)
 bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem> item)
 {
   // Playback ended due to user interaction
+
+  CSingleLock lock(m_critSection);
 
   bool bChanged = false;
 
@@ -174,36 +191,43 @@ void CPVRPlaybackState::OnPlaybackEnded(const std::shared_ptr<CFileItem> item)
 
 bool CPVRPlaybackState::IsPlaying() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannel != nullptr || m_playingRecording != nullptr || m_playingEpgTag != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingTV() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannel && !m_playingChannel->IsRadio();
 }
 
 bool CPVRPlaybackState::IsPlayingRadio() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannel && m_playingChannel->IsRadio();
 }
 
 bool CPVRPlaybackState::IsPlayingEncryptedChannel() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannel && m_playingChannel->IsEncrypted();
 }
 
 bool CPVRPlaybackState::IsPlayingRecording() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingRecording != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingEpgTag() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingEpgTag != nullptr;
 }
 
 bool CPVRPlaybackState::IsPlayingChannel(int iClientID, int iUniqueChannelID) const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannel && m_playingClientId == iClientID && m_playingChannelUniqueId == iUniqueChannelID;
 }
 
@@ -245,31 +269,37 @@ bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& e
 
 std::shared_ptr<CPVRChannel> CPVRPlaybackState::GetPlayingChannel() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannel;
 }
 
 std::shared_ptr<CPVRRecording> CPVRPlaybackState::GetPlayingRecording() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingRecording;
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVRPlaybackState::GetPlayingEpgTag() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingEpgTag;
 }
 
 int CPVRPlaybackState::GetPlayingChannelUniqueID() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingChannelUniqueId;
 }
 
 std::string CPVRPlaybackState::GetPlayingClientName() const
 {
+  CSingleLock lock(m_critSection);
   return m_strPlayingClientName;
 }
 
 int CPVRPlaybackState::GetPlayingClientID() const
 {
+  CSingleLock lock(m_critSection);
   return m_playingClientId;
 }
 

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
+
 #include <memory>
 #include <string>
 
@@ -33,6 +35,11 @@ public:
    * @brief dtor.
    */
   virtual ~CPVRPlaybackState();
+
+  /*!
+   * @brief clear all data.
+   */
+  void Clear();
 
   /*!
    * @brief Inform that playback of an item just started.
@@ -212,6 +219,8 @@ private:
    * @param time The last watched time to set
    */
   void UpdateLastWatched(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& time);
+
+  mutable CCriticalSection m_critSection;
 
   std::shared_ptr<CPVRChannel> m_playingChannel;
   std::shared_ptr<CPVRRecording> m_playingRecording;


### PR DESCRIPTION
This fixes a deadlock I recently encountered.


T21 (connectionstatechange lambda job) want epg container mtx, has pvr mgr ctx
T22 (epgcontainerstartjob) wantspvr mgr mtx, has epg container mtx

```log
* thread #21, name = 'JobWorker'
    frame #0: 0x00007fff6d81f062 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000127c56398 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 101
    frame #2: 0x0000000127c541d8 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 225
    frame #3: 0x000000010015bee5 kodi.bin`XbmcThreads::CRecursiveMutex::lock(this=0x000000012a8725e0) at RecursiveMutex.h:33:26
    frame #4: 0x000000010015bebc kodi.bin`XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock(this=0x000000012a8725e0) at Lockables.h:49:32
    frame #5: 0x000000010015be9a kodi.bin`XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(this=0x0000700002a9a7e8, lockable=0x000000012a8725e0) at Lockables.h:112:83
    frame #6: 0x000000010015be60 kodi.bin`CSingleLock::CSingleLock(this=0x0000700002a9a7e8, cs=0x000000012a8725e0) at SingleLock.h:27:55
    frame #7: 0x000000010015be0d kodi.bin`CSingleLock::CSingleLock(this=0x0000700002a9a7e8, cs=0x000000012a8725e0) at SingleLock.h:27:101
====> wants epg container mtx
  * frame #8: 0x00000001059cecd6 kodi.bin`PVR::CPVREpgContainer::Stop(this=0x000000012a8722e8) at EpgContainer.cpp:239:15
    frame #9: 0x00000001059ced39 kodi.bin`PVR::CPVREpgContainer::Clear(this=0x000000012a8722e8) at EpgContainer.cpp:146:5
    frame #10: 0x00000001056043e0 kodi.bin`PVR::CPVRManager::Clear(this=0x000000012a872000) at PVRManager.cpp:310:18
    frame #11: 0x0000000105604716 kodi.bin`PVR::CPVRManager::ResetProperties(this=0x000000012a872000) at PVRManager.cpp:328:3
====> has pvr mgr mtx
    frame #12: 0x0000000105605077 kodi.bin`PVR::CPVRManager::Stop(this=0x000000012a872000) at PVRManager.cpp:404:3
    frame #13: 0x0000000105604da5 kodi.bin`PVR::CPVRManager::Start(this=0x000000012a872000) at PVRManager.cpp:361:3
    frame #14: 0x000000010576191a kodi.bin`PVR::CPVRClients::ConnectionStateChange(this=0x0000000127e79c50, client=0x0000000135685908, strConnectionString="tv-server:9982", newState=PVR_CONNECTION_STATE_CONNECTED, strMessage="") at PVRClients.cpp:677:37
    frame #15: 0x000000010563b71e kodi.bin`PVR::CPVRManager::ConnectionStateChange(this=0x000000013594a060)::$_10::operator()() const at PVRManager.cpp:828:16
    frame #16: 0x000000010563b58e kodi.bin`CLambdaJob<PVR::CPVRManager::ConnectionStateChange(PVR::CPVRClient*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, PVR_CONNECTION_STATE, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_10>::DoWork(this=0x000000013594a050) at JobManager.h:39:5
    frame #17: 0x00000001065d6106 kodi.bin`CJobWorker::Process(this=0x00000001332467f0) at JobManager.cpp:55:22
    frame #18: 0x00000001063a3c8e kodi.bin`CThread::Action(this=0x00000001332467f0) at Thread.cpp:282:5
    frame #19: 0x00000001063cc170 kodi.bin`CThread::Create(this=0x000000013323e820, pThread=0x00000001332467f0, promise=promise<bool> @ 0x0000700002a9af10)::$_0::operator()(CThread*, std::__1::promise<bool>) const at Thread.cpp:140:18
    frame #20: 0x00000001063cbece kodi.bin`decltype(__f=0x000000013323e820, __args=0x000000013323e828, __args=0x000000013323e830)::$_0>(fp)(std::__1::forward<CThread*>(fp0), std::__1::forward<std::__1::promise<bool> >(fp0))) std::__1::__invoke<CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::__1::promise<bool>&&) at type_traits:3545:1
    frame #21: 0x00000001063cbdf7 kodi.bin`void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool>, 2ul, 3ul>(__t=size=4, (null)=__tuple_indices<2, 3> @ 0x0000700002a9af58)::$_0, CThread*, std::__1::promise<bool> >&, std::__1::__tuple_indices<2ul, 3ul>) at thread:273:5
    frame #22: 0x00000001063cb4d6 kodi.bin`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool> > >(__vp=0x000000013323e820) at thread:284:5
    frame #23: 0x0000000127c58c65 libsystem_pthread.dylib`_pthread_start + 148
    frame #24: 0x0000000127c544af libsystem_pthread.dylib`thread_start + 15



  thread #22, name = 'JobWorker'
    frame #0: 0x00007fff6d81f062 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000127c56398 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 101
    frame #2: 0x0000000127c541d8 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 225
    frame #3: 0x000000010015bee5 kodi.bin`XbmcThreads::CRecursiveMutex::lock(this=0x000000012a872978) at RecursiveMutex.h:33:26
    frame #4: 0x000000010015bebc kodi.bin`XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock(this=0x000000012a872978) at Lockables.h:49:32
    frame #5: 0x000000010015be9a kodi.bin`XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(this=0x0000700002b1d6c0, lockable=0x000000012a872978) at Lockables.h:112:83
    frame #6: 0x000000010015be60 kodi.bin`CSingleLock::CSingleLock(this=0x0000700002b1d6c0, cs=0x000000012a872978) at SingleLock.h:27:55
    frame #7: 0x000000010015be0d kodi.bin`CSingleLock::CSingleLock(this=0x0000700002b1d6c0, cs=0x000000012a872978) at SingleLock.h:27:101
====> wants pvr mgr mtx
    frame #8: 0x000000010560431f kodi.bin`PVR::CPVRManager::PlaybackState(this=0x000000012a872000) const at PVRManager.cpp:297:15
    frame #9: 0x0000000105ab672d kodi.bin`PVR::CPVREpgTagsCache::Refresh(this=0x0000000141249690, bUpdateIfNeeded=false) at EpgTagsCache.cpp:70:39
    frame #10: 0x0000000105ab6e7d kodi.bin`PVR::CPVREpgTagsCache::GetNowActiveTag(this=0x0000000141249690, bUpdateIfNeeded=false) at EpgTagsCache.cpp:46:3
    frame #11: 0x0000000105adfcdc kodi.bin`PVR::CPVREpgTagsContainer::GetActiveTag(this=0x00000001412665f8, bUpdateIfNeeded=false) const at EpgTagsContainer.cpp:403:23
    frame #12: 0x00000001059a187e kodi.bin`PVR::CPVREpg::GetTagNow(this=0x0000000141266540, bUpdateIfNeeded=false) const at Epg.cpp:92:17
    frame #13: 0x00000001059a1a02 kodi.bin`PVR::CPVREpg::CheckPlayingEvent(this=0x0000000141266540) at Epg.cpp:109:55
    frame #14: 0x00000001059cfb90 kodi.bin`PVR::CPVREpgContainer::CheckPlayingEvents(this=0x000000012a8722e8) at EpgContainer.cpp:826:40
====> has epg container mtx
    frame #15: 0x00000001059cf804 kodi.bin`PVR::CPVREpgContainer::Start(this=0x000000012a8722e8, bAsync=false) at EpgContainer.cpp:217:7
    frame #16: 0x00000001059d6c53 kodi.bin`PVR::CPVREpgContainerStartJob::DoWork(this=0x00000001404143f0) at EpgContainer.cpp:182:52
    frame #17: 0x00000001065d6106 kodi.bin`CJobWorker::Process(this=0x00000001332546e0) at JobManager.cpp:55:22
    frame #18: 0x00000001063a3c8e kodi.bin`CThread::Action(this=0x00000001332546e0) at Thread.cpp:282:5
    frame #19: 0x00000001063cc170 kodi.bin`CThread::Create(this=0x00000001332575c0, pThread=0x00000001332546e0, promise=promise<bool> @ 0x0000700002b1df10)::$_0::operator()(CThread*, std::__1::promise<bool>) const at Thread.cpp:140:18
    frame #20: 0x00000001063cbece kodi.bin`decltype(__f=0x00000001332575c0, __args=0x00000001332575c8, __args=0x00000001332575d0)::$_0>(fp)(std::__1::forward<CThread*>(fp0), std::__1::forward<std::__1::promise<bool> >(fp0))) std::__1::__invoke<CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::__1::promise<bool>&&) at type_traits:3545:1
    frame #21: 0x00000001063cbdf7 kodi.bin`void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool>, 2ul, 3ul>(__t=size=4, (null)=__tuple_indices<2, 3> @ 0x0000700002b1df58)::$_0, CThread*, std::__1::promise<bool> >&, std::__1::__tuple_indices<2ul, 3ul>) at thread:273:5
    frame #22: 0x00000001063cb4d6 kodi.bin`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool> > >(__vp=0x00000001332575c0) at thread:284:5
    frame #23: 0x0000000127c58c65 libsystem_pthread.dylib`_pthread_start + 148
    frame #24: 0x0000000127c544af libsystem_pthread.dylib`thread_start + 15
```

@phunkyfish when you find some time for a review...