### PR TITLE
Fix music db migration on MySQL/MariaDB of unexpectedly large lists of artist fanart

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -754,6 +754,7 @@ private:
   bool SearchSongs(const std::string& strSearch, CFileItemList &songs);
   int GetSongIDFromPath(const std::string &filePath);
   void NormaliseSongDates(std::string& strRelease, std::string& strOriginal);
+  bool TrimImageURLs(std::string& strImage, const size_t space);
 
   /*! \brief Build SQL  for sort subquery from ignore article token list
   \param strField original name or title field that articles could be removed from


### PR DESCRIPTION
On MySQL/MariaDB columns if type TEXT, the type used to store the lists of URLs of artwork  available from remote sites, are limited to 64KB. In most cases this is way more than sufficient. However after the combining of artist fanart into the same field as the other artwork, and having new Python music scrapers that fetch more art than before, it is possible the list of art availlable may exceed that limit. No limit exists with SQLite, it simply expands the field as necessary.

A user has reported failure to migrate an existing music db to v82 because some artists that exceed that limit. It would also cause an issue if scraping (remotely or from NFO) returned large lists of artwork URLs.

The fix for MySQL/MariaDB is to ensure that the data is limited to 64KB by
- On migration to v82 and concatenating artist table columns intelligently trimming strFanart and strImage 
- When saving artists or albums intelligently trimming strImage values

The implementation takes care that the value is truncated at the end of a xml tag. This is a follow up to https://github.com/xbmc/xbmc/pull/18536 that merged artist fanart URLs into the main artist artist URLs field `strImage`.

Tested on MySQL both when migrating strFanart and strImage values that exceed 64KB, and when scraping artist Hailee Steinfeld (mbid="373f5bcf-f1ce-4515-83ed-0b8ed636bc14")
