### PR TITLE
Do not encode a Python script path to "system" encoding on Windows

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -273,15 +273,8 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
 
     Py_DECREF(sysMod); // release ref to sysMod
 
-#ifdef TARGET_WINDOWS
-    std::string pyPathUtf8;
-    g_charsetConverter.systemToUtf8(m_pythonPath, pyPathUtf8, false);
-    CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): setting the Python path to %s", GetId(),
-              m_sourceFile.c_str(), pyPathUtf8.c_str());
-#else // ! TARGET_WINDOWS
     CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): setting the Python path to %s", GetId(),
               m_sourceFile.c_str(), m_pythonPath.c_str());
-#endif // ! TARGET_WINDOWS
 
     std::wstring pypath;
     g_charsetConverter.utf8ToW(m_pythonPath, pypath);
@@ -321,17 +314,10 @@ bool CPythonInvoker::execute(const std::string& script, const std::vector<std::w
       // We need to have python open the file because on Windows the DLL that python
       //  is linked against may not be the DLL that xbmc is linked against so
       //  passing a FILE* to python from an fopen has the potential to crash.
-      std::string nativeFilename(realFilename); // filename in system encoding
-#ifdef TARGET_WINDOWS
-      if (!g_charsetConverter.utf8ToSystem(nativeFilename, true))
-      {
-        CLog::Log(LOGERROR,
-                  "CPythonInvoker(%d, %s): can't convert filename \"%s\" to system encoding",
-                  GetId(), m_sourceFile.c_str(), realFilename.c_str());
-        return false;
-      }
-#endif
-      FILE* fp = _Py_fopen(nativeFilename.c_str(), "rb");
+
+      PyObject* pyRealFilename = Py_BuildValue("s", realFilename.c_str());
+      FILE* fp = _Py_fopen_obj(pyRealFilename, "rb");
+      Py_DECREF(pyRealFilename);
 
       if (fp != NULL)
       {


### PR DESCRIPTION
This fixes xbmc/xbmc#18557

## Description

This PR fixes xbmc/xbmc#18557 the following way:
1. It removes Windows-specific code that transcodes UTF-8 file paths to "system" Windows encoding.
2. It uses `_Py_fopen_obj` instead of `_Py_fopen` to get a file pointer to a Python script.

## Motivation and Context

Previously Python on Windows handled file paths in so-called "system" encoding that is one of the legacy 8-bit fixed-length encodings depending on the system locale. E.g. win1251 for Cyrillic languages (Ukrainian, Russian), win1252 for Western European languages and so on. Because of this in Kodi on Windows a Python script paths are being transcoded to a "system" encoding before being passed to `_Py_fopen` function.

But in latest versions Python switched to UTF-8 for Windows file paths: https://www.python.org/dev/peps/pep-0529/. As the result of this `_Py_fopen` function now expects a UTF-8 encoded path. This leads to `UnicodeDecodeError` internal exception being thrown if a script paths contains non-UTF-8 byte blocks. Because of this, transcoding script paths to a "system" Windows encoding is no longer needed.

However, `_Py_fopen` seems to be buggy because in cannot open a valid file path that contain multi-byte UTF-8 code blocks (non-ASCII characters) and returns `NULL` in this case. It can be fixed by enabling UTF-8 support in Windows 10: **Control Panel > Region > Administrative > Change System Locale > Beta: Use UTF-8...**. But this would require additional actions from affected users.

In contrast, `_Py_fopen_obj` function does not seem to be affected by this problem and always works correctly regardless of UTF-8 support on Windows.

## How Has This Been Tested?

A build with the fix has been tested on Windows by several users. I also tested in on Linux to make sure that nothing is broken.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
