### PR TITLE
[addons] CAddonDll ctor has to set m_binaryAddonBase. Fixes PVR addon update

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "addons/AddonStatusHandler.h"
 #include "addons/binary-addons/BinaryAddonBase.h"
+#include "addons/binary-addons/BinaryAddonManager.h"
 #include "addons/settings/AddonSettings.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
@@ -31,7 +32,9 @@ CAddonDll::CAddonDll(const AddonInfoPtr& addonInfo, BinaryAddonBasePtr addonBase
 {
 }
 
-CAddonDll::CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType) : CAddon(addonInfo, addonType)
+CAddonDll::CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType)
+  : CAddon(addonInfo, addonType),
+    m_binaryAddonBase(CServiceBroker::GetBinaryAddonManager().GetRunningAddonBase(addonInfo->ID()))
 {
 }
 

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -46,7 +46,7 @@ class CAddonDll : public CAddon
 {
 public:
   CAddonDll(const AddonInfoPtr& addonInfo, BinaryAddonBasePtr addonBase);
-  explicit CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType);
+  CAddonDll(const AddonInfoPtr& addonInfo, TYPE addonType);
   ~CAddonDll() override;
 
   virtual ADDON_STATUS GetStatus();

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -62,13 +62,24 @@ void CBinaryAddonManager::ReleaseAddonBase(const BinaryAddonBasePtr& addonBase,
   m_runningAddons.erase(addon);
 }
 
+BinaryAddonBasePtr CBinaryAddonManager::GetRunningAddonBase(const std::string& addonId) const
+{
+  CSingleLock lock(m_critSection);
+
+  const auto& addonInstances = m_runningAddons.find(addonId);
+  if (addonInstances != m_runningAddons.end())
+    return addonInstances->second;
+
+  return nullptr;
+}
+
 AddonPtr CBinaryAddonManager::GetRunningAddon(const std::string& addonId) const
 {
   CSingleLock lock(m_critSection);
 
-  auto addon = m_runningAddons.find(addonId);
-  if (addon != m_runningAddons.end())
-    return addon->second->GetActiveAddon();
+  const BinaryAddonBasePtr base = GetRunningAddonBase(addonId);
+  if (base)
+    return base->GetActiveAddon();
 
   return nullptr;
 }

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -62,6 +62,15 @@ namespace ADDON
     void ReleaseAddonBase(const BinaryAddonBasePtr& addonBase, IAddonInstanceHandler* handler);
 
     /*!
+     * @brief Get running addon base class for a given addon id.
+     *
+     * @param[in] addonId the addon id
+     * @return running addon base class if found, nullptr otherwise.
+     *
+     */
+    BinaryAddonBasePtr GetRunningAddonBase(const std::string& addonId) const;
+
+    /*!
      * @brief Used from other addon manager to get active addon over a from him
      * created CAddonDll.
      *


### PR DESCRIPTION
Fixes PVR update addon not working. Installed without errors, but old version shown in GUI afterwards and still marked as to update until next Kodi restart.

@AlwinEsch please review