### PR TITLE
[Estouchy] Add scrollbar to EPG

### DIFF
--- a/addons/skin.estouchy/xml/ViewsPVR.xml
+++ b/addons/skin.estouchy/xml/ViewsPVR.xml
@@ -182,11 +182,11 @@
 			<width>$PARAM[panel-width]</width>
 			<height>550</height>
 			<onleft>2</onleft>
-			<onright>10</onright>
+			<onright>60</onright>
 			<onup>10</onup>
 			<ondown>10</ondown>
 			<viewtype label="19069">list</viewtype>
-			<pagecontrol>10</pagecontrol>
+			<pagecontrol>60</pagecontrol>
 			<scrolltime>200</scrolltime>
 			<timeblocks>40</timeblocks>
 			<rulerunit>6</rulerunit>
@@ -245,7 +245,6 @@
 					<font>font20</font>
 					<aligny>center</aligny>
 					<selectedcolor>blue</selectedcolor>
-					<align>right</align>
 					<label>[B]$INFO[ListItem.ChannelNumberLabel,,.] $INFO[ListItem.ChannelName][/B]</label>
 					<scroll>false</scroll>
 				</control>
@@ -282,7 +281,6 @@
 					<font>font20</font>
 					<aligny>center</aligny>
 					<selectedcolor>blue</selectedcolor>
-					<align>right</align>
 					<label>[B]$INFO[ListItem.ChannelNumberLabel,,.] $INFO[ListItem.ChannelName][/B]</label>
 					<scroll>false</scroll>
 				</control>
@@ -309,26 +307,26 @@
 					<scroll>false</scroll>
 				</control>
 				<control type="image">
-					<posx>5</posx>
+					<posx>7</posx>
 					<posy>45</posy>
-					<width>20</width>
-					<height>20</height>
+					<width>15</width>
+					<height>15</height>
 					<texture>epg_record.png</texture>
 					<visible>ListItem.IsRecording</visible>
 				</control>
 				<control type="image">
-					<posx>5</posx>
+					<posx>7</posx>
 					<posy>45</posy>
-					<width>20</width>
-					<height>20</height>
+					<width>15</width>
+					<height>15</height>
 					<texture>epg_schedule.png</texture>
 					<visible>ListItem.HasTimer</visible>
 				</control>
 				<control type="image">
-					<posx>5</posx>
+					<posx>7</posx>
 					<posy>45</posy>
-					<width>20</width>
-					<height>20</height>
+					<width>15</width>
+					<height>15</height>
 					<texture>epg_archive.png</texture>
 					<visible>![ListItem.IsRecording | ListItem.HasTimer] + ListItem.IsPlayable</visible>
 				</control>
@@ -364,7 +362,7 @@
 				</control>
 				<control type="image">
 					<posx>7</posx>
-					<posy>44</posy>
+					<posy>45</posy>
 					<width>15</width>
 					<height>15</height>
 					<texture>epg_record.png</texture>
@@ -372,7 +370,7 @@
 				</control>
 				<control type="image">
 					<posx>7</posx>
-					<posy>44</posy>
+					<posy>45</posy>
 					<width>15</width>
 					<height>15</height>
 					<texture>epg_schedule.png</texture>
@@ -380,13 +378,27 @@
 				</control>
 				<control type="image">
 					<posx>7</posx>
-					<posy>44</posy>
+					<posy>45</posy>
 					<width>15</width>
 					<height>15</height>
 					<texture>epg_archive.png</texture>
 					<visible>![ListItem.IsRecording | ListItem.HasTimer] + ListItem.IsPlayable</visible>
 				</control>
 			</focusedlayout>
+		</control>
+		<control type="scrollbar" id="60">
+			<posx>50r</posx>
+			<posy>105</posy>
+			<width>26</width>
+			<height>550</height>
+			<texturesliderbackground colordiffuse="30FFFFFF">white.png</texturesliderbackground>
+			<texturesliderbar colordiffuse="grey">white.png</texturesliderbar>
+			<texturesliderbarfocus colordiffuse="blue">white.png</texturesliderbarfocus>
+			<textureslidernib>blank.png</textureslidernib>
+			<textureslidernibfocus>blank.png</textureslidernibfocus>
+			<onleft>10</onleft>
+			<orientation>vertical</orientation>
+			<visible>Control.IsVisible(10)</visible>
 		</control>
 	</include>
 	<include name="PVRInfo">


### PR DESCRIPTION
## Description
A few improvements to the EPG Guide view in the Estouchy skin:
- add a scrollbar
- left align the channel names
- slightly smaller epg record / timer / archive icons

## Motivation and Context
fixes https://github.com/xbmc/xbmc/issues/18564


## Screenshots (if appropriate):
![guide](https://user-images.githubusercontent.com/687265/96355313-82e9a100-10e0-11eb-9f3f-a405ebc2f680.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
