### PR TITLE
[Android] Enable LegacyExternalStorage (part of SDK 29 bump) Fix Typo

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -48,7 +48,7 @@
         android:hasCode="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:logo="@drawable/banner">
+        android:logo="@drawable/banner"
         android:requestLegacyExternalStorage="true">
         <activity
             android:name=".Splash"


### PR DESCRIPTION
Fix typo in manifest change in https://github.com/xbmc/xbmc/pull/18802 that enables `LegacyExternalStorage` permission to allow external storage access.

The pain of attempting Android stuff without that platform and/or @peak3d  - it bit back!
