### PR TITLE
Tone mapping: small fixes and clean up

### DIFF
--- a/system/shaders/output_d3d.fx
+++ b/system/shaders/output_d3d.fx
@@ -42,16 +42,15 @@ SamplerState DitherSampler : IMMUTABLE
 };
 #endif
 #if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE) || defined(KODI_HLG_TO_PQ))
-const float ST2084_m1 = 2610.0f / (4096.0f * 4.0f);
-const float ST2084_m2 = (2523.0f / 4096.0f) * 128.0f;
-const float ST2084_c1 = 3424.0f / 4096.0f;
-const float ST2084_c2 = (2413.0f / 4096.0f) * 32.0f;
-const float ST2084_c3 = (2392.0f / 4096.0f) * 32.0f;
+static const float ST2084_m1 = 2610.0f / (4096.0f * 4.0f);
+static const float ST2084_m2 = (2523.0f / 4096.0f) * 128.0f;
+static const float ST2084_c1 = 3424.0f / 4096.0f;
+static const float ST2084_c2 = (2413.0f / 4096.0f) * 32.0f;
+static const float ST2084_c3 = (2392.0f / 4096.0f) * 32.0f;
 #endif
 #if defined(KODI_TONE_MAPPING_REINHARD)
 float g_toneP1;
 float3 g_coefsDst;
-float g_luminance;
 
 float reinhard(float x)
 {
@@ -73,8 +72,8 @@ float3 aces(float3 x)
 }
 #endif
 #if defined(KODI_TONE_MAPPING_HABLE)
-float g_luminance;
 float g_toneP1;
+float g_toneP2;
 
 float3 hable(float3 x)
 {
@@ -136,8 +135,7 @@ float4 output4(float4 color, float2 uv)
 #if defined(KODI_TONE_MAPPING_HABLE)
   color.rgb = inversePQ(color.rgb);
   color.rgb *= g_toneP1;
-  float wp = g_luminance / 100.0f;
-  color.rgb = hable(color.rgb * wp) / hable(wp);
+  color.rgb = hable(color.rgb * g_toneP2) / hable(g_toneP2);
   color.rgb = pow(color.rgb, 1.0f / 2.2f);
 #endif
 #if defined(KODI_HLG_TO_PQ)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -216,9 +216,10 @@ void COutputShader::ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWid
   else if (m_toneMapping && m_toneMappingMethod == VS_TONEMAPMETHOD_HABLE)
   {
     float lumin = GetLuminanceValue();
-    float param = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
-    effect.SetScalar("g_luminance", lumin);
-    effect.SetScalar("g_toneP1", param);
+    float lumin_factor = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
+    float lumin_div100 = lumin / (100.0f * m_toneMappingParam);
+    effect.SetScalar("g_toneP1", lumin_factor);
+    effect.SetScalar("g_toneP2", lumin_div100);
   }
 }
 


### PR DESCRIPTION
## Description
- Fix missing static modifier in pixel shaders global constants.
- Deleted unused variable `g_luminance` on Reinhard method.
- Moved simple multiplication outside of shaders code to to simplify as much as possible (due ps_2_0 instruction slots limitation).

## Motivation and Context
Found pixel shaders compilation warning while doing anoter things:
```
(45,13-50): warning X3207: Initializer used on a global 'const' variable. This requires setting an external constant. If a literal is desired, use 'static const' instead.
(46,13-52): warning X3207: Initializer used on a global 'const' variable. This requires setting an external constant. If a literal is desired, use 'static const' instead.
(47,13-41): warning X3207: Initializer used on a global 'const' variable. This requires setting an external constant. If a literal is desired, use 'static const' instead.
(48,13-51): warning X3207: Initializer used on a global 'const' variable. This requires setting an external constant. If a literal is desired, use 'static const' instead.
(49,13-51): warning X3207: Initializer used on a global 'const' variable. This requires setting an external constant. If a literal is desired, use 'static const' instead.
```
Also i want change `g_luminance / 100.0f` to `g_luminance / (100.0f * ToneMapParam)` on Hable's method because scales it better but due limitation of instruction slots is reached maximum complexity permitted on ps_2_0. So this multiplication is moved outside of shaders code.

No output change for default toneMapParam = 1.0 and scales it better for values < 1.0.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
