### PR TITLE
DXVA2: Fix crash playing HEVC videos on systems with 16 cores / 32 threads

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1212,6 +1212,14 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
   if (avctx->active_thread_type & FF_THREAD_FRAME)
     m_refs += avctx->thread_count;
 
+  // Limit decoder surfaces to 32 maximum in any case. Since with some 16 cores / 32 threads
+  // new CPU's (Ryzen 5950x) this number may be higher than what the graphics card can handle.
+  if (m_refs > 32)
+  {
+    CLog::LogF(LOGWARNING, "The number of decoder surfaces has been limited from {} to 32.", m_refs);
+    m_refs = 32;
+  }
+
   // Check if available video memory is sufficient for 4K decoding (is need ~3000 MB)
   if (avctx->width >= 3840 && m_refs > 16 && videoMem < (3000ull * MB))
   {


### PR DESCRIPTION
## Description
Fix crash playing HEVC videos on systems with new 16 cores / 32 threads CPU's (e.g. Ryzen 5950x)

NOTE: this patch does not change anything for systems with up to 16 threads (they already used 32 or less decoder surfaces anyway). Then it's safe to merge without side effects.

## Motivation and Context
See https://forum.kodi.tv/showthread.php?tid=358549

## How Has This Been Tested?
User forum has confirmed that crash is gone:
https://forum.kodi.tv/showthread.php?tid=358549&pid=2990254#pid2990254

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
