### PR TITLE
[pvr] docs for GetDriveSpace() changed correctly to KB

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/PVR.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/PVR.h
@@ -623,8 +623,8 @@ public:
   //============================================================================
   /// @brief Get the disk space reported by the backend (if supported).
   ///
-  /// @param[in] total The total disk space in bytes.
-  /// @param[in] used The used disk space in bytes.
+  /// @param[in] total The total disk space in KiB.
+  /// @param[in] used The used disk space in KiB.
   /// @return @ref PVR_ERROR_NO_ERROR if the drive space has been fetched
   ///         successfully.
   ///
@@ -635,8 +635,8 @@ public:
   /// ~~~~~~~~~~~~~{.cpp}
   /// PVR_ERROR CMyPVRClient::GetDriveSpace(uint64_t& total, uint64_t& used)
   /// {
-  ///   total = 10 * 1024 * 1024 * 1024; // To set complete size of drive in bytes
-  ///   used =  122324243; // To set the used amount
+  ///   total = 100 * 1024 * 1024; // To set complete size of drive in KiB (100GB)
+  ///   used =  12232424; // To set the used amount
   ///   return PVR_ERROR_NO_ERROR;
   /// }
   /// ~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Documentation is incorrect here. Any values read from the client are multiplied by 1024 so the unit is KB and not bytes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Docs wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
