### PR TITLE
VideoPlayer: Improve "no data" handling in our ffmpeg demuxer

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -979,8 +979,8 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
       m_pkt.pkt.size = 0;
       m_pkt.pkt.data = NULL;
 
-      // timeout reads after 100ms
-      m_timeout.Set(20000);
+      // timeout reads after 1000ms
+      m_timeout.Set(1000);
       m_pkt.result = av_read_frame(m_pFormatContext, &m_pkt.pkt);
       m_timeout.SetInfinite();
     }
@@ -992,10 +992,14 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
     }
     else if (m_pkt.result == AVERROR_EOF)
     {
+      if (m_pInput->IsRealtime())
+        bReturnEmpty = true;
     }
     else if (m_pkt.result < 0)
     {
       Flush();
+      if (m_pInput->IsRealtime())
+        bReturnEmpty = true;
     }
     // check size and stream index for being in a valid range
     else if (m_pkt.pkt.size < 0 ||

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -238,9 +238,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
   // open the demuxer
   m_pFormatContext  = avformat_alloc_context();
   m_pFormatContext->interrupt_callback = int_cb;
-
-  // try to abort after 30 seconds
-  m_timeout.Set(30000);
+  unsigned int ffInterruptTimeout = m_pInput->IsRealtime() ? 5000 : 30000;
 
   if (m_pInput->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
   {
@@ -256,6 +254,9 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
       // try mmsh, then mmst
       url.SetProtocol("mmsh");
       url.SetProtocolOptions("");
+
+      // Set a timeout for the open input action
+      m_timeout.Set(ffInterruptTimeout);
       result = avformat_open_input(&m_pFormatContext, url.Get().c_str(), iformat, &options);
       if (result < 0)
       {
@@ -295,6 +296,8 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
     if (result < 0)
     {
       m_pFormatContext->flags |= AVFMT_FLAG_PRIV_OPT;
+      // Set a timeout for the open input action
+      m_timeout.Set(ffInterruptTimeout);
       if (avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
       {
         CLog::Log(LOGDEBUG, "Error, could not open file %s", CURL::GetRedacted(strFile).c_str());
@@ -309,6 +312,8 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
       m_pFormatContext->flags &= ~AVFMT_FLAG_PRIV_OPT;
       AVDictionary* options = GetFFMpegOptionsFromInput();
       av_dict_set_int(&options, "load_all_variants", 0, AV_OPT_SEARCH_CHILDREN);
+      // Set a timeout for the open input action
+      m_timeout.Set(ffInterruptTimeout);
       if (avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
       {
         CLog::Log(LOGDEBUG, "Error, could not open file (2) %s", CURL::GetRedacted(strFile).c_str());
@@ -321,6 +326,10 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
   }
   else
   {
+    // Set a timeout of 30 seconds
+    // for the next block of ffmpeg calls
+    m_timeout.Set(30000);
+
     bool seekable = true;
     if (m_pInput->Seek(0, SEEK_POSSIBLE) == 0)
     {


### PR DESCRIPTION
## Description
Our ffmpeg demuxer has 2 issues:
* It freezes the UI for >20s when you read from streams that have no data
* It freezes the UI for ~30s when you start playback of a stream that has no data

This PR tries to improve both scenarios for livetv streams.
We do not want to freeze the UI for that big amount of time in either of the usecases.

## How Has This Been Tested?
Tested with live feeds and pvr.iptvsimple

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@FernetMenta In case your're interested, your feedback is welcome (as usual) - thx.