### PR TITLE
[pvr] override SetYear for recordings

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -583,6 +583,12 @@ CDateTime CPVRRecording::FirstAired() const
   return m_firstAired;
 }
 
+void CPVRRecording::SetYear(int year)
+{
+  if (year > 0)
+    m_premiered = CDateTime(year, 1, 1, 0, 0, 0);
+}
+
 int CPVRRecording::GetYear() const
 {
   return m_premiered.GetYear();

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -304,13 +304,13 @@ namespace PVR
    void SetGenre(int iGenreType, int iGenreSubType, const std::string& strGenre);
 
     /*!
-     * @brief Get the genre type ID of this event.
+     * @brief Get the genre type ID of this recording.
      * @return The genre type ID.
      */
     int GenreType() const { return m_iGenreType; }
 
     /*!
-     * @brief Get the genre subtype ID of this event.
+     * @brief Get the genre subtype ID of this recording.
      * @return The genre subtype ID.
      */
     int GenreSubType() const { return m_iGenreSubType; }
@@ -322,32 +322,32 @@ namespace PVR
     const std::vector<std::string> Genre() const { return m_genre; }
 
     /*!
-     * @brief Get the genre(s) of this event as formatted string.
+     * @brief Get the genre(s) of this recording as formatted string.
      * @return The genres label.
      */
    const std::string GetGenresLabel() const;
 
    /*!
-    * @brief Get the first air date of this event.
+    * @brief Get the first air date of this recording.
     * @return The first air date.
     */
    CDateTime FirstAired() const;
 
    /*!
-    * @brief Get the premiere year of this event.
+    * @brief Get the premiere year of this recording.
     * @return The premiere year
     */
    int GetYear() const override;
 
    /*!
-    * @brief Set the premiere year of this event.
+    * @brief Set the premiere year of this recording.
     * @param year The premiere year
     */
    void SetYear(int year) override;
 
    /*!
-    * @brief Check if the premiere year of this event is valid
-    * @return True if the event has as valid premiere date, false otherwise
+    * @brief Check if the premiere year of this recording is valid
+    * @return True if the recording has as valid premiere date, false otherwise
     */
    bool HasYear() const override;
 

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -340,6 +340,12 @@ namespace PVR
    int GetYear() const override;
 
    /*!
+    * @brief Set the premiere year of this event.
+    * @param year The premiere year
+    */
+   void SetYear(int year) override;
+
+   /*!
     * @brief Check if the premiere year of this event is valid
     * @return True if the event has as valid premiere date, false otherwise
     */

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -139,7 +139,7 @@ public:
   void SetUniqueIDs(std::map<std::string, std::string> uniqueIDs);
   void SetPremiered(const CDateTime& premiered);
   void SetPremieredFromDBDate(const std::string& premieredString);
-  void SetYear(int year);
+  virtual void SetYear(int year);
   void SetArtist(std::vector<std::string> artist);
   void SetSet(std::string set);
   void SetSetOverview(std::string setOverview);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

Fix issue with year not displaying for PVR recordings introduced by https://github.com/xbmc/xbmc/pull/17217

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Alpha3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

OSX with pvr.vuplus

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
