### PR TITLE
[Android] Add DRM GetPropertyByteArray

### DIFF
--- a/xbmc/interfaces/legacy/DrmCryptoSession.cpp
+++ b/xbmc/interfaces/legacy/DrmCryptoSession.cpp
@@ -36,6 +36,14 @@ namespace XBMCAddon
       return Buffer();
     }
 
+    Buffer CryptoSession::GetPropertyByteArray(const String &name)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->GetPropertyByteArray(name);
+
+      return Buffer();
+    }
+
     String CryptoSession::GetPropertyString(const String &name)
     {
       if (m_cryptoSession)

--- a/xbmc/interfaces/legacy/DrmCryptoSession.h
+++ b/xbmc/interfaces/legacy/DrmCryptoSession.h
@@ -140,6 +140,26 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ GetPropertyByteArray(name) }
+      /// Request a system specific property value of the %DRM system.
+      ///
+      ///\anchor xbmcdrm_GetPropertyByteArray
+      /// @param      Name    string - Name of the property to query
+      ///
+      /// @return     Value of the requested property
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      GetPropertyByteArray(...);
+#else
+      XbmcCommons::Buffer GetPropertyByteArray(const String &name);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
       /// @brief \python_func{ GetPropertyString(name) }
       /// Request a system specific property value of the %DRM system.
       ///

--- a/xbmc/media/drm/CryptoSession.h
+++ b/xbmc/media/drm/CryptoSession.h
@@ -30,6 +30,7 @@ namespace DRM
 
     // Interface methods
     virtual XbmcCommons::Buffer GetKeyRequest(const XbmcCommons::Buffer& init, const std::string& mimeType, bool offlineKey, const std::map<std::string, std::string>& parameters) = 0;
+    virtual XbmcCommons::Buffer GetPropertyByteArray(const std::string& name) = 0;
     virtual std::string GetPropertyString(const std::string& name) = 0;
     virtual std::string ProvideKeyResponse(const XbmcCommons::Buffer& response) = 0;
     virtual void RemoveKeys() = 0;

--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
@@ -134,6 +134,13 @@ Buffer CMediaDrmCryptoSession::GetKeyRequest(const Buffer& init,
   return Buffer();
 }
 
+Buffer CMediaDrmCryptoSession::GetPropertyByteArray(const std::string& name)
+{
+  if (m_mediaDrm)
+    return CharVecBuffer(m_mediaDrm->getPropertyByteArray(name));
+
+  return Buffer();
+}
 
 std::string CMediaDrmCryptoSession::GetPropertyString(const std::string& name)
 {

--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.h
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.h
@@ -43,6 +43,7 @@ namespace DRM
 
     // Interface methods
     XbmcCommons::Buffer GetKeyRequest(const XbmcCommons::Buffer& init, const std::string& mimeType, bool offlineKey, const std::map<std::string, std::string>& parameters) override;
+    XbmcCommons::Buffer GetPropertyByteArray(const std::string& name) override;
     std::string GetPropertyString(const std::string& name) override;
     std::string ProvideKeyResponse(const XbmcCommons::Buffer& response) override;
     void RemoveKeys() override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->
This add the support to get the bytearray DRM properties values

Mandatory before require merge of PR: https://github.com/xbmc/libandroidjni/pull/21

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Lack of support to get this information,
this can be useful for example to obtain a unique device ID otherwise impossible to obtain under Android
the values that can be obtained can be used for various purposes such as encryption of sensitive data
or particular functions required for VOD addons

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
To test if the values obtained are good,
i have builded Kodi for android APK, with https://github.com/xbmc/libandroidjni/pull/21
i have installed Kaltura Device Info (Android) app, this is the app screenshot
where we can see `deviceUniqueId` and `provisioningUniqueId` values encoded as base64 (that are in origin bytearrays):
![image](https://user-images.githubusercontent.com/3257156/99643997-aa1fef00-2a4d-11eb-931b-46348f311097.png)

These are the (same) values obtained by Nfx addon by using `GetPropertyByteArray`:
<pre>
2020-11-19 09:30:57.899 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine CryptoSession successful constructed
2020-11-19 09:30:57.905 T:8476  WARNING <general>: [plugin.video.nfx (0)] deviceUniqueId [TYPE] &lt;class 'bytearray'\&gt;
2020-11-19 09:30:57.905 T:8476  WARNING <general>: [plugin.video.nfx (0)] deviceUniqueId [VALUE] bytearray(b'######{mfliwDcJsFMuVlFmTqBrek\x00')
2020-11-19 09:30:57.905 T:8476  WARNING <general>: [plugin.video.nfx (0)] deviceUniqueId [ENCODED VALUE] b'#######ye2F7bWZsaXdEY0pzRk11VmxGbVRxQnJlawA='
2020-11-19 09:30:57.905 T:8476  WARNING <general>: [plugin.video.nfx (0)] provisioningUniqueId [TYPE] &lt;class 'bytearray'&gt;
2020-11-19 09:30:57.905 T:8476  WARNING <general>: [plugin.video.nfx (0)] provisioningUniqueId [VALUE] bytearray(b'##########\xa1\xdd\x88\x89\xc1\xa8\n\xaf\xf3')
2020-11-19 09:30:57.905 T:8476  WARNING <general>: [plugin.video.nfx (0)] provisioningUniqueId [ENCODED VALUE] b'########5j6HdiInBqAqv8w=='
2020-11-19 09:30:57.905 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine version: 1.0
2020-11-19 09:30:57.905 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine CryptoSession system id: 4445
2020-11-19 09:30:57.905 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine CryptoSession security level: L3
2020-11-19 09:30:57.905 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine CryptoSession current hdcp level: Unprotected
2020-11-19 09:30:57.905 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine CryptoSession max hdcp level supported: Unprotected
2020-11-19 09:30:57.906 T:8476    DEBUG <general>: [plugin.video.nfx (0)] Widevine CryptoSession algorithms: AES/CBC/NoPadding,HmacSHA256
</pre>

I have censured part of the info due to my security

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
