### PR TITLE
[UWP] Fix typo in kernelVersionFull string

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -554,7 +554,7 @@ std::string CSysInfo::GetKernelVersionFull(void)
   unsigned long long v4 = (v & 0x000000000000FFFFL);
   kernelVersionFull = StringUtils::Format("%lld.%lld.%lld", v1, v2, v3);
   if (v4)
-    kernelVersionFull += StringUtils::Format(".ll%d", v4);
+    kernelVersionFull += StringUtils::Format(".%lld", v4);
 
 #elif defined(TARGET_POSIX)
   struct utsname un;


### PR DESCRIPTION
## Description
[UWP] Fix typo in kernelVersionFull string

## Motivation and Context
Found at looking issue https://github.com/xbmc/xbmc/issues/18846 debug log

(this does not fix the bug reported in this issue)

## How Has This Been Tested?
Before:  10.0.19042.ll630

After:  10.0.19042.630

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
