### PR TITLE
Android: Drop everything below Version 24

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -6,7 +6,7 @@
     android:versionName="@APP_VERSION@">
 
     <uses-sdk
-        android:minSdkVersion="21"
+        android:minSdkVersion="24"
         android:targetSdkVersion="26" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId "@APP_PACKAGE@"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 28
         versionCode @APP_VERSION_CODE_ANDROID@
         versionName "@APP_VERSION@"

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -41,7 +41,7 @@ case $XBMC_PLATFORM_DIR in
 
   android)
     DEFAULT_NDK_VERSION="20" # NDK package version (newer API can be inside)
-    DEFAULT_NDK_API="21" # Lollipop API level (21) defined in package ./sysroot/usr/include/android/api-level.h
+    DEFAULT_NDK_API="24" # Nougat API level (24) defined in package ./sysroot/usr/include/android/api-level.h
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -79,9 +79,9 @@ AC_ARG_WITH([sdk],
 
 AC_ARG_WITH([ndk-api],
   [AS_HELP_STRING([--with-ndk-api],
-  [specify ndk level (optional for android), default is 21.])],
+  [specify ndk level (optional for android), default is 24.])],
   [use_ndk_api=$withval],
-  [use_ndk_api=21])
+  [use_ndk_api=24])
 
 AC_ARG_ENABLE([gplv3],
   [AS_HELP_STRING([--enable-gplv3],

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -125,16 +125,13 @@ CAndroidUtils::CAndroidUtils()
   std::string displaySize;
   m_width = m_height = 0;
 
-  if (CJNIBase::GetSDKVersion() >= 24)
+  fetchDisplayModes();
+  for (auto res : s_res_displayModes)
   {
-    fetchDisplayModes();
-    for (const auto& res : s_res_displayModes)
+    if (res.iWidth > m_width || res.iHeight > m_height)
     {
-      if (res.iWidth > m_width || res.iHeight > m_height)
-      {
-        m_width = res.iWidth;
-        m_height = res.iHeight;
-      }
+      m_width = res.iWidth;
+      m_height = res.iHeight;
     }
   }
 
@@ -310,8 +307,7 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
 
 bool CAndroidUtils::UpdateDisplayModes()
 {
-  if (CJNIBase::GetSDKVersion() >= 24)
-    fetchDisplayModes();
+  fetchDisplayModes();
   return true;
 }
 


### PR DESCRIPTION
Android Version 24 was released August 2016 (Android 7)
Android Version 23 was released November 2015 (Android 6)

With this PR, we drop backwards compatibility for version 23 (Android 6 in the code) and require at least Android 7.

No hard feelings here, if someone steps up and wants to keep it, totally fine with me.

As you see in the code: Most problems we have in Audio-Part, as the old version did not have the blocking attribute