### PR TITLE
[addons] fix: don't check updated repos for updates during migration

### DIFF
--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -56,6 +56,12 @@ enum class InstallModalPrompt
   NO_PROMPT,
 };
 
+enum class AllowCheckForUpdates
+{
+  YES,
+  NO,
+};
+
 class CAddonInstaller : public IJobCallback
 {
 public:
@@ -96,11 +102,15 @@ public:
                                  const ADDON::RepositoryPtr& repo);
 
   /*! \brief Installs a vector of addons
-   \param addons the list of addons to install
-   \param wait if the method should wait for all the DoInstall jobs to finish or if it should return right away
-   \sa DoInstall
+   *  \param addons the list of addons to install
+   *  \param wait if the method should wait for all the DoInstall jobs to finish or if it should return right away
+   *  \param allowCheckForUpdates indicates if content update checks are allowed
+   *         after installation of a repository addon from the vector
+   *  \sa DoInstall
    */
-  void InstallAddons(const ADDON::VECADDONS& addons, bool wait);
+  void InstallAddons(const ADDON::VECADDONS& addons,
+                     bool wait,
+                     AllowCheckForUpdates allowCheckForUpdates);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from
@@ -162,17 +172,24 @@ private:
   ~CAddonInstaller() override;
 
   /*! \brief Install an addon from a repository or zip
-   \param addon the AddonPtr describing the addon
-   \param repo the repository to install addon from
-   \param background whether to install in the background or not.
-   \return true on successful install, false on failure.
+   *  \param addon the AddonPtr describing the addon
+   *  \param repo the repository to install addon from
+   *  \param background whether to install in the background or not.
+   *  \param modal whether to install in modal mode or not.
+   *  \param autoUpdate whether the addon is installed in auto update mode.
+   *         (i.e. no notification)
+   *  \param dependsInstall whether this is the installation of a dependency addon
+   *  \param allowCheckForUpdates whether content update check after installation of
+   *         a repository addon is allowed
+   *  \return true on successful install, false on failure.
    */
   bool DoInstall(const ADDON::AddonPtr& addon,
                  const ADDON::RepositoryPtr& repo,
                  BackgroundJob background,
                  ModalJob modal,
                  AutoUpdateJob autoUpdate,
-                 DependencyJob dependsInstall);
+                 DependencyJob dependsInstall,
+                 AllowCheckForUpdates allowCheckForUpdates);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -221,6 +238,10 @@ public:
   static bool GetAddon(const std::string& addonID, ADDON::RepositoryPtr& repo, ADDON::AddonPtr& addon);
 
   void SetDependsInstall(DependencyJob dependsInstall) { m_dependsInstall = dependsInstall; };
+  void SetAllowCheckForUpdates(AllowCheckForUpdates allowCheckForUpdates)
+  {
+    m_allowCheckForUpdates = allowCheckForUpdates;
+  };
 
 private:
   void OnPreInstall();
@@ -242,6 +263,7 @@ private:
   bool m_isUpdate;
   AutoUpdateJob m_isAutoUpdate;
   DependencyJob m_dependsInstall = DependencyJob::NO;
+  AllowCheckForUpdates m_allowCheckForUpdates = AllowCheckForUpdates::YES;
   const char* m_currentType = TYPE_DOWNLOAD;
 };
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -458,7 +458,7 @@ std::vector<AddonInfoPtr> CAddonMgr::MigrateAddons()
   CLog::Log(LOGINFO, "ADDON: waiting for add-ons to update...");
   VECADDONS updates;
   GetAddonUpdateCandidates(updates);
-  InstallAddonUpdates(updates, true);
+  InstallAddonUpdates(updates, true, AllowCheckForUpdates::NO);
 
   // get addons that became incompatible and disable them
   std::vector<AddonInfoPtr> incompatible;
@@ -497,7 +497,7 @@ void CAddonMgr::CheckAndInstallAddonUpdates(bool wait) const
   std::lock_guard<std::mutex> lock(m_installAddonsMutex);
   VECADDONS updates;
   GetAddonUpdateCandidates(updates);
-  InstallAddonUpdates(updates, wait);
+  InstallAddonUpdates(updates, wait, AllowCheckForUpdates::YES);
 }
 
 bool CAddonMgr::GetAddonUpdateCandidates(VECADDONS& updates) const
@@ -556,11 +556,13 @@ void CAddonMgr::SortByDependencies(VECADDONS& updates) const
   updates = sorted;
 }
 
-void CAddonMgr::InstallAddonUpdates(VECADDONS& updates, bool wait) const
+void CAddonMgr::InstallAddonUpdates(VECADDONS& updates,
+                                    bool wait,
+                                    AllowCheckForUpdates allowCheckForUpdates) const
 {
   // sort addons by dependencies (ensure install order) and install all
   SortByDependencies(updates);
-  CAddonInstaller::GetInstance().InstallAddons(updates, wait);
+  CAddonInstaller::GetInstance().InstallAddons(updates, wait, allowCheckForUpdates);
 }
 
 bool CAddonMgr::GetAddon(const std::string& str,

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -26,6 +26,8 @@ namespace ADDON
 
   const std::string ADDON_PYTHON_EXT           = "*.py";
 
+  enum class AllowCheckForUpdates;
+
   enum class AddonCheckType
   {
     OUTDATED_ADDONS,
@@ -556,8 +558,12 @@ namespace ADDON
      * Install the list of addon updates via AddonInstaller
      * \param[in,out] updates the vector of addons to install (will be sorted)
      * \param wait if the process should wait for all addons to install
+     * \param allowCheckForUpdates indicates if content update checks are allowed
+     *        after installation of a repository addon from the list
      */
-    void InstallAddonUpdates(VECADDONS& updates, bool wait) const;
+    void InstallAddonUpdates(VECADDONS& updates,
+                             bool wait,
+                             AllowCheckForUpdates allowCheckForUpdates) const;
 
     // This guards the addon installation process to make sure
     // addon updates are not installed concurrently


### PR DESCRIPTION
## Description
If third-party repositories are updated during a migration v18 -> v19 process and checked for content updates afterwards, kodi would stuck on the startup splash `Add-on migration in progress - please wait...`

the root issue may be competing `CheckForUpdates()` calls that submit update-jobs. this pr skips the content-update-check for repositories during addon-migration. as we are reaching beta this approach needs to be assessed at a later point

## Motivation and Context
closes #18723 
thanks to @vlmaksime for reporting and providing your repo for testing 

## How Has This Been Tested?
confirm passing addon migration with the provided home-directory
https://vlmaksime.github.io/repository.vlmaksime.test/files/kodi_data.zip
debian buster

@glennguy would be nice if you could test if this pr affects/harms the changes you introduced with #18417
@phunkyfish 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
