### PR TITLE
linux: add windowing system to SystemInfo screen

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22355,3 +22355,8 @@ msgstr ""
 msgctxt "#39152"
 msgid "Integer scaling (IS) is a Nearest-Neighbor(NN) upscaling technique using Display Engine"
 msgstr ""
+
+#: xbmc/windows/GUIWindowSystemInfo.cpp
+msgctxt "#39153"
+msgid "Windowing system:"
+msgstr ""

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -457,7 +457,7 @@
 #define SYSTEM_PLATFORM_DARWIN_IOS  745
 #define SYSTEM_PLATFORM_UWP         746
 #define SYSTEM_PLATFORM_ANDROID     747
-// previously used by rpi           748
+#define SYSTEM_PLATFORM_WINDOWING   748
 #define SYSTEM_PLATFORM_WIN10       749
 
 #define SYSTEM_CAN_POWERDOWN        750

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -308,6 +308,12 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     case SYSTEM_ADDON_UPDATE_COUNT:
       value = CServiceBroker::GetAddonMgr().GetLastAvailableUpdatesCountAsString();
       return true;
+#if defined(TARGET_LINUX)
+    case SYSTEM_PLATFORM_WINDOWING:
+      value = CServiceBroker::GetWinSystem()->GetName();
+      StringUtils::ToCapitalize(value);
+      return true;
+#endif
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // NETWORK_*

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -50,6 +50,8 @@ public:
   // Access render system interface
   virtual CRenderSystemBase *GetRenderSystem() { return nullptr; }
 
+  virtual const std::string GetName() { return "platform default"; }
+
   // windowing interfaces
   virtual bool InitWindowSystem();
   virtual bool DestroyWindowSystem();

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -37,6 +37,8 @@ public:
   CWinSystemX11();
   ~CWinSystemX11() override;
 
+  const std::string GetName() override { return "x11"; }
+
   // CWinSystemBase
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -34,6 +34,8 @@ public:
   CWinSystemGbm();
   ~CWinSystemGbm() override = default;
 
+  const std::string GetName() override { return "gbm"; }
+
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
 

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -52,6 +52,8 @@ public:
   CWinSystemWayland();
   ~CWinSystemWayland() noexcept override;
 
+  const std::string GetName() override { return "wayland"; }
+
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
 

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -135,6 +135,9 @@ void CGUIWindowSystemInfo::FrameMove()
 #ifndef HAS_DX
     SetControlLabel(i++, "%s %s", 22007, SYSTEM_RENDER_VENDOR);
     SetControlLabel(i++, "%s %s", 22009, SYSTEM_RENDER_VERSION);
+#if defined(TARGET_LINUX)
+    SetControlLabel(i++, "%s %s", 39153, SYSTEM_PLATFORM_WINDOWING);
+#endif
 #else
     SetControlLabel(i++, "%s %s", 22024, SYSTEM_RENDER_VERSION);
 #endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This adds the used windowing system to the system info screen

![alt text](https://imgur.com/RChdS92l.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
