### PR TITLE
[Fix] [Github action] Action only runs at xbmc/xbmc

### DIFF
--- a/.github/workflows/gh-action-weblate-upload.yml
+++ b/.github/workflows/gh-action-weblate-upload.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/gh-action-weblate-upload.yml"
 jobs:
   weblate:
+    if: github.repository == 'xbmc/xbmc'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
This makes sure that gh-action-weblate-upload.yml action only runs at xbmc/xbmc repo.

@chewitt As mentioned at Slack.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)