### PR TITLE
[addons][videoplayer] Fix and simplify crypto session handling.

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -513,7 +513,11 @@ class ATTRIBUTE_HIDDEN InputstreamInfo : public CStructHdl<InputstreamInfo, INPU
 public:
   /*! \cond PRIVATE */
   InputstreamInfo() = default;
-  InputstreamInfo(const InputstreamInfo& stream) : CStructHdl(stream) { CopyExtraData(); }
+  InputstreamInfo(const InputstreamInfo& stream) : CStructHdl(stream)
+  {
+    SetCryptoSession(stream.GetCryptoSession());
+    CopyExtraData();
+  }
   /*! \endcond */
 
   /// @defgroup cpp_kodi_addon_inputstream_Defs_Interface_InputstreamInfo_Help Value Help
@@ -797,7 +801,6 @@ public:
   void SetCryptoSession(const kodi::addon::StreamCryptoSession& cryptoSession)
   {
     m_cryptoSession = cryptoSession;
-    m_cryptoSession.SetSessionId(cryptoSession.GetSessionId());
     memcpy(&m_cStructure->m_cryptoSession, m_cryptoSession.GetCStructure(),
            sizeof(STREAM_CRYPTO_SESSION));
   }
@@ -902,8 +905,16 @@ public:
   ///@}
 
 private:
-  InputstreamInfo(const INPUTSTREAM_INFO* stream) : CStructHdl(stream) { CopyExtraData(); }
-  InputstreamInfo(INPUTSTREAM_INFO* stream) : CStructHdl(stream) { CopyExtraData(); }
+  InputstreamInfo(const INPUTSTREAM_INFO* stream) : CStructHdl(stream)
+  {
+    SetCryptoSession(StreamCryptoSession(&stream->m_cryptoSession));
+    CopyExtraData();
+  }
+  InputstreamInfo(INPUTSTREAM_INFO* stream) : CStructHdl(stream)
+  {
+    SetCryptoSession(StreamCryptoSession(&stream->m_cryptoSession));
+    CopyExtraData();
+  }
 
   void CopyExtraData()
   {

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h
@@ -50,10 +50,7 @@ class ATTRIBUTE_HIDDEN StreamCryptoSession
 public:
   /*! \cond PRIVATE */
   StreamCryptoSession() { memset(m_cStructure, 0, sizeof(STREAM_CRYPTO_SESSION)); }
-  StreamCryptoSession(const StreamCryptoSession& session)
-    : CStructHdl(session), m_sessionId(session.m_sessionId)
-  {
-  }
+  StreamCryptoSession(const StreamCryptoSession& session) : CStructHdl(session) {}
   /*! \endcond */
 
   /// @defgroup cpp_kodi_addon_inputstream_Defs_Info_StreamCryptoSession_Help Value Help
@@ -85,33 +82,15 @@ public:
   /// @brief To set the crypto session key identifier.
   void SetSessionId(const std::string& sessionId)
   {
-    m_sessionId = sessionId;
-    if (!m_sessionId.empty())
-    {
-      m_cStructure->sessionId = m_sessionId.c_str();
-      m_cStructure->sessionIdSize = m_sessionId.size();
-    }
-    else
-    {
-      m_cStructure->sessionId = nullptr;
-      m_cStructure->sessionIdSize = 0;
-    }
+    strncpy(m_cStructure->sessionId, sessionId.c_str(), sizeof(m_cStructure->sessionId) - 1);
   }
 
   /// @brief To get the crypto session key identifier.
-  std::string GetSessionId() const { return m_sessionId; }
+  std::string GetSessionId() const { return m_cStructure->sessionId; }
 
 private:
-  StreamCryptoSession(const STREAM_CRYPTO_SESSION* session)
-    : CStructHdl(session), m_sessionId(session->sessionId)
-  {
-  }
-  StreamCryptoSession(STREAM_CRYPTO_SESSION* session)
-    : CStructHdl(session), m_sessionId(session->sessionId)
-  {
-  }
-
-  std::string m_sessionId;
+  StreamCryptoSession(const STREAM_CRYPTO_SESSION* session) : CStructHdl(session) {}
+  StreamCryptoSession(STREAM_CRYPTO_SESSION* session) : CStructHdl(session) {}
 };
 
 } /* namespace addon */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h
@@ -116,14 +116,8 @@ extern "C"
     // Flags to use special conditions, see STREAM_CRYPTO_FLAGS for available flags.
     uint8_t flags;
 
-    // The size of the crypto session key id set in sessionId.
-    uint16_t sessionIdSize;
-
     // The crypto session key id.
-    //
-    // WARNING The data set here is not copied and its pointer must still be
-    // available.
-    const char* sessionId;
+    char sessionId[256];
   };
   ///@}
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -172,7 +172,7 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h" \
                                                       "c-api/addon-instance/visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.0.1"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.0.2"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.0.1"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "c-api/addon-instance/video_codec.h" \

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -250,7 +250,9 @@ PROCESSDECODER:
       return false;
     }
 
-    m_crypto = new CJNIMediaCrypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId, m_hints.cryptoSession->sessionId + m_hints.cryptoSession->sessionIdSize));
+    m_crypto =
+        new CJNIMediaCrypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId.begin(),
+                                                    m_hints.cryptoSession->sessionId.end()));
 
     if (xbmc_jnienv()->ExceptionCheck())
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -136,9 +136,9 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
     default:
       return false;
     }
-    initData.cryptoSession.sessionIdSize = hints.cryptoSession->sessionIdSize;
-    //We assume that we need this sessionid only for the directly following call
-    initData.cryptoSession.sessionId = hints.cryptoSession->sessionId;
+
+    strncpy(initData.cryptoSession.sessionId, hints.cryptoSession->sessionId.c_str(),
+            sizeof(initData.cryptoSession.sessionId) - 1);
   }
 
   initData.extraData = reinterpret_cast<const uint8_t*>(hints.extradata);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -589,9 +589,8 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
                 m_hints.cryptoSession->keySystem);
       goto FAIL;
     }
-    CJNIMediaCrypto crypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId,
-                                                   m_hints.cryptoSession->sessionId +
-                                                       m_hints.cryptoSession->sessionIdSize));
+    CJNIMediaCrypto crypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId.begin(),
+                                                   m_hints.cryptoSession->sessionId.end()));
     m_needSecureDecoder =
         crypto.requiresSecureDecoderComponent(m_mime) &&
         (m_hints.cryptoSession->flags & DemuxCryptoSession::FLAG_SECURE_DECODER) != 0;
@@ -700,9 +699,8 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::Open Initializing MediaCrypto");
 
     m_crypto =
-        new CJNIMediaCrypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId,
-                                                    m_hints.cryptoSession->sessionId +
-                                                        m_hints.cryptoSession->sessionIdSize));
+        new CJNIMediaCrypto(uuid, std::vector<char>(m_hints.cryptoSession->sessionId.begin(),
+                                                    m_hints.cryptoSession->sessionId.end()));
 
     if (!m_crypto)
     {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -533,9 +533,9 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
         CRYPTO_SESSION_SYSTEM_PLAYREADY,
         CRYPTO_SESSION_SYSTEM_WISEPLAY,
     };
-    demuxStream->cryptoSession = std::shared_ptr<DemuxCryptoSession>(new DemuxCryptoSession(
-        map[stream->m_cryptoSession.keySystem], stream->m_cryptoSession.sessionIdSize,
-        stream->m_cryptoSession.sessionId, stream->m_cryptoSession.flags));
+    demuxStream->cryptoSession = std::shared_ptr<DemuxCryptoSession>(
+        new DemuxCryptoSession(map[stream->m_cryptoSession.keySystem],
+                               stream->m_cryptoSession.sessionId, stream->m_cryptoSession.flags));
 
     if ((stream->m_features & INPUTSTREAM_FEATURE_DECODE) != 0)
       demuxStream->externalInterfaces = thisClass->m_subAddonProvider;

--- a/xbmc/cores/VideoPlayer/Interface/DemuxCrypto.h
+++ b/xbmc/cores/VideoPlayer/Interface/DemuxCrypto.h
@@ -10,7 +10,7 @@
 
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/stream_crypto.h"
 
-#include <string.h>
+#include <string>
 
 //CryptoSession is usually obtained once per stream, but could change if an key expires
 
@@ -24,30 +24,18 @@ enum CryptoSessionSystem : uint8_t
 
 struct DemuxCryptoSession
 {
-  DemuxCryptoSession(const CryptoSessionSystem sys, const uint16_t sSize, const char *sData, const uint8_t flags)
-    : sessionId(new char[sSize])
-    , sessionIdSize(sSize)
-    , keySystem(sys)
-    , flags(flags)
+  DemuxCryptoSession(const CryptoSessionSystem sys, const char* sData, const uint8_t flags)
+    : sessionId(sData), keySystem(sys), flags(flags)
   {
-    memcpy(sessionId, sData, sSize);
-  };
-
-  ~DemuxCryptoSession()
-  {
-    delete[] sessionId;
   }
 
   bool operator == (const DemuxCryptoSession &other) const
   {
-    return sessionIdSize == other.sessionIdSize &&
-      keySystem == other.keySystem &&
-      memcmp(sessionId, other.sessionId, sessionIdSize) == 0;
+    return keySystem == other.keySystem && sessionId == other.sessionId;
   };
 
   // encryped stream infos
-  char * sessionId;
-  uint16_t sessionIdSize;
+  std::string sessionId;
   CryptoSessionSystem keySystem;
 
   static const uint8_t FLAG_SECURE_DECODER = 1;


### PR DESCRIPTION
## Description
Fixes nfx and apv (and maybe other) addons playback after recent binary addon API changes (can't remember the exact PR, sorry). 

## Motivation and Context
On non-android platforms playback of nfx and apv addons did not or not reliably work anymore.

Root cause of the bug was that the crypto session Id was not passed correctly (garbage at end of string due to not always correct null-termination, depending on memory state it sometimes worked by luck). 

## How Has This Been Tested?
Runtime-tested on macOS and Android with latest Kodi master.

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

@AlwinEsch do we need API version bumps for this? If yes, which exactly? And which addons need to be recompiled (re-released)?