### PR TITLE
[Artwork] Fix season-all posters and manage context menu item

### DIFF
--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -81,9 +81,13 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
     pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting
     pItem->SetProperty("watchedepisodes", watched);
     pItem->SetProperty("unwatchedepisodes", unwatched);
-    if (items.Size() && items[0]->GetVideoInfoTag())
+
+    // @note: the items list contains the (..) upper directory navigation fileitem plus all the
+    // season directory fileitems for a given show. We want to assign the "All Seasons" listitem
+    // the infotag of the tv show - so do not use the first item in the list!
+    if (items.Size() && items[items.Size() - 1]->GetVideoInfoTag())
     {
-      *pItem->GetVideoInfoTag() = *items[0]->GetVideoInfoTag();
+      *pItem->GetVideoInfoTag() = *items[items.Size() - 1]->GetVideoInfoTag();
       pItem->GetVideoInfoTag()->m_iSeason = -1;
     }
     pItem->GetVideoInfoTag()->m_strTitle = strLabel;


### PR DESCRIPTION
## Description
This fixes a feature that has been broken since Kodi Krypton (included). Users can have `season-all-*`  artwork (e.g. season-all-poster.png) in the root folder of a show. When using metadata.local scrapper this artwork is taken into account and added to the database, being later displayed when selecting "All". Furthermore, users can use the "manage" context menu item to modify the artwork of the "All seasons" listitem.

When the "All Seasons" listitem is created, the list of items containing all the seasons of the show that is present on the mediawindow **also includes the top level (..) fileitem**. The infotag can come from any of the listitems in the list...except the first. This was the one being used :) 

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/18634

## How Has This Been Tested?
Library of shows made of strm files with nfos scraped via tinymediamanager. Added season-all-poster.jpg to one of the shows

## Screenshots (if appropriate):

**Before:**

![Before](https://i.imgur.com/Ps8PfpA.png "Before")


**Now:**

![Now](https://i.imgur.com/O74gOUh.png "Now")

![Nowmanage](https://i.imgur.com/VNiqYuY.png "Nowmanage")

Note: I used a random picture from another show just to test the functionality.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
