### PR TITLE
[Music] Fix  availability "scan to library" context menu button

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -565,15 +565,6 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
         else if (item->IsPlayList() || m_vecItems->IsPlayList())
           buttons.Add(CONTEXT_BUTTON_EDIT, 586);
       }
-      if (!m_vecItems->IsMusicDb() && !m_vecItems->IsInternetStream()           &&
-          !item->IsPath("add") && !item->IsParentFolder() &&
-          !item->IsPlugin() && !item->IsMusicDb()         &&
-          !item->IsLibraryFolder() &&
-          !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
-          (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
-      {
-        buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
-      }
 #ifdef HAS_DVD_DRIVE
       // enable Rip CD Audio or Track button if we have an audio disc
       if (CServiceBroker::GetMediaManager().IsDiscInDrive() && m_vecItems->IsCDDA())

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -561,10 +561,8 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 #endif
-      if (!inPlaylists && !m_vecItems->IsInternetStream() &&
-        !item->IsPath("add") && !item->IsParentFolder() &&
-        !item->IsPlugin() &&
-        !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
+      // Scan button for music sources except  ".." and "Add music source" items
+      if (!item->IsPath("add") && !item->IsParentFolder() &&
         (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
@@ -574,6 +572,22 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
     else
     {
       CGUIWindowMusicBase::GetContextButtons(itemNumber, buttons);
+
+      // Scan button for real folders containing files when navigating within music sources.
+      // Blacklist the bespoke Kodi protocols as to many valid external protocols to whitelist
+      if (m_vecItems->GetContent() == "files" && // Other content not scanned to library
+          !inPlaylists && !m_vecItems->IsInternetStream() && // Not playlists locations or streams
+          !item->IsPath("add") && !item->IsParentFolder() && // Not ".." and "Add items
+          item->m_bIsFolder && // Folders only, but playlists can be folders too
+          !URIUtils::IsLibraryContent(item->GetPath()) && // database folder or .xsp files
+          !URIUtils::IsSpecial(item->GetPath()) && !item->IsPlugin() && !item->IsScript() &&
+          !item->IsPlayList() && // .m3u etc. that as flagged as folders when playlistasfolders
+          !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
+          (profileManager->GetCurrentProfile().canWriteDatabases() ||
+           g_passwordManager.bMasterUser))
+      {
+        buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
+      }
 
       CMusicDatabaseDirectory dir;
 


### PR DESCRIPTION
Fix availability of "scan to library" context menu button to show for music sources and folders in file view.

Scan to library is an action that only applies to music sources, or folders within music sources when navigating in file view, but was being displayed on other music media windows and for the wrong items. This includes:
- all items on the music playlists node including the "New Playlist..." and "New Smart Playlist..." items.
-  smart playlists (.xsp files) that are navigated to within a music source (they are unlikely to be outside the `userdata/playlists` folder and that folder is unlikely to be added as a music source, but users can do odd things).

Recently had a user accidentally scan "New Smart Playlist..." item into his library  https://forum.kodi.tv/showthread.php?tid=358568 which needs to be prevented.

Rationalise where `CONTEXT_BUTTON_SCAN` is added to the context menu to be entirely in `CGUIWindowMusicNav` as `CGUIWindowMusicPlayList` and `CGUIWindowMusicPlaylistEditor`,  the other descendants of `CGUIWindowMusicBase`, do not need scan to library facility. 

Tested by browsing various music nav screens.
"Scan to library" correctly shown in file view screen on music sources and on folders beneath those.
"Scan to library" correctly _not_ shown:
- in file view screen when item is playlist, smart playlists, "add...", ".." items 
- on any item in the music playlists node even if playlists are arranged in subfolders within userdata/playlists/music
- in music addons
