### PR TITLE
[addons] store number of available updates to member for performant use

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -211,8 +211,20 @@ bool CAddonMgr::ReloadSettings(const std::string &id)
 
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdates() const
 {
-  return GetAvailableUpdatesOrOutdatedAddons(false);
+  std::vector<std::shared_ptr<IAddon>> availableUpdates =
+      GetAvailableUpdatesOrOutdatedAddons(false);
+
+  std::lock_guard<std::mutex> lock(m_lastAvailableUpdatesCountMutex);
+  m_lastAvailableUpdatesCountAsString = std::to_string(availableUpdates.size());
+
+  return availableUpdates;
 }
+
+const std::string& CAddonMgr::GetLastAvailableUpdatesCountAsString() const
+{
+  std::lock_guard<std::mutex> lock(m_lastAvailableUpdatesCountMutex);
+  return m_lastAvailableUpdatesCountAsString;
+};
 
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetOutdatedAddons() const
 {

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -486,6 +486,14 @@ namespace ADDON
     bool GetCompatibleVersions(const std::string& addonId,
                                std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const;
 
+    /*!
+     * \brief Return number of available updates formatted as string
+     *        this can be used as a lightweight method of retrieving the number of updates
+     *        rather than using the expensive GetAvailableUpdates call
+     * \return number of available updates
+     */
+    const std::string& GetLastAvailableUpdatesCountAsString() const;
+
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;
 
@@ -561,6 +569,12 @@ namespace ADDON
 
     // Temporary path given to add-ons, whose content is deleted when Kodi is stopped
     const std::string m_tempAddonBasePath = "special://temp/addons";
+
+    /*!
+     * latest count of available updates
+     */
+    mutable std::string m_lastAvailableUpdatesCountAsString;
+    mutable std::mutex m_lastAvailableUpdatesCountMutex;
   };
 
 }; /* namespace ADDON */

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -306,8 +306,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       value = CServiceBroker::GetRenderSystem()->GetRenderVersionString();
       return true;
     case SYSTEM_ADDON_UPDATE_COUNT:
-      value =
-          StringUtils::Format("{0}", CServiceBroker::GetAddonMgr().GetAvailableUpdates().size());
+      value = CServiceBroker::GetAddonMgr().GetLastAvailableUpdatesCountAsString();
       return true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
stores the number of available addon-updates to a private member for use with infolabel `AddonUpdateCount`.
prevents the expensive call to `GetAvailableUpdates()` in a tight loop.

## Motivation and Context
closes #18588 

## How Has This Been Tested?
debian buster local

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
