### PR TITLE
AESinkPULSE: Require version 11.0

### DIFF
--- a/cmake/modules/FindPulseAudio.cmake
+++ b/cmake/modules/FindPulseAudio.cmake
@@ -14,14 +14,10 @@
 #
 #   PulseAudio::PulseAudio   - The PulseAudio library
 
-if(NOT PulseAudio_FIND_VERSION)
-  set(PulseAudio_FIND_VERSION 2.0.0)
-endif()
-
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_PULSEAUDIO libpulse>=${PulseAudio_FIND_VERSION} QUIET)
-  pkg_check_modules(PC_PULSEAUDIO_MAINLOOP libpulse-mainloop-glib QUIET)
-  pkg_check_modules(PC_PULSEAUDIO_SIMPLE libpulse-simple QUIET)
+  pkg_check_modules(PC_PULSEAUDIO libpulse>=11.0.0 QUIET)
+  pkg_check_modules(PC_PULSEAUDIO_MAINLOOP libpulse-mainloop-glib>=11.0.0 QUIET)
+  pkg_check_modules(PC_PULSEAUDIO_SIMPLE libpulse-simple>=11.0.0 QUIET)
 endif()
 
 find_path(PULSEAUDIO_INCLUDE_DIR NAMES pulse/pulseaudio.h pulse/simple.h


### PR DESCRIPTION
## Description
This change drops the backwards compatibility beyond version 11.0 of pulseaudio. With Ubuntu 16.04 going EOL in April next year, we don't want to support it through entire Matrix. Every modern distribution is using 11.0 or later, especially 18.04 LTS and 20.04 LTS.

## Motivation and Context
Remove special mixing path for old pulse where we tried to map the speakers ourselves to workaround a server shortcoming that mapped in an unpleasant way. With the setting introduced in 11.0 namely r**emixing-use-all-sink-channels** this behaviour can be chosen by the enduser without the need to cause a different behaviour from kodi overwriting systemd defaults.

This change requires a change in:

* Documentation: Bump minimal version on Wiki