### PR TITLE
[linux] drm object changes

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -19,34 +19,34 @@ extern "C"
 namespace DRMPRIME
 {
 
-int GetColorEncoding(const VideoPicture& picture)
+std::string GetColorEncoding(const VideoPicture& picture)
 {
   switch (picture.color_space)
   {
     case AVCOL_SPC_BT2020_CL:
     case AVCOL_SPC_BT2020_NCL:
-      return DRM_COLOR_YCBCR_BT2020;
+      return "ITU-R BT.2020 YCbCr";
     case AVCOL_SPC_SMPTE170M:
     case AVCOL_SPC_BT470BG:
     case AVCOL_SPC_FCC:
-      return DRM_COLOR_YCBCR_BT601;
+      return "ITU-R BT.601 YCbCr";
     case AVCOL_SPC_BT709:
-      return DRM_COLOR_YCBCR_BT709;
+      return "ITU-R BT.709 YCbCr";
     case AVCOL_SPC_RESERVED:
     case AVCOL_SPC_UNSPECIFIED:
     default:
       if (picture.iWidth > 1024 || picture.iHeight >= 600)
-        return DRM_COLOR_YCBCR_BT709;
+        return "ITU-R BT.709 YCbCr";
       else
-        return DRM_COLOR_YCBCR_BT601;
+        return "ITU-R BT.601 YCbCr";
   }
 }
 
-int GetColorRange(const VideoPicture& picture)
+std::string GetColorRange(const VideoPicture& picture)
 {
   if (picture.color_range)
-    return DRM_COLOR_YCBCR_FULL_RANGE;
-  return DRM_COLOR_YCBCR_LIMITED_RANGE;
+    return "YCbCr full range";
+  return "YCbCr limited range";
 }
 
 uint8_t GetEOTF(const VideoPicture& picture)

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -21,19 +21,6 @@ extern "C"
 namespace DRMPRIME
 {
 
-// Color enums is copied from linux include/drm/drm_color_mgmt.h (strangely not part of uapi)
-enum drm_color_encoding
-{
-  DRM_COLOR_YCBCR_BT601,
-  DRM_COLOR_YCBCR_BT709,
-  DRM_COLOR_YCBCR_BT2020,
-};
-enum drm_color_range
-{
-  DRM_COLOR_YCBCR_LIMITED_RANGE,
-  DRM_COLOR_YCBCR_FULL_RANGE,
-};
-
 // HDR enums is copied from linux include/linux/hdmi.h (strangely not part of uapi)
 enum hdmi_metadata_type
 {
@@ -47,8 +34,8 @@ enum hdmi_eotf
   HDMI_EOTF_BT_2100_HLG,
 };
 
-int GetColorEncoding(const VideoPicture& picture);
-int GetColorRange(const VideoPicture& picture);
+std::string GetColorEncoding(const VideoPicture& picture);
+std::string GetColorRange(const VideoPicture& picture);
 uint8_t GetEOTF(const VideoPicture& picture);
 const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
 const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -12,6 +12,42 @@
 
 using namespace DRMPRIME;
 
+namespace
+{
+
+int GetEGLColorSpace(const VideoPicture& picture)
+{
+  switch (picture.color_space)
+  {
+    case AVCOL_SPC_BT2020_CL:
+    case AVCOL_SPC_BT2020_NCL:
+      return EGL_ITU_REC2020_EXT;
+    case AVCOL_SPC_SMPTE170M:
+    case AVCOL_SPC_BT470BG:
+    case AVCOL_SPC_FCC:
+      return EGL_ITU_REC601_EXT;
+    case AVCOL_SPC_BT709:
+      return EGL_ITU_REC709_EXT;
+    case AVCOL_SPC_RESERVED:
+    case AVCOL_SPC_UNSPECIFIED:
+    default:
+      if (picture.iWidth > 1024 || picture.iHeight >= 600)
+        return EGL_ITU_REC709_EXT;
+      else
+        return EGL_ITU_REC601_EXT;
+  }
+}
+
+int GetEGLColorRange(const VideoPicture& picture)
+{
+  if (picture.color_range)
+    return EGL_YUV_FULL_RANGE_EXT;
+
+  return EGL_YUV_NARROW_RANGE_EXT;
+}
+
+} // namespace
+
 CDRMPRIMETexture::~CDRMPRIMETexture()
 {
   glDeleteTextures(1, &m_texture);
@@ -55,8 +91,8 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
     attribs.width = m_texWidth;
     attribs.height = m_texHeight;
     attribs.format = layer->format;
-    attribs.colorSpace = GetColorSpace(DRMPRIME::GetColorEncoding(buffer->GetPicture()));
-    attribs.colorRange = GetColorRange(DRMPRIME::GetColorRange(buffer->GetPicture()));
+    attribs.colorSpace = GetEGLColorSpace(buffer->GetPicture());
+    attribs.colorRange = GetEGLColorRange(buffer->GetPicture());
     attribs.planes = planes;
 
     if (!m_eglImage->CreateImage(attribs))
@@ -93,30 +129,4 @@ void CDRMPRIMETexture::Unmap()
 
   m_primebuffer->Release();
   m_primebuffer = nullptr;
-}
-
-int CDRMPRIMETexture::GetColorSpace(int colorSpace)
-{
-  switch (colorSpace)
-  {
-    case DRM_COLOR_YCBCR_BT2020:
-      return EGL_ITU_REC2020_EXT;
-    case DRM_COLOR_YCBCR_BT601:
-      return EGL_ITU_REC601_EXT;
-    case DRM_COLOR_YCBCR_BT709:
-    default:
-      return EGL_ITU_REC709_EXT;
-  }
-}
-
-int CDRMPRIMETexture::GetColorRange(int colorRange)
-{
-  switch (colorRange)
-  {
-    case DRM_COLOR_YCBCR_FULL_RANGE:
-      return EGL_YUV_FULL_RANGE_EXT;
-    case DRM_COLOR_YCBCR_LIMITED_RANGE:
-    default:
-      return EGL_YUV_NARROW_RANGE_EXT;
-  }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -35,8 +35,4 @@ protected:
   GLuint m_texture{0};
   int m_texWidth{0};
   int m_texHeight{0};
-
-private:
-  static int GetColorSpace(int colorSpace);
-  static int GetColorRange(int colorRange);
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -162,11 +162,14 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 
   auto plane = m_DRM->GetVideoPlane();
 
+  bool result;
   uint64_t value;
-  if (plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture), value))
+  std::tie(result, value) = plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture));
+  if (result)
     m_DRM->AddProperty(plane, "COLOR_ENCODING", value);
 
-  if (plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture), value))
+  std::tie(result, value) = plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture));
+  if (result)
     m_DRM->AddProperty(plane, "COLOR_RANGE", value);
 
   auto connector = m_DRM->GetConnector();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -161,11 +161,13 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   const VideoPicture& picture = buffer->GetPicture();
 
   auto plane = m_DRM->GetVideoPlane();
-  if (plane->SupportsPropertyAndValue("COLOR_ENCODING", GetColorEncoding(picture)))
-    m_DRM->AddProperty(plane, "COLOR_ENCODING", GetColorEncoding(picture));
 
-  if (plane->SupportsPropertyAndValue("COLOR_RANGE", GetColorRange(picture)))
-    m_DRM->AddProperty(plane, "COLOR_RANGE", GetColorRange(picture));
+  uint64_t value;
+  if (plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture), value))
+    m_DRM->AddProperty(plane, "COLOR_ENCODING", value);
+
+  if (plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture), value))
+    m_DRM->AddProperty(plane, "COLOR_RANGE", value);
 
   auto connector = m_DRM->GetConnector();
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -46,19 +46,21 @@ uint32_t GetScalingFactor(uint32_t srcWidth,
 
 bool CDRMAtomic::SetScalingFilter(CDRMObject* object, const char* name, const char* type)
 {
-  uint64_t filter_type{};
-  if (m_gui_plane->GetPropertyValue(name, type, filter_type))
-  {
-    if (AddProperty(object, name, filter_type))
-    {
-      uint32_t mar_scale_factor =
-          GetScalingFactor(m_width, m_height, m_mode->hdisplay, m_mode->vdisplay);
-      AddProperty(object, "CRTC_W", (mar_scale_factor * m_width));
-      AddProperty(object, "CRTC_H", (mar_scale_factor * m_height));
-      return true;
-    }
-  }
-  return false;
+  bool result;
+  uint64_t value;
+  std::tie(result, value) = m_gui_plane->GetPropertyValue(name, type);
+  if (!result)
+    return false;
+
+  if (!AddProperty(object, name, value))
+    return false;
+
+  uint32_t mar_scale_factor =
+      GetScalingFactor(m_width, m_height, m_mode->hdisplay, m_mode->vdisplay);
+  AddProperty(object, "CRTC_W", (mar_scale_factor * m_width));
+  AddProperty(object, "CRTC_H", (mar_scale_factor * m_height));
+
+  return true;
 }
 
 void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer)

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -8,7 +8,6 @@
 
 #include "DRMObject.h"
 
-#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -56,9 +55,8 @@ std::string CDRMObject::GetPropertyName(uint32_t propertyId) const
 
 uint32_t CDRMObject::GetPropertyId(const char* name) const
 {
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [&name](auto& prop) {
-    return StringUtils::EqualsNoCase(prop->name, name);
-  });
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
+                               [&name](auto& prop) { return prop->name == name; });
 
   if (property != m_propsInfo.end())
     return property->get()->prop_id;
@@ -110,9 +108,8 @@ std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
 
 bool CDRMObject::SetProperty(const char* name, uint64_t value)
 {
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [&name](auto& prop) {
-    return StringUtils::EqualsNoCase(prop->name, name);
-  });
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
+                               [&name](auto& prop) { return prop->name == name; });
 
   if (property != m_propsInfo.end())
   {
@@ -126,9 +123,8 @@ bool CDRMObject::SetProperty(const char* name, uint64_t value)
 
 bool CDRMObject::SupportsProperty(const char* name)
 {
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [&name](auto& prop) {
-    return StringUtils::EqualsNoCase(prop->name, name);
-  });
+  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
+                               [&name](auto& prop) { return prop->name == name; });
 
   if (property != m_propsInfo.end())
     return true;

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -53,7 +53,7 @@ std::string CDRMObject::GetPropertyName(uint32_t propertyId) const
   return "invalid property";
 }
 
-uint32_t CDRMObject::GetPropertyId(const char* name) const
+uint32_t CDRMObject::GetPropertyId(const std::string& name) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](auto& prop) { return prop->name == name; });
@@ -106,7 +106,7 @@ std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
   return std::make_tuple(false, 0);
 }
 
-bool CDRMObject::SetProperty(const char* name, uint64_t value)
+bool CDRMObject::SetProperty(const std::string& name, uint64_t value)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](auto& prop) { return prop->name == name; });
@@ -121,7 +121,7 @@ bool CDRMObject::SetProperty(const char* name, uint64_t value)
   return false;
 }
 
-bool CDRMObject::SupportsProperty(const char* name)
+bool CDRMObject::SupportsProperty(const std::string& name)
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](auto& prop) { return prop->name == name; });

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -135,27 +135,3 @@ bool CDRMObject::SupportsProperty(const char* name)
 
   return false;
 }
-
-bool CDRMObject::SupportsPropertyAndValue(const char* name, uint64_t value)
-{
-  auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(), [&name](auto& prop) {
-    return StringUtils::EqualsNoCase(prop->name, name);
-  });
-
-  if (property != m_propsInfo.end())
-  {
-    if (drm_property_type_is(property->get(), DRM_MODE_PROP_ENUM) != 0)
-    {
-      for (int j = 0; j < property->get()->count_enums; j++)
-      {
-        if (property->get()->enums[j].value == value)
-          return true;
-      }
-    }
-
-    CLog::Log(LOGDEBUG, "CDRMObject::{} - property '{}' does not support value '{}'", __FUNCTION__,
-              name, value);
-  }
-
-  return false;
-}

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -34,7 +34,8 @@ public:
 
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const char* name) const;
-  bool GetPropertyValue(std::string name, const std::string& type, uint64_t& value) const;
+  std::tuple<bool, uint64_t> GetPropertyValue(const std::string& name,
+                                              const std::string& valueName) const;
 
   bool SetProperty(const char* name, uint64_t value);
   bool SupportsProperty(const char* name);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -39,7 +39,6 @@ public:
 
   bool SetProperty(const char* name, uint64_t value);
   bool SupportsProperty(const char* name);
-  bool SupportsPropertyAndValue(const char* name, uint64_t value);
 
 protected:
   explicit CDRMObject(int fd);

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -33,12 +33,12 @@ public:
   std::string GetPropertyName(uint32_t propertyId) const;
 
   uint32_t GetId() const { return m_id; }
-  uint32_t GetPropertyId(const char* name) const;
+  uint32_t GetPropertyId(const std::string& name) const;
   std::tuple<bool, uint64_t> GetPropertyValue(const std::string& name,
                                               const std::string& valueName) const;
 
-  bool SetProperty(const char* name, uint64_t value);
-  bool SupportsProperty(const char* name);
+  bool SetProperty(const std::string& name, uint64_t value);
+  bool SupportsProperty(const std::string& name);
 
 protected:
   explicit CDRMObject(int fd);


### PR DESCRIPTION
This PR does a few different things, I'll try and explain them logically:

 1) Moving the egl colorspace/colorrange functions removes the dependency on the CVideoBufferDRMPRIME methods for converting colorspace
 2) Corrects the behavior of the querying the drm property enum value from the kernel. The value may change on different platforms (I don't think it does) so we need to query the value instead of blindly setting it. This also allows us to remove some defines that were added from the linux kernel which aren't needed when querying the kernel for the values.
 3) This changes the method `GetPropertyValue` to use `std::tuple`. This allows use to check if the function was successful and allows us to get the value of the property without passing by reference. The values are uint64_t and 0 is a valid value so we cannot accurately check if the return failed by the value alone. This behaviour will be further improved by c++17 which allows the use of auto when returning `std::tuple`. I like this format and I'll likely use it more in the future.
 4) removes the old `SupportsPropertyAndValue` method as it's not needed
 5) removes unneeded stringutils
 6) changes to pass std::string by const refference

~~I did add a small feature in here to allow settings the `Colorspace` connector property. This only adds support for bt2020 for now. I can remove this commit if not desired for v19.~~ (Dropped)

I'd like to get this into v19 to reduce my patch set however I will understand if we bump it to v20 because it's not exactly a bugfix. These changes are only related to drm/kms and the drmprime rendering methods so impact is likely small.

EDIT:
This also changes to have case-sensitive checks for property names.