### PR TITLE
[PVR] Fix channeldata overwrite

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -513,7 +513,7 @@ bool CPVRDatabase::RemoveStaleChannelsFromGroup(const CPVRChannelGroup& group)
         if (!group.IsGroupMember(iChannelId))
         {
           int iClientId = GetClientIdByChannelId(iChannelId);
-          if (iClientId == PVR_INVALID_CLIENT_ID || !group.IsMissingChannelsFromClient(iClientId))
+          if (iClientId == PVR_INVALID_CLIENT_ID || group.HasValidDataFromClient(iClientId))
           {
             channelsToDelete.emplace_back(iChannelId);
           }
@@ -561,7 +561,7 @@ bool CPVRDatabase::Delete(const CPVRChannelGroup& group)
     for (int iChannelId : currentMembers)
     {
       int iClientId = GetClientIdByChannelId(iChannelId);
-      if (iClientId != PVR_INVALID_CLIENT_ID && group.IsMissingChannelGroupMembersFromClient(iClientId))
+      if (iClientId != PVR_INVALID_CLIENT_ID && !group.HasValidDataFromClient(iClientId))
       {
         bIgnoreChannel = true;
         break;
@@ -668,7 +668,7 @@ int CPVRDatabase::Get(CPVRChannelGroup& group, const CPVRChannelGroup& allGroup)
         {
           // remove the channel from the table if it doesn't exist on client (anymore)
           int iClientId = GetClientIdByChannelId(iChannelId);
-          if (iClientId == PVR_INVALID_CLIENT_ID || !allGroup.IsMissingChannelsFromClient(iClientId))
+          if (iClientId == PVR_INVALID_CLIENT_ID || allGroup.HasValidDataFromClient(iClientId))
           {
             Filter filter;
             filter.AppendWhere(PrepareSQL("idGroup = %u", group.GroupID()));

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -598,6 +598,11 @@ bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()
   return bChanged;
 }
 
+bool CPVRChannelGroup::ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel)
+{
+  return !IsMissingChannelGroupMembersFromClient(channel->ClientID());
+}
+
 std::vector<std::shared_ptr<CPVRChannel>> CPVRChannelGroup::RemoveDeletedChannels(const CPVRChannelGroup& channels)
 {
   std::vector<std::shared_ptr<CPVRChannel>> removedChannels;
@@ -607,11 +612,11 @@ std::vector<std::shared_ptr<CPVRChannel>> CPVRChannelGroup::RemoveDeletedChannel
   for (std::vector<std::shared_ptr<PVRChannelGroupMember>>::iterator it = m_sortedMembers.begin(); it != m_sortedMembers.end();)
   {
     const std::shared_ptr<CPVRChannel> channel = (*it)->channel;
-    if (channels.m_members.find(channel->StorageId()) == channels.m_members.end())
+    if (channels.m_members.find(channel->StorageId()) == channels.m_members.end() &&
+        ShouldRemoveChannel(channel))
     {
-      /* channel was not found */
-      CLog::Log(LOGINFO, "Deleted {} channel '{}' from group '{}'", IsRadio() ? "radio" : "TV",
-                channel->ChannelName(), GroupName());
+      CLog::Log(LOGINFO, "Removed stale {} channel '{}' from group '{}'",
+                IsRadio() ? "radio" : "TV", channel->ChannelName(), GroupName());
 
       removedChannels.emplace_back(channel);
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -139,8 +139,7 @@ void CPVRChannelGroup::Unload()
   CSingleLock lock(m_critSection);
   m_sortedMembers.clear();
   m_members.clear();
-  m_failedClientsForChannels.clear();
-  m_failedClientsForChannelGroupMembers.clear();
+  m_failedClients.clear();
 }
 
 bool CPVRChannelGroup::Update(std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove)
@@ -152,7 +151,7 @@ bool CPVRChannelGroup::Update(std::vector<std::shared_ptr<CPVRChannel>>& channel
   CPVRChannelGroup PVRChannels_tmp(m_path, m_iGroupId, m_allChannelsGroup);
   PVRChannels_tmp.SetPreventSortAndRenumber();
   PVRChannels_tmp.LoadFromClients();
-  m_failedClientsForChannelGroupMembers = PVRChannels_tmp.m_failedClientsForChannelGroupMembers;
+  m_failedClients = PVRChannels_tmp.m_failedClients;
   return UpdateGroupEntries(PVRChannels_tmp, channelsToRemove);
 }
 
@@ -487,7 +486,8 @@ int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
 bool CPVRChannelGroup::LoadFromClients()
 {
   /* get the channels from the backends */
-  return CServiceBroker::GetPVRManager().Clients()->GetChannelGroupMembers(this, m_failedClientsForChannelGroupMembers) == PVR_ERROR_NO_ERROR;
+  return CServiceBroker::GetPVRManager().Clients()->GetChannelGroupMembers(this, m_failedClients) ==
+         PVR_ERROR_NO_ERROR;
 }
 
 bool CPVRChannelGroup::AddAndUpdateChannels(const CPVRChannelGroup& channels, bool bUseBackendChannelNumbers)
@@ -542,18 +542,10 @@ bool CPVRChannelGroup::AddAndUpdateChannels(const CPVRChannelGroup& channels, bo
   return bReturn;
 }
 
-bool CPVRChannelGroup::IsMissingChannelsFromClient(int iClientId) const
+bool CPVRChannelGroup::HasValidDataFromClient(int iClientId) const
 {
-  return std::find(m_failedClientsForChannels.begin(),
-                   m_failedClientsForChannels.end(),
-                   iClientId) != m_failedClientsForChannels.end();
-}
-
-bool CPVRChannelGroup::IsMissingChannelGroupMembersFromClient(int iClientId) const
-{
-  return std::find(m_failedClientsForChannelGroupMembers.begin(),
-                   m_failedClientsForChannelGroupMembers.end(),
-                   iClientId) != m_failedClientsForChannelGroupMembers.end();
+  return std::find(m_failedClients.begin(), m_failedClients.end(), iClientId) ==
+         m_failedClients.end();
 }
 
 void CPVRChannelGroup::UpdateClientOrder()
@@ -598,11 +590,6 @@ bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()
   return bChanged;
 }
 
-bool CPVRChannelGroup::ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel)
-{
-  return !IsMissingChannelGroupMembersFromClient(channel->ClientID());
-}
-
 std::vector<std::shared_ptr<CPVRChannel>> CPVRChannelGroup::RemoveDeletedChannels(const CPVRChannelGroup& channels)
 {
   std::vector<std::shared_ptr<CPVRChannel>> removedChannels;
@@ -613,7 +600,7 @@ std::vector<std::shared_ptr<CPVRChannel>> CPVRChannelGroup::RemoveDeletedChannel
   {
     const std::shared_ptr<CPVRChannel> channel = (*it)->channel;
     if (channels.m_members.find(channel->StorageId()) == channels.m_members.end() &&
-        ShouldRemoveChannel(channel))
+        HasValidDataFromClient(channel->ClientID()))
     {
       CLog::Log(LOGINFO, "Removed stale {} channel '{}' from group '{}'",
                 IsRadio() ? "radio" : "TV", channel->ChannelName(), GroupName());

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -523,12 +523,19 @@ namespace PVR
     virtual bool UpdateGroupEntries(const CPVRChannelGroup& channels, std::vector<std::shared_ptr<CPVRChannel>>& channelsToRemove);
 
     /*!
-     * @brief Add new channels to this group; updtae data.
+     * @brief Add new channels to this group; update data.
      * @param channels The new channels to use for this group.
      * @param bUseBackendChannelNumbers True, if channel numbers from backends shall be used.
      * @return True if everything went well, false otherwise.
      */
     virtual bool AddAndUpdateChannels(const CPVRChannelGroup& channels, bool bUseBackendChannelNumbers);
+
+    /*!
+     * @brief Check whether a channel should be removed from this group.
+     * @param channel The channel to check.
+     * @return True if channel should be removed, false otherwise.
+     */
+    virtual bool ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel);
 
     /*!
      * @brief Remove deleted channels from this group.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -462,18 +462,12 @@ namespace PVR
     void SetPosition(int iPosition);
 
     /*!
-     * @brief Check, whether channel group member data for a given pvr client are currently missing, for instance, because the client was offline when data was last queried.
+     * @brief Check, whether data for a given pvr client are currently valid. For instance, data
+     * can be invalid because the client's backend was offline when data was last queried.
      * @param iClientId The id of the client.
-     * @return True, if data is currently missing, false otherwise.
+     * @return True, if data is currently valid, false otherwise.
      */
-    bool IsMissingChannelGroupMembersFromClient(int iClientId) const;
-
-    /*!
-     * @brief Check, whether channel data for a given pvr client are currently missing, for instance, because the client was offline when data was last queried.
-     * @param iClientId The id of the client.
-     * @return True, if data is currently missing, false otherwise.
-     */
-    bool IsMissingChannelsFromClient(int iClientId) const;
+    bool HasValidDataFromClient(int iClientId) const;
 
     /*!
      * @brief For each channel and its corresponding epg channel data update the order from the group members
@@ -531,13 +525,6 @@ namespace PVR
     virtual bool AddAndUpdateChannels(const CPVRChannelGroup& channels, bool bUseBackendChannelNumbers);
 
     /*!
-     * @brief Check whether a channel should be removed from this group.
-     * @param channel The channel to check.
-     * @return True if channel should be removed, false otherwise.
-     */
-    virtual bool ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel);
-
-    /*!
      * @brief Remove deleted channels from this group.
      * @param channels The new channels to use for this group.
      * @return The removed channels.
@@ -584,8 +571,7 @@ namespace PVR
     std::vector<std::shared_ptr<PVRChannelGroupMember>> m_sortedMembers; /*!< members sorted by channel number */
     std::map<std::pair<int, int>, std::shared_ptr<PVRChannelGroupMember>> m_members; /*!< members with key clientid+uniqueid */
     mutable CCriticalSection m_critSection;
-    std::vector<int> m_failedClientsForChannels;
-    std::vector<int> m_failedClientsForChannelGroupMembers;
+    std::vector<int> m_failedClients;
     CEventSource<PVREvent> m_events;
     bool m_bIsSelectedGroup = false; /*!< Whether or not this group is currently selected */
     bool m_bStartGroupChannelNumbersFromOne = false; /*!< true if we start group channel numbers from one when not using backend channel numbers, false otherwise */

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -277,21 +277,19 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup& chan
   return bReturn;
 }
 
+bool CPVRChannelGroupInternal::ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel)
+{
+  return !IsMissingChannelsFromClient(channel->ClientID());
+}
+
 std::vector<std::shared_ptr<CPVRChannel>> CPVRChannelGroupInternal::RemoveDeletedChannels(const CPVRChannelGroup& channels)
 {
   std::vector<std::shared_ptr<CPVRChannel>> removedChannels = CPVRChannelGroup::RemoveDeletedChannels(channels);
 
-  if (!removedChannels.empty())
+  for (const auto& channel : removedChannels)
   {
-    for (const auto& channel : removedChannels)
-    {
-      /* do we have valid data from channel's client? */
-      if (!IsMissingChannelsFromClient(channel->ClientID()))
-      {
-        /* since channel was not found in the internal group, it was deleted from the backend */
-        channel->Delete();
-      }
-    }
+    // since channel was not found in the internal group, it was deleted from the backend
+    channel->Delete();
   }
 
   return removedChannels;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -110,7 +110,7 @@ bool CPVRChannelGroupInternal::Update(std::vector<std::shared_ptr<CPVRChannel>>&
   CPVRChannelGroupInternal PVRChannels_tmp(IsRadio());
   PVRChannels_tmp.SetPreventSortAndRenumber();
   PVRChannels_tmp.LoadFromClients();
-  m_failedClientsForChannels = PVRChannels_tmp.m_failedClientsForChannels;
+  m_failedClients = PVRChannels_tmp.m_failedClients;
   return UpdateGroupEntries(PVRChannels_tmp, channelsToRemove);
 }
 
@@ -219,7 +219,8 @@ int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
 bool CPVRChannelGroupInternal::LoadFromClients()
 {
   /* get the channels from the backends */
-  return CServiceBroker::GetPVRManager().Clients()->GetChannels(this, m_failedClientsForChannels) == PVR_ERROR_NO_ERROR;
+  return CServiceBroker::GetPVRManager().Clients()->GetChannels(this, m_failedClients) ==
+         PVR_ERROR_NO_ERROR;
 }
 
 bool CPVRChannelGroupInternal::IsGroupMember(const std::shared_ptr<CPVRChannel>& channel) const
@@ -275,11 +276,6 @@ bool CPVRChannelGroupInternal::AddAndUpdateChannels(const CPVRChannelGroup& chan
     SortAndRenumber();
 
   return bReturn;
-}
-
-bool CPVRChannelGroupInternal::ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel)
-{
-  return !IsMissingChannelsFromClient(channel->ClientID());
 }
 
 std::vector<std::shared_ptr<CPVRChannel>> CPVRChannelGroupInternal::RemoveDeletedChannels(const CPVRChannelGroup& channels)

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -120,6 +120,13 @@ namespace PVR
     bool AddAndUpdateChannels(const CPVRChannelGroup& channels, bool bUseBackendChannelNumbers) override;
 
     /*!
+     * @brief Check whether a channel should be removed from this group.
+     * @param channel The channel to check.
+     * @return True if channel should be removed, false otherwise.
+     */
+    bool ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel) override;
+
+    /*!
      * @brief Remove deleted channels from this group.
      * @param channels The new channels to use for this group.
      * @return The removed channels.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -120,13 +120,6 @@ namespace PVR
     bool AddAndUpdateChannels(const CPVRChannelGroup& channels, bool bUseBackendChannelNumbers) override;
 
     /*!
-     * @brief Check whether a channel should be removed from this group.
-     * @param channel The channel to check.
-     * @return True if channel should be removed, false otherwise.
-     */
-    bool ShouldRemoveChannel(const std::shared_ptr<CPVRChannel>& channel) override;
-
-    /*!
      * @brief Remove deleted channels from this group.
      * @param channels The new channels to use for this group.
      * @return The removed channels.


### PR DESCRIPTION
This fixes a bug where all recently played channels disappear from Estuary PVR home screen. Reason is that in a very special error scenario some channel data stored in the TV databases will be overwritten with defaults. For "last played" default is 0 which makes the entries disappear from the homescreen widget. 

The bug scenario:

1. Kodi started successfully; PVR addon successfully loaded channels and channel group members from the backend.
2. PVR addon looses connection to backend. Next load of channel data and group members fails.
3. PVR addon reconnects to backend. Next load of channels and channel groups succeeds again.
=> Then and only if 1 and 2 happened, step three overwrites the channel data in the database.

I was hunting this bug for a long time and recently I found a possibility to reproduce it. ;-)

@phunkyfish when you find time for a review.