### PR TITLE
OMlSync: Enable by default

### DIFF
--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -129,7 +129,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_limiterHold;
     float m_limiterRelease;
 
-    bool  m_omlSync = false;
+    bool  m_omlSync = true;
 
     float m_videoSubsDelayRange;
     float m_videoAudioDelayRange;

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -37,5 +37,5 @@ public:
   Display *m_dpy;
 
 protected:
-  bool m_omlSync = false;
+  bool m_omlSync = true;
 };


### PR DESCRIPTION
In most cases Kodi wants swapBuffers to be blocking, in order to maintain sync. Modern OpenGL implementations use triple, quadruple, whatever buffering and much more driver internally which then does not halt our mainloop correctly in this non-blocking fashion, they e.g. return early but doing the real swap later on (Tearfree, Compositors, etc.). That's nice if you don't want to be blocked, but not nice if you want to know what exactly is on screen. Fences also don't help much here with that behaviour.

This code is there for many years already, but disabled by default. As kodi relies on a "semi-blocking" SwapBuffers behaviour I would try to enable it again for v19.

This aims at the X11 system 