### PR TITLE
Align `ignorepercentatend` to `playcountminimumpercent`

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -140,7 +140,7 @@ void CAdvancedSettings::Initialize()
   m_videoPPFFmpegPostProc = "ha:128:7,va,dr";
   m_videoDefaultPlayer = "VideoPlayer";
   m_videoIgnoreSecondsAtStart = 3*60;
-  m_videoIgnorePercentAtEnd   = 8.0f;
+  m_videoIgnorePercentAtEnd   = 10.0f;
   m_videoPlayCountMinimumPercent = 90.0f;
   m_videoVDPAUScaling = -1;
   m_videoNonLinStretchRatio = 0.5f;


### PR DESCRIPTION
## Description
As explained in the documentation, there is a gap between the offset used for `playcount` and resumepoints.
https://kodi.wiki/view/HOW-TO:Modify_automatic_watch_and_resume_points#Settings_explained


## Motivation and Context
Because of this, an episode could be marked as being watched _and_ being still be watching.
Maybe there are reasons for having two options diverge, but I do not think it is a good default.

## How Has This Been Tested?
Not.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed