### PR TITLE
[keymaps] FullscreenInfo: map longpress return and  lonpress enter to PlayPause

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -442,6 +442,8 @@
       <d mod="ctrl">Back</d>
       <m>OSD</m>
       <menu>OSD</menu>
+      <return mod="longpress">PlayPause</return>
+      <enter mod="longpress">PlayPause</enter>
     </keyboard>
   </FullscreenInfo>
   <PlayerControls>


### PR DESCRIPTION
When playing video/music/... in fullscreen, keyboard longpress return/enter pauses/resumes the playback. This also works when the player OSD is active, but it currently does not work when the fullscreen info dialog is open.

This PR adds the missing mapping to the default keyboard keymap.

Runtime-tested on macOS and Android, latest Kodi master.

No idea who could review this kind of changes - @ronie maybe? 