### PR TITLE
[addons] fix crash when updating addon with private repo in manifest

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -62,6 +62,16 @@ public:
   bool HasType(TYPE type) const override { return m_addonInfo->HasType(type); }
 
   /**
+   * @brief To check complete addon (not only this) has a specific type
+   * defined in its first extension point including the provided subcontent
+   * e.g. video or audio
+   *
+   * @param[in] type Type identifier to be checked
+   * @return true in case the wanted type is the main type, false if not
+   */
+  bool HasMainType(TYPE type) const override { return m_addonInfo->HasType(type, true); }
+
+  /**
    * @brief The get for given addon type information and extension data
    *
    * @param[in] type The wanted type data

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -675,7 +675,7 @@ bool CAddonInstallJob::DoWork()
   {
     origin = ORIGIN_SYSTEM; // keep system add-on origin as ORIGIN_SYSTEM
   }
-  else if (m_addon->HasType(ADDON_REPOSITORY))
+  else if (m_addon->HasMainType(ADDON_REPOSITORY))
   {
     origin = m_addon->ID(); // use own id as origin if repository
     if (m_isUpdate)

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -36,6 +36,7 @@ namespace ADDON
     virtual TYPE MainType() const = 0;
     virtual TYPE Type() const =0;
     virtual bool HasType(TYPE type) const = 0;
+    virtual bool HasMainType(TYPE type) const = 0;
     virtual std::string ID() const =0;
     virtual std::string Name() const =0;
     virtual bool IsInUse() const =0;


### PR DESCRIPTION
## Description
fixes crash by correcting call to `IAddon->HasType()`

## Motivation and Context
closes #18715 

## How Has This Been Tested?
by issue reporter. thanks @djp952 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
