### PR TITLE
Fix music playlists context menu

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -318,6 +318,12 @@ bool CPlay::IsVisible(const CFileItem& itemIn) const
   if (IsActiveRecordingsFolder(item))
     return true;
 
+  // Music nav window has own "Play" context menu button, do not show this one. Playlist files
+  // like .m3u and .strm return IsVideo() true but from music nav window play with paplayer.
+  const int currentWindow = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
+  if (currentWindow == WINDOW_MUSIC_NAV)
+    return false;
+
   if (item.m_bIsFolder)
     return false; //! @todo implement
 


### PR DESCRIPTION
A second "play" button appears on the context menu for .m3u and .strm file items when browsing the music playlists node. This removes that unwanted extra button.

![context menu before/after](https://i.imgur.com/ipxnBxy.jpg?1)

All the context menu buttons for the music nav screens are still implemented in `CGUIWindowMusicNav`, it has not been updated to use the context menu manager approach. However .m3u playlist files can contain music or video files hence `IsVideo()` returns true, and so the context menu action for starting video playback (that is managed by the context menu manager) is shown.  