### PR TITLE
[addons] improve ShowDependencyList dialog label creation

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15838,27 +15838,41 @@ msgstr ""
 
 #24171-24179 reserved for future use of lifecycle state name (to have continuous chain of GUI)
 
+#. The minimum version a dependency must meet. This is set in the <requires> tag of the dependee
+#. {3:s} reserved for an empty string or the " (optional)" optional string. see #24184
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 msgctxt "#24180"
-msgid "Minimum: {0:s}"
+msgid "Minimum: {0:s}{3:s}"
 msgstr ""
 
+#. The minimum version, plus the version going to be installed
+#. {3:s} reserved for an empty string or the " (optional)" optional string. see #24184
 #: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 msgctxt "#24181"
-msgid " => Install: {0:s}"
+msgid "Minimum: {0:s} => Install: {2:s}{3:s}"
 msgstr ""
 
+#. The minimum version, plus the currently installed version
+#. {3:s} reserved for an empty string or the " (optional)" optional string. see #24184
 #: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 msgctxt "#24182"
-msgid " / Installed: {0:s}"
+msgid "Minimum: {0:s} / Installed: {1:s}{3:s}"
 msgstr ""
 
+#. The minimum version, the currently installed, plus the updated version we're going to install
+#. {3:s} reserved for an empty string or the " (optional)" optional string. see #24184
 #: xbmc/addons/gui/GUIDialogAddonInfo.cpp
 msgctxt "#24183"
-msgid " => Update to: {0:s}"
+msgid "Minimum: {0:s} / Installed: {1:s} => Update to: {2:s}{3:s}"
 msgstr ""
 
-#empty strings from id 24184 to 24990
+#. used in #24180 - #24183 as {3:s}
+#: xbmc/addons/gui/GUIDialogAddonInfo.cpp
+msgctxt "#24184"
+msgid " (optional)"
+msgstr ""
+
+#empty strings from id 24185 to 24990
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -616,43 +616,32 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
             (entryPoint == EntryPoint::UPDATE && !it.m_isInstalledUpToDate()))
         {
           const CFileItemPtr item = std::make_shared<CFileItem>(infoAddon->Name());
-          std::stringstream str;
-
-          str << StringUtils::Format(g_localizeStrings.Get(24180).c_str(),
-                                     it.m_depInfo.versionMin.asString().c_str()); // min: x.y.z
+          int messageId = 24180; // minversion only
 
           // dep not installed locally, but it is available from a repo!
           if (!it.m_installed)
           {
             if (entryPoint != EntryPoint::SHOW_DEPENDENCIES)
             {
-              str << StringUtils::Format(
-                  g_localizeStrings.Get(24181).c_str(),
-                  it.m_available->Version().asString().c_str()); // => install
+              messageId = 24181; // => install
             }
           }
           else // dep is installed locally
           {
-            str << StringUtils::Format(
-                g_localizeStrings.Get(24182).c_str(),
-                it.m_installed->Version().asString().c_str()); // => installed
+            messageId = 24182; // => installed
 
             if (!it.m_isInstalledUpToDate())
             {
-              str << StringUtils::Format(
-                  g_localizeStrings.Get(24183).c_str(),
-                  it.m_available->Version().asString().c_str()); // => update to
+              messageId = 24183; // => update to
             }
           }
 
-          if (it.m_depInfo.optional)
-          {
-            str << " "
-                << StringUtils::Format(g_localizeStrings.Get(39022).c_str(),
-                                       g_localizeStrings.Get(39018).c_str()); // (optional)
-          }
+          item->SetLabel2(StringUtils::Format(
+              g_localizeStrings.Get(messageId).c_str(), it.m_depInfo.versionMin.asString().c_str(),
+              it.m_installed ? it.m_installed->Version().asString().c_str() : "",
+              it.m_available ? it.m_available->Version().asString().c_str() : "",
+              it.m_depInfo.optional ? g_localizeStrings.Get(24184).c_str() : ""));
 
-          item->SetLabel2(str.str());
           item->SetArt("icon", infoAddon->Icon());
           item->SetProperty("addon_id", it.m_depInfo.id);
           items.Add(item);


### PR DESCRIPTION
## Description
follow up on #18675
labels in the DependencyList dialog are no longer assembled in core. allows easier translation especially to RTL languages

## Motivation and Context
resolve leftover

## How Has This Been Tested?
debian buster local
observed no behavior change

@phunkyfish if you mind having a look

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
