### PR TITLE
[addons] fix: set addon origin correctly

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -702,12 +702,17 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
     if (!m_pDS2)
       return false;
 
-    m_pDS2->query(PrepareSQL("SELECT * FROM addons WHERE id=%i", id));
+    m_pDS2->query(PrepareSQL("SELECT addons.*, repo.addonID as origin FROM addons "
+                             "JOIN addonlinkrepo ON addonlinkrepo.idAddon=addons.id "
+                             "JOIN repo ON repo.id=addonlinkrepo.idRepo "
+                             "WHERE addons.id=%i",
+                             id));
     if (m_pDS2->eof())
       return false;
 
     CAddonInfoBuilder::CFromDB builder;
     builder.SetId(m_pDS2->fv("addonID").get_asString());
+    builder.SetOrigin(m_pDS2->fv("origin").get_asString());
     builder.SetVersion(AddonVersion(m_pDS2->fv("version").get_asString()));
     builder.SetName(m_pDS2->fv("name").get_asString());
     builder.SetSummary(m_pDS2->fv("summary").get_asString());


### PR DESCRIPTION
## Description
internal addon database function `GetAddon(int id, ADDON::AddonPtr& addon);` which is used to get an addon from the database by its dataset-id missed to set the origin properly.

this leads to an unset origin et al. for addon search results, showing wrong origin icons, and therefor finally preventing installation...

**addon search results: (searched for expression 'slide')**
before:
![before](https://user-images.githubusercontent.com/58829855/96632196-a77b8e00-1317-11eb-959f-eed8674a6608.png)

after:
![after](https://user-images.githubusercontent.com/58829855/96632301-cd089780-1317-11eb-81a2-8b3dd6978971.png)

## How Has This Been Tested?
searched for 'slide', got the correct result (from official repo), installation of `artist.slideshow` successful.. on debian buster local


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
