### PR TITLE
Added ability to override minTempo - WFM

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -579,7 +579,7 @@ float CProcessInfo::MaxTempoPlatform()
 
 bool CProcessInfo::IsTempoAllowed(float tempo)
 {
-  if (tempo > MinTempoPlatform() &&
+  if ((tempo > MinTempoPlatform() || tempo > CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_minTempo) &&
       (tempo < MaxTempoPlatform() || tempo < CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_maxTempo))
     return true;
 

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -579,8 +579,8 @@ float CProcessInfo::MaxTempoPlatform()
 
 bool CProcessInfo::IsTempoAllowed(float tempo)
 {
-  if ((tempo > MinTempoPlatform() || tempo > CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_minTempo) &&
-      (tempo < MaxTempoPlatform() || tempo < CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_maxTempo))
+  if ((tempo > MinTempoPlatform() || tempo >= CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_minTempo) &&
+      (tempo < MaxTempoPlatform() || tempo <= CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_maxTempo))
     return true;
 
   return false;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -700,7 +700,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
-    XMLUtils::GetFloat(pElement, "mintempo", m_minTempo, 0.3, 0.9);
+    XMLUtils::GetFloat(pElement, "mintempo", m_minTempo, 0.5, 0.9);
     XMLUtils::GetFloat(pElement, "maxtempo", m_maxTempo, 1.5, 2.1);
     XMLUtils::GetBoolean(pElement, "preferstereostream", m_videoPreferStereoStream);
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -152,6 +152,7 @@ void CAdvancedSettings::Initialize()
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
   m_videoFpsDetect = 1;
+  m_minTempo = 0.75f;
   m_maxTempo = 1.55f;
   m_videoPreferStereoStream = false;
 
@@ -699,6 +700,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
+    XMLUtils::GetFloat(pElement, "mintempo", m_minTempo, 0.3, 0.9);
     XMLUtils::GetFloat(pElement, "maxtempo", m_maxTempo, 1.5, 2.1);
     XMLUtils::GetBoolean(pElement, "preferstereostream", m_videoPreferStereoStream);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -171,6 +171,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
     int  m_videoFpsDetect;
+    float m_minTempo;
     float m_maxTempo;
     bool m_videoPreferStereoStream = false;
 


### PR DESCRIPTION
Added ability to override minTempo based on commit found in https://github.com/xbmc/xbmc/pull/13325

Not sure why only maxTempo was added in that commit. FernetMenta did
react to Rechi that this was intended, I have no idea why unfortunately.

Wanted to be able to play at 0.5 speed. Seen requests for this from sports fans, personally I wanted it for playing back recordings from my dance lessons of fast paced dances to be able to learn them easier.