### PR TITLE
[addons] Retry repo update one hour after failed attempt, not immediately

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -239,6 +239,7 @@ CRepository::FetchStatus CRepository::FetchIfChanged(const std::string& oldCheck
       int recheckAfterThisDir;
       if (!FetchChecksum(dir.checksum, part, recheckAfterThisDir))
       {
+        recheckAfter = 1 * 60 * 60; // retry after 1 hour
         CLog::Log(LOGERROR, "CRepository: failed read '%s'", dir.checksum.c_str());
         return STATUS_ERROR;
       }


### PR DESCRIPTION
Followup to #18227 

If Kodi is disconnected from network or repo update check fails for some other reason, Kodi will do the next update check immediately. This PR changes this behavior (which is problematic for example because it causes high CPU load and eventually laggy Kodi GU) to recheck after 1 hour in case of an error.

@yol when you find some time for a review...
