### PR TITLE
DVDDemuxFFmpeg: compare audio channels in IsProgramChange()

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2009,6 +2009,10 @@ bool CDVDDemuxFFmpeg::IsProgramChange()
       return true;
     if (m_pFormatContext->streams[idx]->codecpar->codec_id != stream->codec)
       return true;
+    if (m_pFormatContext->streams[idx]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+        m_pFormatContext->streams[idx]->codecpar->channels !=
+            static_cast<CDemuxStreamAudio*>(stream)->iChannels)
+      return true;
     if (m_pFormatContext->streams[idx]->codecpar->extradata_size != static_cast<int>(stream->ExtraSize))
       return true;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
Detect and use all audio streams when playing video. Check number of audio channels when looking for stream changes. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
In this [debug log](http://ix.io/2BiU) av_find_stream_info first detects:
```
2020-10-17 23:39:15.005 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:0[0x229]: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(tv, bt709, progressive), 1280x720 [SAR 1:1 DAR 16:9], 50 fps, 50 tbr, 90k tbn, 100 tbc
2020-10-17 23:39:15.005 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:1[0x22a](deu): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, stereo, fltp, 256 kb/s
2020-10-17 23:39:15.005 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:2[0x22b](mis): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, stereo, fltp, 192 kb/s
2020-10-17 23:39:15.005 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:3[0x22d](mul): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, stereo, fltp, 192 kb/s
2020-10-17 23:39:15.005 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:4[0x22c](deu): Audio: ac3 ([6][0][0][0] / 0x0006), 48000 Hz, stereo, fltp, 448 kb/s
2020-10-17 23:39:15.005 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:5[0x669](deu): Subtitle: dvb_subtitle ([6][0][0][0] / 0x0006) (hearing impaired)
```

The following stream change events stop with:
```
2020-10-17 23:39:15.017 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:0[0x229]: Video: h264 ([27][0][0][0] / 0x001B), none, 1280x720, 90k tbn
2020-10-17 23:39:15.017 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:1[0x22a](deu): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, 2 channels, 256 kb/s
2020-10-17 23:39:15.017 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:2[0x22b](mis): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, 2 channels, 192 kb/s
2020-10-17 23:39:15.017 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:3[0x22d](mul): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, 2 channels, 192 kb/s
2020-10-17 23:39:15.017 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:4[0x22c](deu): Audio: ac3 ([6][0][0][0] / 0x0006), 0 channels
2020-10-17 23:39:15.017 T:27437    INFO <general>: ffmpeg[0x6935150X]:     Stream #0:5[0x669](deu): Subtitle: dvb_subtitle ([6][0][0][0] / 0x0006) (hearing impaired)
```

and the 0 channels ac3 stream is ignored.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
With the change the ac3 stream is detected and played ([debug log](http://ix.io/2Bj8)):
```
2020-10-17 23:40:33.978 T:27663    INFO <general>: ffmpeg[0x60e22d0X]:     Stream #0:0[0x229]: Video: h264 ([27][0][0][0] / 0x001B), none, 1280x720, 90k tbn
2020-10-17 23:40:33.978 T:27663    INFO <general>: ffmpeg[0x60e22d0X]:     Stream #0:1[0x22a](deu): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, 2 channels, 256 kb/s
2020-10-17 23:40:33.978 T:27663    INFO <general>: ffmpeg[0x60e22d0X]:     Stream #0:2[0x22b](mis): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, 2 channels, 192 kb/s
2020-10-17 23:40:33.978 T:27663    INFO <general>: ffmpeg[0x60e22d0X]:     Stream #0:3[0x22d](mul): Audio: mp2 ([3][0][0][0] / 0x0003), 48000 Hz, 2 channels, 192 kb/s
2020-10-17 23:40:33.978 T:27663    INFO <general>: ffmpeg[0x60e22d0X]:     Stream #0:4[0x22c](deu): Audio: ac3 ([6][0][0][0] / 0x0006), 48000 Hz, stereo, 448 kb/s
2020-10-17 23:40:33.978 T:27663    INFO <general>: ffmpeg[0x60e22d0X]:     Stream #0:5[0x669](deu): Subtitle: dvb_subtitle ([6][0][0][0] / 0x0006) (hearing impaired)
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
