### PR TITLE
 Tone mapping: Extend default video settings to store tone map method

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -96,7 +96,7 @@ private:
   unsigned m_sourceHeight = 0;
   int m_lutSize = 0;
   int m_ditherDepth = 0;
-  int m_toneMappingMethod = VS_TONEMAPMETHOD_REINHARD;
+  int m_toneMappingMethod = 0;
   float m_toneMappingParam = 1.0f;
 
   CRect m_sourceRect = {};

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -36,6 +36,10 @@ CVideoSettings::CVideoSettings()
   m_StereoMode = 0;
   m_StereoInvert = false;
   m_VideoStream = -1;
+  m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
+  m_ToneMapParam = 1.0f;
+  m_Orientation = 0;
+  m_CenterMixLevel = 0;
 }
 
 bool CVideoSettings::operator!=(const CVideoSettings &right) const

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -90,8 +90,8 @@ public:
   bool operator!=(const CVideoSettings &right) const;
 
   EINTERLACEMETHOD m_InterlaceMethod;
-  ESCALINGMETHOD   m_ScalingMethod;
-  int m_ViewMode;   // current view mode
+  ESCALINGMETHOD m_ScalingMethod;
+  int m_ViewMode; // current view mode
   float m_CustomZoomAmount; // custom setting zoom amount
   float m_CustomPixelRatio; // custom setting pixel ratio
   float m_CustomVerticalShift; // custom setting vertical shift
@@ -113,10 +113,10 @@ public:
   int m_StereoMode;
   bool m_StereoInvert;
   int m_VideoStream;
-  int m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
-  float m_ToneMapParam = 1.0;
-  int m_Orientation = 0;
-  int m_CenterMixLevel = 0; // relative to metadata or default
+  int m_ToneMapMethod;
+  float m_ToneMapParam;
+  int m_Orientation;
+  int m_CenterMixLevel; // relative to metadata or default
 };
 
 class CCriticalSection;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -114,10 +114,11 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
       m_defaultVideoSettings.m_StereoMode = 0;
     if (!XMLUtils::GetInt(pElement, "centermixlevel", m_defaultVideoSettings.m_CenterMixLevel))
       m_defaultVideoSettings.m_CenterMixLevel = 0;
-
-    m_defaultVideoSettings.m_ToneMapMethod = 1;
-    m_defaultVideoSettings.m_ToneMapParam = 1.0f;
     m_defaultVideoSettings.m_SubtitleCached = false;
+    if (!XMLUtils::GetInt(pElement, "tonemapmethod", m_defaultVideoSettings.m_ToneMapMethod))
+      m_defaultVideoSettings.m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
+    if (!XMLUtils::GetFloat(pElement, "tonemapparam", m_defaultVideoSettings.m_ToneMapParam, 0.1f, 5.0f))
+      m_defaultVideoSettings.m_ToneMapParam = 1.0f;
   }
 
   m_defaultGameSettings.Reset();
@@ -220,6 +221,8 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
   XMLUtils::SetBoolean(pNode, "nonlinstretch", m_defaultVideoSettings.m_CustomNonLinStretch);
   XMLUtils::SetInt(pNode, "stereomode", m_defaultVideoSettings.m_StereoMode);
   XMLUtils::SetInt(pNode, "centermixlevel", m_defaultVideoSettings.m_CenterMixLevel);
+  XMLUtils::SetInt(pNode, "tonemapmethod", m_defaultVideoSettings.m_ToneMapMethod);
+  XMLUtils::SetFloat(pNode, "tonemapparam", m_defaultVideoSettings.m_ToneMapParam);
 
   // default audio settings for dsp addons
   TiXmlElement audioSettingsNode("defaultaudiosettings");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4469,12 +4469,6 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
       settings.m_Orientation = m_pDS->fv("Orientation").get_asInt();
       settings.m_CenterMixLevel = m_pDS->fv("CenterMixLevel").get_asInt();
       m_pDS->close();
-
-      if (settings.m_ToneMapParam == 0.0)
-      {
-        settings.m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
-        settings.m_ToneMapParam = 1.0;
-      }
       return true;
     }
     m_pDS->close();


### PR DESCRIPTION
## Description
- Extend default video settings to store tone map method & param (user preference for all videos).
- Clean up of `CVideoSettings` class: move all initialization values to constructor, ~~delete unused element `m_SubtitleCached`~~
- ~~Round tone map param to 2 decimal places to avoid store inexact values e.g. 0.9988346789~~  (*)
- Fixes https://github.com/xbmc/xbmc/issues/16257

(*) Removed code that fix this because Team not wants merge (someone will doing it better).

## Motivation and Context
Users may want change default tone map method and use always one of the new methods (ACES or Hable). Without this PR the only way is enter on OSD video settings for every new video is playing. Setting is stored but only for current video.

"Set as default for all media" does not work. This PR fix this.

This change does not affect users that has video library items with custom tonemap settings. Only affects to new video library items added or items without tonemap settings.

## How Has This Been Tested?
Check that on userdata folder **guisettings.xml** stores user preference for `defaultvideosettings`

New `<tonemapmethod>1</tonemapmethod>`  and `<tonemapparam>1.000000</tonemapparam>` entry is created.

```
    <defaultvideosettings>
        <interlacemethod>1</interlacemethod>
        <scalingmethod>1</scalingmethod>
        <noisereduction>0.000000</noisereduction>
        <postprocess>true</postprocess>
        <sharpness>0.000000</sharpness>
        <viewmode>6</viewmode>
        <zoomamount>1.000000</zoomamount>
        <pixelratio>1.000000</pixelratio>
        <verticalshift>0.000000</verticalshift>
        <volumeamplification>0.000000</volumeamplification>
        <showsubtitles>true</showsubtitles>
        <brightness>50.000000</brightness>
        <contrast>50.000000</contrast>
        <gamma>20.000000</gamma>
        <audiodelay>0.000000</audiodelay>
        <subtitledelay>0.000000</subtitledelay>
        <nonlinstretch>false</nonlinstretch>
        <stereomode>0</stereomode>
        <centermixlevel>0</centermixlevel>
        <tonemapmethod>1</tonemapmethod>
        <tonemapparam>1.000000</tonemapparam>
    </defaultvideosettings>
```
And all videos on database that not has its own tonemap setting is using the default video settings.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
