### PR TITLE
windowing/wayland: fix spelling error in egl guard

### DIFF
--- a/xbmc/windowing/wayland/OptionalsReg.cpp
+++ b/xbmc/windowing/wayland/OptionalsReg.cpp
@@ -11,7 +11,7 @@
 //-----------------------------------------------------------------------------
 // VAAPI
 //-----------------------------------------------------------------------------
-#if defined (HAVE_LIBVA) && defined(HAVE_EGL)
+#if defined(HAVE_LIBVA) && defined(HAS_EGL)
 #include <va/va_wayland.h>
 #include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h"


### PR DESCRIPTION
introduced in #18493. my bad.

https://github.com/xbmc/xbmc/blob/master/cmake/modules/FindEGL.cmake#L37