### PR TITLE
Android: Update README to specify '--sdk_root'

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -92,10 +92,10 @@ unzip $HOME/Downloads/android-ndk-r20-linux-x86_64.zip -d $HOME/android-tools
 Before Android SDK can be used, you need to accept the licenses and configure it:
 ```
 cd $HOME/android-tools/android-sdk-linux/cmdline-tools/tools/bin
-./sdkmanager --licenses
-./sdkmanager platform-tools
-./sdkmanager "platforms;android-28"
-./sdkmanager "build-tools;28.0.3"
+./sdkmanager --sdk_root=$(pwd)/../.. --licenses
+./sdkmanager --sdk_root=$(pwd)/../.. platform-tools
+./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-28"
+./sdkmanager --sdk_root=$(pwd)/../.. "build-tools;28.0.3"
 ```
 
 ### 3.3. Create a key to sign debug APKs


### PR DESCRIPTION
## Description

Currently, if the sdk manager is called without the `--sdk_root` parameter, it fails with the following error message:

    | Warning: Could not create settings
    | java.lang.IllegalArgumentException

Included in the output appears the option '--sdk_root'. A quick stack overflow search reveals that this parameter is now necessary to call sdkmanager.

## Motivation and Context

I made this change when working on https://github.com/filecoin-project/cpp-filecoin/pull/114. Forgot to PR. Then https://github.com/xbmc/xbmc/pull/18694 was opened and I remembered I needed this to build Android back in February. @peak3d plans to rebase the 29 bump on this once it's merged.

## How Has This Been Tested?

Tried to build using existing instructions. Got the above error. Used the new instructions. Android with my Filecoin patches built successfully.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
