### PR TITLE
[addons] db: fix error log on dataset insert

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -1295,11 +1295,16 @@ bool CAddonDatabase::AddInstalledAddon(const std::shared_ptr<CAddonInfo>& addon,
     if (!m_pDS)
       return false;
 
-    std::string now = CDateTime::GetCurrentDateTime().GetAsDBDateTime();
+    m_pDS->query(PrepareSQL("SELECT * FROM installed WHERE addonID='%s'", addon->ID().c_str()));
 
-    m_pDS->exec(PrepareSQL("INSERT INTO installed(addonID, enabled, installDate, origin) "
-                           "VALUES('%s', 1, '%s', '%s')",
-                           addon->ID().c_str(), now.c_str(), origin.c_str()));
+    if (m_pDS->eof())
+    {
+      std::string now = CDateTime::GetCurrentDateTime().GetAsDBDateTime();
+
+      m_pDS->exec(PrepareSQL("INSERT INTO installed(addonID, enabled, installDate, origin) "
+                             "VALUES('%s', 1, '%s', '%s')",
+                             addon->ID().c_str(), now.c_str(), origin.c_str()));
+    }
   }
   catch (...)
   {

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -610,12 +610,8 @@ bool CAddonMgr::FindAddon(const std::string& addonId,
   CLog::Log(LOGINFO, "CAddonMgr::{}: {} v{} installed", __FUNCTION__, addonId,
             addonVersion.asString());
 
-  if (!IsAddonInstalled(addonId))
-  {
-    m_database.AddInstalledAddon(it->second, origin);
-  }
-
   m_installedAddons[addonId] = it->second; // insert/replace entry
+  m_database.AddInstalledAddon(it->second, origin);
 
   // Reload caches
   std::map<std::string, AddonDisabledReason> tmpDisabled;


### PR DESCRIPTION
## Description
follow up to #18538

## Motivation and Context
datasets are tried to be inserted into the `installed` table, even though they're already there when installing addon-updates automatically.

```
INFO <general>: CAddonMgr::FindAddon: metadata.themoviedb.org v5.2.2 installed
ERROR <general>: SQL: [Addons33.db] SQLite error SQLITE_CONSTRAINT_UNIQUE (UNIQUE constraint failed: installed.addonID)
                 Query: INSERT INTO installed(addonID, enabled, installDate, origin) VALUES('metadata.themoviedb.org', 1, '2020-10-16 16:20:58', 'repository.xbmc.org') (UNIQUE constraint failed: installed.addonID)
ERROR <general>: AddInstalledAddon failed
```

this pr fixes that issue by adding an existence check for the addonId before `INSERTing`

## How Has This Been Tested?
debian stretch local

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
