### PR TITLE
Implement global gui texture mipmapping option with negative LOD bias (disabled by default)

### DIFF
--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -26,6 +26,9 @@
 
 #include <d3dcompiler.h>
 
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+
 using namespace DirectX;
 using namespace Microsoft::WRL;
 
@@ -156,8 +159,16 @@ bool CGUIShaderDX::CreateSamplers()
   sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
   sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
   sampDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
-  sampDesc.MinLOD = 0;
+  sampDesc.MinLOD = -D3D11_FLOAT32_MAX;
   sampDesc.MaxLOD = D3D11_FLOAT32_MAX;
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingGlobal)
+  {
+    sampDesc.MipLODBias = -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingGlobalSharpen;
+  }
+  else
+  {
+    sampDesc.MipLODBias = -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingSpecialSharpen;
+  }
 
   if (FAILED(DX::DeviceResources::Get()->GetD3DDevice()->CreateSamplerState(&sampDesc, m_pSampLinear.ReleaseAndGetAddressOf())))
     return false;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -477,12 +477,19 @@ bool CTexture::HasAlpha() const
   return m_hasAlpha;
 }
 
-void CTexture::SetMipmapping()
+void CTexture::SetMipmapping(bool FlagAsSpecial)
 {
   m_mipmapping = true;
+  if (FlagAsSpecial)
+    m_mipmappingspecial = true;
 }
 
 bool CTexture::IsMipmapped() const
 {
   return m_mipmapping;
+}
+
+bool CTexture::IsMipmappedSpecial() const
+{
+  return m_mipmappingspecial;
 }

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -72,8 +72,9 @@ public:
 
   bool HasAlpha() const;
 
-  void SetMipmapping();
+  void SetMipmapping(bool FlagAsSpecial = false);
   bool IsMipmapped() const;
+  bool IsMipmappedSpecial() const;
   void SetScalingMethod(TEXTURE_SCALING scalingMethod) { m_scalingMethod = scalingMethod; }
   TEXTURE_SCALING GetScalingMethod() const { return m_scalingMethod; }
   void SetCacheMemory(bool bCacheMemory) { m_bCacheMemory = bCacheMemory; }
@@ -133,6 +134,7 @@ protected:
   int m_orientation;
   bool m_hasAlpha =  true ;
   bool m_mipmapping =  false ;
+  bool m_mipmappingspecial =  false ;
   TEXTURE_SCALING m_scalingMethod = TEXTURE_SCALING::LINEAR;
   bool m_bCacheMemory = false;
 };

--- a/xbmc/guilib/TextureDX.cpp
+++ b/xbmc/guilib/TextureDX.cpp
@@ -11,6 +11,10 @@
 #include "utils/MemUtils.h"
 #include "utils/log.h"
 
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+
 CTexture* CTexture::CreateTexture(unsigned int width, unsigned int height, unsigned int format)
 {
   return new CDXTexture(width, height, format);
@@ -83,12 +87,12 @@ void CDXTexture::LoadToGPU()
     if (m_format != XB_FMT_RGB8)
     {
       // this is faster way to create texture with initial data instead of create empty and then copy to it
-      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingGlobal ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
       if (m_texture.Get() != nullptr)
         needUpdate = false;
     }
     else
-      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingGlobal ? 0 : 1, usage, GetFormat());
 
     if (m_texture.Get() == nullptr)
     {
@@ -109,7 +113,7 @@ void CDXTexture::LoadToGPU()
       m_texture.Release();
       usage = D3D11_USAGE_DYNAMIC;
 
-      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
+      m_texture.Create(m_textureWidth, m_textureHeight, IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingGlobal ? 0 : 1, usage, GetFormat(), m_pixels, GetPitch());
       if (m_texture.Get() == nullptr)
       {
         CLog::Log(LOGDEBUG, "CDXTexture::CDXTexture: Error creating new texture for size %d x %d.", m_textureWidth, m_textureHeight);
@@ -169,7 +173,7 @@ void CDXTexture::LoadToGPU()
       CLog::LogF(LOGERROR, "failed to lock texture.");
     }
     m_texture.UnlockRect(0);
-    if (usage != D3D11_USAGE_STAGING && IsMipmapped())
+    if (usage != D3D11_USAGE_STAGING && (IsMipmapped() || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageMipMappingGlobal))
       m_texture.GenerateMipmaps();
   }
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -128,7 +128,7 @@ void CSlideShowPic::SetTexture_Internal(int iSlideNumber,
   m_fHeight = (float)pTexture->GetHeight();
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_SLIDESHOW_HIGHQUALITYDOWNSCALING))
   { // activate mipmapping when high quality downscaling is 'on'
-    pTexture->SetMipmapping();
+    pTexture->SetMipmapping(true);
   }
   // reset our counter
   m_iCounter = 0;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -258,6 +258,10 @@ void CAdvancedSettings::Initialize()
   m_imageRes = 720;
   m_imageScalingAlgorithm = CPictureScalingAlgorithm::Default;
 
+  m_imageMipMappingGlobal = false;
+  m_imageMipMappingGlobalSharpen = 1.0f;
+  m_imageMipMappingSpecialSharpen = 0.5f;
+
   m_sambaclienttimeout = 30;
   m_sambadoscodepage = "";
   m_sambastatfiles = true;
@@ -1033,6 +1037,11 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 9999);
   if (XMLUtils::GetString(pRootElement, "imagescalingalgorithm", tmp))
     m_imageScalingAlgorithm = CPictureScalingAlgorithm::FromString(tmp);
+
+  XMLUtils::GetBoolean(pRootElement, "imagemipmappingglobal", m_imageMipMappingGlobal);
+  XMLUtils::GetFloat(pRootElement, "imagemipmappingglobalsharpen", m_imageMipMappingGlobalSharpen, 0.0f, 3.0f);
+  XMLUtils::GetFloat(pRootElement, "imagemipmappingspecialsharpen", m_imageMipMappingSpecialSharpen, 0.0f, 3.0f);
+
   XMLUtils::GetBoolean(pRootElement, "playlistasfolders", m_playlistAsFolders);
   XMLUtils::GetBoolean(pRootElement, "uselocalecollation", m_useLocaleCollation);
   XMLUtils::GetBoolean(pRootElement, "detectasudf", m_detectAsUdf);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -221,6 +221,10 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     unsigned int m_imageRes;  ///< \brief the maximal resolution to cache images at (assumes 16x9)
     CPictureScalingAlgorithm::Algorithm m_imageScalingAlgorithm;
 
+    bool m_imageMipMappingGlobal;
+    float m_imageMipMappingGlobalSharpen;
+    float m_imageMipMappingSpecialSharpen;
+
     int m_sambaclienttimeout;
     std::string m_sambadoscodepage;
     bool m_sambastatfiles;


### PR DESCRIPTION
## Description
Implements global gui texture mipmapping option with negative LOD bias (disabled by default)

Following up on the discussions from 2008-2019:

- https://github.com/xbmc/xbmc/pull/8409
- https://forum.kodi.tv/showthread.php?tid=42857
- https://forum.kodi.tv/showthread.php?tid=200401

Can be enabled via "advancedsettings.xml":

imagemipmappingglobal (false/true, default=false) _- Enables global mipmapping for all GUI textures_

Changing the default negative LOD bias values is possible:

imagemipmappingglobalsharpen (0-3, default=1) _- negative LOD bias / sharpening value for global mipmapping_
imagemipmappingspecialsharpen (0-3, default=0.5) _- negative LOD bias / sharpening value for mipmapping in special areas like picture slideshow (same value as in the past)_ 


After extensive testing i ended up with 2 different good negative LOD bias values:

-1 for all GUI textures
-0.5 (which has been determined in the old PR https://github.com/xbmc/xbmc/pull/8409 ) for special areas like the picture slideshow animations

Recommended "advancedsettings.xml" settings to enable and benefit most from this solution and the now usable quality potential:

(1080p display)
```
<imagemipmappingglobal>true</imagemipmappingglobal>
<imageres>1080</imageres>
<fanartres>1080</fanartres>
<imagescalingalgorithm>lanczos</imagescalingalgorithm>
```

(2160p display)
```
<imagemipmappingglobal>true</imagemipmappingglobal>
<imageres>2160</imageres>
<fanartres>2160</fanartres>
<imagescalingalgorithm>lanczos</imagescalingalgorithm>
```

(Delete userdata\Thumbnails folder after changes)

## Motivation and Context
Implements global gui texture mipmapping option with negative LOD bias to avoid badly scaled textures. Without this solution, the larger the decimation factor, the worse the scaled texture result gets:

http://nakunana24519x.bplaced.net/_tmp/k-bettergui/pixelation_example_small_234235.png
http://nakunana24519x.bplaced.net/_tmp/k-bettergui/pixelation_example_22353425.png

## How Has This Been Tested?
I've tested this on Windows 7/10, LibreELEC/Linux, Mac OS and used the solution on regularly used Kodi systems for ~2 years now. (Windows 7/10 Intel/AMD GPU+LibreELEC/Linux Intel NUC)

I'm not really a C+ dev and created this mainly because of my passion for better UI/UX quality - but i hope this PR / picked up discussion leads somewhere. :-)

## Screenshots (if appropriate):
https://forum.kodi.tv/showthread.php?tid=348790
http://nakunana24519x.bplaced.net/_tmp/k-bettergui/pixelation_example_small_234235.png
http://nakunana24519x.bplaced.net/_tmp/k-bettergui/pixelation_example_22353425.png

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
