### PR TITLE
[darwinembedded] deb packaging handle symlink settings

### DIFF
--- a/tools/darwin/packaging/darwin_embedded/mkdeb-darwin_embedded.sh.in
+++ b/tools/darwin/packaging/darwin_embedded/mkdeb-darwin_embedded.sh.in
@@ -102,7 +102,7 @@ chmod +x $DIRNAME/$PACKAGE/DEBIAN/postinst
 
 # prep @APP_NAME@.app
 mkdir -p $DIRNAME/$PACKAGE/Applications
-cp -r $APP $DIRNAME/$PACKAGE/Applications/
+rsync -a --no-links $APP $DIRNAME/$PACKAGE/Applications/
 find $DIRNAME/$PACKAGE/Applications/ -name '.svn' -exec rm -rf {} \;
 find $DIRNAME/$PACKAGE/Applications/ -name '.git*' -exec rm -rf {} \;
 find $DIRNAME/$PACKAGE/Applications/ -name '.DS_Store'  -exec rm -rf {} \;


### PR DESCRIPTION
## Description
cp doesnt like symlinks, and is erroring out for deb packaging on ios/tvos
use rsync, and dont follow symlinks

## Motivation and Context
ios/tvos deb packaging fails after the freebsd setting symlink pr from lrusak

## How Has This Been Tested?
locally for ios

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
