### PR TITLE
[cmake] allow doxygen documentation generation for cross builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,16 +415,16 @@ if(CORE_HOST_IS_TARGET AND ENABLE_TESTING)
       message(FATAL_ERROR "Code coverage not (yet) implemented for platform ${CORE_SYSTEM_NAME}")
     endif()
   endif()
+endif()
 
-  # Documentation
-  find_package(Doxygen)
-  if(DOXYGEN_FOUND)
-    add_custom_target(doc
-                      COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/doxygen/Doxyfile.doxy
-                      COMMAND ${CMAKE_COMMAND} -E echo "Documentation built to: file://${CMAKE_SOURCE_DIR}/docs/html/index.html"
-                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/doxygen
-                      COMMENT "Generating Doxygen documentation" VERBATIM)
-  endif()
+# Documentation
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+  add_custom_target(doc
+                    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/doxygen/Doxyfile.doxy
+                    COMMAND ${CMAKE_COMMAND} -E echo "Documentation built to: file://${CMAKE_SOURCE_DIR}/docs/html/index.html"
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/doxygen
+                    COMMENT "Generating Doxygen documentation" VERBATIM)
 endif()
 
 # link wrapper


### PR DESCRIPTION
## Description
allow doxygen documentation generation for cross builds

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
