### PR TITLE
Fix navigation & context menu in Music Playlist Editor 

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -19,6 +19,7 @@ public:
   ~CGUIWindowMusicPlaylistEditor(void) override;
 
   bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction &action) override;
   bool OnBack(int actionID) override;
 
 protected:
@@ -27,7 +28,6 @@ protected:
   bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
   void OnPrepareFileItems(CFileItemList &items) override;
   void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
-  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   void OnQueueItem(int iItem, bool) override;
   std::string GetStartFolder(const std::string &dir) override { return ""; };
 


### PR DESCRIPTION
## Description
This fixes two things in the Music Playlist Editor:
- navigating into the Files directory would display an incorrect listing
- the context menu on the right container was broken (it didn't show up at all)

## How Has This Been Tested?
Tested in Estuary by creating a new playlist and:
- adding items
- deleting items
- moving items up
- moving items down

## Screenshots (if appropriate):
Files directory (before):
![files-b](https://user-images.githubusercontent.com/687265/99889549-9abfc200-2c56-11eb-8fd3-5f3d1462a962.jpg)


Files directory (after):
![files-a](https://user-images.githubusercontent.com/687265/99889551-9e534900-2c56-11eb-91f0-adf34193d421.jpg)


Context menu:
![context](https://user-images.githubusercontent.com/687265/99889555-a1e6d000-2c56-11eb-9324-1d74fff47de7.jpg)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
