### PR TITLE
[linux] fix texture deletion on DRMPRIMEGLES

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -60,7 +60,8 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
       return false;
     }
 
-    glGenTextures(1, &m_texture);
+    if (!glIsTexture(m_texture))
+      glGenTextures(1, &m_texture);
     glBindTexture(m_textureTarget, m_texture);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -12,6 +12,11 @@
 
 using namespace DRMPRIME;
 
+CDRMPRIMETexture::~CDRMPRIMETexture()
+{
+  glDeleteTextures(1, &m_texture);
+}
+
 void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
 {
   m_eglImage.reset(new CEGLImage(eglDisplay));
@@ -83,8 +88,6 @@ void CDRMPRIMETexture::Unmap()
     return;
 
   m_eglImage->DestroyImage();
-
-  glDeleteTextures(1, &m_texture);
 
   m_primebuffer->ReleaseDescriptor();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -17,6 +17,9 @@
 class CDRMPRIMETexture
 {
 public:
+  CDRMPRIMETexture() = default;
+  ~CDRMPRIMETexture();
+
   bool Map(CVideoBufferDRMPRIME* buffer);
   void Unmap();
   void Init(EGLDisplay eglDisplay);


### PR DESCRIPTION
This fixes an issue where textures are constantly being deleted when they can be reused instead.

I added some test logging to show the issue: (constantly increasing)
```
2020-11-19 09:09:33.456 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 325
2020-11-19 09:09:33.473 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 325
2020-11-19 09:09:33.489 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 326
2020-11-19 09:09:33.506 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 326
2020-11-19 09:09:33.524 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 327
2020-11-19 09:09:33.540 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 327
2020-11-19 09:09:33.557 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 327
2020-11-19 09:09:33.574 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 328
2020-11-19 09:09:33.590 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 328
2020-11-19 09:09:33.607 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 329
2020-11-19 09:09:33.623 T:1195597   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 329
...
```

and the fix: (textures being reused)
```
2020-11-19 09:10:49.857 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 87
2020-11-19 09:10:49.875 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 88
2020-11-19 09:10:49.891 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 88
2020-11-19 09:10:49.908 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 88
2020-11-19 09:10:49.925 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 89
2020-11-19 09:10:49.941 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 89
2020-11-19 09:10:49.957 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 83
2020-11-19 09:10:49.973 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 83
2020-11-19 09:10:49.989 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 83
2020-11-19 09:10:50.006 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 86
2020-11-19 09:10:50.022 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 86
2020-11-19 09:10:50.039 T:1197384   DEBUG <general>: CRendererDRMPRIMEGLES:Render Texture ID: 86

```

I'm not sure if this would cause an issue if rendering long enough if GL would run out of textures or if it would start reusing them.