### PR TITLE
[addons] prevent lockout on auto update of repositories

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -497,7 +497,7 @@ void CAddonMgr::CheckAndInstallAddonUpdates(bool wait) const
   std::lock_guard<std::mutex> lock(m_installAddonsMutex);
   VECADDONS updates;
   GetAddonUpdateCandidates(updates);
-  InstallAddonUpdates(updates, wait, AllowCheckForUpdates::YES);
+  InstallAddonUpdates(updates, wait, AllowCheckForUpdates::NO);
 }
 
 bool CAddonMgr::GetAddonUpdateCandidates(VECADDONS& updates) const


### PR DESCRIPTION
## Description
the pr is precautious to prevent deadlocks if repository addons are updated and content checked afterwards during a running auto update. in this case a content update check should not be allowed.

## Motivation and Context
deadlocks already happened during addon migration and needed to work around.
better take care about that before it happens

## How Has This Been Tested?
untested

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

@phunkyfish & @enen92 would you please have a look? a 1-liner change