### PR TITLE
[addons][python] Add plugin callback for actions watched/unwatched/reset resume point

### DIFF
--- a/xbmc/interfaces/json-rpc/schema/notifications.json
+++ b/xbmc/interfaces/json-rpc/schema/notifications.json
@@ -253,7 +253,9 @@
           "type": { "type": "string", "id": "Notifications.Library.Video.Type", "enum": [ "movie", "tvshow", "episode", "musicvideo" ], "required": true },
           "playcount": { "type": "integer", "minimum": 0, "default": -1 },
           "transaction": { "$ref": "Optional.Boolean", "description": "True if the update is being performed within a transaction." },
-          "added": { "$ref": "Optional.Boolean", "description": "True if the update is for a newly added item." }
+          "added": { "$ref": "Optional.Boolean", "description": "True if the update is for a newly added item." },
+          "action": { "$ref": "Optional.String", "description": "Describes the type of action performed." },
+          "url": { "$ref": "Optional.String", "description": "Provide the url of the updated item." }
         }
       }
     ],
@@ -283,7 +285,9 @@
         "properties": {
           "id": { "$ref": "Library.Id", "required": true },
           "type": { "$ref": "Notifications.Library.Video.Type", "required": true },
-          "transaction": { "$ref": "Optional.Boolean", "description": "True if the removal is being performed within a transaction." }
+          "transaction": { "$ref": "Optional.Boolean", "description": "True if the removal is being performed within a transaction." },
+          "action": { "$ref": "Optional.String", "description": "Describes the type of action performed." },
+          "url": { "$ref": "Optional.String", "description": "Provide the url of the removed item." }
         }
       }
     ],

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -338,7 +338,16 @@ namespace XBMCAddon
           else if (key == "watched") // backward compat - do we need it?
             videotag.SetPlayCount(strtol(value.c_str(), nullptr, 10));
           else if (key == "playcount")
+          {
+            // Note to "preservewatchedpoint"
+            // When a plugin wants to manage the watched status autonomously set playcount and
+            // resumetime to ListItem, but Kodi assumes these values in a generic way,
+            // we need to know when allow to modify the database or not, so when a user
+            // try change these values manually (e.g. by context menu)
+            // not invalidate existing database values currently not used
+            item->SetProperty("preservewatchedpoint", "true");
             videotag.SetPlayCount(strtol(value.c_str(), nullptr, 10));
+          }
           else if (key == "overlay")
           {
             long overlay = strtol(value.c_str(), nullptr, 10);

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -880,6 +880,7 @@ namespace XBMCAddon
       /// | StartPercent  | float (15.0) - Set the percentage at which to start playback of the item
       /// | StationName   | string ("My Station Name") - Used to enforce/override MusicPlayer.StationName infolabel from addons (e.g. in radio addons)
       /// | TotalTime     | float (7848.0) - Set the total time of the item in seconds
+      /// | preservewatchedpoint | string - "true", "false" - When set to False allow to overwrite the watched status in the database after user interaction, **mandatory use it after set ListItem.setInfo() with "playcount" value**
       ///
       ///-----------------------------------------------------------------------
       ///

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1013,6 +1013,6 @@ private:
   std::vector<int> CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
                                   std::map<int, bool> &pathsDeleteDecisions, std::string &deletedFileIDs, bool silent);
 
-  static void AnnounceRemove(std::string content, int id, bool scanning = false);
-  static void AnnounceUpdate(std::string content, int id);
+  static void AnnounceRemove(std::string content, int id, bool scanning = false, std::string action = "");
+  static void AnnounceUpdate(std::string content, int id, std::string action = "", CVariant data = CVariant::VariantTypeObject);
 };

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -94,8 +94,10 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
     if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->GetPath().empty())
       path = item->GetVideoInfoTag()->GetPath();
 
-    // With both mark as watched and unwatched we want the resume bookmarks to be reset
-    db.ClearBookMarksOfFile(path, CBookmark::RESUME);
+    // Do not modify the database when a plugin manages the values autonomously
+    if (!item->GetProperty("preservewatchedpoint").asBoolean())
+        // With both mark as watched and unwatched we want the resume bookmarks to be reset
+        db.ClearBookMarksOfFile(path, CBookmark::RESUME);
 
     if (m_mark)
       db.IncrementPlayCount(*item);


### PR DESCRIPTION
## Description and Motivation
I prefer to extend the explanation to try to clarify the situation as best i can with my non commestibile english,

This is a first attempt to resolve Issue: https://github.com/xbmc/xbmc/issues/17372
will make VOD add-ons happy and so keep also consistent Kodi UI with context menus.

Usually a VOD add-on, can autonomously manage the watched status of listItems
but there is a big gap when a user want to change manually the watched status
(e.g. by context menu or shortcut keys) cause implementation issues to VOD add-ons.
what are the problems?

- A VOD add-on usually need to communicate changes in real time to a VOD service, but an action callback is missing
- If an addon manages the watched status autonomously (PlayCount/ResumeTime set to all ListItems) have to apply the changes also to his data, currently not possible
- Currently Kodi standard context menus/shortcuts "Toggle watched" or "Reset resume point" are very poorly manageable with VOD addons
- Currently there is a case where the kodi database is modified when it should not be modified

This problems involves several workarounds for VOD addons,
e.g. by adding custom context menus to to the same thing of kodi context menus,
so doubling the amount of menus unnecessarily and causing confusion to the user and extra code.

I solved the problems by adding two properties that can be used to set a partial path used for the plugin callback on each listItem that need this.

I choose to use a partial path (to the properties values), to avoid possible security problems,
then the callback path is built by join the base path of the listitem url (used for playback)
and the partial path set in the listItem property.

### How works

When a VOD addon need a callback to a ListItem,
simply add these properties e.g.:

`ListItem.setProperty("CallBackPathMarkWatched", "action/cb_mark_watched")`
`ListItem.setProperty("CallBackPathResetResume", "action/cb_reset_resume")`

When a user try to change watched/unwatched status, Kodi will call the addon path:
plugin://plugin.video.netflix/action/cb_mark_watched
and on `sys.argv` will be reported two arguments:
- isMarkWatched=True or False
- urlPath=plugin://plugin.video.netflix/play/movie/5670368 (the play url path encoded)

When a user try to Reset resume position, Kodi will call the addon path:
plugin://plugin.video.netflix/action/cb_reset_resume
and on `sys.argv` will be reported the argument:
- urlPath=plugin://plugin.video.netflix/play/movie/5670368 (the play url path encoded)

### There are two main use cases:

#### >>>> An add-on autonomously manage the watched status:

Usually in this case the addon set these properties to each ListItems:
`ListItem.setInfo('video': {'playcount': 0})`
`ListItem.setProperty('ResumeTime', 1500)`
`ListItem.setProperty('TotalTime', 3000)`
in order to exclude the Kodi watched status method.

[**What happen before**]

If a user try to manually change the watched status, will not be able to do this,
the context menus/shortcutkeys will have no apparent effect, and an addon can not use these.

Why "will have no apparent effect" ?
because kodi overwrite the watched status in his database values
with an inconsistent values because is based on a ListItem with forced properties values,
and in this case this saved data to kodi database will never be used.

[**What happen now**]

An user can manually change the watched status by using context menu/shortcuts keys etc.. as usual,
then the addon can receive a python callback and so update his database/VOD service
and so return the ListItems with updated watched status.

This action will not modify the kodi database,
giving the opportunity to the addons to keep two contexts separate,
then allow users to choose which context to use (if supported by the addon, i do this with netflix),
in other words an addon can show the same video ListItems elements in two ways:
- Show the elements by using watched status provided by kodi database
- Show the elements by using watched status provided by VOD service

And if someone prefers to save the information also in the kodi database? (old behaviour)
If an addon want to keep old behaviour, have to add `preservewatchedpoint` property to `false` after _setInfo_, example:
```python
ListItem.setInfo(....)
ListItem.setProperty('preservewatchedpoint', 'false')
```

#### >>>> An add-on leave the watched status management to kodi (normal behaviour):

[**What happen before**]

If a user try to manually change the watched status (e.g. context menu),
an addon has no way of knowing if it happened.

[**What happen now**]

If a user try to manually change the watched status (e.g. context menu),
then the addon can receive a python callback and so update his VOD service.

## How Has This Been Tested?

I have tested on Window 10 with netflix add-on:
in my case NF addon use the "two contexts" explained before,
so an user can enable/disable VOD watched status sync mode at any time,
then i need the callback to save the watched status in addon database, only when the VOD w.s. sync is enabled.

**I'm waiting for a feedback from other VOD add-ons,
I would like to wait some days to have some opinions**

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
