### PR TITLE
Add subtitle notification when no subtitles are available

### DIFF
--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -50,7 +50,12 @@ bool CPlayerController::OnAction(const CAction &action)
       case ACTION_SHOW_SUBTITLES:
       {
         if (g_application.GetAppPlayer().GetSubtitleCount() == 0)
+        {
+          CGUIDialogKaiToast::QueueNotification(
+              CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), g_localizeStrings.Get(10005),
+              DisplTime, false, MsgTime);
           return true;
+        }
 
         bool subsOn = !g_application.GetAppPlayer().GetSubtitleVisible();
         g_application.GetAppPlayer().SetSubtitleVisible(subsOn);


### PR DESCRIPTION
## Description
When you press 't' as a user and a movie does not have
any subtitles, there is no user feedback and you
wonder if it worked or not.
This adds a toaster to indicate that no subtitle is available.

## Motivation and Context
Improve user feedback and thus usability.

## How Has This Been Tested?
Tested in Linux

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
