### PR TITLE
Application: Cleanup skin unload log messages.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1386,10 +1386,8 @@ bool CApplication::LoadSkin(const std::string& skinID)
   return true;
 }
 
-void CApplication::UnloadSkin(bool forReload /* = false */)
+void CApplication::UnloadSkin()
 {
-  CLog::Log(LOGINFO, "Unloading old skin %s...", forReload ? "for reload " : "");
-
   if (g_SkinInfo != nullptr && m_saveSkinOnUnloading)
     g_SkinInfo->SaveSettings();
   else if (!m_saveSkinOnUnloading)
@@ -1419,6 +1417,8 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
 //  The g_SkinInfo shared_ptr ought to be reset here
 // but there are too many places it's used without checking for NULL
 // and as a result a race condition on exit can cause a crash.
+
+  CLog::Log(LOGINFO, "Unloaded skin");
 }
 
 bool CApplication::LoadCustomWindows()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -157,7 +157,7 @@ public:
 
   bool IsCurrentThread() const;
   void Stop(int exitCode);
-  void UnloadSkin(bool forReload = false);
+  void UnloadSkin();
   bool LoadCustomWindows();
   void ReloadSkin(bool confirm = false);
   const std::string& CurrentFile();

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -48,7 +48,7 @@ static int ReloadSkin(const std::vector<std::string>& params)
  */
 static int UnloadSkin(const std::vector<std::string>& params)
 {
-  g_application.UnloadSkin(true); // we're reloading the skin after this
+  g_application.UnloadSkin();
 
   return 0;
 }


### PR DESCRIPTION
Cleanup of log messages related to skin unloading. I was always asking myself why I see "Unloading **old** skin ..." in the log when Kodi exits.

```log
2020-10-18 07:50:56.142457+0200 kodi.bin[94125:2549822] 2020-10-18 07:50:56.142 T:2549822    INFO <general>: unload skin
2020-10-18 07:50:56.142794+0200 kodi.bin[94125:2549822] 2020-10-18 07:50:56.142 T:2549822    INFO <general>: Unloading old skin ...
2020-10-18 07:50:56.244401+0200 kodi.bin[94125:2549822] 2020-10-18 07:50:56.244 T:2549822    INFO <general>: unload sections
2020-10-18 07:50:56.273990+0200 kodi.bin[94125:2549822] 2020-10-18 07:50:56.273 T:2549822    INFO <general>: XBApplicationEx: application stopped!
```

This PR changes the log a bit:

```log
2020-10-18 08:19:39.366946+0200 kodi.bin[96023:2572379] 2020-10-18 08:19:39.366 T:2572379    INFO <general>: unload skin
2020-10-18 08:19:39.435500+0200 kodi.bin[96023:2572379] 2020-10-18 08:19:39.435 T:2572379    INFO <general>: Unloaded skin
2020-10-18 08:19:39.440843+0200 kodi.bin[96023:2572379] 2020-10-18 08:19:39.440 T:2572379    INFO <general>: unload sections
2020-10-18 08:19:39.598554+0200 kodi.bin[96023:2572379] 2020-10-18 08:19:39.598 T:2572379    INFO <general>: XBApplicationEx: application stopped!
```