### PR TITLE
[addons][guiinfo] Speedup LISTITEM_ADDON_ORIGIN guiinfo label calculation

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -107,6 +107,7 @@ public:
   CDateTime LastUpdated() const override { return m_addonInfo->LastUpdated(); }
   CDateTime LastUsed() const override { return m_addonInfo->LastUsed(); }
   std::string Origin() const override { return m_addonInfo->Origin(); }
+  std::string OriginName() const override { return m_addonInfo->OriginName(); }
   uint64_t PackageSize() const override { return m_addonInfo->PackageSize(); }
   const InfoMap& ExtraInfo() const override { return m_addonInfo->ExtraInfo(); }
   const std::vector<DependencyInfo>& GetDependencies() const override { return m_addonInfo->GetDependencies(); }

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -60,6 +60,7 @@ namespace ADDON
     virtual CDateTime LastUpdated() const =0;
     virtual CDateTime LastUsed() const =0;
     virtual std::string Origin() const =0;
+    virtual std::string OriginName() const = 0;
     virtual uint64_t PackageSize() const =0;
     virtual const InfoMap &ExtraInfo() const =0;
     virtual bool HasSettings() =0;

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -9,6 +9,9 @@
 #include "AddonInfo.h"
 
 #include "LangInfo.h"
+#include "ServiceBroker.h"
+#include "addons/AddonManager.h"
+#include "addons/IAddon.h"
 #include "guilib/LocalizeStrings.h"
 
 #include <algorithm>
@@ -69,6 +72,19 @@ static const TypeMapping types[] =
    {"kodi.imagedecoder",                 "", ADDON_IMAGEDECODER,        39015, "DefaultAddonImageDecoder.png" },
   };
 // clang-format on
+
+const std::string& CAddonInfo::OriginName() const
+{
+  if (!m_originName)
+  {
+    ADDON::AddonPtr origin;
+    if (CServiceBroker::GetAddonMgr().GetAddon(m_origin, origin, ADDON::ADDON_UNKNOWN, false))
+      m_originName = std::make_unique<std::string>(origin->Name());
+    else
+      m_originName = std::make_unique<std::string>(); // remember we tried to fetch the name
+  }
+  return *m_originName;
+}
 
 /**
  * static public helper functions

--- a/xbmc/addons/addoninfo/AddonInfo.h
+++ b/xbmc/addons/addoninfo/AddonInfo.h
@@ -196,6 +196,8 @@ public:
     return GetTranslatedText(m_lifecycleStateDescription);
   }
   const std::string& Origin() const { return m_origin; }
+  const std::string& OriginName() const;
+
   const InfoMap& ExtraInfo() const { return m_extrainfo; }
 
   bool MeetsVersion(const AddonVersion& versionMin, const AddonVersion& version) const;
@@ -246,6 +248,7 @@ private:
   CDateTime m_lastUpdated;
   CDateTime m_lastUsed;
   std::string m_origin;
+  mutable std::unique_ptr<std::string> m_originName; // @todo use std::optional once we use c++17
   uint64_t m_packageSize = 0;
   std::string m_libname;
   InfoMap m_extrainfo;

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -112,10 +112,9 @@ bool CAddonsGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
           value = g_localizeStrings.Get(24992);
           return true;
         }
-        ADDON::AddonPtr origin;
-        if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->Origin(), origin, ADDON::ADDON_UNKNOWN, false))
+        if (!item->GetAddonInfo()->OriginName().empty())
         {
-          value = origin->Name();
+          value = item->GetAddonInfo()->OriginName();
           return true;
         }
         else if (!item->GetAddonInfo()->Origin().empty())


### PR DESCRIPTION
@howie-f as discussed on internal slack, we need to cache the value for the name of the addon origin as the value is requested with high frequency if LISTITEM_ADDON_ORIGIN is used by skins (example: Estuary addon info dialog).

@phunkyfish for code review?