### PR TITLE
[Content] Fix art thumb served when adding items to favourites

### DIFF
--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -16,6 +16,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ContentUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -156,7 +157,7 @@ bool CFavouritesService::AddOrRemove(const CFileItem& item, int contextWindow)
       const CFileItemPtr favourite(std::make_shared<CFileItem>(item.GetLabel()));
       if (item.GetLabel().empty())
         favourite->SetLabel(CUtil::GetTitleFromPath(item.GetPath(), item.m_bIsFolder));
-      favourite->SetArt("thumb", item.GetArt("thumb"));
+      favourite->SetArt("thumb", ContentUtils::GetPreferredArtImage(item));
       favourite->SetPath(favUrl);
       m_favourites.Add(favourite);
     }

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -24,6 +24,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ContentUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -579,13 +580,9 @@ BuildObject(CFileItem&                    item,
         if (!thumb_loader.IsNull())
             thumb_loader->LoadItem(&item);
 
-        // finally apply the found artwork
-        // note: movies should use poster as the preferred "thumb" image
-        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_type == MediaTypeMovie &&
-            item.HasArt("poster"))
-          thumb = item.GetArt("poster");
-        else
-          thumb = item.GetArt("thumb");
+        // we have to decide the best art type to serve to the client - use ContentUtils
+        // to get it since it depends on the mediatype of the item being served
+        thumb = ContentUtils::GetPreferredArtImage(item);
 
         if (!thumb.empty()) {
             PLT_AlbumArtInfo art;

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES ActorProtocol.cpp
             CharsetConverter.cpp
             CharsetDetection.cpp
             ColorUtils.cpp
+            ContentUtils.cpp
             CPUInfo.cpp
             Crc32.cpp
             CryptThreading.cpp
@@ -89,6 +90,7 @@ set(HEADERS ActorProtocol.h
             CPUInfo.h
             Color.h
             ColorUtils.h
+            ContentUtils.h
             Crc32.h
             CryptThreading.h
             DatabaseUtils.h

--- a/xbmc/utils/ContentUtils.cpp
+++ b/xbmc/utils/ContentUtils.cpp
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ContentUtils.h"
+
+#include "FileItem.h"
+#include "video/VideoInfoTag.h"
+
+namespace
+{
+const bool HasPreferredArtType(const CFileItem& item)
+{
+  return item.HasVideoInfoTag() && (item.GetVideoInfoTag()->m_type == MediaTypeMovie ||
+                                    item.GetVideoInfoTag()->m_type == MediaTypeTvShow ||
+                                    item.GetVideoInfoTag()->m_type == MediaTypeSeason ||
+                                    item.GetVideoInfoTag()->m_type == MediaTypeVideoCollection);
+}
+
+const std::string GetPreferredArtType(MediaType type)
+{
+  if (type == MediaTypeMovie || type == MediaTypeTvShow || type == MediaTypeSeason ||
+      type == MediaTypeVideoCollection)
+  {
+    return "poster";
+  }
+  return "thumb";
+}
+} // namespace
+
+const std::string ContentUtils::GetPreferredArtImage(const CFileItem& item)
+{
+  if (HasPreferredArtType(item))
+  {
+    auto preferredArtType = GetPreferredArtType(item.GetVideoInfoTag()->m_type);
+    if (item.HasArt(preferredArtType))
+    {
+      return item.GetArt(preferredArtType);
+    }
+  }
+  return item.GetArt("thumb");
+}

--- a/xbmc/utils/ContentUtils.h
+++ b/xbmc/utils/ContentUtils.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "media/MediaType.h"
+
+#include <string>
+
+class CFileItem;
+
+class ContentUtils
+{
+public:
+  /*! \brief Gets the preferred art image for a given item (depending on its media type). Provided a CFileItem
+    with many art types on its art map, this method will return a default preferred image (content dependent) for situations where the
+    the client expects a single image to represent the item. For instance, for movies and shows this will return the poster, while for
+    episodes it will return the thumb.
+    \param item The CFileItem to process
+    \return the preferred art image
+  */
+  static const std::string GetPreferredArtImage(const CFileItem& item);
+};


### PR DESCRIPTION
## Description
This fixes the thumb/icon being selected when adding movies/shows/seasons to favourites introduced when the old global fallback from poster to thumb was removed. Since this is the second time the issue shows, and to reuse the code, I moved the image selection code to a new class in utils.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18565

## How Has This Been Tested?
Runtime tested with the addition of different media items (different media type) to favourites. Used vlc to confirm the library served by upnp was still behaving the same.

## Screenshots (if appropriate):

![alt text](https://i.postimg.cc/R0NMKmqP/Screenshot-2020-11-07-at-18-44-31.png "Fix")

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
