### PR TITLE
[PVR] Reminders: Add option to switch to channel on auto-close of the reminder popup.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11123,7 +11123,31 @@ msgctxt "#19329"
 msgid "Allow backend channel numbers with more than one PVR add-on"
 msgstr ""
 
-#empty strings from id 19330 to 19498
+#. pvr settings "switch to channel on reminder auto-close" setting label
+#: system/settings/settings.xml
+msgctxt "#19330"
+msgid "Switch to channel when auto-closing the reminder popup"
+msgstr ""
+
+#. additional text for reminder announcement dialog, used if a recording can be scheduled
+#: xbmc/pvr/timers/PVRGUIActions.cpp
+msgctxt "#19331"
+msgid "(Auto-close of this reminder will switch to channel...)"
+msgstr ""
+
+#. text for event log entry for logging auto channel switch for auto-closed reminders
+#: xbmc/pvr/timers/PVRGUIActions.cpp
+msgctxt "#19332"
+msgid "Switched to channel for auto-closed PVR reminder for '{0:s}' on channel '{1:s}' at '{2:s}'"
+msgstr ""
+
+#. text for event log entry for logging auto scheduled recordings for auto-closed reminders
+#: xbmc/pvr/timers/PVRGUIActions.cpp
+msgctxt "#19333"
+msgid "Switched to channel for auto-closed PVR reminder for channel '{0:s}' at '{1:s}'"
+msgstr ""
+
+#empty strings from id 19334 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp
@@ -20173,7 +20197,12 @@ msgctxt "#36433"
 msgid "When enabled, VAAPI render method is preferred and the CPU has less load. If you experience hangs, disable this option."
 msgstr ""
 
-#empty strings from id 36434 to 36435
+#: system/settings/settings.xml
+msgctxt "#36434"
+msgid "If enabled, switch to the channel with the programme to remind when auto-closing the reminder popup."
+msgstr ""
+
+#empty strings from id 36435 to 36435
 
 #. Description for setting #310: "Keyboard layouts"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1784,6 +1784,11 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="pvrreminders.autoswitch" type="boolean" label="19330" help="36434">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
     <category id="pvrpowermanagement" label="14095" help="36240">

--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -219,20 +219,18 @@ namespace PVR
   };
 
   CPVRGUIActions::CPVRGUIActions()
-  : m_settings({
-      CSettings::SETTING_LOOKANDFEEL_STARTUPACTION,
-      CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL,
-      CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME,
-      CSettings::SETTING_PVRRECORD_INSTANTRECORDACTION,
-      CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH,
-      CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREENCHANNELTYPES,
-      CSettings::SETTING_PVRPARENTAL_PIN,
-      CSettings::SETTING_PVRPARENTAL_ENABLED,
-      CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
-      CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME,
-      CSettings::SETTING_PVRREMINDERS_AUTOCLOSEDELAY,
-      CSettings::SETTING_PVRREMINDERS_AUTORECORD
-    })
+    : m_settings({CSettings::SETTING_LOOKANDFEEL_STARTUPACTION,
+                  CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL,
+                  CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME,
+                  CSettings::SETTING_PVRRECORD_INSTANTRECORDACTION,
+                  CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH,
+                  CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREENCHANNELTYPES,
+                  CSettings::SETTING_PVRPARENTAL_PIN, CSettings::SETTING_PVRPARENTAL_ENABLED,
+                  CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME,
+                  CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME,
+                  CSettings::SETTING_PVRREMINDERS_AUTOCLOSEDELAY,
+                  CSettings::SETTING_PVRREMINDERS_AUTORECORD,
+                  CSettings::SETTING_PVRREMINDERS_AUTOSWITCH})
   {
   }
 
@@ -2072,7 +2070,11 @@ namespace PVR
       dialog->ShowChoice(2, CVariant{222}); // "Cancel"
 
       if (m_settings.GetBoolValue(CSettings::SETTING_PVRREMINDERS_AUTORECORD))
-        text += "\n\n" + g_localizeStrings.Get(19309); // (Auto-close of this reminder will schedule a recording...)
+        text += "\n\n" + g_localizeStrings.Get(
+                             19309); // (Auto-close of this reminder will schedule a recording...)
+      else if (m_settings.GetBoolValue(CSettings::SETTING_PVRREMINDERS_AUTOSWITCH))
+        text += "\n\n" + g_localizeStrings.Get(
+                             19331); // (Auto-close of this reminder will swicth to channel...)
     }
     else
     {
@@ -2105,54 +2107,59 @@ namespace PVR
 
     dialog->Close();
 
-    if (iRemaining <= 0) // auto-closed?
+    bool bAutoClosed = (iRemaining <= 0);
+    bool bSwitch = (result == 0);
+    bool bRecord = (result == 1);
+
+    if (bAutoClosed)
     {
-      if (bCanRecord && m_settings.GetBoolValue(CSettings::SETTING_PVRREMINDERS_AUTORECORD))
-        result = 1; // -> schedule recording
-      else
-        result = CGUIDialogProgress::CHOICE_CANCELED; // -> do nothing
+      bRecord = (bCanRecord && m_settings.GetBoolValue(CSettings::SETTING_PVRREMINDERS_AUTORECORD));
+      bSwitch = m_settings.GetBoolValue(CSettings::SETTING_PVRREMINDERS_AUTOSWITCH);
     }
 
-    switch (result)
+    if (bRecord)
     {
-      case 0:
-        SwitchToChannel(std::make_shared<CFileItem>(timer->Channel()), false);
-        break;
-      case 1:
-        if (bCanRecord)
+      std::shared_ptr<CPVRTimerInfoTag> newTimer;
+
+      std::shared_ptr<CPVREpgInfoTag> epgTag = timer->GetEpgInfoTag();
+      if (epgTag)
+      {
+        newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, false);
+        if (newTimer)
         {
-          std::shared_ptr<CPVRTimerInfoTag> newTimer;
-
-          std::shared_ptr<CPVREpgInfoTag> epgTag = timer->GetEpgInfoTag();
-          if (epgTag)
-          {
-            newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, false);
-            if (newTimer)
-            {
-              // an epgtag can only have max one timer - we need to clear the reminder to be able to attach the recording timer
-              DeleteTimer(timer, false, false);
-            }
-          }
-          else
-          {
-            int iDuration = (timer->EndAsUTC() - timer->StartAsUTC()).GetSecondsTotal() / 60;
-            newTimer = CPVRTimerInfoTag::CreateTimerTag(timer->Channel(), timer->StartAsUTC(), iDuration);
-          }
-
-          if (newTimer)
-          {
-            // schedule recording
-            AddTimer(std::make_shared<CFileItem>(newTimer), false);
-          }
-
-          if (iRemaining <= 0) // auto-closed?
-          {
-            AddEventLogEntry(timer, 19310, 19311); // Scheduled recording for auto-closed PVR reminder ...
-          }
+          // an epgtag can only have max one timer - we need to clear the reminder to be able to
+          // attach the recording timer
+          DeleteTimer(timer, false, false);
         }
-        break;
-      default:
-        break;
+      }
+      else
+      {
+        int iDuration = (timer->EndAsUTC() - timer->StartAsUTC()).GetSecondsTotal() / 60;
+        newTimer =
+            CPVRTimerInfoTag::CreateTimerTag(timer->Channel(), timer->StartAsUTC(), iDuration);
+      }
+
+      if (newTimer)
+      {
+        // schedule recording
+        AddTimer(std::make_shared<CFileItem>(newTimer), false);
+      }
+
+      if (bAutoClosed)
+      {
+        AddEventLogEntry(timer, 19310,
+                         19311); // Scheduled recording for auto-closed PVR reminder ...
+      }
+    }
+
+    if (bSwitch)
+    {
+      SwitchToChannel(std::make_shared<CFileItem>(timer->Channel()), false);
+
+      if (bAutoClosed)
+      {
+        AddEventLogEntry(timer, 19332, 19333); // Switched channel for auto-closed PVR reminder ...
+      }
     }
   }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -230,6 +230,7 @@ const std::string CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS = "pvrrecord.t
 const std::string CSettings::SETTING_PVRRECORD_GROUPRECORDINGS = "pvrrecord.grouprecordings";
 const std::string CSettings::SETTING_PVRREMINDERS_AUTOCLOSEDELAY = "pvrreminders.autoclosedelay";
 const std::string CSettings::SETTING_PVRREMINDERS_AUTORECORD = "pvrreminders.autorecord";
+const std::string CSettings::SETTING_PVRREMINDERS_AUTOSWITCH = "pvrreminders.autoswitch";
 const std::string CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED = "pvrpowermanagement.enabled";
 const std::string CSettings::SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME = "pvrpowermanagement.backendidletime";
 const std::string CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD = "pvrpowermanagement.setwakeupcmd";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -191,6 +191,7 @@ public:
   static const std::string SETTING_PVRRECORD_GROUPRECORDINGS;
   static const std::string SETTING_PVRREMINDERS_AUTOCLOSEDELAY;
   static const std::string SETTING_PVRREMINDERS_AUTORECORD;
+  static const std::string SETTING_PVRREMINDERS_AUTOSWITCH;
   static const std::string SETTING_PVRPOWERMANAGEMENT_ENABLED;
   static const std::string SETTING_PVRPOWERMANAGEMENT_BACKENDIDLETIME;
   static const std::string SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD;


### PR DESCRIPTION
People want to have full freedom to decide what happens when they do not react until a PVR reminder popup auto-closes.

This PR adds a new setting to switch to the channel with the programme just reminded when the popup closes automatically without any user interaction.

 Now, users can decide whether they want Kodi to

* do nothing 
* start a recording
* swicth to the channel
* start a recording and switch to the channel

![screenshot00000](https://user-images.githubusercontent.com/3226626/97118841-9dd59a00-170c-11eb-8da0-ee47326bbec2.png)

@b-jesch fyi
@phunkyfish for review?
