### PR TITLE
[tvos] jenkins defaultenv bump to xcode 11.3.1 SDK 13.2

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -25,10 +25,10 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   tvos)
-    DEFAULT_SDK_VERSION=12.2
+    DEFAULT_SDK_VERSION=13.2
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
-    DEFAULT_XCODE_APP="Xcode10.2.app"
+    DEFAULT_XCODE_APP="Xcode11.3.1.app"
     ;;
 
   osx64)


### PR DESCRIPTION
## Description
Looks to bring jenkins tvos build to a newer base SDK/xcode version.
Jenkins will run with Mojave with Xcode 11.3.1 against tvos SDK 13.2

## Motivation and Context
Before we set in for the long haul of stable 19, get jenkins building against newer sdk

## How Has This Been Tested?
Jenkins

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
