### PR TITLE
tools/depends: add automake patch to fix race in parallel builds

### DIFF
--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -40,7 +40,7 @@ flatbuffers: cmake
 heimdal: libtool
 libtool: automake
 libjpeg-turbo: cmake yasm
-libpng: zlib
+libpng: zlib automake
 meson: python3 setuptools
 ninja: meson
 swig: pcre

--- a/tools/depends/native/automake/01-fix-help2man-error.patch
+++ b/tools/depends/native/automake/01-fix-help2man-error.patch
@@ -1,0 +1,12 @@
+diff -Naur a/Makefile.in b/Makefile.in
+--- a/Makefile.in	2020-03-16 19:11:10.000000000 -0700
++++ b/Makefile.in	2020-10-22 08:06:24.606751367 -0700
+@@ -699,7 +699,7 @@
+ update_mans = \
+   $(AM_V_GEN): \
+     && $(MKDIR_P) doc \
+-    && ./pre-inst-env $(PERL) $(srcdir)/doc/help2man --output=$@
++    && ./pre-inst-env $(PERL) $(srcdir)/doc/help2man --output=$@ --no-discard-stderr
+ 
+ amhello_sources = \
+   doc/amhello/configure.ac \

--- a/tools/depends/native/automake/Makefile
+++ b/tools/depends/native/automake/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.include
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-fix-help2man-error.patch
 
 # lib name, version
 LIBNAME=automake
@@ -21,6 +21,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../01-fix-help2man-error.patch
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
we seem to get random jenkins failures and I found a log that points to a failure in automake

```
help2man: can't get `--help' info from automake-1.16
Try `--no-discard-stderr' if option outputs to stderr
make[3]: *** [doc/automake-1.16.1] Error 127
```

https://jenkins.kodi.tv/job/IOS-ARM64/13839/consoleText

