### PR TITLE
[Music]Fix immediate playback of .m3u playlists on click when not playlistsasfolder

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -34,6 +34,7 @@
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "profiles/ProfileManager.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -349,6 +350,12 @@ bool CGUIWindowMusicNav::OnClick(int iItem, const std::string &player /* = "" */
   if (item->IsMusicDb() && !item->m_bIsFolder)
     m_musicdatabase.SetPropertiesForFileItem(*item);
 
+  if (item->IsPlayList() &&
+    !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders)
+  {
+    PlayItem(iItem);
+    return true;
+  }
   return CGUIWindowMusicBase::OnClick(iItem, player);
 }
 


### PR DESCRIPTION
Since v18 the option to have .m3u playlists play immediately on click, rather than be treated as a folder and the contents displayed, has been broken and the behaviour is pretty wierd.

When `<playlistasfolders>`  in advancedsettings.xml  is false, clicking on a .m3u playlist file item in the music Playlists node results in playback starting, however:
- during the playback of each music file listed in the .m3u file the player OSD shows only the name of the .m3u file (not the song title from tags or library, or even the individual music file name) and only default icon (no artwork). 
-  _all_ the other .m3u or .strm items and the "New playlist..." and "New smart playlist..." items are added to the current queue. In effect everything listed in the playlists node that isn't a smart playlist gets queued!

This regression was introduced by https://github.com/xbmc/xbmc/pull/13777

This is fixed by restoring the functionality from v17 and before - with `<playlistasfolders>`  disabled the behaviour on clicking on a .m3u playlist is the same as "Play" on the context menu or `<p>` keyboard shortcut action. That is only the contents of the .m3u being added to the current queue and playback started, with correct song information and artwork displayed on the OSD.

Raised by user and discussed in https://forum.kodi.tv/showthread.php?tid=349498

To test set `<playlistasfolders>` false  in advancedsettings.xml and add some music .m3u playlists in `userdata/playlists/music`
