### PR TITLE
Clean up compile warnings by handling music ids consistently as int 

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2275,7 +2275,7 @@ bool CFileItemList::IsEmpty() const
   return m_items.empty();
 }
 
-void CFileItemList::Reserve(int iCount)
+void CFileItemList::Reserve(size_t iCount)
 {
   CSingleLock lock(m_lock);
   m_items.reserve(iCount);

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -675,7 +675,7 @@ public:
   void Append(const CFileItemList& itemlist);
   void Assign(const CFileItemList& itemlist, bool append = false);
   bool Copy  (const CFileItemList& item, bool copyItems = true);
-  void Reserve(int iCount);
+  void Reserve(size_t iCount);
   void Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute sortAttributes = SortAttributeNone);
   /* \brief Sorts the items based on the given sorting options
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -299,6 +299,40 @@ std::string CDatabase::GetSingleValue(const std::string &query)
   return GetSingleValue(query, m_pDS);
 }
 
+int CDatabase::GetSingleValueInt(const std::string& query, std::unique_ptr<Dataset>& ds)
+{
+  int ret = 0;
+  try
+  {
+    if (!m_pDB || !ds)
+      return ret;
+
+    if (ds->query(query) && ds->num_rows() > 0)
+      ret = ds->fv(0).get_asInt();
+
+    ds->close();
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s - failed on query '%s'", __FUNCTION__, query.c_str());
+  }
+  return ret;
+}
+
+int CDatabase::GetSingleValueInt(const std::string& strTable,
+                                 const std::string& strColumn,
+                                 const std::string& strWhereClause /* = std::string() */,
+                                 const std::string& strOrderBy /* = std::string() */)
+{
+  std::string strResult = GetSingleValue(strTable, strColumn, strWhereClause, strOrderBy);
+  return static_cast<int>(strtol(strResult.c_str(), NULL, 10));
+}
+
+int CDatabase::GetSingleValueInt(const std::string& query)
+{
+  return GetSingleValueInt(query, m_pDS);
+}
+
 bool CDatabase::DeleteValues(const std::string &strTable, const Filter &filter /* = Filter() */)
 {
   std::string strQuery;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -130,6 +130,28 @@ public:
   std::string GetSingleValue(const std::string &query, std::unique_ptr<dbiplus::Dataset> &ds);
 
   /*!
+ * @brief Get a single integer value from a table.
+ * @remarks The values of the strWhereClause and strOrderBy parameters have to be FormatSQL'ed when used.
+ * @param strTable The table to get the value from.
+ * @param strColumn The column to get.
+ * @param strWhereClause If set, use this WHERE clause.
+ * @param strOrderBy If set, use this ORDER BY clause.
+ * @return The requested value or 0 if it wasn't found.
+ */
+  int GetSingleValueInt(const std::string& strTable,
+                        const std::string& strColumn,
+                        const std::string& strWhereClause = std::string(),
+                        const std::string& strOrderBy = std::string());
+  int GetSingleValueInt(const std::string& query);
+
+  /*! \brief Get a single integer value from a query on a dataset.
+   \param query the query in question.
+   \param ds the dataset to use for the query.
+   \return the value from the query, 0 on failure.
+   */
+  int GetSingleValueInt(const std::string& query, std::unique_ptr<dbiplus::Dataset>& ds);
+
+  /*!
    * @brief Delete values from a table.
    * @param strTable The table to delete the values from.
    * @param filter The Filter to apply to this query.

--- a/xbmc/filesystem/MusicDatabaseDirectory/QueryParams.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/QueryParams.cpp
@@ -24,7 +24,7 @@ CQueryParams::CQueryParams()
 
 void CQueryParams::SetQueryParam(NODE_TYPE NodeType, const std::string& strNodeName)
 {
-  long idDb=atol(strNodeName.c_str());
+  int idDb = atoi(strNodeName.c_str());
 
   switch (NodeType)
   {

--- a/xbmc/filesystem/MusicDatabaseDirectory/QueryParams.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/QueryParams.h
@@ -18,24 +18,24 @@ namespace XFILE
     {
     public:
       CQueryParams();
-      long GetArtistId() { return m_idArtist; }
-      long GetAlbumId() { return m_idAlbum; }
-      long GetGenreId() { return m_idGenre; }
-      long GetSongId() { return m_idSong; }
-      long GetYear() { return m_year; }
-      long GetDisc() { return m_disc; }
+      int GetArtistId() { return m_idArtist; }
+      int GetAlbumId() { return m_idAlbum; }
+      int GetGenreId() { return m_idGenre; }
+      int GetSongId() { return m_idSong; }
+      int GetYear() { return m_year; }
+      int GetDisc() { return m_disc; }
 
     protected:
       void SetQueryParam(NODE_TYPE NodeType, const std::string& strNodeName);
 
       friend class CDirectoryNode;
     private:
-      long m_idArtist;
-      long m_idAlbum;
-      long m_idGenre;
-      long m_idSong;
-      long m_year;
-      long m_disc;
+      int m_idArtist;
+      int m_idAlbum;
+      int m_idGenre;
+      int m_idSong;
+      int m_year;
+      int m_disc;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -35,7 +35,7 @@ std::string CMusicDatabaseFile::TranslateUrl(const CURL& url)
   if (!StringUtils::IsNaturalNumber(strFileName))
     return "";
 
-  long idSong=atol(strFileName.c_str());
+  int idSong = atoi(strFileName.c_str());
 
   CSong song;
   if (!musicDatabase.GetSong(idSong, song))

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -796,9 +796,9 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const std::string &method, ITransp
   if (ParameterNotNull(parameterObject, "rating"))
     album.fRating = parameterObject["rating"].asFloat();
   if (ParameterNotNull(parameterObject, "userrating"))
-    album.iUserrating = parameterObject["userrating"].asInteger();
+    album.iUserrating = static_cast<int>(parameterObject["userrating"].asInteger());
   if (ParameterNotNull(parameterObject, "votes"))
-    album.iVotes = parameterObject["votes"].asInteger();
+    album.iVotes = static_cast<int>(parameterObject["votes"].asInteger());
   if (ParameterNotNull(parameterObject, "year"))
     album.strReleaseDate = parameterObject["year"].asString();
   if (ParameterNotNull(parameterObject, "musicbrainzalbumid"))
@@ -891,7 +891,7 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
   if (ParameterNotNull(parameterObject, "rating"))
     song.rating = parameterObject["rating"].asFloat();
   if (ParameterNotNull(parameterObject, "userrating"))
-    song.userrating = parameterObject["userrating"].asInteger();
+    song.userrating = static_cast<int>(parameterObject["userrating"].asInteger());
   if (ParameterNotNull(parameterObject, "track"))
     song.iTrack = (song.iTrack & 0xffff0000) | ((int)parameterObject["track"].asInteger() & 0xffff);
   if (ParameterNotNull(parameterObject, "disc"))

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -277,7 +277,7 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
       for (unsigned int index = 0; index < result["albums"].size(); index++)
       {
         CFileItem item;
-        item.GetMusicInfoTag()->SetDatabaseId(result["albums"][index]["albumid"].asInteger(), MediaTypeAlbum);
+        item.GetMusicInfoTag()->SetDatabaseId(result["albums"][index]["albumid"].asInteger32(), MediaTypeAlbum);
 
         // Could use FillDetails, but it does unnecessary serialization of empty MusiInfoTag
         // CFileItemPtr itemptr(new CFileItem(item));
@@ -432,9 +432,9 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
         CFileItem item;
         // Only needs song and album id (if we have it) set to get art
         // Getting art is quicker if "albumid" has been fetched
-        item.GetMusicInfoTag()->SetDatabaseId(result["songs"][index]["songid"].asInteger(), MediaTypeSong);
+        item.GetMusicInfoTag()->SetDatabaseId(result["songs"][index]["songid"].asInteger32(), MediaTypeSong);
         if (result["songs"][index].isMember("albumid"))
-          item.GetMusicInfoTag()->SetAlbumId(result["songs"][index]["albumid"].asInteger());
+          item.GetMusicInfoTag()->SetAlbumId(result["songs"][index]["albumid"].asInteger32());
         else
           item.GetMusicInfoTag()->SetAlbumId(-1);
 

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -957,7 +957,7 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant& value,
   // If we have a string, we need to check the length
   if (HasType(type, StringValue) && value.isString())
   {
-    int size = value.asString().size();
+    int size = static_cast<int>(value.asString().size());
     if (size < minLength)
     {
       CLog::Log(LOGDEBUG, "JSONRPC: Value does not meet minLength requirements in type %s", name.c_str());
@@ -1225,7 +1225,7 @@ JSONSchemaTypeDefinition::CJsonSchemaPropertiesMap::JSONSchemaPropertiesIterator
 
 unsigned int JSONSchemaTypeDefinition::CJsonSchemaPropertiesMap::size() const
 {
-  return m_propertiesmap.size();
+  return static_cast<unsigned int>(m_propertiesmap.size());
 }
 
 JsonRpcMethod::JsonRpcMethod()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -497,7 +497,7 @@ namespace XBMCAddon
 
           //! @todo add the rest of the infolabels
           if (key == "dbid" && !type.empty())
-            musictag.SetDatabaseId(strtol(value.c_str(), NULL, 10), type);
+            musictag.SetDatabaseId(static_cast<int>(strtol(value.c_str(), NULL, 10)), type);
           else if (key == "tracknumber")
             musictag.SetTrackNumber(strtol(value.c_str(), NULL, 10));
           else if (key == "discnumber")

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -141,7 +141,7 @@ public:
   bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
   bool Save(TiXmlNode *node, const std::string &tag, const std::string& strPath);
 
-  long idAlbum = -1;
+  int idAlbum = -1;
   std::string strAlbum;
   std::string strMusicBrainzAlbumID;
   std::string strReleaseGroupMBID;

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -32,7 +32,7 @@ public:
 class CArtist
 {
 public:
-  long idArtist = -1;
+  int idArtist = -1;
   bool operator<(const CArtist& a) const
   {
     if (strMusicBrainzArtistID.empty() && a.strMusicBrainzArtistID.empty())
@@ -164,7 +164,7 @@ public:
   void SetScrapedMBID(bool scrapedMBID) { this->m_bScrapedMBID = scrapedMBID; }
 
 private:
-  long idArtist = -1;
+  int idArtist = -1;
   std::string m_strArtist;
   std::string m_strSortName;
   std::string m_strMusicBrainzArtistID;
@@ -176,7 +176,7 @@ typedef std::vector<CArtistCredit> VECARTISTCREDITS;
 
 const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
 const std::string BLANKARTIST_NAME = "[Missing Tag]";
-const long BLANKARTIST_ID = 1;
+const int BLANKARTIST_ID = 1;
 const std::string VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
 #define ROLE_ARTIST 1  //Default role
@@ -189,7 +189,7 @@ public:
     : idRole(-1), m_strRole(std::move(strRole)), m_strArtist(std::move(strArtist)), idArtist(-1)
   {
   }
-  CMusicRole(int role, std::string strRole, std::string strArtist, long ArtistId)
+  CMusicRole(int role, std::string strRole, std::string strArtist, int ArtistId)
     : idRole(role),
       m_strRole(std::move(strRole)),
       m_strArtist(std::move(strArtist)),
@@ -199,8 +199,8 @@ public:
   std::string GetArtist() const { return m_strArtist; }
   std::string GetRoleDesc() const { return m_strRole; }
   int GetRoleId() const { return idRole; }
-  long GetArtistId() const { return idArtist; }
-  void SetArtistId(long iArtistId) { idArtist = iArtistId;  }
+  int GetArtistId() const { return idArtist; }
+  void SetArtistId(int iArtistId) { idArtist = iArtistId;  }
 
   bool operator==(const CMusicRole& a) const
   {
@@ -213,7 +213,7 @@ private:
   int idRole;
   std::string m_strRole;
   std::string m_strArtist;
-  long idArtist;
+  int idArtist;
 };
 
 typedef std::vector<CMusicRole> VECMUSICROLES;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -685,7 +685,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
     AddAlbumArtist(artistCredit->idArtist,
                    album.idAlbum,
                    artistCredit->GetArtist(),
-                   std::distance(album.artistCredits.begin(), artistCredit));
+                   static_cast<int>(std::distance(album.artistCredits.begin(), artistCredit)));
   }
 
   for (auto song = album.songs.begin(); song != album.songs.end(); ++song)
@@ -724,7 +724,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
                     song->idSong,
                     ROLE_ARTIST,
                     artistCredit->GetArtist(), // we don't have song artist breakdowns from scrapers, yet
-                    std::distance(song->artistCredits.begin(), artistCredit));
+                    static_cast<int>(std::distance(song->artistCredits.begin(), artistCredit)));
     }
     // Having added artist credits (maybe with MBID) add the other contributing artists (no MBID)
     // and use COMPOSERSORT tag data to provide sort names for artists that are composers
@@ -883,7 +883,7 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
       AddAlbumArtist(artistCredit->idArtist,
         album.idAlbum,
         artistCredit->GetArtist(),
-        std::distance(album.artistCredits.begin(), artistCredit));
+        static_cast<int>(std::distance(album.artistCredits.begin(), artistCredit)));
     }
     /* Replace the songs with those scraped or imported, but if new songs is empty
        (such as when called from JSON) do not remove the original ones
@@ -1169,7 +1169,7 @@ bool CMusicDatabase::UpdateSong(CSong& song,
         song.idSong,
         ROLE_ARTIST,
         artistCredit->GetArtist(),
-        std::distance(song.artistCredits.begin(), artistCredit));
+        static_cast<int>(std::distance(song.artistCredits.begin(), artistCredit)));
     }
     // Having added artist credits (maybe with MBID) add the other contributing artists (MBID unknown)
     // and use COMPOSERSORT tag data to provide sort names for artists that are composers
@@ -6306,7 +6306,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string>& fields, 
     // Adjust where in the results record the join fields are allowing for the
     // inline view fields (Quicker than finding field by name every time)
     // idArtist + other artist fields    
-    joinLayout.AdjustRecordNumbers(1 + dbfieldindex.size());
+    joinLayout.AdjustRecordNumbers(static_cast<int>(1 + dbfieldindex.size()));
 
     // Build full query
     // When have multiple value joins e.g. song genres, use inline view
@@ -6828,7 +6828,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string>& fields, c
     // Adjust where in the results record the join fields are allowing for the
     // inline view fields (Quicker than finding field by name every time)
     // idAlbum + other album fields    
-    joinLayout.AdjustRecordNumbers(1 + dbfieldindex.size());
+    joinLayout.AdjustRecordNumbers(static_cast<int>(1 + dbfieldindex.size()));
     
     // Build full query
     // When have multiple value joins (artists or song genres) use inline view
@@ -7391,7 +7391,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(const std::set<std::string>& fields, co
     // Adjust where in the results record the join fields are allowing for the
     // inline view fields (Quicker than finding field by name every time)
     // idSong + other song fields
-    joinLayout.AdjustRecordNumbers(1 + dbfieldindex.size());
+    joinLayout.AdjustRecordNumbers(static_cast<int>(1 + dbfieldindex.size()));
 
     // Build full query
     // When have multiple value joins use inline view
@@ -8789,7 +8789,7 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter &filter, std::vector<
       m_pDS->next();
     }    // cleanup
     m_pDS->close();
-    return songIDs.size();
+    return static_cast<unsigned int>(songIDs.size());
   }
   catch (...)
   {

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -98,7 +98,7 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
     if (pItem->HasProperty("artistid") && pItem->GetProperty("artistid").isArray())
     {
       CVariant::const_iterator_array varid = pItem->GetProperty("artistid").begin_array();
-      int idArtist = varid->asInteger();
+      int idArtist = static_cast<int>(varid->asInteger());
       artistfound = database.GetArtist(idArtist, artist, false);
     }
     else

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -65,7 +65,7 @@ namespace MUSIC_UTILS
           for (CVariant::const_iterator_array varid = pSongItem->GetProperty("artistid").begin_array();
             varid != pSongItem->GetProperty("artistid").end_array(); varid++)
           {
-            int idArtist = varid->asInteger();
+            int idArtist = static_cast<int>(varid->asInteger());
             result = (itemID == idArtist);
             if (result)
               break;

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -66,8 +66,8 @@ CSong::CSong(CFileItem& item)
   dateAdded = tag.GetDateAdded();
   replayGain = tag.GetReplayGain();
   strThumb = item.GetUserMusicThumb(true);
-  iStartOffset = item.m_lStartOffset;
-  iEndOffset = item.m_lEndOffset;
+  iStartOffset = static_cast<int>(item.m_lStartOffset);
+  iEndOffset = static_cast<int>(item.m_lEndOffset);
   idSong = -1;
   iTimesPlayed = 0;
   idAlbum = -1;

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -34,7 +34,7 @@ class CVariant;
 class CGenre
 {
 public:
-  long idGenre;
+  int idGenre;
   std::string strGenre;
 };
 
@@ -157,7 +157,7 @@ public:
   void SetArtistCredits(const std::vector<std::string>& names, const std::vector<std::string>& hints,
     const std::vector<std::string>& mbids);
 
-  long idSong;
+  int idSong;
   int idAlbum;
   std::string strFileName;
   std::string strTitle;

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -979,12 +979,12 @@ void CGUIDialogMusicInfo::ShowFor(CFileItem* pItem)
   }
   else if (pItem->HasProperty("artist_musicid"))
   {
-    musicitem.GetMusicInfoTag()->SetDatabaseId(pItem->GetProperty("artist_musicid").asInteger(),
+    musicitem.GetMusicInfoTag()->SetDatabaseId(pItem->GetProperty("artist_musicid").asInteger32(),
                                                MediaTypeArtist);
   }
   else if (pItem->HasProperty("album_musicid"))
   {
-    musicitem.GetMusicInfoTag()->SetDatabaseId(pItem->GetProperty("album_musicid").asInteger(),
+    musicitem.GetMusicInfoTag()->SetDatabaseId(pItem->GetProperty("album_musicid").asInteger32(),
                                                MediaTypeAlbum);
   }
   else

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -945,7 +945,7 @@ int CMusicInfoScanner::RetrieveMusicInfo(const std::string& strDirectory, CFileI
     m_musicDatabase.AddAlbum(album, m_idSourcePath);
     m_albumsAdded.insert(album.idAlbum);
 
-    numAdded += album.songs.size();
+    numAdded += static_cast<int>(album.songs.size());
   }
   return numAdded;
 }
@@ -999,7 +999,7 @@ void MUSIC_INFO::CMusicInfoScanner::ScrapeInfoAddedAlbums()
       if (m_handle)
       {
         m_handle->SetText(album.GetAlbumArtistString() + " - " + album.strAlbum);
-        m_handle->SetProgress(i, m_albumsAdded.size());
+        m_handle->SetProgress(i, static_cast<int>(m_albumsAdded.size()));
       }
 
       // Fetch any artist mbids for album artist(s) and song artists when scraping those too.
@@ -1168,7 +1168,7 @@ void MUSIC_INFO::CMusicInfoScanner::RetrieveLocalArt()
     if (m_handle)
     {
       m_handle->SetText(album.GetAlbumArtistString() + " - " + album.strAlbum);
-      m_handle->SetProgress(count, m_albumsAdded.size());
+      m_handle->SetProgress(count, static_cast<int>(m_albumsAdded.size()));
     }
 
     /*

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -442,7 +442,7 @@ void CMusicInfoTag::SetYear(int year)
     m_strReleaseDate.clear();
 }
 
-void CMusicInfoTag::SetDatabaseId(long id, const std::string &type)
+void CMusicInfoTag::SetDatabaseId(int id, const std::string &type)
 {
   m_iDbId = id;
   m_type = type;
@@ -1107,7 +1107,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     for (int i = 0; i < iMusicRolesSize; ++i)
     {
       int idRole;
-      long idArtist;
+      int idArtist;
       std::string strArtist;
       std::string strRole;
       ar >> idRole;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -107,7 +107,7 @@ public:
   void SetYear(int year);
   void SetOriginalDate(const std::string& strOriginalDate);
   void SetReleaseDate(const std::string& strReleaseDate);
-  void SetDatabaseId(long id, const std::string &type);
+  void SetDatabaseId(int id, const std::string &type);
   void SetTrackNumber(int iTrack);
   void SetDiscNumber(int iDiscNumber);
   void SetTrackAndDiscNumber(int iTrackAndDisc);

--- a/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
@@ -100,9 +100,11 @@ bool CMusicInfoTagLoaderFFmpeg::Load(const std::string& strFileName, CMusicInfoT
                               tag.SetGenre(avtag->value);
                             else if (StringUtils::CompareNoCase(avtag->key, "part_number") == 0 ||
                                      StringUtils::CompareNoCase(avtag->key, "track") == 0)
-                              tag.SetTrackNumber(strtol(avtag->value, nullptr, 10));
+                              tag.SetTrackNumber(
+                                  static_cast<int>(strtol(avtag->value, nullptr, 10)));
                             else if (StringUtils::CompareNoCase(avtag->key, "disc") == 0)
-                              tag.SetDiscNumber(strtol(avtag->value, nullptr, 10));
+                              tag.SetDiscNumber(
+                                  static_cast<int>(strtol(avtag->value, nullptr, 10)));
                             else if (StringUtils::CompareNoCase(avtag->key, "date") == 0)
                               tag.SetReleaseDate(avtag->value);
                             else if (StringUtils::CompareNoCase(avtag->key, "compilation") == 0)
@@ -131,7 +133,7 @@ bool CMusicInfoTagLoaderFFmpeg::Load(const std::string& strFileName, CMusicInfoT
                             else if (StringUtils::CompareNoCase(avtag->key, "TYER") == 0)
                               tag.AddReleaseDate(avtag->value); // YYYY part
                             else if (StringUtils::CompareNoCase(avtag->key, "TBPM") == 0)
-                              tag.SetBPM(strtol(avtag->value, nullptr, 10));
+                              tag.SetBPM(static_cast<int>(strtol(avtag->value, nullptr, 10)));
                             else if (StringUtils::CompareNoCase(avtag->key, "TDTG") == 0) {} // Tagging time
                             else if (StringUtils::CompareNoCase(avtag->key, "language") == 0 ||
                                      StringUtils::CompareNoCase(avtag->key, "TLAN") == 0) {} // Languages

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -298,8 +298,12 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
     else if (it->first == "TSOC")   SetComposerSort(tag, GetID3v2StringList(it->second));
     else if (it->first == "TIT2")   tag.SetTitle(it->second.front()->toString().to8Bit(true));
     else if (it->first == "TCON")   SetGenre(tag, GetID3v2StringList(it->second));
-    else if (it->first == "TRCK")   tag.SetTrackNumber(strtol(it->second.front()->toString().toCString(true), nullptr, 10));
-    else if (it->first == "TPOS")   tag.SetDiscNumber(strtol(it->second.front()->toString().toCString(true), nullptr, 10));
+    else if (it->first == "TRCK")
+      tag.SetTrackNumber(
+          static_cast<int>(strtol(it->second.front()->toString().toCString(true), nullptr, 10)));
+    else if (it->first == "TPOS")
+      tag.SetDiscNumber(
+          static_cast<int>(strtol(it->second.front()->toString().toCString(true), nullptr, 10)));
     else if (it->first == "TDOR" || it->first == "TORY") // TDOR - ID3v2.4, TORY - ID3v2.3
       tag.SetOriginalDate(it->second.front()->toString().to8Bit(true));
     else if (it->first == "TDAT")   {} // empty as taglib has moved the value to TDRC
@@ -320,7 +324,8 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, EmbeddedArt *art, MUSIC_INFO:
     else if (it->first == "TSST")
       tag.SetDiscSubtitle(it->second.front()->toString().to8Bit(true));
     else if (it->first == "TBPM")
-      tag.SetBPM(strtol(it->second.front()->toString().toCString(true), nullptr, 10));
+      tag.SetBPM(
+          static_cast<int>(strtol(it->second.front()->toString().toCString(true), nullptr, 10)));
     else if (it->first == "USLT")
       // Loop through any lyrics frames. Could there be multiple frames, how to choose?
       for (ID3v2::FrameList::ConstIterator lt = it->second.begin(); lt != it->second.end(); ++lt)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1051,7 +1051,7 @@ bool CGUIWindowMusicBase::OnSelect(int iItem)
         if (choice == MUSIC_SELECT_ACTION_RESUME)
         {
           (*itemIt)->SetProperty("audiobook_bookmark", bookmark);
-          return CGUIMediaWindow::OnSelect(itemIt - m_vecItems->cbegin());
+          return CGUIMediaWindow::OnSelect(static_cast<int>(itemIt - m_vecItems->cbegin()));
         }
         else if (choice < 0)
           return true;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -668,7 +668,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       // music videos - artists
       if (StringUtils::StartsWithNoCase(item->GetPath(), "videodb://musicvideos/artists/"))
       {
-        long idArtist = m_musicdatabase.GetArtistByName(item->GetLabel());
+        int idArtist = m_musicdatabase.GetArtistByName(item->GetLabel());
         if (idArtist == -1)
           return false;
         std::string path = StringUtils::Format("musicdb://artists/%ld/", idArtist);
@@ -685,7 +685,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       // music videos - albums
       if (StringUtils::StartsWithNoCase(item->GetPath(), "videodb://musicvideos/albums/"))
       {
-        long idAlbum = m_musicdatabase.GetAlbumByName(item->GetLabel());
+        int idAlbum = m_musicdatabase.GetAlbumByName(item->GetLabel());
         if (idAlbum == -1)
           return false;
         std::string path = StringUtils::Format("musicdb://albums/%ld/", idAlbum);

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -444,7 +444,7 @@ int CGUIDialogLibExportSettings::GetExportItemsFromSetting(const SettingConstPtr
       CLog::Log(LOGERROR, "CGUIDialogLibExportSettings::%s - wrong items value type", __FUNCTION__);
       return 0;
     }
-    exportitems += value.asInteger();
+    exportitems += static_cast<int>(value.asInteger());
   }
   return exportitems;
 }

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -340,7 +340,7 @@ bool CRecentlyAddedJob::UpdateTotal()
   musicdatabase.GetArtistsByWhere(musicUrl.ToString(), filter, items, SortDescription(), true);
   int MusArtistTotals = 0;
   if (items.Size() == 1 && items.Get(0)->HasProperty("total"))
-    MusArtistTotals = items.Get(0)->GetProperty("total").asInteger();
+    MusArtistTotals = static_cast<int>(items.Get(0)->GetProperty("total").asInteger());
 
   int MusSongTotals   = atoi(musicdatabase.GetSingleValue("songview"       , "count(1)").c_str());
   int MusAlbumTotals  = atoi(musicdatabase.GetSingleValue("songview"       , "count(distinct strAlbum)").c_str());

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -212,7 +212,7 @@ bool CRecentlyAddedJob::UpdateMusic()
 
   if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://songs/", musicItems, NUM_ITEMS))
   {
-    long idAlbum = -1;
+    int idAlbum = -1;
     std::string strAlbumThumb;
     std::string strAlbumFanart;
     for (; i < musicItems.Size(); ++i)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -702,7 +702,9 @@ std::vector<std::string> StringUtils::Split(const std::string& input, const std:
   return result;
 }
 
-std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string> &input, const std::vector<std::string> &delimiters, unsigned int iMaxStrings /* = 0 */)
+std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string>& input,
+                                                 const std::vector<std::string>& delimiters,
+                                                 size_t iMaxStrings /* = 0 */)
 {
   if (input.empty())
     return std::vector<std::string>();
@@ -731,7 +733,7 @@ std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string> 
 
   // Control the number of strings input is split into, keeping the original strings.
   // Note iMaxStrings > input.size()
-  int iNew = iMaxStrings - results.size();
+  int64_t iNew = iMaxStrings - results.size();
   for (size_t di = 0; di < delimiters.size(); di++)
   {
     for (size_t i = 0; i < results.size(); i++)
@@ -1236,7 +1238,7 @@ int StringUtils::AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, 
       // do we have numbers?
       if (lnum != rnum)
       { // yes - and they're different!
-        return lnum - rnum;
+        return static_cast<int>(lnum - rnum);
       }
       // Advance to after digits
       i = ld;

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -242,7 +242,9 @@ public:
   \param delimiters Delimiter strings to be used to split the input strings
   \param iMaxStrings (optional) Maximum number of resulting split strings
   */
-  static std::vector<std::string> SplitMulti(const std::vector<std::string> &input, const std::vector<std::string> &delimiters, unsigned int iMaxStrings = 0);
+  static std::vector<std::string> SplitMulti(const std::vector<std::string>& input,
+                                             const std::vector<std::string>& delimiters,
+                                             size_t iMaxStrings = 0);
   static int FindNumber(const std::string& strInput, const std::string &strFind);
   static int64_t AlphaNumericCompare(const wchar_t *left, const wchar_t *right);
   static int AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, const void* pKey2);


### PR DESCRIPTION
Motivation was to clean up compiler warnings of implicit conversion loses integer precision: 'long' to 'int'.  This clears ~150 warnings.

Many of these warnings were caused by the use of `long` for music ids in just a few structures, while everywhere else it is `int`. This means that practically music ids within Kodi have been limited to `int` range so it makes sense to use this consistently. In doing that it also made sense to add some helper methods to fetch an `int` result from a SQL query rather than repeat the convertion of  string to `long` and cast to `int` in many places. 

Warnings of implicit conversion loses were also reduced in a few places by adding missing casting or rationalising parameter types. 