### PR TITLE
Fixing self assigment bug

### DIFF
--- a/xbmc/network/websocket/WebSocketManager.cpp
+++ b/xbmc/network/websocket/WebSocketManager.cpp
@@ -49,7 +49,7 @@ CWebSocket* CWebSocketManager::Handle(const char* data, unsigned int length, std
   {
     CLog::Log(LOGINFO, "WebSocket: missing Sec-WebSocket-Version");
     CHttpResponse httpResponse(HTTP::Get, HTTP::BadRequest, HTTP::Version1_1);
-    response = response = httpResponse.Create();;
+    response = httpResponse.Create();
 
     return NULL;
   }
@@ -65,7 +65,7 @@ CWebSocket* CWebSocketManager::Handle(const char* data, unsigned int length, std
     CLog::Log(LOGINFO, "WebSocket: Unsupported Sec-WebSocket-Version %s", value);
     CHttpResponse httpResponse(HTTP::Get, HTTP::UpgradeRequired, HTTP::Version1_1);
     httpResponse.AddHeader(WS_HEADER_VERSION, WS_SUPPORTED_VERSIONS);
-    response = response = httpResponse.Create();
+    response = httpResponse.Create();
 
     return NULL;
   }

--- a/xbmc/network/websocket/WebSocketV8.cpp
+++ b/xbmc/network/websocket/WebSocketV8.cpp
@@ -116,7 +116,7 @@ bool CWebSocketV8::Handshake(const char* data, size_t length, std::string &respo
   if (!websocketProtocol.empty())
     httpResponse.AddHeader(WS_HEADER_PROTOCOL, websocketProtocol);
 
-  response = response = httpResponse.Create();
+  response = httpResponse.Create();
 
   m_state = WebSocketStateConnected;
 

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -1285,7 +1285,6 @@ void CTeletextDecoder::RenderPage()
         else
         {
           SetPosX(33+i);
-          m_RenderInfo.PageChar[32+i] = m_RenderInfo.PageChar[32+i];
         }
       }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
I noticed that there was a issue that mention that there were problems with self assigment so I fixed the issue #18717 by @qarmin



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
