### PR TITLE
[linux] fix video rendering on GLES

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -18,6 +18,7 @@
 #include "utils/EGLImage.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
+#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 #include "windowing/linux/WinSystemEGL.h"
 
@@ -179,6 +180,68 @@ void CRendererDRMPRIMEGLES::Update()
   ManageRenderArea();
 }
 
+void CRendererDRMPRIMEGLES::DrawBlackBars()
+{
+  CRect windowRect(0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
+                   CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight());
+
+  auto quads = windowRect.SubtractRect(m_destRect);
+
+  struct Svertex
+  {
+    float x, y;
+  };
+
+  std::vector<Svertex> vertices(6 * quads.size());
+
+  GLubyte count = 0;
+  for (const auto& quad : quads)
+  {
+    vertices[count + 1].x = quad.x1;
+    vertices[count + 1].y = quad.y1;
+
+    vertices[count + 0].x = vertices[count + 5].x = quad.x1;
+    vertices[count + 0].y = vertices[count + 5].y = quad.y2;
+
+    vertices[count + 2].x = vertices[count + 3].x = quad.x2;
+    vertices[count + 2].y = vertices[count + 3].y = quad.y1;
+
+    vertices[count + 4].x = quad.x2;
+    vertices[count + 4].y = quad.y2;
+
+    count += 6;
+  }
+
+  glDisable(GL_BLEND);
+
+  CRenderSystemGLES* renderSystem =
+      dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+  if (!renderSystem)
+    return;
+
+  renderSystem->EnableGUIShader(SM_DEFAULT);
+  GLint posLoc = renderSystem->GUIShaderGetPos();
+  GLint uniCol = renderSystem->GUIShaderGetUniCol();
+
+  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+
+  GLuint vertexVBO;
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
+
+  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
+  glEnableVertexAttribArray(posLoc);
+
+  glDrawArrays(GL_TRIANGLES, 0, vertices.size());
+
+  glDisableVertexAttribArray(posLoc);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+
+  renderSystem->DisableGUIShader();
+}
+
 void CRendererDRMPRIMEGLES::RenderUpdate(
     int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
@@ -189,9 +252,14 @@ void CRendererDRMPRIMEGLES::RenderUpdate(
 
   if (clear)
   {
-    glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
-    glClear(GL_COLOR_BUFFER_BIT);
-    glClearColor(0, 0, 0, 0);
+    if (alpha == 255)
+      DrawBlackBars();
+    else
+    {
+      glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
+      glClear(GL_COLOR_BUFFER_BIT);
+      glClearColor(0, 0, 0, 0);
+    }
   }
 
   if (alpha < 255)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -55,6 +55,7 @@ public:
   bool Supports(ESCALINGMETHOD method) override;
 
 private:
+  void DrawBlackBars();
   void Render(unsigned int flags, int index);
 
   bool m_configured = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -209,4 +209,7 @@ protected:
   // clear colour for "black" bars
   float m_clearColour{0.0f};
   CRect m_viewRect;
+
+private:
+  void DrawBlackBars();
 };


### PR DESCRIPTION
This adds a `DrawBlackBars()` method for both `CRendererDRMPRIMEGLES` and `CLinuxRendererGLES`.

This likely was never an issue before because most don't use GLES rendering in a windowing environment and the background is black anyways.

This fixes an issue as shown in the following screenshot:

![gles-renderer](https://user-images.githubusercontent.com/1616460/99696031-177a5280-2a43-11eb-9383-21e0ed429ba8.png)
