### PR TITLE
Fix powermanager init

### DIFF
--- a/xbmc/platform/overrides/android/PlatformAndroid.cpp
+++ b/xbmc/platform/overrides/android/PlatformAndroid.cpp
@@ -11,6 +11,8 @@
 #include "filesystem/SpecialProtocol.h"
 #include "windowing/android/WinSystemAndroidGLESContext.h"
 
+#include "platform/android/powermanagement/AndroidPowerSyscall.h"
+
 #include <stdlib.h>
 
 CPlatform* CPlatform::CreateInstance()
@@ -27,6 +29,8 @@ bool CPlatformAndroid::Init()
   setenv("OS", "Linux", true); // for python scripts that check the OS
 
   CWinSystemAndroidGLESContext::Register();
+
+  CAndroidPowerSyscall::Register();
 
   return true;
 }

--- a/xbmc/platform/overrides/darwin_embedded/PlatformDarwinEmbedded.cpp
+++ b/xbmc/platform/overrides/darwin_embedded/PlatformDarwinEmbedded.cpp
@@ -15,6 +15,7 @@
 #include "windowing/ios/WinSystemIOS.h"
 #endif
 #if defined(TARGET_DARWIN_TVOS)
+#include "platform/darwin/tvos/powermanagement/TVOSPowerSyscall.h"
 #include "windowing/tvos/WinSystemTVOS.h"
 #endif
 // clang-format on
@@ -35,6 +36,8 @@ bool CPlatformDarwinEmbedded::Init()
 #endif
 #if defined(TARGET_DARWIN_TVOS)
   CWinSystemTVOS::Register();
+
+  CTVOSPowerSyscall::Register();
 #endif
 
   return true;

--- a/xbmc/platform/overrides/freebsd/PlatformFreebsd.cpp
+++ b/xbmc/platform/overrides/freebsd/PlatformFreebsd.cpp
@@ -8,6 +8,8 @@
 
 #include "PlatformFreebsd.h"
 
+#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
+
 // clang-format off
 #if defined(HAS_GLES)
 #if defined(HAVE_WAYLAND)
@@ -71,6 +73,8 @@ bool CPlatformFreebsd::Init()
   KODI::WINDOWING::GBM::CWinSystemGbmGLContext::Register();
 #endif
 #endif
+
+  CLinuxPowerSyscall::Register();
 
   return true;
 }

--- a/xbmc/platform/overrides/linux/PlatformLinux.cpp
+++ b/xbmc/platform/overrides/linux/PlatformLinux.cpp
@@ -8,6 +8,8 @@
 
 #include "PlatformLinux.h"
 
+#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
+
 // clang-format off
 #if defined(HAS_GLES)
 #if defined(HAVE_WAYLAND)
@@ -71,6 +73,8 @@ bool CPlatformLinux::Init()
   KODI::WINDOWING::GBM::CWinSystemGbmGLContext::Register();
 #endif
 #endif
+
+  CLinuxPowerSyscall::Register();
 
   return true;
 }

--- a/xbmc/platform/overrides/osx/PlatformDarwinOSX.cpp
+++ b/xbmc/platform/overrides/osx/PlatformDarwinOSX.cpp
@@ -8,8 +8,10 @@
 
 #include "PlatformDarwinOSX.h"
 
-#include "platform/darwin/osx/XBMCHelper.h"
 #include "windowing/osx/WinSystemOSXGL.h"
+
+#include "platform/darwin/osx/XBMCHelper.h"
+#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 
 CPlatform* CPlatform::CreateInstance()
 {
@@ -25,6 +27,8 @@ bool CPlatformDarwinOSX::Init()
   XBMCHelper::GetInstance().Configure();
 
   CWinSystemOSXGL::Register();
+
+  CCocoaPowerSyscall::Register();
 
   return true;
 }

--- a/xbmc/platform/overrides/windows/PlatformWin32.cpp
+++ b/xbmc/platform/overrides/windows/PlatformWin32.cpp
@@ -12,6 +12,8 @@
 #include "win32util.h"
 #include "windowing/windows/WinSystemWin32DX.h"
 
+#include "platform/win32/powermanagement/Win32PowerSyscall.h"
+
 CPlatform* CPlatform::CreateInstance()
 {
   return new CPlatformWin32();
@@ -28,6 +30,8 @@ bool CPlatformWin32::Init()
   CWIN32Util::SetThreadLocalLocale(true);
 
   CWinSystemWin32DX::Register();
+
+  CWin32PowerSyscall::Register();
 
   return true;
 }

--- a/xbmc/platform/overrides/windowsstore/PlatformWin10.cpp
+++ b/xbmc/platform/overrides/windowsstore/PlatformWin10.cpp
@@ -13,6 +13,8 @@
 #include "win32util.h"
 #include "windowing/win10/WinSystemWin10DX.h"
 
+#include "platform/win10/powermanagement/Win10PowerSyscall.h"
+
 #include <stdlib.h>
 
 CPlatform* CPlatform::CreateInstance()
@@ -33,6 +35,8 @@ bool CPlatformWin10::Init()
   CWIN32Util::SetThreadLocalLocale(true);
 
   CWinSystemWin10DX::Register();
+
+  CPowerSyscall::Register();
 
   return true;
 }

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -27,8 +27,6 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
-
 #include <string>
 #include <vector>
 
@@ -56,7 +54,6 @@ CWinSystemX11::CWinSystemX11() : CWinSystemBase()
 
   m_winEventsX11 = new CWinEventsX11(*this);
   m_winEvents.reset(m_winEventsX11);
-  CLinuxPowerSyscall::Register();
 }
 
 CWinSystemX11::~CWinSystemX11() = default;

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -33,7 +33,6 @@
 #include "platform/android/activity/XBMCApp.h"
 #include "platform/android/media/decoderfilter/MediaCodecDecoderFilterManager.h"
 #include "platform/android/media/drm/MediaDrmCryptoSession.h"
-#include "platform/android/powermanagement/AndroidPowerSyscall.h"
 
 #include <float.h>
 #include <string.h>
@@ -57,7 +56,6 @@ CWinSystemAndroid::CWinSystemAndroid()
   m_android = nullptr;
 
   m_winEvents.reset(new CWinEventsAndroid());
-  CAndroidPowerSyscall::Register();
 }
 
 CWinSystemAndroid::~CWinSystemAndroid()

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -25,7 +25,6 @@
 
 #include "platform/freebsd/OptionalsReg.h"
 #include "platform/linux/OptionalsReg.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 
 #include <string.h>
 
@@ -75,7 +74,6 @@ CWinSystemGbm::CWinSystemGbm() :
   }
 
   m_dpms = std::make_shared<CGBMDPMSSupport>();
-  CLinuxPowerSyscall::Register();
   m_lirc.reset(OPTIONALS::LircRegister());
   m_libinput->Start();
 }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -43,7 +43,6 @@
 #include "platform/darwin/osx/CocoaInterface.h"
 #import "platform/darwin/osx/OSXTextInputResponder.h"
 #include "platform/darwin/osx/XBMCHelper.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 
 #include <cstdlib>
 #include <signal.h>
@@ -273,7 +272,7 @@ CFArrayRef GetAllDisplayModes(CGDirectDisplayID display)
 // mimic former behavior of deprecated CGDisplayBestModeForParameters
 CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display, size_t bitsPerPixel, size_t width, size_t height, boolean_t &match)
 {
-  
+
   // Get a copy of the current display mode
   CGDisplayModeRef displayMode = CGDisplayCopyDisplayMode(display);
 
@@ -670,7 +669,6 @@ CWinSystemOSX::CWinSystemOSX()
 
   AE::CAESinkFactory::ClearSinks();
   CAESinkDARWINOSX::Register();
-  CCocoaPowerSyscall::Register();
   m_dpms = std::make_shared<CCocoaDPMSSupport>();
 }
 
@@ -1125,7 +1123,7 @@ void CWinSystemOSX::UpdateResolutions()
 
   int dispIdx = GetDisplayIndex(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
   GetScreenResolution(&w, &h, &fps, dispIdx);
-  NSString *dispName = screenNameForDisplay(GetDisplayID(dispIdx));  
+  NSString* dispName = screenNameForDisplay(GetDisplayID(dispIdx));
   UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP), [dispName UTF8String], w, h, fps, 0);
 
   CDisplaySettings::GetInstance().ClearCustomResolutions();

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -37,7 +37,6 @@
 #import "platform/darwin/DarwinUtils.h"
 #import "platform/darwin/tvos/TVOSDisplayManager.h"
 #import "platform/darwin/tvos/XBMCController.h"
-#include "platform/darwin/tvos/powermanagement/TVOSPowerSyscall.h"
 
 #include <memory>
 #include <vector>
@@ -141,7 +140,6 @@ CWinSystemTVOS::CWinSystemTVOS() : CWinSystemBase(), m_lostDeviceTimer(this)
   m_winEvents.reset(new CWinEventsTVOS());
 
   CAESinkDARWINTVOS::Register();
-  CTVOSPowerSyscall::Register();
 }
 
 CWinSystemTVOS::~CWinSystemTVOS()

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -46,7 +46,6 @@
 #include "platform/freebsd/OptionalsReg.h"
 #include "platform/linux/OptionalsReg.h"
 #include "platform/linux/TimeUtils.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 
 #include <algorithm>
 #include <limits>
@@ -178,7 +177,6 @@ CWinSystemWayland::CWinSystemWayland()
     }
   }
   m_winEvents.reset(new CWinEventsWayland());
-  CLinuxPowerSyscall::Register();
   m_lirc.reset(OPTIONALS::LircRegister());
 }
 

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -12,7 +12,6 @@
 #include "cores/AudioEngine/Sinks/AESinkWASAPI.h"
 #include "windowing/GraphicContext.h"
 #include "platform/win10/AsyncHelpers.h"
-#include "platform/win10/powermanagement/Win10PowerSyscall.h"
 #include "platform/win32/CharsetConverter.h"
 #include "rendering/dx/DirectXHelper.h"
 #include "rendering/dx/RenderContext.h"
@@ -65,7 +64,6 @@ CWinSystemWin10::CWinSystemWin10()
   {
     CAESinkWASAPI::Register();
   }
-  CPowerSyscall::Register();
 }
 
 CWinSystemWin10::~CWinSystemWin10()

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -33,7 +33,6 @@
 
 #include "platform/win32/CharsetConverter.h"
 #include "platform/win32/input/IRServerSuite.h"
-#include "platform/win32/powermanagement/Win32PowerSyscall.h"
 
 #include <algorithm>
 
@@ -72,7 +71,6 @@ CWinSystemWin32::CWinSystemWin32()
   AE::CAESinkFactory::ClearSinks();
   CAESinkDirectSound::Register();
   CAESinkWASAPI::Register();
-  CWin32PowerSyscall::Register();
   CScreenshotSurfaceWindows::Register();
 
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bScanIRServer)


### PR DESCRIPTION
this fixes #18664 

Powemanager was registered by the window system which isn't constructed till after initstagetwo now. So let's move the powermanagement registers to CPlatform where they can be registered early.