### PR TITLE
[Android] Fix MediaCodec OES/EGL rendering

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -311,7 +311,6 @@ CDVDVideoCodecAndroidMediaCodec::CDVDVideoCodecAndroidMediaCodec(CProcessInfo &p
 , m_formatname("mediacodec")
 , m_opened(false)
 , m_jnivideoview(nullptr)
-, m_jnisurface(nullptr)
 , m_textureId(0)
 , m_OutputDuration(0)
 , m_fpsDuration(0)
@@ -796,10 +795,6 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
   }
   ReleaseSurfaceTexture();
 
-  if (m_jnisurface)
-    m_jnisurface->release();
-  m_jnisurface = nullptr;
-
   m_InstanceGuard.exchange(false);
   if (m_render_surface)
   {
@@ -1223,10 +1218,9 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
   // configure and start the codec.
   // use the MediaFormat that we have setup.
   // use a null MediaCrypto, our content is not encrypted.
-
-  int flags = 0;
   m_codec->configure(mediaformat, m_jnivideosurface,
-                     m_crypto ? *m_crypto : CJNIMediaCrypto(jni::jhobject(NULL)), flags);
+                     m_crypto ? *m_crypto : CJNIMediaCrypto(jni::jhobject(NULL)), 0);
+
   if (xbmc_jnienv()->ExceptionCheck())
   {
     xbmc_jnienv()->ExceptionClear();
@@ -1446,7 +1440,7 @@ void CDVDVideoCodecAndroidMediaCodec::InitSurfaceTexture(void)
     m_surfaceTexture = std::shared_ptr<CJNISurfaceTexture>(new CJNISurfaceTexture(m_textureId));
     // hook the surfaceTexture OnFrameAvailable callback
     m_frameAvailable = std::shared_ptr<CDVDMediaCodecOnFrameAvailable>(new CDVDMediaCodecOnFrameAvailable(m_surfaceTexture));
-    m_jnisurface = new CJNISurface(*m_surfaceTexture);
+    m_jnivideosurface = CJNISurface(*m_surfaceTexture);
   }
   else
   {
@@ -1468,7 +1462,7 @@ void CDVDVideoCodecAndroidMediaCodec::ReleaseSurfaceTexture(void)
 
   // it is safe to delete here even though these items
   // were created in the main thread instance
-  SAFE_DELETE(m_jnisurface);
+  m_jnivideosurface = CJNISurface(jni::jhobject(NULL));
   m_frameAvailable.reset();
   m_surfaceTexture.reset();
 
@@ -1509,8 +1503,8 @@ void CDVDVideoCodecAndroidMediaCodec::surfaceDestroyed(CJNISurfaceHolder holder)
   if (m_state != MEDIACODEC_STATE_STOPPED && m_state != MEDIACODEC_STATE_UNINITIALIZED)
   {
     m_state = MEDIACODEC_STATE_STOPPED;
-    if (m_jnisurface)
-      m_jnisurface->release();
+    if (m_jnivideosurface)
+      m_jnivideosurface.release();
     m_codec->stop();
     xbmc_jnienv()->ExceptionClear();
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -147,7 +147,6 @@ protected:
   int             m_noPictureLoop;
 
   std::shared_ptr<CJNIXBMCVideoView> m_jnivideoview;
-  CJNISurface* m_jnisurface;
   CJNISurface m_jnivideosurface;
   unsigned int m_textureId;
   std::shared_ptr<CJNIMediaCodec> m_codec;


### PR DESCRIPTION
This is a backport of: #18481

Without this fix, Mediacodec with disabled Surface is not usable and results in a blackscreen. This affects all Leia Android devices. It was introduced by accident when doing the NDK to JNI transition late in 18.7 cycle.