### PR TITLE
[tvOS] relocate DarwinNSUserDefaults to tvOS

### DIFF
--- a/xbmc/platform/darwin/ios-common/CMakeLists.txt
+++ b/xbmc/platform/darwin/ios-common/CMakeLists.txt
@@ -4,7 +4,6 @@ set(SOURCES AnnounceReceiver.mm
             DarwinEmbedKeyboardView.mm
             DarwinEmbedNowPlayingInfoManager.mm
             DarwinEmbedUtils.mm
-            DarwinNSUserDefaults.mm
             NSData+GZIP.m)
 
 set(HEADERS AnnounceReceiver.h
@@ -13,7 +12,6 @@ set(HEADERS AnnounceReceiver.h
             DarwinEmbedKeyboardView.h
             DarwinEmbedNowPlayingInfoManager.h
             DarwinEmbedUtils.h
-            DarwinNSUserDefaults.h
             NSData+GZIP.h)
 
 core_add_library(platform_ios-common)

--- a/xbmc/platform/darwin/tvos/CMakeLists.txt
+++ b/xbmc/platform/darwin/tvos/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES PreflightHandler.mm
             TVOSDisplayManager.mm
             TVOSEAGLView.mm
             TVOSKeyboardView.mm
+            TVOSNSUserDefaults.mm
             TVOSSettingsHandler.mm
             tvosShared.mm
             TVOSTopShelf.mm
@@ -11,6 +12,7 @@ set(HEADERS PreflightHandler.h
             TVOSDisplayManager.h
             TVOSEAGLView.h
             TVOSKeyboardView.h
+            TVOSNSUserDefaults.h
             TVOSSettingsHandler.h
             tvosShared.h
             TVOSTopShelf.h

--- a/xbmc/platform/darwin/tvos/PreflightHandler.mm
+++ b/xbmc/platform/darwin/tvos/PreflightHandler.mm
@@ -25,7 +25,7 @@
 #include "utils/log.h"
 
 #import "platform/darwin/NSLogDebugHelpers.h"
-#import "platform/darwin/ios-common/DarwinNSUserDefaults.h"
+#import "platform/darwin/tvos/TVOSNSUserDefaults.h"
 #import "platform/darwin/tvos/filesystem/TVOSFile.h"
 #import "platform/darwin/tvos/filesystem/TVOSFileUtils.h"
 #include "platform/posix/filesystem/PosixFile.h"

--- a/xbmc/platform/darwin/tvos/TVOSNSUserDefaults.h
+++ b/xbmc/platform/darwin/tvos/TVOSNSUserDefaults.h
@@ -9,7 +9,7 @@
 
 #include <string>
 
-class CDarwinNSUserDefaults
+class CTVOSNSUserDefaults
 {
 public:
   static bool Synchronize();

--- a/xbmc/platform/darwin/tvos/TVOSNSUserDefaults.mm
+++ b/xbmc/platform/darwin/tvos/TVOSNSUserDefaults.mm
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#import "DarwinNSUserDefaults.h"
+#import "TVOSNSUserDefaults.h"
 
 #import "filesystem/SpecialProtocol.h"
 #import "utils/URIUtils.h"
@@ -59,13 +59,13 @@ static bool translatePathIntoKey(const std::string& path, std::string& key)
   return false;
 }
 
-bool CDarwinNSUserDefaults::Synchronize()
+bool CTVOSNSUserDefaults::Synchronize()
 {
   return [[NSUserDefaults standardUserDefaults] synchronize] == YES;
 }
 
-void CDarwinNSUserDefaults::GetDirectoryContents(const std::string& path,
-                                                 std::vector<std::string>& contents)
+void CTVOSNSUserDefaults::GetDirectoryContents(const std::string& path,
+                                               std::vector<std::string>& contents)
 {
   // tvos path adds /private/../..
   // We need to strip this as GetUserHomeDirectory() doesnt have private in the path
@@ -101,7 +101,7 @@ void CDarwinNSUserDefaults::GetDirectoryContents(const std::string& path,
   }
 }
 
-bool CDarwinNSUserDefaults::GetKey(const std::string& key, std::string& value)
+bool CTVOSNSUserDefaults::GetKey(const std::string& key, std::string& value)
 {
   if (!key.empty())
   {
@@ -119,7 +119,7 @@ bool CDarwinNSUserDefaults::GetKey(const std::string& key, std::string& value)
   return false;
 }
 
-bool CDarwinNSUserDefaults::GetKeyData(const std::string& key, void* lpBuf, size_t& uiBufSize)
+bool CTVOSNSUserDefaults::GetKeyData(const std::string& key, void* lpBuf, size_t& uiBufSize)
 {
   if (key.empty())
   {
@@ -150,9 +150,7 @@ bool CDarwinNSUserDefaults::GetKeyData(const std::string& key, void* lpBuf, size
   return true;
 }
 
-bool CDarwinNSUserDefaults::SetKey(const std::string& key,
-                                   const std::string& value,
-                                   bool synchronize)
+bool CTVOSNSUserDefaults::SetKey(const std::string& key, const std::string& value, bool synchronize)
 {
   if (!key.empty() && !value.empty())
   {
@@ -171,10 +169,10 @@ bool CDarwinNSUserDefaults::SetKey(const std::string& key,
   return false;
 }
 
-bool CDarwinNSUserDefaults::SetKeyData(const std::string& key,
-                                       const void* lpBuf,
-                                       size_t uiBufSize,
-                                       bool synchronize)
+bool CTVOSNSUserDefaults::SetKeyData(const std::string& key,
+                                     const void* lpBuf,
+                                     size_t uiBufSize,
+                                     bool synchronize)
 {
   if (!key.empty() && lpBuf != nullptr && uiBufSize > 0)
   {
@@ -196,7 +194,7 @@ bool CDarwinNSUserDefaults::SetKeyData(const std::string& key,
   return false;
 }
 
-bool CDarwinNSUserDefaults::DeleteKey(const std::string& key, bool synchronize)
+bool CTVOSNSUserDefaults::DeleteKey(const std::string& key, bool synchronize)
 {
   if (!key.empty())
   {
@@ -212,7 +210,7 @@ bool CDarwinNSUserDefaults::DeleteKey(const std::string& key, bool synchronize)
   return false;
 }
 
-bool CDarwinNSUserDefaults::KeyExists(const std::string& key)
+bool CTVOSNSUserDefaults::KeyExists(const std::string& key)
 {
   if (!key.empty())
   {
@@ -224,7 +222,7 @@ bool CDarwinNSUserDefaults::KeyExists(const std::string& key)
   return false;
 }
 
-bool CDarwinNSUserDefaults::IsKeyFromPath(const std::string& path)
+bool CTVOSNSUserDefaults::IsKeyFromPath(const std::string& path)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty())
@@ -236,63 +234,63 @@ bool CDarwinNSUserDefaults::IsKeyFromPath(const std::string& path)
   return false;
 }
 
-bool CDarwinNSUserDefaults::GetKeyFromPath(const std::string& path, std::string& value)
+bool CTVOSNSUserDefaults::GetKeyFromPath(const std::string& path, std::string& value)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty())
-    return CDarwinNSUserDefaults::GetKey(translated_key, value);
+    return CTVOSNSUserDefaults::GetKey(translated_key, value);
 
   return false;
 }
 
-bool CDarwinNSUserDefaults::GetKeyDataFromPath(const std::string& path,
-                                               void* lpBuf,
-                                               size_t& uiBufSize)
+bool CTVOSNSUserDefaults::GetKeyDataFromPath(const std::string& path,
+                                             void* lpBuf,
+                                             size_t& uiBufSize)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty())
-    return CDarwinNSUserDefaults::GetKeyData(translated_key, lpBuf, uiBufSize);
+    return CTVOSNSUserDefaults::GetKeyData(translated_key, lpBuf, uiBufSize);
 
   return false;
 }
 
-bool CDarwinNSUserDefaults::SetKeyFromPath(const std::string& path,
-                                           const std::string& value,
-                                           bool synchronize)
+bool CTVOSNSUserDefaults::SetKeyFromPath(const std::string& path,
+                                         const std::string& value,
+                                         bool synchronize)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty() && !value.empty())
-    return CDarwinNSUserDefaults::SetKey(translated_key, value, synchronize);
+    return CTVOSNSUserDefaults::SetKey(translated_key, value, synchronize);
 
   return false;
 }
 
-bool CDarwinNSUserDefaults::SetKeyDataFromPath(const std::string& path,
-                                               const void* lpBuf,
-                                               size_t uiBufSize,
-                                               bool synchronize)
+bool CTVOSNSUserDefaults::SetKeyDataFromPath(const std::string& path,
+                                             const void* lpBuf,
+                                             size_t uiBufSize,
+                                             bool synchronize)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty())
-    return CDarwinNSUserDefaults::SetKeyData(translated_key, lpBuf, uiBufSize, synchronize);
+    return CTVOSNSUserDefaults::SetKeyData(translated_key, lpBuf, uiBufSize, synchronize);
 
   return false;
 }
 
-bool CDarwinNSUserDefaults::DeleteKeyFromPath(const std::string& path, bool synchronize)
+bool CTVOSNSUserDefaults::DeleteKeyFromPath(const std::string& path, bool synchronize)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty())
-    return CDarwinNSUserDefaults::DeleteKey(translated_key, synchronize);
+    return CTVOSNSUserDefaults::DeleteKey(translated_key, synchronize);
 
   return false;
 }
 
-bool CDarwinNSUserDefaults::KeyFromPathExists(const std::string& path)
+bool CTVOSNSUserDefaults::KeyFromPathExists(const std::string& path)
 {
   std::string translated_key;
   if (translatePathIntoKey(path, translated_key) && !translated_key.empty())
-    return CDarwinNSUserDefaults::KeyExists(translated_key);
+    return CTVOSNSUserDefaults::KeyExists(translated_key);
 
   return false;
 }

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSDirectory.cpp
@@ -27,7 +27,7 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
-#include "platform/darwin/ios-common/DarwinNSUserDefaults.h"
+#include "platform/darwin/tvos/TVOSNSUserDefaults.h"
 #include "platform/darwin/tvos/filesystem/TVOSFile.h"
 #include "platform/darwin/tvos/filesystem/TVOSFileUtils.h"
 #include "platform/posix/filesystem/PosixDirectory.h"
@@ -74,7 +74,7 @@ bool CTVOSDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
   // GetDirectoryContents will return full paths
   std::vector<std::string> contents;
-  CDarwinNSUserDefaults::GetDirectoryContents(rootpath, contents);
+  CTVOSNSUserDefaults::GetDirectoryContents(rootpath, contents);
   for (const auto& path : contents)
   {
     CFileItemPtr pItem(new CFileItem(URIUtils::GetFileName(path)));

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSFile.cpp
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSFile.cpp
@@ -24,7 +24,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
-#include "platform/darwin/ios-common/DarwinNSUserDefaults.h"
+#include "platform/darwin/tvos/TVOSNSUserDefaults.h"
 #include "platform/posix/filesystem/PosixFile.h"
 
 #include <sys/stat.h>
@@ -41,7 +41,7 @@ bool CTVOSFile::WantsFile(const CURL& url)
   if (!StringUtils::EqualsNoCase(url.GetFileType(), "xml") ||
       StringUtils::StartsWithNoCase(url.GetFileNameWithoutPath(), "customcontroller.SiriRemote"))
     return false;
-  return CDarwinNSUserDefaults::IsKeyFromPath(url.Get());
+  return CTVOSNSUserDefaults::IsKeyFromPath(url.Get());
 }
 
 int CTVOSFile::CacheStat(const CURL& url, struct __stat64* buffer)
@@ -50,7 +50,7 @@ int CTVOSFile::CacheStat(const CURL& url, struct __stat64* buffer)
   {
     size_t size = 0;
     // get the size from the data by passing in a nullptr
-    if (CDarwinNSUserDefaults::GetKeyDataFromPath(url.Get(), nullptr, size))
+    if (CTVOSNSUserDefaults::GetKeyDataFromPath(url.Get(), nullptr, size))
     {
       memset(buffer, 0, sizeof(struct __stat64));
       // mimic stat
@@ -69,7 +69,7 @@ int CTVOSFile::CacheStat(const CURL& url, struct __stat64* buffer)
 
 bool CTVOSFile::Open(const CURL& url)
 {
-  if (CDarwinNSUserDefaults::KeyFromPathExists(url.Get()))
+  if (CTVOSNSUserDefaults::KeyFromPathExists(url.Get()))
   {
     m_url = url;
     m_position = 0;
@@ -86,7 +86,7 @@ bool CTVOSFile::Open(const CURL& url)
 
 bool CTVOSFile::OpenForWrite(const CURL& url, bool bOverWrite /* = false */)
 {
-  if (CDarwinNSUserDefaults::KeyFromPathExists(url.Get()) && !bOverWrite)
+  if (CTVOSNSUserDefaults::KeyFromPathExists(url.Get()) && !bOverWrite)
     return false; // no overwrite
 
   bool ret = WantsFile(url); // if we want the file we can write it ...
@@ -100,7 +100,7 @@ bool CTVOSFile::OpenForWrite(const CURL& url, bool bOverWrite /* = false */)
 
 bool CTVOSFile::Delete(const CURL& url)
 {
-  bool ret = CDarwinNSUserDefaults::DeleteKeyFromPath(url.Get(), true);
+  bool ret = CTVOSNSUserDefaults::DeleteKeyFromPath(url.Get(), true);
 
   if (!ret)
   {
@@ -112,7 +112,7 @@ bool CTVOSFile::Delete(const CURL& url)
 
 bool CTVOSFile::Exists(const CURL& url)
 {
-  bool ret = CDarwinNSUserDefaults::KeyFromPathExists(url.Get());
+  bool ret = CTVOSNSUserDefaults::KeyFromPathExists(url.Get());
   if (!ret)
   {
     CPosixFile posix;
@@ -139,14 +139,14 @@ bool CTVOSFile::Rename(const CURL& url, const CURL& urlnew)
   {
     void* lpBuf = nullptr;
     size_t uiBufSize = 0;
-    if (CDarwinNSUserDefaults::GetKeyDataFromPath(url.Get(), lpBuf,
-                                                  uiBufSize)) // get size from old file
+    if (CTVOSNSUserDefaults::GetKeyDataFromPath(url.Get(), lpBuf,
+                                                uiBufSize)) // get size from old file
     {
       lpBuf = static_cast<void*>(new char[uiBufSize]);
-      if (CDarwinNSUserDefaults::GetKeyDataFromPath(url.Get(), lpBuf, uiBufSize)) // read old file
+      if (CTVOSNSUserDefaults::GetKeyDataFromPath(url.Get(), lpBuf, uiBufSize)) // read old file
       {
-        if (CDarwinNSUserDefaults::SetKeyDataFromPath(urlnew.Get(), lpBuf, uiBufSize,
-                                                      true)) // write to new url
+        if (CTVOSNSUserDefaults::SetKeyDataFromPath(urlnew.Get(), lpBuf, uiBufSize,
+                                                    true)) // write to new url
         {
           // remove old file
           Delete(url);
@@ -181,12 +181,12 @@ ssize_t CTVOSFile::Read(void* lpBuf, size_t uiBufSize)
   if (m_position > 0 && m_position == GetLength())
     return 0; // simulate read 0 bytes on EOF
 
-  if (CDarwinNSUserDefaults::GetKeyDataFromPath(m_url.Get(), lpBufInternal,
-                                                uiBufSize)) // read size of file
+  if (CTVOSNSUserDefaults::GetKeyDataFromPath(m_url.Get(), lpBufInternal,
+                                              uiBufSize)) // read size of file
   {
     lpBufInternal = static_cast<void*>(new char[uiBufSize]);
-    if (CDarwinNSUserDefaults::GetKeyDataFromPath(m_url.Get(), lpBufInternal,
-                                                  uiBufSize)) // read file
+    if (CTVOSNSUserDefaults::GetKeyDataFromPath(m_url.Get(), lpBufInternal,
+                                                uiBufSize)) // read file
     {
       memcpy(lpBuf, lpBufInternal, uiBufSize);
     }
@@ -201,8 +201,8 @@ ssize_t CTVOSFile::Write(const void* lpBuf, size_t uiBufSize)
   if (m_pFallbackFile != nullptr)
     return m_pFallbackFile->Write(lpBuf, uiBufSize);
 
-  if (CDarwinNSUserDefaults::SetKeyDataFromPath(m_url.Get(), lpBuf, uiBufSize,
-                                                true)) // write to file
+  if (CTVOSNSUserDefaults::SetKeyDataFromPath(m_url.Get(), lpBuf, uiBufSize,
+                                              true)) // write to file
   {
     m_position = uiBufSize;
     CacheStat(m_url, &m_cachedStat);


### PR DESCRIPTION
## Description
It cannot be used on iOS, as it calls `CTVOSFileUtils::GetUserHomeDirectory()`.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
