### PR TITLE
AdvancedSettings: add grabinputdevice setting

### DIFF
--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -12,6 +12,9 @@
 #include "LibInputPointer.h"
 #include "LibInputSettings.h"
 #include "LibInputTouch.h"
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -33,10 +36,14 @@ static int open_restricted(const char *path, int flags, void __attribute__((unus
     return -errno;
   }
 
-  auto ret = ioctl(fd, EVIOCGRAB, (void*)1);
-  if (ret < 0)
+
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_grabInputDevice)
   {
-    CLog::Log(LOGDEBUG, "%s - grab requested, but failed for %s (%s)", __FUNCTION__, path, strerror(errno));
+    auto ret = ioctl(fd, EVIOCGRAB, (void*)1);
+    if (ret < 0)
+    {
+      CLog::Log(LOGDEBUG, "%s - grab requested, but failed for %s (%s)", __FUNCTION__, path, strerror(errno));
+    }
   }
 
   return fd;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -250,6 +250,7 @@ void CAdvancedSettings::Initialize()
 
   m_remoteDelay = 3;
   m_bScanIRServer = true;
+  m_grabInputDevice = true;
 
   m_playlistAsFolders = true;
   m_detectAsUdf = false;
@@ -1028,6 +1029,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetInt(pRootElement, "remotedelay", m_remoteDelay, 0, 20);
   XMLUtils::GetBoolean(pRootElement, "scanirserver", m_bScanIRServer);
+  XMLUtils::GetBoolean(pRootElement, "grabinputdevice", m_grabInputDevice);
 
   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 9999);
   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 9999);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -213,6 +213,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     StringMapping m_pathSubstitutions;
     int m_remoteDelay; ///< \brief number of remote messages to ignore before repeating
     bool m_bScanIRServer;
+    bool m_grabInputDevice; ///< \brief grab input device for exclusive access (Linux)
 
     bool m_playlistAsFolders;
     bool m_detectAsUdf;


### PR DESCRIPTION
## Description

this boolean setting controls whether Linux input devices are opened
for exclusive access. Default value is true. Set to false to allow input
events to be handled by the kernel (e.g. KEY_RFKILL) or other processes.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
I have kodi running on a Banana Pi M2 Zero board under LibreELEC, with an RF-kill switch attached to the GPIO and configured via device tree. The switch works fine before kodi starts, but stops working once kodi is running, because the corresponding input device is grabbed exclusively.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
