### PR TITLE
windowing/x11: add namespace

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -192,7 +192,7 @@ bool CVDPAUContext::CreateContext()
     if (!m_display)
       return false;
 
-    screen = static_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem())->GetScreen();
+    screen = static_cast<KODI::WINDOWING::X11::CWinSystemX11*>(CServiceBroker::GetWinSystem())->GetScreen();
   }
 
   VdpStatus vdp_st;

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -38,7 +38,7 @@
 #include "windowing/WinSystem.h"
 
 #if defined(HAVE_X11)
-#define WIN_SYSTEM_CLASS CWinSystemX11
+#define WIN_SYSTEM_CLASS KODI::WINDOWING::X11::CWinSystemX11
 #include "windowing/X11/WinSystemX11.h"
 #elif defined(TARGET_DARWIN_OSX)
 #define WIN_SYSTEM_CLASS CWinSystemOSX

--- a/xbmc/windowing/X11/GLContextGLX.cpp
+++ b/xbmc/windowing/X11/GLContextGLX.cpp
@@ -14,6 +14,8 @@
 
 #include "system_gl.h"
 
+using namespace KODI::WINDOWING::X11;
+
 CGLContextGLX::CGLContextGLX(Display *dpy) : CGLContext(dpy)
 {
   m_extPrefix = "GLX_";

--- a/xbmc/windowing/X11/GLContextGLX.h
+++ b/xbmc/windowing/X11/GLContextGLX.h
@@ -12,6 +12,13 @@
 
 #include <GL/glx.h>
 
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CGLContextGLX : public CGLContext
 {
 public:
@@ -35,3 +42,7 @@ protected:
   int m_iVSyncErrors;
   int m_vsyncMode;
 };
+
+}
+}
+}

--- a/xbmc/windowing/X11/OptionalsReg.cpp
+++ b/xbmc/windowing/X11/OptionalsReg.cpp
@@ -16,6 +16,15 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"
 
+using namespace KODI::WINDOWING::X11;
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CWinSystemX11GLContext;
 
 class CVaapiProxy : public VAAPI::IVaapiWinSystem
@@ -30,61 +39,74 @@ public:
   void *eglDisplay;
 };
 
-CVaapiProxy* X11::VaapiProxyCreate()
+CVaapiProxy* VaapiProxyCreate()
 {
   return new CVaapiProxy();
 }
 
-void X11::VaapiProxyDelete(CVaapiProxy *proxy)
+void VaapiProxyDelete(CVaapiProxy *proxy)
 {
   delete proxy;
 }
 
-void X11::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
+void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
 {
   proxy->dpy = static_cast<Display*>(dpy);
   proxy->eglDisplay = eglDpy;
 }
 
-void X11::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
+void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
   VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
   EGLDisplay eglDpy = winSystem->eglDisplay;
   VADisplay vaDpy = vaGetDisplay(winSystem->dpy);
   CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, deepColor);
 }
 
+}
+}
+}
+
 #else
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
 
 class CVaapiProxy
 {
 };
 
-CVaapiProxy* X11::VaapiProxyCreate()
+CVaapiProxy* VaapiProxyCreate()
 {
   return nullptr;
 }
 
-void X11::VaapiProxyDelete(CVaapiProxy *proxy)
+void VaapiProxyDelete(CVaapiProxy *proxy)
 {
 }
 
-void X11::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
+void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
 {
 }
 
-void X11::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
+void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
 }
 
-void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
 }
 
+}
+}
+}
 #endif
 
 //-----------------------------------------------------------------------------
@@ -96,48 +118,69 @@ void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepC
 #include "VideoSyncGLX.h"
 #include "GLContextGLX.h"
 
-XID X11::GLXGetWindow(void* context)
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
+XID GLXGetWindow(void* context)
 {
   return static_cast<CGLContextGLX*>(context)->m_glxWindow;
 }
 
-void* X11::GLXGetContext(void* context)
+void* GLXGetContext(void* context)
 {
   return static_cast<CGLContextGLX*>(context)->m_glxContext;
 }
 
-CGLContext* X11::GLXContextCreate(Display *dpy)
+CGLContext* GLXContextCreate(Display *dpy)
 {
   return new CGLContextGLX(dpy);
 }
 
-CVideoSync* X11::GLXVideoSyncCreate(void *clock, CWinSystemX11GLContext& winSystem)
+
+CVideoSync* GLXVideoSyncCreate(void* clock, CWinSystemX11GLContext& winSystem)
 {
   return new  CVideoSyncGLX(clock, winSystem);
 }
 
+}
+}
+}
 #else
 
-XID X11::GLXGetWindow(void* context)
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
+XID GLXGetWindow(void* context)
 {
   return 0;
 }
 
-void* X11::GLXGetContext(void* context)
+void* GLXGetContext(void* context)
 {
   return nullptr;
 }
 
-CGLContext* X11::GLXContextCreate(Display *dpy)
+CGLContext* GLXContextCreate(Display *dpy)
 {
   return nullptr;
 }
 
-CVideoSync* X11::GLXVideoSyncCreate(void *clock, CWinSystemX11GLContext& winSystem)
+CVideoSync* GLXVideoSyncCreate(void* clock, CWinSystemX11GLContext& winSystem)
 {
   return nullptr;
 }
 
+}
+}
+}
 #endif
 
 //-----------------------------------------------------------------------------
@@ -148,26 +191,47 @@ CVideoSync* X11::GLXVideoSyncCreate(void *clock, CWinSystemX11GLContext& winSyst
 #include "cores/VideoPlayer/DVDCodecs/Video/VDPAU.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.h"
 
-void X11::VDPAURegisterRender()
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
+void VDPAURegisterRender()
 {
   CRendererVDPAU::Register();
 }
 
-void X11::VDPAURegister()
+void VDPAURegister()
 {
   VDPAU::CDecoder::Register();
 }
 
+}
+}
+}
 #else
 
-void X11::VDPAURegisterRender()
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
+void VDPAURegisterRender()
 {
 
 }
 
-void X11::VDPAURegister()
+void VDPAURegister()
 {
 
+}
+
+}
+}
 }
 #endif
 

--- a/xbmc/windowing/X11/OptionalsReg.h
+++ b/xbmc/windowing/X11/OptionalsReg.h
@@ -14,15 +14,22 @@
 // VAAPI
 //-----------------------------------------------------------------------------
 
-class CVaapiProxy;
-
+namespace KODI
+{
+namespace WINDOWING
+{
 namespace X11
 {
+
+class CVaapiProxy;
+
 CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy);
 void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
 void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
+}
+}
 }
 
 //-----------------------------------------------------------------------------
@@ -31,22 +38,36 @@ void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 
 class CVideoSync;
 class CGLContext;
-class CWinSystemX11GLContext;
 
+namespace KODI
+{
+namespace WINDOWING
+{
 namespace X11
 {
+
+class CWinSystemX11GLContext;
+
 XID GLXGetWindow(void* context);
 void* GLXGetContext(void* context);
 CGLContext* GLXContextCreate(Display *dpy);
 CVideoSync* GLXVideoSyncCreate(void *clock, CWinSystemX11GLContext& winSystem);
+}
+}
 }
 
 //-----------------------------------------------------------------------------
 // VDPAU
 //-----------------------------------------------------------------------------
 
+namespace KODI
+{
+namespace WINDOWING
+{
 namespace X11
 {
 void VDPAURegisterRender();
 void VDPAURegister();
+}
+}
 }

--- a/xbmc/windowing/X11/VideoSyncGLX.cpp
+++ b/xbmc/windowing/X11/VideoSyncGLX.cpp
@@ -19,6 +19,8 @@
 
 #include <X11/extensions/Xrandr.h>
 
+using namespace KODI::WINDOWING::X11;
+
 Display* CVideoSyncGLX::m_Dpy = NULL;
 
 void CVideoSyncGLX::OnLostDisplay()

--- a/xbmc/windowing/X11/VideoSyncGLX.h
+++ b/xbmc/windowing/X11/VideoSyncGLX.h
@@ -18,6 +18,15 @@
 
 #include "system_gl.h"
 
+
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CWinSystemX11GLContext;
 
 class CVideoSyncGLX : public CVideoSync, IDispResource
@@ -45,3 +54,7 @@ private:
   volatile bool m_displayReset;
   CEvent m_lostEvent;
 };
+
+}
+}
+}

--- a/xbmc/windowing/X11/VideoSyncOML.cpp
+++ b/xbmc/windowing/X11/VideoSyncOML.cpp
@@ -13,6 +13,7 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/X11/WinSystemX11GLContext.h"
 
+using namespace KODI::WINDOWING::X11;
 
 bool CVideoSyncOML::Setup(PUPDATECLOCK func)
 {

--- a/xbmc/windowing/X11/VideoSyncOML.h
+++ b/xbmc/windowing/X11/VideoSyncOML.h
@@ -13,6 +13,14 @@
 
 #include <atomic>
 
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CWinSystemX11GLContext;
 
 class CVideoSyncOML : public CVideoSync, IDispResource
@@ -31,3 +39,6 @@ private:
   CWinSystemX11GLContext &m_winSystem;
 };
 
+}
+}
+}

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -28,6 +28,7 @@
 #include <X11/keysymdef.h>
 
 using namespace KODI::MESSAGING;
+using namespace KODI::WINDOWING::X11;
 
 static uint32_t SymMappingsX11[][2] =
 {

--- a/xbmc/windowing/X11/WinEventsX11.h
+++ b/xbmc/windowing/X11/WinEventsX11.h
@@ -17,6 +17,13 @@
 
 #include <X11/Xlib.h>
 
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CWinEventsX11 : public IWinEvents
 {
 public:
@@ -47,3 +54,7 @@ protected:
   bool m_xrrEventPending;
   CWinSystemX11& m_winSystem;
 };
+
+}
+}
+}

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -36,7 +36,7 @@
 #include <X11/extensions/Xrandr.h>
 
 using namespace KODI::MESSAGING;
-using namespace KODI::WINDOWING;
+using namespace KODI::WINDOWING::X11;
 
 #define EGL_NO_CONFIG (EGLConfig)0
 
@@ -477,7 +477,7 @@ void CWinSystemX11::ShowOSMouse(bool show)
     XDefineCursor(m_dpy,m_mainWindow, m_invisibleCursor);
 }
 
-std::unique_ptr<IOSScreenSaver> CWinSystemX11::GetOSScreenSaverImpl()
+std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> CWinSystemX11::GetOSScreenSaverImpl()
 {
   std::unique_ptr<IOSScreenSaver> ret;
   if (m_dpy)

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -21,6 +21,14 @@
 #include <X11/Xutil.h>
 
 class IDispResource;
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CWinEventsX11;
 
 class CWinSystemX11 : public CWinSystemBase
@@ -100,3 +108,7 @@ private:
   bool HasWindowManager();
   void UpdateCrtc();
 };
+
+}
+}
+}

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -35,6 +35,8 @@
 #include <X11/Xutil.h>
 
 using namespace KODI;
+using namespace KODI::WINDOWING::X11;
+
 
 std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
 {
@@ -120,12 +122,12 @@ bool CWinSystemX11GLContext::IsExtSupported(const char* extension) const
 
 XID CWinSystemX11GLContext::GetWindow() const
 {
-  return X11::GLXGetWindow(m_pGLContext);
+  return GLXGetWindow(m_pGLContext);
 }
 
 void* CWinSystemX11GLContext::GetGlxContext() const
 {
-  return X11::GLXGetContext(m_pGLContext);
+  return GLXGetContext(m_pGLContext);
 }
 
 EGLDisplay CWinSystemX11GLContext::GetEGLDisplay() const
@@ -296,15 +298,15 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
     {
       if (!isNvidia)
       {
-        m_vaapiProxy.reset(X11::VaapiProxyCreate());
-        X11::VaapiProxyConfig(m_vaapiProxy.get(), GetDisplay(),
+        m_vaapiProxy.reset(VaapiProxyCreate());
+        VaapiProxyConfig(m_vaapiProxy.get(), GetDisplay(),
                               static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay);
         bool general = false;
         bool deepColor = false;
-        X11::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+        VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
         if (general)
         {
-          X11::VAAPIRegister(m_vaapiProxy.get(), deepColor);
+          VAAPIRegister(m_vaapiProxy.get(), deepColor);
           return true;
         }
         if (isIntel || gli == "EGL")
@@ -322,12 +324,12 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
   delete m_pGLContext;
 
   // fallback for vdpau
-  m_pGLContext = X11::GLXContextCreate(m_dpy);
+  m_pGLContext = GLXContextCreate(m_dpy);
   success = m_pGLContext->Refresh(force, m_screen, m_glWindow, m_newGlContext);
   if (success)
   {
-    X11::VDPAURegister();
-    X11::VDPAURegisterRender();
+    VDPAURegister();
+    VDPAURegisterRender();
   }
   return success;
 }
@@ -342,7 +344,7 @@ std::unique_ptr<CVideoSync> CWinSystemX11GLContext::GetVideoSync(void *clock)
   }
   else
   {
-    pVSync.reset(X11::GLXVideoSyncCreate(clock, *this));
+    pVSync.reset(GLXVideoSyncCreate(clock, *this));
   }
 
   return pVSync;
@@ -373,5 +375,5 @@ uint64_t CWinSystemX11GLContext::GetVblankTiming(uint64_t &msc, uint64_t &interv
 
 void CWinSystemX11GLContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) const
 {
-  X11::VaapiProxyDelete(p);
+  VaapiProxyDelete(p);
 }

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -19,6 +19,14 @@
 #include <EGL/egl.h>
 
 class CGLContext;
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CVaapiProxy;
 
 class CWinSystemX11GLContext : public CWinSystemX11, public CRenderSystemGL
@@ -68,3 +76,7 @@ protected:
 
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
 };
+
+}
+}
+}

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -27,6 +27,7 @@
 #include "platform/linux/OptionalsReg.h"
 
 using namespace KODI;
+using namespace KODI::WINDOWING::X11;
 
 std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
 {
@@ -268,8 +269,8 @@ XVisualInfo* CWinSystemX11GLESContext::GetVisual()
     return nullptr;
   }
   int num_visuals;
-  XVisualInfo* visual = 
-    XGetVisualInfo(m_dpy, VisualIDMask, &x11_visual_info_template, &num_visuals);
+  XVisualInfo* visual =
+      XGetVisualInfo(m_dpy, VisualIDMask, &x11_visual_info_template, &num_visuals);
   return visual;
 }
 

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -18,6 +18,13 @@
 
 class CGLContextEGL;
 
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace X11
+{
+
 class CWinSystemX11GLESContext : public CWinSystemX11, public CRenderSystemGLES
 {
 public:
@@ -52,3 +59,7 @@ protected:
 
   std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
 };
+
+} // namespace X11
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/X11/X11DPMSSupport.cpp
+++ b/xbmc/windowing/X11/X11DPMSSupport.cpp
@@ -15,6 +15,8 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/dpms.h>
 
+using namespace KODI::WINDOWING::X11;
+
 namespace
 {
 // Mapping of PowerSavingMode to X11's mode constants.


### PR DESCRIPTION
In an effort to get the change list down for #18534 I'm splitting some things out.

This doesn't have any functional changes, it simple adds name-spacing to the X11 window system like we have for GBM and Wayland