### PR TITLE
[BACKPORT][Leia]TexturePacker: Do not leak image data memory

### DIFF
--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -31,6 +31,8 @@ bool GIFDecoder::CanDecode(const std::string &filename)
 bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
 {
   int n = 0;
+  bool result = false;
+
   GifHelper *gifImage = new GifHelper();
   if (gifImage->LoadGif(filename.c_str()))
   {
@@ -53,28 +55,20 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
         frame.rgbaImage.bbp = 32;
         frame.rgbaImage.pitch = pitch;
         frame.delay = extractedFrames[i]->m_delay;
+        frame.decoder = this;
 
         frames.frameList.push_back(frame);
       }
     }
-    frames.user = gifImage;
-    return true;
+    result = true;
   }
-  else
-  {
-    delete gifImage;
-    return false;
-  }
+  delete gifImage;
+  return result;
 }
 
-void GIFDecoder::FreeDecodedFrames(DecodedFrames &frames)
+void GIFDecoder::FreeDecodedFrame(DecodedFrame &frame)
 {
-  for (unsigned int i = 0; i < frames.frameList.size(); i++)
-  {
-    delete [] frames.frameList[i].rgbaImage.pixels;
-  }
-  delete (GifHelper *)frames.user;
-  frames.clear();
+  delete [] frame.rgbaImage.pixels;
 }
 
 void GIFDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
@@ -28,7 +28,7 @@ class GIFDecoder : public IDecoder
     ~GIFDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string &filename, DecodedFrames &frames) override;
-    void FreeDecodedFrames(DecodedFrames &frames) override;
+    void FreeDecodedFrame(DecodedFrame &frame) override;
     const char* GetImageFormatName() override { return "GIF"; }
     const char* GetDecoderName() override { return "libgif"; }
   protected:

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
@@ -84,7 +84,6 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   // Image Size is calculated as (width * height * bytes per pixel = 4
   ImageSize = cinfo.image_width * cinfo.image_height * 4;
 
-  frames.user = NULL;
   DecodedFrame frame;
 
   frame.rgbaImage.pixels = (char *)new char[ImageSize];
@@ -115,20 +114,18 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frame.rgbaImage.width = cinfo.image_width;
   frame.rgbaImage.bbp = 32;
   frame.rgbaImage.pitch = 4 * cinfo.image_width;
+
+  frame.decoder = this;
+
   frames.frameList.push_back(frame);
 
   delete arq;
   return true;
 }
 
-void JPGDecoder::FreeDecodedFrames(DecodedFrames &frames)
+void JPGDecoder::FreeDecodedFrame(DecodedFrame &frame)
 {
-  for (unsigned int i = 0; i < frames.frameList.size(); i++)
-  {
-    delete [] frames.frameList[i].rgbaImage.pixels;
-  }
-
-  frames.clear();
+  delete [] frame.rgbaImage.pixels;
 }
 
 void JPGDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.h
@@ -28,7 +28,7 @@ class JPGDecoder : public IDecoder
     ~JPGDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string &filename, DecodedFrames &frames) override;
-    void FreeDecodedFrames(DecodedFrames &frames) override;
+    void FreeDecodedFrame(DecodedFrame &frame) override;
     const char* GetImageFormatName() override { return "JPG"; }
     const char* GetDecoderName() override { return "libjpeg"; }
   protected:

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
@@ -214,7 +214,6 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   // read the png into image_data through row_pointers
   png_read_image(png_ptr, row_pointers);
 
-  frames.user = NULL;
   DecodedFrame frame;
 
   frame.rgbaImage.pixels = (char *)image_data;
@@ -222,6 +221,9 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frame.rgbaImage.width = temp_width;
   frame.rgbaImage.bbp = 32;
   frame.rgbaImage.pitch = 4 * temp_width;
+
+  frame.decoder = this;
+
   frames.frameList.push_back(frame);
   // clean up
   png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
@@ -229,14 +231,9 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   return true;
 }
 
-void PNGDecoder::FreeDecodedFrames(DecodedFrames &frames)
+void PNGDecoder::FreeDecodedFrame(DecodedFrame &frame)
 {
-  for (unsigned int i = 0; i < frames.frameList.size(); i++)
-  {
-    delete [] frames.frameList[i].rgbaImage.pixels;
-  }
-
-  frames.clear();
+  delete [] frame.rgbaImage.pixels;
 }
 
 void PNGDecoder::FillSupportedExtensions()

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.h
@@ -28,7 +28,7 @@ class PNGDecoder : public IDecoder
     ~PNGDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string &filename, DecodedFrames &frames) override;
-    void FreeDecodedFrames(DecodedFrames &frames) override;
+    void FreeDecodedFrame(DecodedFrame &frame) override;
     const char* GetImageFormatName() override { return "PNG"; }
     const char* GetDecoderName() override { return "libpng"; }
   protected:


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/18362

Building Kodi with asan+lsan+ubsan breaks with the following error:

=================================================================
==241706==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 69370335 byte(s) in 661 object(s) allocated from:
    #0 0x7fb290a737a7 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.6+0xab7a7)
    #1 0x563e2bed8b09 in PNGDecoder::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, DecodedFrames&) (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x17cb09)
    #2 0x563e2be71392 in DecoderManager::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, DecodedFrames&) (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x115392)
    #3 0x563e2be7d1bf in createBundle(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double, unsigned int, bool) (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x1211bf)
    #4 0x563e2be69990 in main (/build/kodi-18.8+dfsg1/kodi_build_x11/build/texturepacker/TexturePacker+0x10d990)
    #5 0x7fb28fbc7cc9 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: 69370335 byte(s) leaked in 661 allocation(s).

The root cause of the leak is decoder's FreeDecodedFrames never called.

This commit fixes the leak by refactoring the following aspects:

 * Introducing the pointer to decoder object in the decoded frame,
 * Changing IDecoder::FreeDecodedFrames to IDecoder::FreeDecodedFrame
   cleaning single frame at a time
 * Moving iteration over frames to DecoderManager::FreeDecodedFrames
 * Removing unnecessary DecodedFrames.user

## How Has This Been Tested?

Build Leia

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
