### PR TITLE
[subtitles][ass] fix/extend detection of font attachments (mimetype)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -70,6 +70,31 @@ static const struct StereoModeConversionMap WmvToInternalStereoModeMap[] =
   {}
 };
 
+namespace
+{
+const std::vector<std::string> font_mimetypes = {"application/x-truetype-font",
+                                                 "application/vnd.ms-opentype",
+                                                 "application/x-font-ttf",
+                                                 "application/x-font", // probably incorrect
+                                                 "application/font-sfnt",
+                                                 "font/collection",
+                                                 "font/otf",
+                                                 "font/sfnt",
+                                                 "font/ttf"};
+
+bool AttachmentIsFont(const AVDictionaryEntry* dict)
+{
+  if (dict)
+  {
+    const std::string mimeType = dict->value;
+    return std::find_if(font_mimetypes.begin(), font_mimetypes.end(), [&mimeType](std::string str) {
+             return str == mimeType;
+           }) != font_mimetypes.end();
+  }
+  return false;
+}
+} // namespace
+
 #define FF_MAX_EXTRADATA_SIZE ((1 << 28) - AV_INPUT_BUFFER_PADDING_SIZE)
 
 std::string CDemuxStreamAudioFFmpeg::GetStreamName()
@@ -1652,9 +1677,13 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         }
       }
       case AVMEDIA_TYPE_ATTACHMENT:
-      { //mkv attachments. Only bothering with fonts for now.
+      {
+        // mkv attachments. Only bothering with fonts for now.
+        AVDictionaryEntry* attachmentMimetype =
+            av_dict_get(pStream->metadata, "mimetype", nullptr, 0);
+
         if (pStream->codecpar->codec_id == AV_CODEC_ID_TTF ||
-            pStream->codecpar->codec_id == AV_CODEC_ID_OTF)
+            pStream->codecpar->codec_id == AV_CODEC_ID_OTF || AttachmentIsFont(attachmentMimetype))
         {
           std::string fileName = "special://temp/fonts/";
           XFILE::CDirectory::Create(fileName);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -22,17 +22,8 @@
 
 namespace
 {
-void AppendFont(const std::string& font)
+std::string GetDefaultFontPath(std::string& font)
 {
-  std::string finalFontPath = URIUtils::AddFileToFolder("special://temp/fonts/", font);
-  if (XFILE::CFile::Exists(finalFontPath))
-  {
-    CLog::Log(LOGDEBUG,
-              "CDVDSubtitlesLibass: Skipping copy of {} to special://temp/fonts/ (already exists)",
-              font);
-    return;
-  }
-
   std::string fontSources[]{"special://home/media/Fonts/", "special://xbmc/media/Fonts/"};
 
   for (const auto& path : fontSources)
@@ -40,12 +31,11 @@ void AppendFont(const std::string& font)
     auto fontPath = URIUtils::AddFileToFolder(path, font);
     if (XFILE::CFile::Exists(fontPath))
     {
-      XFILE::CFile::Copy(fontPath, finalFontPath);
-      CLog::Log(LOGDEBUG, "CDVDSubtitlesLibass: Copied {} to {}", fontPath, finalFontPath);
-      return;
+      return CSpecialProtocol::TranslatePath(fontPath).c_str();
     }
-    CLog::Log(LOGDEBUG, "CDVDSubtitlesLibass: Could not find font {} in font sources", font);
   }
+  CLog::Log(LOGERROR, "CDVDSubtitlesLibass: Could not find font {} in font sources", font);
+  return "";
 }
 } // namespace
 
@@ -69,19 +59,18 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
 
   ass_set_message_cb(m_library, libass_log, this);
 
-  // Add configured subtitle font to special://temp/fonts/. This needs to be done before
-  // ass_set_fonts_dir. If fontconfig fails it will use the default font.
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  std::string forcedFont = settings->GetString(CSettings::SETTING_SUBTITLES_FONT);
-  AppendFont(forcedFont);
-  strPath = URIUtils::AddFileToFolder(strPath, forcedFont);
-
   CLog::Log(LOGINFO, "CDVDSubtitlesLibass: Initializing ASS library font settings");
-  // libass uses fontconfig (system lib) which is not wrapped
-  //  so translate the path before calling into libass
-  ass_set_fonts_dir(m_library,  CSpecialProtocol::TranslatePath(strPath).c_str());
-  ass_set_extract_fonts(m_library, 1);
-  ass_set_style_overrides(m_library, NULL);
+
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  bool overrideFont = settings->GetBool(CSettings::SETTING_SUBTITLES_OVERRIDEASSFONTS);
+  if (!overrideFont)
+  {
+    // libass uses fontconfig (system lib) which is not wrapped
+    // so translate the path before calling into libass
+    ass_set_fonts_dir(m_library, CSpecialProtocol::TranslatePath(strPath).c_str());
+    ass_set_extract_fonts(m_library, 1);
+    ass_set_style_overrides(m_library, nullptr);
+  }
 
   CLog::Log(LOGINFO, "CDVDSubtitlesLibass: Initializing ASS Renderer");
 
@@ -94,10 +83,10 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   ass_set_use_margins(m_renderer, 0);
   ass_set_font_scale(m_renderer, 1);
 
-  int fontconfig = settings->GetBool(CSettings::SETTING_SUBTITLES_OVERRIDEASSFONTS) ? 0 : 1;
   // libass uses fontconfig (system lib) which is not wrapped
-  //  so translate the path before calling into libass
-  ass_set_fonts(m_renderer, CSpecialProtocol::TranslatePath(strPath).c_str(), "Arial", fontconfig,
+  // so translate the path before calling into libass
+  std::string forcedFont = settings->GetString(CSettings::SETTING_SUBTITLES_FONT);
+  ass_set_fonts(m_renderer, GetDefaultFontPath(forcedFont).c_str(), "Arial", overrideFont ? 0 : 1,
                 nullptr, 1);
 }
 


### PR DESCRIPTION
## Description
For some mkvs that include ASS subtitles and font attachments, kodi was skipping the extraction of the fonts because the demuxer doesn't flag them as `AV_CODEC_ID_TTF` or `AV_CODEC_ID_OTF`. This leads libass to load the incorrect font and, consequently, to the likelihood of overflowing the defined overlay margins in some cases.
Other players that also use libass (f.e. mpv) also look into the attachment mimetype to decide if it is a font and should be loaded into memory.

You can find similar implementations in:
https://gitlab.websupport.sk/peter.kovar/ffmpeg-mvc/commit/7e6b3ad6930c2f1daa5c4831bbeda3fb931921e6
https://github.com/mpv-player/mpv/blob/91ce87bd89940b8b83d1bd044288008182cf3a2e/sub/sd_ass.c#L98-L109

While looking into this also noticed that in https://github.com/xbmc/xbmc/pull/18794 a mistake was made and `strPath` was in the wrong place. So basically `ass_set_fonts_dir` was receiving the default font file instead of the font folder. Fixing this broke the setting again :) So this PR also includes a fix for the setting.

## Motivation and Context
Fixes an issue reported in irc by _xD, sample file: https://anonfiles.com/Z5j9b9tdp8/clip_bug_tar 

## How Has This Been Tested?
Using the sample files and also all the ass samples in the ftp server

## Screenshots (if appropriate):

**master:**
![mastert](https://i.imgur.com/5frwN89.png "master")

**pr:**
![pr](https://i.imgur.com/E8EvRra.png "pr")

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
