### PR TITLE
Revert "[Fix] Cast not showing when play next is set to episodes"

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2894,7 +2894,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       CVideoDatabase dbs;
       dbs.Open();
 
-      std::string path = item.GetDynPath();
+      std::string path = item.GetPath();
       std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
       if (videoInfoTagPath.find("removable://") == 0)
         path = videoInfoTagPath;


### PR DESCRIPTION
Reverts xbmc/xbmc#18770

@enen92 @phunkyfish 

PR raised issue passing resume, seek properties from pvr:// and plugins:// to the Kodi player.

Tested by reverting change and re-building. Confirmed fixed after revert.
