### PR TITLE
[fix] add tvOS @available check for GCExtendedGamepad.(left|right)ThumbstickButton

### DIFF
--- a/xbmc/platform/darwin/ios-common/peripherals/Input_Gamecontroller.mm
+++ b/xbmc/platform/darwin/ios-common/peripherals/Input_Gamecontroller.mm
@@ -395,7 +395,7 @@ struct PlayerControllerState
                              withAxis:GCCONTROLLER_EXTENDED_GAMEPAD_AXIS::RIGHT
                       withplayerIndex:playerIndex];
     }
-    if (@available(iOS 12.1, *))
+    if (@available(iOS 12.1, tvOS 12.1, *))
     {
       // Left Thumbstick Button
       if (gamepad.leftThumbstickButton == element)
@@ -566,7 +566,7 @@ struct PlayerControllerState
         [controller.extendedGamepad performSelector:@selector(buttonOptions)] != nil)
       ++optionalButtonCount;
 
-    if (@available(iOS 12.1, *))
+    if (@available(iOS 12.1, tvOS 12.1, *))
     {
       if (controller.extendedGamepad.leftThumbstickButton)
         ++optionalButtonCount;


### PR DESCRIPTION
## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
