### PR TITLE
VAAPI: fix logging by removing trailing characters

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -62,12 +62,14 @@ const std::string SETTING_VIDEOPLAYER_PREFERVAAPIRENDER = "videoplayer.prefervaa
 
 void VAAPI::VaErrorCallback(void *user_context, const char *message)
 {
-  CLog::Log(LOGERROR, "libva error: {}", message);
+  std::string str{message};
+  CLog::Log(LOGERROR, "libva error: {}", StringUtils::TrimRight(str));
 }
 
 void VAAPI::VaInfoCallback(void *user_context, const char *message)
 {
-  CLog::Log(LOGDEBUG, "libva info: {}", message);
+  std::string str{message};
+  CLog::Log(LOGDEBUG, "libva info: {}", StringUtils::TrimRight(str));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes an issue where vaapi messages seem to print with a newline character at the end.

before:
```
2020-10-19 09:53:25.708 T:2326007   DEBUG <general>: libva info: VA-API version 1.7.0

2020-10-19 09:53:25.708 T:2326007   DEBUG <general>: libva info: Trying to open /usr/lib64/dri/radeonsi_drv_video.so

2020-10-19 09:53:25.708 T:2326007   DEBUG <general>: libva info: Found init function __vaDriverInit_1_7

2020-10-19 09:53:25.716 T:2326007   DEBUG <general>: libva info: va_openDriver() returns 0

2020-10-19 09:53:25.716 T:2326007   DEBUG <general>: VAAPI - initialize version 1.7
```

after:
```
2020-10-21 12:02:24.035 T:2521357   DEBUG <general>: libva info: VA-API version 1.7.0
2020-10-21 12:02:24.035 T:2521357   DEBUG <general>: libva info: Trying to open /usr/lib64/dri/radeonsi_drv_video.so
2020-10-21 12:02:24.035 T:2521357   DEBUG <general>: libva info: Found init function __vaDriverInit_1_7
2020-10-21 12:02:24.040 T:2521357   DEBUG <general>: libva info: va_openDriver() returns 0
2020-10-21 12:02:24.040 T:2521357   DEBUG <general>: VAAPI - initialize version 1.7
```