### PR TITLE
Allow resume options to appear for .STRM files in Menus

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -579,7 +579,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int64_t& st
   startoffset = 0;
   partNumber = 0;
 
-  if (!item->IsNFO() && !item->IsPlayList())
+  if (!item->IsNFO())
   {
     if (item->GetCurrentResumeTimeAndPartNumber(startoffset, partNumber))
     {


### PR DESCRIPTION
## Description

I have removed code that prevents STRM files from displaying the resume menu/resume option in the context menu when a STRM file has a resume point in the database file. My motivation for this pull request was to enable resume functionality on STRM files.

## How Has This Been Tested?

I have compiled a build of Kodi with the modified file and the resume menu prompted for STRM files.
## Types of change

- [X ] **Improvement** (non-breaking change which improves existing functionality)

