### PR TITLE
Coverity fix Member initialisation in DX DeviceResources

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -80,6 +80,7 @@ DX::DeviceResources::DeviceResources()
   , m_deviceNotify(nullptr)
   , m_stereoEnabled(false)
   , m_bDeviceCreated(false)
+  , m_IsHDROutput(false)
 {
 }
 


### PR DESCRIPTION
Fix Coverty report
```
*** CID 215512:  Uninitialized members  (UNINIT_CTOR)
/xbmc/rendering/dx/DeviceResources.cpp: 84 in DX::DeviceResources::DeviceResources()()
78       , m_dpi(DisplayMetrics::Dpi100)
79       , m_effectiveDpi(DisplayMetrics::Dpi100)
80       , m_deviceNotify(nullptr)
81       , m_stereoEnabled(false)
82       , m_bDeviceCreated(false)
83     {
>>>     CID 215512:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "m_IsHDROutput" is not initialized in this constructor nor in any functions that it calls.
84     }
```