### PR TITLE
[ios] Fix keyboard crash on iOS 14

### DIFF
--- a/xbmc/platform/darwin/ios-common/DarwinEmbedKeyboard.mm
+++ b/xbmc/platform/darwin/ios-common/DarwinEmbedKeyboard.mm
@@ -124,8 +124,11 @@ void CDarwinEmbedKeyboard::invalidateCallback()
 bool CDarwinEmbedKeyboard::hasExternalKeyboard()
 {
 #if defined(TARGET_DARWIN_IOS)
+  // @todo: use @available after switching to iOS 14 SDK or later
+  if (auto keyboardClassIOS14 = NSClassFromString(@"GCKeyboard"))
+    return [keyboardClassIOS14 performSelector:@selector(coalescedKeyboard)] != nil;
+
   // https://stackoverflow.com/questions/31991873/how-to-reliably-detect-if-an-external-keyboard-is-connected-on-ios-9
-  // @todo: use public API when it appears
   const auto keyboardClassStr = "UIKeyboardImpl";
   auto keyboardClass = NSClassFromString(@(keyboardClassStr));
   if (!keyboardClass)


### PR DESCRIPTION
## Description
Changes from #18327 result in crash on iOS 14 (probably 14.2 and later). Fortunately, iOS 14 added public API to detect external keyboard.

## Motivation and Context
Fixes #18815

## How Has This Been Tested?
Runtime tested on iPhone XR 14.2 and iPhone 6+ 12.4.9 that there's no more crash and keyboard is detected correctly.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
