### PR TITLE
[addons] change binary addon system to have prepared for hidden functions / some other cleanups

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -326,11 +326,6 @@ AddonVersion CAddonDll::GetTypeMinVersionDll(int type) const
   return AddonVersion(m_pDll ? m_pDll->GetAddonTypeMinVersion(type) : nullptr);
 }
 
-ADDON_STATUS CAddonDll::GetStatus()
-{
-  return m_pDll->GetStatus();
-}
-
 void CAddonDll::SaveSettings()
 {
   // must save first, as TransferSettings() reloads saved settings!

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -49,8 +49,6 @@ public:
   explicit CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType);
   ~CAddonDll() override;
 
-  virtual ADDON_STATUS GetStatus();
-
   // Implementation of IAddon via CAddon
   std::string LibPath() const override;
 

--- a/xbmc/addons/binary-addons/DllAddon.h
+++ b/xbmc/addons/binary-addons/DllAddon.h
@@ -18,7 +18,6 @@ public:
   virtual void GetAddon(void* pAddon) =0;
   virtual ADDON_STATUS Create(void* cb, const char* globalApiVersion, void* info) = 0;
   virtual void Destroy() =0;
-  virtual ADDON_STATUS GetStatus() =0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
   virtual const char* GetAddonTypeVersion(int type)=0;
   virtual const char* GetAddonTypeMinVersion(int type) = 0;
@@ -30,7 +29,6 @@ public:
   DECLARE_DLL_WRAPPER_TEMPLATE(DllAddon)
   DEFINE_METHOD3(ADDON_STATUS, Create, (void* p1, const char* p2, void* p3))
   DEFINE_METHOD0(void, Destroy)
-  DEFINE_METHOD0(ADDON_STATUS, GetStatus)
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (void* p1))
   DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
@@ -40,7 +38,6 @@ public:
     RESOLVE_METHOD_RENAME_OPTIONAL(get_addon, GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
     RESOLVE_METHOD_RENAME(ADDON_Destroy, Destroy)
-    RESOLVE_METHOD_RENAME(ADDON_GetStatus, GetStatus)
     RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetTypeVersion, GetAddonTypeVersion)
     RESOLVE_METHOD_RENAME_OPTIONAL(ADDON_GetTypeMinVersion, GetAddonTypeMinVersion)

--- a/xbmc/addons/binary-addons/DllAddon.h
+++ b/xbmc/addons/binary-addons/DllAddon.h
@@ -15,10 +15,7 @@ class DllAddonInterface
 {
 public:
   virtual ~DllAddonInterface() = default;
-  virtual void GetAddon(void* pAddon) =0;
   virtual ADDON_STATUS Create(void* cb, const char* globalApiVersion, void* info) = 0;
-  virtual void Destroy() =0;
-  virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
   virtual const char* GetAddonTypeVersion(int type)=0;
   virtual const char* GetAddonTypeMinVersion(int type) = 0;
 };
@@ -28,17 +25,11 @@ class DllAddon : public DllDynamic, public DllAddonInterface
 public:
   DECLARE_DLL_WRAPPER_TEMPLATE(DllAddon)
   DEFINE_METHOD3(ADDON_STATUS, Create, (void* p1, const char* p2, void* p3))
-  DEFINE_METHOD0(void, Destroy)
-  DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
-  DEFINE_METHOD1(void, GetAddon, (void* p1))
   DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
   DEFINE_METHOD1(const char*, GetAddonTypeMinVersion, (int p1))
   bool GetAddonTypeMinVersion_available() { return m_GetAddonTypeMinVersion != nullptr; }
   BEGIN_METHOD_RESOLVE()
-    RESOLVE_METHOD_RENAME_OPTIONAL(get_addon, GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
-    RESOLVE_METHOD_RENAME(ADDON_Destroy, Destroy)
-    RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetTypeVersion, GetAddonTypeVersion)
     RESOLVE_METHOD_RENAME_OPTIONAL(ADDON_GetTypeMinVersion, GetAddonTypeMinVersion)
   END_METHOD_RESOLVE()

--- a/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_cpp.dox
+++ b/xbmc/addons/kodi-dev-kit/doxygen/Modules/modules_cpp.dox
@@ -93,6 +93,8 @@ Here is a table of the types currently possible:
     */
   /*!
   \defgroup cpp_kodi_addon_instances Addon type instances
+  \brief **Group of possible processing instances which can be made available by an add-on**\n
+  Kodi enables numerous different ways in which the necessary documentation is included in this group.
   \ingroup cpp_kodi_addon
   */
     /*!

--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -1288,7 +1288,7 @@ inline void* GetInterface(const std::string& name, const std::string& version)
  * Becomes really cleaned up soon :D
  */
 #define ADDONCREATOR(AddonClass) \
-  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_Create( \
+  extern "C" ATTRIBUTE_DLL_EXPORT ADDON_STATUS ADDON_Create( \
       KODI_HANDLE addonInterface, const char* /*globalApiVersion*/, void* /*unused*/) \
   { \
     kodi::addon::CAddonBase::m_interface = static_cast<AddonGlobalInterface*>(addonInterface); \
@@ -1296,24 +1296,24 @@ inline void* GetInterface(const std::string& name, const std::string& version)
     return static_cast<kodi::addon::CAddonBase*>(kodi::addon::CAddonBase::m_interface->addonBase) \
         ->Create(); \
   } \
-  extern "C" __declspec(dllexport) void ADDON_Destroy() \
+  extern "C" ATTRIBUTE_DLL_EXPORT void ADDON_Destroy() \
   { \
     kodi::addon::CAddonBase::ADDONBASE_Destroy(); \
   } \
-  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_GetStatus() \
+  extern "C" ATTRIBUTE_DLL_EXPORT ADDON_STATUS ADDON_GetStatus() \
   { \
     return kodi::addon::CAddonBase::ADDONBASE_GetStatus(); \
   } \
-  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_SetSetting(const char* settingName, \
+  extern "C" ATTRIBUTE_DLL_EXPORT ADDON_STATUS ADDON_SetSetting(const char* settingName, \
                                                                  const void* settingValue) \
   { \
     return kodi::addon::CAddonBase::ADDONBASE_SetSetting(settingName, settingValue); \
   } \
-  extern "C" __declspec(dllexport) const char* ADDON_GetTypeVersion(int type) \
+  extern "C" ATTRIBUTE_DLL_EXPORT const char* ADDON_GetTypeVersion(int type) \
   { \
     return kodi::addon::GetTypeVersion(type); \
   } \
-  extern "C" __declspec(dllexport) const char* ADDON_GetTypeMinVersion(int type) \
+  extern "C" ATTRIBUTE_DLL_EXPORT const char* ADDON_GetTypeMinVersion(int type) \
   { \
     return kodi::addon::GetTypeMinVersion(type); \
   } \

--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -318,7 +318,6 @@ public:
   CAddonBase()
   {
     m_interface->toAddon->destroy = ADDONBASE_Destroy;
-    m_interface->toAddon->get_status = ADDONBASE_GetStatus;
     m_interface->toAddon->create_instance = ADDONBASE_CreateInstance;
     m_interface->toAddon->destroy_instance = ADDONBASE_DestroyInstance;
     m_interface->toAddon->set_setting = ADDONBASE_SetSetting;
@@ -488,11 +487,6 @@ public:
   {
     delete static_cast<CAddonBase*>(m_interface->addonBase);
     m_interface->addonBase = nullptr;
-  }
-
-  static inline ADDON_STATUS ADDONBASE_GetStatus()
-  {
-    return static_cast<CAddonBase*>(m_interface->addonBase)->GetStatus();
   }
 
   static inline ADDON_STATUS ADDONBASE_SetSetting(const char* settingName, const void* settingValue)
@@ -1299,10 +1293,6 @@ inline void* GetInterface(const std::string& name, const std::string& version)
   extern "C" ATTRIBUTE_DLL_EXPORT void ADDON_Destroy() \
   { \
     kodi::addon::CAddonBase::ADDONBASE_Destroy(); \
-  } \
-  extern "C" ATTRIBUTE_DLL_EXPORT ADDON_STATUS ADDON_GetStatus() \
-  { \
-    return kodi::addon::CAddonBase::ADDONBASE_GetStatus(); \
   } \
   extern "C" ATTRIBUTE_DLL_EXPORT ADDON_STATUS ADDON_SetSetting(const char* settingName, \
                                                                  const void* settingValue) \

--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -65,7 +65,8 @@ using HardwareContext = ADDON_HARDWARE_CONTEXT;
 //==============================================================================
 /// @ingroup cpp_kodi_addon_addonbase_Defs
 /// @defgroup cpp_kodi_addon_addonbase_Defs_CSettingValue class CSettingValue
-/// @brief Inside addon main instance used helper class to give settings value.
+/// @brief **Setting value handler**\n
+/// Inside addon main instance used helper class to give settings value.
 ///
 /// This is used on @ref addon::CAddonBase::SetSetting() to inform addon about
 /// settings change by used. This becomes then used to give the related value
@@ -311,10 +312,19 @@ private:
   bool m_owner = false;
 };
 
-/// Add-on main instance class.
+//============================================================================
+/// @addtogroup cpp_kodi_addon_addonbase
+/// @brief **Add-on main instance class**\n
+/// This is the addon main class, similar to an <b>`int main()`</b> in executable and
+/// carries out initial work and later management of it.
+///
 class ATTRIBUTE_HIDDEN CAddonBase
 {
 public:
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_addonbase
+  /// @brief Addon base class constructor.
+  ///
   CAddonBase()
   {
     m_interface->toAddon->destroy = ADDONBASE_Destroy;
@@ -322,11 +332,35 @@ public:
     m_interface->toAddon->destroy_instance = ADDONBASE_DestroyInstance;
     m_interface->toAddon->set_setting = ADDONBASE_SetSetting;
   }
+  //----------------------------------------------------------------------------
 
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_addonbase
+  /// @brief Destructor.
+  ///
   virtual ~CAddonBase() = default;
+  //----------------------------------------------------------------------------
 
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_addonbase
+  /// @brief Main addon creation function
+  ///
+  /// With this function addon can carry out necessary work which is required
+  /// at later points or start necessary processes.
+  ///
+  /// This function is optional and necessary work can also be carried out
+  /// using @ref CreateInstance (if it concerns any instance types).
+  ///
+  /// @return @ref ADDON_STATUS_OK if correct, for possible errors see
+  ///         @ref ADDON_STATUS
+  ///
+  /// @note Terminating the add-on must be carried out using the class destructor
+  /// given by child.
+  ///
   virtual ADDON_STATUS Create() { return ADDON_STATUS_OK; }
+  //----------------------------------------------------------------------------
 
+  // obsolete
   virtual ADDON_STATUS GetStatus() { return ADDON_STATUS_OK; }
 
   //============================================================================
@@ -413,8 +447,8 @@ public:
   ///
   /// ...
   ///
-  /// /* If you use only one instance in your add-on, can be instanceType and
-  ///  * instanceID ignored */
+  /// // If you use only one instance in your add-on, can be instanceType and
+  /// // instanceID ignored
   /// ADDON_STATUS CMyAddon::CreateInstance(int instanceType,
   ///                                       const std::string& instanceID,
   ///                                       KODI_HANDLE instance,
@@ -584,7 +618,7 @@ private:
 } /* namespace addon */
 
 //==============================================================================
-/// @ingroup cpp_kodi_addon
+/// @ingroup cpp_kodi
 /// @brief To get used version inside Kodi itself about asked type.
 ///
 /// This thought to allow a addon a handling of newer addon versions within
@@ -606,6 +640,11 @@ inline std::string ATTRIBUTE_HIDDEN GetKodiTypeVersion(int type)
 //------------------------------------------------------------------------------
 
 //==============================================================================
+/// @ingroup cpp_kodi
+/// @brief To get the addon system installation folder.
+///
+/// @param[in] append [optional] Path to append to given string
+/// @return Path where addon is installed
 ///
 inline std::string ATTRIBUTE_HIDDEN GetAddonPath(const std::string& append = "")
 {
@@ -630,6 +669,14 @@ inline std::string ATTRIBUTE_HIDDEN GetAddonPath(const std::string& append = "")
 //------------------------------------------------------------------------------
 
 //==============================================================================
+/// @ingroup cpp_kodi
+/// @brief To get the user-related folder of the addon.
+///
+/// @note This folder is not created automatically and has to be created by the
+/// addon the first time.
+///
+/// @param[in] append [optional] Path to append to given string
+/// @return User path of addon
 ///
 inline std::string ATTRIBUTE_HIDDEN GetBaseUserPath(const std::string& append = "")
 {
@@ -654,6 +701,19 @@ inline std::string ATTRIBUTE_HIDDEN GetBaseUserPath(const std::string& append = 
 //------------------------------------------------------------------------------
 
 //==============================================================================
+/// @ingroup cpp_kodi
+/// @brief This function gives OS associated executable binary path of the addon.
+///
+/// With some systems this can differ from the addon path at @ref GetAddonPath.
+///
+/// As an example on Linux:
+/// - Addon path is at `/usr/share/kodi/addons/YOUR_ADDON_ID`
+/// - Library path is at `/usr/lib/kodi/addons/YOUR_ADDON_ID`
+///
+/// @note In addition, in this function, for a given folder, the add-on path
+/// itself, but its parent.
+///
+/// @return Kodi's sytem library path where related addons are installed.
 ///
 inline std::string ATTRIBUTE_HIDDEN GetLibPath()
 {
@@ -1216,6 +1276,11 @@ inline void ATTRIBUTE_HIDDEN SetSettingEnum(const std::string& settingName, enum
 /*!@}*/
 
 //============================================================================
+/// @ingroup cpp_kodi
+/// @brief Get to related @ref ADDON_STATUS a human readable text.
+///
+/// @param[in] status Status value to get name for
+/// @return Wanted name, as "Unknown" if status not known
 ///
 inline std::string ATTRIBUTE_HIDDEN TranslateAddonStatus(ADDON_STATUS status)
 {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audio_decoder.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_AUDIO_DECODER_H
 #define C_API_ADDONINSTANCE_AUDIO_DECODER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audio_encoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audio_encoder.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_AUDIO_ENCODER_H
 #define C_API_ADDONINSTANCE_AUDIO_ENCODER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_GAME_H
 #define C_API_ADDONINSTANCE_GAME_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/image_decoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/image_decoder.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_IMAGE_DECODER_H
 #define C_API_ADDONINSTANCE_IMAGE_DECODER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PERIPHERAL_H
 #define C_API_ADDONINSTANCE_PERIPHERAL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_H
 #define C_API_ADDONINSTANCE_PVR_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channel_groups.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channel_groups.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_CHANNEL_GROUPS_H
 #define C_API_ADDONINSTANCE_PVR_CHANNEL_GROUPS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_CHANNELS_H
 #define C_API_ADDONINSTANCE_PVR_CHANNELS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_DEFINES_H
 #define C_API_ADDONINSTANCE_PVR_DEFINES_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_edl.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_edl.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_EDL_H
 #define C_API_ADDONINSTANCE_PVR_EDL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_EPG_H
 #define C_API_ADDONINSTANCE_PVR_EPG_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_GENERAL_H
 #define C_API_ADDONINSTANCE_PVR_GENERAL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_menu_hook.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_menu_hook.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_MENUHOOK_H
 #define C_API_ADDONINSTANCE_PVR_MENUHOOK_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_RECORDINGS_H
 #define C_API_ADDONINSTANCE_PVR_RECORDINGS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_stream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_stream.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_STREAM_H
 #define C_API_ADDONINSTANCE_PVR_STREAM_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_timers.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_PVR_TIMERS_H
 #define C_API_ADDONINSTANCE_PVR_TIMERS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_SCREENSAVER_H
 #define C_API_ADDONINSTANCE_SCREENSAVER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/screensaver.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#ifndef C_API_ADDONINSTANCE_SCREENSAVER_H
+#define C_API_ADDONINSTANCE_SCREENSAVER_H
+
 #include "../addon_base.h"
 
 #ifdef __cplusplus
@@ -73,3 +76,5 @@ extern "C"
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */
+
+#endif /* !C_API_ADDONINSTANCE_SCREENSAVER_H */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/vfs.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/vfs.h
@@ -94,7 +94,7 @@ extern "C"
                                                 VFS_FILE_HANDLE context);
     bool(__cdecl* io_control_get_cache_status)(const struct AddonInstance_VFSEntry* instance,
                                                VFS_FILE_HANDLE context,
-                                               VFS_CACHE_STATUS_DATA* status);
+                                               struct VFS_CACHE_STATUS_DATA* status);
     bool(__cdecl* io_control_set_cache_rate)(const struct AddonInstance_VFSEntry* instance,
                                              VFS_FILE_HANDLE context,
                                              unsigned int rate);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/vfs.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/vfs.h
@@ -5,8 +5,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_VFS_H
 #define C_API_ADDONINSTANCE_VFS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/visualization.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/visualization.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#ifndef C_API_ADDONINSTANCE_VISUALIZATION_H
+#define C_API_ADDONINSTANCE_VISUALIZATION_H
+
 #include "../addon_base.h"
 
 #define VIZ_LYRICS_SIZE 32768
@@ -115,3 +118,5 @@ extern "C"
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */
+
+#endif /* !C_API_ADDONINSTANCE_VISUALIZATION_H */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/visualization.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/visualization.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDONINSTANCE_VISUALIZATION_H
 #define C_API_ADDONINSTANCE_VISUALIZATION_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -96,9 +96,11 @@ extern "C"
 #endif /* __cplusplus */
 
   //============================================================================
-  /// @ingroup cpp_kodi_addon_addonbase
-  /// @brief Return value of functions in @ref cpp_kodi_addon_addonbase "kodi::addon::CAddonBase"
-  /// and associated classes.
+  /// @ingroup cpp_kodi_addon_addonbase_Defs
+  /// @defgroup cpp_kodi_addon_addonbase_Defs_ADDON_STATUS enum ADDON_STATUS
+  /// @brief <b>Return value of functions in @ref cpp_kodi_addon_addonbase "kodi::addon::CAddonBase"
+  /// and associated classes</b>\n
+  /// With this Kodi can do any follow-up work or add-on e.g. declare it as defective.
   ///
   ///@{
   typedef enum ADDON_STATUS

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -27,6 +27,8 @@
 #endif
 #endif
 
+// Generic helper definitions for smallest possible alignment
+//@{
 #undef ATTRIBUTE_PACKED
 #undef PRAGMA_PACK_BEGIN
 #undef PRAGMA_PACK_END
@@ -34,18 +36,16 @@
 #if defined(__GNUC__)
 #define ATTRIBUTE_PACKED __attribute__((packed))
 #define PRAGMA_PACK 0
-#define ATTRIBUTE_HIDDEN __attribute__((visibility("hidden")))
 #endif
 
 #if !defined(ATTRIBUTE_PACKED)
 #define ATTRIBUTE_PACKED
 #define PRAGMA_PACK 1
 #endif
+//@}
 
-#if !defined(ATTRIBUTE_HIDDEN)
-#define ATTRIBUTE_HIDDEN
-#endif
-
+// Generic helper definitions for inline function support
+//@{
 #ifdef _MSC_VER
 #define ATTRIBUTE_FORCEINLINE __forceinline
 #elif defined(__GNUC__)
@@ -59,6 +59,27 @@
 #else
 #define ATTRIBUTE_FORCEINLINE inline
 #endif
+//@}
+
+// Generic helper definitions for shared library support
+//@{
+#if defined _WIN32 || defined __CYGWIN__
+#define ATTRIBUTE_DLL_IMPORT __declspec(dllimport)
+#define ATTRIBUTE_DLL_EXPORT __declspec(dllexport)
+#define ATTRIBUTE_DLL_LOCAL
+#else
+#if __GNUC__ >= 4
+#define ATTRIBUTE_DLL_IMPORT __attribute__ ((visibility ("default")))
+#define ATTRIBUTE_DLL_EXPORT __attribute__ ((visibility ("default")))
+#define ATTRIBUTE_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define ATTRIBUTE_DLL_IMPORT
+#define ATTRIBUTE_DLL_EXPORT
+#define ATTRIBUTE_DLL_LOCAL
+#endif
+#endif
+#define ATTRIBUTE_HIDDEN ATTRIBUTE_DLL_LOCAL // Fallback to old
+//@}
 
 // Hardware specific device context interface
 #define ADDON_HARDWARE_CONTEXT void*

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_ADDON_BASE_H
 #define C_API_ADDON_BASE_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -232,7 +232,7 @@ extern "C"
   typedef struct KodiToAddonFuncTable_Addon
   {
     void (*destroy)();
-    ADDON_STATUS (*get_status)();
+    ADDON_STATUS (*get_status)(); // TODO unused remove by next min version increase
     ADDON_STATUS(*create_instance)
     (int instanceType,
      const char* instanceID,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/audio_engine.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/audio_engine.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_AUDIO_ENGINE_H
 #define C_API_AUDIO_ENGINE_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/filesystem.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_FILESYSTEM_H
 #define C_API_FILESYSTEM_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/general.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GENERAL_H
 #define C_API_GENERAL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/button.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/button.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_BUTTON_H
 #define C_API_GUI_CONTROLS_BUTTON_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/edit.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/edit.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_EDIT_H
 #define C_API_GUI_CONTROLS_EDIT_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/fade_label.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/fade_label.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_FADE_LABEL_H
 #define C_API_GUI_CONTROLS_FADE_LABEL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/image.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/image.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_IMAGE_H
 #define C_API_GUI_CONTROLS_IMAGE_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/label.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/label.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_LABEL_H
 #define C_API_GUI_CONTROLS_LABEL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/progress.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/progress.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_PROGRESS_H
 #define C_API_GUI_CONTROLS_PROGRESS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/radio_button.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/radio_button.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_RADIO_BUTTON_H
 #define C_API_GUI_CONTROLS_RADIO_BUTTON_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/rendering.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/rendering.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_RENDERING_H
 #define C_API_GUI_CONTROLS_RENDERING_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/settings_slider.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/settings_slider.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_SETTINGS_SLIDER_H
 #define C_API_GUI_CONTROLS_SETTINGS_SLIDER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/slider.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/slider.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_SLIDER_H
 #define C_API_GUI_CONTROLS_SLIDER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/spin.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/spin.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_SPIN_H
 #define C_API_GUI_CONTROLS_SPIN_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/text_box.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/controls/text_box.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_CONTROLS_TEXT_BOX_H
 #define C_API_GUI_CONTROLS_TEXT_BOX_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/definitions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/definitions.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DEFINITIONS_H
 #define C_API_GUI_DEFINITIONS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/context_menu.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/context_menu.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_CONTEXT_MENU_H
 #define C_API_GUI_DIALOGS_CONTEXT_MENU_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/extended_progress.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/extended_progress.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_EXTENDED_PROGRESS_H
 #define C_API_GUI_DIALOGS_EXTENDED_PROGRESS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/filebrowser.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/filebrowser.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_FILEBROWSER_H
 #define C_API_GUI_DIALOGS_FILEBROWSER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/keyboard.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/keyboard.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_KEYBOARD_H
 #define C_API_GUI_DIALOGS_KEYBOARD_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/numeric.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/numeric.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_NUMERIC_H
 #define C_API_GUI_DIALOGS_NUMERIC_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/ok.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/ok.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_OK_H
 #define C_API_GUI_DIALOGS_OK_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/progress.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/progress.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_PROGRESS_H
 #define C_API_GUI_DIALOGS_PROGRESS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/select.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/select.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_SELECT_H
 #define C_API_GUI_DIALOGS_SELECT_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/text_viewer.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/text_viewer.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_TEXT_VIEWER_H
 #define C_API_GUI_DIALOGS_TEXT_VIEWER_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/yes_no.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/dialogs/yes_no.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_DIALOGS_YES_NO_H
 #define C_API_GUI_DIALOGS_YES_NO_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/general.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_GENERAL_H
 #define C_API_GUI_GENERAL_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_ACTION_IDS_H
 #define C_API_GUI_ACTION_IDS_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/list_item.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/list_item.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_LIST_ITEM_H
 #define C_API_GUI_LIST_ITEM_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/window.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/window.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_GUI_WINDOW_H
 #define C_API_GUI_WINDOW_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/network.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/network.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_NETWORK_H
 #define C_API_NETWORK_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/platform/android/system.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/platform/android/system.h
@@ -6,8 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#pragma once
-
 #ifndef C_API_PLATFORM_ANDROID_H
 #define C_API_PLATFORM_ANDROID_H
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -170,15 +170,18 @@
 // clang-format on
 
 //==============================================================================
-///
-/// @ingroup cpp_kodi_addon_addonbase
-/// The currently available instance types for Kodi add-ons
+/// @ingroup cpp_kodi_addon_addonbase_Defs
+/// @defgroup cpp_kodi_addon_addonbase_Defs_ADDON_TYPE enum ADDON_TYPE
+/// **The currently available instance types for Kodi add-ons**\n
+/// This identifies the associated API part on the interface in Kodi and in the
+/// addon.
 ///
 /// \internal
 /// @note For add of new types take a new number on end. To change
 /// existing numbers can be make problems on already compiled add-ons.
 /// \endinternal
 ///
+///@{
 typedef enum ADDON_TYPE
 {
   /* addon global parts */
@@ -228,6 +231,7 @@ typedef enum ADDON_TYPE
   /// Video Decoder instance, see \ref cpp_kodi_addon_videocodec "kodi::addon::CInstanceVideoCodec"
   ADDON_INSTANCE_VIDEOCODEC = 112,
 } ADDON_TYPE;
+///@}
 //------------------------------------------------------------------------------
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -37,7 +37,7 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.2.4"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.3.0"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.2.0"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#ifndef KODI_VERSIONS_H
+#define KODI_VERSIONS_H
+
 #include <string.h>
 
 #define STR_HELPER(x) #x
@@ -490,3 +493,5 @@ inline int GetTypeId(const char* name)
 } /* namespace kodi */
 } /* extern "C" */
 #endif
+
+#endif /* !KODI_VERSIONS_H */


### PR DESCRIPTION
## Description

With this, the API orgy is drawing to a close, only for few types after the hidden is default need changes and 1-2 request until end.

The main reason for this is to fix the export defined in the macro "ADDONCREATOR", which only referred to Windows.
This means that addons created in the future will be suitable and all other functions in cmake with `set (CMAKE_CXX_VISIBILITY_PRESET hidden)` and `set (CMAKE_VISIBILITY_INLINES_HIDDEN YES)` can be avoided.
This avoids called conflicts if the same thing is due to two different addons or in Kodi.

In addition, a few other little things are used.

Commit 1:
---------------------------
**[addons][vfs] fix "C" API by add of missing "struct" on value**

There was on one function value the for "C" needed "struct" before related structure name missing. For C++ it is OK without only mandatory for use on "C".

Commit 2:
---------------------------
**[addons] add on 3 "C" related headers the ifdef's for header include**

On three headers was still the ifdef's about alternative of "pragma once" missing. This add them.

Is good to have as "pragma once" not a standardized part and possible that not supported everywhere, the "ifdef" instead works always.

This only be on "C" related headers as them maybe base for other languages.

Commit 3:
---------------------------
**[addons] add new dll export definitions**

- ATTRIBUTE_DLL_IMPORT (to import external lib functions)
- ATTRIBUTE_DLL_EXPORT (to export lib functions and have available outside)
- ATTRIBUTE_DLL_LOCAL (to set functions as private and not available outside of Dll)

This done to prevent problems about wrongly exported parts and conflicts that another addon takes wrong places. Related fix to have whole addon (except needed parts) private, where comes on another request.

Before was inside the addon main macro "ADDONCREATOR" only the windows export used. As there now becomes ATTRIBUTE_DLL_EXPORT used is it exported on all OS.

Commit 4:
---------------------------
**[addons] remove unused GetStatus call**

Them was since very long time not needed and mainly on begin by PVR addons to check for e.g. connection or something else.

This remove it, only to have no min version increase is inside addon_base function structure it still inside and need remove in future.

Commit 5:
---------------------------
**[addons] remove all no more needed DllExport functions**

This removes some functions where not needed anymore.

Only stays in:
- ADDON_Create
- ADDON_GetTypeVersion
- ADDON_GetTypeMinVersion

The rest is done via the structure with function addresses.

Also is now after a long time a documentation added to the ADDONCREATOR macro.

Commit 6:
---------------------------
**[addons] improve some documentations**

Before was some parts missing and not good shown inside Doxygen, specially related to CAddonBase and functions with AddonBase.h.

Thie improve it and to have more usable.

There still parts where can be better and from here one step for it.

Commit 7:
---------------------------
**[addons] increase global API version to 1.3.0**

The Min stays the same and older addons still usable.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?

Still need to test on addons!
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
