### PR TITLE
[PVR] Prevent timer notifications if previous addon GetTimers call failed

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -1123,7 +1123,7 @@ void CPVRTimerInfoTag::SetFirstDayFromLocalTime(const CDateTime& firstDay)
   m_FirstDay = ConvertLocalTimeToUTC(firstDay);
 }
 
-void CPVRTimerInfoTag::GetNotificationText(std::string& strText) const
+std::string CPVRTimerInfoTag::GetNotificationText() const
 {
   CSingleLock lock(m_critSection);
 
@@ -1160,8 +1160,11 @@ void CPVRTimerInfoTag::GetNotificationText(std::string& strText) const
   default:
     break;
   }
+
   if (stringID != 0)
-    strText = StringUtils::Format("%s: '%s'", g_localizeStrings.Get(stringID).c_str(), m_strTitle.c_str());
+    return StringUtils::Format("%s: '%s'", g_localizeStrings.Get(stringID).c_str(), m_strTitle.c_str());
+
+  return {};
 }
 
 std::string CPVRTimerInfoTag::GetDeletedNotificationText() const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -250,13 +250,12 @@ namespace PVR
 
     /*!
      * @brief Get the text for the notification.
-     * @param strText The notification.
      */
-    void GetNotificationText(std::string& strText) const;
+    std::string GetNotificationText() const;
 
     /*!
-    * @brief Get the text for the notification when a timer has been deleted
-    */
+     * @brief Get the text for the notification when a timer has been deleted
+     */
     std::string GetDeletedNotificationText() const;
 
     const std::string& Title() const;

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -285,9 +285,17 @@ namespace PVR
     std::vector<std::shared_ptr<CPVRTimerInfoTag>> GetActiveRecordings(const TimerKind& eKind) const;
     int AmountActiveRecordings(const TimerKind& eKind) const;
 
+    bool CheckAndAppendTimerNotification(
+        std::vector<std::pair<int, std::string>>& timerNotifications,
+        const std::shared_ptr<CPVRTimerInfoTag>& tag,
+        bool bDeleted) const;
+
     bool m_bIsUpdating = false;
     CPVRSettings m_settings;
     std::queue<std::shared_ptr<CPVRTimerInfoTag>> m_remindersToAnnounce;
     bool m_bReminderRulesUpdatePending = false;
+
+    bool m_bFirstUpdate = true;
+    std::vector<int> m_failedClients;
   };
 }


### PR DESCRIPTION
Fixes a long-standing bug. If the very first addon call to GetTimers fails after Kodi startup, after the first successful call to GetTimers, all timers will be notified as "added", which is disturbing and unwanted behavior. User shall never see any toasts for the first successful GetTimers call, only the timer changes for subsequent successful calls.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish got some time for  a review?