### PR TITLE
[addons] fix logic for CAddonMgr::FindInstallableById() when addon is…

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -383,16 +383,17 @@ bool CAddonMgr::FindInstallableById(const std::string& addonId, AddonPtr& result
 
   if (GetAddon(addonId, addonToUpdate, ADDON_UNKNOWN, false))
   {
-    return addonRepos.DoAddonUpdateCheck(addonToUpdate, result);
+    if (addonRepos.DoAddonUpdateCheck(addonToUpdate, result))
+      return true;
   }
 
   // get the latest version from all repos if the
-  // addon is not installed yet (e.g. for addon select dialog)
+  // addon is up-to-date or not installed yet
 
-  CLog::Log(
-      LOGDEBUG,
-      "CAddonMgr::{}: addon {} is not installed. falling back to get latest version from ALL repos",
-      __FUNCTION__, addonId);
+  CLog::Log(LOGDEBUG,
+            "CAddonMgr::{}: addon {} is up-to-date or not installed. falling back to get latest "
+            "version from all repos",
+            __FUNCTION__, addonId);
 
   return addonRepos.GetLatestAddonVersionFromAllRepos(addonId, result);
 }

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -223,8 +223,8 @@ void CAddonRepos::BuildAddonsWithUpdateList(
 bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
                                      std::shared_ptr<IAddon>& update) const
 {
-  CLog::Log(LOGDEBUG, "ADDONS: update check: addonID = {} / Origin = {}", addon->ID(),
-            addon->Origin());
+  CLog::Log(LOGDEBUG, "ADDONS: update check: addonID = {} / Origin = {} / Version = {}",
+            addon->ID(), addon->Origin(), addon->Version().asString());
 
   update.reset();
 


### PR DESCRIPTION
… up-to-date

## Description
`CAddonMgr::FindInstallableById()` doesn't work as it claims if the queried addon is installed and up to date.

this was introduced with pr #18207 but never noticed

fixes the issue, that certain dependencies won't show up in the select-dialog.
(even though some of them e.g. `script.module...` should be hidden to the user anyway later)

would be good to have this in alpha3

## How Has This Been Tested?
debian buster

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@phunkyfish you might want to take a quick look?