### PR TITLE
[metadata.local] Define assets and bump version for matrix

### DIFF
--- a/addons/metadata.local/addon.xml
+++ b/addons/metadata.local/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.local"
        name="Local information only"
-       version="1.0.0"
+       version="1.0.1"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="1.0"/>
@@ -22,8 +22,12 @@
              language="multi"
              library="local.xml"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en">Local Infomation only pseudo-scraper</summary>
-    <description lang="en">Use local information only</description>
+    <summary lang="en_GB">Local Infomation only pseudo-scraper</summary>
+    <description lang="en_GB">Use local information only</description>
     <platform>all</platform>
+    <license>GPL-2.0-only</license>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
## Description
Noticed while working on other stuff that the icon for the metadata.local dummy scrapper is not showing in matrix. This defines the assets element in addon.xml and bump its version for matrix.

## Motivation and Context
Minor fix

## How Has This Been Tested?
Compile and see

## Screenshots (if appropriate):

**Before**

![before](https://i.imgur.com/N6wm8vd.png "Before")

**PR**

![pr](https://i.imgur.com/N8foouP.png "PR")


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
