### PR TITLE
[OSX][packaging] allow ability create dmg from xcode generated project

### DIFF
--- a/cmake/scripts/osx/Install.cmake
+++ b/cmake/scripts/osx/Install.cmake
@@ -52,6 +52,7 @@ add_custom_target(dmg
             "DEV_TEAM=${DEV_TEAM}"
             "EXPANDED_CODE_SIGN_IDENTITY_NAME=${CODE_SIGN_IDENTITY}"
             "PLATFORM_NAME=${PLATFORM}"
+            "XCODE_BUILDTYPE=${CMAKE_CFG_INTDIR}"
             ./mkdmg-osx.sh ${CORE_BUILD_CONFIG_LOWERCASED}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx)
 set_target_properties(dmg PROPERTIES FOLDER "Build Utilities")

--- a/tools/darwin/packaging/osx/mkdmg-osx.sh.in
+++ b/tools/darwin/packaging/osx/mkdmg-osx.sh.in
@@ -2,20 +2,32 @@
 
 # usage: ./mkdmg-osx.sh release/debug (case insensitive)
 # Allows us to run mkdmg-osx.sh from anywhere in the three, rather than the tools/darwin/packaging/osx folder only
-SWITCH="$1"
+
+case "$XCODE_BUILDTYPE" in
+ ".") SWITCH="$1" ;;
+ *) SWITCH="$XCODE_BUILDTYPE" ;;
+esac
+
 DIRNAME=`dirname $0`
 
-if [ ${SWITCH:-""} = "debug" ]; then
-  echo "Packaging Debug target for OSX"
-  APP="$DIRNAME/../../../../build/Debug/@APP_NAME@.app"
-elif [ ${SWITCH:-""} = "release" ]; then
-  echo "Packaging Release target for OSX"
-  APP="$DIRNAME/../../../../build/Release/@APP_NAME@.app"
-  isReleaseBuild=1
-else
-  echo "You need to specify the build target"
-  exit 1
-fi
+# use for case insensitive match. revert to system default after this block
+shopt -s nocasematch
+case "$SWITCH" in
+  "debug" )
+    echo "Packaging Debug target for OSX"
+    APP="$DIRNAME/../../../../build/Debug/@APP_NAME@.app"
+  ;;
+  "release" )
+    echo "Packaging Release target for OSX"
+    APP="$DIRNAME/../../../../build/Release/@APP_NAME@.app"
+    isReleaseBuild=1
+  ;;
+  *)
+    echo "You need to specify the build target"
+    exit 1
+  ;;
+esac
+shopt -u nocasematch
 
 if [ ! -d $APP ]; then
   echo "@APP_NAME@.app not found! are you sure you built $1 target?"


### PR DESCRIPTION
## Description

currently the mkdmg-osx.sh script will fail when project is an xcode generated project

  You need to specify the build target

The issue is that xcode projects arent a set configuration type at cmake generation time
CORE_BUILD_CONFIG will be empty. This passes the xcode configuration type to the script
so the type can be used to build the dmg correctly.

## Motivation and Context
Stumbled across this chasing another issue.

## How Has This Been Tested?
Locally on osx using xcode 12.2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
