### PR TITLE
[linux] fix using CDVDVideoCodecDRMPRIME on wayland

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -252,27 +252,16 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
 #if defined(HAVE_GBM)
     auto winSystem = dynamic_cast<KODI::WINDOWING::GBM::CWinSystemGbm*>(CServiceBroker::GetWinSystem());
 
-    if (!winSystem)
-      return false;
+    if (winSystem)
+    {
+      auto drm = winSystem->GetDrm();
 
-    auto drm = winSystem->GetDrm();
+      if (!drm)
+        return false;
 
-    if (!drm)
-      return false;
-
-    int fd = drm->GetFileDescriptor();
-
-    if (fd < 0)
-      return false;
-
-    if (!device)
-      device = drmGetRenderDeviceNameFromFd(fd);
-
-    if (!device)
-      device = drmGetDeviceNameFromFd2(fd);
-
-    if (!device)
-      device = drmGetDeviceNameFromFd(fd);
+      if (!device)
+        device = drm->GetRenderDevicePath();
+    }
 #endif
 
     //! @todo: fix with proper device when dma-hints wayland protocol works

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -351,8 +351,16 @@ bool CDRMUtils::OpenDrm(bool needConnector)
     PrintDrmDeviceInfo(device);
 
     const char* renderPath = drmGetRenderDeviceNameFromFd(m_fd);
+
+    if (!renderPath)
+      renderPath = drmGetDeviceNameFromFd2(m_fd);
+
+    if (!renderPath)
+      renderPath = drmGetDeviceNameFromFd(m_fd);
+
     if (renderPath)
     {
+      m_renderDevicePath = renderPath;
       m_renderFd = open(renderPath, O_RDWR | O_CLOEXEC);
       if (m_renderFd != 0)
         CLog::Log(LOGDEBUG, "CDRMUtils::{} - opened render node: {}", __FUNCTION__, renderPath);

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -47,6 +47,7 @@ public:
 
   int GetFileDescriptor() const { return m_fd; }
   int GetRenderNodeFileDescriptor() const { return m_renderFd; }
+  const char* GetRenderDevicePath() const { return m_renderDevicePath; }
   CDRMPlane* GetVideoPlane() const { return m_video_plane; }
   CDRMPlane* GetGuiPlane() const { return m_gui_plane; }
   CDRMCrtc* GetCrtc() const { return m_crtc; }
@@ -89,6 +90,7 @@ private:
   void PrintDrmDeviceInfo(drmDevicePtr device);
 
   int m_renderFd;
+  const char* m_renderDevicePath{nullptr};
 
   std::vector<std::unique_ptr<CDRMConnector>> m_connectors;
   std::vector<std::unique_ptr<CDRMEncoder>> m_encoders;


### PR DESCRIPTION
This fixes an issues where using `CDVDVideoCodecDRMPRIME` is broken with hardware decoding after https://github.com/xbmc/xbmc/commit/8d9b456576f0622a221bc315c56b02005843f190

The `dynamic_cast` to `CWinSystemGbm` would fail and return false when running on wayland. This would only occur if building for GBM and Wayland simultaneously.