### PR TITLE
[GBM] implement an atomic queue

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -10,6 +10,11 @@
 
 #include "DRMUtils.h"
 
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+
 namespace KODI
 {
 namespace WINDOWING
@@ -38,7 +43,37 @@ private:
 
   bool m_need_modeset;
   bool m_active = true;
-  drmModeAtomicReq *m_req = nullptr;
+
+  class CDRMAtomicRequest
+  {
+  public:
+    CDRMAtomicRequest();
+    ~CDRMAtomicRequest() = default;
+    CDRMAtomicRequest(const CDRMAtomicRequest& right) = delete;
+
+    drmModeAtomicReqPtr Get() const { return m_atomicRequest.get(); }
+
+    bool AddProperty(CDRMObject* object, const char* name, uint64_t value);
+    void LogAtomicRequest();
+
+    static void LogAtomicDiff(CDRMAtomicRequest* current, CDRMAtomicRequest* old);
+
+  private:
+    static void LogAtomicRequest(
+        uint8_t logLevel, std::map<CDRMObject*, std::map<uint32_t, uint64_t>>& atomicRequestItems);
+
+    std::map<CDRMObject*, std::map<uint32_t, uint64_t>> m_atomicRequestItems;
+
+    struct DrmModeAtomicReqDeleter
+    {
+      void operator()(drmModeAtomicReqPtr p) const;
+    };
+
+    std::unique_ptr<drmModeAtomicReq, DrmModeAtomicReqDeleter> m_atomicRequest;
+  };
+
+  CDRMAtomicRequest* m_req = nullptr;
+  std::deque<std::unique_ptr<CDRMAtomicRequest>> m_atomicRequestQueue;
 };
 
 }

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -12,11 +12,46 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <array>
 
 using namespace KODI::WINDOWING::GBM;
 
+namespace
+{
+
+constexpr std::array<std::pair<uint32_t, const char*>, 8> DrmModeObjectTypes = {
+    {{DRM_MODE_OBJECT_CRTC, "crtc"},
+     {DRM_MODE_OBJECT_CONNECTOR, "connector"},
+     {DRM_MODE_OBJECT_ENCODER, "encoder"},
+     {DRM_MODE_OBJECT_MODE, "mode"},
+     {DRM_MODE_OBJECT_PROPERTY, "property"},
+     {DRM_MODE_OBJECT_FB, "framebuffer"},
+     {DRM_MODE_OBJECT_BLOB, "blob"},
+     {DRM_MODE_OBJECT_PLANE, "plane"}}};
+}
+
 CDRMObject::CDRMObject(int fd) : m_fd(fd)
 {
+}
+
+std::string CDRMObject::GetTypeName() const
+{
+  auto name = std::find_if(DrmModeObjectTypes.begin(), DrmModeObjectTypes.end(),
+                           [this](auto& p) { return p.first == m_type; });
+  if (name != DrmModeObjectTypes.end())
+    return name->second;
+
+  return "invalid type";
+}
+
+std::string CDRMObject::GetPropertyName(uint32_t propertyId) const
+{
+  auto prop = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
+                           [&propertyId](auto& p) { return p->prop_id == propertyId; });
+  if (prop != m_propsInfo.end())
+    return prop->get()->name;
+
+  return "invalid property";
 }
 
 uint32_t CDRMObject::GetPropertyId(const char* name) const

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -29,6 +29,9 @@ public:
   CDRMObject& operator=(const CDRMObject&) = delete;
   virtual ~CDRMObject() = default;
 
+  std::string GetTypeName() const;
+  std::string GetPropertyName(uint32_t propertyId) const;
+
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const char* name) const;
 


### PR DESCRIPTION
This adds an atomic queue to the atomic DRM windowing. This allows us to avoid having the gui possibly enter an unusable state in the case of a bad request.

I've implemented this as a stack using `std::deque` (I didn't use `std::stack` because I need to access the other elements).

So if there is an unsuccessful request there should also be a "successful" request in the stack. The successful request only gets removed when another successful request is added. This allows us to fallback to the successful request in case there is an unsuccessful request. I hope this makes sense.

This allows us to fallback gracefully in case the atomic (test) commit fails. The only thing that will be updated is the fb id (this allows us to avoid tearing and keep up with the swapchain).

I've also implemented a custom class that wraps the `drmModeAtomicReq` object. This is so we can track the atomic request with all the objects, properties, and values being submitted. We want to do this so we can either log the info (if `LOGWINDOWING` component logging is enabled) or in case the request fails we can log the difference between the two requests to see what is different. The only real way to check what cause the failure is to look at the kernel logs with atomic drm logging enabled.

The logging looks like this:

----

diff
```
2020-10-19 09:31:50.340 T:2320878   DEBUG <general>: CDRMAtomicRequest::LogAtomicDiff - DRM Atomic Request Diff:
2020-10-19 09:31:50.340 T:2320878   ERROR <general>:
                                                   Object: plane        ID: 45
                                                     Property: CRTC_W   ID: 15  Value: 18446744073709551615
                                                     Property: CRTC_H   ID: 16  Value: 18446744073709551615
                                                     Property: FB_ID    ID: 17  Value: 100
```
For this failed request I forced a value of `-1` to the `CRTC_W` and `CRTC_H` This cause a failure because it expects a uint64_t value. The FB_ID is shown here also because that will be different than the last request as the swapchain rotates.

I used this commit to test this: https://github.com/lrusak/xbmc/commit/b52a8413960a748dc62755a01ad17dff5ca708a3

----

full request
```
2020-10-19 09:11:03.447 T:2314219   DEBUG <general>: CDRMAtomicRequest::LogAtomicRequest - DRM Atomic Request:
2020-10-19 09:11:03.447 T:2314219   DEBUG <general>:
                                                   Object: plane        ID: 45
                                                     Property: SRC_X    ID: 9   Value: 0
                                                     Property: SRC_Y    ID: 10  Value: 0
                                                     Property: SRC_W    ID: 11  Value: 125829120
                                                     Property: SRC_H    ID: 12  Value: 70778880
                                                     Property: CRTC_X   ID: 13  Value: 0
                                                     Property: CRTC_Y   ID: 14  Value: 0
                                                     Property: CRTC_W   ID: 15  Value: 1920
                                                     Property: CRTC_H   ID: 16  Value: 1080
                                                     Property: FB_ID    ID: 17  Value: 97
                                                     Property: CRTC_ID  ID: 20  Value: 47
```


I don't love the indirection of the `UpdateRequestQueue` method but I feel it's still better to have as a helper function to make it more clear what is happening if the request is successful or unsuccessful.