### PR TITLE
[dialogs] CGUIDialogKaiToast::AddToQueue: Avoid duplicates in a row.

### DIFF
--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -72,6 +72,14 @@ void CGUIDialogKaiToast::AddToQueue(const std::string& aImageFile, const eMessag
 {
   CSingleLock lock(m_critical);
 
+  if (!m_notifications.empty())
+  {
+    const auto& last = m_notifications.back();
+    if (last.eType == eType && last.imagefile == aImageFile && last.caption == aCaption &&
+        last.description == aDescription)
+      return; // avoid duplicates in a row.
+  }
+
   Notification toast;
   toast.eType = eType;
   toast.imagefile = aImageFile;


### PR DESCRIPTION
This fix prevents adding the same toast message multiple time in a row. 

I experienced an "addon x update available toast" on Android TV displayed for some minutes after switching my system back on in the morning after suspending it for the night. Actually it was not one toast being displayed that long, but it was multiple toasts with the same caption/message/icon/... 

Over night, several toasts (due to hourly repo update check!) were queued but not displayed, because on Android we destroy the window system when system is put to sleep, which causes toasts to be queued only, not displayed. When window system gets recreated on system resume, all collected toast will be displayed.

Runtime-tested on macOS (regression test) and Android (the actual fix), latest Kodi master.

@phunkyfish are you in the mood for a code review?