### PR TITLE
Fix PlayMedia builtin to play music files in mixed .m3u playlists 

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -477,13 +477,19 @@ static int PlayMedia(const std::vector<std::string>& params)
       else
         items.Sort(SortByLabel, SortOrderAscending);
 
-      int playlist = containsVideo? PLAYLIST_VIDEO : PLAYLIST_MUSIC;;
-      if (containsMusic && containsVideo) //mixed content found in the folder
+      int playlist = containsVideo? PLAYLIST_VIDEO : PLAYLIST_MUSIC;
+      // Mixed playlist item played by music player, mixed content folder has music removed
+      if (containsMusic && containsVideo)
       {
-        for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
+        if (item.IsPlayList())
+          playlist = PLAYLIST_MUSIC;
+        else
         {
-          if (!items[i]->IsVideo())
-            items.Remove(i);
+          for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
+          {
+            if (!items[i]->IsVideo())
+              items.Remove(i);
+          }
         }
       }
 


### PR DESCRIPTION
Since v18 the `PlayMedia` builtin no longer correctly handles playback of mixed music and video  .m3u playlists. Previously such .m3u files played both music and video when playback initiated from keymaps or scripts, but now the music files are ignored and only video files are played. 

This regression was introduced by a number of changes starting from https://github.com/xbmc/xbmc/pull/11747

This is fixed by restoring the functionality from v17 and before - mixed .m3u files are played on the music playlist.

To test create a .m3u file with both music and video files, and then add a keymap..xml entry to play it e.g. 
```
<f9>PlayMedia(C:\MusicTest\Test\MixedPlaylistBug\playlist1.m3u)</f9>
```

