### PR TITLE
windowing/wayland: fix namespacing for CVaapiProxy

### DIFF
--- a/xbmc/windowing/wayland/OptionalsReg.cpp
+++ b/xbmc/windowing/wayland/OptionalsReg.cpp
@@ -16,6 +16,13 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"
 
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace WAYLAND
+{
+
 class CVaapiProxy : public VAAPI::IVaapiWinSystem
 {
 public:
@@ -28,62 +35,79 @@ public:
   void *eglDisplay;
 };
 
-CVaapiProxy* WAYLAND::VaapiProxyCreate()
+CVaapiProxy* VaapiProxyCreate()
 {
   return new CVaapiProxy();
 }
 
-void WAYLAND::VaapiProxyDelete(CVaapiProxy *proxy)
+void VaapiProxyDelete(CVaapiProxy* proxy)
 {
   delete proxy;
 }
 
-void WAYLAND::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
+void VaapiProxyConfig(CVaapiProxy* proxy, void* dpy, void* eglDpy)
 {
   proxy->dpy = static_cast<wl_display*>(dpy);
   proxy->eglDisplay = eglDpy;
 }
 
-void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
+void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor)
 {
   VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+void VAAPIRegisterRender(CVaapiProxy* winSystem, bool& general, bool& deepColor)
 {
   EGLDisplay eglDpy = winSystem->eglDisplay;
   VADisplay vaDpy = vaGetDisplayWl(winSystem->dpy);
   CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, deepColor);
 }
 
+} // namespace WAYLAND
+} // namespace WINDOWING
+} // namespace KODI
+
 #else
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace WAYLAND
+{
 
 class CVaapiProxy
 {
 };
 
-CVaapiProxy* WAYLAND::VaapiProxyCreate()
+CVaapiProxy* VaapiProxyCreate()
 {
   return nullptr;
 }
 
-void WAYLAND::VaapiProxyDelete(CVaapiProxy *proxy)
+void VaapiProxyDelete(CVaapiProxy* proxy)
 {
 }
 
-void WAYLAND::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
-{
-
-}
-
-void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
+void VaapiProxyConfig(CVaapiProxy* proxy, void* dpy, void* eglDpy)
 {
 
 }
 
-void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
+void VAAPIRegister(CVaapiProxy* winSystem, bool deepColor)
 {
 
 }
+
+void VAAPIRegisterRender(CVaapiProxy* winSystem, bool& general, bool& deepColor)
+{
+
+}
+
+
+} // namespace WAYLAND
+} // namespace WINDOWING
+} // namespace KODI
+
 #endif
 

--- a/xbmc/windowing/wayland/OptionalsReg.h
+++ b/xbmc/windowing/wayland/OptionalsReg.h
@@ -13,14 +13,20 @@
 // VAAPI
 //-----------------------------------------------------------------------------
 
-class CVaapiProxy;
-
+namespace KODI
+{
+namespace WINDOWING
+{
 namespace WAYLAND
 {
+class CVaapiProxy;
+
 CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy);
 void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
 void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
-}
 
+} // namespace WAYLAND
+} // namespace WINDOWING
+} // namespace KODI

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -42,13 +42,13 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
   bool general, deepColor;
-  m_vaapiProxy.reset(::WAYLAND::VaapiProxyCreate());
-  ::WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(),GetConnection()->GetDisplay(),
-                              m_eglContext.GetEGLDisplay());
-  ::WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+  m_vaapiProxy.reset(WAYLAND::VaapiProxyCreate());
+  WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(), GetConnection()->GetDisplay(),
+                            m_eglContext.GetEGLDisplay());
+  WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
   if (general)
   {
-    ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
+    WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
 
   CBufferObjectFactory::ClearBufferObjects();
@@ -117,5 +117,5 @@ void CWinSystemWaylandEGLContextGL::PresentRenderImpl(bool rendered)
 
 void CWinSystemWaylandEGLContextGL::delete_CVaapiProxy::operator()(CVaapiProxy *p) const
 {
-  ::WAYLAND::VaapiProxyDelete(p);
+  WAYLAND::VaapiProxyDelete(p);
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h
@@ -11,14 +11,14 @@
 #include "WinSystemWaylandEGLContext.h"
 #include "rendering/gl/RenderSystemGL.h"
 
-class CVaapiProxy;
-
 namespace KODI
 {
 namespace WINDOWING
 {
 namespace WAYLAND
 {
+
+class CVaapiProxy;
 
 class CWinSystemWaylandEGLContextGL : public CWinSystemWaylandEGLContext, public CRenderSystemGL
 {

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -48,13 +48,13 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   bool general, deepColor;
-  m_vaapiProxy.reset(::WAYLAND::VaapiProxyCreate());
-  ::WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(),GetConnection()->GetDisplay(),
-                              m_eglContext.GetEGLDisplay());
-  ::WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
+  m_vaapiProxy.reset(WAYLAND::VaapiProxyCreate());
+  WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(), GetConnection()->GetDisplay(),
+                            m_eglContext.GetEGLDisplay());
+  WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
   if (general)
   {
-    ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
+    WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
 
   CBufferObjectFactory::ClearBufferObjects();
@@ -107,5 +107,5 @@ void CWinSystemWaylandEGLContextGLES::PresentRenderImpl(bool rendered)
 
 void CWinSystemWaylandEGLContextGLES::delete_CVaapiProxy::operator()(CVaapiProxy *p) const
 {
-  ::WAYLAND::VaapiProxyDelete(p);
+  WAYLAND::VaapiProxyDelete(p);
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.h
@@ -11,14 +11,14 @@
 #include "WinSystemWaylandEGLContext.h"
 #include "rendering/gles/RenderSystemGLES.h"
 
-class CVaapiProxy;
-
 namespace KODI
 {
 namespace WINDOWING
 {
 namespace WAYLAND
 {
+
+class CVaapiProxy;
 
 class CWinSystemWaylandEGLContextGLES : public CWinSystemWaylandEGLContext, public CRenderSystemGLES
 {


### PR DESCRIPTION
Similar to #18558 I'm trying to get the change list down for #18534 

This just adjusts the namespacing to be inline with other windowing platforms