### PR TITLE
[Windows] Enables HLG HDR passthrough using HLG to PQ shaders

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -372,19 +372,18 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceSource(CRenderBuffer* view,
   // UHDTV
   if (view->primaries == AVCOL_PRI_BT2020)
   {
-    if (view->color_transfer == AVCOL_TRC_SMPTEST2084 && supportHDR) // HDR10
-      // Could also be:
-      // DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020
+    // Windows 10 doesn't support HLG passthrough, always is used PQ for HDR passthrough
+    if ((view->color_transfer == AVCOL_TRC_SMPTEST2084 ||
+         view->color_transfer == AVCOL_TRC_ARIB_STD_B67) && supportHDR) // is HDR display ON
       return DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020;
 
-    if (view->color_transfer == AVCOL_TRC_ARIB_STD_B67 && supportHLG) // HLG
+    // HLG transfer can be used for HLG source in SDR display if is supported
+    if (view->color_transfer == AVCOL_TRC_ARIB_STD_B67 && supportHLG) // driver supports HLG
       return DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020;
 
     if (view->full_range)
       return DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P2020;
 
-    // Could also be:
-    // DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_TOPLEFT_P2020
     return DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020;
   }
   // SDTV
@@ -418,17 +417,12 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(CRenderBuffer* view)
   if (!DX::Windowing()->IsHDROutput())
     return color;
 
-  // HDR10
-  if (view->color_transfer == AVCOL_TRC_SMPTE2084 && view->primaries == AVCOL_PRI_BT2020)
+  // HDR10 or HLG
+  if (view->primaries == AVCOL_PRI_BT2020 && (view->color_transfer == AVCOL_TRC_SMPTE2084 ||
+                                              view->color_transfer == AVCOL_TRC_ARIB_STD_B67))
   {
     color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
                                                : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
-  }
-  // HLG or Rec.2020
-  else if (view->primaries == AVCOL_PRI_BT2020)
-  {
-    color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020
-                                               : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020;
   }
 
   return color;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -221,13 +221,18 @@ void COutputShader::GetDefines(DefinesMap& map) const
   {
     map["KODI_TONE_MAPPING"] = "";
   }
+  if (m_useHLGtoPQ)
+  {
+    map["KODI_HLG_TO_PQ"] = "";
+  }
 }
 
-bool COutputShader::Create(bool useLUT, bool useDithering, int ditherDepth, bool toneMapping)
+bool COutputShader::Create(bool useLUT, bool useDithering, int ditherDepth, bool toneMapping, bool HLGtoPQ)
 {
   m_useLut = useLUT;
   m_ditherDepth = ditherDepth;
   m_toneMapping = toneMapping && !DX::Windowing()->IsHDROutput();
+  m_useHLGtoPQ = HLGtoPQ;
 
   CWinShader::CreateVertexBuffer(4, sizeof(Vertex));
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -60,7 +60,7 @@ public:
 
   void ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWidth, unsigned sourceHeight);
   void GetDefines(DefinesMap &map) const;
-  bool Create(bool useLUT, bool useDithering, int ditherDepth, bool toneMapping);
+  bool Create(bool useLUT, bool useDithering, int ditherDepth, bool toneMapping, bool HLGtoPQ);
   void Render(CD3DTexture& sourceTexture, CRect sourceRect, const CPoint points[4]
             , CD3DTexture& target, unsigned range = 0, float contrast = 0.5f, float brightness = 0.5f);
   void Render(CD3DTexture& sourceTexture, CRect sourceRect, CRect destRect
@@ -87,6 +87,8 @@ private:
   bool m_useLut = false;
   bool m_useDithering = false;
   bool m_toneMapping = false;
+  bool m_useHLGtoPQ = false;
+
   bool m_hasDisplayMetadata = false;
   bool m_hasLightMetadata = false;
   unsigned m_sourceWidth = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -48,8 +48,7 @@ enum class HDR_TYPE : uint32_t
 {
   HDR_NONE_SDR = 0x00,
   HDR_HDR10 = 0x01,
-  HDR_HLG = 0x02,
-  HDR_REC2020 = 0x03
+  HDR_HLG = 0x02
 };
 
 class CRenderBuffer
@@ -158,6 +157,7 @@ protected:
   bool m_useDithering = false;
   bool m_cmsOn = false;
   bool m_clutLoaded = false;
+  bool m_useHLGtoPQ = false;
 
   int m_iBufferIndex = 0;
   int m_iNumBuffers = 0;
@@ -183,6 +183,5 @@ protected:
 
   DXGI_HDR_METADATA_HDR10 m_lastHdr10 = {};
   HDR_TYPE m_HdrType = HDR_TYPE::HDR_NONE_SDR;
-  int m_iCntMetaData = 0;
   bool m_AutoSwitchHDR = false;
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1183,12 +1183,6 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
         case DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020:
           cs = DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020;
           break;
-        case DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020:
-          cs = DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020;
-          break;
-        case DXGI_COLOR_SPACE_YCBCR_FULL_GHLG_TOPLEFT_P2020:
-          cs = DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020;
-          break;
       }
     }
     if (SUCCEEDED(swapChain3->SetColorSpace1(cs)))


### PR DESCRIPTION
## Description
- Enables HLG HDR passthrough using HLG to PQ shaders.
- Simplified code for HDR toggle logic.
- Cleanup unused code.

## Motivation and Context
Following PR https://github.com/xbmc/xbmc/pull/18581 HLG image colors and black level are correct on both HDR and SDR displays but due Windows only supports HDR10 as HDR output format, HLG in HDR output mode loses the HDR part and is displayed as SDR (although Windows HDR is ON).

In other words, Windows only admits `DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020` for output HDR.
`DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020` can be used (if driver supports it) only as **input** color space.

The solution is convert HLG transfer to PQ transfer and outputs as HDR10 with `DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020`. To carry out this conversion, shaders are used taking as reference 1000 nits as maximum luminosity both in the conversion formula and in the generated metadata.

Although other values could be used, 1000 nits it's a safe and sanity value because all current HDR TV should support it. 
e.g. using 4000 nits in the formula if the TV only supports 2000 nits the signal would be too bright for that TV but since the metadata exists the TV knows the signal is 4000 nits and scales internally (remaps to 2000 nits). Even so, in the end the result must be the same because precisely the metadata serves to make the result consistent regardless of TV and the range of the input signal.

## How Has This Been Tested?
Intel NUC8i3BEK and TV Sony KD-55AG9 using this HLG test stream: 
http://www.lelabodejay.com/files/videos/upload/LDJ_082020_HLG_3840x2160_50MBPS.mp4

Compared test pattern saturation, brightness, black level, etc., playing on both TV internal player and through Kodi.

Also other users has confirmed that works with NVIDIA:
https://forum.kodi.tv/showthread.php?tid=357799&pid=2983342#pid2983342
and Ryzen: 
https://forum.kodi.tv/showthread.php?tid=357799&pid=2983359#pid2983359

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
