### PR TITLE
DXVA-HD: checks if HLG color space conversion is supported by video driver

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -49,7 +49,7 @@ public:
   void OnCreateDevice() override  {}
   void OnDestroyDevice(bool) override { CSingleLock lock(m_section); UnInit(); }
 
-  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(CRenderBuffer* view, bool supportHDR);
+  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(CRenderBuffer* view, bool supportHDR, bool supportHLG);
   static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(CRenderBuffer* view);
 
 protected:
@@ -70,6 +70,7 @@ protected:
   D3D11_VIDEO_PROCESSOR_CAPS m_vcaps = {};
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps = {};
   bool m_bSupportHDR10 = false;
+  bool m_bSupportHLG = false;
 
   struct ProcAmpInfo
   {


### PR DESCRIPTION
## Description
DXVA-HD: checks if HLG color space conversion is supported by video driver.

Fixes HLG wrong colors / black level using DXVA render method.

## Motivation and Context
Following a post in forum https://forum.kodi.tv/showthread.php?tid=357585 I have done some tests with HLG sources and I've noticed that the colors were incorrect using DXVA render method.

Is not need HDR display to test this since it affects the conversion BT.2020 to BT.709 to display in SRD:

Source DXGI color space `DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020` needs to be converted to `DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709` to render in a normal PC display or SRD TV.

If video driver does not supports this conversion fails silently and very wrong picture is obtained. This is because conversion does more things (in addition to HLG transfer):

YCbCr studio ---> RGB full
BT.2020 ---> BT.709

Now if the driver does not support HLG, defaults to `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020` so that the rest of conversions are done (YCbCr to RGB full and BT.2020 to BT.709). In this case the image obtained is not perfect but it is very close to the original because the HLG system is designed for this and is backward compatible with devices that do not support it (https://en.wikipedia.org/wiki/Hybrid_Log-Gamma).

## How Has This Been Tested?
Used this test source: http://www.lelabodejay.com/files/videos/upload/LDJ_082020_HLG_3840x2160_50MBPS.mp4

## Screenshots (if appropriate):
Before:
![screenshot00002](https://user-images.githubusercontent.com/58434170/96334004-c2c37080-106d-11eb-8be0-5ebdb4611177.png)

![screenshot00003](https://user-images.githubusercontent.com/58434170/96334023-d5d64080-106d-11eb-9911-75cc0dcbf087.png)

After:
![screenshot00006](https://user-images.githubusercontent.com/58434170/96334029-e25a9900-106d-11eb-89ca-e3960ed7ce60.png)

![screenshot00007](https://user-images.githubusercontent.com/58434170/96334030-e686b680-106d-11eb-93bb-51df9c0bbb0c.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
