### PR TITLE
[addons][inputstream][videocodec] Fix wrong flags bit shift

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -219,34 +219,34 @@ extern "C"
   enum INPUTSTREAM_FLAGS
   {
     /// @brief **0000 0000 0000 0000 :** Empty to set if nothing is used
-    INPUTSTREAM_FLAG_NONE = (1 << 0),
+    INPUTSTREAM_FLAG_NONE = 0,
 
     /// @brief **0000 0000 0000 0001 :** Default
-    INPUTSTREAM_FLAG_DEFAULT = (1 << 1),
+    INPUTSTREAM_FLAG_DEFAULT = (1 << 0),
 
     /// @brief **0000 0000 0000 0010 :** Dub
-    INPUTSTREAM_FLAG_DUB = (1 << 2),
+    INPUTSTREAM_FLAG_DUB = (1 << 1),
 
     /// @brief **0000 0000 0000 0100 :** Original
-    INPUTSTREAM_FLAG_ORIGINAL = (1 << 3),
+    INPUTSTREAM_FLAG_ORIGINAL = (1 << 2),
 
     /// @brief **0000 0000 0000 1000 :** Comment
-    INPUTSTREAM_FLAG_COMMENT = (1 << 4),
+    INPUTSTREAM_FLAG_COMMENT = (1 << 3),
 
     /// @brief **0000 0000 0001 0000 :** Lyrics
-    INPUTSTREAM_FLAG_LYRICS = (1 << 5),
+    INPUTSTREAM_FLAG_LYRICS = (1 << 4),
 
     /// @brief **0000 0000 0010 0000 :** Karaoke
-    INPUTSTREAM_FLAG_KARAOKE = (1 << 6),
+    INPUTSTREAM_FLAG_KARAOKE = (1 << 5),
 
     /// @brief **0000 0000 0100 0000 :** Forced
-    INPUTSTREAM_FLAG_FORCED = (1 << 7),
+    INPUTSTREAM_FLAG_FORCED = (1 << 6),
 
     /// @brief **0000 0000 1000 0000 :** Hearing impaired
-    INPUTSTREAM_FLAG_HEARING_IMPAIRED = (1 << 8),
+    INPUTSTREAM_FLAG_HEARING_IMPAIRED = (1 << 7),
 
     /// @brief **0000 0001 0000 0000 :** Visual impaired
-    INPUTSTREAM_FLAG_VISUAL_IMPAIRED = (1 << 9),
+    INPUTSTREAM_FLAG_VISUAL_IMPAIRED = (1 << 8),
   };
   ///@}
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -19,7 +19,7 @@
 #include <time.h>
 
 // Increment this level always if you add features which can lead to compile failures in the addon
-#define INPUTSTREAM_VERSION_LEVEL 3
+#define INPUTSTREAM_VERSION_LEVEL 4
 
 #define INPUTSTREAM_MAX_INFO_COUNT 8
 #define INPUTSTREAM_MAX_STREAM_COUNT 256

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -107,8 +107,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.0.0"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.0.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.0.1"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.0.1"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
                                                       "c-api/addon-instance/inputstream/demux_packet.h" \
@@ -172,8 +172,8 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h" \
                                                       "c-api/addon-instance/visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.0.0"
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.0.0"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.0.1"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.0.1"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "c-api/addon-instance/video_codec.h" \
                                                       "c-api/addon-instance/inputstream/stream_codec.h" \


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
The PR https://github.com/xbmc/xbmc/pull/17438 has introduced a wrong bit shift that cause impossibility to set audio streams properties
@AlwinEsch
@peak3d i think need new ISA build (but this is not related to the problem of playback start)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The modified enum should be translatable with:
https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/Interface/StreamInfo.h#L18-L30

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested with NF addon related to Issue: https://github.com/peak3d/inputstream.adaptive/issues/548

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
