### PR TITLE
[Estuary] Fix Music Viz & Remove Time Remaining

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -143,32 +143,6 @@
 						</include>
 					</control>
 				</control>
-				<control type="label">
-					<centertop>145</centertop>
-					<right>20</right>
-					<width>400</width>
-					<height>100</height>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<wrapmultiline>true</wrapmultiline>
-					<animation effect="fade" time="200">VisibleChange</animation>
-					<label>$INFO[Player.TimeRemaining,[COLOR button_focus]$LOCALIZE[31134]:[CR][/COLOR]]</label>
-					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo) | VideoPlayer.HasEpg] + !Window.IsActive(fullscreeninfo)</visible>
-				</control>
-				<control type="label">
-					<centertop>125</centertop>
-					<right>20</right>
-					<width>400</width>
-					<height>100</height>
-					<align>right</align>
-					<aligny>center</aligny>
-					<font>font13</font>
-					<wrapmultiline>true</wrapmultiline>
-					<animation effect="fade" time="200">VisibleChange</animation>
-					<label>$INFO[PVR.EpgEventRemainingTime,[COLOR button_focus]$LOCALIZE[31134]:[CR][/COLOR]]</label>
-					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo)] + VideoPlayer.HasEpg + !Window.IsActive(fullscreeninfo)</visible>
-				</control>
 			</control>
 			<control type="label">
 				<centerleft>50%</centerleft>

--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -44,7 +44,7 @@
 			<bottom>0</bottom>
 			<control type="image">
 				<left>0</left>
-				<width>100%</width>
+				<width>120%</width>
 				<height>280</height>
 				<texture colordiffuse="80FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 			</control>


### PR DESCRIPTION
## Description
Fix and clean up the Music Viz and Video OSD

## Motivation and Context

###  [CEANUP] - Remove time remaining labels

After introduction of the new top seekbar the **time remaining** info is never displayed. So if it's not wanted anymore it should be removed.

###  [FIX] - Modify music viz Info background image width

Following https://github.com/xbmc/xbmc/pull/18465 the Music Viz info background as well as cover image & metadata slide off to the left, this caused the right edge of the background to be seen as it slides off.

 **Before Fix**
 ![image](https://user-images.githubusercontent.com/5781142/98444263-98af1c80-2108-11eb-853b-58a87e904de4.png)
 
Video does not have this problem, here the background image is set to 120% and setting the Music Viz image to the same fixes the issue.

**After Fix**
![image](https://user-images.githubusercontent.com/5781142/98444311-d4e27d00-2108-11eb-9944-aed946840fe1.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
