### PR TITLE
windows: fix coverity build

### DIFF
--- a/xbmc/platform/win32/pch.h
+++ b/xbmc/platform/win32/pch.h
@@ -20,6 +20,11 @@
 #include <string>
 #include <vector>
 
+// workaround for broken [[deprecated]] in coverity
+#if defined(__COVERITY__)
+#undef FMT_DEPRECATED
+#define FMT_DEPRECATED
+#endif
 #include <fmt/core.h>
 #include <fmt/format.h> // 53 seconds
 #include <intrin.h> // 97 seconds

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -26,7 +26,7 @@
 #include <sstream>
 #include <locale>
 
-// workaround for broken [[depreciated]] in coverity
+// workaround for broken [[deprecated]] in coverity
 #if defined(__COVERITY__)
 #undef FMT_DEPRECATED
 #define FMT_DEPRECATED


### PR DESCRIPTION
coverity broke after 5d62d8921c72e84c6e70b2464ce654c386512a45 and I never noticed. This is a similar fix to 0250fc8d9f2d95a0482b09013ef0dc63813550a7.

I will try and get something fixed properly upstream