### PR TITLE
Fix: HQ scalers should be used with DXVA/PS render methods when AUTO or incompatible scaler method is selected

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererHQ.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererHQ.h
@@ -25,9 +25,10 @@ protected:
 
   void SelectPSVideoFilter();
   bool HasHQScaler() const;
+  bool IsHQScalingAllowed() const;
 
   ESCALINGMETHOD m_scalingMethod = VS_SCALINGMETHOD_AUTO;
-  ESCALINGMETHOD m_scalingMethodGui = VS_SCALINGMETHOD_AUTO;
+  ESCALINGMETHOD m_scalingMethodGui = VS_SCALINGMETHOD_MAX;
   std::unique_ptr<CConvolutionShader> m_scalerShader = nullptr;
   bool m_bUseHQScaler = false;
 };


### PR DESCRIPTION
## Description
- Fix broken code to determine use or not HQ scaler when scaler method is set to AUTO or LINEAR (settings default).
- Fix incorrect/confusing log message "chosen scaling method 1 is not supported by renderer" appears also when is not needed scaler.

## Motivation and Context
Debug log message "WARNING: chosen scaling method 1 is not supported by renderer" it has always intrigued me because it appears in most of the logs that users post on the forum. After analyzing the code I have seen several things that worked erratically and I have tried to solve several of the issues.

## How Has This Been Tested?
Common to all tests: render method = DXVA / Auto detect

**TEST 1: source 720p --> Display 1080p scale method LINEAR (clean install default)**
**Before:** 
Since renderer method DXVA des not support LINEAR method trigers "chosen scaling method 1 is not supported by renderer" and defaults to AUTO method but HQ scalers are NOT enabled.
**After:**
Fallbacks to AUTO method with the log message "chosen scaling method 1 is not supported by renderer, fallback to AUTO scaling method" and HQ scalers are enabled with default convolution kernel 4x4.

**TEST 2: source 720p --> Display 1080p scale method AUTO**
**Before:** 
HQ scalers are NOT enabled since in RendererHQ.h `m_scalingMethodGui = VS_SCALINGMETHOD_AUTO;` and not triggers initial filter update (works OK if is selected from video OSD menu while playing).
**After:**
HQ scalers are enabled with default convolution kernel 4x4.

**TEST 3: source 4K --> Display 4K scale method Lanczos3**
**Before:** 
HQ scalers are not enabled because not needed but triggers WARNING message "chosen scaling method x is not supported by renderer"
**After:**
HQ scalers are not enabled because not needed and not logs any warning message.

**TEST 4: source 1080p --> Display 4K scale method Lanczos3**
**Before:** 
HQ scalers are enabled although is hard to see in log because no specific message appears.
**After:**
HQ scalers are enabled with log INFO message  "HQ scaler will be used (Convolution kernel 6x6)".

**TEST 5: source 1080p --> Display 4K scale method AUTO**
**Before:** 
HQ scalers are NOT enabled. (same as TEST 2)
**After:**
HQ scalers are enabled with log INFO message  "HQ scaler will be used (Convolution kernel 4x4)".


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
