### PR TITLE
[addons] fixes to depends select dialog / DialogAddonInfo and toast messages

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15838,7 +15838,27 @@ msgstr ""
 
 #24171-24179 reserved for future use of lifecycle state name (to have continuous chain of GUI)
 
-#empty strings from id 24180 to 24990
+#: xbmc/addons/GUIDialogAddonInfo.cpp
+msgctxt "#24180"
+msgid "Minimum: {0:s}"
+msgstr ""
+
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#24181"
+msgid " => Install: {0:s}"
+msgstr ""
+
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#24182"
+msgid " / Installed: {0:s}"
+msgstr ""
+
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#24183"
+msgid " => Update to: {0:s}"
+msgstr ""
+
+#empty strings from id 24184 to 24990
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -66,9 +66,9 @@
 					</control>
 					<control type="textbox">
 						<left>135</left>
-						<top>52</top>
+						<top>50</top>
 						<right>20</right>
-						<height>65</height>
+						<height>67</height>
 						<font>font12</font>
 						<textcolor>grey</textcolor>
 						<label>$INFO[ListItem.Label2]</label>
@@ -103,9 +103,9 @@
 					</control>
 					<control type="textbox">
 						<left>135</left>
-						<top>52</top>
+						<top>50</top>
 						<right>20</right>
-						<height>65</height>
+						<height>67</height>
 						<font>font12</font>
 						<label>$INFO[ListItem.Label2]</label>
 					</control>

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -743,7 +743,7 @@ bool CAddonInstallJob::DoWork()
   bool notify = (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                      CSettings::SETTING_ADDONS_NOTIFICATIONS) ||
                  m_isAutoUpdate == AutoUpdateJob::NO) &&
-                !IsModal();
+                !IsModal() && m_dependsInstall == DependencyJob::NO;
   CServiceBroker::GetEventLog().Add(
       EventPtr(new CAddonManagementEvent(m_addon, m_isUpdate ? 24065 : 24084)), notify, false);
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -160,10 +160,10 @@ bool CGUIDialogAddonInfo::OnAction(const CAction& action)
 void CGUIDialogAddonInfo::OnInitWindow()
 {
   CGUIDialog::OnInitWindow();
-  UpdateControls();
+  UpdateControls(PerformButtonFocus::YES);
 }
 
-void CGUIDialogAddonInfo::UpdateControls()
+void CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus performButtonFocus)
 {
   if (!m_item)
     return;
@@ -202,7 +202,7 @@ void CGUIDialogAddonInfo::UpdateControls()
     }
 
     CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canInstall);
-    if (canInstall)
+    if (canInstall && performButtonFocus == PerformButtonFocus::YES)
     {
       SET_CONTROL_FOCUS(CONTROL_BTN_INSTALL, 0);
     }
@@ -244,7 +244,7 @@ void CGUIDialogAddonInfo::UpdateControls()
   SET_CONTROL_LABEL(CONTROL_BTN_SELECT, CanUse() ? 21480 : (CanOpen() ? 21478 : 21479));
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_SETTINGS, isInstalled && m_localAddon->HasSettings());
-  if (isInstalled && m_localAddon->HasSettings())
+  if (isInstalled && m_localAddon->HasSettings() && performButtonFocus == PerformButtonFocus::YES)
   {
     SET_CONTROL_FOCUS(CONTROL_BTN_SETTINGS, 0);
   }
@@ -586,7 +586,7 @@ void CGUIDialogAddonInfo::OnEnableDisable()
     CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID());
   }
 
-  UpdateControls();
+  UpdateControls(PerformButtonFocus::NO);
 }
 
 void CGUIDialogAddonInfo::OnSettings()

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -113,7 +113,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_BTN_DEPENDENCIES)
       {
         auto deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(m_item->GetAddonInfo()->ID());
-        ShowDependencyList(deps, true);
+        ShowDependencyList(deps, Reactivate::YES);
         return true;
       }
       else if (iControl == CONTROL_BTN_AUTOUPDATE)
@@ -312,7 +312,7 @@ void CGUIDialogAddonInfo::OnUpdate()
 
   Close();
   const auto& deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(addonId);
-  if (!deps.empty() && !ShowDependencyList(deps, false))
+  if (!deps.empty() && !ShowDependencyList(deps, Reactivate::NO))
     return;
 
   CAddonInstaller::GetInstance().Install(addonId, version, origin);
@@ -461,7 +461,7 @@ void CGUIDialogAddonInfo::OnInstall()
 
   Close();
   const auto& deps = CServiceBroker::GetAddonMgr().GetDepsRecursive(addonId);
-  if (!deps.empty() && !ShowDependencyList(deps, false))
+  if (!deps.empty() && !ShowDependencyList(deps, Reactivate::NO))
     return;
 
   CAddonInstaller::GetInstance().Install(addonId, version, origin);
@@ -595,7 +595,7 @@ void CGUIDialogAddonInfo::OnSettings()
 }
 
 bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::DependencyInfo>& deps,
-                                             bool reactivate)
+                                             Reactivate reactivate)
 {
   auto pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
       WINDOW_DIALOG_SELECT);
@@ -647,11 +647,11 @@ bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::Dependency
   while (true)
   {
     pDialog->Reset();
-    pDialog->SetHeading(reactivate ? 39024 : 39020);
+    pDialog->SetHeading(reactivate == Reactivate::YES ? 39024 : 39020);
     pDialog->SetUseDetails(true);
     for (auto& it : items)
       pDialog->Add(*it);
-    pDialog->EnableButton(!reactivate, 186);
+    pDialog->EnableButton(reactivate == Reactivate::NO, 186);
     pDialog->SetButtonFocus(true);
     pDialog->Open();
 
@@ -674,7 +674,7 @@ bool CGUIDialogAddonInfo::ShowDependencyList(const std::vector<ADDON::Dependency
       break;
   }
   SetItem(backup_item);
-  if (reactivate)
+  if (reactivate == Reactivate::YES)
     Open();
 
   return false;

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -11,6 +11,7 @@
 #include "addons/IAddon.h"
 #include "guilib/GUIDialog.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,6 +26,25 @@ enum class PerformButtonFocus
 {
   YES,
   NO,
+};
+
+enum class EntryPoint
+{
+  INSTALL,
+  UPDATE,
+  SHOW_DEPENDENCIES,
+};
+
+struct CInstalledWithAvailable
+{
+  ADDON::DependencyInfo m_depInfo;
+  std::shared_ptr<ADDON::IAddon> m_installed;
+  std::shared_ptr<ADDON::IAddon> m_available;
+  bool m_isInstalledUpToDate() const
+  {
+    return ((m_installed && m_available) && (m_installed->Version() == m_available->Version())) ||
+           (m_installed && !m_available);
+  };
 };
 
 class CGUIDialogAddonInfo : public CGUIDialog
@@ -90,11 +110,16 @@ private:
   /*!
    * @brief Show a dialog with the addon's dependencies.
    *
-   * @param[in] deps List of dependencies
    * @param[in] reactivate If true, reactivate info dialog when done
+   * @param[in] entryPoint INSTALL, UPDATE or SHOW_DEPENDENCIES
    * @return True if okay was selected, false otherwise
    */
-  bool ShowDependencyList(const std::vector<ADDON::DependencyInfo>& deps, Reactivate reactivate);
+  bool ShowDependencyList(Reactivate reactivate, EntryPoint entryPoint);
+
+  /*!
+   * @brief Used to build up the dependency list shown by @ref ShowDependencyList()
+   */
+  void BuildDependencyList();
 
   CFileItemPtr m_item;
   ADDON::AddonPtr m_localAddon;
@@ -105,4 +130,8 @@ private:
    *   be removed before installing a new version.
    */
   bool m_silentUninstall = false;
+
+  bool m_allDepsInstalled = true;
+  std::vector<ADDON::DependencyInfo> m_deps;
+  std::vector<CInstalledWithAvailable> m_depsInstalledWithAvailable;
 };

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -15,6 +15,12 @@
 #include <utility>
 #include <vector>
 
+enum class Reactivate
+{
+  YES,
+  NO,
+};
+
 class CGUIDialogAddonInfo : public CGUIDialog
 {
 public:
@@ -82,7 +88,7 @@ private:
    * @param[in] reactivate If true, reactivate info dialog when done
    * @return True if okay was selected, false otherwise
    */
-  bool ShowDependencyList(const std::vector<ADDON::DependencyInfo>& deps, bool reactivate);
+  bool ShowDependencyList(const std::vector<ADDON::DependencyInfo>& deps, Reactivate reactivate);
 
   CFileItemPtr m_item;
   ADDON::AddonPtr m_localAddon;

--- a/xbmc/addons/gui/GUIDialogAddonInfo.h
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.h
@@ -21,6 +21,12 @@ enum class Reactivate
   NO,
 };
 
+enum class PerformButtonFocus
+{
+  YES,
+  NO,
+};
+
 class CGUIDialogAddonInfo : public CGUIDialog
 {
 public:
@@ -44,7 +50,7 @@ private:
    * @return true if we can display information, false otherwise
    */
   bool SetItem(const CFileItemPtr& item);
-  void UpdateControls();
+  void UpdateControls(PerformButtonFocus performButtonFocus);
 
   void OnUpdate();
   void OnSelectVersion();


### PR DESCRIPTION
## Description

### Commit 1
ejects another bool parameter and replaces it with an enum

### Commit 2
suppresses toast notifications for successfully installed dependencies. toast notifications now only appear when installation of the `Main` or parent addon succeeds or fails. notifications for the dependencies only appear on a failed installation

### Commit 3
new behavior of DialogAddonInfo is a focused `Settings` button if settings are configurable, but `enabling` or `disabling` the addon focused the settings-button again. this is the fixup commit

### Commit 4
optional addons are now sorted to the top of the list

![screenshot00003](https://user-images.githubusercontent.com/58829855/97865175-125e9900-1d0a-11eb-8a0b-245c791fca93.png)

triggering installation of an addon with missing dependencies will show the dependency versions going to be installed

![screenshot00005](https://user-images.githubusercontent.com/58829855/97865450-839e4c00-1d0a-11eb-908d-ac6cf0e0ab1b.png)

if all needed dependecies are already installed on the system, the select-dialog will no longer pop up after pushing the install button.

dependencies of type `ADDON_SCRIPT_MODULE` are now hidden from the dialog.
previously dependencies (for example) `script.module.unidecode`, `...simpleeval` and `...routing` were also displayed which is not informative but may be confusing to a consumer.

finally an example for dependencies with updates pending

![screenshot00006](https://user-images.githubusercontent.com/58829855/97865685-ded03e80-1d0a-11eb-84c6-b8b590661dfa.png)

_note that this screenshot shows 'hidden' addons for demonstration purposes_
`Minimum: 2.12.4 / Installed: 2.22.0.1 => Update to: 2.22.0+matrix.1`

## How Has This Been Tested?
debian buster local

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
