### PR TITLE
[PVR] Fix CPVRChannel::Serialize not to include EPG data directly.

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -83,12 +83,7 @@ void CPVRChannel::Serialize(CVariant& value) const
 
   std::shared_ptr<CPVREpgInfoTag> epg = GetEPGNow();
   if (epg)
-  {
-    // add the properties of the current EPG item to the main object
-    epg->Serialize(value);
-    // and add an extra sub-object with only the current EPG details
     epg->Serialize(value["broadcastnow"]);
-  }
 
   epg = GetEPGNext();
   if (epg)


### PR DESCRIPTION
As @Tolriq pointed out here https://github.com/xbmc/xbmc/pull/18628#issuecomment-715923533 ff., firstly, this violates the JSON-RPC schema. 

Secondly, all EPG data are already available in the 'broadcastnow' field, which is well documented in the JSON-RPC schema.

So, this PR removes the bogues and redundant EPG data from channel serialization making our JSON-RPC API more schema conform.

@DaveTBlake is this something that needs a JOSON-RPC API version bump? I don't think so because it changes only undocumented behavior.