### PR TITLE
[Android] Enable LegacyExternalStorage (part of SDK 29 bump)

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -49,6 +49,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:logo="@drawable/banner">
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".Splash"
             android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen|screenLayout|screenSize|colorMode"


### PR DESCRIPTION
Essential manifest change to go with the bump to SDK 29 of https://github.com/xbmc/xbmc/pull/18694, that enables `LegacyExternalStorage` permission to allow external storage access.  

Discussed in that PR  and tested in combination with SDK bump by temporary PR https://github.com/xbmc/xbmc/pull/18778 

@peak3d has not been about, so doing this in his absence (hope you are OK peak3d)

