### PR TITLE
Fixes to Music Playlist Editor

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2586,6 +2586,8 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/PlayListPlayer.cpp
+#: xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
 msgctxt "#559"
 msgid "Playlist"
 msgstr ""
@@ -18016,6 +18018,7 @@ msgstr ""
 
 #. Label on emulators with a savestate in the emulator selection dialog
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+#: xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
 msgctxt "#35259"
 msgid "Saved"
 msgstr ""

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -14,6 +14,7 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "dialogs/GUIDialogFileBrowser.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/PlaylistFileDirectory.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/LocalizeStrings.h"
@@ -31,6 +32,7 @@
 #define CONTROL_SAVE_PLAYLIST      7
 #define CONTROL_CLEAR_PLAYLIST     8
 
+#define CONTROL_LIST              50
 #define CONTROL_PLAYLIST         100
 #define CONTROL_LABEL_PLAYLIST   101
 
@@ -57,13 +59,34 @@ bool CGUIWindowMusicPlaylistEditor::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_CONTEXT_MENU)
   {
-    if (GetFocusedControlID() == CONTROL_PLAYLIST)
+    int iControl = GetFocusedControlID();
+    if (iControl == CONTROL_PLAYLIST)
     {
       OnPlaylistContext();
       return true;
     }
+    else if (iControl == CONTROL_LIST)
+    {
+      OnSourcesContext();
+      return true;
+    }
   }
   return CGUIWindow::OnAction(action);
+}
+
+bool CGUIWindowMusicPlaylistEditor::OnClick(int iItem, const std::string& player /* = "" */)
+{
+  if (iItem < 0 || iItem >= m_vecItems->Size()) return false;
+  CFileItemPtr item = m_vecItems->Get(iItem);  
+
+  // Expand .m3u files in sources list when clicked on regardless of <playlistasfolders>
+  if (item->IsFileFolder(EFILEFOLDER_MASK_ONBROWSE))
+    return Update(item->GetPath());
+  // Avoid playback (default click behaviour) of media files
+  if (!item->m_bIsFolder)
+    return false;
+
+  return CGUIWindowMusicBase::OnClick(iItem, player);
 }
 
 bool CGUIWindowMusicPlaylistEditor::OnMessage(CGUIMessage& message)
@@ -103,10 +126,27 @@ bool CGUIWindowMusicPlaylistEditor::OnMessage(CGUIMessage& message)
       int control = message.GetSenderId();
       if (control == CONTROL_PLAYLIST)
       {
+        int item = GetCurrentPlaylistItem();
         int action = message.GetParam1();
         if (action == ACTION_CONTEXT_MENU || action == ACTION_MOUSE_RIGHT_CLICK)
           OnPlaylistContext();
+        else if (action == ACTION_QUEUE_ITEM || action == ACTION_DELETE_ITEM ||
+                 action == ACTION_MOUSE_MIDDLE_CLICK)
+          OnDeletePlaylistItem(item);
+        else if (action == ACTION_MOVE_ITEM_UP)
+          OnMovePlaylistItem(item, -1);
+        else if (action == ACTION_MOVE_ITEM_DOWN)
+          OnMovePlaylistItem(item, 1);
         return true;
+      }
+      else if (control == CONTROL_LIST)
+      {
+        int action = message.GetParam1();
+        if (action == ACTION_CONTEXT_MENU || action == ACTION_MOUSE_RIGHT_CLICK)
+        {
+          OnSourcesContext();
+          return true;
+        }
       }
       else if (control == CONTROL_LOAD_PLAYLIST)
       { // load a playlist
@@ -141,7 +181,7 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const std::string &strDirectory
     files->m_bIsShareOrDrive = true;
     items.Add(files);
 
-    CFileItemPtr mdb(new CFileItem("musicdb://", true));
+    CFileItemPtr mdb(new CFileItem("library://music/", true));
     mdb->SetLabel(g_localizeStrings.Get(14022));
     mdb->SetLabelPreformatted(true);
     mdb->m_bIsShareOrDrive = true;
@@ -294,29 +334,13 @@ void CGUIWindowMusicPlaylistEditor::OnMovePlaylistItem(int item, int direction)
   OnMessage(msg);
 }
 
-void CGUIWindowMusicPlaylistEditor::GetContextButtons(int itemNumber, CContextButtons &buttons)
-{
-  CFileItemPtr item;
-  if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
-    item = m_vecItems->Get(itemNumber);
-
-  if (item && !item->IsParentFolder() && !m_vecItems->IsVirtualDirectoryRoot())
-    buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 15019);
-}
-
 void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
 {
-  // prompt user for file to load
+  // Prompt user for file to load from music playlists folder
   std::string playlist;
-  VECSOURCES shares;
-  m_rootDir.GetSources(shares);
-  // add the playlist share
-  CMediaSource share;
-  share.strName = g_localizeStrings.Get(20011);
-  share.strPath = "special://musicplaylists/";
-  if (find(shares.begin(), shares.end(), share) == shares.end())
-    shares.push_back(share);
-  if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".m3u|.pls|.b4s|.wpl|.xspf", g_localizeStrings.Get(656), playlist))
+  if (CGUIDialogFileBrowser::ShowAndGetFile("special://musicplaylists/",
+                                            ".m3u|.pls|.b4s|.wpl|.xspf", g_localizeStrings.Get(656),
+                                            playlist))
     LoadPlaylist(playlist);
 }
 
@@ -357,6 +381,9 @@ void CGUIWindowMusicPlaylistEditor::OnSavePlaylist()
 
     playlist.Save(path);
     m_strLoadedPlaylist = name;
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                          g_localizeStrings.Get(559), // "Playlist"
+                                          g_localizeStrings.Get(35259)); // "Saved"
   }
 }
 
@@ -366,6 +393,22 @@ void CGUIWindowMusicPlaylistEditor::AppendToPlaylist(CFileItemList &newItems)
   FormatItemLabels(newItems, LABEL_MASKS(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_MUSICFILES_TRACKFORMAT), "%D", "%L", ""));
   m_playlist->Append(newItems);
   UpdatePlaylist();
+}
+
+void CGUIWindowMusicPlaylistEditor::OnSourcesContext()
+{
+  CFileItemPtr item = GetCurrentListItem();
+  CContextButtons buttons;
+  if (item->IsFileFolder(EFILEFOLDER_MASK_ONBROWSE))
+    buttons.Add(CONTEXT_BUTTON_BROWSE_INTO, 37015); //Browse into
+  if (item && !item->IsParentFolder() && !m_vecItems->IsVirtualDirectoryRoot())
+    buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 15019); // Add (to playlist)
+
+  int btnid = CGUIDialogContextMenu::ShowAndGetChoice(buttons);
+  if (btnid == CONTEXT_BUTTON_QUEUE_ITEM)
+    OnQueueItem(m_viewControl.GetSelectedItem(), false);
+  else if (btnid == CONTEXT_BUTTON_BROWSE_INTO)
+    Update(item->GetPath());
 }
 
 void CGUIWindowMusicPlaylistEditor::OnPlaylistContext()

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -20,6 +20,7 @@ public:
 
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
+  bool OnClick(int iItem, const std::string &player = "") override;
   bool OnBack(int actionID) override;
 
 protected:
@@ -27,10 +28,10 @@ protected:
   void UpdateButtons() override;
   bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
   void OnPrepareFileItems(CFileItemList &items) override;
-  void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
   void OnQueueItem(int iItem, bool) override;
   std::string GetStartFolder(const std::string &dir) override { return ""; };
 
+  void OnSourcesContext();
   void OnPlaylistContext();
   int GetCurrentPlaylistItem();
   void OnDeletePlaylistItem(int item);

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -508,5 +508,5 @@ const std::string& CPlayList::ResolveURL(const CFileItemPtr &item ) const
   if (item->IsMusicDb() && item->HasMusicInfoTag())
     return item->GetMusicInfoTag()->GetURL();
   else
-    return item->GetPath();
+    return item->GetDynPath();
 }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -901,7 +901,9 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     showLabel = 1026;
   else if (m_vecItems->IsPath("sources://games/"))
     showLabel = 35250; // "Add games..."
-  if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons())) // add 'add source button'
+   // Add 'Add source ' item
+  if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons()) &&
+      iWindow != WINDOW_MUSIC_PLAYLIST_EDITOR)
   {
     const std::string& strLabel = g_localizeStrings.Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));


### PR DESCRIPTION
A few more fixes to the music playlist editor screen 

 - Sources list (left panel) context menu
Ensure the only context menu button for items on the left hand side sources list is "add" .
Despite being a descendent of  `CGUIWindowMusicBase` this screen does not need the standard media window context menu buttons on items of either of the list controls. Having navigated within one of the top system items ("Files" / "Library" / "Music Videos") of the left hand list the only action is to add the music files of the item to the playlist.
- Reinstate U/D/Del keyboard shortcuts 
Keyboard controls U, D and Del  can again be used in the right hand panel to move the highlighted item Up, Down or Deleted. Lost in the previous fix #18838.
- Remove "Add music source" item from within "files" source list
- On click behaviour on items in sources list 
Browse into .m3u files (treat like folder), avoid starting playback of media files (do nothing)
- Open button shows music playlists
- Save notification
Add a "saved" toast when playlist saved on clicking  save button.
- Music Videos
Correct URL (not virtual path) saved to .m3u file, so playback of the resulting playlists does not skip those videos