### PR TITLE
[Fix] Cast not showing when play next is set to episodes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2885,7 +2885,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       CVideoDatabase dbs;
       dbs.Open();
 
-      std::string path = item.GetPath();
+      std::string path = item.GetDynPath();
       std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
       if (videoInfoTagPath.find("removable://") == 0)
         path = videoInfoTagPath;


### PR DESCRIPTION
## Description
This fixes another path/dynpath leftover. The `dbs.LoadVideoInfo(path, *item.GetVideoInfoTag());` always take into consideration the real path of the file being played (thus the one stored in dynpath) to identify the file id in the database (GetFileId) and load any info missing in the infotag (such as the show cast). 

Decided not to touch the fallback for "removable://" paths below since I don't know what regressions that may cause. Maybe something to look up in the future.

## Motivation and Context
Fix https://github.com/xbmc/xbmc/issues/18556

## How Has This Been Tested?
Runtime tested with the setting on and off - verified cast is present in the infotag.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
