### PR TITLE
[Video] Modify Streamdetails to return correct resolution for 4:3 video

### DIFF
--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -566,16 +566,16 @@ std::string CStreamDetails::VideoDimsToResolutionDescription(int iWidth, int iHe
   else if (iWidth <= 960 && iHeight <= 544)
     return "540";
   // 1280x720
-  else if (iWidth <= 1280 && iHeight <= 720)
+  else if (iWidth <= 1280 && iHeight <= 962)
     return "720";
   // 1920x1080
-  else if (iWidth <= 1920 && iHeight <= 1080)
+  else if (iWidth <= 1920 && iHeight <= 1440)
     return "1080";
   // 4K
-  else if (iWidth <= 4096 && iHeight <= 2160)
+  else if (iWidth <= 4096 && iHeight <= 3072)
     return "4K";
   // 8K
-  else if (iWidth <= 8192 && iHeight <= 4320)
+  else if (iWidth <= 8192 && iHeight <= 6144)
     return "8K";
   else
     return "";


### PR DESCRIPTION
## Description

Modify Streamdetails to return correct video resolution for 4:3 videos

## Motivation and Context
Forum user report of a 3840 x 2880 4K in a 4:3 aspect being flagged as 8K, this was due to 4K height being limited to 2160p previously and as can be seen here https://www.wearethefirehouse.com/aspect-ratio-cheat-sheet this is not correct for 4:3 apect ratio video.

In addition I've modified 720p, 1080p, & 8K to take account of 4:3 ratios, again using as a reference https://www.wearethefirehouse.com/aspect-ratio-cheat-sheet

## How Has This Been Tested?
Tested locally with a variety of videos to make sure there's no regression however I don't have any 4:3 videos greater than 720p in resolution. This therefore needs to be sanity checked as perhaps there was good reason not to include 4:3 aspect ratio heights.

## Screenshots (if appropriate):

From user on forum showing the problem

![image](https://user-images.githubusercontent.com/5781142/99877299-f6596380-2bf4-11eb-8662-8c58de3cf23a.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
