### PR TITLE
[Fix] Cast not showing when play next is set to episodes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2894,9 +2894,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       CVideoDatabase dbs;
       dbs.Open();
 
-      std::string path = item.GetDynPath();
+      std::string path = item.GetPath();
       std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
-      if (videoInfoTagPath.find("removable://") == 0)
+      if (videoInfoTagPath.find("removable://") == 0 || item.IsVideoDb())
         path = videoInfoTagPath;
       dbs.LoadVideoInfo(path, *item.GetVideoInfoTag());
 


### PR DESCRIPTION
Provides an alternative to https://github.com/xbmc/xbmc/pull/18770 to fix https://github.com/xbmc/xbmc/issues/18556 by reverting the previous change and provide an alternative.

Superseeds https://github.com/xbmc/xbmc/pull/18842 as it also implements the revert. Refer to the PR for the rational.