### PR TITLE
Fix "Party mode playlist" item actions and context menu buttons 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8766,6 +8766,8 @@ msgctxt "#16034"
 msgid "Couldn't get songs from database."
 msgstr ""
 
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+#: xbmc/video/windows/GUIWindowVideoBase.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
 msgctxt "#16035"
 msgid "Party mode playlist"

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -35,6 +35,7 @@
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -381,6 +382,16 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem, bool first)
 
   if (item->IsRAR() || item->IsZIP())
     return;
+  
+  // Check for the partymode playlist item, do nothing when "PartyMode.xsp" not exist
+  if (item->IsSmartPlayList())
+  {
+    const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
+    if ((item->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
+      !XFILE::CFile::Exists(item->GetPath()))
+      return;
+  }
 
   //  Allow queuing of unqueueable items
   //  when we try to queue them directly
@@ -531,6 +542,16 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
   if (item)
   {
     const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
+
+    // Check for the partymode playlist item. 
+    // When "PartyMode.xsp" not exist, only context menu button is edit
+    if (item->IsSmartPlayList() &&
+        (item->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
+        !XFILE::CFile::Exists(item->GetPath()))
+    {
+      buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
+      return;
+    }
 
     if (item && !item->IsParentFolder())
     {
@@ -741,6 +762,16 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
     return;
   }
 #endif
+
+  // Check for the partymode playlist item, do nothing when "PartyMode.xsp" not exist
+  if (pItem->IsSmartPlayList())
+  {
+    const std::shared_ptr<CProfileManager> profileManager =
+        CServiceBroker::GetSettingsComponent()->GetProfileManager();
+    if ((pItem->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
+        !XFILE::CFile::Exists(pItem->GetPath()))
+      return;
+  }
 
   // if its a folder, build a playlist
   if (pItem->m_bIsFolder && !pItem->IsPlugin())


### PR DESCRIPTION
Fix actions and context menu button visibility for "Party mode playlist" item on music playlists node.

This is a special item always shown on the music playlists node, even when the user has not yet specified filter rules for party mode (held in userdata/PartyMode.xsp). But as @KarellenX pointed out on another PR, having context menu buttons to play, queue, play next, browse into a non-existent smart playlist makes no sense. The only meaningful action is to "edit playlist" and enter the playlist rules.  Playing and adding to queue are also actions triggered by keyboard shortcuts or scripts. Hence these actions need to be intercepted too. 

This PR ensures that play, add to queue and browse etc. are not allowed for the Party mode playlist" item when PartyMode.xsp file does not exist.

