### PR TITLE
[addons][skin] fix: set CheckAddonPath correctly / DialogAddonInfo layout fix

### DIFF
--- a/addons/skin.estuary/xml/DialogAddonInfo.xml
+++ b/addons/skin.estuary/xml/DialogAddonInfo.xml
@@ -216,14 +216,14 @@
 									<visible>!String.IsEmpty(ListItem.AddonSize)</visible>
 								</item>
 								<item>
-									<label>$LOCALIZE[126]:</label>
-									<label2>$INFO[ListItem.Property(Addon.Status)]$INFO[ListItem.Property(Addon.ValidUpdateVersion),[CR]($LOCALIZE[19114]: ,)]</label2>
-									<visible>!String.IsEmpty(ListItem.Property(Addon.Status))</visible>
-								</item>
-								<item>
 									<label>$LOCALIZE[467]:</label>
 									<label2>$LOCALIZE[31135]</label2>
 									<visible>ListItem.Property(Addon.IsBinary)</visible>
+								</item>
+								<item>
+									<label>$LOCALIZE[126]:</label>
+									<label2>$INFO[ListItem.Property(Addon.Status)]$INFO[ListItem.Property(Addon.ValidUpdateVersion),[CR]($LOCALIZE[19114]: ,)]</label2>
+									<visible>!String.IsEmpty(ListItem.Property(Addon.Status))</visible>
 								</item>
 							</content>
 						</control>

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -501,7 +501,7 @@ void CAddonRepos::BuildCompatibleVersionsList(
   {
     if (m_addonMgr.IsCompatible(*addon))
     {
-      if (IsFromOfficialRepo(addon, CheckAddonPath::NO))
+      if (IsFromOfficialRepo(addon, CheckAddonPath::YES))
       {
         officialVersions.emplace_back(addon);
       }

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -105,6 +105,9 @@ public:
    * \brief Checks if the origin-repository of a given addon is defined as official repo
    *        and can also verify if the origin-path (e.g. https://mirrors.kodi.tv ...)
    *        is matching
+   * \note if this function is called on locally installed add-ons, for instance when populating
+   *       'My add-ons', the local installation path is returned as origin.
+   *       thus parameter CheckAddonPath::NO needs to be passed in such cases
    * \param addon pointer to addon to be checked
    * \param checkAddonPath also check origin path
    * \return true if the repository id of a given addon is defined as official


### PR DESCRIPTION
## Description

### Commit 1:

in pr #18527 an official repo check is wrongly called without checking the origin path.
parameter `CheckAddonPath::NO` should be `CheckAddonPath::YES`
this is just a small fixup and documents the need of the parameter.

### Commit 2:
Skin Estuary: DialogAddonInfo:
position of items `Status` and `Type` are switched because having a multiline status leads to label overlapping.

<img width="2080" alt="Screenshot" src="https://user-images.githubusercontent.com/58829855/96026866-60912280-0e57-11eb-9407-d4412d9a9d6c.png">

## How Has This Been Tested?
debian stretch

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
