### PR TITLE
[linux] check for display envs before starting

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -63,6 +63,13 @@ CWinSystemX11::~CWinSystemX11() = default;
 
 bool CWinSystemX11::InitWindowSystem()
 {
+  const char* env = getenv("DISPLAY");
+  if (!env)
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemX11::{} - DISPLAY env not set", __FUNCTION__);
+    return false;
+  }
+
   if ((m_dpy = XOpenDisplay(NULL)))
   {
     bool ret = CWinSystemBase::InitWindowSystem();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -82,6 +82,15 @@ CWinSystemGbm::CWinSystemGbm() :
 
 bool CWinSystemGbm::InitWindowSystem()
 {
+  const char* x11 = getenv("DISPLAY");
+  const char* wayland = getenv("WAYLAND_DISPLAY");
+  if (x11 || wayland)
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - not allowed to run GBM under a window manager",
+              __FUNCTION__);
+    return false;
+  }
+
   m_DRM = std::make_shared<CDRMAtomic>();
 
   if (!m_DRM->InitDrm())

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -188,6 +188,13 @@ CWinSystemWayland::~CWinSystemWayland() noexcept
 
 bool CWinSystemWayland::InitWindowSystem()
 {
+  const char* env = getenv("WAYLAND_DISPLAY");
+  if (!env)
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemWayland::{} - WAYLAND_DISPLAY env not set", __FUNCTION__);
+    return false;
+  }
+
   wayland::set_log_handler([](std::string message)
   {
     CLog::Log(LOGWARNING, "wayland-client log message: %s", message.c_str());


### PR DESCRIPTION
Split out from #18534 

This is just a sanity check to make sure we can run with the given windowing method.

This should also stop people from locking their keyboard out when starting gbm under a normal terminal :wink: @wsnipex 