### PR TITLE
Tone mapping: misc fixes and improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -187,15 +187,18 @@ void COutputShader::ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWid
   }
   if (m_toneMapping)
   {
-    float param = 0.7;
+    const float def_param = log10(100.0f) / log10(600.0f); // 600 nits --> 0.72
+    float param = def_param;
+
     if (m_hasLightMetadata)
-      param = log10(100) / log10(m_lightMetadata.MaxCLL);
+      param = static_cast<float>(log10(100) / log10(m_lightMetadata.MaxCLL));
     else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance)
-      param = log10(100) / log10(m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den);
+      param = static_cast<float>(log10(100) / log10(m_displayMetadata.max_luminance.num /
+                                                    m_displayMetadata.max_luminance.den));
 
     // Sanity check
     if (param < 0.1f || param > 5.0f)
-      param = 0.7f;
+      param = def_param;
 
     param *= m_toneMappingParam;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -423,12 +423,12 @@ void CRendererBase::CheckVideoParameters()
 {
   CRenderBuffer* buf = m_renderBuffers[m_iBufferIndex];
 
-  bool toneMap = false;
-  if (m_videoSettings.m_ToneMapMethod != VS_TONEMAPMETHOD_OFF && !DX::Windowing()->IsHDROutput())
-  {
-    if (buf->hasLightMetadata || buf->hasDisplayMetadata && buf->displayMetadata.has_luminance)
-      toneMap = true;
-  }
+  bool isHDRPQ = (buf->color_transfer == AVCOL_TRC_SMPTE2084 && buf->primaries == AVCOL_PRI_BT2020);
+
+  // HDR_TYPE::HDR_NONE_SDR is equivalent to !DX::Windowing()->IsHDROutput() using local variable
+  bool toneMap = (isHDRPQ && m_HdrType == HDR_TYPE::HDR_NONE_SDR &&
+                  m_videoSettings.m_ToneMapMethod != VS_TONEMAPMETHOD_OFF);
+
   bool hlg = (m_HdrType == HDR_TYPE::HDR_HLG);
 
   if (toneMap != m_toneMapping || m_cmsOn != m_colorManager->IsEnabled() || hlg != m_useHLGtoPQ)

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -406,11 +406,17 @@ void CGUIDialogVideoSettings::InitializeSettings()
   // tone mapping
   if (g_application.GetAppPlayer().Supports(RENDERFEATURE_TONEMAP))
   {
+    bool visible = !(CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                         CServiceBroker::GetWinSystem()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
+                     CServiceBroker::GetWinSystem()->IsHDRDisplay());
     entries.clear();
     entries.push_back(TranslatableIntegerSettingOption(36554, VS_TONEMAPMETHOD_OFF));
     entries.push_back(TranslatableIntegerSettingOption(36555, VS_TONEMAPMETHOD_REINHARD));
-    AddSpinner(groupVideo, SETTING_VIDEO_TONEMAP_METHOD, 36553, SettingLevel::Basic, videoSettings.m_ToneMapMethod, entries);
-    AddSlider(groupVideo, SETTING_VIDEO_TONEMAP_PARAM, 36556, SettingLevel::Basic, videoSettings.m_ToneMapParam, "%2.2f", 0.1f, 0.1f, 5.0f, 36556, usePopup);
+    AddSpinner(groupVideo, SETTING_VIDEO_TONEMAP_METHOD, 36553, SettingLevel::Basic,
+               videoSettings.m_ToneMapMethod, entries, false, visible);
+    AddSlider(groupVideo, SETTING_VIDEO_TONEMAP_PARAM, 36556, SettingLevel::Basic,
+              videoSettings.m_ToneMapParam, "%2.2f", 0.1f, 0.1f, 5.0f, 36556, usePopup, false,
+              visible);
   }
 
   // stereoscopic settings


### PR DESCRIPTION
## Description
- Improves/fix detection of some HDR PQ streams.
- Hides tone mapping settings from video OSD menu when is used HDR display (HDR passtrough).
- Removes compilation warnings.

## Motivation and Context
See https://forum.kodi.tv/showthread.php?tid=349861&pid=2985392#pid2985392 
Some HDR PQ sources has not Mastering Luminance and neither Light Metadata. 
This enables tone mapping for these sources using 600 nits by default.

Tone mapping is disabled by code when using HDR passthrough, but the settings (video OSD menu) are displayed anyway and can cause some confusion because does nothing change Reinhard slider.

## How Has This Been Tested?
The Mandalorian on SDR PC display.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
