### PR TITLE
[cmake] bail out if waylandpp isn't found via pkg-config

### DIFF
--- a/cmake/modules/FindWaylandpp.cmake
+++ b/cmake/modules/FindWaylandpp.cmake
@@ -11,12 +11,19 @@
 # WAYLANDPP_SCANNER      - path to wayland-scanner++
 
 pkg_check_modules(PC_WAYLANDPP wayland-client++ wayland-egl++ wayland-cursor++ QUIET)
-pkg_check_modules(PC_WAYLANDPP_SCANNER wayland-scanner++ QUIET)
+
 if(PC_WAYLANDPP_FOUND)
   pkg_get_variable(PC_WAYLANDPP_PKGDATADIR wayland-client++ pkgdatadir)
+else()
+  message(SEND_ERROR "wayland-client++ not found via pkg-config")
 endif()
+
+pkg_check_modules(PC_WAYLANDPP_SCANNER wayland-scanner++ QUIET)
+
 if(PC_WAYLANDPP_SCANNER_FOUND)
   pkg_get_variable(PC_WAYLANDPP_SCANNER wayland-scanner++ wayland_scannerpp)
+else()
+  message(SEND_ERROR "wayland-scanner++ not found via pkg-config")
 endif()
 
 find_path(WAYLANDPP_INCLUDE_DIR wayland-client.hpp PATHS ${PC_WAYLANDPP_INCLUDEDIR})

--- a/tools/depends/target/waylandpp/Makefile
+++ b/tools/depends/target/waylandpp/Makefile
@@ -49,6 +49,9 @@ $(LIBDYLIB): $(PLATFORM)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(BUILDDIR) install
+
+	# We want to use the native wayland-scanner++
+	ln -sf $(NATIVEPREFIX)/lib/pkgconfig/wayland-scanner++.pc $(PREFIX)/lib/pkgconfig/wayland-scanner++.pc
 	touch $@
 
 clean:


### PR DESCRIPTION
This has been a consistent thorn in my side for a while. I've always had to compile kodi-wayland with `PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:$PKG_CONFIG_PATH cmake ..`.

~~This PR adds `/usr/local` (the normal unix custom installation path) to the `CMAKE_PREFIX_PATH` variable. This is used to set the default search paths for various cmake things include pkg-config searches. see https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html~~

I've also added to the FindWaylandpp.cmake module to bail out if the pkg-config variables cannot be found.

I decided to do this after trying to setup the FreeBSD build box to build for wayland also. This resulted in the following error after waylandpp was installed to `/usr/local`

```
17:53:36 gmake[2]: *** No rule to make target '/protocols/presentation-time.xml', needed by 'wayland-extra-protocols.hpp'.  Stop.
17:53:36 gmake[1]: *** [CMakeFiles/Makefile2:487: CMakeFiles/generate-wayland-extra-protocols.dir/all] Error 2
```
This happened because even though cmake could find waylandpp, the pkg-config module couldn't and thus `PC_WAYLANDPP_PKGDATADIR` was empty which resulted in the variable `WAYLANDPP_PROTOCOLS_DIR` being set to `/protocols` which is obviously incorrect.

After this change the variable is set to the correct path
```
WAYLANDPP_PROTOCOLS_DIR:INTERNAL=/usr/local/share/waylandpp/protocols
```
