### PR TITLE
[Subtitles][Ass] Add [Events] as possible parser option

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -51,7 +51,8 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
       {
         return new CDVDSubtitleParserVplayer(std::move(pStream), strFile.c_str());
       }
-      else if ((!memcmp(line, "Dialogue: Marked", 16)) || (!memcmp(line, "Dialogue: ", 10)))
+      else if ((!memcmp(line, "Dialogue: Marked", 16)) || (!memcmp(line, "Dialogue: ", 10)) ||
+               (!memcmp(line, "[Events]", 8)))
       {
         return new CDVDSubtitleParserSSA(std::move(pStream), strFile.c_str());
       }


### PR DESCRIPTION
## Description
The subtitle factory looks for `Dialog:` lines to decide if the provided subtitle is ASS. If the first line is long enough that it exceeds the istream buffersize (without finding the '\n' delimiter) the whole parsing fails and the subtitle is not further passed to libass. See:

https://github.com/xbmc/xbmc/blob/770c691bfeea88d561b39d2e38348ac434db3adc/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp#L154

https://github.com/xbmc/xbmc/blob/770c691bfeea88d561b39d2e38348ac434db3adc/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp#L65

Since increasing the buffer is probably not an option, this PR adds the `[Events]` existence also as an indicator the subtitle being parsed is ASS.  According to the specification (see for example https://www.matroska.org/technical/subtitles.html#ssaass-subtitles), the `[Events]` block is mandatory and introduces all the actual events/dialogs the subtitle may contain.

## Motivation and Context
Fixes https://github.com/xbmc/xbmc/issues/17004

## How Has This Been Tested?
Provided subtitles in the issue report. Compared the result to vlc.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
