### PR TITLE
[PVR] GetRecordings: Do not delete recordings for failed clients.

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -510,11 +510,16 @@ PVR_ERROR CPVRClients::GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>
   });
 }
 
-PVR_ERROR CPVRClients::GetRecordings(CPVRRecordings* recordings, bool deleted)
+PVR_ERROR CPVRClients::GetRecordings(CPVRRecordings* recordings,
+                                     bool deleted,
+                                     std::vector<int>& failedClients)
 {
-  return ForCreatedClients(__FUNCTION__, [recordings, deleted](const std::shared_ptr<CPVRClient>& client) {
-    return client->GetRecordings(recordings, deleted);
-  });
+  return ForCreatedClients(
+      __FUNCTION__,
+      [recordings, deleted](const std::shared_ptr<CPVRClient>& client) {
+        return client->GetRecordings(recordings, deleted);
+      },
+      failedClients);
 }
 
 PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -200,9 +200,12 @@ namespace PVR
      * @brief Get all recordings from clients
      * @param recordings Store the recordings in this container.
      * @param deleted If true, return deleted recordings, return not deleted recordings otherwise.
+     * @param failedClients in case of errors will contain the ids of the clients for which the recordings could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
      */
-    PVR_ERROR GetRecordings(CPVRRecordings* recordings, bool deleted);
+    PVR_ERROR GetRecordings(CPVRRecordings* recordings,
+                            bool deleted,
+                            std::vector<int>& failedClients);
 
     /*!
      * @brief Delete all "soft" deleted recordings permanently on the backend.

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -40,13 +40,15 @@ void CPVRRecordings::UpdateFromClients()
   for (const auto& recording : m_recordings)
     recording.second->SetDirty(true);
 
-  CServiceBroker::GetPVRManager().Clients()->GetRecordings(this, false);
-  CServiceBroker::GetPVRManager().Clients()->GetRecordings(this, true);
+  std::vector<int> failedClients;
+  CServiceBroker::GetPVRManager().Clients()->GetRecordings(this, false, failedClients);
+  CServiceBroker::GetPVRManager().Clients()->GetRecordings(this, true, failedClients);
 
   // remove recordings that were deleted at the backend
   for (auto it = m_recordings.begin(); it != m_recordings.end();)
   {
-    if ((*it).second->IsDirty())
+    if ((*it).second->IsDirty() && std::find(failedClients.begin(), failedClients.end(),
+                                             (*it).second->ClientID()) == failedClients.end())
       it = m_recordings.erase(it);
     else
       ++it;


### PR DESCRIPTION
Followup to #18671 , where I forgot to add proper multi-client support.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish mind looking at the code change.