### PR TITLE
[depends][python] update darwinembedded patchset

### DIFF
--- a/tools/depends/target/python3/darwin_embedded.patch
+++ b/tools/depends/target/python3/darwin_embedded.patch
@@ -30,6 +30,15 @@
  
 --- a/Lib/subprocess.py
 +++ b/Lib/subprocess.py
+@@ -737,6 +737,8 @@
+                  restore_signals=True, start_new_session=False,
+                  pass_fds=(), *, encoding=None, errors=None, text=None):
+         """Create new Popen instance."""
++        raise RuntimeError("Subprocesses are not supported on this platform.")
++
+         _cleanup()
+         # Held while anything is calling waitpid before returncode has been
+         # updated to prevent clobbering returncode if wait() or poll() are
 @@ -936,6 +936,7 @@
          if not self._child_created:
              # We didn't get to successfully create a child process.
@@ -62,6 +71,24 @@
  
              if errpipe_data:
                  try:
+@@ -1721,7 +1724,7 @@
+                 raise SubprocessError("Unknown child exit status!")
+ 
+ 
+-        def _internal_poll(self, _deadstate=None, _waitpid=os.waitpid,
++        def _internal_poll(self, _deadstate=None, _waitpid=None,
+                 _WNOHANG=os.WNOHANG, _ECHILD=errno.ECHILD):
+             """Check if child process has terminated.  Returns returncode
+             attribute.
+@@ -1730,6 +1733,8 @@
+             outside of the local scope (nor can any methods it calls).
+ 
+             """
++            if _waitpid is None:
++                _waitpid = os.waitpid
+             if self.returncode is None:
+                 if not self._waitpid_lock.acquire(False):
+                     # Something else is busy calling waitpid.  Don't allow two
 --- a/Lib/urllib/request.py
 +++ b/Lib/urllib/request.py
 @@ -2616,11 +2616,9 @@


### PR DESCRIPTION
## Description
Update darwinembedded py3 patch
Fixes any "import os" calls that would fail due to waitpid call in _internal_poll method usage

Please note, ive no idea if the addon in the reported issue will work, but it doesnt fail immediately now.

## Motivation and Context
fixes #18820 

## How Has This Been Tested?
ios 14.2 pseudo.live.tv addon installed and able to execute.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
