### PR TITLE
[test] add test for XbmcThreads::EndTime class

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1931,7 +1931,7 @@ void CMusicInfoScanner::ScannerWait(unsigned int milliseconds)
     m_StopEvent.WaitMSec(milliseconds);
   }
   else
-    XbmcThreads::ThreadSleep(milliseconds);
+    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }
 
 bool CMusicInfoScanner::AddArtistArtwork(CArtist& artist, const std::string& artfolder)

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -59,9 +59,4 @@ namespace XbmcThreads
     inline unsigned int GetInitialTimeoutValue(void) const { return totalWaitTime; }
     inline unsigned int GetStartTime(void) const { return startTime; }
   };
-
-  inline void ThreadSleep(unsigned int millis)
-  {
-    std::this_thread::sleep_for(std::chrono::microseconds(millis));
-  }
 }

--- a/xbmc/threads/test/CMakeLists.txt
+++ b/xbmc/threads/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestEvent.cpp
-            TestSharedSection.cpp)
+            TestSharedSection.cpp
+            TestEndTime.cpp)
 
 set(HEADERS TestHelpers.h)
 

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "threads/SystemClock.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+void CommonTests(XbmcThreads::EndTime& endTime)
+{
+  EXPECT_EQ(static_cast<unsigned int>(100), endTime.GetInitialTimeoutValue());
+  EXPECT_LE(static_cast<unsigned int>(0), endTime.GetStartTime());
+
+  EXPECT_FALSE(endTime.IsTimePast());
+  EXPECT_LT(static_cast<unsigned int>(0), endTime.MillisLeft());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  EXPECT_TRUE(endTime.IsTimePast());
+  EXPECT_EQ(static_cast<unsigned int>(0), endTime.MillisLeft());
+
+  endTime.SetInfinite();
+  EXPECT_EQ(std::numeric_limits<unsigned int>::max(), endTime.GetInitialTimeoutValue());
+  endTime.SetExpired();
+  EXPECT_EQ(static_cast<unsigned int>(0), endTime.GetInitialTimeoutValue());
+}
+
+} // namespace
+
+TEST(TestEndTime, DefaultConstructor)
+{
+  XbmcThreads::EndTime endTime;
+  endTime.Set(static_cast<unsigned int>(100));
+
+  CommonTests(endTime);
+}
+
+TEST(TestEndTime, ExplicitConstructor)
+{
+  XbmcThreads::EndTime endTime(static_cast<unsigned int>(100));
+
+  CommonTests(endTime);
+}

--- a/xbmc/threads/test/TestHelpers.h
+++ b/xbmc/threads/test/TestHelpers.h
@@ -14,7 +14,10 @@
 
 #define MILLIS(x) x
 
-inline static void SleepMillis(unsigned int millis) { XbmcThreads::ThreadSleep(millis); }
+inline static void SleepMillis(unsigned int millis)
+{
+  std::this_thread::sleep_for(std::chrono::milliseconds(millis));
+}
 
 template<class E> inline static bool waitForWaiters(E& event, int numWaiters, int milliseconds)
 {


### PR DESCRIPTION
This adds a test using for the `XbmcThreads::EndTime` class. I wrote this while I was converting this class to use std::chrono. That code is available here: https://github.com/lrusak/xbmc/tree/systemtime-chrono however I don't think that will make it in for V19 so I wanted to PR these tests for inclusion.

I found a bug in the `XbmcThreads::ThreadSleep` function so I removed that method completely. The problem was that the millisecond value was being treated as microseconds.
```
std::this_thread::sleep_for(std::chrono::microseconds(millis));
```
This didn't really effect much though as only one place used this method (other than in tests).

Should be safe for inclusion into V19