### PR TITLE
[GBM] add ability to screenshot with video plane

### DIFF
--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -13,7 +13,7 @@ class IScreenshotSurface
 public:
   virtual ~IScreenshotSurface() = default;
   virtual bool Capture() { return false; }
-  virtual bool CaptureVideo(bool blendToBuffer) { return true; }
+  virtual bool CaptureVideo() { return true; }
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -13,7 +13,7 @@ class IScreenshotSurface
 public:
   virtual ~IScreenshotSurface() = default;
   virtual bool Capture() { return false; }
-  virtual void CaptureVideo(bool blendToBuffer) { };
+  virtual bool CaptureVideo(bool blendToBuffer) { return true; }
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -47,7 +47,7 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
     return;
   }
 
-  if (!surface->CaptureVideo(true))
+  if (!surface->CaptureVideo())
   {
     CLog::Log(LOGERROR, "Screenshot video %s failed", CURL::GetRedacted(filename).c_str());
     return;

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -47,7 +47,11 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
     return;
   }
 
-  surface->CaptureVideo(true);
+  if (!surface->CaptureVideo(true))
+  {
+    CLog::Log(LOGERROR, "Screenshot video %s failed", CURL::GetRedacted(filename).c_str());
+    return;
+  }
 
   CLog::Log(LOGDEBUG, "Saving screenshot %s", CURL::GetRedacted(filename).c_str());
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -28,6 +28,7 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
+#include "windowing/gbm/drm/ScreenshotSurfaceDRM.h"
 
 #include <gbm.h>
 
@@ -77,6 +78,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   VIDEOPLAYER::CProcessInfoGBM::Register();
 
   CScreenshotSurfaceGLES::Register();
+  CScreenshotSurfaceDRM::Register();
 
   CBufferObjectFactory::ClearBufferObjects();
   CDumbBufferObject::Register();

--- a/xbmc/windowing/gbm/drm/CMakeLists.txt
+++ b/xbmc/windowing/gbm/drm/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCES DRMAtomic.cpp
             DRMObject.cpp
             DRMPlane.cpp
             DRMUtils.cpp
-            OffScreenModeSetting.cpp)
+            OffScreenModeSetting.cpp
+            ScreenshotSurfaceDRM.cpp)
 
 set(HEADERS DRMAtomic.h
             DRMConnector.h
@@ -16,6 +17,7 @@ set(HEADERS DRMAtomic.h
             DRMObject.h
             DRMPlane.h
             DRMUtils.h
-            OffScreenModeSetting.h)
+            OffScreenModeSetting.h
+            ScreenshotSurfaceDRM.h)
 
 core_add_library(windowing_gbm_drm)

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -82,6 +82,21 @@ bool CDRMObject::GetProperties(uint32_t id, uint32_t type)
   return true;
 }
 
+uint64_t CDRMObject::GetProperty(const std::string& name) const
+{
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [&name](auto& prop) {
+    return StringUtils::EqualsNoCase(prop->name, name);
+  });
+
+  if (property == m_propsInfo.end())
+    return 0;
+
+  std::unique_ptr<drmModeObjectProperties, DrmModeObjectPropertiesDeleter> props(
+      drmModeObjectGetProperties(m_fd, m_id, m_type));
+
+  return props->prop_values[std::distance(m_propsInfo.begin(), property)];
+}
+
 bool CDRMObject::GetPropertyValue(std::string name, const std::string& type, uint64_t& value) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [&name](auto& prop) {

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -34,6 +34,7 @@ public:
 
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const char* name) const;
+  uint64_t GetProperty(const std::string& name) const;
   bool GetPropertyValue(std::string name, const std::string& type, uint64_t& value) const;
 
   bool SetProperty(const char* name, uint64_t value);

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -23,6 +23,16 @@ CDRMPlane::CDRMPlane(int fd, uint32_t plane) : CDRMObject(fd), m_plane(drmModeGe
                              std::to_string(m_plane->plane_id));
 }
 
+uint32_t CDRMPlane::GetPlaneFbId() const
+{
+  std::unique_ptr<drmModePlane, DrmModePlaneDeleter> plane(
+      drmModeGetPlane(m_fd, m_plane->plane_id));
+  if (!plane)
+    return 0;
+
+  return plane->fb_id;
+}
+
 bool CDRMPlane::SupportsFormat(uint32_t format)
 {
   for (uint32_t i = 0; i < m_plane->count_formats; i++)

--- a/xbmc/windowing/gbm/drm/DRMPlane.h
+++ b/xbmc/windowing/gbm/drm/DRMPlane.h
@@ -31,6 +31,7 @@ public:
 
   uint32_t GetPlaneId() const { return m_plane->plane_id; }
   uint32_t GetPossibleCrtcs() const { return m_plane->possible_crtcs; }
+  uint32_t GetPlaneFbId() const;
 
   void FindModifiers();
 

--- a/xbmc/windowing/gbm/drm/ScreenshotSurfaceDRM.cpp
+++ b/xbmc/windowing/gbm/drm/ScreenshotSurfaceDRM.cpp
@@ -1,0 +1,292 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ScreenshotSurfaceDRM.h"
+
+#include "ServiceBroker.h"
+#include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
+#include "cores/VideoPlayer/VideoRenderers/FrameBufferObject.h"
+#include "rendering/gles/RenderSystemGLES.h"
+#include "threads/SingleLock.h"
+#include "utils/EGLImage.h"
+#include "utils/Screenshot.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
+#include "windowing/gbm/WinSystemGbm.h"
+#include "windowing/gbm/drm/DRMAtomic.h"
+#include "windowing/linux/WinSystemEGL.h"
+
+#include <array>
+
+#include <xf86drmMode.h>
+
+#include "system_gl.h"
+
+namespace
+{
+
+int GetColorSpace(int colorSpace)
+{
+  switch (colorSpace)
+  {
+    case DRMPRIME::DRM_COLOR_YCBCR_BT2020:
+      return EGL_ITU_REC2020_EXT;
+    case DRMPRIME::DRM_COLOR_YCBCR_BT601:
+      return EGL_ITU_REC601_EXT;
+    case DRMPRIME::DRM_COLOR_YCBCR_BT709:
+    default:
+      return EGL_ITU_REC709_EXT;
+  }
+}
+
+int GetColorRange(int colorRange)
+{
+  switch (colorRange)
+  {
+    case DRMPRIME::DRM_COLOR_YCBCR_FULL_RANGE:
+      return EGL_YUV_FULL_RANGE_EXT;
+    case DRMPRIME::DRM_COLOR_YCBCR_LIMITED_RANGE:
+    default:
+      return EGL_YUV_NARROW_RANGE_EXT;
+  }
+}
+
+} // namespace
+
+void CScreenshotSurfaceDRM::Register()
+{
+  CScreenShot::Register(CScreenshotSurfaceDRM::CreateSurface);
+}
+
+std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceDRM::CreateSurface()
+{
+  return std::make_unique<CScreenshotSurfaceDRM>();
+}
+
+bool CScreenshotSurfaceDRM::CaptureVideo()
+{
+  auto renderSystem = static_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+  if (!renderSystem)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to get render system", __FUNCTION__);
+    return false;
+  }
+
+  auto winSystem =
+      static_cast<KODI::WINDOWING::GBM::CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to get window system", __FUNCTION__);
+    return false;
+  }
+
+  CSingleLock lock(winSystem->GetGfxContext());
+
+  auto winSystemEGL =
+      dynamic_cast<KODI::WINDOWING::LINUX::CWinSystemEGL*>(CServiceBroker::GetWinSystem());
+  if (!winSystemEGL)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to get egl window system",
+              __FUNCTION__);
+    return false;
+  }
+
+  auto drm = std::static_pointer_cast<KODI::WINDOWING::GBM::CDRMAtomic>(winSystem->GetDrm());
+  if (!drm)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to get drm system", __FUNCTION__);
+    return false;
+  }
+
+  auto videoPlane = drm->GetVideoPlane();
+  if (!videoPlane)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - video plane unavailable", __FUNCTION__);
+    return true; // video plane may not be present so this isn't a failure
+  }
+
+  uint32_t fb_id = videoPlane->GetPlaneFbId();
+  if (fb_id == 0)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - video plane doesn't have an attached fb_id",
+              __FUNCTION__);
+    return true; // video plane may exists but doesn't currently have a bound fb
+  }
+
+  auto fb = drmModeGetFB2(drm->GetFileDescriptor(), fb_id);
+  if (!fb)
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to get framebuffer for id: {}",
+              __FUNCTION__, fb_id);
+    return false;
+  }
+
+  std::array<CEGLImage::EglPlane, CEGLImage::MAX_NUM_PLANES> planes;
+
+  for (int i = 0; i < CEGLImage::MAX_NUM_PLANES; i++)
+  {
+    drmPrimeHandleToFD(drm->GetFileDescriptor(), fb->handles[i], 0, &planes[i].fd);
+    planes[i].offset = fb->offsets[i];
+    planes[i].pitch = fb->pitches[i];
+    planes[i].modifier = fb->modifier;
+  }
+
+  CEGLImage::EglAttrs attribs;
+
+  attribs.width = m_width;
+  attribs.height = m_height;
+  attribs.format = fb->pixel_format;
+  attribs.colorSpace = GetColorSpace(videoPlane->GetProperty("COLOR_ENCODING"));
+  attribs.colorRange = GetColorRange(videoPlane->GetProperty("COLOR_RANGE"));
+  attribs.planes = planes;
+
+  CEGLImage image(winSystemEGL->GetEGLDisplay());
+
+  if (!image.CreateImage(attribs))
+    return false;
+
+  CFrameBufferObject fbo;
+  if (!fbo.Initialize())
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to initialize framebuffer object",
+              __FUNCTION__);
+    return false;
+  }
+
+  if (!fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_width, m_height, GL_RGBA))
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to create framebuffer object texture",
+              __FUNCTION__);
+    return false;
+  }
+
+  GLuint texture;
+  glGenTextures(1, &texture);
+  glBindTexture(GL_TEXTURE_EXTERNAL_OES, texture);
+  glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  image.UploadImage(GL_TEXTURE_EXTERNAL_OES);
+  image.DestroyImage();
+
+  if (!fbo.BeginRender())
+  {
+    CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - failed to bind framebuffer object",
+              __FUNCTION__);
+    return false;
+  }
+
+  renderSystem->EnableGUIShader(SM_TEXTURE_RGBA_OES);
+
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+  GLuint vertexVBO;
+  GLuint indexVBO;
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  };
+
+  std::array<PackedVertex, 4> vertex;
+
+  GLint vertLoc = renderSystem->GUIShaderGetPos();
+  GLint loc = renderSystem->GUIShaderGetCoord0();
+
+  // top left
+  vertex[0].x = 0.0f;
+  vertex[0].y = m_height;
+  vertex[0].z = 0.0f;
+  vertex[0].u1 = 0.0f;
+  vertex[0].v1 = 0.0f;
+
+  // top right
+  vertex[1].x = m_width;
+  vertex[1].y = m_height;
+  vertex[1].z = 0.0f;
+  vertex[1].u1 = 1.0f;
+  vertex[1].v1 = 0.0f;
+
+  // bottom right
+  vertex[2].x = m_width;
+  vertex[2].y = 0.0f;
+  vertex[2].z = 0.0f;
+  vertex[2].u1 = 1.0f;
+  vertex[2].v1 = 1.0f;
+
+  // bottom left
+  vertex[3].x = 0.0f;
+  vertex[3].y = 0.0f;
+  vertex[3].z = 0.0f;
+  vertex[3].u1 = 0.0f;
+  vertex[3].v1 = 1.0f;
+
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * vertex.size(), vertex.data(),
+               GL_STATIC_DRAW);
+
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+
+  glEnableVertexAttribArray(vertLoc);
+  glEnableVertexAttribArray(loc);
+
+  glGenBuffers(1, &indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+  glDisableVertexAttribArray(vertLoc);
+  glDisableVertexAttribArray(loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &indexVBO);
+
+  renderSystem->DisableGUIShader();
+
+  std::vector<uint8_t> surface(m_stride * m_height);
+  glReadBuffer(GL_COLOR_ATTACHMENT0);
+  glReadPixels(0, 0, m_width, m_height, GL_RGBA, GL_UNSIGNED_BYTE,
+               static_cast<GLvoid*>(surface.data()));
+
+  fbo.Cleanup();
+
+  unsigned char* buffer = m_buffer;
+
+  for (int y = 0; y < m_height; ++y)
+  {
+    unsigned char* videoPtr = surface.data() + y * m_stride;
+
+    for (int x = 0; x < m_width; ++x, buffer += 4, videoPtr += 4)
+    {
+      float alpha = buffer[3] / 255.0f;
+
+      //B
+      buffer[0] =
+          alpha * static_cast<float>(buffer[0]) + (1 - alpha) * static_cast<float>(videoPtr[2]);
+      //G
+      buffer[1] =
+          alpha * static_cast<float>(buffer[1]) + (1 - alpha) * static_cast<float>(videoPtr[1]);
+      //R
+      buffer[2] =
+          alpha * static_cast<float>(buffer[2]) + (1 - alpha) * static_cast<float>(videoPtr[0]);
+      //A
+      buffer[3] = 0xFF;
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "CScreenshotSurfaceDRM::{} - success", __FUNCTION__);
+
+  return true;
+}

--- a/xbmc/windowing/gbm/drm/ScreenshotSurfaceDRM.h
+++ b/xbmc/windowing/gbm/drm/ScreenshotSurfaceDRM.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "rendering/gles/ScreenshotSurfaceGLES.h"
+
+#include <memory>
+
+class CScreenshotSurfaceDRM : public CScreenshotSurfaceGLES
+{
+public:
+  static void Register();
+  static std::unique_ptr<IScreenshotSurface> CreateSurface();
+
+  bool CaptureVideo() override;
+};


### PR DESCRIPTION
This is a pretty ugly bunch of code but it works (™).

This includes all the bits of code created for drm/gbm just to be able to take a screenshot 😂 The reason for that is we need to convert the YUV colorspace into RGB and (IMO) the easiest way to do this is with OES shaders. Mesa gallium drivers support importing YUV420, NV12, P010, by default but some devices may require modifiers which may not be supported. I've tested this on intel using (experimental) VAAPI drm-prime patches to allow VAAPI images to be used with the direct-to-plane rendering. These images are produced with modifiers and it seems the `Iris` mesa driver can handle this ok. This may be a problem on RPi where the EGL interop isn't able to import SAND modifier images (as of yet).

I've had an occasional crash but I have a feeling this may be due to the iris driver failing to map a framebuffer.

This will be interesting to test on low powered arm devices to see how heavy the glReadPixels call is especially with 4K.

There is a couple other alternatives to this that I can see:
1) Implement some sort of call into videoplayer to copy the pixels of the currently rendered image (could be tough to implement nicely)
2) Use the writeback connector drm interface (only a few devices even support this at the moment and would still require importing into GL AFAIK).
3) Something else that I'm not even thinking of.
4) EDIT: possibly using another EGL Image to blit from YUV -> RGB then just access those pixels directly by mapping the dmabuf to the cpu. I'll try this soon.

This is a feature but could also be considered a fix as not being able to screenshot with the video playback may be a bug. 🤷‍♂️ 


![screenshot00003](https://user-images.githubusercontent.com/1616460/98319600-f4a56400-1f95-11eb-8c5d-e21bfc7bfbcf.png)
