### PR TITLE
[guiinfo][PVR][music][video] Implement proper fallback logic for (MUSIC|VIDEO)PLAYER_TITLE

### DIFF
--- a/xbmc/guilib/guiinfo/GUIInfoProvider.h
+++ b/xbmc/guilib/guiinfo/GUIInfoProvider.h
@@ -26,6 +26,15 @@ public:
   CGUIInfoProvider() = default;
   ~CGUIInfoProvider() override = default;
 
+  bool GetFallbackLabel(std::string& value,
+                        const CFileItem* item,
+                        int contextWindow,
+                        const CGUIInfo& info,
+                        std::string* fallback) override
+  {
+    return false;
+  }
+
   void UpdateAVInfo(const AudioStreamInfo& audioInfo, const VideoStreamInfo& videoInfo, const SubtitleStreamInfo& subtitleInfo) override
   { m_audioInfo = audioInfo, m_videoInfo = videoInfo, m_subtitleInfo = subtitleInfo; }
 

--- a/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoProviders.cpp
@@ -85,6 +85,11 @@ bool CGUIInfoProviders::GetLabel(std::string& value, const CFileItem *item, int 
     if (provider->GetLabel(value, item, contextWindow, info, fallback))
       return true;
   }
+  for (const auto& provider : m_providers)
+  {
+    if (provider->GetFallbackLabel(value, item, contextWindow, info, fallback))
+      return true;
+  }
   return false;
 }
 

--- a/xbmc/guilib/guiinfo/IGUIInfoProvider.h
+++ b/xbmc/guilib/guiinfo/IGUIInfoProvider.h
@@ -49,6 +49,22 @@ public:
   virtual bool GetLabel(std::string &value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const = 0;
 
   /*!
+   * @brief Get a GUIInfoManager label fallback string. Will be called if none of the registered
+   * provider's GetLabel() implementation has returned success.
+   * @param value Will be filled with the requested value.
+   * @param item The item to get the value for. Can be nullptr.
+   * @param contextWindow The context window. Can be 0.
+   * @param info The GUI info (label id + additional data).
+   * @param fallback A fallback value. Can be nullptr.
+   * @return True if the value was filled successfully, false otherwise.
+   */
+  virtual bool GetFallbackLabel(std::string& value,
+                                const CFileItem* item,
+                                int contextWindow,
+                                const CGUIInfo& info,
+                                std::string* fallback) = 0;
+
+  /*!
    * @brief Get a GUIInfoManager integer value.
    * @param value Will be filled with the requested value.
    * @param item The item to get the value for. Can be nullptr.

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -41,11 +41,6 @@ bool CMusicGUIInfo::InitCurrentItem(CFileItem *item)
     item->LoadMusicTag();
 
     CMusicInfoTag* tag = item->GetMusicInfoTag(); // creates item if not yet set, so no nullptr checks needed
-    if (tag->GetTitle().empty())
-    {
-      // No title in tag, show filename only
-      tag->SetTitle(CUtil::GetTitleFromPath(item->GetPath()));
-    }
     tag->SetLoaded(true);
 
     // find a thumb for this file.
@@ -103,11 +98,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return !value.empty();
       case MUSICPLAYER_TITLE:
         value = tag->GetTitle();
-        if (value.empty())
-          value = item->GetLabel();
-        if (value.empty())
-          value = CUtil::GetTitleFromPath(item->GetPath());
-        return true;
+        return !value.empty();
       case LISTITEM_TITLE:
         value = tag->GetTitle();
         return true;
@@ -572,6 +563,32 @@ bool CMusicGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo &info) co
   }
 
   return GetLabel(value, playlistItem.get(), 0, CGUIInfo(info.m_info), nullptr);
+}
+
+bool CMusicGUIInfo::GetFallbackLabel(std::string& value,
+                                     const CFileItem* item,
+                                     int contextWindow,
+                                     const CGUIInfo& info,
+                                     std::string* fallback)
+{
+  const CMusicInfoTag* tag = item->GetMusicInfoTag();
+  if (tag)
+  {
+    switch (info.m_info)
+    {
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // MUSICPLAYER_*
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      case MUSICPLAYER_TITLE:
+        value = item->GetLabel();
+        if (value.empty())
+          value = CUtil::GetTitleFromPath(item->GetPath());
+        return true;
+      default:
+        break;
+    }
+  }
+  return false;
 }
 
 bool CMusicGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.h
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.h
@@ -28,6 +28,11 @@ public:
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
   bool InitCurrentItem(CFileItem *item) override;
   bool GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const override;
+  bool GetFallbackLabel(std::string& value,
+                        const CFileItem* item,
+                        int contextWindow,
+                        const CGUIInfo& info,
+                        std::string* fallback) override;
   bool GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -116,11 +116,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return !value.empty();
       case VIDEOPLAYER_TITLE:
         value = tag->m_strTitle;
-        if (value.empty())
-          value = item->GetLabel();
-        if (value.empty())
-          value = CUtil::GetTitleFromPath(item->GetPath());
-        return true;
+        return !value.empty();
       case LISTITEM_TITLE:
         value = tag->m_strTitle;
         return true;
@@ -635,6 +631,32 @@ bool CVideoGUIInfo::GetPlaylistInfo(std::string& value, const CGUIInfo& info) co
   }
 
   return GetLabel(value, playlistItem.get(), 0, CGUIInfo(info.m_info), nullptr);
+}
+
+bool CVideoGUIInfo::GetFallbackLabel(std::string& value,
+                                     const CFileItem* item,
+                                     int contextWindow,
+                                     const CGUIInfo& info,
+                                     std::string* fallback)
+{
+  const CVideoInfoTag* tag = item->GetVideoInfoTag();
+  if (tag)
+  {
+    switch (info.m_info)
+    {
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // VIDEOPLAYER_*
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      case VIDEOPLAYER_TITLE:
+        value = item->GetLabel();
+        if (value.empty())
+          value = CUtil::GetTitleFromPath(item->GetPath());
+        return true;
+      default:
+        break;
+    }
+  }
+  return false;
 }
 
 bool CVideoGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWindow, const CGUIInfo &info) const

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.h
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.h
@@ -30,6 +30,11 @@ public:
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
   bool InitCurrentItem(CFileItem *item) override;
   bool GetLabel(std::string& value, const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback) const override;
+  bool GetFallbackLabel(std::string& value,
+                        const CFileItem* item,
+                        int contextWindow,
+                        const CGUIInfo& info,
+                        std::string* fallback) override;
   bool GetInt(int& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
   bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const CGUIInfo &info) const override;
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -301,6 +301,20 @@ namespace
     return datetime.IsValid() ? datetime.GetAsLocalizedDateTime(false, false) : "";
   }
 
+  std::string GetEpgTagTitle(const std::shared_ptr<CPVREpgInfoTag>& epgTag)
+  {
+    if (epgTag)
+    {
+      if (CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
+        return g_localizeStrings.Get(19266); // Parental locked
+      else if (!epgTag->Title().empty() ||
+               CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                   CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
+        return epgTag->Title();
+    }
+    return g_localizeStrings.Get(19055); // no information available
+  }
+
 } // unnamed namespace
 
 bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInfo& info, std::string& strValue) const
@@ -490,20 +504,13 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
     {
       // special handling for channels without epg or with radio rds data
       case PLAYER_TITLE:
-      case VIDEOPLAYER_TITLE:
       case LISTITEM_TITLE:
       case VIDEOPLAYER_NEXT_TITLE:
       case LISTITEM_NEXT_TITLE:
       case LISTITEM_EPG_EVENT_TITLE:
         // Note: in difference to LISTITEM_TITLE, LISTITEM_EPG_EVENT_TITLE returns the title
         // associated with the epg event of a timer, if any, and not the title of the timer.
-        if (epgTag)
-        {
-          bool bLocked = CServiceBroker::GetPVRManager().IsParentalLocked(epgTag);
-          strValue = bLocked ? g_localizeStrings.Get(19266) /* Parental locked */ : epgTag->Title();
-        }
-        if (strValue.empty() && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-          strValue = g_localizeStrings.Get(19055); // no information available
+        strValue = GetEpgTagTitle(epgTag);
         return true;
     }
   }
@@ -1043,6 +1050,30 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, 
     case RDS_GET_RADIOTEXT_LINE:
       strValue = g_application.GetAppPlayer().GetRadioText(info.GetData1());
       return true;
+  }
+  return false;
+}
+
+bool CPVRGUIInfo::GetFallbackLabel(std::string& value,
+                                   const CFileItem* item,
+                                   int contextWindow,
+                                   const CGUIInfo& info,
+                                   std::string* fallback)
+{
+  if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
+  {
+    switch (info.m_info)
+    {
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // VIDEOPLAYER_*, MUSICPLAYER_*
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      case VIDEOPLAYER_TITLE:
+      case MUSICPLAYER_TITLE:
+        value = GetEpgTagTitle(CPVRItem(item).GetEpgInfoTag());
+        return !value.empty();
+      default:
+        break;
+    }
   }
   return false;
 }

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -55,6 +55,11 @@ namespace PVR
     // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
     bool InitCurrentItem(CFileItem* item) override;
     bool GetLabel(std::string& value, const CFileItem* item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo& info, std::string* fallback) const override;
+    bool GetFallbackLabel(std::string& value,
+                          const CFileItem* item,
+                          int contextWindow,
+                          const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                          std::string* fallback) override;
     bool GetInt(int& value, const CGUIListItem* item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo& info) const override;
     bool GetBool(bool& value, const CGUIListItem* item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo& info) const override;
 


### PR DESCRIPTION
MUSICPLAYER_TITLE and VIDEOPLAYER_TITLE have fallbacks to get the info label value from item's label or item's path. This prevents other guiinfo providers, which may have better alternatives from providing them.

Example: Items for PVR radio channels with RDS data have both a CPVChannel and a CMusicInfoTag. In case the music info tag title has no value (happens quite often when no music is playing, but news or traffic advisory is aired, the title from the EPG tag associated with the channel should be used.

![screenshot00001](https://user-images.githubusercontent.com/3226626/97083172-afd11300-160e-11eb-9050-f3ab4af30e7a.png)

This PR introduces a logic to pull fallback values from the guiinfo providers only, if no value was obtained in the first place.
 
Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish are you in the mood for another review?