### PR TITLE
[modernize] Update XbmcThreads::EndTime class to use std::chrono

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -124,7 +124,8 @@ void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
 {
   CSingleLock lock(m_instance->m_cs);
 
-  list.emplace_back(g_localizeStrings.Get(20422), XbmcThreads::EndTime::InfiniteValue);
+  list.emplace_back(g_localizeStrings.Get(20422),
+                    static_cast<int>(XbmcThreads::EndTime::InfiniteValue.count()));
   list.emplace_back(g_localizeStrings.Get(13551), 0);
 
   if (m_instance->m_audioEngine.SupportsSilenceTimeout())

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1140,7 +1140,7 @@ void CActiveAESink::GenerateNoise()
 void CActiveAESink::SetSilenceTimer()
 {
   if (m_extStreaming)
-    m_extSilenceTimeout = XbmcThreads::EndTime::InfiniteValue;
+    m_extSilenceTimeout = static_cast<unsigned int>(XbmcThreads::EndTime::InfiniteValue.count());
   else if (m_extAppFocused)
     m_extSilenceTimeout = m_silenceTimeOut;
   else

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -36,7 +36,8 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       int timeoutMS = ceil(timeout * 1000);
-      XbmcThreads::EndTime endTime(timeoutMS > 0 ? timeoutMS : XbmcThreads::EndTime::InfiniteValue);
+      XbmcThreads::EndTime endTime(timeoutMS > 0 ? timeoutMS
+                                                 : XbmcThreads::EndTime::InfiniteValue.count());
       while (!endTime.IsTimePast())
       {
         {

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -460,7 +460,7 @@ void CPVREpgContainer::Process()
 
   // store data on exit
   CLog::Log(LOGINFO, "EPG Container: Persisting unsaved events...");
-  PersistAll(XbmcThreads::EndTime::InfiniteValue);
+  PersistAll(static_cast<unsigned int>(XbmcThreads::EndTime::InfiniteValue.count()));
   CLog::Log(LOGINFO, "EPG Container: Persisting events done");
 }
 
@@ -543,7 +543,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetTags(
     const PVREpgSearchData& searchData) const
 {
   // make sure we have up-to-date data in the database.
-  PersistAll(XbmcThreads::EndTime::InfiniteValue);
+  PersistAll(static_cast<unsigned int>(XbmcThreads::EndTime::InfiniteValue.count()));
 
   const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
   std::vector<std::shared_ptr<CPVREpgInfoTag>> results = database->GetEpgTags(searchData);

--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -14,20 +14,73 @@
 
 namespace XbmcThreads
 {
-  unsigned int SystemClockMillis()
-  {
-    uint64_t now_time;
-    static uint64_t start_time = 0;
-    static bool start_time_set = false;
 
-    now_time = static_cast<uint64_t>(1000 * CurrentHostCounter() / CurrentHostFrequency());
+EndTime::EndTime() : m_startTime(std::chrono::system_clock::now())
+{
+}
 
-    if (!start_time_set)
-    {
-      start_time = now_time;
-      start_time_set = true;
-    }
-    return (unsigned int)(now_time - start_time);
-  }
-  const unsigned int EndTime::InfiniteValue = std::numeric_limits<unsigned int>::max();
+EndTime::EndTime(unsigned int millisecondsIntoTheFuture)
+  : m_startTime(std::chrono::system_clock::now()),
+    m_totalWaitTime(static_cast<std::chrono::milliseconds>(millisecondsIntoTheFuture))
+{
+}
+
+void EndTime::Set(unsigned int millisecondsIntoTheFuture)
+{
+  m_startTime = std::chrono::system_clock::now();
+  m_totalWaitTime = static_cast<std::chrono::milliseconds>(millisecondsIntoTheFuture);
+}
+
+bool EndTime::IsTimePast() const
+{
+  if (m_totalWaitTime == InfiniteValue)
+    return false;
+
+  if (m_totalWaitTime == std::chrono::milliseconds(0))
+    return true;
+
+  return ((std::chrono::system_clock::now() - m_startTime) >= m_totalWaitTime);
+}
+
+unsigned int EndTime::MillisLeft() const
+{
+  if (m_totalWaitTime == InfiniteValue)
+    return static_cast<unsigned int>(InfiniteValue.count());
+
+  if (m_totalWaitTime == std::chrono::milliseconds(0))
+    return 0;
+
+  std::chrono::milliseconds timeWaitedAlready =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() -
+                                                            m_startTime);
+
+  if (timeWaitedAlready >= m_totalWaitTime)
+    return 0;
+
+  return static_cast<unsigned int>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(m_totalWaitTime - timeWaitedAlready)
+          .count());
+}
+
+unsigned int EndTime::GetInitialTimeoutValue() const
+{
+  return static_cast<unsigned int>(m_totalWaitTime.count());
+}
+
+unsigned int EndTime::GetStartTime() const
+{
+  return static_cast<unsigned int>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(m_startTime.time_since_epoch())
+          .count());
+}
+
+unsigned int SystemClockMillis()
+{
+  return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       std::chrono::system_clock::now().time_since_epoch())
+                                       .count());
+}
+
+const std::chrono::milliseconds EndTime::InfiniteValue =
+    std::numeric_limits<std::chrono::milliseconds>::max();
 }

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -22,6 +22,7 @@ namespace XbmcThreads
    *
    * Of course, on windows it just calls timeGetTime, so you're on your own.
    */
+
   unsigned int SystemClockMillis();
 
   /**
@@ -32,31 +33,29 @@ namespace XbmcThreads
    */
   class EndTime
   {
-    unsigned int startTime = 0;
-    unsigned int totalWaitTime = 0;
   public:
-    static const unsigned int InfiniteValue;
-    inline EndTime() = default;
-    inline explicit EndTime(unsigned int millisecondsIntoTheFuture) : startTime(SystemClockMillis()), totalWaitTime(millisecondsIntoTheFuture) {}
+    EndTime();
+    explicit EndTime(unsigned int millisecondsIntoTheFuture);
+    EndTime(const EndTime& right) = delete;
+    ~EndTime() = default;
 
-    inline void Set(unsigned int millisecondsIntoTheFuture) { startTime = SystemClockMillis(); totalWaitTime = millisecondsIntoTheFuture; }
+    void Set(unsigned int millisecondsIntoTheFuture);
 
-    inline bool IsTimePast() const { return totalWaitTime == InfiniteValue ? false : (totalWaitTime == 0 ? true : (SystemClockMillis() - startTime) >= totalWaitTime); }
+    bool IsTimePast() const;
 
-    inline unsigned int MillisLeft() const
-    {
-      if (totalWaitTime == InfiniteValue)
-        return InfiniteValue;
-      if (totalWaitTime == 0)
-        return 0;
-      unsigned int timeWaitedAlready = (SystemClockMillis() - startTime);
-      return (timeWaitedAlready >= totalWaitTime) ? 0 : (totalWaitTime - timeWaitedAlready);
-    }
+    unsigned int MillisLeft() const;
 
-    inline void SetExpired() { totalWaitTime = 0; }
-    inline void SetInfinite() { totalWaitTime = InfiniteValue; }
-    inline bool IsInfinite(void) const { return (totalWaitTime == InfiniteValue); }
-    inline unsigned int GetInitialTimeoutValue(void) const { return totalWaitTime; }
-    inline unsigned int GetStartTime(void) const { return startTime; }
+    void SetExpired() { m_totalWaitTime = std::chrono::milliseconds(0); }
+    void SetInfinite() { m_totalWaitTime = InfiniteValue; }
+    bool IsInfinite() const { return (m_totalWaitTime == InfiniteValue); }
+
+    unsigned int GetInitialTimeoutValue() const;
+    unsigned int GetStartTime() const;
+
+    static const std::chrono::milliseconds InfiniteValue;
+
+  private:
+    std::chrono::system_clock::time_point m_startTime;
+    std::chrono::milliseconds m_totalWaitTime;
   };
 }

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -16,7 +16,7 @@ namespace
 void CommonTests(XbmcThreads::EndTime& endTime)
 {
   EXPECT_EQ(static_cast<unsigned int>(100), endTime.GetInitialTimeoutValue());
-  EXPECT_LE(static_cast<unsigned int>(0), endTime.GetStartTime());
+  EXPECT_LT(static_cast<unsigned int>(0), endTime.GetStartTime());
 
   EXPECT_FALSE(endTime.IsTimePast());
   EXPECT_LT(static_cast<unsigned int>(0), endTime.MillisLeft());
@@ -27,7 +27,9 @@ void CommonTests(XbmcThreads::EndTime& endTime)
   EXPECT_EQ(static_cast<unsigned int>(0), endTime.MillisLeft());
 
   endTime.SetInfinite();
-  EXPECT_EQ(std::numeric_limits<unsigned int>::max(), endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(
+      static_cast<unsigned int>(std::numeric_limits<std::chrono::milliseconds>::max().count()),
+      endTime.GetInitialTimeoutValue());
   endTime.SetExpired();
   EXPECT_EQ(static_cast<unsigned int>(0), endTime.GetInitialTimeoutValue());
 }


### PR DESCRIPTION
It seems that this change was already done for the addon includes here https://github.com/xbmc/xbmc/commit/a72506202681298487da8a90c9621b0091697304

This updates the build in class to use std::chrono and is why I added the tests for this class in #18764 

This should probably go into V20 unless @DaveTBlake okays it for V19.