### PR TITLE
[addons] fix/improve updates for system addons from official repos 

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4497,6 +4497,14 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @skinning_v19 **[New Boolean Condition]** \link ListItem_Property_AddonIsUpdate `ListItem.Property(Addon.IsUpdate)`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.Property(Addon.ValidUpdateOrigin)`</b>,
+///                  \anchor ListItem_Property_ValidUpdateOrigin
+///                  _string_,
+///     @return The origin string of a valid update for the addon. Empty string if there is no valid update available.
+///     <p><hr>
+///     @skinning_v19 **[New Infolabel]** \link ListItem_Property_ValidUpdateOrigin `ListItem.Property(Addon.ValidUpdateOrigin)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.Property(Addon.ValidUpdateVersion)`</b>,
 ///                  \anchor ListItem_Property_ValidUpdateVersion
 ///                  _string_,

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -212,7 +212,7 @@ bool CAddonMgr::ReloadSettings(const std::string &id)
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdates() const
 {
   std::vector<std::shared_ptr<IAddon>> availableUpdates =
-      GetAvailableUpdatesOrOutdatedAddons(false);
+      GetAvailableUpdatesOrOutdatedAddons(AddonCheckType::AVAILABLE_UPDATES);
 
   std::lock_guard<std::mutex> lock(m_lastAvailableUpdatesCountMutex);
   m_lastAvailableUpdatesCountAsString = std::to_string(availableUpdates.size());
@@ -228,11 +228,11 @@ const std::string& CAddonMgr::GetLastAvailableUpdatesCountAsString() const
 
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetOutdatedAddons() const
 {
-  return GetAvailableUpdatesOrOutdatedAddons(true);
+  return GetAvailableUpdatesOrOutdatedAddons(AddonCheckType::OUTDATED_ADDONS);
 }
 
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAddons(
-    bool returnOutdatedAddons) const
+    AddonCheckType addonCheckType) const
 {
   CSingleLock lock(m_critSection);
   auto start = XbmcThreads::SystemClockMillis();
@@ -245,14 +245,7 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAdd
 
   GetAddonsForUpdate(installed);
 
-  if (returnOutdatedAddons)
-  {
-    addonRepos.BuildOutdatedList(installed, result);
-  }
-  else
-  {
-    addonRepos.BuildUpdateList(installed, result);
-  }
+  addonRepos.BuildUpdateOrOutdatedList(installed, result, addonCheckType);
 
   CLog::Log(LOGDEBUG, "CAddonMgr::GetAvailableUpdatesOrOutdatedAddons took %i ms",
             XbmcThreads::SystemClockMillis() - start);

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -891,7 +891,19 @@ bool CAddonMgr::IsAddonInstalled(const std::string& ID)
 bool CAddonMgr::IsAddonInstalled(const std::string& ID, const std::string& origin) const
 {
   AddonPtr tmp;
-  return (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp && tmp->Origin() == origin);
+
+  if (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp)
+  {
+    if (tmp->Origin() == ORIGIN_SYSTEM)
+    {
+      return CAddonRepos::IsOfficialRepo(origin);
+    }
+    else
+    {
+      return tmp->Origin() == origin;
+    }
+  }
+  return false;
 }
 
 bool CAddonMgr::IsAddonInstalled(const std::string& ID,
@@ -899,8 +911,19 @@ bool CAddonMgr::IsAddonInstalled(const std::string& ID,
                                  const AddonVersion& version)
 {
   AddonPtr tmp;
-  return (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp && tmp->Origin() == origin &&
-          tmp->Version() == version);
+
+  if (GetAddon(ID, tmp, ADDON_UNKNOWN, false) && tmp)
+  {
+    if (tmp->Origin() == ORIGIN_SYSTEM)
+    {
+      return CAddonRepos::IsOfficialRepo(origin) && tmp->Version() == version;
+    }
+    else
+    {
+      return tmp->Origin() == origin && tmp->Version() == version;
+    }
+  }
+  return false;
 }
 
 bool CAddonMgr::CanAddonBeInstalled(const AddonPtr& addon)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -26,6 +26,12 @@ namespace ADDON
 
   const std::string ADDON_PYTHON_EXT           = "*.py";
 
+  enum class AddonCheckType
+  {
+    OUTDATED_ADDONS,
+    AVAILABLE_UPDATES
+  };
+
   struct CAddonWithUpdate;
 
   /**
@@ -507,7 +513,7 @@ namespace ADDON
      * \return vector filled with either available updates or outdated addons
      */
     std::vector<std::shared_ptr<IAddon>> GetAvailableUpdatesOrOutdatedAddons(
-        bool returnOutdatedAddons) const;
+        AddonCheckType addonCheckType) const;
 
     bool GetAddonsInternal(const TYPE& type,
                            VECADDONS& addons,

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -248,6 +248,8 @@ namespace ADDON
 
     /* \brief Checks whether an addon is installed from a
      *        particular origin repo
+     * \note if checked for an origin defined as official (i.e. repository.xbmc.org)
+     *       this function will return true even if the addon is a shipped system add-on
      * \param ID id of the addon
      * \param origin origin repository id
      */
@@ -255,6 +257,8 @@ namespace ADDON
 
     /* \brief Checks whether an addon is installed from a
      *        particular origin repo and version
+     * \note if checked for an origin defined as official (i.e. repository.xbmc.org)
+     *       this function will return true even if the addon is a shipped system add-on
      * \param ID id of the addon
      * \param origin origin repository id
      * \param version the version of the addon

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -175,32 +175,20 @@ void CAddonRepos::AddAddonIfLatest(
   }
 }
 
-void CAddonRepos::BuildUpdateList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                                  std::vector<std::shared_ptr<IAddon>>& updates) const
-{
-  BuildUpdateOrOutdatedList(installed, updates, false);
-}
-
-void CAddonRepos::BuildOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                                    std::vector<std::shared_ptr<IAddon>>& outdated) const
-{
-  BuildUpdateOrOutdatedList(installed, outdated, true);
-}
-
 void CAddonRepos::BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
                                             std::vector<std::shared_ptr<IAddon>>& result,
-                                            bool returnOutdatedAddons) const
+                                            AddonCheckType addonCheckType) const
 {
   std::shared_ptr<IAddon> update;
 
   CLog::Log(LOGDEBUG, "CAddonRepos::{}: Building {} list from installed add-ons", __func__,
-            returnOutdatedAddons ? "outdated" : "update");
+            addonCheckType == AddonCheckType::OUTDATED_ADDONS ? "outdated" : "update");
 
   for (const auto& addon : installed)
   {
     if (DoAddonUpdateCheck(addon, update))
     {
-      result.emplace_back(returnOutdatedAddons ? addon : update);
+      result.emplace_back(addonCheckType == AddonCheckType::OUTDATED_ADDONS ? addon : update);
     }
   }
 }

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -50,6 +50,14 @@ bool CAddonRepos::IsFromOfficialRepo(const std::shared_ptr<IAddon>& addon,
          std::any_of(officialRepoInfos.begin(), officialRepoInfos.end(), comparator);
 }
 
+bool CAddonRepos::IsOfficialRepo(const std::string& repoId)
+{
+  return repoId == ORIGIN_SYSTEM || std::any_of(officialRepoInfos.begin(), officialRepoInfos.end(),
+                                                [&repoId](const RepoInfo& officialRepo) {
+                                                  return repoId == officialRepo.m_repoId;
+                                                });
+}
+
 bool CAddonRepos::LoadAddonsFromDatabase(const CAddonDatabase& database)
 {
   return LoadAddonsFromDatabase(database, "", nullptr);

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -113,6 +113,14 @@ public:
                                  CheckAddonPath checkAddonPath);
 
   /*!
+   * \brief Checks if the passed in repository is defined as official repo
+   *        which includes ORIGIN_SYSTEM
+   * \param repoId repository id to check
+   * \return true if the repository id is defined as official, false otherwise
+   */
+  static bool IsOfficialRepo(const std::string& repoId);
+
+  /*!
    * \brief Check if an update is available for a single addon
    * \param addon that is checked for an update
    * \param[out] update pointer to the found update

--- a/xbmc/addons/AddonRepos.h
+++ b/xbmc/addons/AddonRepos.h
@@ -21,6 +21,7 @@ class CAddonDatabase;
 class CAddonMgr;
 class CRepository;
 class IAddon;
+enum class AddonCheckType;
 
 enum class CheckAddonPath
 {
@@ -75,22 +76,17 @@ public:
 
   /*!
    * \brief Build the list of addons to be updated depending on defined rules
+   *        or the list of outdated addons
    * \param installed vector of all addons installed on the system that are
    *        checked for an update
-   * \param[out] updates list of addon versions that are going to be installed
+   * \param[in] addonCheckType build list of OUTDATED or UPDATES
+   * \param[out] result list of addon versions that are going to be installed
+   *             or are outdated
    */
-  void BuildUpdateList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                       std::vector<std::shared_ptr<IAddon>>& updates) const;
+  void BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
+                                 std::vector<std::shared_ptr<IAddon>>& result,
+                                 AddonCheckType addonCheckType) const;
 
-  /*!
-   * \brief Build the list of addons that are outdated and have an update
-   *        available depending on defined rules
-   * \param installed vector of all addons installed on the system that are
-   *        checked for an update
-   * \param[out] outdated list of addon versions that have an update available
-   */
-  void BuildOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                         std::vector<std::shared_ptr<IAddon>>& outdated) const;
 
   /*!
    * \brief Build the list of outdated addons and their available updates.
@@ -187,14 +183,6 @@ public:
   void BuildCompatibleVersionsList(std::vector<std::shared_ptr<IAddon>>& compatibleVersions) const;
 
 private:
-  /*!
-   * \brief Executor for BuildUpdateList() and BuildOutdatedList()
-   * \sa BuildUpdateList() BuildOutdatedList()
-   */
-  void BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IAddon>>& installed,
-                                 std::vector<std::shared_ptr<IAddon>>& result,
-                                 bool returnOutdatedAddons) const;
-
   /*!
    * \brief Load the map of addons
    * \note this function should only by called from publicly exposed wrappers

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -304,10 +304,6 @@ int CGUIDialogAddonInfo::AskForVersion(std::vector<std::pair<AddonVersion, std::
 
 void CGUIDialogAddonInfo::OnUpdate()
 {
-  // prompt user to be sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24138}, CVariant{750}))
-    return;
-
   const auto& itemAddonInfo = m_item->GetAddonInfo();
   const std::string& addonId = itemAddonInfo->ID();
   const std::string& origin = m_item->GetProperty("Addon.ValidUpdateOrigin").asString();

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -309,8 +309,8 @@ void CGUIDialogAddonInfo::OnUpdate()
     return;
 
   const auto& itemAddonInfo = m_item->GetAddonInfo();
-  const std::string& origin = itemAddonInfo->Origin();
   const std::string& addonId = itemAddonInfo->ID();
+  const std::string& origin = m_item->GetProperty("Addon.ValidUpdateOrigin").asString();
   const AddonVersion& version =
       static_cast<AddonVersion>(m_item->GetProperty("Addon.ValidUpdateVersion").asString());
 
@@ -437,23 +437,25 @@ void CGUIDialogAddonInfo::OnInstall()
   const auto& itemAddonInfo = m_item->GetAddonInfo();
   const std::string& origin = itemAddonInfo->Origin();
 
-  if (m_localAddon && (m_localAddon->Origin() != origin) &&
-      (CAddonSystemSettings::GetInstance().GetAddonRepoUpdateMode() !=
-       AddonRepoUpdateMode::ANY_REPOSITORY))
+  if (m_localAddon && CAddonSystemSettings::GetInstance().GetAddonRepoUpdateMode() !=
+                          AddonRepoUpdateMode::ANY_REPOSITORY)
   {
-    const std::string& header = g_localizeStrings.Get(19098); // Warning!
-    const std::string text =
-        StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->ID(),
-                            m_localAddon->Origin(), m_localAddon->Version().asString());
+    if (m_localAddon->Origin() != origin && m_localAddon->Origin() != ORIGIN_SYSTEM)
+    {
+      const std::string& header = g_localizeStrings.Get(19098); // Warning!
+      const std::string text =
+          StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->ID(),
+                              m_localAddon->Origin(), m_localAddon->Version().asString());
 
-    if (CGUIDialogYesNo::ShowAndGetInput(header, text))
-    {
-      m_silentUninstall = true;
-      OnUninstall();
-    }
-    else
-    {
-      return;
+      if (CGUIDialogYesNo::ShowAndGetInput(header, text))
+      {
+        m_silentUninstall = true;
+        OnUninstall();
+      }
+      else
+      {
+        return;
+      }
     }
   }
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -827,10 +827,12 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     bool hasUpdate = CheckOutdatedOrUpdate(true); // check if it's an outdated addon
 
     std::string validUpdateVersion;
+    std::string validUpdateOrigin;
     if (hasUpdate)
     {
       auto mapEntry = addonsWithUpdate.find(addon->ID());
       validUpdateVersion = mapEntry->second.m_update->Version().asString();
+      validUpdateOrigin = mapEntry->second.m_update->Origin();
     }
 
     bool fromOfficialRepo = CAddonRepos::IsFromOfficialRepo(addon, CheckAddonPath::NO);
@@ -840,6 +842,7 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     pItem->SetProperty("Addon.HasUpdate", hasUpdate);
     pItem->SetProperty("Addon.IsUpdate", isUpdate);
     pItem->SetProperty("Addon.ValidUpdateVersion", validUpdateVersion);
+    pItem->SetProperty("Addon.ValidUpdateOrigin", validUpdateOrigin);
     pItem->SetProperty("Addon.IsFromOfficialRepo", fromOfficialRepo);
     pItem->SetProperty("Addon.IsBinary", addon->IsBinary());
 


### PR DESCRIPTION
## Description
### Commit 1:
refactoring, but no functional changes

### Commit 2:
with PR #18398 all non-optional system add-ons get reset to ORIGIN_SYSTEM at startup.
this pr addresses some issues regarding the update process of system addons via official kodi repos, like wrong origin detection and incomprehensible install/update-paths.

### Commit 3:
removes (imo) superfluous y/n-confirmation dialog for the new update/versions-button in `DialogAddonInfo`

## How Has This Been Tested?
tested locally on debian buster and tried to catch all possible constellations and edge-cases

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
