### PR TITLE
[linux] eglimage logging

### DIFF
--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -166,24 +166,27 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
       std::string keyStr;
       std::string valueStr;
 
-      auto eglAttr = eglAttributes.find(attrs[i]);
-      if (eglAttr != eglAttributes.end())
+      auto eglAttrKey = eglAttributes.find(attrs[i]);
+      if (eglAttrKey != eglAttributes.end())
       {
-        keyStr = eglAttr->second;
+        keyStr = eglAttrKey->second;
       }
       else
       {
         keyStr = std::to_string(attrs[i]);
       }
 
-      eglAttr = eglAttributes.find(attrs[i + 1]);
-      if (eglAttr != eglAttributes.end())
+      auto eglAttrValue = eglAttributes.find(attrs[i + 1]);
+      if (eglAttrValue != eglAttributes.end())
       {
-        valueStr = eglAttr->second;
+        valueStr = eglAttrValue->second;
       }
       else
       {
-        valueStr = std::to_string(attrs[i + 1]);
+        if (eglAttrKey->first == EGL_LINUX_DRM_FOURCC_EXT)
+          valueStr = FourCCToString(attrs[i + 1]);
+        else
+          valueStr = std::to_string(attrs[i + 1]);
       }
 
       eglString.append(StringUtils::Format("%s: %s\n", keyStr, valueStr));

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -8,6 +8,7 @@
 
 #include "EGLImage.h"
 
+#include "ServiceBroker.h"
 #include "utils/EGLUtils.h"
 #include "utils/log.h"
 
@@ -154,11 +155,8 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
 
   m_image = m_eglCreateImageKHR(m_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attribs.Get());
 
-  if(!m_image)
+  if (!m_image || CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
   {
-    CLog::Log(LOGERROR, "CEGLImage::{} - failed to import buffer into EGL image: {:#4x}",
-              __FUNCTION__, eglGetError());
-
     const EGLint* attrs = attribs.Get();
 
     std::string eglString;
@@ -192,7 +190,12 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
     }
 
     CLog::Log(LOGDEBUG, "CEGLImage::{} - attributes:\n{}", __FUNCTION__, eglString);
+  }
 
+  if (!m_image)
+  {
+    CLog::Log(LOGERROR, "CEGLImage::{} - failed to import buffer into EGL image: {:#4x}",
+              __FUNCTION__, eglGetError());
     return false;
   }
 


### PR DESCRIPTION
This adds the ability to enable reading the egl image attributes when using the `video` component logging.

This PR also adds the ability to convert the drm format to a human readable format using the `FourCCToString` helper.

These changes are very helpful when debugging EGL image creation problems.

@DaveTBlake I've marked this as v19 but if you want to bump it to v20 that's ok