### PR TITLE
Revert "[pvr] add refetch timeout for IsPlayable on an EPG tag"

### DIFF
--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -606,18 +606,16 @@ bool CPVREpgInfoTag::IsRecordable() const
 
 bool CPVREpgInfoTag::IsPlayable() const
 {
+  bool bIsPlayable = false;
+
   CSingleLock lock(m_critSection);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
-  if (client && m_isPlayableRefetchTimeout.IsTimePast())
+  if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {
-    // @todo: root cause should be fixed. details: https://github.com/xbmc/xbmc/pull/14961
-    m_isPlayableRefetchTimeout.Set(60000); // update is playable from backend at most every 1 min
-
-    bool bIsPlayable = false;
-    if (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR)
-      m_bIsPlayable = bIsPlayable;
+    // fallback
+    bIsPlayable = false;
   }
-  return m_bIsPlayable;
+  return bIsPlayable;
 }
 
 bool CPVREpgInfoTag::IsSeries() const

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -10,7 +10,6 @@
 
 #include "XBDateTime.h"
 #include "threads/CriticalSection.h"
-#include "threads/SystemClock.h"
 #include "utils/ISerializable.h"
 
 #include <memory>
@@ -483,8 +482,6 @@ namespace PVR
     unsigned int m_iFlags = 0; /*!< the flags applicable to this EPG entry */
     std::string m_strSeriesLink; /*!< series link */
     bool m_bIsGapTag = false;
-    mutable bool m_bIsPlayable = false;
-    mutable XbmcThreads::EndTime m_isPlayableRefetchTimeout;
 
     mutable CCriticalSection m_critSection;
     std::shared_ptr<CPVREpgChannelData> m_channelData;


### PR DESCRIPTION
This reverts commit 6fe5abf8b74d79b3244194376d9b5dfdf32bc687.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Upon further review the refetch timeout added in this commit is redundant and should be removed.

The revert commit is from this PR: https://github.com/xbmc/xbmc/pull/18643

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

We don't need code that effectively does nothing ;)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
